### PR TITLE
ci: Bump platform checks runtimes

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -529,7 +529,7 @@ steps:
       - id: checks-restart-cockroach
         label: "Checks + restart Cockroach"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           # A larger instance is needed due to frequent OOMs, same in all other platform-checks
           queue: hetzner-aarch64-16cpu-32gb
@@ -541,7 +541,7 @@ steps:
       - id: checks-restart-entire-mz
         label: "Checks + restart of the entire Mz"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -552,7 +552,7 @@ steps:
       - id: checks-backup-restore-before-manipulate
         label: "Checks backup + restore between the two manipulate()"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -563,7 +563,7 @@ steps:
       - id: checks-backup-restore-after-manipulate
         label: "Checks backup + restore after manipulate()"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -574,7 +574,7 @@ steps:
       - id: checks-backup-multi
         label: "Checks + multiple backups/restores"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -585,7 +585,7 @@ steps:
       - id: checks-backup-rollback
         label: "Checks + backup + rollback to previous"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -597,7 +597,7 @@ steps:
         label: "Checks parallel + DROP/CREATE replica"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -609,7 +609,7 @@ steps:
         label: "Checks parallel + restart compute clusterd"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -621,7 +621,7 @@ steps:
         label: "Checks parallel + restart of the entire Mz"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -633,7 +633,7 @@ steps:
         label: "Checks parallel + restart of environmentd & storage clusterd"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -645,7 +645,7 @@ steps:
         label: "Checks parallel + kill storage clusterd"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -657,7 +657,7 @@ steps:
         label: "Checks parallel + restart Redpanda & Debezium"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -668,7 +668,7 @@ steps:
       - id: checks-upgrade-entire-mz
         label: "Checks upgrade, whole-Mz restart"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -679,7 +679,7 @@ steps:
       - id: checks-preflight-check-continue
         label: "Checks preflight-check and continue upgrade"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -690,7 +690,7 @@ steps:
       - id: checks-preflight-check-rollback
         label: "Checks preflight-check and roll back upgrade"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -701,7 +701,7 @@ steps:
       - id: checks-upgrade-entire-mz-two-versions
         label: "Checks upgrade across two versions"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -712,7 +712,7 @@ steps:
       - id: checks-upgrade-entire-mz-four-versions
         label: "Checks upgrade across four versions"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -723,7 +723,7 @@ steps:
       - id: checks-upgrade-clusterd-compute-first
         label: "Platform checks upgrade, restarting compute clusterd first"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -734,7 +734,7 @@ steps:
       - id: checks-upgrade-clusterd-compute-last
         label: "Platform checks upgrade, restarting compute clusterd last"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -745,7 +745,7 @@ steps:
       - id: checks-kill-clusterd-storage
         label: "Checks + kill storage clusterd"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -756,7 +756,7 @@ steps:
       - id: checks-restart-source-postgres
         label: "Checks + restart source Postgres"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -767,7 +767,7 @@ steps:
       - id: checks-restart-clusterd-compute
         label: "Checks + restart clusterd compute"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -778,7 +778,7 @@ steps:
       - id: checks-drop-create-default-replica
         label: "Checks + DROP/CREATE replica"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           # Seems to require more memory on aarch64
           queue: hetzner-aarch64-16cpu-32gb
@@ -790,7 +790,7 @@ steps:
       - id: checks-0dt-restart-entire-mz
         label: "Checks 0dt restart of the entire Mz"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -802,7 +802,7 @@ steps:
       - id: checks-0dt-restart-entire-mz-forced-migrations
         label: "Checks 0dt restart of the entire Mz with forced migrations"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -814,7 +814,7 @@ steps:
       - id: checks-0dt-upgrade-entire-mz
         label: "Checks 0dt upgrade, whole-Mz restart"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -826,7 +826,7 @@ steps:
       - id: checks-0dt-upgrade-entire-mz-two-versions
         label: "Checks 0dt upgrade across two versions"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -838,7 +838,7 @@ steps:
       - id: checks-0dt-upgrade-entire-mz-four-versions
         label: "Checks 0dt upgrade across four versions"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -850,7 +850,7 @@ steps:
       - id: checks-0dt-bump-version
         label: "Checks 0dt upgrade to a bumped version"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           # TODO(def-): Switch back to hetzner
           queue: builder-linux-aarch64
@@ -862,7 +862,7 @@ steps:
       - id: cloudtest-upgrade
         label: "Platform checks upgrade in Cloudtest/K8s"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:


### PR DESCRIPTION
Somehow not very consistent, timed out in https://buildkite.com/materialize/nightly/builds/9306#01919de7-58c1-47cd-a682-3b07d6f8e297

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
