### PR TITLE
adapter: Refactor `RelationDesc`

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1365,9 +1365,10 @@ mod builtin_migration_tests {
             let item = match self.item {
                 SimplifiedItem::Table => CatalogItem::Table(Table {
                     create_sql: Some("CREATE TABLE materialize.public.t (a INT)".to_string()),
-                    desc: RelationDesc::empty()
+                    desc: RelationDesc::builder()
                         .with_column("a", ScalarType::Int32.nullable(true))
-                        .with_key(vec![0]),
+                        .with_key(vec![0])
+                        .finish(),
                     defaults: vec![Expr::null(); 1],
                     conn_id: None,
                     resolved_ids: ResolvedIds(BTreeSet::new()),
@@ -1403,9 +1404,10 @@ mod builtin_migration_tests {
                                 keys: Vec::new(),
                             },
                         }),
-                        desc: RelationDesc::empty()
+                        desc: RelationDesc::builder()
                             .with_column("a", ScalarType::Int32.nullable(true))
-                            .with_key(vec![0]),
+                            .with_key(vec![0])
+                            .finish(),
                         resolved_ids: ResolvedIds(resolved_ids),
                         cluster_id: ClusterId::User(1),
                         non_null_assertions: vec![],

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -3197,6 +3197,20 @@ pub static MZ_AWS_CONNECTIONS: LazyLock<BuiltinTable> = LazyLock::new(|| Builtin
     desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("endpoint", ScalarType::String.nullable(true))
+        .with_column("region", ScalarType::String.nullable(true))
+        .with_column("access_key_id", ScalarType::String.nullable(true))
+        .with_column("access_key_id_secret_id", ScalarType::String.nullable(true))
+        .with_column(
+            "secret_access_key_secret_id",
+            ScalarType::String.nullable(true),
+        )
+        .with_column("session_token", ScalarType::String.nullable(true))
+        .with_column("session_token_secret_id", ScalarType::String.nullable(true))
+        .with_column("assume_role_arn", ScalarType::String.nullable(true))
+        .with_column(
+            "assume_role_session_name",
+            ScalarType::String.nullable(true),
+        )
         .with_column("principal", ScalarType::String.nullable(true))
         .with_column("external_id", ScalarType::String.nullable(true))
         .with_column("example_trust_policy", ScalarType::Jsonb.nullable(true))

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -3369,7 +3369,7 @@ pub static MZ_SOURCE_REFERENCES: LazyLock<BuiltinTable> = LazyLock::new(|| Built
     name: "mz_source_references",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_SOURCE_REFERENCES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("source_id", ScalarType::String.nullable(false))
         .with_column("namespace", ScalarType::String.nullable(true))
         .with_column("name", ScalarType::String.nullable(false))
@@ -3384,7 +3384,8 @@ pub static MZ_SOURCE_REFERENCES: LazyLock<BuiltinTable> = LazyLock::new(|| Built
                 custom_id: None,
             }
             .nullable(true),
-        ),
+        )
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2003,10 +2003,11 @@ pub static MZ_KAFKA_SINKS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTabl
     name: "mz_kafka_sinks",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_KAFKA_SINKS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("topic", ScalarType::String.nullable(false))
-        .with_key(vec![0]),
+        .with_key(vec![0])
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2014,13 +2015,14 @@ pub static MZ_KAFKA_CONNECTIONS: LazyLock<BuiltinTable> = LazyLock::new(|| Built
     name: "mz_kafka_connections",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_KAFKA_CONNECTIONS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column(
             "brokers",
             ScalarType::Array(Box::new(ScalarType::String)).nullable(false),
         )
-        .with_column("sink_progress_topic", ScalarType::String.nullable(false)),
+        .with_column("sink_progress_topic", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2029,10 +2031,11 @@ pub static MZ_KAFKA_SOURCES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTa
     // `mz_internal` for now, while we work out the desc.
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_KAFKA_SOURCES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("group_id_prefix", ScalarType::String.nullable(false))
-        .with_column("topic", ScalarType::String.nullable(false)),
+        .with_column("topic", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2040,10 +2043,11 @@ pub static MZ_POSTGRES_SOURCES: LazyLock<BuiltinTable> = LazyLock::new(|| Builti
     name: "mz_postgres_sources",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_POSTGRES_SOURCES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("replication_slot", ScalarType::String.nullable(false))
-        .with_column("timeline_id", ScalarType::UInt64.nullable(true)),
+        .with_column("timeline_id", ScalarType::UInt64.nullable(true))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2051,10 +2055,11 @@ pub static MZ_POSTGRES_SOURCE_TABLES: LazyLock<BuiltinTable> = LazyLock::new(|| 
     name: "mz_postgres_source_tables",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_POSTGRES_SOURCE_TABLES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("schema_name", ScalarType::String.nullable(false))
-        .with_column("table_name", ScalarType::String.nullable(false)),
+        .with_column("table_name", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: true,
     access: vec![PUBLIC_SELECT],
 });
@@ -2062,10 +2067,11 @@ pub static MZ_MYSQL_SOURCE_TABLES: LazyLock<BuiltinTable> = LazyLock::new(|| Bui
     name: "mz_mysql_source_tables",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_MYSQL_SOURCE_TABLES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("schema_name", ScalarType::String.nullable(false))
-        .with_column("table_name", ScalarType::String.nullable(false)),
+        .with_column("table_name", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: true,
     access: vec![PUBLIC_SELECT],
 });
@@ -2073,9 +2079,10 @@ pub static MZ_OBJECT_DEPENDENCIES: LazyLock<BuiltinTable> = LazyLock::new(|| Bui
     name: "mz_object_dependencies",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_OBJECT_DEPENDENCIES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("object_id", ScalarType::String.nullable(false))
-        .with_column("referenced_object_id", ScalarType::String.nullable(false)),
+        .with_column("referenced_object_id", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: true,
     access: vec![PUBLIC_SELECT],
 });
@@ -2084,9 +2091,10 @@ pub static MZ_COMPUTE_DEPENDENCIES: LazyLock<BuiltinSource> = LazyLock::new(|| B
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::SOURCE_MZ_COMPUTE_DEPENDENCIES_OID,
     data_source: IntrospectionType::ComputeDependencies,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("object_id", ScalarType::String.nullable(false))
-        .with_column("dependency_id", ScalarType::String.nullable(false)),
+        .with_column("dependency_id", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2096,12 +2104,13 @@ pub static MZ_COMPUTE_OPERATOR_HYDRATION_STATUSES_PER_WORKER: LazyLock<BuiltinSo
         schema: MZ_INTERNAL_SCHEMA,
         oid: oid::SOURCE_MZ_COMPUTE_OPERATOR_HYDRATION_STATUSES_PER_WORKER_OID,
         data_source: IntrospectionType::ComputeOperatorHydrationStatus,
-        desc: RelationDesc::empty()
+        desc: RelationDesc::builder()
             .with_column("object_id", ScalarType::String.nullable(false))
             .with_column("physical_plan_node_id", ScalarType::UInt64.nullable(false))
             .with_column("replica_id", ScalarType::String.nullable(false))
             .with_column("worker_id", ScalarType::UInt64.nullable(false))
-            .with_column("hydrated", ScalarType::Bool.nullable(false)),
+            .with_column("hydrated", ScalarType::Bool.nullable(false))
+            .finish(),
         is_retained_metrics_object: false,
         access: vec![PUBLIC_SELECT],
     });
@@ -2110,7 +2119,7 @@ pub static MZ_DATABASES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable 
     name: "mz_databases",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_DATABASES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
@@ -2120,7 +2129,8 @@ pub static MZ_DATABASES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable 
             ScalarType::Array(Box::new(ScalarType::MzAclItem)).nullable(false),
         )
         .with_key(vec![0])
-        .with_key(vec![1]),
+        .with_key(vec![1])
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2128,7 +2138,7 @@ pub static MZ_SCHEMAS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
     name: "mz_schemas",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_SCHEMAS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("database_id", ScalarType::String.nullable(true))
@@ -2139,7 +2149,8 @@ pub static MZ_SCHEMAS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
             ScalarType::Array(Box::new(ScalarType::MzAclItem)).nullable(false),
         )
         .with_key(vec![0])
-        .with_key(vec![1]),
+        .with_key(vec![1])
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2147,7 +2158,7 @@ pub static MZ_COLUMNS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
     name: "mz_columns",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_COLUMNS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false)) // not a key
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("position", ScalarType::UInt64.nullable(false))
@@ -2155,7 +2166,8 @@ pub static MZ_COLUMNS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
         .with_column("type", ScalarType::String.nullable(false))
         .with_column("default", ScalarType::String.nullable(true))
         .with_column("type_oid", ScalarType::Oid.nullable(false))
-        .with_column("type_mod", ScalarType::Int32.nullable(false)),
+        .with_column("type_mod", ScalarType::Int32.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2163,7 +2175,7 @@ pub static MZ_INDEXES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
     name: "mz_indexes",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_INDEXES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
@@ -2173,7 +2185,8 @@ pub static MZ_INDEXES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
         .with_column("create_sql", ScalarType::String.nullable(false))
         .with_column("redacted_create_sql", ScalarType::String.nullable(false))
         .with_key(vec![0])
-        .with_key(vec![1]),
+        .with_key(vec![1])
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2181,12 +2194,13 @@ pub static MZ_INDEX_COLUMNS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTa
     name: "mz_index_columns",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_INDEX_COLUMNS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("index_id", ScalarType::String.nullable(false))
         .with_column("index_position", ScalarType::UInt64.nullable(false))
         .with_column("on_position", ScalarType::UInt64.nullable(true))
         .with_column("on_expression", ScalarType::String.nullable(true))
-        .with_column("nullable", ScalarType::Bool.nullable(false)),
+        .with_column("nullable", ScalarType::Bool.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2194,7 +2208,7 @@ pub static MZ_TABLES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
     name: "mz_tables",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_TABLES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::String.nullable(false))
@@ -2207,7 +2221,8 @@ pub static MZ_TABLES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
         .with_column("create_sql", ScalarType::String.nullable(true))
         .with_column("redacted_create_sql", ScalarType::String.nullable(true))
         .with_key(vec![0])
-        .with_key(vec![1]),
+        .with_key(vec![1])
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2215,7 +2230,7 @@ pub static MZ_CONNECTIONS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTabl
     name: "mz_connections",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_CONNECTIONS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::String.nullable(false))
@@ -2229,7 +2244,8 @@ pub static MZ_CONNECTIONS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTabl
         .with_column("create_sql", ScalarType::String.nullable(false))
         .with_column("redacted_create_sql", ScalarType::String.nullable(false))
         .with_key(vec![0])
-        .with_key(vec![1]),
+        .with_key(vec![1])
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2237,10 +2253,11 @@ pub static MZ_SSH_TUNNEL_CONNECTIONS: LazyLock<BuiltinTable> = LazyLock::new(|| 
     name: "mz_ssh_tunnel_connections",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_SSH_TUNNEL_CONNECTIONS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("public_key_1", ScalarType::String.nullable(false))
-        .with_column("public_key_2", ScalarType::String.nullable(false)),
+        .with_column("public_key_2", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2248,7 +2265,7 @@ pub static MZ_SOURCES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
     name: "mz_sources",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_SOURCES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::String.nullable(false))
@@ -2268,7 +2285,8 @@ pub static MZ_SOURCES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
         .with_column("create_sql", ScalarType::String.nullable(true))
         .with_column("redacted_create_sql", ScalarType::String.nullable(true))
         .with_key(vec![0])
-        .with_key(vec![1]),
+        .with_key(vec![1])
+        .finish(),
     is_retained_metrics_object: true,
     access: vec![PUBLIC_SELECT],
 });
@@ -2276,7 +2294,7 @@ pub static MZ_SINKS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
     name: "mz_sinks",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_SINKS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::String.nullable(false))
@@ -2295,7 +2313,8 @@ pub static MZ_SINKS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
         .with_column("create_sql", ScalarType::String.nullable(false))
         .with_column("redacted_create_sql", ScalarType::String.nullable(false))
         .with_key(vec![0])
-        .with_key(vec![1]),
+        .with_key(vec![1])
+        .finish(),
     is_retained_metrics_object: true,
     access: vec![PUBLIC_SELECT],
 });
@@ -2303,7 +2322,7 @@ pub static MZ_VIEWS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
     name: "mz_views",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_VIEWS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::String.nullable(false))
@@ -2317,7 +2336,8 @@ pub static MZ_VIEWS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
         .with_column("create_sql", ScalarType::String.nullable(false))
         .with_column("redacted_create_sql", ScalarType::String.nullable(false))
         .with_key(vec![0])
-        .with_key(vec![1]),
+        .with_key(vec![1])
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2325,7 +2345,7 @@ pub static MZ_MATERIALIZED_VIEWS: LazyLock<BuiltinTable> = LazyLock::new(|| Buil
     name: "mz_materialized_views",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_MATERIALIZED_VIEWS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::String.nullable(false))
@@ -2340,7 +2360,8 @@ pub static MZ_MATERIALIZED_VIEWS: LazyLock<BuiltinTable> = LazyLock::new(|| Buil
         .with_column("create_sql", ScalarType::String.nullable(false))
         .with_column("redacted_create_sql", ScalarType::String.nullable(false))
         .with_key(vec![0])
-        .with_key(vec![1]),
+        .with_key(vec![1])
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2349,7 +2370,7 @@ pub static MZ_MATERIALIZED_VIEW_REFRESH_STRATEGIES: LazyLock<BuiltinTable> =
         name: "mz_materialized_view_refresh_strategies",
         schema: MZ_INTERNAL_SCHEMA,
         oid: oid::TABLE_MZ_MATERIALIZED_VIEW_REFRESH_STRATEGIES_OID,
-        desc: RelationDesc::empty()
+        desc: RelationDesc::builder()
             .with_column("materialized_view_id", ScalarType::String.nullable(false))
             .with_column("type", ScalarType::String.nullable(false))
             .with_column("interval", ScalarType::Interval.nullable(true))
@@ -2360,7 +2381,8 @@ pub static MZ_MATERIALIZED_VIEW_REFRESH_STRATEGIES: LazyLock<BuiltinTable> =
             .with_column(
                 "at",
                 ScalarType::TimestampTz { precision: None }.nullable(true),
-            ),
+            )
+            .finish(),
         is_retained_metrics_object: false,
         access: vec![PUBLIC_SELECT],
     });
@@ -2368,7 +2390,7 @@ pub static MZ_TYPES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
     name: "mz_types",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_TYPES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::String.nullable(false))
@@ -2382,7 +2404,8 @@ pub static MZ_TYPES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
         .with_column("create_sql", ScalarType::String.nullable(true))
         .with_column("redacted_create_sql", ScalarType::String.nullable(true))
         .with_key(vec![0])
