### PR TITLE
ci: Don't terminate buildkite-agent after failed job

### DIFF
--- a/ci/plugins/cloudtest/hooks/post-command
+++ b/ci/plugins/cloudtest/hooks/post-command
@@ -58,6 +58,7 @@ if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
           rm coverage/"$BUILDKITE_JOB_ID"-*.lcov
           bin/ci-builder run stable zstd coverage/"$BUILDKITE_JOB_ID".lcov
           buildkite-agent artifact upload coverage/"$BUILDKITE_JOB_ID".lcov.zst
+          rm -rf coverage
         fi
     fi
 fi

--- a/ci/plugins/cloudtest/hooks/pre-exit
+++ b/ci/plugins/cloudtest/hooks/pre-exit
@@ -13,11 +13,5 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
-if [ "$BUILDKITE_COMMAND_EXIT_STATUS" -ne "0" ] || [ "$BUILDKITE_LAST_HOOK_EXIT_STATUS" -ne "0" ]; then
-   ci_unimportant_heading "Buildkite job failure reported, terminating the Buildkite agent in case it is tainted"
-   # Supposedly the 'official' way of terminating the buildkite agent
-   kill -s SIGTERM "$(/bin/pidof buildkite-agent)"
-fi
-
 ci_unimportant_heading "cloudtest: Resetting..."
 bin/ci-builder run stable test/cloudtest/reset

--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -13,12 +13,6 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
-if [ "$BUILDKITE_COMMAND_EXIT_STATUS" -ne "0" ] || [ "$BUILDKITE_LAST_HOOK_EXIT_STATUS" -ne "0" ]; then
-   ci_unimportant_heading "Buildkite job failure reported, terminating the Buildkite agent in case it is tainted"
-   # Supposedly the 'official' way of terminating the buildkite agent
-   kill -s SIGTERM "$(/bin/pidof buildkite-agent)"
-fi
-
 ci_unimportant_heading ":docker: Cleaning up after mzcompose"
 
 run() {


### PR DESCRIPTION
This stopped working anyway:

> /var/lib/buildkite-agent/builds/hetzner-aarch64-4cpu-8gb-e32bf9b3/materialize/coverage/ci/plugins/mzcompose/hooks/pre-exit: line 19: kill: 2813 2789: arguments must be process or job IDs

We have more reliable methods of regaining disk space. Reverts https://github.com/MaterializeInc/materialize/pull/22131

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
