### PR TITLE
sql_council: Filter out build files for Slack notifier

### DIFF
--- a/.github/workflows/slack_notify_sql_parser.yml
+++ b/.github/workflows/slack_notify_sql_parser.yml
@@ -54,8 +54,12 @@ jobs:
             sql-parser:
               - 'src/sql-parser/**'
               - 'src/sql-lexer/**'
+              - '!**/Cargo.toml'
+              - '!**/BUILD.bazel'
             system-catalog:
               - 'src/catalog/src/builtin.rs'
+              - '!**/Cargo.toml'
+              - '!**/BUILD.bazel'
       - name: "Push to Slack"
         if: steps.filter.outputs.sql-parser == 'true' || steps.filter.outputs.system-catalog == 'true'
         uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a


### PR DESCRIPTION
As it says on the tin, filters out `BUILD.bazel` and `Cargo.toml` files from the change detection.

### Motivation

Cut down on noise for the SQL council.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
