### PR TITLE
catalog: Clean up some tests

### DIFF
--- a/src/catalog/src/durable/persist/tests.rs
+++ b/src/catalog/src/durable/persist/tests.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use mz_ore::now::NOW_ZERO;
+use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::PersistLocation;
 use uuid::Uuid;
@@ -49,7 +49,7 @@ async fn test_upgrade_shard() {
         .expect_build("failed to create persist catalog")
         .await;
     let _persist_state = persist_openable_state
-        .open(NOW_ZERO(), &test_bootstrap_args())
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .expect("failed to open persist catalog");
 
@@ -109,7 +109,7 @@ async fn test_upgrade_shard() {
         .expect_build("failed to create persist catalog")
         .await;
     let _persist_state = persist_openable_state
-        .open_savepoint(NOW_ZERO(), &test_bootstrap_args())
+        .open_savepoint(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .expect("failed to open savepoint persist catalog");
 
@@ -138,7 +138,7 @@ async fn test_upgrade_shard() {
         .expect_build("failed to create persist catalog")
         .await;
     let _persist_state = persist_openable_state
-        .open(NOW_ZERO(), &test_bootstrap_args())
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .expect("failed to open readonly persist catalog");
 
@@ -178,7 +178,7 @@ async fn test_version_regression() {
         .expect_build("failed to create persist catalog")
         .await;
     let _persist_state = persist_openable_state
-        .open(NOW_ZERO(), &test_bootstrap_args())
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .expect("failed to open persist catalog");
 
@@ -199,7 +199,7 @@ async fn test_version_regression() {
         .expect_build("failed to create persist catalog")
         .await;
     let _persist_state = persist_openable_state
-        .open(NOW_ZERO(), &test_bootstrap_args())
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .expect("failed to open readonly persist catalog");
 

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -512,8 +512,7 @@ async fn test_unopened_epoch_fencing(state_builder: TestCatalogStateBuilder) {
             .clone()
             .unwrap_build()
             .await
-            // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-            .open(NOW_ZERO(), &test_bootstrap_args())
+            .open(SYSTEM_TIME(), &test_bootstrap_args())
             .await
             .unwrap();
         // drain catalog updates.
@@ -540,8 +539,7 @@ async fn test_unopened_epoch_fencing(state_builder: TestCatalogStateBuilder) {
         .clone()
         .unwrap_build()
         .await
-        // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args())
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -586,8 +584,7 @@ async fn test_unopened_deploy_generation_fencing(state_builder: TestCatalogState
             .clone()
             .unwrap_build()
             .await
-            // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-            .open(NOW_ZERO(), &test_bootstrap_args())
+            .open(SYSTEM_TIME(), &test_bootstrap_args())
             .await
             .unwrap();
         // drain catalog updates.
@@ -615,8 +612,7 @@ async fn test_unopened_deploy_generation_fencing(state_builder: TestCatalogState
         .with_deploy_generation(deploy_generation + 1)
         .unwrap_build()
         .await
-        // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args())
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -672,8 +668,7 @@ async fn test_opened_epoch_fencing(state_builder: TestCatalogStateBuilder) {
         .clone()
         .unwrap_build()
         .await
-        // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args())
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -682,8 +677,7 @@ async fn test_opened_epoch_fencing(state_builder: TestCatalogStateBuilder) {
         .clone()
         .unwrap_build()
         .await
-        // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args())
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -722,8 +716,7 @@ async fn test_opened_deploy_generation_fencing(state_builder: TestCatalogStateBu
         .with_deploy_generation(deploy_generation)
         .unwrap_build()
         .await
-        // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args())
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -733,8 +726,7 @@ async fn test_opened_deploy_generation_fencing(state_builder: TestCatalogStateBu
         .with_deploy_generation(deploy_generation + 1)
         .unwrap_build()
         .await
-        // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args())
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -777,8 +769,7 @@ async fn test_fencing_during_write(state_builder: TestCatalogStateBuilder) {
         .with_deploy_generation(deploy_generation)
         .unwrap_build()
         .await
-        // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args())
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
     // Drain updates.
@@ -792,8 +783,7 @@ async fn test_fencing_during_write(state_builder: TestCatalogStateBuilder) {
         .with_deploy_generation(deploy_generation)
         .unwrap_build()
         .await
-        // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args())
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
     // Drain updates.
@@ -818,8 +808,7 @@ async fn test_fencing_during_write(state_builder: TestCatalogStateBuilder) {
         .with_deploy_generation(deploy_generation + 1)
         .unwrap_build()
         .await
-        // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args())
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
         .await
         .unwrap();
 
@@ -858,7 +847,7 @@ async fn test_persist_version_fencing() {
             .unwrap_build()
             .await;
         let _persist_state = persist_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args())
+            .open(SYSTEM_TIME(), &test_bootstrap_args())
             .await
             .unwrap();
 


### PR DESCRIPTION
Previously, a lot of catalog tests had copy and pasted `NOW_ZERO()` as
the clock and a comment explaining why we were using that clock. The
comment is not actually valid for the majority of the tests, so this
commit removes the comment and switches to `SYSTEM_CLOCK()` which is
what the catalog uses in production.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
