### PR TITLE
bin/cloud-push: use proper prerelease versions

### DIFF
--- a/bin/cloud-push
+++ b/bin/cloud-push
@@ -18,12 +18,15 @@ cd "$(dirname "$0")/.."
 . misc/shlib/shlib.bash
 
 if [[ $# -lt 2 ]]; then
-    die "usage: $0 DOCKER-HUB-USERNAME TAG [arguments for mzimage]"
+    die "usage: $0 DOCKER-HUB-USERNAME ADDITIONAL-BUILD-METADATA [arguments for mzimage]"
 fi
 username=$1
 shift
-tag=$1
+additional_build_metadata=$1
 shift
+
+version=$(bin/pyactivate -c "from materialize.mz_version import MzVersion; print(MzVersion.parse_cargo())")
+tag="$version--local.$additional_build_metadata"
 
 for image in environmentd clusterd; do
     bin/mzimage acquire --arch=aarch64 "$image" "$@"


### PR DESCRIPTION
Rather than using a random tag, use a tag that includes the current version from Cargo.toml. That way, the cloud orchestration layer will be able to understand precisely what features (e.g., CLI arguments) this custom build supports.

(Of course, if the custom build adds *new* features that are meant to be understood by the cloud orchestration layer, that will require bumping the version in Cargo.toml; that's fundamental to this approach of using prerelease versions to gate features that impact the cloud orchestration layer, though.)

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

This will make the cloud version detection logic (https://github.com/MaterializeInc/cloud/pull/9978) work better  when someone is using `bin/cloud-push` to push up custom images to staging.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