-        .with_key(vec![1]),
+        .with_key(vec![1])
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2392,10 +2415,11 @@ pub static MZ_TYPE_PG_METADATA: LazyLock<BuiltinTable> = LazyLock::new(|| Builti
     name: "mz_type_pg_metadata",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_TYPE_PG_METADATA_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("typinput", ScalarType::Oid.nullable(false))
-        .with_column("typreceive", ScalarType::Oid.nullable(false)),
+        .with_column("typreceive", ScalarType::Oid.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2403,9 +2427,10 @@ pub static MZ_ARRAY_TYPES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTabl
     name: "mz_array_types",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_ARRAY_TYPES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
-        .with_column("element_id", ScalarType::String.nullable(false)),
+        .with_column("element_id", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2413,7 +2438,9 @@ pub static MZ_BASE_TYPES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable
     name: "mz_base_types",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_BASE_TYPES_OID,
-    desc: RelationDesc::empty().with_column("id", ScalarType::String.nullable(false)),
+    desc: RelationDesc::builder()
+        .with_column("id", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2421,7 +2448,7 @@ pub static MZ_LIST_TYPES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable
     name: "mz_list_types",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_LIST_TYPES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("element_id", ScalarType::String.nullable(false))
         .with_column(
@@ -2431,7 +2458,8 @@ pub static MZ_LIST_TYPES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable
                 custom_id: None,
             }
             .nullable(true),
-        ),
+        )
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2439,7 +2467,7 @@ pub static MZ_MAP_TYPES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable 
     name: "mz_map_types",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_MAP_TYPES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("key_id", ScalarType::String.nullable(false))
         .with_column("value_id", ScalarType::String.nullable(false))
@@ -2458,7 +2486,8 @@ pub static MZ_MAP_TYPES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable 
                 custom_id: None,
             }
             .nullable(true),
-        ),
+        )
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2466,13 +2495,14 @@ pub static MZ_ROLES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
     name: "mz_roles",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_ROLES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("inherit", ScalarType::Bool.nullable(false))
         .with_key(vec![0])
-        .with_key(vec![1]),
+        .with_key(vec![1])
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2480,10 +2510,11 @@ pub static MZ_ROLE_MEMBERS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTab
     name: "mz_role_members",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_ROLE_MEMBERS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("role_id", ScalarType::String.nullable(false))
         .with_column("member", ScalarType::String.nullable(false))
-        .with_column("grantor", ScalarType::String.nullable(false)),
+        .with_column("grantor", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2491,10 +2522,11 @@ pub static MZ_ROLE_PARAMETERS: LazyLock<BuiltinTable> = LazyLock::new(|| Builtin
     name: "mz_role_parameters",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_ROLE_PARAMETERS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("role_id", ScalarType::String.nullable(false))
         .with_column("parameter_name", ScalarType::String.nullable(false))
-        .with_column("parameter_value", ScalarType::String.nullable(false)),
+        .with_column("parameter_value", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2502,7 +2534,9 @@ pub static MZ_PSEUDO_TYPES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTab
     name: "mz_pseudo_types",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_PSEUDO_TYPES_OID,
-    desc: RelationDesc::empty().with_column("id", ScalarType::String.nullable(false)),
+    desc: RelationDesc::builder()
+        .with_column("id", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2510,7 +2544,7 @@ pub static MZ_FUNCTIONS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable 
     name: "mz_functions",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_FUNCTIONS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false)) // not a key!
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::String.nullable(false))
@@ -2525,7 +2559,8 @@ pub static MZ_FUNCTIONS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable 
         )
         .with_column("return_type_id", ScalarType::String.nullable(true))
         .with_column("returns_set", ScalarType::Bool.nullable(false))
-        .with_column("owner_id", ScalarType::String.nullable(false)),
+        .with_column("owner_id", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2533,14 +2568,15 @@ pub static MZ_OPERATORS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable 
     name: "mz_operators",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_OPERATORS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
         .with_column(
             "argument_type_ids",
             ScalarType::Array(Box::new(ScalarType::String)).nullable(false),
         )
-        .with_column("return_type_id", ScalarType::String.nullable(true)),
+        .with_column("return_type_id", ScalarType::String.nullable(true))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2548,10 +2584,11 @@ pub static MZ_AGGREGATES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable
     name: "mz_aggregates",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_AGGREGATES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("agg_kind", ScalarType::String.nullable(false))
-        .with_column("agg_num_direct_args", ScalarType::Int16.nullable(false)),
+        .with_column("agg_num_direct_args", ScalarType::Int16.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2560,7 +2597,7 @@ pub static MZ_CLUSTERS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
     name: "mz_clusters",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_CLUSTERS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("owner_id", ScalarType::String.nullable(false))
@@ -2585,7 +2622,8 @@ pub static MZ_CLUSTERS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
             "introspection_interval",
             ScalarType::Interval.nullable(true),
         )
-        .with_key(vec![0]),
+        .with_key(vec![0])
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2594,10 +2632,11 @@ pub static MZ_CLUSTER_WORKLOAD_CLASSES: LazyLock<BuiltinTable> = LazyLock::new(|
     name: "mz_cluster_workload_classes",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_CLUSTER_WORKLOAD_CLASSES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("workload_class", ScalarType::String.nullable(true))
-        .with_key(vec![0]),
+        .with_key(vec![0])
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2615,13 +2654,14 @@ pub static MZ_CLUSTER_SCHEDULES: LazyLock<BuiltinTable> = LazyLock::new(|| Built
     name: "mz_cluster_schedules",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_CLUSTER_SCHEDULES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("cluster_id", ScalarType::String.nullable(false))
         .with_column("type", ScalarType::String.nullable(false))
         .with_column(
             "refresh_hydration_time_estimate",
             ScalarType::Interval.nullable(true),
-        ),
+        )
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2630,7 +2670,7 @@ pub static MZ_SECRETS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
     name: "mz_secrets",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_SECRETS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::String.nullable(false))
@@ -2639,7 +2679,8 @@ pub static MZ_SECRETS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
         .with_column(
             "privileges",
             ScalarType::Array(Box::new(ScalarType::MzAclItem)).nullable(false),
-        ),
+        )
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2648,7 +2689,7 @@ pub static MZ_CLUSTER_REPLICAS: LazyLock<BuiltinTable> = LazyLock::new(|| Builti
     name: "mz_cluster_replicas",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_CLUSTER_REPLICAS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("cluster_id", ScalarType::String.nullable(false))
@@ -2657,7 +2698,8 @@ pub static MZ_CLUSTER_REPLICAS: LazyLock<BuiltinTable> = LazyLock::new(|| Builti
         // hasn't specified them.
         .with_column("availability_zone", ScalarType::String.nullable(true))
         .with_column("owner_id", ScalarType::String.nullable(false))
-        .with_column("disk", ScalarType::Bool.nullable(true)),
+        .with_column("disk", ScalarType::Bool.nullable(true))
+        .finish(),
     is_retained_metrics_object: true,
     access: vec![PUBLIC_SELECT],
 });
@@ -2666,7 +2708,9 @@ pub static MZ_INTERNAL_CLUSTER_REPLICAS: LazyLock<BuiltinTable> = LazyLock::new(
     name: "mz_internal_cluster_replicas",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_INTERNAL_CLUSTER_REPLICAS_OID,
-    desc: RelationDesc::empty().with_column("id", ScalarType::String.nullable(false)),
+    desc: RelationDesc::builder()
+        .with_column("id", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2675,7 +2719,9 @@ pub static MZ_PENDING_CLUSTER_REPLICAS: LazyLock<BuiltinTable> = LazyLock::new(|
     name: "mz_pending_cluster_replicas",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_PENDING_CLUSTER_REPLICAS_OID,
-    desc: RelationDesc::empty().with_column("id", ScalarType::String.nullable(false)),
+    desc: RelationDesc::builder()
+        .with_column("id", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2684,7 +2730,7 @@ pub static MZ_CLUSTER_REPLICA_STATUSES: LazyLock<BuiltinTable> = LazyLock::new(|
     name: "mz_cluster_replica_statuses",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_CLUSTER_REPLICA_STATUSES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("replica_id", ScalarType::String.nullable(false))
         .with_column("process_id", ScalarType::UInt64.nullable(false))
         .with_column("status", ScalarType::String.nullable(false))
@@ -2692,7 +2738,8 @@ pub static MZ_CLUSTER_REPLICA_STATUSES: LazyLock<BuiltinTable> = LazyLock::new(|
         .with_column(
             "updated_at",
             ScalarType::TimestampTz { precision: None }.nullable(false),
-        ),
+        )
+        .finish(),
     is_retained_metrics_object: true,
     access: vec![PUBLIC_SELECT],
 });
@@ -2701,7 +2748,7 @@ pub static MZ_CLUSTER_REPLICA_SIZES: LazyLock<BuiltinTable> = LazyLock::new(|| B
     name: "mz_cluster_replica_sizes",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_CLUSTER_REPLICA_SIZES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("size", ScalarType::String.nullable(false))
         .with_column("processes", ScalarType::UInt64.nullable(false))
         .with_column("workers", ScalarType::UInt64.nullable(false))
@@ -2711,7 +2758,8 @@ pub static MZ_CLUSTER_REPLICA_SIZES: LazyLock<BuiltinTable> = LazyLock::new(|| B
         .with_column(
             "credits_per_hour",
             ScalarType::Numeric { max_scale: None }.nullable(false),
-        ),
+        )
+        .finish(),
     is_retained_metrics_object: true,
     access: vec![PUBLIC_SELECT],
 });
@@ -2720,7 +2768,7 @@ pub static MZ_AUDIT_EVENTS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTab
     name: "mz_audit_events",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_AUDIT_EVENTS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::UInt64.nullable(false))
         .with_column("event_type", ScalarType::String.nullable(false))
         .with_column("object_type", ScalarType::String.nullable(false))
@@ -2730,7 +2778,8 @@ pub static MZ_AUDIT_EVENTS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTab
             "occurred_at",
             ScalarType::TimestampTz { precision: None }.nullable(false),
         )
-        .with_key(vec![0]),
+        .with_key(vec![0])
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -2964,13 +3013,14 @@ pub static MZ_STATEMENT_LIFECYCLE_HISTORY: LazyLock<BuiltinSource> =
         name: "mz_statement_lifecycle_history",
         schema: MZ_INTERNAL_SCHEMA,
         oid: oid::SOURCE_MZ_STATEMENT_LIFECYCLE_HISTORY_OID,
-        desc: RelationDesc::empty()
+        desc: RelationDesc::builder()
             .with_column("statement_id", ScalarType::Uuid.nullable(false))
             .with_column("event_type", ScalarType::String.nullable(false))
             .with_column(
                 "occurred_at",
                 ScalarType::TimestampTz { precision: None }.nullable(false),
-            ),
+            )
+            .finish(),
         data_source: IntrospectionType::StatementLifecycleHistory,
         is_retained_metrics_object: false,
         // TODO[btv]: Maybe this should be public instead of
@@ -3103,14 +3153,15 @@ pub static MZ_STORAGE_USAGE_BY_SHARD: LazyLock<BuiltinTable> = LazyLock::new(|| 
     name: "mz_storage_usage_by_shard",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_STORAGE_USAGE_BY_SHARD_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::UInt64.nullable(false))
         .with_column("shard_id", ScalarType::String.nullable(true))
         .with_column("size_bytes", ScalarType::UInt64.nullable(false))
         .with_column(
             "collection_timestamp",
             ScalarType::TimestampTz { precision: None }.nullable(false),
-        ),
+        )
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -3119,7 +3170,9 @@ pub static MZ_EGRESS_IPS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable
     name: "mz_egress_ips",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_EGRESS_IPS_OID,
-    desc: RelationDesc::empty().with_column("egress_ip", ScalarType::String.nullable(false)),
+    desc: RelationDesc::builder()
+        .with_column("egress_ip", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -3129,9 +3182,10 @@ pub static MZ_AWS_PRIVATELINK_CONNECTIONS: LazyLock<BuiltinTable> =
         name: "mz_aws_privatelink_connections",
         schema: MZ_CATALOG_SCHEMA,
         oid: oid::TABLE_MZ_AWS_PRIVATELINK_CONNECTIONS_OID,
-        desc: RelationDesc::empty()
+        desc: RelationDesc::builder()
             .with_column("id", ScalarType::String.nullable(false))
-            .with_column("principal", ScalarType::String.nullable(false)),
+            .with_column("principal", ScalarType::String.nullable(false))
+            .finish(),
         is_retained_metrics_object: false,
         access: vec![PUBLIC_SELECT],
     });
@@ -3140,26 +3194,13 @@ pub static MZ_AWS_CONNECTIONS: LazyLock<BuiltinTable> = LazyLock::new(|| Builtin
     name: "mz_aws_connections",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_AWS_CONNECTIONS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("endpoint", ScalarType::String.nullable(true))
-        .with_column("region", ScalarType::String.nullable(true))
-        .with_column("access_key_id", ScalarType::String.nullable(true))
-        .with_column("access_key_id_secret_id", ScalarType::String.nullable(true))
-        .with_column(
-            "secret_access_key_secret_id",
-            ScalarType::String.nullable(true),
-        )
-        .with_column("session_token", ScalarType::String.nullable(true))
-        .with_column("session_token_secret_id", ScalarType::String.nullable(true))
-        .with_column("assume_role_arn", ScalarType::String.nullable(true))
-        .with_column(
-            "assume_role_session_name",
-            ScalarType::String.nullable(true),
-        )
         .with_column("principal", ScalarType::String.nullable(true))
         .with_column("external_id", ScalarType::String.nullable(true))
-        .with_column("example_trust_policy", ScalarType::Jsonb.nullable(true)),
+        .with_column("example_trust_policy", ScalarType::Jsonb.nullable(true))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -3170,12 +3211,13 @@ pub static MZ_CLUSTER_REPLICA_METRICS: LazyLock<BuiltinTable> = LazyLock::new(||
     // the corresponding Storage tables.
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_CLUSTER_REPLICA_METRICS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("replica_id", ScalarType::String.nullable(false))
         .with_column("process_id", ScalarType::UInt64.nullable(false))
         .with_column("cpu_nano_cores", ScalarType::UInt64.nullable(true))
         .with_column("memory_bytes", ScalarType::UInt64.nullable(true))
-        .with_column("disk_bytes", ScalarType::UInt64.nullable(true)),
+        .with_column("disk_bytes", ScalarType::UInt64.nullable(true))
+        .finish(),
     is_retained_metrics_object: true,
     access: vec![PUBLIC_SELECT],
 });
@@ -3186,10 +3228,11 @@ pub static MZ_CLUSTER_REPLICA_FRONTIERS: LazyLock<BuiltinSource> =
         schema: MZ_INTERNAL_SCHEMA,
         oid: oid::SOURCE_MZ_CLUSTER_REPLICA_FRONTIERS_OID,
         data_source: IntrospectionType::ReplicaFrontiers,
-        desc: RelationDesc::empty()
+        desc: RelationDesc::builder()
             .with_column("object_id", ScalarType::String.nullable(false))
             .with_column("replica_id", ScalarType::String.nullable(false))
