### PR TITLE
catalog: Improve fencing

### DIFF
--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -185,6 +185,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         persist_client,
         organization_id,
         BUILD_INFO.semver_version(),
+        None,
         metrics,
     )
     .await?;
@@ -492,7 +493,6 @@ async fn upgrade_check(
     cluster_replica_sizes: ClusterReplicaSizeMap,
     start: Instant,
 ) -> Result<(), anyhow::Error> {
-    let deploy_generation = 0;
     let now = SYSTEM_TIME.clone();
     let mut storage = openable_state
         .open_savepoint(
@@ -502,7 +502,6 @@ async fn upgrade_check(
                     "DEFAULT CLUSTER REPLICA SIZE IS ONLY USED FOR NEW ENVIRONMENTS".into(),
                 bootstrap_role: None,
             },
-            deploy_generation,
             None,
         )
         .await?;

--- a/src/catalog/src/durable/error.rs
+++ b/src/catalog/src/durable/error.rs
@@ -137,7 +137,7 @@ impl From<TryFromProtoError> for DurableCatalogError {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, thiserror::Error)]
 pub enum FenceError {
     /// This instance was fenced by another instance with a higher deployment generation. This
-    /// necessary means that the other instance also had a higher epoch. The instance that fenced
+    /// necessarily means that the other instance also had a higher epoch. The instance that fenced
     /// us believes that they are from a later generation than us.
     #[error("current catalog deployment generation {current_generation} fenced by new catalog epoch {fence_generation}")]
     DeployGeneration {

--- a/src/catalog/src/durable/error.rs
+++ b/src/catalog/src/durable/error.rs
@@ -171,7 +171,7 @@ pub enum FenceError {
     #[error(
         "builtin table migration shard upper {expected_upper:?} fenced by new builtin table migration shard upper {actual_upper:?}"
     )]
-    Migration {
+    MigrationUpper {
         expected_upper: Timestamp,
         actual_upper: Timestamp,
     },
@@ -193,7 +193,7 @@ impl FenceError {
     }
 
     pub fn migration(err: UpperMismatch<Timestamp>) -> Self {
-        Self::Migration {
+        Self::MigrationUpper {
             expected_upper: antichain_to_timestamp(err.expected),
             actual_upper: antichain_to_timestamp(err.current),
         }
@@ -222,7 +222,7 @@ mod tests {
         };
         assert!(epoch < upper);
 
-        let migration = FenceError::Migration {
+        let migration = FenceError::MigrationUpper {
             expected_upper: 60.into(),
             actual_upper: 61.into(),
         };

--- a/src/catalog/src/durable/error.rs
+++ b/src/catalog/src/durable/error.rs
@@ -9,10 +9,14 @@
 
 use std::fmt::Debug;
 
+use mz_persist_client::error::UpperMismatch;
 use mz_proto::TryFromProtoError;
 use mz_repr::Timestamp;
 use mz_sql::catalog::CatalogError as SqlCatalogError;
 use mz_storage_types::controller::StorageError;
+
+use crate::durable::persist::antichain_to_timestamp;
+use crate::durable::Epoch;
 
 #[derive(Debug, thiserror::Error)]
 pub enum CatalogError {
@@ -28,12 +32,19 @@ impl From<TryFromProtoError> for CatalogError {
     }
 }
 
+impl From<FenceError> for CatalogError {
+    fn from(err: FenceError) -> Self {
+        let err: DurableCatalogError = err.into();
+        err.into()
+    }
+}
+
 /// An error that can occur while interacting with a durable catalog.
 #[derive(Debug, thiserror::Error)]
 pub enum DurableCatalogError {
     /// Catalog has been fenced by another writer.
-    #[error("{0}")]
-    Fence(String),
+    #[error(transparent)]
+    Fence(#[from] FenceError),
     /// The persisted catalog's version is too old for the current catalog to migrate.
     #[error(
         "incompatible Catalog version {found_version}, minimum: {min_catalog_version}, current: {catalog_version}"
@@ -117,5 +128,104 @@ impl From<StorageError<Timestamp>> for DurableCatalogError {
 impl From<TryFromProtoError> for DurableCatalogError {
     fn from(e: TryFromProtoError) -> Self {
         DurableCatalogError::Proto(e)
+    }
+}
+
+/// An error that indicates the durable catalog has been fenced.
+///
+/// The order of this enum indicates the most information to the least information.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, thiserror::Error)]
+pub enum FenceError {
+    /// This instance was fenced by another instance with a higher deployment generation. This
+    /// necessary means that the other instance also had a higher epoch. The instance that fenced
+    /// us believes that they are from a later generation than us.
+    #[error("current catalog deployment generation {current_generation} fenced by new catalog epoch {fence_generation}")]
+    DeployGeneration {
+        current_generation: u64,
+        fence_generation: u64,
+    },
+    /// This instance was fenced by another instance with a higher epoch. The instance that fenced
+    /// us may or may not be from a later generation than us, we were unable to determine.
+    #[error("current catalog epoch {current_epoch} fenced by new catalog epoch {fence_epoch}")]
+    Epoch {
+        current_epoch: Epoch,
+        fence_epoch: Epoch,
+    },
+    // It's very likely that if we were to read the latest updates after this error, then we'd see
+    // a higher epoch/deploy generation from the other writer and get fenced through that. We could
+    // potentially always do that and eliminate this fence variant. However, the catalog debug tool
+    // is able to write to the catalog without incrementing the epoch and therefore would not be
+    // able to fence this instance. It's technically possible for this instance to survive and
+    // respond to a write from the catalog debug tool, but until more thought is put into it, the
+    // safest thing to do is crash and reboot.
+    /// This instance was fenced while trying to write to the catalog by some other writer.
+    #[error(
+        "current catalog upper {expected_upper:?} fenced by new catalog upper {actual_upper:?}"
+    )]
+    Upper {
+        expected_upper: Timestamp,
+        actual_upper: Timestamp,
+    },
+    /// This instance was fenced while writing to the migration shard during 0dt builtin table
+    /// migrations.
+    #[error(
+        "builtin table migration shard upper {expected_upper:?} fenced by new builtin table migration shard upper {actual_upper:?}"
+    )]
+    Migration {
+        expected_upper: Timestamp,
+        actual_upper: Timestamp,
+    },
+}
+
+impl FenceError {
+    pub fn deploy_generation(current_generation: u64, fence_generation: u64) -> Self {
+        Self::DeployGeneration {
+            current_generation,
+            fence_generation,
+        }
+    }
+
+    pub fn epoch(current_epoch: Epoch, fence_epoch: Epoch) -> Self {
+        Self::Epoch {
+            current_epoch,
+            fence_epoch,
+        }
+    }
+
+    pub fn migration(err: UpperMismatch<Timestamp>) -> Self {
+        Self::Migration {
+            expected_upper: antichain_to_timestamp(err.expected),
+            actual_upper: antichain_to_timestamp(err.current),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::durable::{Epoch, FenceError};
+
+    #[mz_ore::test]
+    fn test_fence_err_ord() {
+        let deploy_generation = FenceError::DeployGeneration {
+            current_generation: 90,
+            fence_generation: 91,
+        };
+        let epoch = FenceError::Epoch {
+            current_epoch: Epoch::new(80).expect("non zero"),
+            fence_epoch: Epoch::new(81).expect("non zero"),
+        };
+        assert!(deploy_generation < epoch);
+
+        let upper = FenceError::Upper {
+            expected_upper: 70.into(),
+            actual_upper: 71.into(),
+        };
+        assert!(epoch < upper);
+
+        let migration = FenceError::Migration {
+            expected_upper: 60.into(),
+            actual_upper: 61.into(),
+        };
+        assert!(upper < migration);
     }
 }

--- a/src/environmentd/src/deployment/preflight.rs
+++ b/src/environmentd/src/deployment/preflight.rs
@@ -77,7 +77,6 @@ pub async fn preflight_legacy(
                     default_cluster_replica_size: bootstrap_default_cluster_replica_size,
                     bootstrap_role,
                 },
-                deploy_generation,
                 None,
             )
             .await
@@ -95,6 +94,7 @@ pub async fn preflight_legacy(
                     persist_client,
                     environment_id.organization_id(),
                     BUILD_INFO.semver_version(),
+                    Some(deploy_generation),
                     Arc::clone(&catalog_metrics),
                 )
                 .await?);
@@ -113,6 +113,7 @@ pub async fn preflight_legacy(
             persist_client,
             environment_id.organization_id(),
             BUILD_INFO.semver_version(),
+            Some(deploy_generation),
             Arc::clone(&catalog_metrics),
         )
         .await?)
@@ -194,6 +195,7 @@ pub async fn preflight_0dt(
                     persist_client.clone(),
                     environment_id.organization_id(),
                     BUILD_INFO.semver_version(),
+                    Some(deploy_generation),
                     Arc::clone(&catalog_metrics),
                 )
                 .await
@@ -207,7 +209,6 @@ pub async fn preflight_0dt(
                                 .clone(),
                             bootstrap_role: bootstrap_role.clone(),
                         },
-                        deploy_generation,
                         None,
                     )
                     .await;

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -345,6 +345,7 @@ impl Listeners {
             persist_client.clone(),
             config.environment_id.organization_id(),
             BUILD_INFO.semver_version(),
+            Some(config.controller.deploy_generation),
             Arc::clone(&config.catalog_config.metrics),
         )
         .await?;
@@ -510,12 +511,7 @@ impl Listeners {
             // TODO: behavior of migrations when booting in savepoint mode is
             // not well defined.
             let adapter_storage = openable_adapter_storage
-                .open_savepoint(
-                    boot_ts,
-                    &bootstrap_args,
-                    config.controller.deploy_generation,
-                    None,
-                )
+                .open_savepoint(boot_ts, &bootstrap_args, None)
                 .await?;
 
             // In read-only mode, we intentionally do not call `set_is_leader`,
@@ -525,12 +521,7 @@ impl Listeners {
             adapter_storage
         } else {
             let adapter_storage = openable_adapter_storage
-                .open(
-                    boot_ts,
-                    &bootstrap_args,
-                    config.controller.deploy_generation,
-                    None,
-                )
+                .open(boot_ts, &bootstrap_args, None)
                 .await?;
 
             // Once we have successfully opened the adapter storage in


### PR DESCRIPTION
Previously, the durable catalog could be fenced by one of the
following ways:

  - It tried to listen to the durable catalog and saw a higher epoch.
  - It tried to listen to the durable catalog and saw a higher binary
    version.
  - It tried to write to the durable catalog and had an upper
    mismatch.
  - It tried to write to the catalog migration shard and had an upper
    mismatch.

These would either result in a non-descriptive
`DurableCatalogError::Fence` error or a
`DurableCatalogError::IncompatiblePersistVersion` error. Additionally,
if multiple of these conditions happened at the same time, it was
non-deterministic which error would be returned.

This commit modifies the conditions for when the durable catalog can be
fenced to the following conditions:

  - It tried to listen to the durable catalog and saw a higher deploy
    generation.
  - It tried to listen to the durable catalog and saw a higher epoch.
  - It tried to write to the durable catalog shard and had an upper
    mismatch.
  - It tried to write to the catalog migration shard and had an upper
    mismatch.

When initializing the catalog, we still check that the current binary
version is not less than the catalog binary version, but we no longer
check during every update. After the catalog has been initialized,
another catalog can only increase the binary version by also fencing
the current catalog by another method.

This commit also creates a new error enum to explicitly codify these
different types of fences. When multiple of these conditions happen at
the same time, then we deterministically will return a fence error with
the priority of how the conditions are ordered above. The context of
the fence is useful to higher layers in determining what action to
take. For example if the deploy generation has increased, then we'd
like to gracefully exit with exit code 0 and let the new instance take
over.

Works towards resolving #29199

### Motivation

This PR fixes a recognized bug.

### Tips for reviewer
I would recommend reviewing the files in the following order:

1. `error.rs`
2. `persist.rs`
3. `durable.rs`
4. `environmentd/src/lib.rs`
5. `preflight.rs`
6. `builtin_item_migrations.rs`
7. `catalog-debug/src/main.rs`
8. `catalog.rs`
9. All other files (which happen to only contain tests).

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
