### PR TITLE
cluster: don't panic on activator_tx send failure

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -353,9 +353,11 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
             move |scope| {
                 let mut container = Default::default();
                 source(scope, "CmdSource", |capability, info| {
-                    // Send activator for this operator back
+                    // Send activator for this operator back.
                     let activator = scope.sync_activator_for(&info.address[..]);
-                    activator_tx.send(activator).expect("activator_tx working");
+                    // This might fail if the client has already shut down, which is fine. The rest
+                    // of the operator implementation knows how to handle a disconnected client.
+                    let _ = activator_tx.send(activator);
 
                     //Hold onto capbility until we receive a disconnected error
                     let mut cap_opt = Some(capability);

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -368,9 +368,9 @@ impl<'w, A: Allocate> Worker<'w, A> {
         while !shutdown {
             match self.client_rx.recv() {
                 Ok((rx, tx, activator_tx)) => {
-                    activator_tx
-                        .send(std::thread::current())
-                        .expect("activator_tx working");
+                    // This might fail if the client has already shut down, which is fine.
+                    // `run_client` knows how to handle a disconnected client.
+                    let _ = activator_tx.send(std::thread::current());
                     self.run_client(rx, tx)
                 }
                 Err(_) => {


### PR DESCRIPTION
If the `ClusterClient` shuts down before it has accepted the Timely activator, the Timely worker will fail to send the activator through the `activator_tx`. Handle such send failures gracefully, rather than panicking.

### Motivation

  * This PR fixes a recognized bug.

Fixes #29241 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