-            .with_column("write_frontier", ScalarType::MzTimestamp.nullable(true)),
+            .with_column("write_frontier", ScalarType::MzTimestamp.nullable(true))
+            .finish(),
         is_retained_metrics_object: false,
         access: vec![PUBLIC_SELECT],
     });
@@ -3199,10 +3242,11 @@ pub static MZ_FRONTIERS: LazyLock<BuiltinSource> = LazyLock::new(|| BuiltinSourc
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::SOURCE_MZ_FRONTIERS_OID,
     data_source: IntrospectionType::Frontiers,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("object_id", ScalarType::String.nullable(false))
         .with_column("read_frontier", ScalarType::MzTimestamp.nullable(true))
-        .with_column("write_frontier", ScalarType::MzTimestamp.nullable(true)),
+        .with_column("write_frontier", ScalarType::MzTimestamp.nullable(true))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -3226,13 +3270,14 @@ pub static MZ_MATERIALIZED_VIEW_REFRESHES: LazyLock<BuiltinSource> =
         schema: MZ_INTERNAL_SCHEMA,
         oid: oid::SOURCE_MZ_MATERIALIZED_VIEW_REFRESHES_OID,
         data_source: IntrospectionType::ComputeMaterializedViewRefreshes,
-        desc: RelationDesc::empty()
+        desc: RelationDesc::builder()
             .with_column("materialized_view_id", ScalarType::String.nullable(false))
             .with_column(
                 "last_completed_refresh",
                 ScalarType::MzTimestamp.nullable(true),
             )
-            .with_column("next_refresh", ScalarType::MzTimestamp.nullable(true)),
+            .with_column("next_refresh", ScalarType::MzTimestamp.nullable(true))
+            .finish(),
         is_retained_metrics_object: false,
         access: vec![PUBLIC_SELECT],
     });
@@ -3241,7 +3286,7 @@ pub static MZ_SUBSCRIPTIONS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTa
     name: "mz_subscriptions",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_SUBSCRIPTIONS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("session_id", ScalarType::Uuid.nullable(false))
         .with_column("cluster_id", ScalarType::String.nullable(false))
@@ -3256,7 +3301,8 @@ pub static MZ_SUBSCRIPTIONS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTa
                 custom_id: None,
             }
             .nullable(false),
