### PR TITLE
bazel: capture `bazel-explain.log` as a build artifact

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -58,6 +58,7 @@ steps:
           - "WORKSPACE"
           - ".bazelrc"
           - "**/*.bzl"
+        artifact_paths: bazel-explain.log
         depends_on: []
         timeout_in_minutes: 60
         agents:
@@ -71,6 +72,7 @@ steps:
           - "WORKSPACE"
           - ".bazelrc"
           - "**/*.bzl"
+        artifact_paths: bazel-explain.log
         depends_on: []
         timeout_in_minutes: 60
         agents:


### PR DESCRIPTION
This should make it such that we capture `bazel-explain.log` as a build artifact which will help us debug builds in CI.

Note: Soon we'll turn off explains by default because it seems to contribute to non-trivial amount of time to the build

### Motivation

Progress towards https://github.com/MaterializeInc/materialize/issues/26796

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
