### PR TITLE
persist: fix bug where non-struct stats caused us to skip columnar data

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -961,7 +961,10 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
                         match result {
                             Ok((struct_ext, _stats)) => struct_ext,
                             Err(err) => {
-                                tracing::error!(?err, "failed to encode in columnar format!");
+                                soft_panic_or_log!(
+                                    "failed to encode in columnar format! {:?}",
+                                    err
+                                );
                                 None
                             }
                         }
@@ -1066,7 +1069,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
 
                         // We can't collect stats if we failed to encode in a columnar format.
                         let Ok((extended_cols, stats)) = result else {
-                            tracing::error!(?result, "failed to encode in columnar format!");
+                            soft_panic_or_log!("failed to encode in columnar format! {:?}", result);
                             break 'collect_stats None;
                         };
 

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -16,7 +16,7 @@ use mz_dyncfg::{Config, ConfigSet};
 use mz_persist::indexed::columnar::ColumnarRecordsStructuredExt;
 use mz_persist::indexed::encoding::BlobTraceUpdates;
 use mz_persist_types::columnar::{codec_to_schema2, ColumnDecoder, Schema2};
-use mz_persist_types::stats::{ColumnStatKinds, PartStats};
+use mz_persist_types::stats::PartStats;
 use mz_persist_types::Codec;
 
 use crate::batch::UntrimmableColumns;
@@ -148,12 +148,6 @@ where
         .decoder_any(ext.key.as_ref())
         .map_err(|e| e.to_string())?
         .stats();
-    let key_stats = match key_stats.into_non_null_values() {
-        Some(ColumnStatKinds::Struct(stats)) => stats,
-        key_stats => Err(format!(
-            "found non-StructStats when encoding updates, {key_stats:?}"
-        ))?,
-    };
 
     Ok((Some(ext), PartStats { key: key_stats }))
 }

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -104,6 +104,7 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                 {
                     let mut x = ::mz_dyncfg::ConfigUpdates::default();
                     x.add_dynamic("persist_batch_columnar_format", ::mz_dyncfg::ConfigVal::String("both_v2".into()));
+                    x.add_dynamic("persist_batch_columnar_format_percent", ::mz_dyncfg::ConfigVal::Usize(100));
                     x.add_dynamic("persist_part_decode_format", ::mz_dyncfg::ConfigVal::String("arrow".into()));
                     x
                 },

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -9,6 +9,7 @@
 
 //! Implementations of [Codec] for stdlib types.
 
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
@@ -20,7 +21,7 @@ use bytes::{BufMut, Bytes};
 use timely::order::Product;
 
 use crate::columnar::{ColumnDecoder, ColumnEncoder, Schema2};
-use crate::stats::{ColumnarStats, NoneStats};
+use crate::stats::{ColumnStatKinds, ColumnarStats, NoneStats, StructStats};
 use crate::{Codec, Codec64, Opaque, ShardId};
 
 /// An implementation of [Schema2] for [()].
@@ -88,8 +89,11 @@ impl ColumnDecoder<()> for UnitColumnar {
         }
     }
 
-    fn stats(&self) -> ColumnarStats {
-        ColumnarStats::NONE
+    fn stats(&self) -> StructStats {
+        StructStats {
+            len: self.len,
+            cols: BTreeMap::new(),
+        }
     }
 }
 
@@ -232,8 +236,8 @@ impl<T: SimpleColumnarData> ColumnDecoder<T> for SimpleColumnarDecoder<T> {
         self.0.is_null(idx)
     }
 
-    fn stats(&self) -> ColumnarStats {
-        ColumnarStats::NONE
+    fn stats(&self) -> StructStats {
+        ColumnarStats::one_column_struct(self.0.len(), ColumnStatKinds::None)
     }
 }
 
@@ -502,7 +506,7 @@ impl<T> ColumnDecoder<T> for TodoColumnarDecoder<T> {
         panic!("TODO")
     }
 
-    fn stats(&self) -> ColumnarStats {
+    fn stats(&self) -> StructStats {
         panic!("TODO")
     }
 }

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -30,7 +30,7 @@ use arrow::array::{Array, ArrayRef, BinaryArray, BinaryBuilder};
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use crate::stats::{ColumnarStats, DynStats};
+use crate::stats::{DynStats, StructStats};
 use crate::Codec;
 
 /// A __stable__ encoding for a type that gets durably persisted in an
