### PR TITLE
bazel: tweak `.bazelrc` for better remote caching

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,6 +29,9 @@ common --copt=-mmacosx-version-min=14.0
 common --linkopt=-mmacosx-version-min=14.0
 common --macos_sdk_version=14.0
 
+common --copt=-Wno-unused-command-line-argument
+common --linkopt=-Wno-unused-command-line-argument
+
 # Config for building protobuf.
 build --copt=-Wno-error=deprecated-declarations
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -28,7 +28,8 @@ build --incompatible_strict_action_env
 common --copt=-mmacosx-version-min=14.0
 common --linkopt=-mmacosx-version-min=14.0
 common --macos_sdk_version=14.0
-
+# Note(parkmycar): Ideally we would error on unused command line arguments, but
+# trying to constrain the above arguments to just macos doesn't seem to work.
 common --copt=-Wno-unused-command-line-argument
 common --linkopt=-Wno-unused-command-line-argument
 
@@ -60,7 +61,7 @@ build:macos --experimental_inmemory_sandbox_stashes
 
 # Always have Bazel output why it rebuilt something, should make debugging builds easier.
 #
-# TODO(parkmycar): Enable this under a "debug" or "verbose" 
+# TODO(parkmycar): Enable this under a "debug" or "verbose"
 # common --explain=bazel-explain.log
 # common --verbose_explanations
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -25,8 +25,8 @@ build --incompatible_strict_action_env
 
 # Bazel provides the macOS 14.5 SDK as the sysroot, we also set the minimum
 # version to prevent breaking the remote cache across developer machines.
-common:macos --copt=-mmacosx-version-min=14.0
-common:macos --linkopt=-mmacosx-version-min=14.0
+common --copt=-mmacosx-version-min=14.0
+common --linkopt=-mmacosx-version-min=14.0
 common --macos_sdk_version=14.0
 
 # Config for building protobuf.
@@ -56,8 +56,10 @@ build:macos --experimental_inprocess_symlink_creation
 build:macos --experimental_inmemory_sandbox_stashes
 
 # Always have Bazel output why it rebuilt something, should make debugging builds easier.
-common --explain=bazel-explain.log
-common --verbose_explanations
+#
+# TODO(parkmycar): Enable this under a "debug" or "verbose" 
+# common --explain=bazel-explain.log
+# common --verbose_explanations
 
 # Compress any artifacts larger than 2MiB with zstd.
 common --remote_cache_compression


### PR DESCRIPTION
After experiments with @danhhz these are the tweaks we needed to get remote caching working.

* Always set `-mmacosx-version-min` C flag
* Comment out bazel explains for now. This one wasn't actually needed but is something I've been meaning to do

### Tips for reviewer

Progress towards https://github.com/MaterializeInc/materialize/issues/26796

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
