### PR TITLE
Window function fusion

### DIFF
--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -247,6 +247,9 @@ impl From<&OptimizerConfig> for mz_sql::plan::HirToMirConfig {
             enable_new_outer_join_lowering: config.features.enable_new_outer_join_lowering,
             enable_variadic_left_join_lowering: config.features.enable_variadic_left_join_lowering,
             enable_outer_join_null_filter: config.features.enable_outer_join_null_filter,
+            enable_value_window_function_fusion: config
+                .features
+                .enable_value_window_function_fusion,
         }
     }
 }

--- a/src/compute-types/src/plan/reduce.rs
+++ b/src/compute-types/src/plan/reduce.rs
@@ -997,7 +997,8 @@ pub fn reduction_type(func: &AggregateFunc) -> ReductionType {
         | AggregateFunc::LagLead { .. }
         | AggregateFunc::FirstValue { .. }
         | AggregateFunc::LastValue { .. }
-        | AggregateFunc::WindowAggregate { .. } => ReductionType::Basic,
+        | AggregateFunc::WindowAggregate { .. }
+        | AggregateFunc::FusedValueWindowFunc { .. } => ReductionType::Basic,
     }
 }
 

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -2414,7 +2414,8 @@ mod monoids {
             | AggregateFunc::LagLead { .. }
             | AggregateFunc::FirstValue { .. }
             | AggregateFunc::LastValue { .. }
-            | AggregateFunc::WindowAggregate { .. } => None,
+            | AggregateFunc::WindowAggregate { .. }
+            | AggregateFunc::FusedValueWindowFunc { .. } => None,
         }
     }
 }

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -788,8 +788,8 @@ where
                     let key_len = datums_local.len();
                     datums_local.push(
                         // Note that this is not necessarily a window aggregation, in which case
-                        // `eval_fast_window_agg` delegates to the normal `eval`.
-                        func.eval_fast_window_agg::<_, window_agg_helpers::OneByOneAggrImpls>(
+                        // `eval_with_fast_window_agg` delegates to the normal `eval`.
+                        func.eval_with_fast_window_agg::<_, window_agg_helpers::OneByOneAggrImpls>(
                             iter,
                             &temp_storage,
                         ),
@@ -845,7 +845,7 @@ where
                         let mut datums_local = datums2.borrow();
                         datums_local.extend(datum_iter);
                         datums_local.push(
-                            func2.eval_fast_window_agg::<_, window_agg_helpers::OneByOneAggrImpls>(
+                            func2.eval_with_fast_window_agg::<_, window_agg_helpers::OneByOneAggrImpls>(
                                 iter,
                                 &temp_storage,
                             ),

--- a/src/expr/src/relation.proto
+++ b/src/expr/src/relation.proto
@@ -84,6 +84,11 @@ message ProtoAggregateFunc {
         mz_expr.relation.ProtoWindowFrame window_frame = 3;
     }
 
+    message ProtoFusedValueWindowFunc {
+        repeated ProtoAggregateFunc funcs = 1;
+        ProtoColumnOrders order_by = 2;
+    }
+
     message ProtoMapAgg {
         ProtoColumnOrders order_by = 1;
         mz_repr.relation_and_scalar.ProtoScalarType value_type = 2;
@@ -136,6 +141,7 @@ message ProtoAggregateFunc {
         ProtoFramedWindowFunc first_value = 41;
         ProtoFramedWindowFunc last_value = 42;
         ProtoWindowAggregate window_aggregate = 55;
+        ProtoFusedValueWindowFunc fused_value_window_func = 57;
         google.protobuf.Empty max_uint16 = 43;
         google.protobuf.Empty max_uint32 = 44;
         google.protobuf.Empty max_uint64 = 45;

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -1862,7 +1862,54 @@ impl AggregateFunc {
             AggregateFunc::FirstValue { .. } => Datum::empty_list(),
             AggregateFunc::LastValue { .. } => Datum::empty_list(),
             AggregateFunc::WindowAggregate { .. } => Datum::empty_list(),
-            _ => Datum::Null,
+            AggregateFunc::MaxNumeric
+            | AggregateFunc::MaxInt16
+            | AggregateFunc::MaxInt32
+            | AggregateFunc::MaxInt64
+            | AggregateFunc::MaxUInt16
+            | AggregateFunc::MaxUInt32
+            | AggregateFunc::MaxUInt64
+            | AggregateFunc::MaxMzTimestamp
+            | AggregateFunc::MaxFloat32
+            | AggregateFunc::MaxFloat64
+            | AggregateFunc::MaxBool
+            | AggregateFunc::MaxString
+            | AggregateFunc::MaxDate
+            | AggregateFunc::MaxTimestamp
+            | AggregateFunc::MaxTimestampTz
+            | AggregateFunc::MaxInterval
+            | AggregateFunc::MaxTime
+            | AggregateFunc::MinNumeric
+            | AggregateFunc::MinInt16
+            | AggregateFunc::MinInt32
+            | AggregateFunc::MinInt64
+            | AggregateFunc::MinUInt16
+            | AggregateFunc::MinUInt32
+            | AggregateFunc::MinUInt64
+            | AggregateFunc::MinMzTimestamp
+            | AggregateFunc::MinFloat32
+            | AggregateFunc::MinFloat64
+            | AggregateFunc::MinBool
+            | AggregateFunc::MinString
+            | AggregateFunc::MinDate
+            | AggregateFunc::MinTimestamp
+            | AggregateFunc::MinTimestampTz
+            | AggregateFunc::MinInterval
+            | AggregateFunc::MinTime
+            | AggregateFunc::SumInt16
+            | AggregateFunc::SumInt32
+            | AggregateFunc::SumInt64
+            | AggregateFunc::SumUInt16
+            | AggregateFunc::SumUInt32
+            | AggregateFunc::SumUInt64
+            | AggregateFunc::SumFloat32
+            | AggregateFunc::SumFloat64
+            | AggregateFunc::SumNumeric
+            | AggregateFunc::Count
+            | AggregateFunc::JsonbAgg { .. }
+            | AggregateFunc::JsonbObjectAgg { .. }
+            | AggregateFunc::MapAgg { .. }
+            | AggregateFunc::StringAgg { .. } => Datum::Null,
         }
     }
 
@@ -2001,10 +2048,47 @@ impl AggregateFunc {
                     custom_id: None,
                 }
             }
+            AggregateFunc::Dummy
+            | AggregateFunc::MaxNumeric
+            | AggregateFunc::MaxInt16
+            | AggregateFunc::MaxInt32
+            | AggregateFunc::MaxInt64
+            | AggregateFunc::MaxUInt16
+            | AggregateFunc::MaxUInt32
+            | AggregateFunc::MaxUInt64
+            | AggregateFunc::MaxMzTimestamp
+            | AggregateFunc::MaxFloat32
+            | AggregateFunc::MaxFloat64
+            | AggregateFunc::MaxBool
             // Note AggregateFunc::MaxString, MinString rely on returning input
             // type as output type to support the proper return type for
             // character input.
-            _ => input_type.scalar_type.clone(),
+            | AggregateFunc::MaxString
+            | AggregateFunc::MaxDate
+            | AggregateFunc::MaxTimestamp
+            | AggregateFunc::MaxTimestampTz
+            | AggregateFunc::MaxInterval
+            | AggregateFunc::MaxTime
+            | AggregateFunc::MinNumeric
+            | AggregateFunc::MinInt16
+            | AggregateFunc::MinInt32
+            | AggregateFunc::MinInt64
+            | AggregateFunc::MinUInt16
+            | AggregateFunc::MinUInt32
+            | AggregateFunc::MinUInt64
+            | AggregateFunc::MinMzTimestamp
+            | AggregateFunc::MinFloat32
+            | AggregateFunc::MinFloat64
+            | AggregateFunc::MinBool
+            | AggregateFunc::MinString
+            | AggregateFunc::MinDate
+            | AggregateFunc::MinTimestamp
+            | AggregateFunc::MinTimestampTz
+            | AggregateFunc::MinInterval
+            | AggregateFunc::MinTime
+            | AggregateFunc::SumFloat32
+            | AggregateFunc::SumFloat64
+            | AggregateFunc::SumNumeric => input_type.scalar_type.clone(),
         };
         // Count never produces null, and other aggregations only produce
         // null in the presence of null inputs.

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -1813,7 +1813,11 @@ impl AggregateFunc {
     /// Like `eval`, but it's given a [OneByOneAggr]. If `self` is a `WindowAggregate`, then
     /// the given [OneByOneAggr] will be used to evaluate the wrapped aggregate inside the
     /// `WindowAggregate`. If `self` is not a `WindowAggregate`, then it simply calls `eval`.
-    pub fn eval_fast_window_agg<'a, I, W>(&self, datums: I, temp_storage: &'a RowArena) -> Datum<'a>
+    pub fn eval_with_fast_window_agg<'a, I, W>(
+        &self,
+        datums: I,
+        temp_storage: &'a RowArena,
+    ) -> Datum<'a>
     where
         I: IntoIterator<Item = Datum<'a>>,
         W: OneByOneAggr,

--- a/src/expr/src/scalar/func/impls/record.rs
+++ b/src/expr/src/scalar/func/impls/record.rs
@@ -162,7 +162,10 @@ impl LazyUnaryFunc for RecordGet {
                 ty.nullable = ty.nullable || input_type.nullable;
                 ty
             }
-            _ => unreachable!("RecordGet specified nonexistent field"),
+            _ => unreachable!(
+                "RecordGet on non-record input: {:?}",
+                input_type.scalar_type
+            ),
         }
     }
 

