### PR TITLE
persist: add metrics tracking fetch_upper calls

### DIFF
--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -137,6 +137,7 @@ where
 
     /// Fetches the latest state from Consensus and passes its `upper` to the provided closure.
     pub async fn fetch_upper<R, F: FnMut(&Antichain<T>) -> R>(&mut self, mut f: F) -> R {
+        self.metrics.cmds.fetch_upper_count.inc();
         self.fetch_and_update_state(None).await;
         self.upper(|_seqno, upper| f(upper))
     }

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -420,6 +420,10 @@ impl MetricsVecs {
             merge_res: self.cmd_metrics("merge_res"),
             become_tombstone: self.cmd_metrics("become_tombstone"),
             compare_and_evolve_schema: self.cmd_metrics("compare_and_evolve_schema"),
+            fetch_upper_count: registry.register(metric!(
+                name: "mz_persist_cmd_fetch_upper_count",
+                help: "count of fetch_upper calls",
+            ))
         }
     }
 
@@ -622,6 +626,7 @@ pub struct CmdsMetrics {
     pub(crate) merge_res: CmdMetrics,
     pub(crate) become_tombstone: CmdMetrics,
     pub(crate) compare_and_evolve_schema: CmdMetrics,
+    pub(crate) fetch_upper_count: IntCounter,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Discovered this hole in our persist introspection while debugging an increase in the number of consensus_scan calls in the latest release candidate.


### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
