### PR TITLE
catalog: Remove upper fence error

### DIFF
--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -685,7 +685,7 @@ async fn test_opened_epoch_fencing(state_builder: TestCatalogStateBuilder) {
         .await
         .unwrap();
 
-    // Unopened catalog should be fenced now with an epoch fence.
+    // Opened catalog should be fenced now with an epoch fence.
     let err = state.snapshot().await.unwrap_err();
     assert!(
         matches!(
@@ -736,7 +736,7 @@ async fn test_opened_deploy_generation_fencing(state_builder: TestCatalogStateBu
         .await
         .unwrap();
 
-    // Unopened catalog should be fenced now with an epoch fence.
+    // Opened catalog should be fenced now with an epoch fence.
     let err = state.snapshot().await.unwrap_err();
     assert!(
         matches!(
@@ -749,6 +749,80 @@ async fn test_opened_deploy_generation_fencing(state_builder: TestCatalogStateBu
     );
 
     let err = state.transaction().await.unwrap_err();
+    assert!(
+        matches!(
+            err,
+            CatalogError::Durable(DurableCatalogError::Fence(
+                FenceError::DeployGeneration { .. }
+            ))
+        ),
+        "unexpected err: {err:?}"
+    );
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_persist_fencing_during_write() {
+    let persist_client = PersistClient::new_for_tests().await;
+    let state_builder = TestCatalogStateBuilder::new(persist_client);
+    test_fencing_during_write(state_builder).await;
+}
+
+async fn test_fencing_during_write(state_builder: TestCatalogStateBuilder) {
+    let deploy_generation = 0;
+    let mut state = state_builder
+        .clone()
+        .with_deploy_generation(deploy_generation)
+        .unwrap_build()
+        .await
+        // Use `NOW_ZERO` for consistent timestamps in the snapshots.
+        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .await
+        .unwrap();
+    // Drain updates.
+    let _ = state.sync_to_current_updates().await;
+    let mut txn = state.transaction().await.unwrap();
+    txn.set_config("cmu".to_string(), Some(1900)).unwrap();
+
+    // Open catalog, which will bump the epoch.
+    let mut state = state_builder
+        .clone()
+        .with_deploy_generation(deploy_generation)
+        .unwrap_build()
+        .await
+        // Use `NOW_ZERO` for consistent timestamps in the snapshots.
+        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .await
+        .unwrap();
+    // Drain updates.
+    let _ = state.sync_to_current_updates().await;
+
+    // Committing results in an epoch fence error.
+    let err = txn.commit().await.unwrap_err();
+    assert!(
+        matches!(
+            err,
+            CatalogError::Durable(DurableCatalogError::Fence(FenceError::Epoch { .. }))
+        ),
+        "unexpected err: {err:?}"
+    );
+
+    let mut txn = state.transaction().await.unwrap();
+    txn.set_config("wes".to_string(), Some(1831)).unwrap();
+
+    // Open catalog, which will bump the epoch AND deploy generation.
+    let _state = state_builder
+        .clone()
+        .with_deploy_generation(deploy_generation + 1)
+        .unwrap_build()
+        .await
+        // Use `NOW_ZERO` for consistent timestamps in the snapshots.
+        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .await
+        .unwrap();
+
+    // Committing results in a deploy generation fence error.
+    let err = txn.commit().await.unwrap_err();
     assert!(
         matches!(
             err,

--- a/src/environmentd/src/deployment/preflight.rs
+++ b/src/environmentd/src/deployment/preflight.rs
@@ -215,22 +215,22 @@ pub async fn preflight_0dt(
 
                 match res {
                     Ok(_catalog) => break,
-                    Err(error) => {
-                        match error {
-                            CatalogError::Durable(
-                                mz_catalog::durable::DurableCatalogError::Fence(error),
-                            ) => {
-                                tracing::info!("fenced while trying to fence out old deployment ({}), retrying...", error);
-                                continue;
-                            }
-                            error => {
-                                panic!(
-                                    "unexpected error while fencing out old deployment: {:?}",
-                                    error
-                                );
-                            }
+                    Err(error) => match error {
+                        CatalogError::Durable(
+                            error @ mz_catalog::durable::DurableCatalogError::UpperMismatch {
+                                ..
+                            },
+                        ) => {
+                            tracing::info!("upper mismatch while trying to fence out old deployment ({}), retrying...", error);
+                            continue;
                         }
-                    }
+                        error => {
+                            panic!(
+                                "unexpected error while fencing out old deployment: {:?}",
+                                error
+                            );
+                        }
+                    },
                 }
             }
 


### PR DESCRIPTION
da7c2af16a3ad1a1a7454ea4ecc2eb55e645dc89 incorrectly asserted that the catalog debug tool does not fence out other writers when performing writes. The catalog debug tool does in face increment the epoch on every write, fencing out all other catalogs.

As a result, it's not possible for a process to write to the catalog without also fencing out all other catalog processes. Therefore, whenever a process encounters an upper mismatch error on write, there is always a more descriptive fencing error that could be returned.

This commit removes the `FenceError:Upper` variant and returns a more
descriptive error instead. Additionally, it adds some tests to validate
this behavior.


### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