-        ),
+        )
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -3265,14 +3311,15 @@ pub static MZ_SESSIONS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
     name: "mz_sessions",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_SESSIONS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::Uuid.nullable(false))
         .with_column("connection_id", ScalarType::UInt32.nullable(false))
         .with_column("role_id", ScalarType::String.nullable(false))
         .with_column(
             "connected_at",
             ScalarType::TimestampTz { precision: None }.nullable(false),
-        ),
+        )
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -3281,13 +3328,14 @@ pub static MZ_DEFAULT_PRIVILEGES: LazyLock<BuiltinTable> = LazyLock::new(|| Buil
     name: "mz_default_privileges",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_DEFAULT_PRIVILEGES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("role_id", ScalarType::String.nullable(false))
         .with_column("database_id", ScalarType::String.nullable(true))
         .with_column("schema_id", ScalarType::String.nullable(true))
         .with_column("object_type", ScalarType::String.nullable(false))
         .with_column("grantee", ScalarType::String.nullable(false))
-        .with_column("privileges", ScalarType::String.nullable(false)),
+        .with_column("privileges", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -3296,7 +3344,9 @@ pub static MZ_SYSTEM_PRIVILEGES: LazyLock<BuiltinTable> = LazyLock::new(|| Built
     name: "mz_system_privileges",
     schema: MZ_CATALOG_SCHEMA,
     oid: oid::TABLE_MZ_SYSTEM_PRIVILEGES_OID,
-    desc: RelationDesc::empty().with_column("privileges", ScalarType::MzAclItem.nullable(false)),
+    desc: RelationDesc::builder()
+        .with_column("privileges", ScalarType::MzAclItem.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -3305,11 +3355,12 @@ pub static MZ_COMMENTS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
     name: "mz_comments",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_COMMENTS_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("object_type", ScalarType::String.nullable(false))
         .with_column("object_sub_id", ScalarType::Int32.nullable(true))
-        .with_column("comment", ScalarType::String.nullable(false)),
+        .with_column("comment", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -3342,10 +3393,11 @@ pub static MZ_WEBHOOKS_SOURCES: LazyLock<BuiltinTable> = LazyLock::new(|| Builti
     name: "mz_webhook_sources",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::TABLE_MZ_WEBHOOK_SOURCES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
-        .with_column("url", ScalarType::String.nullable(false)),
+        .with_column("url", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -3355,10 +3407,11 @@ pub static MZ_HISTORY_RETENTION_STRATEGIES: LazyLock<BuiltinTable> =
         name: "mz_history_retention_strategies",
         schema: MZ_INTERNAL_SCHEMA,
         oid: oid::TABLE_MZ_HISTORY_RETENTION_STRATEGIES_OID,
-        desc: RelationDesc::empty()
+        desc: RelationDesc::builder()
             .with_column("id", ScalarType::String.nullable(false))
             .with_column("strategy", ScalarType::String.nullable(false))
-            .with_column("value", ScalarType::Jsonb.nullable(false)),
+            .with_column("value", ScalarType::Jsonb.nullable(false))
+            .finish(),
         is_retained_metrics_object: false,
         access: vec![PUBLIC_SELECT],
     });
@@ -3389,9 +3442,10 @@ pub static MZ_STORAGE_SHARDS: LazyLock<BuiltinSource> = LazyLock::new(|| Builtin
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::SOURCE_MZ_STORAGE_SHARDS_OID,
     data_source: IntrospectionType::ShardMapping,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("object_id", ScalarType::String.nullable(false))
-        .with_column("shard_id", ScalarType::String.nullable(false)),
+        .with_column("shard_id", ScalarType::String.nullable(false))
+        .finish(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });
@@ -4900,13 +4954,14 @@ pub static MZ_COMPUTE_ERROR_COUNTS_RAW_UNIFIED: LazyLock<BuiltinSource> =
         name: "mz_compute_error_counts_raw_unified",
         schema: MZ_INTERNAL_SCHEMA,
         oid: oid::SOURCE_MZ_COMPUTE_ERROR_COUNTS_RAW_UNIFIED_OID,
-        desc: RelationDesc::empty()
+        desc: RelationDesc::builder()
             .with_column("replica_id", ScalarType::String.nullable(false))
             .with_column("object_id", ScalarType::String.nullable(false))
             .with_column(
                 "count",
                 ScalarType::Numeric { max_scale: None }.nullable(false),
-            ),
+            )
+            .finish(),
         data_source: IntrospectionType::ComputeErrorCounts,
         is_retained_metrics_object: false,
         access: vec![PUBLIC_SELECT],
@@ -4916,10 +4971,11 @@ pub static MZ_COMPUTE_HYDRATION_TIMES: LazyLock<BuiltinSource> = LazyLock::new(|
     name: "mz_compute_hydration_times",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::SOURCE_MZ_COMPUTE_HYDRATION_TIMES_OID,
-    desc: RelationDesc::empty()
+    desc: RelationDesc::builder()
         .with_column("replica_id", ScalarType::String.nullable(false))
         .with_column("object_id", ScalarType::String.nullable(false))
-        .with_column("time_ns", ScalarType::UInt64.nullable(true)),
+        .with_column("time_ns", ScalarType::UInt64.nullable(true))
+        .finish(),
     data_source: IntrospectionType::ComputeHydrationTimes,
     is_retained_metrics_object: true,
     access: vec![PUBLIC_SELECT],

--- a/src/catalog/src/builtin/notice.rs
+++ b/src/catalog/src/builtin/notice.rs
@@ -24,7 +24,7 @@ pub static MZ_OPTIMIZER_NOTICES: LazyLock<BuiltinTable> = LazyLock::new(|| {
         name: "mz_optimizer_notices",
         schema: MZ_INTERNAL_SCHEMA,
         oid: oid::TABLE_MZ_OPTIMIZER_NOTICES_OID,
-        desc: RelationDesc::empty()
+        desc: RelationDesc::builder()
             .with_column("id", String.nullable(false))
             .with_column("notice_type", String.nullable(false))
             .with_column("message", String.nullable(false))
@@ -47,7 +47,8 @@ pub static MZ_OPTIMIZER_NOTICES: LazyLock<BuiltinTable> = LazyLock::new(|| {
                 "created_at",
                 TimestampTz { precision: None }.nullable(false),
             )
-            .with_key(vec![0]),
+            .with_key(vec![0])
+            .finish(),
         is_retained_metrics_object: false,
         access: vec![MONITOR_SELECT],
     }

--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -897,7 +897,7 @@ mod tests {
             // Verify that we can map encode into the "raw" json format. This
             // validates things like contained integers fitting in f64.
             let raw = StateUpdateKindJson::from(kind.clone());
-            let desc = RelationDesc::empty().with_column("a", ScalarType::Jsonb.nullable(false));
+            let desc = RelationDesc::builder().with_column("a", ScalarType::Jsonb.nullable(false)).finish();
 
             // Verify that the raw roundtrips through the SourceData Codec impl.
             let source_data = SourceData::from(raw.clone());

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -1550,7 +1550,9 @@ fn shard_id(organization_id: Uuid, seed: usize) -> ShardId {
 /// Returns the schema of the `Row`s/`SourceData`s stored in the persist
 /// shard backing the catalog.
 fn desc() -> RelationDesc {
-    RelationDesc::empty().with_column("data", ScalarType::Jsonb.nullable(false))
+    RelationDesc::builder()
+        .with_column("data", ScalarType::Jsonb.nullable(false))
+        .finish()
 }
 
 /// Generates a timestamp for reading from `read_handle` that is as fresh as possible, given

--- a/src/catalog/src/durable/upgrade/tests.rs
+++ b/src/catalog/src/durable/upgrade/tests.rs
@@ -62,7 +62,9 @@ fn test_proto_serialization_stability() {
     }
 
     let base64_config = base64::Config::new(base64::CharacterSet::Standard, true);
-    let relation_desc = RelationDesc::empty().with_column("a", ScalarType::Jsonb.nullable(false));
+    let relation_desc = RelationDesc::builder()
+        .with_column("a", ScalarType::Jsonb.nullable(false))
+        .finish();
     for snapshot_file in snapshot_files {
         let encoded_bytes = fs::read(format!("{}/{}.txt", SNAPSHOT_DIRECTORY, snapshot_file))
             .expect("unable to read encoded file");

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -363,31 +363,35 @@ impl LogVariant {
     /// TODO(#25239): Add documentation.
     pub fn desc(&self) -> RelationDesc {
         match self {
-            LogVariant::Timely(TimelyLog::Operates) => RelationDesc::empty()
+            LogVariant::Timely(TimelyLog::Operates) => RelationDesc::builder()
                 .with_column("id", ScalarType::UInt64.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("name", ScalarType::String.nullable(false))
-                .with_key(vec![0, 1]),
+                .with_key(vec![0, 1])
+                .finish(),
 
-            LogVariant::Timely(TimelyLog::Channels) => RelationDesc::empty()
+            LogVariant::Timely(TimelyLog::Channels) => RelationDesc::builder()
                 .with_column("id", ScalarType::UInt64.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("from_index", ScalarType::UInt64.nullable(false))
                 .with_column("from_port", ScalarType::UInt64.nullable(false))
                 .with_column("to_index", ScalarType::UInt64.nullable(false))
                 .with_column("to_port", ScalarType::UInt64.nullable(false))
-                .with_key(vec![0, 1]),
+                .with_key(vec![0, 1])
+                .finish(),
 
-            LogVariant::Timely(TimelyLog::Elapsed) => RelationDesc::empty()
-                .with_column("id", ScalarType::UInt64.nullable(false))
-                .with_column("worker_id", ScalarType::UInt64.nullable(false)),
-
-            LogVariant::Timely(TimelyLog::Histogram) => RelationDesc::empty()
+            LogVariant::Timely(TimelyLog::Elapsed) => RelationDesc::builder()
                 .with_column("id", ScalarType::UInt64.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
-                .with_column("duration_ns", ScalarType::UInt64.nullable(false)),
+                .finish(),
 
-            LogVariant::Timely(TimelyLog::Addresses) => RelationDesc::empty()
+            LogVariant::Timely(TimelyLog::Histogram) => RelationDesc::builder()
+                .with_column("id", ScalarType::UInt64.nullable(false))
+                .with_column("worker_id", ScalarType::UInt64.nullable(false))
+                .with_column("duration_ns", ScalarType::UInt64.nullable(false))
+                .finish(),
+
+            LogVariant::Timely(TimelyLog::Addresses) => RelationDesc::builder()
                 .with_column("id", ScalarType::UInt64.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column(
@@ -398,34 +402,40 @@ impl LogVariant {
                     }
                     .nullable(false),
                 )
-                .with_key(vec![0, 1]),
+                .with_key(vec![0, 1])
+                .finish(),
 
-            LogVariant::Timely(TimelyLog::Parks) => RelationDesc::empty()
+            LogVariant::Timely(TimelyLog::Parks) => RelationDesc::builder()
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("slept_for_ns", ScalarType::UInt64.nullable(false))
-                .with_column("requested_ns", ScalarType::UInt64.nullable(false)),
+                .with_column("requested_ns", ScalarType::UInt64.nullable(false))
+                .finish(),
 
-            LogVariant::Timely(TimelyLog::BatchesReceived) => RelationDesc::empty()
+            LogVariant::Timely(TimelyLog::BatchesReceived) => RelationDesc::builder()
                 .with_column("channel_id", ScalarType::UInt64.nullable(false))
                 .with_column("from_worker_id", ScalarType::UInt64.nullable(false))
-                .with_column("to_worker_id", ScalarType::UInt64.nullable(false)),
+                .with_column("to_worker_id", ScalarType::UInt64.nullable(false))
+                .finish(),
 
-            LogVariant::Timely(TimelyLog::BatchesSent) => RelationDesc::empty()
+            LogVariant::Timely(TimelyLog::BatchesSent) => RelationDesc::builder()
                 .with_column("channel_id", ScalarType::UInt64.nullable(false))
                 .with_column("from_worker_id", ScalarType::UInt64.nullable(false))
-                .with_column("to_worker_id", ScalarType::UInt64.nullable(false)),
+                .with_column("to_worker_id", ScalarType::UInt64.nullable(false))
+                .finish(),
 
-            LogVariant::Timely(TimelyLog::MessagesReceived) => RelationDesc::empty()
+            LogVariant::Timely(TimelyLog::MessagesReceived) => RelationDesc::builder()
                 .with_column("channel_id", ScalarType::UInt64.nullable(false))
                 .with_column("from_worker_id", ScalarType::UInt64.nullable(false))
-                .with_column("to_worker_id", ScalarType::UInt64.nullable(false)),
+                .with_column("to_worker_id", ScalarType::UInt64.nullable(false))
+                .finish(),
 
-            LogVariant::Timely(TimelyLog::MessagesSent) => RelationDesc::empty()
+            LogVariant::Timely(TimelyLog::MessagesSent) => RelationDesc::builder()
                 .with_column("channel_id", ScalarType::UInt64.nullable(false))
                 .with_column("from_worker_id", ScalarType::UInt64.nullable(false))
-                .with_column("to_worker_id", ScalarType::UInt64.nullable(false)),
+                .with_column("to_worker_id", ScalarType::UInt64.nullable(false))
+                .finish(),
 
-            LogVariant::Timely(TimelyLog::Reachability) => RelationDesc::empty()
+            LogVariant::Timely(TimelyLog::Reachability) => RelationDesc::builder()
                 .with_column(
                     "address",
                     ScalarType::List {
@@ -437,7 +447,8 @@ impl LogVariant {
                 .with_column("port", ScalarType::UInt64.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("update_type", ScalarType::String.nullable(false))
-                .with_column("time", ScalarType::MzTimestamp.nullable(true)),
+                .with_column("time", ScalarType::MzTimestamp.nullable(true))
+                .finish(),
 
             LogVariant::Differential(DifferentialLog::ArrangementBatches)
             | LogVariant::Differential(DifferentialLog::ArrangementRecords)
@@ -448,57 +459,68 @@ impl LogVariant {
             | LogVariant::Differential(DifferentialLog::BatcherAllocations)
             | LogVariant::Compute(ComputeLog::ArrangementHeapSize)
             | LogVariant::Compute(ComputeLog::ArrangementHeapCapacity)
-            | LogVariant::Compute(ComputeLog::ArrangementHeapAllocations) => RelationDesc::empty()
-                .with_column("operator_id", ScalarType::UInt64.nullable(false))
-                .with_column("worker_id", ScalarType::UInt64.nullable(false)),
+            | LogVariant::Compute(ComputeLog::ArrangementHeapAllocations) => {
+                RelationDesc::builder()
+                    .with_column("operator_id", ScalarType::UInt64.nullable(false))
+                    .with_column("worker_id", ScalarType::UInt64.nullable(false))
+                    .finish()
+            }
 
-            LogVariant::Compute(ComputeLog::DataflowCurrent) => RelationDesc::empty()
+            LogVariant::Compute(ComputeLog::DataflowCurrent) => RelationDesc::builder()
                 .with_column("export_id", ScalarType::String.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("dataflow_id", ScalarType::UInt64.nullable(false))
-                .with_key(vec![0, 1]),
+                .with_key(vec![0, 1])
+                .finish(),
 
-            LogVariant::Compute(ComputeLog::FrontierCurrent) => RelationDesc::empty()
+            LogVariant::Compute(ComputeLog::FrontierCurrent) => RelationDesc::builder()
                 .with_column("export_id", ScalarType::String.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("time", ScalarType::MzTimestamp.nullable(false))
-                .with_key(vec![0, 1]),
+                .with_key(vec![0, 1])
+                .finish(),
 
-            LogVariant::Compute(ComputeLog::ImportFrontierCurrent) => RelationDesc::empty()
+            LogVariant::Compute(ComputeLog::ImportFrontierCurrent) => RelationDesc::builder()
                 .with_column("export_id", ScalarType::String.nullable(false))
                 .with_column("import_id", ScalarType::String.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("time", ScalarType::MzTimestamp.nullable(false))
-                .with_key(vec![0, 1, 2]),
+                .with_key(vec![0, 1, 2])
+                .finish(),
 
-            LogVariant::Compute(ComputeLog::PeekCurrent) => RelationDesc::empty()
+            LogVariant::Compute(ComputeLog::PeekCurrent) => RelationDesc::builder()
                 .with_column("id", ScalarType::Uuid.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("object_id", ScalarType::String.nullable(false))
                 .with_column("type", ScalarType::String.nullable(false))
                 .with_column("time", ScalarType::MzTimestamp.nullable(false))
-                .with_key(vec![0, 1]),
+                .with_key(vec![0, 1])
+                .finish(),
 
-            LogVariant::Compute(ComputeLog::PeekDuration) => RelationDesc::empty()
+            LogVariant::Compute(ComputeLog::PeekDuration) => RelationDesc::builder()
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("type", ScalarType::String.nullable(false))
-                .with_column("duration_ns", ScalarType::UInt64.nullable(false)),
+                .with_column("duration_ns", ScalarType::UInt64.nullable(false))
+                .finish(),
 
-            LogVariant::Compute(ComputeLog::ShutdownDuration) => RelationDesc::empty()
+            LogVariant::Compute(ComputeLog::ShutdownDuration) => RelationDesc::builder()
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
-                .with_column("duration_ns", ScalarType::UInt64.nullable(false)),
+                .with_column("duration_ns", ScalarType::UInt64.nullable(false))
+                .finish(),
 
-            LogVariant::Compute(ComputeLog::ErrorCount) => RelationDesc::empty()
+            LogVariant::Compute(ComputeLog::ErrorCount) => RelationDesc::builder()
                 .with_column("export_id", ScalarType::String.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("count", ScalarType::Int64.nullable(false))
-                .with_key(vec![0, 1]),
+                .with_key(vec![0, 1])
+                .finish(),
 
-            LogVariant::Compute(ComputeLog::HydrationTime) => RelationDesc::empty()
+            LogVariant::Compute(ComputeLog::HydrationTime) => RelationDesc::builder()
                 .with_column("export_id", ScalarType::String.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("time_ns", ScalarType::UInt64.nullable(true))
-                .with_key(vec![0, 1]),
+                .with_key(vec![0, 1])
+                .finish(),
         }
     }
 }

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -62,9 +62,10 @@ mod tests {
         }"#;
 
         let desc = schema_to_relationdesc(parse_schema(schema)?)?;
-        let expected_desc = RelationDesc::empty()
+        let expected_desc = RelationDesc::builder()
             .with_column("f1", ScalarType::Int32.nullable(false))
-            .with_column("f2", ScalarType::String.nullable(false));
+            .with_column("f2", ScalarType::String.nullable(false))
+            .finish();
 
         assert_eq!(desc, expected_desc);
         Ok(())
@@ -162,7 +163,9 @@ mod tests {
             ),
         ];
         for (typ, datum, expected) in valid_pairings {
-            let desc = RelationDesc::empty().with_column("column1", typ.nullable(false));
+            let desc = RelationDesc::builder()
+                .with_column("column1", typ.nullable(false))
+                .finish();
             let schema_generator =
                 AvroSchemaGenerator::new(desc, false, Default::default(), "row", false, None, true)
                     .unwrap();

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -52,7 +52,8 @@ pub use crate::global_id::GlobalId;
 pub use crate::relation::{
     arb_relation_desc_diff, arb_row_for_relation, ColumnName, ColumnType, NotNullViolation,
     PropRelationDescDiff, ProtoColumnName, ProtoColumnType, ProtoRelationDesc, ProtoRelationType,
-    RelationDesc, RelationDescBuilder, RelationType,
+    RelationDesc, RelationDescBuilder, RelationType, RelationVersion, RelationVersionSelector,
+    VersionedRelationDesc,
 };
 pub use crate::row::collection::{ProtoRowCollection, RowCollection, SortedRowCollectionIter};
 pub use crate::row::encoding2::{RowColumnarDecoder, RowColumnarEncoder};

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -52,7 +52,7 @@ pub use crate::global_id::GlobalId;
 pub use crate::relation::{
     arb_relation_desc_diff, arb_row_for_relation, ColumnName, ColumnType, NotNullViolation,
     PropRelationDescDiff, ProtoColumnName, ProtoColumnType, ProtoRelationDesc, ProtoRelationType,
-    RelationDesc, RelationType,
+    RelationDesc, RelationDescBuilder, RelationType,
 };
 pub use crate::row::collection::{ProtoRowCollection, RowCollection, SortedRowCollectionIter};
 pub use crate::row::encoding2::{RowColumnarDecoder, RowColumnarEncoder};

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -378,7 +378,7 @@ impl RelationVersion {
         RelationVersion(0)
     }
 
-    /// Returns and instance of [`ColumnVersion`] which is "one" higher than `self`.
+    /// Returns an instance of [`RelationVersion`] which is "one" higher than `self`.
     pub fn bump(&self) -> Self {
         let next_version = self
             .0

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -1110,6 +1110,14 @@ impl VersionedRelationDesc {
                 }
             }
 
+            for keys in &desc.typ.keys {
+                for key in keys {
+                    if *key >= desc.typ.column_types.len() {
+                        anyhow::bail!("key index was out of bounds!");
+                    }
+                }
+            }
+
             let versions = desc
                 .metadata
                 .values()

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -9,20 +9,24 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
-use std::{fmt, iter, vec};
+use std::{fmt, vec};
 
 use anyhow::bail;
+use itertools::Itertools;
 use mz_lowertest::MzReflect;
 use mz_ore::str::StrExt;
+use mz_ore::{assert_none, assert_ok};
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use proptest::prelude::*;
 use proptest::strategy::{Strategy, Union};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
+use timely::Container;
 
 use crate::relation_and_scalar::proto_relation_type::ProtoKey;
 pub use crate::relation_and_scalar::{
-    ProtoColumnName, ProtoColumnType, ProtoRelationDesc, ProtoRelationType,
+    ProtoColumnMetadata, ProtoColumnName, ProtoColumnType, ProtoRelationDesc, ProtoRelationType,
+    ProtoRelationVersion,
 };
 use crate::{arb_datum_for_column, Datum, Row, ScalarType};
 
@@ -355,6 +359,65 @@ impl proptest::arbitrary::Arbitrary for ColumnName {
     }
 }
 
+/// Stable index of a column in a [`RelationDesc`].
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Hash, MzReflect,
+)]
+pub struct ColumnIndex(usize);
+
+static_assertions::assert_not_impl_all!(ColumnIndex: Arbitrary);
+
+/// The version a given column was added at.
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Hash, MzReflect,
+)]
+pub struct RelationVersion(u64);
+
+impl RelationVersion {
+    pub fn root() -> Self {
+        RelationVersion(0)
+    }
+
+    /// Returns and instance of [`ColumnVersion`] which is "one" higher than `self`.
+    pub fn bump(&self) -> Self {
+        let next_version = self
+            .0
+            .checked_add(1)
+            .expect("added more than u64::MAX columns?");
+        RelationVersion(next_version)
+    }
+
+    /// Returns the inner value.
+    ///
+    /// TODO(parkmycar): Remove this [`RelationVersion`] should be opaque.
+    pub fn inner(&self) -> &u64 {
+        &self.0
+    }
+}
+
+impl RustType<ProtoRelationVersion> for RelationVersion {
+    fn into_proto(&self) -> ProtoRelationVersion {
+        ProtoRelationVersion { value: self.0 }
+    }
+
+    fn from_proto(proto: ProtoRelationVersion) -> Result<Self, TryFromProtoError> {
+        Ok(RelationVersion(proto.value))
+    }
+}
+
+/// Metadata (other than type) for a column in a [`RelationDesc`].
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+struct ColumnMetadata {
+    /// Name of the column.
+    name: ColumnName,
+    /// Index into a [`RelationType`] for this column.
+    typ_idx: usize,
+    /// Version this column was added at.
+    added: RelationVersion,
+    /// Version this column was dropped at.
+    dropped: Option<RelationVersion>,
+}
+
 /// A description of the shape of a relation.
 ///
 /// It bundles a [`RelationType`] with the name of each column in the relation.
@@ -391,21 +454,61 @@ impl proptest::arbitrary::Arbitrary for ColumnName {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct RelationDesc {
     typ: RelationType,
-    names: Vec<ColumnName>,
+    metadata: BTreeMap<ColumnIndex, ColumnMetadata>,
 }
 
 impl RustType<ProtoRelationDesc> for RelationDesc {
     fn into_proto(&self) -> ProtoRelationDesc {
+        let (names, metadata): (Vec<_>, Vec<_>) = self
+            .metadata
+            .values()
+            .map(|meta| {
+                let metadata = ProtoColumnMetadata {
+                    added: Some(meta.added.into_proto()),
+                    dropped: meta.dropped.map(|v| v.into_proto()),
+                };
+                (meta.name.into_proto(), metadata)
+            })
+            .unzip();
+
         ProtoRelationDesc {
             typ: Some(self.typ.into_proto()),
-            names: self.names.into_proto(),
+            names,
+            metadata,
         }
     }
 
     fn from_proto(proto: ProtoRelationDesc) -> Result<Self, TryFromProtoError> {
+        // Handle `ProtoRelationDesc`s that were created before we added `metadata`.
+        let proto_metadata: Box<dyn Iterator<Item = _>> = if proto.metadata.is_empty() {
+            let val = ProtoColumnMetadata {
+                added: Some(RelationVersion::root().into_proto()),
+                dropped: None,
+            };
+            Box::new(itertools::repeat_n(val, proto.names.len()))
+        } else {
+            Box::new(proto.metadata.into_iter())
+        };
+
+        let metadata = proto
+            .names
+            .into_iter()
+            .zip_eq(proto_metadata)
+            .enumerate()
+            .map(|(idx, (name, metadata))| {
+                let meta = ColumnMetadata {
+                    name: name.into_rust()?,
+                    typ_idx: idx,
+                    added: metadata.added.into_rust_if_some("ColumnMetadata::added")?,
+                    dropped: metadata.dropped.into_rust()?,
+                };
+                Ok::<_, TryFromProtoError>((ColumnIndex(idx), meta))
+            })
+            .collect::<Result<_, _>>()?;
+
         Ok(RelationDesc {
             typ: proto.typ.into_rust_if_some("ProtoRelationDesc::typ")?,
-            names: proto.names.into_rust()?,
+            metadata,
         })
     }
 }
@@ -421,7 +524,7 @@ impl RelationDesc {
     pub fn empty() -> Self {
         RelationDesc {
             typ: RelationType::empty(),
-            names: vec![],
+            metadata: BTreeMap::default(),
         }
     }
 
@@ -442,9 +545,25 @@ impl RelationDesc {
         I: IntoIterator<Item = N>,
         N: Into<ColumnName>,
     {
-        let names: Vec<_> = names.into_iter().map(|name| name.into()).collect();
-        assert_eq!(typ.column_types.len(), names.len());
-        RelationDesc { typ, names }
+        let metadata: BTreeMap<_, _> = names
+            .into_iter()
+            .enumerate()
+            .map(|(idx, name)| {
+                let col_idx = ColumnIndex(idx);
+                let metadata = ColumnMetadata {
+                    name: name.into(),
+                    typ_idx: idx,
+                    added: RelationVersion::root(),
+                    dropped: None,
+                };
+                (col_idx, metadata)
+            })
+            .collect();
+
+        // TODO(parkmycar): Add better validation here.
+        assert_eq!(typ.column_types.len(), metadata.len());
+
+        RelationDesc { typ, metadata }
     }
 
     pub fn from_names_and_types<I, T, N>(iter: I) -> Self
@@ -460,10 +579,41 @@ impl RelationDesc {
     }
 
     /// Concatenates a `RelationDesc` onto the end of this `RelationDesc`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either `self` or `other` have columns that were added at a
+    /// [`RelationVersion`] other than [`RelationVersion::root`] or if any
+    /// columns were dropped.
+    ///
+    /// TODO(parkmycar): Move this method to [`RelationDescBuilder`].
     pub fn concat(mut self, other: Self) -> Self {
         let self_len = self.typ.column_types.len();
-        self.names.extend(other.names);
-        self.typ.column_types.extend(other.typ.column_types);
+
+        for (typ, (_col_idx, meta)) in other
+            .typ
+            .column_types
+            .into_iter()
+            .zip_eq(other.metadata.into_iter())
+        {
+            assert_eq!(meta.added, RelationVersion::root());
+            assert_none!(meta.dropped);
+
+            let new_idx = self.typ.columns().len();
+            let new_meta = ColumnMetadata {
+                name: meta.name,
+                typ_idx: new_idx,
+                added: RelationVersion::root(),
+                dropped: None,
+            };
+
+            self.typ.column_types.push(typ);
+            let prev = self.metadata.insert(ColumnIndex(new_idx), new_meta);
+
+            assert_eq!(self.metadata.len(), self.typ.columns().len());
+            assert_none!(prev);
+        }
+
         for k in other.typ.keys {
             let k = k.into_iter().map(|idx| idx + self_len).collect();
             self = self.with_key(k);
@@ -520,7 +670,7 @@ impl RelationDesc {
 
     /// Returns an iterator over the names of the columns in this relation.
     pub fn iter_names(&self) -> impl Iterator<Item = &ColumnName> {
-        self.names.iter()
+        self.metadata.values().map(|meta| &meta.name)
     }
 
     /// Returns an iterator over the names of the columns in this relation that are "similar" to
@@ -549,7 +699,12 @@ impl RelationDesc {
     ///
     /// Panics if `i` is not a valid column index.
     pub fn get_name(&self, i: usize) -> &ColumnName {
-        &self.names[i]
+        // TODO(parkmycar): Refactor this to use `ColumnIndex`.
+        &self
+            .metadata
+            .get(&ColumnIndex(i))
+            .expect("should exist")
+            .name
     }
 
     /// Mutably gets the name of the `i`th column.
@@ -558,7 +713,12 @@ impl RelationDesc {
     ///
     /// Panics if `i` is not a valid column index.
     pub fn get_name_mut(&mut self, i: usize) -> &mut ColumnName {
-        &mut self.names[i]
+        // TODO(parkmycar): Refactor this to use `ColumnIndex`.
+        &mut self
+            .metadata
+            .get_mut(&ColumnIndex(i))
+            .expect("should exist")
+            .name
     }
 
     /// Gets the name of the `i`th column if that column name is unambiguous.
@@ -570,7 +730,7 @@ impl RelationDesc {
     ///
     /// Panics if `i` is not a valid column index.
     pub fn get_unambiguous_name(&self, i: usize) -> Option<&ColumnName> {
-        let name = &self.names[i];
+        let name = self.get_name(i);
         if self.iter_names().filter(|n| *n == name).count() == 1 {
             Some(name)
         } else {
@@ -583,7 +743,7 @@ impl RelationDesc {
     /// n.b. The only constraint MZ currently supports in NOT NULL, but this
     /// structure will be simple to extend.
     pub fn constraints_met(&self, i: usize, d: &Datum) -> Result<(), NotNullViolation> {
-        let name = &self.names[i];
+        let name = self.get_name(i);
         let typ = &self.typ.column_types[i];
         if d == &Datum::Null && !typ.nullable {
             Err(NotNullViolation(name.clone()))
@@ -622,10 +782,15 @@ pub fn arb_relation_desc(num_cols: std::ops::Range<usize>) -> impl Strategy<Valu
 
 impl IntoIterator for RelationDesc {
     type Item = (ColumnName, ColumnType);
-    type IntoIter = iter::Zip<vec::IntoIter<ColumnName>, vec::IntoIter<ColumnType>>;
+    type IntoIter = Box<dyn Iterator<Item = (ColumnName, ColumnType)>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.names.into_iter().zip(self.typ.column_types)
+        let iter = self
+            .metadata
+            .into_values()
+            .zip_eq(self.typ.column_types)
+            .map(|(meta, typ)| (meta.name, typ));
+        Box::new(iter)
     }
 }
 
@@ -707,7 +872,7 @@ impl RelationDescBuilder {
     pub fn concat(mut self, other: Self) -> Self {
         let self_len = self.columns.len();
 
-        self.columns.extend(other.columns.into_iter());
+        self.columns.extend(other.columns);
         for k in other.keys {
             let k = k.into_iter().map(|idx| idx + self_len).collect();
             self = self.with_key(k);
@@ -718,9 +883,212 @@ impl RelationDescBuilder {
 
     /// Finish the builder, returning a [`RelationDesc`].
     pub fn finish(self) -> RelationDesc {
-        let mut desc = RelationDesc::from_names_and_types(self.columns.into_iter());
+        let mut desc = RelationDesc::from_names_and_types(self.columns);
         desc.typ = desc.typ.with_keys(self.keys);
         desc
+    }
+}
+
+/// Describes a [`RelationDesc`] at a specific version of a [`VersionedRelationDesc`].
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub enum RelationVersionSelector {
+    Specific(RelationVersion),
+    Latest,
+}
+
+impl RelationVersionSelector {
+    pub fn specific(version: u64) -> Self {
+        RelationVersionSelector::Specific(RelationVersion(version))
+    }
+}
+
+/// A wrapper around [`RelationDesc`] that provides an interface for adding
+/// columns and generating new versions.
+///
+/// TODO(parkmycar): Using an immutable data structure for RelationDesc would
+/// be great.
+#[derive(Debug, Clone, Serialize)]
+pub struct VersionedRelationDesc {
+    inner: RelationDesc,
+}
+
+impl VersionedRelationDesc {
+    pub fn new(inner: RelationDesc) -> Self {
+        VersionedRelationDesc { inner }
+    }
+
+    /// Adds a new column to this [`RelationDesc`], creating a new version of the [`RelationDesc`].
+    ///
+    /// Note: For building a [`RelationDesc`] see [`RelationDescBuilder::with_column`].
+    #[must_use]
+    pub fn add_column<N, T>(&mut self, name: N, typ: T) -> RelationVersion
+    where
+        N: Into<ColumnName>,
+        T: Into<ColumnType>,
+    {
+        let latest_version = self.latest_version();
+        let new_version = latest_version.bump();
+
+        let next_idx = self.inner.metadata.len();
+        let col_meta = ColumnMetadata {
+            name: name.into(),
+            typ_idx: next_idx,
+            added: new_version,
+            dropped: None,
+        };
+
+        self.inner.typ.column_types.push(typ.into());
+        let prev = self.inner.metadata.insert(ColumnIndex(next_idx), col_meta);
+
+        assert_none!(prev, "column index overlap!");
+        self.validate();
+
+        new_version
+    }
+
+    /// Drops the column `name` from this [`RelationDesc`]. If there are multiple columns with
+    /// `name` drops the left-most one.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a column with `name` does not exist or if the column was already dropped.
+    #[must_use]
+    pub fn drop_column<N>(&mut self, name: N) -> RelationVersion
+    where
+        N: Into<ColumnName>,
+    {
+        let name = name.into();
+        let latest_version = self.latest_version();
+        let new_version = latest_version.bump();
+
+        let col = self
+            .inner
+            .metadata
+            .values_mut()
+            .find(|meta| meta.name == name)
+            .expect("column to exist");
+
+        assert_none!(col.dropped, "column was already dropped");
+        col.dropped = Some(new_version);
+
+        self.validate();
+        new_version
+    }
+
+    /// Returns the [`RelationDesc`] at the latest version.
+    pub fn latest(&self) -> RelationDesc {
+        self.inner.clone()
+    }
+
+    /// Returns this [`RelationDesc`] at the specified version.
+    pub fn at_version(&self, version: RelationVersionSelector) -> RelationDesc {
+        // Get all of the changes from the start, up to whatever version was requested.
+        //
+        // TODO(parkmycar): We should probably panic on unknown verisons?
+        let up_to_version = match version {
+            RelationVersionSelector::Latest => RelationVersion(u64::MAX),
+            RelationVersionSelector::Specific(v) => v,
+        };
+
+        let valid_columns = self.inner.metadata.iter().filter(|(_col_idx, meta)| {
+            let added = meta.added <= up_to_version;
+            let dropped = meta
+                .dropped
+                .map(|dropped_at| up_to_version >= dropped_at)
+                .unwrap_or(false);
+
+            added && !dropped
+        });
+
+        let mut column_types = Vec::new();
+        let mut column_metas = BTreeMap::new();
+
+        // N.B. At this point we need to be careful because col_idx might not
+        // equal typ_idx.
+        for (col_idx, meta) in valid_columns {
+            let new_meta = ColumnMetadata {
+                name: meta.name.clone(),
+                typ_idx: column_types.len(),
+                added: meta.added.clone(),
+                dropped: meta.dropped.clone(),
+            };
+            column_types.push(self.inner.typ.columns()[meta.typ_idx].clone());
+            column_metas.insert(*col_idx, new_meta);
+        }
+
+        let relation_type = RelationType {
+            column_types,
+            keys: self.inner.typ.keys.clone(),
+        };
+
+        RelationDesc {
+            typ: relation_type,
+            metadata: column_metas,
+        }
+    }
+
+    pub fn latest_version(&self) -> RelationVersion {
+        self.inner
+            .metadata
+            .values()
+            // N.B. Dropped is always greater than added.
+            .map(|meta| meta.dropped.unwrap_or(meta.added))
+            .max()
+            // If there aren't any columns we're implicitly the root version.
+            .unwrap_or(RelationVersion::root())
+    }
+
+    /// Validates internal contraints of the [`RelationDesc`] are correct.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a constraint is not satisfied.
+    fn validate(&self) {
+        fn validate_inner(desc: &RelationDesc) -> Result<(), anyhow::Error> {
+            if desc.typ.column_types.len() != desc.metadata.len() {
+                anyhow::bail!("mismatch between number of types and metadatas");
+            }
+
+            for (col_idx, meta) in &desc.metadata {
+                if col_idx.0 > desc.metadata.len() {
+                    anyhow::bail!("column index out of bounds");
+                }
+                if meta.added >= meta.dropped.unwrap_or(RelationVersion(u64::MAX)) {
+                    anyhow::bail!("column was added after it was dropped?");
+                }
+                if desc.typ().columns().get(meta.typ_idx).is_none() {
+                    anyhow::bail!("typ_idx incorrect");
+                }
+            }
+
+            let versions = desc
+                .metadata
+                .values()
+                .map(|meta| meta.dropped.unwrap_or(meta.added));
+            let mut max = 0;
+            let mut sum = 0;
+            for version in versions {
+                max = std::cmp::max(max, version.0);
+                sum += version.0;
+            }
+
+            // Other than RelationVersion(0), we should never have duplicate
+            // versions and they should always increase by 1. In other words, the
+            // sum of all RelationVersions should be the sum of [0, max].
+            //
+            // N.B. n * (n + 1) / 2 = sum of [0, n]
+            //
+            // While I normally don't like tricks like this, it allows us to
+            // validate that our column versions are correct in O(n) time and
+            // without allocations.
+            if sum != (max * (max + 1) / 2) {
+                anyhow::bail!("there is a duplicate or missing relation version");
+            }
+
+            Ok(())
+        }
+
+        assert_ok!(validate_inner(&self.inner), "validate failed! {self:?}");
     }
 }
 
@@ -730,7 +1098,6 @@ impl RelationDescBuilder {
 pub enum PropRelationDescDiff {
     AddColumn { name: ColumnName, typ: ColumnType },
     DropColumn { name: ColumnName },
-    MovePosition { name: ColumnName, new_pos: usize },
     ToggleNullability { name: ColumnName },
     ChangeType { name: ColumnName, typ: ColumnType },
 }
@@ -739,41 +1106,33 @@ impl PropRelationDescDiff {
     pub fn apply(self, desc: &mut RelationDesc) {
         match self {
             PropRelationDescDiff::AddColumn { name, typ } => {
-                desc.names.push(name);
+                let new_idx = desc.metadata.len();
+                let meta = ColumnMetadata {
+                    name,
+                    typ_idx: new_idx,
+                    added: RelationVersion(0),
+                    dropped: None,
+                };
+                let prev = desc.metadata.insert(ColumnIndex(new_idx), meta);
                 desc.typ.column_types.push(typ);
-                assert_eq!(desc.names.len(), desc.typ.column_types.len());
+
+                assert_none!(prev);
+                assert_eq!(desc.metadata.len(), desc.typ.column_types.len());
             }
             PropRelationDescDiff::DropColumn { name } => {
-                let Some(pos) = desc.names.iter().position(|col| *col == name) else {
+                let next_version = desc
+                    .metadata
+                    .values()
+                    .map(|meta| meta.dropped.unwrap_or(meta.added))
+                    .max()
+                    .unwrap_or(RelationVersion::root())
+                    .bump();
+                let Some(metadata) = desc.metadata.values_mut().find(|meta| meta.name == name)
+                else {
                     return;
                 };
-                desc.names.remove(pos);
-                desc.typ.column_types.remove(pos);
-                for key_set in &mut desc.typ.keys {
-                    let Some(key_pos) = key_set.iter().position(|col_idx| *col_idx == pos) else {
-                        continue;
-                    };
-                    key_set.remove(key_pos);
-                }
-            }
-            PropRelationDescDiff::MovePosition { name, new_pos } => {
-                let num_columns = desc.typ.columns().len();
-                if num_columns == 0 {
-                    return;
-                }
-
-                let Some((current_pos, _)) = desc.get_by_name(&name) else {
-                    return;
-                };
-                let new_pos = new_pos % num_columns;
-                desc.names.swap(current_pos, new_pos);
-                desc.typ.column_types.swap(current_pos, new_pos);
-                for key_set in &mut desc.typ.keys {
-                    for key in key_set.iter_mut() {
-                        if *key == current_pos {
-                            *key = new_pos;
-                        }
-                    }
+                if metadata.dropped.is_none() {
+                    metadata.dropped = Some(next_version);
                 }
             }
             PropRelationDescDiff::ToggleNullability { name } => {
@@ -838,19 +1197,6 @@ pub fn arb_relation_desc_diff(
     });
 
     let source_ = Rc::clone(&source);
-    let move_columns_strat = (0..num_source_columns).prop_perturb(move |num_columns, mut rng| {
-        let mut map = BTreeMap::default();
-        for _ in 0..num_columns {
-            let col_idx = rng.gen_range(0..num_source_columns);
-            let new_pos = rng.gen_range(0..num_source_columns);
-            map.insert(source_.get_name(col_idx).clone(), new_pos);
-        }
-        map.into_iter()
-            .map(|(name, new_pos)| PropRelationDescDiff::MovePosition { name, new_pos })
-            .collect::<Vec<_>>()
-    });
-
-    let source_ = Rc::clone(&source);
     let toggle_nullability_strat =
         (0..num_source_columns).prop_perturb(move |num_columns, mut rng| {
             let mut set = BTreeSet::default();
@@ -887,18 +1233,204 @@ pub fn arb_relation_desc_diff(
     (
         add_columns_strat,
         drop_columns_strat,
-        move_columns_strat,
         toggle_nullability_strat,
         change_type_strat,
     )
-        .prop_map(|(adds, drops, moves, toggles, changes)| {
+        .prop_map(|(adds, drops, toggles, changes)| {
             adds.into_iter()
                 .chain(drops)
-                .chain(moves)
                 .chain(toggles)
                 .chain(changes)
                 .collect::<Vec<_>>()
         })
         .prop_shuffle()
         .boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    #[mz_ore::test]
+    fn smoktest_at_version() {
+        let desc = RelationDesc::builder()
+            .with_column("a", ScalarType::Bool.nullable(true))
+            .with_column("z", ScalarType::String.nullable(false))
+            .finish();
+
+        let mut versioned_desc = VersionedRelationDesc {
+            inner: desc.clone(),
+        };
+        versioned_desc.validate();
+
+        let latest = versioned_desc.at_version(RelationVersionSelector::Latest);
+        assert_eq!(desc, latest);
+
+        let v0 = versioned_desc.at_version(RelationVersionSelector::specific(0));
+        assert_eq!(desc, v0);
+
+        let v3 = versioned_desc.at_version(RelationVersionSelector::specific(3));
+        assert_eq!(desc, v3);
+
+        let v1 = versioned_desc.add_column("b", ScalarType::Bytes.nullable(false));
+        assert_eq!(v1, RelationVersion(1));
+
+        let v1 = versioned_desc.at_version(RelationVersionSelector::Specific(v1));
+        insta::assert_json_snapshot!(v1.metadata, @r###"
+        {
+          "0": {
+            "name": "a",
+            "typ_idx": 0,
+            "added": 0,
+            "dropped": null
+          },
+          "1": {
+            "name": "z",
+            "typ_idx": 1,
+            "added": 0,
+            "dropped": null
+          },
+          "2": {
+            "name": "b",
+            "typ_idx": 2,
+            "added": 1,
+            "dropped": null
+          }
+        }
+        "###);
+
+        // Check that V0 doesn't show the new column.
+        let v0_b = versioned_desc.at_version(RelationVersionSelector::specific(0));
+        assert!(v0.iter().eq(v0_b.iter()));
+
+        let v2 = versioned_desc.drop_column("z");
+        assert_eq!(v2, RelationVersion(2));
+
+        let v2 = versioned_desc.at_version(RelationVersionSelector::Specific(v2));
+        insta::assert_json_snapshot!(v2.metadata, @r###"
+        {
+          "0": {
+            "name": "a",
+            "typ_idx": 0,
+            "added": 0,
+            "dropped": null
+          },
+          "2": {
+            "name": "b",
+            "typ_idx": 1,
+            "added": 1,
+            "dropped": null
+          }
+        }
+        "###);
+
+        // Check that V0 and V1 are still correct.
+        let v0_c = versioned_desc.at_version(RelationVersionSelector::specific(0));
+        assert!(v0.iter().eq(v0_c.iter()));
+
+        let v1_b = versioned_desc.at_version(RelationVersionSelector::specific(1));
+        assert!(v1.iter().eq(v1_b.iter()));
+
+        insta::assert_json_snapshot!(versioned_desc.inner.metadata, @r###"
+        {
+          "0": {
+            "name": "a",
+            "typ_idx": 0,
+            "added": 0,
+            "dropped": null
+          },
+          "1": {
+            "name": "z",
+            "typ_idx": 1,
+            "added": 0,
+            "dropped": 2
+          },
+          "2": {
+            "name": "b",
+            "typ_idx": 2,
+            "added": 1,
+            "dropped": null
+          }
+        }
+        "###);
+    }
+
+    #[mz_ore::test]
+    fn roundtrip_relation_desc_without_metadata() {
+        let typ = ProtoRelationType {
+            column_types: vec![
+                ScalarType::String.nullable(false).into_proto(),
+                ScalarType::Bool.nullable(true).into_proto(),
+            ],
+            keys: vec![],
+        };
+        let proto = ProtoRelationDesc {
+            typ: Some(typ),
+            names: vec![
+                ColumnName("a".to_string()).into_proto(),
+                ColumnName("b".to_string()).into_proto(),
+            ],
+            metadata: vec![],
+        };
+        let desc: RelationDesc = proto.into_rust().unwrap();
+
+        insta::assert_json_snapshot!(desc, @r###"
+        {
+          "typ": {
+            "column_types": [
+              {
+                "scalar_type": "String",
+                "nullable": false
+              },
+              {
+                "scalar_type": "Bool",
+                "nullable": true
+              }
+            ],
+            "keys": []
+          },
+          "metadata": {
+            "0": {
+              "name": "a",
+              "typ_idx": 0,
+              "added": 0,
+              "dropped": null
+            },
+            "1": {
+              "name": "b",
+              "typ_idx": 1,
+              "added": 0,
+              "dropped": null
+            }
+          }
+        }
+        "###);
+    }
+
+    #[mz_ore::test]
+    fn proptest_relation_desc_roundtrips() {
+        fn testcase(og: RelationDesc) {
+            let bytes = og.into_proto().encode_to_vec();
+            let proto = ProtoRelationDesc::decode(&bytes[..]).unwrap();
+            let rnd = RelationDesc::from_proto(proto).unwrap();
+
+            assert_eq!(og, rnd);
+        }
+
+        proptest!(|(desc in any::<RelationDesc>())| {
+            testcase(desc);
+        });
+
+        let strat = any::<RelationDesc>().prop_flat_map(|desc| {
+            arb_relation_desc_diff(&desc).prop_map(move |diffs| (desc.clone(), diffs))
+        });
+
+        proptest!(|((mut desc, diffs) in strat)| {
+            for diff in diffs {
+                diff.apply(&mut desc);
+            };
+            testcase(desc);
+        });
+    }
 }

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -979,8 +979,7 @@ impl VersionedRelationDesc {
     ///
     /// # Panics
     ///
-    /// Panics if a column with `name` does not exist, if the column was already dropped, or the
-    /// dropped column was used as a key.
+    /// Panics if a column with `name` does not exist or the dropped column was used as a key.
     #[must_use]
     pub fn drop_column<N>(&mut self, name: N) -> RelationVersion
     where

--- a/src/repr/src/relation_and_scalar.proto
+++ b/src/repr/src/relation_and_scalar.proto
@@ -38,9 +38,19 @@ message ProtoColumnType {
     bool nullable = 2;
 }
 
+message ProtoRelationVersion {
+    uint64 value = 1;
+}
+
+message ProtoColumnMetadata {
+    ProtoRelationVersion added = 1;
+    ProtoRelationVersion dropped = 2;
+}
+
 message ProtoRelationDesc {
     ProtoRelationType typ = 1;
     repeated ProtoColumnName names = 2;
+    repeated ProtoColumnMetadata metadata = 3;
 }
 
 message ProtoScalarType {

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -478,12 +478,13 @@ mod tests {
             }
         });
 
-        let mut desc = RelationDesc::empty();
+        let mut desc = RelationDesc::builder();
         for (idx, _) in row.iter().enumerate() {
             // HACK(parkmycar): We don't currently validate the types of the `RelationDesc` are
             // correct, just the number of columns. So we can fill in any type here.
             desc = desc.with_column(idx.to_string(), ScalarType::Int32.nullable(true));
         }
+        let desc = desc.finish();
 
         let encoded = row.encode_to_vec();
         assert_eq!(Row::decode(&encoded, &desc), Ok(row));

--- a/src/repr/src/row/encoding2.rs
+++ b/src/repr/src/row/encoding2.rs
@@ -1674,7 +1674,7 @@ mod tests {
         datum: impl Iterator<Item = Datum<'a>>,
         metrics: &ColumnarMetrics,
     ) {
-        let desc = RelationDesc::empty().with_column("a", ty);
+        let desc = RelationDesc::builder().with_column("a", ty).finish();
         let rows = datum.map(|d| Row::pack_slice(&[d])).collect();
         roundtrip_rows(&desc, rows, metrics)
     }
@@ -1852,7 +1852,7 @@ mod tests {
 
     #[mz_ore::test]
     fn smoketest_row() {
-        let desc = RelationDesc::empty()
+        let desc = RelationDesc::builder()
             .with_column("a", ScalarType::Int64.nullable(true))
             .with_column("b", ScalarType::String.nullable(true))
             .with_column("c", ScalarType::Bool.nullable(true))
@@ -1871,7 +1871,8 @@ mod tests {
                     custom_id: None,
                 }
                 .nullable(true),
-            );
+            )
+            .finish();
         let mut encoder = <RelationDesc as Schema2<Row>>::encoder(&desc).unwrap();
 
         let mut og_row = Row::default();
@@ -1910,17 +1911,19 @@ mod tests {
 
     #[mz_ore::test]
     fn test_nested_list() {
-        let desc = RelationDesc::empty().with_column(
-            "a",
-            ScalarType::List {
-                element_type: Box::new(ScalarType::List {
-                    element_type: Box::new(ScalarType::Int64),
+        let desc = RelationDesc::builder()
+            .with_column(
+                "a",
+                ScalarType::List {
+                    element_type: Box::new(ScalarType::List {
+                        element_type: Box::new(ScalarType::Int64),
+                        custom_id: None,
+                    }),
                     custom_id: None,
-                }),
-                custom_id: None,
-            }
-            .nullable(false),
-        );
+                }
+                .nullable(false),
+            )
+            .finish();
         let mut encoder = <RelationDesc as Schema2<Row>>::encoder(&desc).unwrap();
 
         let mut og_row = Row::default();
@@ -1945,25 +1948,27 @@ mod tests {
 
     #[mz_ore::test]
     fn test_record() {
-        let desc = RelationDesc::empty().with_column(
-            "a",
-            ScalarType::Record {
-                fields: vec![
-                    (ColumnName::from("foo"), ScalarType::Int64.nullable(false)),
-                    (ColumnName::from("bar"), ScalarType::String.nullable(true)),
-                    (
-                        ColumnName::from("baz"),
-                        ScalarType::List {
-                            element_type: Box::new(ScalarType::UInt32),
-                            custom_id: None,
-                        }
-                        .nullable(false),
-                    ),
-                ],
-                custom_id: None,
-            }
-            .nullable(true),
-        );
+        let desc = RelationDesc::builder()
+            .with_column(
+                "a",
+                ScalarType::Record {
+                    fields: vec![
+                        (ColumnName::from("foo"), ScalarType::Int64.nullable(true)),
+                        (ColumnName::from("bar"), ScalarType::String.nullable(false)),
+                        (
+                            ColumnName::from("baz"),
+                            ScalarType::List {
+                                element_type: Box::new(ScalarType::UInt32),
+                                custom_id: None,
+                            }
+                            .nullable(false),
+                        ),
+                    ],
+                    custom_id: None,
+                }
+                .nullable(true),
+            )
+            .finish();
         let mut encoder = <RelationDesc as Schema2<Row>>::encoder(&desc).unwrap();
 
         let mut og_row = Row::default();

--- a/src/repr/src/row/encoding2.rs
+++ b/src/repr/src/row/encoding2.rs
@@ -1953,8 +1953,8 @@ mod tests {
                 "a",
                 ScalarType::Record {
                     fields: vec![
-                        (ColumnName::from("foo"), ScalarType::Int64.nullable(true)),
-                        (ColumnName::from("bar"), ScalarType::String.nullable(false)),
+                        (ColumnName::from("foo"), ScalarType::Int64.nullable(false)),
+                        (ColumnName::from("bar"), ScalarType::String.nullable(true)),
                         (
                             ColumnName::from("baz"),
                             ScalarType::List {

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -61,14 +61,18 @@ mod tests {
         }
 
         // Non-nullable version of the column.
-        let schema = RelationDesc::empty().with_column("col", scalar_type.clone().nullable(false));
+        let schema = RelationDesc::builder()
+            .with_column("col", scalar_type.clone().nullable(false))
+            .finish();
         for row in rows.iter() {
             datum_stats_roundtrip_trim(&schema, [row]);
         }
         datum_stats_roundtrip_trim(&schema, &rows[..]);
 
         // Nullable version of the column.
-        let schema = RelationDesc::empty().with_column("col", scalar_type.nullable(true));
+        let schema = RelationDesc::builder()
+            .with_column("col", scalar_type.nullable(true))
+            .finish();
         rows.push(Row::pack(std::iter::once(Datum::Null)));
         for row in rows.iter() {
             datum_stats_roundtrip_trim(&schema, [row]);

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -867,7 +867,7 @@ impl CatalogType<IdReference> {
     pub fn desc(&self, catalog: &dyn SessionCatalog) -> Result<Option<RelationDesc>, PlanError> {
         match &self {
             CatalogType::Record { fields } => {
-                let mut desc = RelationDesc::empty();
+                let mut desc = RelationDesc::builder();
                 for f in fields {
                     let name = f.name.clone();
                     let ty = query::scalar_type_from_catalog(
@@ -880,7 +880,7 @@ impl CatalogType<IdReference> {
                     let ty = ty.nullable(true);
                     desc = desc.with_column(name, ty);
                 }
-                Ok(Some(desc))
+                Ok(Some(desc.finish()))
             }
             _ => Ok(None),
         }

--- a/src/sql/src/plan/side_effecting_func.rs
+++ b/src/sql/src/plan/side_effecting_func.rs
@@ -78,8 +78,9 @@ pub fn describe_select_if_side_effecting(
     // We currently support only a single call to a side-effecting function
     // without an alias, so there is always a single output column is named
     // after the function.
-    let desc =
-        RelationDesc::empty().with_column(sef_call.imp.name, sef_call.imp.return_type.clone());
+    let desc = RelationDesc::builder()
+        .with_column(sef_call.imp.name, sef_call.imp.return_type.clone())
+        .finish();
 
     Ok(Some(desc))
 }

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -104,14 +104,19 @@ pub fn describe_show_variable(
     ShowVariableStatement { variable, .. }: ShowVariableStatement,
 ) -> Result<StatementDesc, PlanError> {
     let desc = if variable.as_str() == UncasedStr::new("ALL") {
-        RelationDesc::empty()
+        RelationDesc::builder()
             .with_column("name", ScalarType::String.nullable(false))
             .with_column("setting", ScalarType::String.nullable(false))
             .with_column("description", ScalarType::String.nullable(false))
+            .finish()
     } else if variable.as_str() == SCHEMA_ALIAS {
-        RelationDesc::empty().with_column(variable.as_str(), ScalarType::String.nullable(true))
+        RelationDesc::builder()
+            .with_column(variable.as_str(), ScalarType::String.nullable(true))
+            .finish()
     } else {
-        RelationDesc::empty().with_column(variable.as_str(), ScalarType::String.nullable(false))
+        RelationDesc::builder()
+            .with_column(variable.as_str(), ScalarType::String.nullable(false))
+            .finish()
     };
     Ok(StatementDesc::new(Some(desc)))
 }
@@ -133,7 +138,9 @@ pub fn describe_inspect_shard(
     _: &StatementContext,
     InspectShardStatement { .. }: InspectShardStatement,
 ) -> Result<StatementDesc, PlanError> {
-    let desc = RelationDesc::empty().with_column("state", ScalarType::Jsonb.nullable(false));
+    let desc = RelationDesc::builder()
+        .with_column("state", ScalarType::Jsonb.nullable(false))
+        .finish();
     Ok(StatementDesc::new(Some(desc)))
 }
 

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -51,9 +51,10 @@ pub fn describe_show_create_view(
     _: ShowCreateViewStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
-        RelationDesc::empty()
+        RelationDesc::builder()
             .with_column("name", ScalarType::String.nullable(false))
-            .with_column("create_sql", ScalarType::String.nullable(false)),
+            .with_column("create_sql", ScalarType::String.nullable(false))
+            .finish(),
     )))
 }
 
@@ -69,9 +70,10 @@ pub fn describe_show_create_materialized_view(
     _: ShowCreateMaterializedViewStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
-        RelationDesc::empty()
+        RelationDesc::builder()
             .with_column("name", ScalarType::String.nullable(false))
-            .with_column("create_sql", ScalarType::String.nullable(false)),
+            .with_column("create_sql", ScalarType::String.nullable(false))
+            .finish(),
     )))
 }
 
@@ -93,9 +95,10 @@ pub fn describe_show_create_table(
     _: ShowCreateTableStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
-        RelationDesc::empty()
+        RelationDesc::builder()
             .with_column("name", ScalarType::String.nullable(false))
-            .with_column("create_sql", ScalarType::String.nullable(false)),
+            .with_column("create_sql", ScalarType::String.nullable(false))
+            .finish(),
     )))
 }
 
@@ -140,9 +143,10 @@ pub fn describe_show_create_source(
     _: ShowCreateSourceStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
-        RelationDesc::empty()
+        RelationDesc::builder()
             .with_column("name", ScalarType::String.nullable(false))
-            .with_column("create_sql", ScalarType::String.nullable(false)),
+            .with_column("create_sql", ScalarType::String.nullable(false))
+            .finish(),
     )))
 }
 
@@ -158,9 +162,10 @@ pub fn describe_show_create_sink(
     _: ShowCreateSinkStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
-        RelationDesc::empty()
+        RelationDesc::builder()
             .with_column("name", ScalarType::String.nullable(false))
-            .with_column("create_sql", ScalarType::String.nullable(false)),
+            .with_column("create_sql", ScalarType::String.nullable(false))
+            .finish(),
     )))
 }
 
@@ -176,9 +181,10 @@ pub fn describe_show_create_index(
     _: ShowCreateIndexStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
-        RelationDesc::empty()
+        RelationDesc::builder()
             .with_column("name", ScalarType::String.nullable(false))
-            .with_column("create_sql", ScalarType::String.nullable(false)),
+            .with_column("create_sql", ScalarType::String.nullable(false))
+            .finish(),
     )))
 }
 
@@ -194,9 +200,10 @@ pub fn describe_show_create_connection(
     _: ShowCreateConnectionStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
-        RelationDesc::empty()
+        RelationDesc::builder()
             .with_column("name", ScalarType::String.nullable(false))
-            .with_column("create_sql", ScalarType::String.nullable(false)),
+            .with_column("create_sql", ScalarType::String.nullable(false))
+            .finish(),
     )))
 }
 
@@ -220,9 +227,10 @@ pub fn describe_show_create_cluster(
     _: ShowCreateClusterStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
-        RelationDesc::empty()
+        RelationDesc::builder()
             .with_column("name", ScalarType::String.nullable(false))
-            .with_column("create_sql", ScalarType::String.nullable(false)),
+            .with_column("create_sql", ScalarType::String.nullable(false))
+            .finish(),
     )))
 }
 

--- a/src/storage-client/src/healthcheck.rs
+++ b/src/storage-client/src/healthcheck.rs
@@ -11,7 +11,7 @@ use mz_repr::{RelationDesc, ScalarType};
 use std::sync::LazyLock;
 
 pub static MZ_PREPARED_STATEMENT_HISTORY_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
-    RelationDesc::empty()
+    RelationDesc::builder()
         .with_column("id", ScalarType::Uuid.nullable(false))
         .with_column("session_id", ScalarType::Uuid.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
@@ -22,10 +22,11 @@ pub static MZ_PREPARED_STATEMENT_HISTORY_DESC: LazyLock<RelationDesc> = LazyLock
         )
         .with_column("statement_type", ScalarType::String.nullable(true))
         .with_column("throttled_count", ScalarType::UInt64.nullable(false))
+        .finish()
 });
 
 pub static MZ_SQL_TEXT_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
-    RelationDesc::empty()
+    RelationDesc::builder()
         .with_column(
             "prepared_day",
             ScalarType::TimestampTz { precision: None }.nullable(false),
@@ -33,10 +34,11 @@ pub static MZ_SQL_TEXT_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
         .with_column("sql_hash", ScalarType::Bytes.nullable(false))
         .with_column("sql", ScalarType::String.nullable(false))
         .with_column("redacted_sql", ScalarType::String.nullable(false))
+        .finish()
 });
 
 pub static MZ_SESSION_HISTORY_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
-    RelationDesc::empty()
+    RelationDesc::builder()
         .with_column("session_id", ScalarType::Uuid.nullable(false))
         .with_column(
             "connected_at",
@@ -47,6 +49,7 @@ pub static MZ_SESSION_HISTORY_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
             ScalarType::String.nullable(false),
         )
         .with_column("authenticated_user", ScalarType::String.nullable(false))
+        .finish()
 });
 
 // NOTE: Update the views `mz_statement_execution_history_redacted`
@@ -56,7 +59,7 @@ pub static MZ_SESSION_HISTORY_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
 // The `redacted` views should contain only those columns that should
 // be queryable by support.
 pub static MZ_STATEMENT_EXECUTION_HISTORY_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
-    RelationDesc::empty()
+    RelationDesc::builder()
         .with_column("id", ScalarType::Uuid.nullable(false))
         .with_column("prepared_statement_id", ScalarType::Uuid.nullable(false))
         .with_column("sample_rate", ScalarType::Float64.nullable(false))
@@ -95,10 +98,11 @@ pub static MZ_STATEMENT_EXECUTION_HISTORY_DESC: LazyLock<RelationDesc> = LazyLoc
         .with_column("error_message", ScalarType::String.nullable(true))
         .with_column("rows_returned", ScalarType::Int64.nullable(true))
         .with_column("execution_strategy", ScalarType::String.nullable(true))
+        .finish()
 });
 
 pub static MZ_SOURCE_STATUS_HISTORY_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
-    RelationDesc::empty()
+    RelationDesc::builder()
         .with_column(
             "occurred_at",
             ScalarType::TimestampTz { precision: None }.nullable(false),
@@ -107,10 +111,11 @@ pub static MZ_SOURCE_STATUS_HISTORY_DESC: LazyLock<RelationDesc> = LazyLock::new
         .with_column("status", ScalarType::String.nullable(false))
         .with_column("error", ScalarType::String.nullable(true))
         .with_column("details", ScalarType::Jsonb.nullable(true))
+        .finish()
 });
 
 pub static MZ_SINK_STATUS_HISTORY_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
-    RelationDesc::empty()
+    RelationDesc::builder()
         .with_column(
             "occurred_at",
             ScalarType::TimestampTz { precision: None }.nullable(false),
@@ -119,15 +124,17 @@ pub static MZ_SINK_STATUS_HISTORY_DESC: LazyLock<RelationDesc> = LazyLock::new(|
         .with_column("status", ScalarType::String.nullable(false))
         .with_column("error", ScalarType::String.nullable(true))
         .with_column("details", ScalarType::Jsonb.nullable(true))
+        .finish()
 });
 
 pub static MZ_AWS_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC: LazyLock<RelationDesc> =
     LazyLock::new(|| {
-        RelationDesc::empty()
+        RelationDesc::builder()
             .with_column(
                 "occurred_at",
                 ScalarType::TimestampTz { precision: None }.nullable(false),
             )
             .with_column("connection_id", ScalarType::String.nullable(false))
             .with_column("status", ScalarType::String.nullable(false))
+            .finish()
     });

--- a/src/storage-client/src/statistics.rs
+++ b/src/storage-client/src/statistics.rs
@@ -27,7 +27,7 @@ use mz_repr::{GlobalId, RelationDesc, Row, ScalarType};
 include!(concat!(env!("OUT_DIR"), "/mz_storage_client.statistics.rs"));
 
 pub static MZ_SOURCE_STATISTICS_RAW_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
-    RelationDesc::empty()
+    RelationDesc::builder()
         // Id of the source (or subsource).
         .with_column("id", ScalarType::String.nullable(false))
         //
@@ -90,10 +90,11 @@ pub static MZ_SOURCE_STATISTICS_RAW_DESC: LazyLock<RelationDesc> = LazyLock::new
         // A gauge of the number of _values_ (source defined unit) we have committed.
         // Never resets. Not to be confused with any of the counters above.
         .with_column("offset_committed", ScalarType::UInt64.nullable(true))
+        .finish()
 });
 
 pub static MZ_SINK_STATISTICS_RAW_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
-    RelationDesc::empty()
+    RelationDesc::builder()
         // Id of the sink.
         .with_column("id", ScalarType::String.nullable(false))
         //
@@ -111,6 +112,7 @@ pub static MZ_SINK_STATISTICS_RAW_DESC: LazyLock<RelationDesc> = LazyLock::new(|
         // A counter of the bytes we have committed.
         // Never resets.
         .with_column("bytes_committed", ScalarType::UInt64.nullable(false))
+        .finish()
 });
 
 // Types of statistics (counter and various types of gauges), that have different semantics

--- a/src/storage-types/src/controller.rs
+++ b/src/storage-types/src/controller.rs
@@ -375,10 +375,11 @@ pub struct TxnsCodecRow;
 
 impl TxnsCodecRow {
     pub fn desc() -> RelationDesc {
-        RelationDesc::empty()
+        RelationDesc::builder()
             .with_column("shard_id", ScalarType::String.nullable(false))
             .with_column("ts", ScalarType::UInt64.nullable(false))
             .with_column("batch", ScalarType::Bytes.nullable(true))
+            .finish()
     }
 }
 

--- a/src/storage-types/src/sources/kafka.rs
+++ b/src/storage-types/src/sources/kafka.rs
@@ -86,7 +86,7 @@ impl<R: ConnectionResolver> IntoInlineConnection<KafkaSourceConnection, R>
 }
 
 pub static KAFKA_PROGRESS_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
-    RelationDesc::empty()
+    RelationDesc::builder()
         .with_column(
             "partition",
             ScalarType::Range {
@@ -95,6 +95,7 @@ pub static KAFKA_PROGRESS_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
             .nullable(false),
         )
         .with_column("offset", ScalarType::UInt64.nullable(true))
+        .finish()
 });
 
 impl KafkaSourceConnection {
@@ -194,11 +195,15 @@ impl<C: ConnectionAccess> SourceConnection for KafkaSourceConnection<C> {
     }
 
     fn key_desc(&self) -> RelationDesc {
-        RelationDesc::empty().with_column("key", ScalarType::Bytes.nullable(true))
+        RelationDesc::builder()
+            .with_column("key", ScalarType::Bytes.nullable(true))
+            .finish()
     }
 
     fn value_desc(&self) -> RelationDesc {
-        RelationDesc::empty().with_column("value", ScalarType::Bytes.nullable(true))
+        RelationDesc::builder()
+            .with_column("value", ScalarType::Bytes.nullable(true))
+            .finish()
     }
 
     fn timestamp_desc(&self) -> RelationDesc {

--- a/src/storage-types/src/sources/load_generator.rs
+++ b/src/storage-types/src/sources/load_generator.rs
@@ -50,7 +50,9 @@ pub struct LoadGeneratorSourceConnection {
 }
 
 pub static LOAD_GEN_PROGRESS_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
-    RelationDesc::empty().with_column("offset", ScalarType::UInt64.nullable(true))
+    RelationDesc::builder()
+        .with_column("offset", ScalarType::UInt64.nullable(true))
+        .finish()
 });
 
 impl SourceConnection for LoadGeneratorSourceConnection {
@@ -66,7 +68,9 @@ impl SourceConnection for LoadGeneratorSourceConnection {
         match &self.load_generator {
             LoadGenerator::KeyValue(_) => {
                 // `"key"` is overridden by the key_envelope in planning.
-                RelationDesc::empty().with_column("key", ScalarType::UInt64.nullable(false))
+                RelationDesc::builder()
+                    .with_column("key", ScalarType::UInt64.nullable(false))
+                    .finish()
             }
             _ => RelationDesc::empty(),
         }
@@ -75,13 +79,15 @@ impl SourceConnection for LoadGeneratorSourceConnection {
     fn value_desc(&self) -> RelationDesc {
         match &self.load_generator {
             LoadGenerator::Auction => RelationDesc::empty(),
-            LoadGenerator::Clock => RelationDesc::empty().with_column(
-                "time",
-                ScalarType::TimestampTz { precision: None }.nullable(false),
-            ),
+            LoadGenerator::Clock => RelationDesc::builder()
+                .with_column(
+                    "time",
+                    ScalarType::TimestampTz { precision: None }.nullable(false),
+                )
+                .finish(),
             LoadGenerator::Datums => {
                 let mut desc =
-                    RelationDesc::empty().with_column("rowid", ScalarType::Int64.nullable(false));
+                    RelationDesc::builder().with_column("rowid", ScalarType::Int64.nullable(false));
                 let typs = ScalarType::enumerate();
                 let mut names = BTreeSet::new();
                 for typ in typs {
@@ -99,22 +105,22 @@ impl SourceConnection for LoadGeneratorSourceConnection {
                     names.insert(name.clone());
                     desc = desc.with_column(name, typ.clone().nullable(true));
                 }
-                desc
+                desc.finish()
             }
-            LoadGenerator::Counter { .. } => {
-                RelationDesc::empty().with_column("counter", ScalarType::Int64.nullable(false))
-            }
+            LoadGenerator::Counter { .. } => RelationDesc::builder()
+                .with_column("counter", ScalarType::Int64.nullable(false))
+                .finish(),
             LoadGenerator::Marketing => RelationDesc::empty(),
             LoadGenerator::Tpch { .. } => RelationDesc::empty(),
             LoadGenerator::KeyValue(KeyValueLoadGenerator { include_offset, .. }) => {
-                let mut desc = RelationDesc::empty()
+                let mut desc = RelationDesc::builder()
                     .with_column("partition", ScalarType::UInt64.nullable(false))
                     .with_column("value", ScalarType::Bytes.nullable(false));
 
                 if let Some(offset_name) = include_offset.as_deref() {
                     desc = desc.with_column(offset_name, ScalarType::UInt64.nullable(false));
                 }
-                desc
+                desc.finish()
             }
         }
     }
@@ -194,30 +200,33 @@ impl LoadGenerator {
             LoadGenerator::Auction => vec![
                 (
                     "organizations",
-                    RelationDesc::empty()
+                    RelationDesc::builder()
                         .with_column("id", ScalarType::Int64.nullable(false))
                         .with_column("name", ScalarType::String.nullable(false))
-                        .with_key(vec![0]),
+                        .with_key(vec![0])
+                        .finish(),
                 ),
                 (
                     "users",
-                    RelationDesc::empty()
+                    RelationDesc::builder()
                         .with_column("id", ScalarType::Int64.nullable(false))
                         .with_column("org_id", ScalarType::Int64.nullable(false))
                         .with_column("name", ScalarType::String.nullable(false))
-                        .with_key(vec![0]),
+                        .with_key(vec![0])
+                        .finish(),
                 ),
                 (
                     "accounts",
-                    RelationDesc::empty()
+                    RelationDesc::builder()
                         .with_column("id", ScalarType::Int64.nullable(false))
                         .with_column("org_id", ScalarType::Int64.nullable(false))
                         .with_column("balance", ScalarType::Int64.nullable(false))
-                        .with_key(vec![0]),
+                        .with_key(vec![0])
+                        .finish(),
                 ),
                 (
                     "auctions",
-                    RelationDesc::empty()
+                    RelationDesc::builder()
                         .with_column("id", ScalarType::Int64.nullable(false))
                         .with_column("seller", ScalarType::Int64.nullable(false))
                         .with_column("item", ScalarType::String.nullable(false))
@@ -225,11 +234,12 @@ impl LoadGenerator {
                             "end_time",
                             ScalarType::TimestampTz { precision: None }.nullable(false),
                         )
-                        .with_key(vec![0]),
+                        .with_key(vec![0])
+                        .finish(),
                 ),
                 (
                     "bids",
-                    RelationDesc::empty()
+                    RelationDesc::builder()
                         .with_column("id", ScalarType::Int64.nullable(false))
                         .with_column("buyer", ScalarType::Int64.nullable(false))
                         .with_column("auction_id", ScalarType::Int64.nullable(false))
@@ -238,7 +248,8 @@ impl LoadGenerator {
                             "bid_time",
                             ScalarType::TimestampTz { precision: None }.nullable(false),
                         )
-                        .with_key(vec![0]),
+                        .with_key(vec![0])
+                        .finish(),
                 ),
             ],
             LoadGenerator::Clock => vec![],
@@ -247,15 +258,16 @@ impl LoadGenerator {
                 vec![
                     (
                         "customers",
-                        RelationDesc::empty()
+                        RelationDesc::builder()
                             .with_column("id", ScalarType::Int64.nullable(false))
                             .with_column("email", ScalarType::String.nullable(false))
                             .with_column("income", ScalarType::Int64.nullable(false))
-                            .with_key(vec![0]),
+                            .with_key(vec![0])
+                            .finish(),
                     ),
                     (
                         "impressions",
-                        RelationDesc::empty()
+                        RelationDesc::builder()
                             .with_column("id", ScalarType::Int64.nullable(false))
                             .with_column("customer_id", ScalarType::Int64.nullable(false))
                             .with_column("campaign_id", ScalarType::Int64.nullable(false))
@@ -263,21 +275,22 @@ impl LoadGenerator {
                                 "impression_time",
                                 ScalarType::TimestampTz { precision: None }.nullable(false),
                             )
-                            .with_key(vec![0]),
+                            .with_key(vec![0])
+                            .finish(),
                     ),
                     (
                         "clicks",
-                        RelationDesc::empty()
+                        RelationDesc::builder()
                             .with_column("impression_id", ScalarType::Int64.nullable(false))
                             .with_column(
                                 "click_time",
                                 ScalarType::TimestampTz { precision: None }.nullable(false),
                             )
-                            .without_keys(),
+                            .finish(),
                     ),
                     (
                         "leads",
-                        RelationDesc::empty()
+                        RelationDesc::builder()
                             .with_column("id", ScalarType::Int64.nullable(false))
                             .with_column("customer_id", ScalarType::Int64.nullable(false))
                             .with_column(
@@ -289,11 +302,12 @@ impl LoadGenerator {
                                 ScalarType::TimestampTz { precision: None }.nullable(true),
                             )
                             .with_column("conversion_amount", ScalarType::Int64.nullable(true))
-                            .with_key(vec![0]),
+                            .with_key(vec![0])
+                            .finish(),
                     ),
                     (
                         "coupons",
-                        RelationDesc::empty()
+                        RelationDesc::builder()
                             .with_column("id", ScalarType::Int64.nullable(false))
                             .with_column("lead_id", ScalarType::Int64.nullable(false))
                             .with_column(
@@ -301,11 +315,12 @@ impl LoadGenerator {
                                 ScalarType::TimestampTz { precision: None }.nullable(false),
                             )
                             .with_column("amount", ScalarType::Int64.nullable(false))
-                            .with_key(vec![0]),
+                            .with_key(vec![0])
+                            .finish(),
                     ),
                     (
                         "conversion_predictions",
-                        RelationDesc::empty()
+                        RelationDesc::builder()
                             .with_column("lead_id", ScalarType::Int64.nullable(false))
                             .with_column("experiment_bucket", ScalarType::String.nullable(false))
                             .with_column(
@@ -313,7 +328,7 @@ impl LoadGenerator {
                                 ScalarType::TimestampTz { precision: None }.nullable(false),
                             )
                             .with_column("score", ScalarType::Float64.nullable(false))
-                            .without_keys(),
+                            .finish(),
                     ),
                 ]
             }
@@ -327,7 +342,7 @@ impl LoadGenerator {
                 vec![
                     (
                         "supplier",
-                        RelationDesc::empty()
+                        RelationDesc::builder()
                             .with_column("s_suppkey", identifier.clone())
                             .with_column("s_name", ScalarType::String.nullable(false))
                             .with_column("s_address", ScalarType::String.nullable(false))
@@ -335,11 +350,12 @@ impl LoadGenerator {
                             .with_column("s_phone", ScalarType::String.nullable(false))
                             .with_column("s_acctbal", decimal.clone())
                             .with_column("s_comment", ScalarType::String.nullable(false))
-                            .with_key(vec![0]),
+                            .with_key(vec![0])
+                            .finish(),
                     ),
                     (
                         "part",
-                        RelationDesc::empty()
+                        RelationDesc::builder()
                             .with_column("p_partkey", identifier.clone())
                             .with_column("p_name", ScalarType::String.nullable(false))
                             .with_column("p_mfgr", ScalarType::String.nullable(false))
@@ -349,21 +365,23 @@ impl LoadGenerator {
                             .with_column("p_container", ScalarType::String.nullable(false))
                             .with_column("p_retailprice", decimal.clone())
                             .with_column("p_comment", ScalarType::String.nullable(false))
-                            .with_key(vec![0]),
+                            .with_key(vec![0])
+                            .finish(),
                     ),
                     (
                         "partsupp",
-                        RelationDesc::empty()
+                        RelationDesc::builder()
                             .with_column("ps_partkey", identifier.clone())
                             .with_column("ps_suppkey", identifier.clone())
                             .with_column("ps_availqty", ScalarType::Int32.nullable(false))
                             .with_column("ps_supplycost", decimal.clone())
                             .with_column("ps_comment", ScalarType::String.nullable(false))
-                            .with_key(vec![0, 1]),
+                            .with_key(vec![0, 1])
+                            .finish(),
                     ),
                     (
                         "customer",
-                        RelationDesc::empty()
+                        RelationDesc::builder()
                             .with_column("c_custkey", identifier.clone())
                             .with_column("c_name", ScalarType::String.nullable(false))
                             .with_column("c_address", ScalarType::String.nullable(false))
@@ -372,11 +390,12 @@ impl LoadGenerator {
                             .with_column("c_acctbal", decimal.clone())
                             .with_column("c_mktsegment", ScalarType::String.nullable(false))
                             .with_column("c_comment", ScalarType::String.nullable(false))
-                            .with_key(vec![0]),
+                            .with_key(vec![0])
+                            .finish(),
                     ),
                     (
                         "orders",
-                        RelationDesc::empty()
+                        RelationDesc::builder()
                             .with_column("o_orderkey", identifier.clone())
                             .with_column("o_custkey", identifier.clone())
                             .with_column("o_orderstatus", ScalarType::String.nullable(false))
@@ -386,11 +405,12 @@ impl LoadGenerator {
                             .with_column("o_clerk", ScalarType::String.nullable(false))
                             .with_column("o_shippriority", ScalarType::Int32.nullable(false))
                             .with_column("o_comment", ScalarType::String.nullable(false))
-                            .with_key(vec![0]),
+                            .with_key(vec![0])
+                            .finish(),
                     ),
                     (
                         "lineitem",
-                        RelationDesc::empty()
+                        RelationDesc::builder()
                             .with_column("l_orderkey", identifier.clone())
                             .with_column("l_partkey", identifier.clone())
                             .with_column("l_suppkey", identifier.clone())
@@ -407,24 +427,27 @@ impl LoadGenerator {
                             .with_column("l_shipinstruct", ScalarType::String.nullable(false))
                             .with_column("l_shipmode", ScalarType::String.nullable(false))
                             .with_column("l_comment", ScalarType::String.nullable(false))
-                            .with_key(vec![0, 3]),
+                            .with_key(vec![0, 3])
+                            .finish(),
                     ),
                     (
                         "nation",
-                        RelationDesc::empty()
+                        RelationDesc::builder()
                             .with_column("n_nationkey", identifier.clone())
                             .with_column("n_name", ScalarType::String.nullable(false))
                             .with_column("n_regionkey", identifier.clone())
                             .with_column("n_comment", ScalarType::String.nullable(false))
-                            .with_key(vec![0]),
+                            .with_key(vec![0])
+                            .finish(),
                     ),
                     (
                         "region",
-                        RelationDesc::empty()
+                        RelationDesc::builder()
                             .with_column("r_regionkey", identifier)
                             .with_column("r_name", ScalarType::String.nullable(false))
                             .with_column("r_comment", ScalarType::String.nullable(false))
-                            .with_key(vec![0]),
+                            .with_key(vec![0])
+                            .finish(),
                     ),
                 ]
             }

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -66,10 +66,11 @@ impl<R: ConnectionResolver> IntoInlineConnection<MySqlSourceConnection, R>
 }
 
 pub static MYSQL_PROGRESS_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
-    RelationDesc::empty()
+    RelationDesc::builder()
         .with_column("source_id_lower", ScalarType::Uuid.nullable(false))
         .with_column("source_id_upper", ScalarType::Uuid.nullable(false))
         .with_column("transaction_id", ScalarType::UInt64.nullable(true))
+        .finish()
 });
 
 impl MySqlSourceConnection {

--- a/src/storage-types/src/sources/postgres.rs
+++ b/src/storage-types/src/sources/postgres.rs
@@ -59,8 +59,11 @@ impl<R: ConnectionResolver> IntoInlineConnection<PostgresSourceConnection, R>
     }
 }
 
-pub static PG_PROGRESS_DESC: LazyLock<RelationDesc> =
-    LazyLock::new(|| RelationDesc::empty().with_column("lsn", ScalarType::UInt64.nullable(true)));
+pub static PG_PROGRESS_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
+    RelationDesc::builder()
+        .with_column("lsn", ScalarType::UInt64.nullable(true))
+        .finish()
+});
 
 impl PostgresSourceConnection {
     pub async fn fetch_write_frontier(

--- a/src/storage-types/src/stats.rs
+++ b/src/storage-types/src/stats.rs
@@ -231,7 +231,9 @@ mod tests {
     use crate::sources::SourceData;
 
     fn validate_stats(column_type: &ColumnType, datums: &[Datum<'_>]) -> Result<(), String> {
-        let schema = RelationDesc::empty().with_column("col", column_type.clone());
+        let schema = RelationDesc::builder()
+            .with_column("col", column_type.clone())
+            .finish();
 
         let mut builder = PartBuilder2::new(&schema, &UnitSchema);
         let mut row = SourceData(Ok(Row::default()));

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -662,7 +662,7 @@ mod tests {
     });
 
     static PROGRESS_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
-        RelationDesc::empty()
+        RelationDesc::builder()
             .with_column(
                 "partition",
                 ScalarType::Range {
@@ -671,6 +671,7 @@ mod tests {
                 .nullable(false),
             )
             .with_column("offset", ScalarType::UInt64.nullable(true))
+            .finish()
     });
 
     async fn make_test_operator(

--- a/src/testdrive/src/action/persist.rs
+++ b/src/testdrive/src/action/persist.rs
@@ -40,10 +40,11 @@ pub async fn run_force_compaction(
         anyhow::bail!("Missing persist blob URL");
     };
 
-    let relation_desc = RelationDesc::empty()
+    let relation_desc = RelationDesc::builder()
         .with_column("key", ScalarType::String.nullable(true))
         .with_column("f1", ScalarType::String.nullable(true))
-        .with_column("f2", ScalarType::Int64.nullable(true));
+        .with_column("f2", ScalarType::Int64.nullable(true))
+        .finish();
 
     mz_persist_client::cli::admin::force_compaction::<SourceData, (), Timestamp, Diff>(
         cfg,


### PR DESCRIPTION
This PR refactors `RelationDesc` to support adding columns to tables, it does a few things:

1. Creates a `RelationDescBuilder` and moves a few methods, namely `with_column(...)` onto the new builder. The goal here was to disambiguate adding a column to a new version of the `RelationDesc` and the initial construction of a `RelationDesc`.
2. Refactors the internals of `RelationDesc` from a `Vec<ColumnName>` to a `BTreeMap<ColumnIndex, ColumnMetadata>`. There are two primary things this enables:
    1. Stable tracking of column positions with `ColumnIndex`
    2. `ColumnMetadata` tracks the version at which a column was added and optionally dropped.

### Motivation

Progress towards https://github.com/MaterializeInc/materialize/issues/28082

### Tips for reviewer

These changes are split into two separate commits:

1. Adding `RelationDescBuilder`, this is more or less code movement.
2. Refactoring the internals of `RelationDesc`. This shouldn't cause any behavior changes but is a decent amount of changes.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
