### PR TITLE
adapter,controller: exclude new builtins from hydration check

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -555,6 +555,7 @@ impl Catalog {
             catalog,
             storage_collections_to_drop: _,
             migrated_storage_collections_0dt: _,
+            new_builtins: _,
             builtin_table_updates: _,
         } = Catalog::open(Config {
             storage,

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -531,11 +531,11 @@ impl Coordinator {
                 }
             }
         }
-        let hydrated = match self
-            .controller
-            .compute
-            .all_collections_hydrated_for_replicas(cluster.id, pending_replicas)
-        {
+        let hydrated = match self.controller.compute.collections_hydrated_for_replicas(
+            cluster.id,
+            pending_replicas,
+            &[].into(),
+        ) {
             Err(e) => {
                 return Err(AdapterError::internal("Failed to check hydration", e));
             }

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -532,6 +532,7 @@ async fn upgrade_check(
         state: _state,
         storage_collections_to_drop: _,
         migrated_storage_collections_0dt: _,
+        new_builtins: _,
         builtin_table_updates: _,
         last_seen_version,
     } = Catalog::initialize_state(


### PR DESCRIPTION
This PR adjusts the 0dt hydration check to exclude newly created builtin objects. These objects are sometimes not able to hydrate because neither the old nor the new environment is writing to them. Excluding them from the check is fine: Clients connected to the old environment don't know of their existence, so no downtime is induced when they are not immediately hydrated after the cutover.

I've rebased https://github.com/MaterializeInc/materialize/pull/29254 on top of this PR, to verify that this indeed fixes the problem with failing 0dt upgrades when there is are new builtin objects.

### Motivation

  * This PR fixes a previously unreported bug.

The 0dt checks in CI fail on PRs that introduce a new indexed `BuiltinSource`.

[See Slack thread.](https://materializeinc.slack.com/archives/C071VTZS1M5/p1724855629186419)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
