### PR TITLE
pgwire: eagerly flush after writing an error

### DIFF
--- a/test/lang/js/params.test.ts
+++ b/test/lang/js/params.test.ts
@@ -126,4 +126,17 @@ describe("query stream api", () => {
       { v: 6 },
     ]);
   });
+
+  it("should throw errors on invalid queries", async () => {
+    const queryStream = new QueryStream("ELECT 1");
+
+    const fetchData = async () => {
+      const rows = [];
+      for await (const row of client.query(queryStream)) {
+        rows.push(row);
+      }
+    };
+
+    await expect(fetchData).rejects.toThrow("Expected a keyword at the beginning of a statement");
+  });
 });


### PR DESCRIPTION
See comment within for justification.

In particular, this fixes a hang when using Node.js's pg-query-stream library with Materialize to submit a query that experiences an error, either during the parsing, planning, or execution phase of the query.

Plausibly related to MaterializeInc/incidents-and-escalations#92.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
