### PR TITLE
persist: Allow appending Datum::Null to Codec Row data

### DIFF
--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -370,6 +370,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::stats::STATS_UNTRIMMABLE_COLUMNS_PREFIX)
         .add(&crate::stats::STATS_UNTRIMMABLE_COLUMNS_SUFFIX)
         .add(&crate::fetch::PART_DECODE_FORMAT)
+        .add(&crate::DANGEROUS_ENABLE_SCHEMA_EVOLUTION)
 }
 
 impl PersistConfig {

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -145,7 +145,7 @@ pub(crate) const DANGEROUS_ENABLE_SCHEMA_EVOLUTION: Config<bool> = Config::new(
     "persist_dangerous_enable_schema_evolution",
     false,
     "\
-DANGEROUS DO NOT ENABLE IN PRODUCTION ENVIRONMENTS!
+DANGEROUS DO NOT ENABLE IN PRODUCTION OR STAGING ENVIRONMENTS!
 
 Enable evolving the schema of a Persist shard. Currently dangerous because \
 compaction does not yet handle batches of data with different schemas.",

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -130,15 +130,20 @@ impl Row {
             col_idx += 1;
         }
 
-        // TODO(parkmycar): This is where we'll add new default values to Codec
-        // data whose upstream relation has had columns added.
+        let num_columns = desc.typ().column_types.len();
+        if col_idx < num_columns {
+            let missing_columns = col_idx..num_columns;
+            for _ in missing_columns {
+                packer.push(Datum::Null);
+                col_idx += 1;
+            }
+        }
 
         // HACK(parkmycar): Only validate that the decoded Row matches the RelationDesc if it was
         // non-empty. We have an optimization for queries like COUNT(*) that returns a fake empty
         // Part instead of decoding the data, which this assertion will fail on.
         //
         // TODO(#28146): Remove the check for if the num_columns is 0.
-        let num_columns = desc.typ().column_types.len();
         if num_columns != 0 && col_idx != 0 {
             mz_ore::soft_assert_eq_or_log!(
                 col_idx,


### PR DESCRIPTION
This PR does two things:

1. Allows pushing `Datum::Null` onto Codec Row data when columns are missing
2. Gates Persist schema evolution, specifically `compare_and_evolve_schema`, behind a scary dyncfg.

We should _**never**_ enable this dyncfg in staging or prod until compaction can handle data that is written in different schemas, but I'm putting it up because it helps me test `ALTER TABLE` end-to-end. @danhhz and I chatted about this [here](https://materializeinc.slack.com/archives/C03P1EGB7A7/p1724710976316039?thread_ts=1724709020.644259&cid=C03P1EGB7A7)

### Motivation

Small progress towards `ALTER TABLE`

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
