### PR TITLE
adapter: add `mz_statement_logging_record_count` metric

### DIFF
--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -676,6 +676,14 @@ impl Coordinator {
         } else {
             distribution.sample(&mut thread_rng())
         };
+
+        // Track how many statements we're recording.
+        let sampled_label = sample.then_some("true").unwrap_or("false");
+        self.metrics
+            .statement_logging_records
+            .with_label_values(&[sampled_label])
+            .inc_by(1);
+
         if let Some((sql, accounted)) = match session.qcell_rw(logging) {
             PreparedStatementLoggingInfo::AlreadyLogged { .. } => None,
             PreparedStatementLoggingInfo::StillToLog { sql, accounted, .. } => {

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -30,6 +30,7 @@ pub struct Metrics {
     pub canceled_peeks: IntCounterVec,
     pub linearize_message_seconds: HistogramVec,
     pub time_to_first_row_seconds: HistogramVec,
+    pub statement_logging_records: IntCounterVec,
     pub statement_logging_unsampled_bytes: IntCounterVec,
     pub statement_logging_actual_bytes: IntCounterVec,
     pub message_batch: HistogramVec,
@@ -112,6 +113,11 @@ impl Metrics {
                 help: "Latency of an execute for a successful query from pgwire's perspective",
                 var_labels: ["instance_id", "isolation_level", "strategy"],
                 buckets: histogram_seconds_buckets(0.000_128, 32.0)
+            }),
+            statement_logging_records: registry.register(metric! {
+                name: "mz_statement_logging_record_count",
+                help: "The total number of SQL statements tagged with whether or not they were recorded.",
+                var_labels: ["sample"],
             }),
             statement_logging_unsampled_bytes: registry.register(metric!(
                 name: "mz_statement_logging_unsampled_bytes",


### PR DESCRIPTION
This PR adds the `mz_statement_logging_record_count` prometheus metric to track the total number of statements we record in the recent activity log, and whether or not that statement was actually sampled.

### Motivation

Chatted about this in the incident response working group, if we change the sampling rate for a user we want a more concrete way to see that the change took effect.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
