### PR TITLE
More buckets for coordinator message handling

### DIFF
--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -130,7 +130,7 @@ impl Metrics {
                 name: "mz_slow_message_handling",
                 help: "Latency for ALL coordinator messages. 'slow' is in the name for legacy reasons, but is not accurate.",
                 var_labels: ["message_kind"],
-                buckets: histogram_seconds_buckets(0.128, 32.0),
+                buckets: histogram_seconds_buckets(0.000_128, 32.0),
             )),
             optimization_notices: registry.register(metric!(
                 name: "mz_optimization_notices",


### PR DESCRIPTION
Add all default buckets for capturing the coordinator message handling duration histogram. At the moment, we only distinguish values starting from 128ms, which means that we cannot observe durations below this value. However, since all of these are blocking, even smaller durations contribute to client-observed latency, so we should be able to attribute which commands cause observable latency.

Fixes #29236.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
