### PR TITLE
catalog: Clean up method args

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -474,16 +474,13 @@ impl Catalog {
         organization_id: Uuid,
     ) -> Result<Catalog, anyhow::Error> {
         let now = SYSTEM_TIME.clone();
-        let epoch_lower_bound = None;
         let environment_id = None;
         let openable_storage = TestCatalogStateBuilder::new(persist_client)
             .with_organization_id(organization_id)
             .with_default_deploy_generation()
             .build()
             .await?;
-        let storage = openable_storage
-            .open(now(), &test_bootstrap_args(), epoch_lower_bound)
-            .await?;
+        let storage = openable_storage.open(now(), &test_bootstrap_args()).await?;
         let system_parameter_defaults = BTreeMap::default();
         Self::open_debug_catalog_inner(storage, now, environment_id, system_parameter_defaults)
             .await

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -511,7 +511,6 @@ async fn upgrade_check(
                     "DEFAULT CLUSTER REPLICA SIZE IS ONLY USED FOR NEW ENVIRONMENTS".into(),
                 bootstrap_role: None,
             },
-            None,
         )
         .await?;
 

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -90,9 +90,6 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// storage, it will never read another update from durable storage. As a
     /// consequence, savepoint catalogs can never be fenced.
     ///
-    /// `epoch_lower_bound` is used as a lower bound for the epoch that is
-    /// used by the returned catalog.
-    ///
     /// Will return an error in the following scenarios:
     ///   - Catalog initialization fails.
     ///   - Catalog migrations fail.