--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -117,6 +117,8 @@ optimizer_feature_flags!({
     // Reoptimize imported views when building and optimizing a
     // `DataflowDescription` in the global MIR optimization phase.
     reoptimize_imported_views: bool,
+    // Enables the value window function fusion optimization.
+    enable_value_window_function_fusion: bool,
 });
 
 /// A trait used to implement layered config construction.

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -2652,6 +2652,21 @@ impl ScalarType {
         }
     }
 
+    /// Returns vector of [`ColumnType`] elements in a [`ScalarType::Record`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on anything other than a [`ScalarType::Record`].
+    pub fn unwrap_record_element_column_type(&self) -> Vec<&ColumnType> {
+        match self {
+            ScalarType::Record { fields, .. } => fields.iter().map(|(_, t)| t).collect_vec(),
+            _ => panic!(
+                "ScalarType::unwrap_record_element_column_type called on {:?}",
+                self
+            ),
+        }
+    }
+
     /// Returns number of dimensions/axes (also known as "rank") on a
     /// [`ScalarType::List`].
     ///

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -178,6 +178,7 @@ From
 Full
 Fullname
 Function
+Fusion
 Generator
 Grant
 Greatest

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2024,6 +2024,7 @@ pub enum ClusterFeatureName {
     EnableVariadicLeftJoinLowering,
     EnableLetrecFixpointAnalysis,
     EnableOuterJoinNullFilter,
+    EnableValueWindowFunctionFusion,
 }
 
 impl WithOptionName for ClusterFeatureName {
@@ -2039,7 +2040,8 @@ impl WithOptionName for ClusterFeatureName {
             | Self::EnableEagerDeltaJoins
             | Self::EnableVariadicLeftJoinLowering
             | Self::EnableLetrecFixpointAnalysis
-            | Self::EnableOuterJoinNullFilter => false,
+            | Self::EnableOuterJoinNullFilter
+            | Self::EnableValueWindowFunctionFusion => false,
         }
     }
 }
@@ -3566,6 +3568,7 @@ pub enum ExplainPlanOptionName {
     EnableVariadicLeftJoinLowering,
     EnableLetrecFixpointAnalysis,
     EnableOuterJoinNullFilter,
+    EnableValueWindowFunctionFusion,
 }
 
 impl WithOptionName for ExplainPlanOptionName {
@@ -3600,7 +3603,8 @@ impl WithOptionName for ExplainPlanOptionName {
             | Self::EnableEagerDeltaJoins
             | Self::EnableVariadicLeftJoinLowering
             | Self::EnableLetrecFixpointAnalysis
-            | Self::EnableOuterJoinNullFilter => false,
+            | Self::EnableOuterJoinNullFilter
+            | Self::EnableValueWindowFunctionFusion => false,
         }
     }
 }

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -1213,7 +1213,54 @@ impl AggregateFunc {
             AggregateFunc::Dummy => Datum::Dummy,
             AggregateFunc::ArrayConcat { .. } => Datum::empty_array(),
             AggregateFunc::ListConcat { .. } => Datum::empty_list(),
-            _ => Datum::Null,
+            AggregateFunc::MaxNumeric
+            | AggregateFunc::MaxInt16
+            | AggregateFunc::MaxInt32
+            | AggregateFunc::MaxInt64
+            | AggregateFunc::MaxUInt16
+            | AggregateFunc::MaxUInt32
+            | AggregateFunc::MaxUInt64
+            | AggregateFunc::MaxMzTimestamp
+            | AggregateFunc::MaxFloat32
+            | AggregateFunc::MaxFloat64
+            | AggregateFunc::MaxBool
+            | AggregateFunc::MaxString
+            | AggregateFunc::MaxDate
+            | AggregateFunc::MaxTimestamp
+            | AggregateFunc::MaxTimestampTz
+            | AggregateFunc::MaxInterval
+            | AggregateFunc::MaxTime
+            | AggregateFunc::MinNumeric
+            | AggregateFunc::MinInt16
+            | AggregateFunc::MinInt32
+            | AggregateFunc::MinInt64
+            | AggregateFunc::MinUInt16
+            | AggregateFunc::MinUInt32
+            | AggregateFunc::MinUInt64
+            | AggregateFunc::MinMzTimestamp
+            | AggregateFunc::MinFloat32
+            | AggregateFunc::MinFloat64
+            | AggregateFunc::MinBool
+            | AggregateFunc::MinString
+            | AggregateFunc::MinDate
+            | AggregateFunc::MinTimestamp
+            | AggregateFunc::MinTimestampTz
+            | AggregateFunc::MinInterval
+            | AggregateFunc::MinTime
+            | AggregateFunc::SumInt16
+            | AggregateFunc::SumInt32
+            | AggregateFunc::SumInt64
+            | AggregateFunc::SumUInt16
+            | AggregateFunc::SumUInt32
+            | AggregateFunc::SumUInt64
+            | AggregateFunc::SumFloat32
+            | AggregateFunc::SumFloat64
+            | AggregateFunc::SumNumeric
+            | AggregateFunc::Count
+            | AggregateFunc::JsonbAgg { .. }
+            | AggregateFunc::JsonbObjectAgg { .. }
+            | AggregateFunc::MapAgg { .. }
+            | AggregateFunc::StringAgg { .. } => Datum::Null,
         }
     }
 
