### PR TITLE
canary cloud test: Increase sleep before creating privatelink source

### DIFF
--- a/test/cloud-canary/canary-redpanda-privatelink-sources.td
+++ b/test/cloud-canary/canary-redpanda-privatelink-sources.td
@@ -21,7 +21,7 @@ abc:abc
 > VALIDATE CONNECTION privatelink_conn;
 
 # When run immediately: ERROR: Meta data fetch error: BrokerTransportFailure
-$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=60s
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=120s
 
 > CREATE CONNECTION redpanda_privatelink_conn TO KAFKA (
   AWS PRIVATELINK privatelink_conn (PORT 30292),


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/9303

@bobbyiliev @jubrad Do you know if this is expected not to work immediately? If not, I'll open an issue

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
