### PR TITLE
feature-benchmark: Record min/max/mean/variance of wallclock

### DIFF
--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -19,7 +19,7 @@ FEATURE_BENCHMARK_SCENARIOS_DIR = FEATURE_BENCHMARK_FRAMEWORK_DIR / "scenarios"
 # Consider increasing the #FEATURE_BENCHMARK_FRAMEWORK_VERSION if changes are expected to impact results!
 SHA256_OF_FRAMEWORK: dict[str, str] = {}
 SHA256_OF_FRAMEWORK["*"] = (
-    "9e5ed3ae21972101c8cef1172ffaaab73051c192fd4ddcdc772b74eb96c1e972"
+    "3833f4d8f9fd24a4f14af873415c4f7b85f28b78a042906c4fb3bfccb1d47e82"
 )
 
 # Consider increasing the scenario's class #version() if changes are expected to impact results!

--- a/misc/python/materialize/feature_benchmark/comparator.py
+++ b/misc/python/materialize/feature_benchmark/comparator.py
@@ -46,6 +46,9 @@ class Comparator(Generic[T]):
     def this(self) -> T:
         return self._points[0]
 
+    def points_this(self) -> list[T]:
+        return self._points
+
     def this_as_str(self) -> str:
         if self.this() is None:
             return "           None"

--- a/misc/python/materialize/test_analytics/data/feature_benchmark/feature_benchmark_result_storage.py
+++ b/misc/python/materialize/test_analytics/data/feature_benchmark/feature_benchmark_result_storage.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 
 from materialize import buildkite
 from materialize.buildkite import BuildkiteEnvVar
+from materialize.feature_benchmark.benchmark import ReportMeasurement
 from materialize.test_analytics.data.base_data_storage import BaseDataStorage
 
 
@@ -20,10 +21,10 @@ class FeatureBenchmarkResultEntry:
     scenario_version: str
     cycle: int
     scale: str
-    wallclock: float | None
-    messages: int | None
-    memory_mz: float | None
-    memory_clusterd: float | None
+    wallclock: ReportMeasurement[float]
+    messages: ReportMeasurement[int]
+    memory_mz: ReportMeasurement[float]
+    memory_clusterd: ReportMeasurement[float]
 
 
 class FeatureBenchmarkResultStorage(BaseDataStorage):
@@ -53,7 +54,11 @@ class FeatureBenchmarkResultStorage(BaseDataStorage):
                     wallclock,
                     messages,
                     memory_mz,
-                    memory_clusterd
+                    memory_clusterd,
+                    wallclock_min,
+                    wallclock_max,
+                    wallclock_mean,
+                    wallclock_variance
                 )
                 SELECT
                     '{job_id}',
@@ -63,10 +68,14 @@ class FeatureBenchmarkResultStorage(BaseDataStorage):
                     '{result_entry.scenario_version}',
                     {result_entry.cycle},
                     '{result_entry.scale}',
-                    {result_entry.wallclock or 'NULL::DOUBLE'},
-                    {result_entry.messages or 'NULL::INT'},
-                    {result_entry.memory_mz or 'NULL::DOUBLE'},
-                    {result_entry.memory_clusterd or 'NULL::DOUBLE'}
+                    {result_entry.wallclock.result or 'NULL::DOUBLE'},
+                    {result_entry.messages.result or 'NULL::INT'},
+                    {result_entry.memory_mz.result or 'NULL::DOUBLE'},
+                    {result_entry.memory_clusterd.result or 'NULL::DOUBLE'},
+                    {result_entry.wallclock.min or 'NULL::DOUBLE'},
+                    {result_entry.wallclock.max or 'NULL::DOUBLE'},
+                    {result_entry.wallclock.mean or 'NULL::DOUBLE'},
+                    {result_entry.wallclock.variance or 'NULL::DOUBLE'}
                 ;
                 """
             )
@@ -96,16 +105,24 @@ class FeatureBenchmarkResultStorage(BaseDataStorage):
                     wallclock,
                     messages,
                     memory_mz,
-                    memory_clusterd
+                    memory_clusterd,
+                    wallclock_min,
+                    wallclock_max,
+                    wallclock_mean,
+                    wallclock_variance
                 )
                 SELECT
                     '{job_id}',
                     '{discarded_entry.scenario_name}',
                     {discarded_entry.cycle},
-                    {discarded_entry.wallclock or 'NULL::DOUBLE'},
-                    {discarded_entry.messages or 'NULL::INT'},
-                    {discarded_entry.memory_mz or 'NULL::DOUBLE'},
-                    {discarded_entry.memory_clusterd or 'NULL::DOUBLE'}
+                    {discarded_entry.wallclock.result or 'NULL::DOUBLE'},
+                    {discarded_entry.messages.result or 'NULL::INT'},
+                    {discarded_entry.memory_mz.result or 'NULL::DOUBLE'},
+                    {discarded_entry.memory_clusterd.result or 'NULL::DOUBLE'},
+                    {discarded_entry.wallclock.min or 'NULL::DOUBLE'},
+                    {discarded_entry.wallclock.max or 'NULL::DOUBLE'},
+                    {discarded_entry.wallclock.mean or 'NULL::DOUBLE'},
+                    {discarded_entry.wallclock.variance or 'NULL::DOUBLE'}
                 ;
                 """
             )

--- a/misc/python/materialize/test_analytics/setup/tables/10-feature-benchmark.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/10-feature-benchmark.sql
@@ -20,7 +20,11 @@ CREATE TABLE feature_benchmark_result (
    wallclock DOUBLE,
    messages INT,
    memory_mz DOUBLE,
-   memory_clusterd DOUBLE
+   memory_clusterd DOUBLE,
+   wallclock_min DOUBLE,
+   wallclock_max DOUBLE,
+   wallclock_mean DOUBLE,
+   wallclock_variance DOUBLE
 );
 
 -- This table holds results of runs that were discarded.
@@ -31,7 +35,11 @@ CREATE TABLE feature_benchmark_discarded_result (
    wallclock DOUBLE,
    messages INT,
    memory_mz DOUBLE,
-   memory_clusterd DOUBLE
+   memory_clusterd DOUBLE,
+   wallclock_min DOUBLE,
+   wallclock_max DOUBLE,
+   wallclock_mean DOUBLE,
+   wallclock_variance DOUBLE
 );
 
 GRANT SELECT, INSERT, UPDATE ON TABLE feature_benchmark_result TO "hetzner-ci";


### PR DESCRIPTION
Not to be used as regression markers but for us to continuously monitor performance and find interesting trends

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