@@ -102,7 +99,6 @@ pub trait OpenableDurableCatalogState: Debug + Send {
         mut self: Box<Self>,
         initial_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
-        epoch_lower_bound: Option<Epoch>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError>;
 
     /// Opens the catalog in read only mode. All mutating methods
@@ -120,13 +116,10 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// needed.
     ///
     /// `initial_ts` is used as the initial timestamp for new environments.
-    /// `epoch_lower_bound` is used as a lower bound for the epoch that is used by the returned
-    /// catalog.
     async fn open(
         mut self: Box<Self>,
         initial_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
-        epoch_lower_bound: Option<Epoch>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError>;
 
     /// Opens the catalog for manual editing of the underlying data. This is helpful for

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -45,7 +45,7 @@ use mz_storage_types::sources::SourceData;
 use sha2::Digest;
 use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
 use timely::Container;
-use tracing::{debug, info};
+use tracing::debug;
 use uuid::Uuid;
 
 use crate::durable::debug::{Collection, DebugCatalogState, Trace};
@@ -229,7 +229,7 @@ pub(crate) trait ApplyUpdate<T: IntoStateUpdateKindJson> {
 #[derive(Debug)]
 pub(crate) struct PersistHandle<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> {
     /// The [`Mode`] that this catalog was opened in.
-    mode: Mode,
+    pub(crate) mode: Mode,
     /// Since handle to control compaction.
     since_handle: SinceHandle<SourceData, (), Timestamp, Diff, i64>,
     /// Write handle to persist.
@@ -980,9 +980,9 @@ impl UnopenedPersistCatalogState {
         mode: Mode,
         initial_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
-        epoch_lower_bound: Option<Epoch>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
-        let read_only = matches!(mode, Mode::Readonly);
+        self.mode = mode;
+        let read_only = matches!(self.mode, Mode::Readonly);
 
         self.sync_to_current_upper().await?;
         let prev_epoch = self.epoch.validate()?;
@@ -993,15 +993,8 @@ impl UnopenedPersistCatalogState {
         }
         let mut current_epoch = prev_epoch.unwrap_or(MIN_EPOCH).get();
         // Only writable catalogs attempt to increment the epoch.
-        if matches!(mode, Mode::Writable) {
-            if let Some(epoch_lower_bound) = &epoch_lower_bound {
-                info!(?epoch_lower_bound);
-            }
-
-            current_epoch = max(
-                current_epoch + 1,
-                epoch_lower_bound.unwrap_or(Epoch::MIN).get(),
-            );
+        if matches!(self.mode, Mode::Writable) {
+            current_epoch = current_epoch + 1;
         }
         let current_epoch = Epoch::new(current_epoch).expect("known to be non-zero");
         fence_updates.push((StateUpdateKind::Epoch(current_epoch), 1));
@@ -1009,26 +1002,28 @@ impl UnopenedPersistCatalogState {
         debug!(
             ?self.upper,
             ?prev_epoch,
-            ?epoch_lower_bound,
             ?current_epoch,
             "fencing previous catalogs"
         );
         self.epoch = current_epoch;
-        if matches!(mode, Mode::Writable) {
+        if matches!(self.mode, Mode::Writable) {
             self.compare_and_append(fence_updates).await?;
         }
 
         let is_initialized = self.is_initialized_inner();
-        if !matches!(mode, Mode::Writable) && !is_initialized {
+        if !matches!(self.mode, Mode::Writable) && !is_initialized {
             return Err(CatalogError::Durable(DurableCatalogError::NotWritable(
-                format!("catalog tables do not exist; will not create in {mode:?} mode"),
+                format!(
+                    "catalog tables do not exist; will not create in {:?} mode",
+                    self.mode
+                ),
             )));
         }
         soft_assert_ne_or_log!(self.upper, Timestamp::minimum());
 
         // Perform data migrations.
         if is_initialized && !read_only {
-            upgrade(&mut self, mode.clone()).await?;
+            upgrade(&mut self).await?;
         }
 
         debug!(
@@ -1037,7 +1032,7 @@ impl UnopenedPersistCatalogState {
             "initializing catalog state"
         );
         let mut catalog = PersistCatalogState {
-            mode: mode.clone(),
+            mode: self.mode,
             since_handle: self.since_handle,
             write_handle: self.write_handle,
             listen: self.listen,
@@ -1106,7 +1101,7 @@ impl UnopenedPersistCatalogState {
         // Now that we've fully opened the catalog at the current version, we can increment the
         // version in the catalog upgrade shard to signal to readers that the allowable versions
         // have increased.
-        if matches!(mode, Mode::Writable) {
+        if matches!(catalog.mode, Mode::Writable) {
             catalog
                 .increment_catalog_upgrade_shard_version(self.update_applier.organization_id)
                 .await;
@@ -1176,16 +1171,10 @@ impl OpenableDurableCatalogState for UnopenedPersistCatalogState {
         mut self: Box<Self>,
         initial_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
-        epoch_lower_bound: Option<Epoch>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
-        self.open_inner(
-            Mode::Savepoint,
-            initial_ts,
-            bootstrap_args,
-            epoch_lower_bound,
-        )
-        .boxed()
-        .await
+        self.open_inner(Mode::Savepoint, initial_ts, bootstrap_args)
+            .boxed()
+            .await
     }
 
     #[mz_ore::instrument]
@@ -1193,7 +1182,7 @@ impl OpenableDurableCatalogState for UnopenedPersistCatalogState {
         mut self: Box<Self>,
         bootstrap_args: &BootstrapArgs,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
-        self.open_inner(Mode::Readonly, EpochMillis::MIN, bootstrap_args, None)
+        self.open_inner(Mode::Readonly, EpochMillis::MIN, bootstrap_args)
             .boxed()
             .await
     }
@@ -1203,16 +1192,10 @@ impl OpenableDurableCatalogState for UnopenedPersistCatalogState {
         mut self: Box<Self>,
         initial_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
-        epoch_lower_bound: Option<Epoch>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
-        self.open_inner(
-            Mode::Writable,
-            initial_ts,
-            bootstrap_args,
-            epoch_lower_bound,
-        )
-        .boxed()
-        .await
+        self.open_inner(Mode::Writable, initial_ts, bootstrap_args)
+            .boxed()
+            .await
     }
 
     #[mz_ore::instrument(level = "debug")]

--- a/src/catalog/src/durable/persist/tests.rs
+++ b/src/catalog/src/durable/persist/tests.rs
@@ -49,7 +49,7 @@ async fn test_upgrade_shard() {
         .expect_build("failed to create persist catalog")
         .await;
     let _persist_state = persist_openable_state
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args())
         .await
         .expect("failed to open persist catalog");
 
@@ -109,7 +109,7 @@ async fn test_upgrade_shard() {
         .expect_build("failed to create persist catalog")
         .await;
     let _persist_state = persist_openable_state
-        .open_savepoint(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open_savepoint(NOW_ZERO(), &test_bootstrap_args())
         .await
         .expect("failed to open savepoint persist catalog");
 
@@ -138,7 +138,7 @@ async fn test_upgrade_shard() {
         .expect_build("failed to create persist catalog")
         .await;
     let _persist_state = persist_openable_state
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args())
         .await
         .expect("failed to open readonly persist catalog");
 
@@ -178,7 +178,7 @@ async fn test_version_regression() {
         .expect_build("failed to create persist catalog")
         .await;
     let _persist_state = persist_openable_state
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args())
         .await
         .expect("failed to open persist catalog");
 
@@ -199,7 +199,7 @@ async fn test_version_regression() {
         .expect_build("failed to create persist catalog")
         .await;
     let _persist_state = persist_openable_state
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args())
         .await
         .expect("failed to open readonly persist catalog");
 

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -2956,13 +2956,13 @@ mod tests {
             .clone()
             .unwrap_build()
             .await
-            .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+            .open(SYSTEM_TIME(), &test_bootstrap_args())
             .await
             .unwrap();
         let mut savepoint_state = state_builder
             .unwrap_build()
             .await
-            .open_savepoint(SYSTEM_TIME(), &test_bootstrap_args(), None)
+            .open_savepoint(SYSTEM_TIME(), &test_bootstrap_args())
             .await
             .unwrap();
 

--- a/src/catalog/tests/debug.rs
+++ b/src/catalog/tests/debug.rs
@@ -126,7 +126,7 @@ async fn test_debug<'a>(state_builder: TestCatalogStateBuilder) {
 
     // Use `NOW_ZERO` for consistent timestamps in the snapshots.
     let _ = openable_state1
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -270,7 +270,7 @@ async fn test_debug_edit_fencing<'a>(state_builder: TestCatalogStateBuilder) {
         .with_default_deploy_generation()
         .unwrap_build()
         .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -332,7 +332,7 @@ async fn test_debug_delete_fencing<'a>(state_builder: TestCatalogStateBuilder) {
         .with_default_deploy_generation()
         .unwrap_build()
         .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
     // Drain state updates.

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -112,7 +112,7 @@ async fn test_is_initialized(state_builder: TestCatalogStateBuilder) {
     );
 
     let state = openable_state1
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
     state.expire().await;
@@ -156,7 +156,7 @@ async fn test_get_deployment_generation(state_builder: TestCatalogStateBuilder) 
         );
 
         let state = openable_state
-            .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+            .open(SYSTEM_TIME(), &test_bootstrap_args())
             .await
             .unwrap();
         state.expire().await;
@@ -199,7 +199,7 @@ async fn test_open_savepoint(state_builder: TestCatalogStateBuilder) {
             .clone()
             .unwrap_build()
             .await
-            .open_savepoint(SYSTEM_TIME(), &test_bootstrap_args(), None)
+            .open_savepoint(SYSTEM_TIME(), &test_bootstrap_args())
             .await
             .unwrap_err();
         match err {
@@ -214,7 +214,7 @@ async fn test_open_savepoint(state_builder: TestCatalogStateBuilder) {
             .clone()
             .unwrap_build()
             .await
-            .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+            .open(SYSTEM_TIME(), &test_bootstrap_args())
             .await
             .unwrap();
         assert_eq!(state.epoch(), Epoch::new(2).expect("known to be non-zero"));
@@ -227,7 +227,7 @@ async fn test_open_savepoint(state_builder: TestCatalogStateBuilder) {
             .clone()
             .unwrap_build()
             .await
-            .open_savepoint(SYSTEM_TIME(), &test_bootstrap_args(), None)
+            .open_savepoint(SYSTEM_TIME(), &test_bootstrap_args())
             .await
             .unwrap();
         // Drain initial updates.
@@ -330,7 +330,7 @@ async fn test_open_savepoint(state_builder: TestCatalogStateBuilder) {
             .clone()
             .unwrap_build()
             .await
-            .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+            .open(SYSTEM_TIME(), &test_bootstrap_args())
             .await
             .unwrap();
         // Write should not have persisted.
@@ -375,7 +375,7 @@ async fn test_open_read_only(state_builder: TestCatalogStateBuilder) {
         .clone()
         .unwrap_build()
         .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
     // Drain initial updates.
@@ -445,7 +445,7 @@ async fn test_open(state_builder: TestCatalogStateBuilder) {
             .unwrap_build()
             .await
             // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args())
             .await
             .unwrap();
 
@@ -469,7 +469,7 @@ async fn test_open(state_builder: TestCatalogStateBuilder) {
             .clone()
             .unwrap_build()
             .await
-            .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+            .open(SYSTEM_TIME(), &test_bootstrap_args())
             .await
             .unwrap();
 
@@ -484,7 +484,7 @@ async fn test_open(state_builder: TestCatalogStateBuilder) {
             .clone()
             .unwrap_build()
             .await
-            .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+            .open(SYSTEM_TIME(), &test_bootstrap_args())
             .await
             .unwrap();
 
@@ -513,7 +513,7 @@ async fn test_unopened_epoch_fencing(state_builder: TestCatalogStateBuilder) {
             .unwrap_build()
             .await
             // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args())
             .await
             .unwrap();
         // drain catalog updates.
@@ -541,7 +541,7 @@ async fn test_unopened_epoch_fencing(state_builder: TestCatalogStateBuilder) {
         .unwrap_build()
         .await
         // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -587,7 +587,7 @@ async fn test_unopened_deploy_generation_fencing(state_builder: TestCatalogState
             .unwrap_build()
             .await
             // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args())
             .await
             .unwrap();
         // drain catalog updates.
@@ -616,7 +616,7 @@ async fn test_unopened_deploy_generation_fencing(state_builder: TestCatalogState
         .unwrap_build()
         .await
         // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -673,7 +673,7 @@ async fn test_opened_epoch_fencing(state_builder: TestCatalogStateBuilder) {
         .unwrap_build()
         .await
         // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -683,7 +683,7 @@ async fn test_opened_epoch_fencing(state_builder: TestCatalogStateBuilder) {
         .unwrap_build()
         .await
         // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -723,7 +723,7 @@ async fn test_opened_deploy_generation_fencing(state_builder: TestCatalogStateBu
         .unwrap_build()
         .await
         // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -734,7 +734,7 @@ async fn test_opened_deploy_generation_fencing(state_builder: TestCatalogStateBu
         .unwrap_build()
         .await
         // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -778,7 +778,7 @@ async fn test_fencing_during_write(state_builder: TestCatalogStateBuilder) {
         .unwrap_build()
         .await
         // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args())
         .await
         .unwrap();
     // Drain updates.
@@ -793,7 +793,7 @@ async fn test_fencing_during_write(state_builder: TestCatalogStateBuilder) {
         .unwrap_build()
         .await
         // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args())
         .await
         .unwrap();
     // Drain updates.
@@ -819,7 +819,7 @@ async fn test_fencing_during_write(state_builder: TestCatalogStateBuilder) {
         .unwrap_build()
         .await
         // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -858,7 +858,7 @@ async fn test_persist_version_fencing() {
             .unwrap_build()
             .await;
         let _persist_state = persist_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args())
             .await
             .unwrap();
 

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -40,7 +40,7 @@ async fn test_confirm_leadership(state_builder: TestCatalogStateBuilder) {
         .clone()
         .unwrap_build()
         .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
     assert_ok!(state1.confirm_leadership().await);
@@ -48,7 +48,7 @@ async fn test_confirm_leadership(state_builder: TestCatalogStateBuilder) {
     let mut state2 = state_builder
         .unwrap_build()
         .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
     assert_ok!(state2.confirm_leadership().await);
@@ -87,7 +87,7 @@ async fn test_allocate_id(state_builder: TestCatalogStateBuilder) {
     let mut state = state_builder
         .unwrap_build()
         .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -164,7 +164,7 @@ async fn test_audit_logs(state_builder: TestCatalogStateBuilder) {
     let mut state = state_builder
         .unwrap_build()
         .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
     // Drain initial updates.
@@ -221,7 +221,7 @@ async fn test_items(state_builder: TestCatalogStateBuilder) {
     let mut state = state_builder
         .unwrap_build()
         .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
     // Drain initial updates.
@@ -275,7 +275,7 @@ async fn test_schemas(state_builder: TestCatalogStateBuilder) {
     let mut state = state_builder
         .unwrap_build()
         .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
     // Drain initial updates.
@@ -339,14 +339,14 @@ async fn test_non_writer_commits(state_builder: TestCatalogStateBuilder) {
         .clone()
         .unwrap_build()
         .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
     let mut savepoint_state = state_builder
         .clone()
         .unwrap_build()
         .await
-        .open_savepoint(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open_savepoint(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
     let mut reader_state = state_builder

--- a/src/environmentd/src/deployment/preflight.rs
+++ b/src/environmentd/src/deployment/preflight.rs
@@ -77,7 +77,6 @@ pub async fn preflight_legacy(
                     default_cluster_replica_size: bootstrap_default_cluster_replica_size,
                     bootstrap_role,
                 },
-                None,
             )
             .await
         {
@@ -209,7 +208,6 @@ pub async fn preflight_0dt(
                                 .clone(),
                             bootstrap_role: bootstrap_role.clone(),
                         },
-                        None,
                     )
                     .await;
 

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -511,7 +511,7 @@ impl Listeners {
             // TODO: behavior of migrations when booting in savepoint mode is
             // not well defined.
             let adapter_storage = openable_adapter_storage
-                .open_savepoint(boot_ts, &bootstrap_args, None)
+                .open_savepoint(boot_ts, &bootstrap_args)
                 .await?;
 
             // In read-only mode, we intentionally do not call `set_is_leader`,
@@ -521,7 +521,7 @@ impl Listeners {
             adapter_storage
         } else {
             let adapter_storage = openable_adapter_storage
-                .open(boot_ts, &bootstrap_args, None)
+                .open(boot_ts, &bootstrap_args)
                 .await?;
 
             // Once we have successfully opened the adapter storage in


### PR DESCRIPTION
This commit removes some necessary arguments from catalog methods.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