@@ -70,9 +70,14 @@ pub trait ColumnDecoder<T> {
     fn is_null(&self, idx: usize) -> bool;
 
     /// Returns statistics for the column. This structure is defined by Persist,
-    /// but the contents are determined by the client; Persist will preserve them
-    /// in the part metadata and make them available to readers.
-    fn stats(&self) -> ColumnarStats;
+    /// but the contents are determined by the client; Persist will preserve
+    /// them in the part metadata and make them available to readers.
+    ///
+    /// TODO: For now, we require that the stats be structured as a non-nullable
+    /// struct. For a single column, map them to a struct with a single column
+    /// named the empty string. Fix this restriction if we end up with non-test
+    /// code that isn't naturally a struct.
+    fn stats(&self) -> StructStats;
 }
 
 /// An encoder for values of a fixed schema

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -52,10 +52,17 @@ pub struct ColumnarStats {
 }
 
 impl ColumnarStats {
-    pub const NONE: Self = ColumnarStats {
-        nulls: None,
-        values: ColumnStatKinds::None,
-    };
+    /// Returns a `[StructStats]` with a single non-nullable column.
+    pub fn one_column_struct(len: usize, col: ColumnStatKinds) -> StructStats {
+        let col = ColumnarStats {
+            nulls: None,
+            values: col,
+        };
+        StructStats {
+            len,
+            cols: [("".to_owned(), col)].into_iter().collect(),
+        }
+    }
 
     /// Returns the inner [`ColumnStatKinds`] if `nulls` is [`None`].
     pub fn as_non_null_values(&self) -> Option<&ColumnStatKinds> {
@@ -355,10 +362,7 @@ impl PartStats {
         K: Schema2<T, Statistics = StructStats>,
     {
         let decoder = K::decoder_any(desc, &part.key).context("decoder_any")?;
-        let stats = decoder
-            .stats()
-            .into_struct_stats()
-            .expect("schema should generate StructStats");
+        let stats = decoder.stats();
         Ok(PartStats { key: stats })
     }
 }

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -32,13 +32,7 @@ mod tests {
         let key_col = part.key.as_struct();
         let decoder =
             <RelationDesc as Schema2<Row>>::decoder(schema, key_col.clone()).expect("success");
-        let stats = decoder.stats();
-
-        let expected = stats
-            .try_as_optional_struct()
-            .expect("key col is StructStats")
-            .some;
-        let mut actual: ProtoStructStats = RustType::into_proto(expected);
+        let mut actual: ProtoStructStats = RustType::into_proto(&decoder.stats());
 
         // It's not particularly easy to give StructStats a PartialEq impl, but
         // verifying that there weren't any panics gets us pretty far.

--- a/src/storage-types/src/stats.rs
+++ b/src/storage-types/src/stats.rs
@@ -244,10 +244,7 @@ mod tests {
         let key_col = part.key.as_struct();
         let decoder = <RelationDesc as Schema2<SourceData>>::decoder(&schema, key_col.clone())
             .expect("success");
-        let key_stats = decoder
-            .stats()
-            .into_struct_stats()
-            .expect("key col is StructStats");
+        let key_stats = decoder.stats();
 
         let metrics = PartStatsMetrics::new(&MetricsRegistry::new());
         let stats = RelationPartStats {
@@ -371,10 +368,7 @@ mod tests {
             let key_col = part.key.as_struct();
             let decoder = <RelationDesc as Schema2<SourceData>>::decoder(&desc, key_col.clone())
                 .expect("success");
-            let key_stats = decoder
-                .stats()
-                .into_struct_stats()
-                .expect("key col is StructStats");
+            let key_stats = decoder.stats();
 
             all_stats.push(key_stats);
         }


### PR DESCRIPTION
`encode_updates` returned an `Err` if either it was unable to encode the data into structured arrow data OR if it was unable to turn the stats into a non-nullable `StructStats`. It turns out that all persist unit tests were returning an unexpected stats type, and so we essentially had much less test coverage than we thought. We were logging an `error!` (thankfully, it doesn't seem to be showing up in sentry), but this wasn't loud enough that we noticed until now.

So, replace the error log with a `soft_assert_or_log!` so that tests (and CI) fail loudly when something unexpected happens. Then fix the new failures :). We could make non-struct stats roundtrip, but it'd be Work and Code and unused in production, so instead require `ColumnDecoder` implementations to figure out how to map themselves into `StructStats`. We can always extend this support later, if needed.

### Motivation

  * This PR fixes a previously unreported bug.


### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
