### PR TITLE
cluster: Remove unnecessary errors

### DIFF
--- a/src/compute-client/src/controller/sequential_hydration.rs
+++ b/src/compute-client/src/controller/sequential_hydration.rs
@@ -331,7 +331,6 @@ async fn forward_messages<C, T>(
                     break; // `SequentialHydration` dropped
                 };
                 if let Err(error) = client.send(command).await {
-                    tracing::error!("error on send");
                     // Client produced an unrecoverable error.
                     let _ = tx.send(Err(error));
                     break;
@@ -341,11 +340,9 @@ async fn forward_messages<C, T>(
                 let response = match response {
                     Ok(Some(response)) => response,
                     Ok(None) => {
-                        tracing::error!("client disconnect");
                         break; // client disconnected
                     }
                     Err(error) => {
-                        tracing::error!("error on receive");
                         // Client produced an unrecoverable error.
                         let _ = tx.send(Err(error));
                         break;


### PR DESCRIPTION
> progress record fetch (60s) less than transaction timeout (600s), defaulting to transaction timeout 600s

Responsible for 60k events in the last 30 days: https://materializeinc.sentry.io/issues/5512940900/

> error on receive

Responsible for 7k events: https://materializeinc.sentry.io/issues/5706103329/

If something more seriously is wrong, or this is a user setup problem, we should fix it there instead.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
