### PR TITLE
ci: build bazel on macos too

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -76,6 +76,21 @@ steps:
         agents:
           queue: builder-linux-aarch64
 
+      - id: build-macos-bazel
+        label: ":bazel: Build macos"
+        command: bin/ci-builder run stable bin/bazel-temp
+        inputs:
+          - "*"
+          - "WORKSPACE"
+          - ".bazelrc"
+          - "**/*.bzl"
+        depends_on: []
+        timeout_in_minutes: 30
+        agents:
+          queue: mac
+        coverage: skip
+        sanitizer: skip
+
       - id: build-wasm
         label: Build WASM
         command: bin/ci-builder run stable bin/pyactivate -m ci.deploy.npm --no-release


### PR DESCRIPTION
This plus pushing to the remote cache should be enough to allow engineers working on macos to get bazel cache hits.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