@@ -1249,7 +1296,44 @@ impl AggregateFunc {
                     _ => unreachable!(),
                 }
             }
-            _ => input_type.scalar_type,
+            AggregateFunc::MaxNumeric
+            | AggregateFunc::MaxInt16
+            | AggregateFunc::MaxInt32
+            | AggregateFunc::MaxInt64
+            | AggregateFunc::MaxUInt16
+            | AggregateFunc::MaxUInt32
+            | AggregateFunc::MaxUInt64
+            | AggregateFunc::MaxMzTimestamp
+            | AggregateFunc::MaxFloat32
+            | AggregateFunc::MaxFloat64
+            | AggregateFunc::MaxBool
+            | AggregateFunc::MaxString
+            | AggregateFunc::MaxDate
+            | AggregateFunc::MaxTimestamp
+            | AggregateFunc::MaxTimestampTz
+            | AggregateFunc::MaxInterval
+            | AggregateFunc::MaxTime
+            | AggregateFunc::MinNumeric
+            | AggregateFunc::MinInt16
+            | AggregateFunc::MinInt32
+            | AggregateFunc::MinInt64
+            | AggregateFunc::MinUInt16
+            | AggregateFunc::MinUInt32
+            | AggregateFunc::MinUInt64
+            | AggregateFunc::MinMzTimestamp
+            | AggregateFunc::MinFloat32
+            | AggregateFunc::MinFloat64
+            | AggregateFunc::MinBool
+            | AggregateFunc::MinString
+            | AggregateFunc::MinDate
+            | AggregateFunc::MinTimestamp
+            | AggregateFunc::MinTimestampTz
+            | AggregateFunc::MinInterval
+            | AggregateFunc::MinTime
+            | AggregateFunc::SumFloat32
+            | AggregateFunc::SumFloat64
+            | AggregateFunc::SumNumeric
+            | AggregateFunc::Dummy => input_type.scalar_type,
         };
         // max/min/sum return null on empty sets
         let nullable = !matches!(self, AggregateFunc::Count);

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -234,10 +234,10 @@ pub struct WindowExpr {
     pub partition_by: Vec<HirScalarExpr>,
     // ORDER BY is represented in a complicated way: `plan_function_order_by` gave us two things:
     //  - the `ColumnOrder`s we have put in the `order_by` fields in the `WindowExprType` in `func`
-    //   above,
+    //    above,
     //  - the `HirScalarExpr`s we have put in the following `order_by` field.
     // These are separated because they are used in different places: the outer `order_by` is used
-    // in the lowering: based on it, we construct a Row that has all the values of the scalar exprs;
+    // in the lowering: based on it, we create a Row constructor that collects the scalar exprs;
     // the inner `order_by` is used in the rendering to actually execute the ordering on these Rows.
     // (`WindowExpr` exists only in HIR, but not in MIR.)
     // Note that the `column` field in the `ColumnOrder`s point into the Row constructed in the
@@ -533,10 +533,11 @@ impl ScalarWindowFunc {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ValueWindowExpr {
     pub func: ValueWindowFunc,
-    // If the argument list has a single element (e.g., for `first_value`), then it's that element.
-    // If the argument list has multiple elements (e.g., for `lag`), then it's encoded in a record,
-    // e.g., `row(#1, 3, null)`.
+    /// If the argument list has a single element (e.g., for `first_value`), then it's that element.
+    /// If the argument list has multiple elements (e.g., for `lag`), then it's encoded in a record,
+    /// e.g., `row(#1, 3, null)`.
     pub args: Box<HirScalarExpr>,
+    /// See comment on `WindowExpr::order_by`.
     pub order_by: Vec<ColumnOrder>,
     pub window_frame: WindowFrame,
     pub ignore_nulls: bool,

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -190,6 +190,7 @@ impl HirRelationExpr {
                     let mut id_gen = mz_ore::id_gen::IdGen::default();
                     transform_expr::split_subquery_predicates(&mut other);
                     transform_expr::try_simplify_quantified_comparisons(&mut other);
+                    transform_expr::fuse_window_functions(&mut other)?;
                     MirRelationExpr::constant(vec![vec![]], RelationType::new(vec![]))
                         .let_in_fallible(&mut id_gen, |id_gen, get_outer| {
                             other.applied_to(
@@ -455,6 +456,7 @@ impl HirRelationExpr {
                                 requires_nonexistent_column
                             })
                             .unwrap_or(scalars.len());
+                        assert!(end_idx > 0, "a Map expression references itself or a later column; lowered_arity: {}, expressions: {:?}", lowered_arity, scalars);
 
                         lowered_arity = lowered_arity + end_idx;
                         let scalars = scalars.drain(0..end_idx).collect_vec();

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -1201,7 +1201,10 @@ impl HirScalarExpr {
                                 .typ(&get_inner.typ().column_types)
                                 .scalar_type;
 
-                            // Build a new record with the original row in a record in a list + the encoded args in a record
+                            // Build a new record that has two fields:
+                            // 1. the original row in a record
+                            // 2. the encoded args (which can be either a single value, or a record
+                            //    if the window function has multiple arguments, such as `lag`)
                             let fn_input_record_fields =
                                 [original_row_record_type, mir_encoded_args_type]
                                     .iter()

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3510,7 +3510,8 @@ generate_extracted_config!(
     (EnableNewOuterJoinLowering, Option<bool>, Default(None)),
     (EnableVariadicLeftJoinLowering, Option<bool>, Default(None)),
     (EnableLetrecFixpointAnalysis, Option<bool>, Default(None)),
-    (EnableOuterJoinNullFilter, Option<bool>, Default(None))
+    (EnableOuterJoinNullFilter, Option<bool>, Default(None)),
+    (EnableValueWindowFunctionFusion, Option<bool>, Default(None))
 );
 
 /// Convert a [`CreateClusterStatement`] into a [`Plan`].
@@ -3648,6 +3649,7 @@ pub fn plan_create_cluster_inner(
             enable_variadic_left_join_lowering,
             enable_letrec_fixpoint_analysis,
             enable_outer_join_null_filter,
+            enable_value_window_function_fusion,
             seen: _,
         } = ClusterFeatureExtracted::try_from(features)?;
         let optimizer_feature_overrides = OptimizerFeatureOverrides {
@@ -3657,6 +3659,7 @@ pub fn plan_create_cluster_inner(
             enable_variadic_left_join_lowering,
             enable_letrec_fixpoint_analysis,
             enable_outer_join_null_filter,
+            enable_value_window_function_fusion,
             ..Default::default()
         };
 
@@ -3752,6 +3755,7 @@ pub fn unplan_create_cluster(
                 enable_variadic_left_join_lowering,
                 enable_letrec_fixpoint_analysis,
                 enable_outer_join_null_filter,
+                enable_value_window_function_fusion,
             } = optimizer_feature_overrides;
             let features_extracted = ClusterFeatureExtracted {
                 // Seen is ignored when unplanning.
@@ -3762,6 +3766,7 @@ pub fn unplan_create_cluster(
                 enable_variadic_left_join_lowering,
                 enable_letrec_fixpoint_analysis,
                 enable_outer_join_null_filter,
+                enable_value_window_function_fusion,
             };
             let features = features_extracted.into_values(scx.catalog);
             let availability_zones = if availability_zones.is_empty() {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -365,7 +365,8 @@ generate_extracted_config!(
     (EnableEagerDeltaJoins, Option<bool>, Default(None)),
     (EnableVariadicLeftJoinLowering, Option<bool>, Default(None)),
     (EnableLetrecFixpointAnalysis, Option<bool>, Default(None)),
-    (EnableOuterJoinNullFilter, Option<bool>, Default(None))
+    (EnableOuterJoinNullFilter, Option<bool>, Default(None)),
+    (EnableValueWindowFunctionFusion, Option<bool>, Default(None))
 );
 
 impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
@@ -417,6 +418,7 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 enable_cardinality_estimates: Default::default(),
                 persist_fast_path_limit: Default::default(),
                 reoptimize_imported_views: v.reoptimize_imported_views,
+                enable_value_window_function_fusion: v.enable_value_window_function_fusion,
             },
         })
     }

--- a/src/sql/src/plan/transform_expr.rs
+++ b/src/sql/src/plan/transform_expr.rs
@@ -353,7 +353,13 @@ fn column_type(
 /// should be to columns that are earlier than the first element of the group. (No need to check
 /// column references in the other direction, i.e., references in other expressions that refer to
 /// columns in the group.)
-pub fn fuse_window_functions(root: &mut HirRelationExpr) -> Result<(), RecursionLimitError> {
+pub fn fuse_window_functions(
+    root: &mut HirRelationExpr,
+    context: &crate::plan::lowering::Context,
+) -> Result<(), RecursionLimitError> {
+    if !context.config.enable_value_window_function_fusion {
+        return Ok(());
+    }
 
     impl HirScalarExpr {
         /// Similar to `MirScalarExpr::support`, but adapted to `HirScalarExpr` in a special way: it

--- a/src/sql/src/plan/transform_expr.rs
+++ b/src/sql/src/plan/transform_expr.rs
@@ -9,14 +9,22 @@
 
 //! Transformations of SQL IR, before decorrelation.
 
-use std::collections::BTreeMap;
-use std::mem;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::LazyLock;
+use std::{iter, mem};
 
-use mz_expr::VariadicFunc;
-use mz_repr::{ColumnType, RelationType, ScalarType};
+use itertools::Itertools;
+use mz_expr::visit::Visit;
+use mz_expr::WindowFrame;
+use mz_expr::{ColumnOrder, UnaryFunc, VariadicFunc};
+use mz_ore::stack::RecursionLimitError;
+use mz_repr::{ColumnName, ColumnType, RelationType, ScalarType};
 
-use crate::plan::expr::{AbstractExpr, AggregateFunc, HirRelationExpr, HirScalarExpr};
+use crate::plan::expr::{
+    AbstractExpr, AggregateFunc, ColumnRef, HirRelationExpr, HirScalarExpr, ValueWindowExpr,
+    ValueWindowFunc, WindowExpr,
+};
+use crate::plan::WindowExprType;
 
 /// Rewrites predicates that contain subqueries so that the subqueries
 /// appear in their own later predicate when possible.
@@ -279,4 +287,341 @@ fn column_type(
 ) -> ColumnType {
     let inner_type = inner.typ(outers, &NO_PARAMS);
     expr.typ(outers, &inner_type, &NO_PARAMS)
+}
+
+/// # Aims and scope
+///
+/// The aim here is to amortize the overhead of the MIR window function pattern
+/// (see `window_func_applied_to`) by fusing groups of window function calls such
+/// that each group can be performed by one instance of the window function MIR
+/// pattern.
+///
+/// For now, we fuse only value window function calls (`WindowExprType::Value`).
+/// TODO: We should consider fusing the other types later:
+/// - `WindowExprType::Aggregate`: Would be great to also fuse these soon, see e.g.
+///   <https://github.com/MaterializeInc/materialize/issues/20741#issuecomment-2231723718>
+/// - `WindowExprType::Scalar`: probably won't need to fuse these for a long time.)
+///
+/// For now, we can fuse value window function calls where the
+/// A. partition by
+/// B. order by
+/// C. window frame
+/// D. ignore nulls
+/// are all the same. (See `extract_options`.)
+/// (Later, we could improve this to only need A. to be the same. This would require
+/// much more code changes, because then we'd have to blow up `ValueWindowExpr`.
+/// TODO: As a much simpler intermediate step, at least we should ignore options that
+/// don't matter. For example, we should be able to fuse a `lag` that has a default
+/// frame with a `first_value` that has some custom frame, because `lag` is not
+/// affected by the frame.)
+///
+/// # Implementation
+///
+/// At a high level, what we are going to do is look for Maps with more than one window function
+/// calls, and for each Map
+/// - remove some groups of window function call expressions from the Map's `scalars`;
+/// - insert a fused version of each group;
+/// - insert some expressions that decompose the results of the fused calls;
+/// - update some column references in `scalars`: those that refer to window function results that
+///   participated in fusion, as well as those that refer to columns that moved around due to
+///   removing and inserting expressions.
+/// - insert a Project above the matched Map to permute columns back to their original places.
+///
+/// It would be tempting to find groups simply by taking a list of all value window function calls
+/// and calling `group_by` with a key function that extracts the above A. B. C. D. properties,
+/// but a complication is that the possible groups that we could theoretically fuse overlap.
+/// This is because when forming groups we need to also take into account column references
+/// that point inside the same Map. For example, imagine a Map with the following scalar
+/// expressions:
+/// C1, E1, C2, C3, where
+/// - E1 refers to C1
+/// - C3 refers to E1.
+/// In this situation, we could either
+/// - fuse C1 and C2, and put the fused expression in the place of C1 (so that E1 can keep referring
+///   to it);
+/// - or fuse C2 and C3.
+/// However, we can't fuse all of C1, C2, C3 into one call, because then there would be
+/// no appropriate place for the fused expression: it would have to be both before and after E1.
+///
+/// So, how we actually form the groups is that, keeping track of a list of non-overlapping groups,
+/// we go through `scalars`, try to put each expression into each of our groups, and the first of
+/// these succeed. When trying to put an expression into a group, we need to be mindful about column
+/// references inside the same Map, as noted above. A constraint that we impose on ourselves for
+/// sanity is that the fused version of each group will be inserted at the place where the first
+/// element of the group originally was. This means that the only condition that we need to check on
+/// column references when adding an expression to a group is that all column references in a group
+/// should be to columns that are earlier than the first element of the group. (No need to check
+/// column references in the other direction, i.e., references in other expressions that refer to
+/// columns in the group.)
+pub fn fuse_window_functions(root: &mut HirRelationExpr) -> Result<(), RecursionLimitError> {
+
+    impl HirScalarExpr {
+        /// Similar to `MirScalarExpr::support`, but adapted to `HirScalarExpr` in a special way: it
+        /// considers column references that target the root level.
+        /// (See `visit_columns_referring_to_root_level`.)
+        fn support(&self) -> Vec<usize> {
+            let mut result = Vec::new();
+            self.visit_columns_referring_to_root_level(&mut |c| result.push(c));
+            result
+        }
+
+        /// Changes column references in `self` by the given remapping.
+        /// Panics if a referred column is not present in `idx_map`!
+        fn remap(mut self, idx_map: &BTreeMap<usize, usize>) -> HirScalarExpr {
+            self.visit_columns_referring_to_root_level_mut(&mut |c| {
+                *c = idx_map[c];
+            });
+            self
+        }
+    }
+
+    /// Those options of a window function call that are relevant for fusion.
+    #[derive(PartialEq, Eq)]
+    struct ValueWindowFuncCallOptions {
+        partition_by: Vec<HirScalarExpr>,
+        outer_order_by: Vec<HirScalarExpr>,
+        inner_order_by: Vec<ColumnOrder>,
+        window_frame: WindowFrame,
+        ignore_nulls: bool,
+    }
+
+    /// Helper function to extract the above options.
+    fn extract_options(call: &HirScalarExpr) -> ValueWindowFuncCallOptions {
+        match call {
+            HirScalarExpr::Windowing(WindowExpr {
+                func:
+                    WindowExprType::Value(ValueWindowExpr {
+                        order_by: inner_order_by,
+                        window_frame,
+                        ignore_nulls,
+                        func: _,
+                        args: _,
+                    }),
+                partition_by,
+                order_by: outer_order_by,
+            }) => ValueWindowFuncCallOptions {
+                partition_by: partition_by.clone(),
+                outer_order_by: outer_order_by.clone(),
+                inner_order_by: inner_order_by.clone(),
+                window_frame: window_frame.clone(),
+                ignore_nulls: ignore_nulls.clone(),
+            },
+            _ => panic!("extract_options should only be called on value window functions"),
+        }
+    }
+
+    struct FusionGroup {
+        /// The original column index of the first element of the group. (This is an index into the
+        /// Map's `scalars` plus the arity of the Map's input.)
+        first_col: usize,
+        /// The options of all the window function calls in the group. (Must be the same for all the
+        /// calls.)
+        options: ValueWindowFuncCallOptions,
+        /// The calls in the group, with their original column indexes.
+        calls: Vec<(usize, HirScalarExpr)>,
+    }
+
+    impl FusionGroup {
+        /// Creates a window function call that is a fused version of all the calls in the group.
+        /// `new_col` is the column index where the fused call will be inserted at.
+        fn fuse(self, new_col: usize) -> (HirScalarExpr, Vec<HirScalarExpr>) {
+            let (fused_funcs, fused_args): (Vec<_>, Vec<_>) = self
+                .calls
+                .iter()
+                .map(|(_idx, call)| {
+                    if let HirScalarExpr::Windowing(WindowExpr {
+                        func:
+                            WindowExprType::Value(ValueWindowExpr {
+                                func,
+                                args,
+                                order_by: _,
+                                window_frame: _,
+                                ignore_nulls: _,
+                            }),
+                        partition_by: _,
+                        order_by: _,
+                    }) = call
+                    {
+                        (func.clone(), (**args).clone())
+                    } else {
+                        panic!("unknown window function in FusionGroup")
+                    }
+                })
+                .unzip();
+            let fused_args = HirScalarExpr::CallVariadic {
+                func: VariadicFunc::RecordCreate {
+                    // These field names are not important, because this record will only be an
+                    // intermediate expression, which we'll manipulate further before it ends up
+                    // anywhere where a column name would be visible.
+                    field_names: iter::repeat(ColumnName::from(""))
+                        .take(fused_args.len())
+                        .collect(),
+                },
+                exprs: fused_args,
+            };
+            let fused = HirScalarExpr::Windowing(WindowExpr {
+                func: WindowExprType::Value(ValueWindowExpr {
+                    func: ValueWindowFunc::Fused(fused_funcs),
+                    args: Box::new(fused_args),
+                    order_by: self.options.inner_order_by,
+                    window_frame: self.options.window_frame,
+                    ignore_nulls: self.options.ignore_nulls,
+                }),
+                partition_by: self.options.partition_by,
+                order_by: self.options.outer_order_by,
+            });
+
+            let decompositions = (0..self.calls.len())
+                .map(|field| HirScalarExpr::CallUnary {
+                    func: UnaryFunc::RecordGet(mz_expr::func::RecordGet(field)),
+                    expr: Box::new(HirScalarExpr::Column(ColumnRef {
+                        level: 0,
+                        column: new_col,
+                    })),
+                })
+                .collect();
+
+            (fused, decompositions)
+        }
+    }
+
+    root.try_visit_mut_post(&mut |rel_expr| {
+        match rel_expr {
+            HirRelationExpr::Map { input, scalars } => {
+                // There will be various variable names involving `idx` or `col`:
+                // - `idx` will always be an index into `scalars` or something similar,
+                // - `col` will always be a column index,
+                //   which is often `arity_before_map` + an index into `scalars`.
+                let arity_before_map = input.arity();
+                let orig_num_scalars = scalars.len();
+
+                // Collect all value window function calls with their column indexes.
+                let value_window_function_calls = scalars
+                    .iter()
+                    .enumerate()
+                    .filter(|(_idx, scalar_expr)| {
+                        // Look for calls only at the root of scalar expressions. This is enough
+                        // because they are always there, see 72e84bb78.
+                        if let HirScalarExpr::Windowing(WindowExpr {
+                            func: WindowExprType::Value(ValueWindowExpr { func, .. }),
+                            ..
+                        }) = scalar_expr
+                        {
+                            // Exclude those calls that are already fused. (We shouldn't currently
+                            // encounter these, because we just do one pass, but it's better to be
+                            // robust against future code changes.)
+                            !matches!(func, ValueWindowFunc::Fused(..))
+                        } else {
+                            false
+                        }
+                    })
+                    .map(|(idx, call)| (idx + arity_before_map, call.clone()))
+                    .collect_vec();
+                // Exit early if obviously no chance for fusion.
+                if value_window_function_calls.len() <= 1 {
+                    // Note that we are doing this only for performance. All plans should be exactly
+                    // the same even if we comment out the following line.
+                    return Ok(());
+                }
+
+                // Determine the fusion groups. (Each group will later be fused into one window
+                // function call.)
+                // Note that this has a quadratic run time in the number of value window function
+                // calls in the worst case. However, this is fine even with 1000 window function
+                // calls.
+                let mut groups: Vec<FusionGroup> = Vec::new();
+                for (col, call) in value_window_function_calls {
+                    let options = extract_options(&call);
+                    let support = call.support();
+                    let to_fuse_with = groups
+                        .iter_mut()
+                        .filter(|group| {
+                            group.options == options && support.iter().all(|c| *c < group.first_col)
+                        })
+                        .next();
+                    if let Some(group) = to_fuse_with {
+                        group.calls.push((col, call.clone()));
+                    } else {
+                        groups.push(FusionGroup {
+                            first_col: col,
+                            options,
+                            calls: vec![(col, call.clone())],
+                        });
+                    }
+                }
+
+                // No fusion to do on groups of 1.
+                groups.retain(|g| g.calls.len() > 1);
+
+                let removals: BTreeSet<usize> = groups
+                    .iter()
+                    .flat_map(|g| g.calls.iter().map(|(col, _)| *col))
+                    .collect();
+
+                // Mutate `scalars`.
+                // We do this by simultaneously iterating through `scalars` and `groups`. (Note that
+                // `groups` is already sorted by `first_col` due to way it was constructed.)
+                // We also compute a remapping of old indexes to new indexes as we go.
+                let mut groups_it = groups.drain(..).peekable();
+                let mut group = groups_it.next();
+                let mut remap = BTreeMap::new();
+                remap.extend((0..arity_before_map).map(|col| (col, col)));
+                let mut new_col: usize = arity_before_map;
+                let mut new_scalars = Vec::new();
+                for (old_col, e) in scalars
+                    .drain(..)
+                    .enumerate()
+                    .map(|(idx, e)| (idx + arity_before_map, e))
+                {
+                    if group.as_ref().is_some_and(|g| g.first_col == old_col) {
+                        // The current expression will be fused away, and a fused expression will
+                        // appear in its place. Additionally, some new expressions will be inserted
+                        // after the fused expression, to decompose the record that is the result of
+                        // the fused call.
+                        assert!(removals.contains(&old_col));
+                        let group_unwrapped = group.expect("checked above");
+                        let calls_cols = group_unwrapped
+                            .calls
+                            .iter()
+                            .map(|(col, _call)| *col)
+                            .collect_vec();
+                        let (fused, decompositions) = group_unwrapped.fuse(new_col);
+                        new_scalars.push(fused.remap(&remap));
+                        new_scalars.extend(decompositions); // (no remapping needed)
+                        new_col += 1;
+                        for call_old_col in calls_cols {
+                            let present = remap.insert(call_old_col, new_col);
+                            assert!(present.is_none());
+                            new_col += 1;
+                        }
+                        group = groups_it.next();
+                    } else if removals.contains(&old_col) {
+                        assert!(remap.contains_key(&old_col));
+                    } else {
+                        new_scalars.push(e.remap(&remap));
+                        let present = remap.insert(old_col, new_col);
+                        assert!(present.is_none());
+                        new_col += 1;
+                    }
+                }
+                *scalars = new_scalars;
+                assert_eq!(remap.len(), arity_before_map + orig_num_scalars);
+
+                // Add a project to permute columns back to their original places.
+                *rel_expr = rel_expr.take().project(
+                    (0..arity_before_map)
+                        .chain((0..orig_num_scalars).map(|idx| {
+                            *remap
+                                .get(&(idx + arity_before_map))
+                                .expect("all columns should be present by now")
+                        }))
+                        .collect(),
+                );
+
+                assert_eq!(rel_expr.arity(), arity_before_map + orig_num_scalars);
+            }
+            _ => {}
+        }
+        Ok(())
+    })
 }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2088,6 +2088,12 @@ feature_flags!(
         default: false,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_value_window_function_fusion,
+        desc: "Enables the value window function fusion optimization",
+        default: true,
+        enable_for_item_parsing: false,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {
@@ -2101,6 +2107,7 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_letrec_fixpoint_analysis: vars.enable_letrec_fixpoint_analysis(),
             enable_cardinality_estimates: vars.enable_cardinality_estimates(),
             enable_outer_join_null_filter: vars.enable_outer_join_null_filter(),
+            enable_value_window_function_fusion: vars.enable_value_window_function_fusion(),
             persist_fast_path_limit: vars.persist_fast_path_limit(),
             reoptimize_imported_views: false,
         }

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -7476,3 +7476,62 @@ ORDER BY x,y;
 13  14  1111  182  2222  27  NULL  27
 15  16  1111  240  2222  31  14  31
 17  18  1111  306  2222  35  16  35
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_value_window_function_fusion = false
+----
+COMPLETE 0
+
+query T multiline
+EXPLAIN
+SELECT
+  *,
+  lag(x) OVER (),
+  lag(y) OVER ()
+FROM t7
+ORDER BY x,y;
+----
+Explained Query:
+  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#3]
+    Project (#3, #4, #6, #5)
+      Map (record_get[1](#1), record_get[0](#2), record_get[1](#2), record_get[3](#2), record_get[0](#1))
+        FlatMap unnest_list(#0)
+          Reduce aggregates=[lag[order_by=[]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[0](#0), record_get[0](#0)), row(record_get[0](record_get[1](#0)), 1, null))))]
+            Project (#1)
+              FlatMap unnest_list(#0)
+                Reduce aggregates=[lag[order_by=[]](row(row(row(#0, #1), row(#1, 1, null))))]
+                  ReadStorage materialize.public.t7
+
+Source materialize.public.t7
+
+Target cluster: quickstart
+
+EOF
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_value_window_function_fusion = true
+----
+COMPLETE 0
+
+query T multiline
+EXPLAIN
+SELECT
+  *,
+  lag(x) OVER (),
+  lag(y) OVER ()
+FROM t7
+ORDER BY x,y;
+----
+Explained Query:
+  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#3]
+    Project (#3, #4, #7, #6)
+      Map (record_get[1](#1), record_get[0](#2), record_get[1](#2), record_get[0](#1), record_get[0](#5), record_get[1](#5))
+        FlatMap unnest_list(#0)
+          Reduce aggregates=[fused_value_window_func[lag[order_by=[]], lag[order_by=[]] order_by=[]](row(row(row(#0, #1), row(row(#1, 1, null), row(#0, 1, null)))))]
+            ReadStorage materialize.public.t7
+
+Source materialize.public.t7
+
+Target cluster: quickstart
+
+EOF

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -7043,7 +7043,112 @@ NULL
 NULL
 NULL
 
-# Complex tests with array_agg and then unnesting the array
+# Test `on_unique` for lag/lead
+query T multiline
+EXPLAIN
+SELECT
+  lag(x,y,100) OVER (PARTITION BY x ORDER BY y+y)
+FROM t9;
+----
+Explained Query:
+  Project (#2)
+    Map (record_get[0](#1))
+      FlatMap unnest_list(#0)
+        Project (#2)
+          Map (list[row(case when (#1) IS NULL then null else case when (#1 = 0) then #0 else 100 end end, row(#0, #1))])
+            ReadStorage materialize.public.t9
+
+Source materialize.public.t9
+
+Target cluster: quickstart
+
+EOF
+
+query I
+SELECT
+  lag(x,y,100) OVER (PARTITION BY x ORDER BY y+y)
+FROM t9;
+----
+NULL
+NULL
+NULL
+100
+100
+100
+100
+100
+100
+
+query I
+SELECT
+  lead(x,y-2,120) OVER (PARTITION BY x ORDER BY x)
+FROM t9;
+----
+NULL
+NULL
+NULL
+1
+120
+120
+120
+120
+120
+
+# Test `on_unique` for `FusedValueWindowFunc`. There should be NO window function call in the following plan.
+query T multiline
+EXPLAIN
+SELECT
+  x,
+  y,
+  lag(x,y,100)    OVER (PARTITION BY x ORDER BY y+y),
+  lag(x,y,110)    OVER (PARTITION BY x ORDER BY y+y),
+  lag(x,y,100)    OVER (PARTITION BY x ORDER BY y+y),
+  first_value(y)  OVER (PARTITION BY x ORDER BY y+y),
+  last_value(y)   OVER (PARTITION BY x ORDER BY y+y),
+  lead(x,y-2,120) OVER (PARTITION BY x ORDER BY y+y)
+FROM t9
+ORDER BY x;
+----
+Explained Query:
+  Finish order_by=[#0 asc nulls_last] output=[#0..=#7]
+    Project (#3, #4, #9, #10, #9, #8, #7, #6)
+      Map (record_get[1](#1), record_get[0](#2), record_get[1](#2), record_get[0](#1), record_get[0](#5), record_get[1](#5), record_get[2](#5), record_get[3](#5), record_get[4](#5))
+        FlatMap unnest_list(#0)
+          Project (#3)
+            Map ((#1) IS NULL, list[row(row(case when #2 then null else case when (0 = (#1 - 2)) then #0 else 120 end end, #1, #1, case when #2 then null else case when (#1 = 0) then #0 else 100 end end, case when #2 then null else case when (#1 = 0) then #0 else 110 end end), row(#0, #1))])
+              ReadStorage materialize.public.t9
+
+Source materialize.public.t9
+
+Target cluster: quickstart
+
+EOF
+
+query IIIIIIII
+SELECT
+  x,
+  y,
+  lag(x,y,100)    OVER (PARTITION BY x ORDER BY y+y),
+  lag(x,y,110)    OVER (PARTITION BY x ORDER BY y+y),
+  lag(x,y,100)    OVER (PARTITION BY x ORDER BY y+y),
+  first_value(y)  OVER (PARTITION BY x ORDER BY y+y),
+  last_value(y)   OVER (PARTITION BY x ORDER BY y+y),
+  lead(x,y-2,120) OVER (PARTITION BY x ORDER BY y+y)
+FROM t9
+ORDER BY x;
+----
+1  2  100  110  100  2  2  1
+3  NULL  NULL  NULL  NULL  NULL  NULL  NULL
+5  6  100  110  100  6  6  120
+7  8  100  110  100  8  8  120
+9  NULL  NULL  NULL  NULL  NULL  NULL  NULL
+11  NULL  NULL  NULL  NULL  NULL  NULL  NULL
+13  14  100  110  100  14  14  120
+15  16  100  110  100  16  16  120
+17  18  100  110  100  18  18  120
+
+
+## Complex tests with array_agg and then unnesting the array
 
 query R
 SELECT avg(u)
@@ -7221,3 +7326,153 @@ where (case when (((select "collection_timestamp" from mz_internal.mz_storage_us
          end
        end
     );
+
+## Tests for window function fusion
+
+query T multiline
+EXPLAIN
+SELECT
+  *,
+  lag(x)          OVER (ORDER BY x),
+  first_value(x)  OVER (ORDER BY x),
+  last_value(x)   OVER (ORDER BY x),
+  x*y,
+  lag(y)          OVER (ORDER BY x),
+  lag(x+x,1,null) OVER (PARTITION BY x ORDER BY y),
+  lead(x,2,null)  OVER (PARTITION BY x ORDER BY -y NULLS FIRST),
+  lead(x,2,null)  OVER (PARTITION BY x ORDER BY -y NULLS LAST),
+  x+y,
+  lag(x+x,2,null) OVER (PARTITION BY x ORDER BY y)
+FROM t7
+ORDER BY x,y;
+----
+Explained Query:
+  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#11]
+    Project (#3, #4, #13, #12, #11, #14, #10, #6, #8, #7, #15, #5)
+      Map (record_get[1](#1), record_get[0](#2), record_get[1](#2), record_get[3](#2), record_get[4](#2), record_get[6](#2), record_get[8](#2), record_get[0](#1), record_get[0](#9), record_get[1](#9), record_get[2](#9), record_get[3](#9), (#3 * #4), (#3 + #4))
+        FlatMap unnest_list(#0)
+          Reduce aggregates=[fused_value_window_func[lag[order_by=[#0 asc nulls_last]], last_value[order_by=[#0 asc nulls_last]], first_value[order_by=[#0 asc nulls_last]], lag[order_by=[#0 asc nulls_last]] order_by=[#0 asc nulls_last]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[2](record_get[1](#0)), record_get[3](record_get[1](#0)), record_get[4](record_get[1](#0)), record_get[5](record_get[1](#0)), record_get[6](record_get[1](#0)), record_get[0](#0), record_get[0](#0)), row(row(record_get[1](record_get[1](#0)), 1, null), record_get[0](record_get[1](#0)), record_get[0](record_get[1](#0)), row(record_get[0](record_get[1](#0)), 1, null))), record_get[0](record_get[1](#0))))]
+            Project (#1)
+              FlatMap unnest_list(#0)
+                Project (#1)
+                  Reduce group_by=[record_get[0](record_get[1](#0))] aggregates=[lead[order_by=[#0 asc nulls_first]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[2](record_get[1](#0)), record_get[3](record_get[1](#0)), record_get[4](record_get[1](#0)), record_get[0](#0), record_get[0](#0)), row(record_get[0](record_get[1](#0)), 2, null)), -(record_get[1](record_get[1](#0)))))]
+                    Project (#1)
+                      FlatMap unnest_list(#0)
+                        Project (#1)
+                          Reduce group_by=[record_get[0](record_get[1](#0))] aggregates=[lead[order_by=[#0 asc nulls_last]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[0](#0), record_get[0](record_get[0](#0)), record_get[1](record_get[0](#0))), row(record_get[0](record_get[1](#0)), 2, null)), -(record_get[1](record_get[1](#0)))))]
+                            Project (#1)
+                              FlatMap unnest_list(#0)
+                                Project (#1)
+                                  Reduce group_by=[#0] aggregates=[fused_value_window_func[lag[order_by=[#0 asc nulls_last]], lag[order_by=[#0 asc nulls_last]] order_by=[#0 asc nulls_last]](row(row(row(#0, #1), row(row((#0 + #0), 2, null), row((#0 + #0), 1, null))), #1))]
+                                    ReadStorage materialize.public.t7
+
+Source materialize.public.t7
+
+Target cluster: quickstart
+
+EOF
+
+query IIIIIIIIIIII
+SELECT
+  *,
+  lag(x)          OVER (ORDER BY x),
+  first_value(x)  OVER (ORDER BY x),
+  last_value(x)   OVER (ORDER BY x),
+  x*y,
+  lag(y)          OVER (ORDER BY x),
+  lag(x+x,1,null) OVER (PARTITION BY x ORDER BY y),
+  lead(x,2,null)  OVER (PARTITION BY x ORDER BY -y NULLS FIRST),
+  lead(x,2,null)  OVER (PARTITION BY x ORDER BY -y NULLS LAST),
+  x+y,
+  lag(x+x,2,null) OVER (PARTITION BY x ORDER BY y)
+FROM t7
+ORDER BY x,y;
+----
+1  2  NULL  1  1  2  NULL  NULL  NULL  NULL  3  NULL
+3  NULL  1  1  3  NULL  2  NULL  NULL  NULL  NULL  NULL
+5  6  3  1  5  30  NULL  NULL  NULL  NULL  11  NULL
+7  8  5  1  7  56  6  NULL  NULL  NULL  15  NULL
+9  NULL  7  1  9  NULL  8  NULL  NULL  NULL  NULL  NULL
+10  -50  9  1  10  -500  NULL  NULL  NULL  NULL  -40  NULL
+10  -40  10  1  10  -400  -50  20  NULL  NULL  -30  NULL
+11  NULL  10  1  11  NULL  -40  NULL  NULL  NULL  NULL  NULL
+13  14  11  1  13  182  NULL  NULL  NULL  NULL  27  NULL
+15  16  13  1  15  240  14  NULL  NULL  NULL  31  NULL
+17  18  15  1  17  306  16  NULL  NULL  NULL  35  NULL
+
+# In the following query, currently we only fuse the two inner `lag`s.
+# In theory, we could also fuse the two `last_value`s.
+query T multiline
+EXPLAIN
+SELECT
+  *,
+  first_value(
+    lag(x*x,y,1111) OVER (PARTITION BY x ORDER BY y)
+  ) OVER (PARTITION BY x ORDER BY y),
+  x*y,
+  last_value(
+    lag(x*x,y,2222) OVER (PARTITION BY x ORDER BY y)
+  ) OVER (PARTITION BY x ORDER BY y+y),
+  last_value(x+y) OVER (PARTITION BY x ORDER BY y+y),
+  lag(y)          OVER (ORDER BY x),
+  x+y
+FROM t7
+ORDER BY x,y;
+----
+Explained Query:
+  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#7]
+    Project (#3, #4, #8, #9, #7, #6, #5, #10)
+      Map (record_get[1](#1), record_get[0](#2), record_get[1](#2), record_get[2](#2), record_get[3](#2), record_get[8](#2), record_get[0](#1), (#3 * #4), (#3 + #4))
+        FlatMap unnest_list(#0)
+          Project (#1)
+            Reduce group_by=[record_get[0](record_get[1](#0))] aggregates=[first_value[order_by=[#0 asc nulls_last]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[2](record_get[1](#0)), record_get[3](record_get[1](#0)), record_get[4](record_get[1](#0)), record_get[5](record_get[1](#0)), record_get[6](record_get[1](#0)), record_get[0](#0), record_get[0](#0)), record_get[6](record_get[1](#0))), record_get[1](record_get[1](#0))))]
+              Project (#1)
+                FlatMap unnest_list(#0)
+                  Project (#1)
+                    Reduce group_by=[record_get[0](record_get[1](#0))] aggregates=[last_value[order_by=[#0 asc nulls_last]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[3](record_get[1](#0)), record_get[5](record_get[1](#0)), record_get[0](#0), record_get[0](record_get[0](#0)), record_get[1](record_get[0](#0))), record_get[0](record_get[0](#0))), (record_get[1](record_get[1](#0)) + record_get[1](record_get[1](#0)))))]
+                      Project (#1)
+                        FlatMap unnest_list(#0)
+                          Project (#1)
+                            Reduce group_by=[record_get[0](record_get[1](#0))] aggregates=[fused_value_window_func[lag[order_by=[#0 asc nulls_last]], lag[order_by=[#0 asc nulls_last]] order_by=[#0 asc nulls_last]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[2](record_get[1](#0)), record_get[3](record_get[1](#0)), record_get[0](#0), record_get[0](#0)), row(row((record_get[0](record_get[1](#0)) * record_get[0](record_get[1](#0))), record_get[1](record_get[1](#0)), 2222), row((record_get[0](record_get[1](#0)) * record_get[0](record_get[1](#0))), record_get[1](record_get[1](#0)), 1111))), record_get[1](record_get[1](#0))))]
+                              Project (#1)
+                                FlatMap unnest_list(#0)
+                                  Project (#1)
+                                    Reduce group_by=[record_get[0](record_get[1](#0))] aggregates=[last_value[order_by=[#0 asc nulls_last]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[0](#0), record_get[0](#0)), (record_get[0](record_get[1](#0)) + record_get[1](record_get[1](#0)))), (record_get[1](record_get[1](#0)) + record_get[1](record_get[1](#0)))))]
+                                      Project (#1)
+                                        FlatMap unnest_list(#0)
+                                          Reduce aggregates=[lag[order_by=[#0 asc nulls_last]](row(row(row(#0, #1), row(#1, 1, null)), #0))]
+                                            ReadStorage materialize.public.t7
+
+Source materialize.public.t7
+
+Target cluster: quickstart
+
+EOF
+
+query IIIIIIII
+SELECT
+  *,
+  first_value(
+    lag(x*x,y,1111) OVER (PARTITION BY x ORDER BY y)
+  ) OVER (PARTITION BY x ORDER BY y),
+  x*y,
+  last_value(
+    lag(x*x,y,2222) OVER (PARTITION BY x ORDER BY y)
+  ) OVER (PARTITION BY x ORDER BY y+y),
+  last_value(x+y) OVER (PARTITION BY x ORDER BY y+y),
+  lag(y)          OVER (ORDER BY x),
+  x+y
+FROM t7
+ORDER BY x,y;
+----
+1  2  1111  2  2222  3  NULL  3
+3  NULL  NULL  NULL  NULL  NULL  2  NULL
+5  6  1111  30  2222  11  NULL  11
+7  8  1111  56  2222  15  6  15
+9  NULL  NULL  NULL  NULL  NULL  8  NULL
+10  -50  1111  -500  2222  -40  NULL  -40
+10  -40  1111  -400  2222  -30  -50  -30
+11  NULL  NULL  NULL  NULL  NULL  -40  NULL
+13  14  1111  182  2222  27  NULL  27
+15  16  1111  240  2222  31  14  31
+17  18  1111  306  2222  35  16  35


### PR DESCRIPTION
This adds the fusion optimization for value window functions (`lag`, `lead`, `first_value`, `last_value`), which is badly needed by https://github.com/MaterializeInc/accounts/issues/3

The point is that it amortizes the various overheads of window functions (e.g., the wrapping/unwrapping of other columns, which gets quadratically big with the number of window functions) by performing the MIR window function pattern only once for a group of window functions.

I've added this as an HIR transform, because an MIR transform would have needed to recognize and manipulate the complicated MIR window function pattern.

See the doc comment on `fuse_window_functions` for how we choose the groups of window functions to be fused.

I've added a new value window function called `Fused`, and implemented the corresponding MIR `AggregateFunc`. In several places in the implementation of `AggregateFunc::FusedValueWindowFunc`, I refactored the implementations of existing value window functions in order to be able to reuse as much code from them as possible.

Note that this does not yet implement fusion for window aggregations, which would be needed by https://github.com/MaterializeInc/accounts/issues/77. I'll implement that in a follow-up PR soon.

### Motivation

  * This PR adds a known-desirable feature: https://github.com/MaterializeInc/materialize/issues/20741

### Tips for reviewer

Look at the commits separately. The first two are just minor preparations (see commit msgs), the 3rd commit is the main one, and then there is a commit that guards the new code behind a feature flag.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
  - Added some new slt tests.
  - In the already-existing tests in `window_funcs.slt`, there were 20 cases where fusion happened.
  - There is also an RQG grammar specifically for window functions.
    - First run: https://buildkite.com/materialize/nightly/builds/9307#01919def-9f3d-45e6-8651-d03339f6d5ce
    - Second run: https://buildkite.com/materialize/nightly/builds/9309
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
