### PR TITLE
adapter: Improve storage usage collection perf

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -686,10 +686,10 @@ impl Catalog {
             .err_into()
     }
 
-    pub async fn allocate_storage_usage_id(&self) -> Result<u64, Error> {
+    pub async fn allocate_storage_usage_ids(&self, amount: u64) -> Result<Vec<u64>, Error> {
         self.storage()
             .await
-            .allocate_storage_usage_id()
+            .allocate_storage_usage_ids(amount)
             .await
             .maybe_terminate("allocating storage usage id")
             .err_into()

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -323,10 +323,9 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
         Ok(ReplicaId::System(id))
     }
 
-    /// Allocates and returns a storage usage ID.
-    async fn allocate_storage_usage_id(&mut self) -> Result<u64, CatalogError> {
-        let id = self.allocate_id(STORAGE_USAGE_ID_ALLOC_KEY, 1).await?;
-        Ok(id.into_element())
+    /// Allocates and returns storage usage IDs.
+    async fn allocate_storage_usage_ids(&mut self, amount: u64) -> Result<Vec<u64>, CatalogError> {
+        self.allocate_id(STORAGE_USAGE_ID_ALLOC_KEY, amount).await
     }
 }
 


### PR DESCRIPTION
Previously, when collection n storage usage events, we'd perform n catalog transactions to allocate an ID for each event. This commit optimizes the code by performing a single transaction to allocate n IDs.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
