### PR TITLE
persist: migrate structured arrow data as necessary on read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4985,6 +4985,7 @@ dependencies = [
  "serde_urlencoded",
  "shell-words",
  "similar-asserts",
+ "stacker",
  "sysctl",
  "tempfile",
  "thiserror",

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -99,6 +99,7 @@ sentry-tracing = "0.29.1"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.125"
 shell-words = "1.1.0"
+stacker = "0.1.15"
 sysctl = "0.5.4"
 tempfile = "3.8.1"
 thiserror = "1.0.37"

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -184,11 +184,12 @@ impl TestHarness {
 
     /// Starts a runtime and returns a [`TestServerWithRuntime`].
     pub fn start_blocking(self) -> TestServerWithRuntime {
-        let runtime = Runtime::new().expect("failed to spawn runtime for test");
-        let runtime = Arc::new(runtime);
-        let server = runtime.block_on(self.start());
-
-        TestServerWithRuntime { runtime, server }
+        stacker::grow(mz_ore::stack::STACK_SIZE, || {
+            let runtime = Runtime::new().expect("failed to spawn runtime for test");
+            let runtime = Arc::new(runtime);
+            let server = runtime.block_on(self.start());
+            TestServerWithRuntime { runtime, server }
+        })
     }
 
     pub fn data_directory(mut self, data_directory: impl Into<PathBuf>) -> Self {

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -736,7 +736,7 @@ pub async fn dangerous_force_compaction_and_break_pushdown<K, V, T, D>(
                 &mut machine,
                 req,
                 write.writer_id.clone(),
-                write.schemas.clone(),
+                write.write_schemas.clone(),
             )
             .await;
             let (res, apply_maintenance) = match res {

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -2481,7 +2481,7 @@ pub mod tests {
                     &cfg,
                     &client.metrics.user,
                     &client.isolated_runtime,
-                    &write.schemas,
+                    &write.write_schemas,
                 )
                 .await;
             let (_, writer_maintenance) = write

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -98,6 +98,8 @@ pub struct Metrics {
     pub tasks: TasksMetrics,
     /// Metrics for columnar data encoding and decoding.
     pub columnar: ColumnarMetrics,
+    /// Metrics for schemas and the schema registry.
+    pub schema: SchemaMetrics,
     /// Metrics for inline writes.
     pub inline: InlineMetrics,
     /// Semaphore to limit memory/disk use by fetches.
@@ -110,6 +112,9 @@ pub struct Metrics {
     pub s3_blob: S3BlobMetrics,
     /// Metrics for Postgres-backed consensus implementation
     pub postgres_consensus: PostgresClientMetrics,
+
+    #[allow(dead_code)]
+    pub(crate) registry: MetricsRegistry,
 }
 
 impl std::fmt::Debug for Metrics {
@@ -163,6 +168,7 @@ impl Metrics {
             blob_cache_mem: BlobMemCache::new(registry),
             tasks: TasksMetrics::new(registry),
             columnar,
+            schema: SchemaMetrics::new(registry),
             inline: InlineMetrics::new(registry),
             semaphore: SemaphoreMetrics::new(cfg.clone(), registry.clone()),
             sink: SinkMetrics::new(registry),
@@ -170,6 +176,7 @@ impl Metrics {
             postgres_consensus: PostgresClientMetrics::new(registry, "mz_persist"),
             _vecs: vecs,
             _uptime: uptime,
+            registry: registry.clone(),
         }
     }
 
@@ -3058,6 +3065,104 @@ impl TasksMetrics {
         registry.register_collector(heartbeat_read.clone());
         TasksMetrics { heartbeat_read }
     }
+}
+
+#[derive(Debug)]
+pub struct SchemaMetrics {
+    pub(crate) cache_fetch_state_count: IntCounter,
+    pub(crate) cache_schema: SchemaCacheMetrics,
+    pub(crate) cache_migration: SchemaCacheMetrics,
+    pub(crate) migration_count_same: IntCounter,
+    pub(crate) migration_count_codec: IntCounter,
+    pub(crate) migration_count_either: IntCounter,
+    pub(crate) migration_len_legacy_codec: IntCounter,
+    pub(crate) migration_len_either_codec: IntCounter,
+    pub(crate) migration_len_either_arrow: IntCounter,
+    pub(crate) migration_new_count: IntCounter,
+    pub(crate) migration_new_seconds: Counter,
+    pub(crate) migration_migrate_seconds: Counter,
+}
+
+impl SchemaMetrics {
+    fn new(registry: &MetricsRegistry) -> Self {
+        let cached: IntCounterVec = registry.register(metric!(
+            name: "mz_persist_schema_cache_cached_count",
+            help: "count of schema cache entries served from cache",
+            var_labels: ["op"],
+        ));
+        let computed: IntCounterVec = registry.register(metric!(
+            name: "mz_persist_schema_cache_computed_count",
+            help: "count of schema cache entries computed",
+            var_labels: ["op"],
+        ));
+        let unavailable: IntCounterVec = registry.register(metric!(
+            name: "mz_persist_schema_cache_unavailable_count",
+            help: "count of schema cache entries unavailable at current state",
+            var_labels: ["op"],
+        ));
+        let added: IntCounterVec = registry.register(metric!(
+            name: "mz_persist_schema_cache_added_count",
+            help: "count of schema cache entries added",
+            var_labels: ["op"],
+        ));
+        let dropped: IntCounterVec = registry.register(metric!(
+            name: "mz_persist_schema_cache_dropped_count",
+            help: "count of schema cache entries dropped",
+            var_labels: ["op"],
+        ));
+        let cache = |name| SchemaCacheMetrics {
+            cached_count: cached.with_label_values(&[name]),
+            computed_count: computed.with_label_values(&[name]),
+            unavailable_count: unavailable.with_label_values(&[name]),
+            added_count: added.with_label_values(&[name]),
+            dropped_count: dropped.with_label_values(&[name]),
+        };
+        let migration_count: IntCounterVec = registry.register(metric!(
+            name: "mz_persist_schema_migration_count",
+            help: "count of fetch part migrations",
+            var_labels: ["op"],
+        ));
+        let migration_len: IntCounterVec = registry.register(metric!(
+            name: "mz_persist_schema_migration_len",
+            help: "count of migrated update records",
+            var_labels: ["op"],
+        ));
+        SchemaMetrics {
+            cache_fetch_state_count: registry.register(metric!(
+                name: "mz_persist_schema_cache_fetch_state_count",
+                help: "count of state fetches by the schema cache",
+            )),
+            cache_schema: cache("schema"),
+            cache_migration: cache("migration"),
+            migration_count_same: migration_count.with_label_values(&["same"]),
+            migration_count_codec: migration_count.with_label_values(&["codec"]),
+            migration_count_either: migration_count.with_label_values(&["either"]),
+            migration_len_legacy_codec: migration_len.with_label_values(&["legacy_codec"]),
+            migration_len_either_codec: migration_len.with_label_values(&["either_codec"]),
+            migration_len_either_arrow: migration_len.with_label_values(&["either_arrow"]),
+            migration_new_count: registry.register(metric!(
+                name: "mz_persist_schema_migration_new_count",
+                help: "count of migrations constructed",
+            )),
+            migration_new_seconds: registry.register(metric!(
+                name: "mz_persist_schema_migration_new_seconds",
+                help: "seconds spent constructing migration logic",
+            )),
+            migration_migrate_seconds: registry.register(metric!(
+                name: "mz_persist_schema_migration_migrate_seconds",
+                help: "seconds spent applying migration logic",
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SchemaCacheMetrics {
+    pub(crate) cached_count: IntCounter,
+    pub(crate) computed_count: IntCounter,
+    pub(crate) unavailable_count: IntCounter,
+    pub(crate) added_count: IntCounter,
+    pub(crate) dropped_count: IntCounter,
 }
 
 #[derive(Debug)]

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1056,8 +1056,14 @@ where
 
         let key_dt = data_type(key_schema);
         let val_dt = data_type(val_schema);
-        let key_fn = backward_compatible(&EncodedSchemas::decode_data_type(&current.key), &key_dt);
-        let val_fn = backward_compatible(&EncodedSchemas::decode_data_type(&current.val), &val_dt);
+        let key_fn = backward_compatible(
+            &EncodedSchemas::decode_data_type(&current.key_data_type),
+            &key_dt,
+        );
+        let val_fn = backward_compatible(
+            &EncodedSchemas::decode_data_type(&current.val_data_type),
+            &val_dt,
+        );
         let (Some(key_fn), Some(val_fn)) = (key_fn, val_fn) else {
             return Break(NoOpStateTransition(CaESchema::Incompatible));
         };

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -431,7 +431,7 @@ impl PersistClient {
         let _ = state_versions
             .maybe_init_shard::<K, V, T, D>(&shard_metrics)
             .await;
-        let schemas = Schemas {
+        let read_schemas = Schemas {
             id: None,
             key: key_schema,
             val: val_schema,
@@ -442,7 +442,7 @@ impl PersistClient {
             metrics: Arc::clone(&self.metrics),
             shard_metrics,
             shard_id,
-            schemas,
+            read_schemas,
             is_transient,
             _phantom: PhantomData,
         };
@@ -859,7 +859,7 @@ mod tests {
         blob: &dyn Blob,
         key: &BlobKey,
         metrics: &Metrics,
-        schemas: &Schemas<K, V>,
+        read_schemas: &Schemas<K, V>,
     ) -> (
         BlobTraceBatchPart<T>,
         Vec<((Result<K, String>, Result<V, String>), T, D)>,
@@ -880,7 +880,10 @@ mod tests {
         let mut updates = Vec::new();
         for ((k, v), t, d) in part.updates.records().iter() {
             updates.push((
-                (K::decode(k, &schemas.key), V::decode(v, &schemas.val)),
+                (
+                    K::decode(k, &read_schemas.key),
+                    V::decode(v, &read_schemas.val),
+                ),
                 T::decode(t),
                 D::decode(d),
             ));

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -405,49 +405,33 @@ impl PersistClient {
         val_schema: Arc<V::Schema>,
         is_transient: bool,
         diagnostics: Diagnostics,
-    ) -> BatchFetcher<K, V, T, D>
+    ) -> Result<BatchFetcher<K, V, T, D>, InvalidUsage<T>>
     where
         K: Debug + Codec,
         V: Debug + Codec,
         T: Timestamp + Lattice + Codec64,
         D: Semigroup + Codec64 + Send + Sync,
     {
-        let state_versions = StateVersions::new(
-            self.cfg.clone(),
-            Arc::clone(&self.consensus),
-            Arc::clone(&self.blob),
-            Arc::clone(&self.metrics),
-        );
-        let shard_metrics = self
-            .metrics
-            .shards
-            .shard(&shard_id, &diagnostics.shard_name);
-
-        // This call ensures that the types match what was used when creating
-        // the shard or puts in place the types that we expect for future
-        // read/write handle creations. It's not technically needed for creating
-        // the `BatchFetcher` but acts as a safety net against accidental
-        // mis-use.
-        let _ = state_versions
-            .maybe_init_shard::<K, V, T, D>(&shard_metrics)
-            .await;
+        let machine = self.make_machine(shard_id, diagnostics.clone()).await?;
         let read_schemas = Schemas {
             id: None,
             key: key_schema,
             val: val_schema,
         };
+        let schema_cache = machine.applier.schema_cache();
         let fetcher = BatchFetcher {
             cfg: BatchFetcherConfig::new(&self.cfg),
             blob: Arc::clone(&self.blob),
             metrics: Arc::clone(&self.metrics),
-            shard_metrics,
+            shard_metrics: Arc::clone(&machine.applier.shard_metrics),
             shard_id,
             read_schemas,
+            schema_cache,
             is_transient,
             _phantom: PhantomData,
         };
 
-        fetcher
+        Ok(fetcher)
     }
 
     /// A convenience [CriticalReaderId] for Materialize controllers.
@@ -1141,7 +1125,7 @@ mod tests {
             let shard_id1 = "s11111111-1111-1111-1111-111111111111"
                 .parse::<ShardId>()
                 .expect("invalid shard id");
-            let fetcher1 = client
+            let mut fetcher1 = client
                 .create_batch_fetcher::<String, String, u64, i64>(
                     shard_id1,
                     Default::default(),
@@ -1149,7 +1133,8 @@ mod tests {
                     false,
                     Diagnostics::for_tests(),
                 )
-                .await;
+                .await
+                .unwrap();
             for batch in snap {
                 let res = fetcher1.fetch_leased_part(&batch).await;
                 assert_eq!(

--- a/src/persist-client/src/schema.rs
+++ b/src/persist-client/src/schema.rs
@@ -9,12 +9,26 @@
 
 //! Persist shard schema information.
 
+use std::collections::BTreeMap;
+use std::fmt::Debug;
 use std::str::FromStr;
+use std::sync::{Arc, RwLock};
+use std::time::Instant;
 
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::lattice::Lattice;
 use mz_ore::cast::CastFrom;
-use mz_persist_types::Codec;
+use mz_persist_types::columnar::data_type;
+use mz_persist_types::schema::{backward_compatible, Migration};
+use mz_persist_types::{Codec, Codec64};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
+use timely::progress::Timestamp;
+
+use crate::internal::apply::Applier;
+use crate::internal::encoding::Schemas;
+use crate::internal::metrics::{SchemaCacheMetrics, SchemaMetrics};
+use crate::internal::state::EncodedSchemas;
 
 /// An ordered identifier for a pair of key and val schemas registered to a
 /// shard.
@@ -49,6 +63,7 @@ impl TryFrom<String> for SchemaId {
 
 /// The result returned by [crate::PersistClient::compare_and_evolve_schema].
 #[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum CaESchema<K: Codec, V: Codec> {
     /// The schema was successfully evolved and registered with the included id.
     Ok(SchemaId),
@@ -66,8 +81,374 @@ pub enum CaESchema<K: Codec, V: Codec> {
     },
 }
 
+/// A cache of decoded schemas and schema migrations.
+///
+/// The decoded schemas are a cache of the registry in state, and so are shared
+/// process-wide.
+///
+/// On the other hand, the migrations have an N^2 problem and so are per-handle.
+/// This also seems reasonable because for any given write handle, the write
+/// schema will be the same for all migration entries, and ditto for read handle
+/// and read schema.
+#[derive(Debug)]
+pub(crate) struct SchemaCache<K: Codec, V: Codec, T, D> {
+    maps: Arc<SchemaCacheMaps<K, V>>,
+    applier: Applier<K, V, T, D>,
+    key_migration_by_ids: MigrationCacheMap,
+    val_migration_by_ids: MigrationCacheMap,
+}
+
+impl<K: Codec, V: Codec, T: Clone, D> Clone for SchemaCache<K, V, T, D> {
+    fn clone(&self) -> Self {
+        Self {
+            maps: Arc::clone(&self.maps),
+            applier: self.applier.clone(),
+            key_migration_by_ids: self.key_migration_by_ids.clone(),
+            val_migration_by_ids: self.val_migration_by_ids.clone(),
+        }
+    }
+}
+
+impl<K: Codec, V: Codec, T, D> Drop for SchemaCache<K, V, T, D> {
+    fn drop(&mut self) {
+        let dropped = u64::cast_from(
+            self.key_migration_by_ids.by_ids.len() + self.val_migration_by_ids.by_ids.len(),
+        );
+        self.applier
+            .metrics
+            .schema
+            .cache_migration
+            .dropped_count
+            .inc_by(dropped);
+    }
+}
+
+impl<K, V, T, D> SchemaCache<K, V, T, D>
+where
+    K: Debug + Codec,
+    V: Debug + Codec,
+    T: Timestamp + Lattice + Codec64,
+    D: Semigroup + Codec64,
+{
+    pub fn new(maps: Arc<SchemaCacheMaps<K, V>>, applier: Applier<K, V, T, D>) -> Self {
+        let key_migration_by_ids = MigrationCacheMap {
+            metrics: applier.metrics.schema.cache_migration.clone(),
+            by_ids: BTreeMap::new(),
+        };
+        let val_migration_by_ids = MigrationCacheMap {
+            metrics: applier.metrics.schema.cache_migration.clone(),
+            by_ids: BTreeMap::new(),
+        };
+        SchemaCache {
+            maps,
+            applier,
+            key_migration_by_ids,
+            val_migration_by_ids,
+        }
+    }
+
+    async fn schemas(&self, id: &SchemaId) -> Option<Schemas<K, V>> {
+        let key = self
+            .get_or_try_init(&self.maps.key_by_id, id, |schemas| {
+                self.maps.key_by_id.metrics.computed_count.inc();
+                schemas.get(id).map(|x| K::decode_schema(&x.key))
+            })
+            .await?;
+        let val = self
+            .get_or_try_init(&self.maps.val_by_id, id, |schemas| {
+                self.maps.val_by_id.metrics.computed_count.inc();
+                schemas.get(id).map(|x| V::decode_schema(&x.val))
+            })
+            .await?;
+        Some(Schemas {
+            id: Some(*id),
+            key,
+            val,
+        })
+    }
+
+    fn key_migration(
+        &mut self,
+        write: &Schemas<K, V>,
+        read: &Schemas<K, V>,
+    ) -> Option<Arc<Migration>> {
+        let migration_fn = || Self::migration::<K>(&write.key, &read.key);
+        let (Some(write_id), Some(read_id)) = (write.id, read.id) else {
+            // TODO: Annoying to cache this because we're missing an id. This
+            // will probably require some sort of refactor to fix so punting for
+            // now.
+            self.key_migration_by_ids.metrics.computed_count.inc();
+            return migration_fn().map(Arc::new);
+        };
+        self.key_migration_by_ids
+            .get_or_try_insert(write_id, read_id, migration_fn)
+    }
+
+    fn val_migration(
+        &mut self,
+        write: &Schemas<K, V>,
+        read: &Schemas<K, V>,
+    ) -> Option<Arc<Migration>> {
+        let migration_fn = || Self::migration::<V>(&write.val, &read.val);
+        let (Some(write_id), Some(read_id)) = (write.id, read.id) else {
+            // TODO: Annoying to cache this because we're missing an id. This
+            // will probably require some sort of refactor to fix so punting for
+            // now.
+            self.val_migration_by_ids.metrics.computed_count.inc();
+            return migration_fn().map(Arc::new);
+        };
+        self.val_migration_by_ids
+            .get_or_try_insert(write_id, read_id, migration_fn)
+    }
+
+    fn migration<C: Codec>(write: &C::Schema, read: &C::Schema) -> Option<Migration> {
+        let write_dt = data_type::<C>(write).expect("valid schema");
+        let read_dt = data_type::<C>(read).expect("valid schema");
+        backward_compatible(&write_dt, &read_dt)
+    }
+
+    async fn get_or_try_init<MK: Clone + Ord, MV: PartialEq + Debug>(
+        &self,
+        map: &SchemaCacheMap<MK, MV>,
+        key: &MK,
+        f: impl Fn(&BTreeMap<SchemaId, EncodedSchemas>) -> Option<MV>,
+    ) -> Option<Arc<MV>> {
+        let ret = map.get_or_try_init(key, || {
+            self.applier
+                .schemas(|seqno, schemas| f(schemas).ok_or(seqno))
+        });
+        let seqno = match ret {
+            Ok(ret) => return Some(ret),
+            Err(seqno) => seqno,
+        };
+        self.applier.metrics.schema.cache_fetch_state_count.inc();
+        self.applier.fetch_and_update_state(Some(seqno)).await;
+        map.get_or_try_init(key, || {
+            self.applier
+                .schemas(|seqno, schemas| f(schemas).ok_or(seqno))
+        })
+        .ok()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SchemaCacheMaps<K: Codec, V: Codec> {
+    key_by_id: SchemaCacheMap<SchemaId, K::Schema>,
+    val_by_id: SchemaCacheMap<SchemaId, V::Schema>,
+}
+
+impl<K: Codec, V: Codec> SchemaCacheMaps<K, V> {
+    pub(crate) fn new(metrics: &SchemaMetrics) -> Self {
+        Self {
+            key_by_id: SchemaCacheMap {
+                metrics: metrics.cache_schema.clone(),
+                map: RwLock::new(BTreeMap::new()),
+            },
+            val_by_id: SchemaCacheMap {
+                metrics: metrics.cache_schema.clone(),
+                map: RwLock::new(BTreeMap::new()),
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SchemaCacheMap<I, S> {
+    metrics: SchemaCacheMetrics,
+    map: RwLock<BTreeMap<I, Arc<S>>>,
+}
+
+impl<I: Clone + Ord, S: PartialEq + Debug> SchemaCacheMap<I, S> {
+    fn get_or_try_init<E>(
+        &self,
+        id: &I,
+        state_fn: impl FnOnce() -> Result<S, E>,
+    ) -> Result<Arc<S>, E> {
+        // First see if we have the value cached.
+        {
+            let map = self.map.read().expect("lock");
+            if let Some(ret) = map.get(id).map(Arc::clone) {
+                self.metrics.cached_count.inc();
+                return Ok(ret);
+            }
+        }
+        // If not, see if we can get the value from current state.
+        let ret = state_fn().map(Arc::new);
+        if let Ok(val) = ret.as_ref() {
+            let mut map = self.map.write().expect("lock");
+            // If any answers got written in the meantime, they should be the
+            // same, so just overwrite
+            let prev = map.insert(id.clone(), Arc::clone(val));
+            match prev {
+                Some(prev) => debug_assert_eq!(*val, prev),
+                None => self.metrics.added_count.inc(),
+            }
+        } else {
+            self.metrics.unavailable_count.inc();
+        }
+        ret
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MigrationCacheMap {
+    metrics: SchemaCacheMetrics,
+    by_ids: BTreeMap<(SchemaId, SchemaId), Arc<Migration>>,
+}
+
+impl MigrationCacheMap {
+    fn get_or_try_insert(
+        &mut self,
+        write_id: SchemaId,
+        read_id: SchemaId,
+        migration_fn: impl FnOnce() -> Option<Migration>,
+    ) -> Option<Arc<Migration>> {
+        if let Some(migration) = self.by_ids.get(&(write_id, read_id)) {
+            self.metrics.cached_count.inc();
+            return Some(Arc::clone(migration));
+        };
+        self.metrics.computed_count.inc();
+        let migration = migration_fn().map(Arc::new);
+        if let Some(migration) = migration.as_ref() {
+            self.metrics.added_count.inc();
+            // We just looked this up above and we've got mutable access, so no
+            // race issues.
+            self.by_ids
+                .insert((write_id, read_id), Arc::clone(migration));
+        } else {
+            self.metrics.unavailable_count.inc();
+        }
+        migration
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum PartMigration<K: Codec, V: Codec> {
+    /// No-op!
+    SameSchema { both: Schemas<K, V> },
+    /// This part predates writing down schema ids, so we have to decode and
+    /// potentially migrate it to the target schema via the legacy Codec path.
+    Codec { read: Schemas<K, V> },
+    /// We have both write and read schemas, and they don't match.
+    Either {
+        _write: Schemas<K, V>,
+        read: Schemas<K, V>,
+        key_migration: Arc<Migration>,
+        val_migration: Arc<Migration>,
+    },
+}
+
+impl<K: Codec, V: Codec> Clone for PartMigration<K, V> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::SameSchema { both } => Self::SameSchema { both: both.clone() },
+            Self::Codec { read } => Self::Codec { read: read.clone() },
+            Self::Either {
+                _write,
+                read,
+                key_migration,
+                val_migration,
+            } => Self::Either {
+                _write: _write.clone(),
+                read: read.clone(),
+                key_migration: Arc::clone(key_migration),
+                val_migration: Arc::clone(val_migration),
+            },
+        }
+    }
+}
+
+impl<K, V> PartMigration<K, V>
+where
+    K: Debug + Codec,
+    V: Debug + Codec,
+{
+    pub(crate) async fn new<T, D>(
+        write: Option<SchemaId>,
+        read: Schemas<K, V>,
+        schema_cache: &mut SchemaCache<K, V, T, D>,
+    ) -> Result<Self, Schemas<K, V>>
+    where
+        T: Timestamp + Lattice + Codec64,
+        D: Semigroup + Codec64,
+    {
+        match (write, read.id) {
+            (None, _) => Ok(PartMigration::Codec { read }),
+            (Some(w), Some(r)) if w == r => Ok(PartMigration::SameSchema { both: read }),
+            (Some(w), _) => {
+                let write = schema_cache
+                    .schemas(&w)
+                    .await
+                    .expect("appended part should reference registered schema");
+                // Even if we missing a schema id, if the schemas are equal, use
+                // `SameSchema`. This isn't a correctness issue, we'd just
+                // generate NoOp migrations, but it'll make the metrics more
+                // intuitive.
+                if write.key == read.key && write.val == read.val {
+                    return Ok(PartMigration::SameSchema { both: read });
+                }
+
+                let start = Instant::now();
+                let key_migration = schema_cache
+                    .key_migration(&write, &read)
+                    .ok_or_else(|| read.clone())?;
+                let val_migration = schema_cache
+                    .val_migration(&write, &read)
+                    .ok_or_else(|| read.clone())?;
+                schema_cache
+                    .applier
+                    .metrics
+                    .schema
+                    .migration_new_count
+                    .inc();
+                schema_cache
+                    .applier
+                    .metrics
+                    .schema
+                    .migration_new_seconds
+                    .inc_by(start.elapsed().as_secs_f64());
+
+                Ok(PartMigration::Either {
+                    _write: write,
+                    read,
+                    key_migration,
+                    val_migration,
+                })
+            }
+        }
+    }
+}
+
+impl<K: Codec, V: Codec> PartMigration<K, V> {
+    pub(crate) fn codec_read(&self) -> &Schemas<K, V> {
+        match self {
+            PartMigration::SameSchema { both } => both,
+            PartMigration::Codec { read } => read,
+            PartMigration::Either { read, .. } => read,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use arrow::array::{
+        as_string_array, Array, ArrayBuilder, StringArray, StringBuilder, StructArray,
+    };
+    use arrow::datatypes::{DataType, Field};
+    use bytes::BufMut;
+    use futures::StreamExt;
+    use mz_dyncfg::ConfigUpdates;
+    use mz_persist_types::codec_impls::UnitSchema;
+    use mz_persist_types::columnar::{ColumnDecoder, ColumnEncoder, Schema2};
+    use mz_persist_types::stats::{NoneStats, StructStats};
+    use mz_persist_types::ShardId;
+    use timely::progress::Antichain;
+
+    use crate::cli::admin::info_log_non_zero_metrics;
+    use crate::read::ReadHandle;
+    use crate::tests::new_test_client;
+    use crate::{Diagnostics, DANGEROUS_ENABLE_SCHEMA_EVOLUTION};
+
     use super::*;
 
     #[mz_ore::test]
@@ -75,5 +456,336 @@ mod tests {
         assert_eq!(SchemaId(1).to_string(), "h1");
         assert_eq!(SchemaId::try_from("h1".to_owned()), Ok(SchemaId(1)));
         assert!(SchemaId::try_from("nope".to_owned()).is_err());
+    }
+
+    #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+    struct Strings(Vec<String>);
+
+    impl Codec for Strings {
+        type Schema = StringsSchema;
+        type Storage = ();
+
+        fn codec_name() -> String {
+            "Strings".into()
+        }
+
+        fn encode<B: BufMut>(&self, buf: &mut B) {
+            buf.put_slice(self.0.join(",").as_bytes());
+        }
+        fn decode<'a>(buf: &'a [u8], schema: &Self::Schema) -> Result<Self, String> {
+            let buf = std::str::from_utf8(buf).map_err(|err| err.to_string())?;
+            let mut ret = buf.split(",").map(|x| x.to_owned()).collect::<Vec<_>>();
+            // Fill in nulls or drop columns to match the requested schema.
+            while schema.0.len() > ret.len() {
+                ret.push("".into());
+            }
+            while schema.0.len() < ret.len() {
+                ret.pop();
+            }
+            Ok(Strings(ret))
+        }
+
+        fn encode_schema(schema: &Self::Schema) -> bytes::Bytes {
+            schema
+                .0
+                .iter()
+                .map(|x| x.then_some('n').unwrap_or(' '))
+                .collect::<String>()
+                .into_bytes()
+                .into()
+        }
+        fn decode_schema(buf: &bytes::Bytes) -> Self::Schema {
+            let buf = std::str::from_utf8(buf).expect("valid schema");
+            StringsSchema(
+                buf.chars()
+                    .map(|x| match x {
+                        'n' => true,
+                        ' ' => false,
+                        _ => unreachable!(),
+                    })
+                    .collect(),
+            )
+        }
+    }
+
+    #[derive(Debug, Clone, Default, PartialEq)]
+    struct StringsSchema(Vec<bool>);
+
+    impl Schema2<Strings> for StringsSchema {
+        type ArrowColumn = StructArray;
+        type Statistics = NoneStats;
+        type Decoder = StringsDecoder;
+        type Encoder = StringsEncoder;
+
+        fn decoder(&self, col: Self::ArrowColumn) -> Result<Self::Decoder, anyhow::Error> {
+            let mut cols = Vec::new();
+            for (idx, _) in self.0.iter().enumerate() {
+                cols.push(as_string_array(col.column_by_name(&idx.to_string()).unwrap()).clone());
+            }
+            Ok(StringsDecoder(cols))
+        }
+        fn encoder(&self) -> Result<Self::Encoder, anyhow::Error> {
+            let mut fields = Vec::new();
+            let mut arrays = Vec::new();
+            for (idx, nullable) in self.0.iter().enumerate() {
+                fields.push(Field::new(idx.to_string(), DataType::Utf8, *nullable));
+                arrays.push(StringBuilder::new());
+            }
+            Ok(StringsEncoder { fields, arrays })
+        }
+    }
+
+    #[derive(Debug)]
+    struct StringsDecoder(Vec<StringArray>);
+    impl ColumnDecoder<Strings> for StringsDecoder {
+        fn decode(&self, idx: usize, val: &mut Strings) {
+            val.0.clear();
+            for col in self.0.iter() {
+                if col.is_valid(idx) {
+                    val.0.push(col.value(idx).into());
+                } else {
+                    val.0.push("".into());
+                }
+            }
+        }
+        fn is_null(&self, _: usize) -> bool {
+            false
+        }
+        fn stats(&self) -> StructStats {
+            StructStats {
+                len: self.0[0].len(),
+                cols: Default::default(),
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct StringsEncoder {
+        fields: Vec<Field>,
+        arrays: Vec<StringBuilder>,
+    }
+    impl ColumnEncoder<Strings> for StringsEncoder {
+        type FinishedColumn = StructArray;
+
+        fn append(&mut self, val: &Strings) {
+            for (idx, val) in val.0.iter().enumerate() {
+                if val.is_empty() {
+                    self.arrays[idx].append_null();
+                } else {
+                    self.arrays[idx].append_value(val);
+                }
+            }
+        }
+        fn append_null(&mut self) {
+            unreachable!()
+        }
+        fn finish(self) -> Self::FinishedColumn {
+            let arrays = self
+                .arrays
+                .into_iter()
+                .map(|mut x| ArrayBuilder::finish(&mut x))
+                .collect();
+            StructArray::new(self.fields.into(), arrays, None)
+        }
+    }
+
+    #[mz_persist_proc::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn compare_and_evolve_schema(mut dyncfgs: ConfigUpdates) {
+        dyncfgs.add(&DANGEROUS_ENABLE_SCHEMA_EVOLUTION, true);
+
+        let client = new_test_client(&dyncfgs).await;
+        let d = Diagnostics::for_tests();
+        let shard_id = ShardId::new();
+        let schema0 = StringsSchema(vec![false]);
+        let schema1 = StringsSchema(vec![false, true]);
+
+        let write0 = client
+            .open_writer::<Strings, (), u64, i64>(
+                shard_id,
+                Arc::new(schema0.clone()),
+                Arc::new(UnitSchema),
+                d.clone(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(write0.write_schemas.id.unwrap(), SchemaId(0));
+
+        // Not backward compatible (yet... we don't support dropping a column at
+        // the moment).
+        let res = client
+            .compare_and_evolve_schema::<Strings, (), u64, i64>(
+                shard_id,
+                SchemaId(0),
+                &StringsSchema(vec![]),
+                &UnitSchema,
+                d.clone(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res, CaESchema::Incompatible);
+
+        // Incorrect expectation
+        let res = client
+            .compare_and_evolve_schema::<Strings, (), u64, i64>(
+                shard_id,
+                SchemaId(1),
+                &schema1,
+                &UnitSchema,
+                d.clone(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            res,
+            CaESchema::ExpectedMismatch {
+                schema_id: SchemaId(0),
+                key: schema0,
+                val: UnitSchema
+            }
+        );
+
+        // Successful evolution
+        let res = client
+            .compare_and_evolve_schema::<Strings, (), u64, i64>(
+                shard_id,
+                SchemaId(0),
+                &schema1,
+                &UnitSchema,
+                d.clone(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res, CaESchema::Ok(SchemaId(1)));
+
+        // Create a write handle with the new schema and validate that it picks
+        // up the correct schema id.
+        let write1 = client
+            .open_writer::<Strings, (), u64, i64>(
+                shard_id,
+                Arc::new(schema1),
+                Arc::new(UnitSchema),
+                d.clone(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(write1.write_schemas.id.unwrap(), SchemaId(1));
+    }
+
+    fn strings(xs: &[((Result<Strings, String>, Result<(), String>), u64, i64)]) -> Vec<Vec<&str>> {
+        xs.iter()
+            .map(|((k, _), _, _)| k.as_ref().unwrap().0.iter().map(|x| x.as_str()).collect())
+            .collect()
+    }
+
+    #[mz_persist_proc::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn schema_evolution(mut dyncfgs: ConfigUpdates) {
+        dyncfgs.add(&DANGEROUS_ENABLE_SCHEMA_EVOLUTION, true);
+
+        async fn snap_streaming(
+            as_of: u64,
+            read: &mut ReadHandle<Strings, (), u64, i64>,
+        ) -> Vec<((Result<Strings, String>, Result<(), String>), u64, i64)> {
+            // NB: We test with both snapshot_and_fetch and snapshot_and_stream
+            // because one uses the consolidating iter and one doesn't.
+            let mut ret = read
+                .snapshot_and_stream(Antichain::from_elem(as_of))
+                .await
+                .unwrap()
+                .collect::<Vec<_>>()
+                .await;
+            ret.sort();
+            ret
+        }
+
+        let client = new_test_client(&dyncfgs).await;
+        let d = Diagnostics::for_tests();
+        let shard_id = ShardId::new();
+        let schema0 = StringsSchema(vec![false]);
+        let schema1 = StringsSchema(vec![false, true]);
+
+        // Write some data at the original schema.
+        let (mut write0, mut read0) = client
+            .open::<Strings, (), u64, i64>(
+                shard_id,
+                Arc::new(schema0.clone()),
+                Arc::new(UnitSchema),
+                d.clone(),
+                true,
+            )
+            .await
+            .unwrap();
+        write0
+            .expect_compare_and_append(&[((Strings(vec!["0 before".into()]), ()), 0, 1)], 0, 1)
+            .await;
+        let expected = vec![vec!["0 before"]];
+        assert_eq!(strings(&snap_streaming(0, &mut read0).await), expected);
+        assert_eq!(strings(&read0.expect_snapshot_and_fetch(0).await), expected);
+
+        // Register and write some data at the new schema.
+        let res = client
+            .compare_and_evolve_schema::<Strings, (), u64, i64>(
+                shard_id,
+                SchemaId(0),
+                &schema1,
+                &UnitSchema,
+                d.clone(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res, CaESchema::Ok(SchemaId(1)));
+        let (mut write1, mut read1) = client
+            .open::<Strings, (), u64, i64>(
+                shard_id,
+                Arc::new(schema1.clone()),
+                Arc::new(UnitSchema),
+                d.clone(),
+                true,
+            )
+            .await
+            .unwrap();
+        write1
+            .expect_compare_and_append(
+                &[
+                    ((Strings(vec!["1 null".into(), "".into()]), ()), 1, 1),
+                    ((Strings(vec!["1 not".into(), "x".into()]), ()), 1, 1),
+                ],
+                1,
+                2,
+            )
+            .await;
+
+        // Continue to write data with the original schema.
+        write0
+            .expect_compare_and_append(&[((Strings(vec!["0 after".into()]), ()), 2, 1)], 2, 3)
+            .await;
+
+        // Original schema drops the new column in data written by new schema.
+        let expected = vec![
+            vec!["0 after"],
+            vec!["0 before"],
+            vec!["1 not"],
+            vec!["1 null"],
+        ];
+        assert_eq!(strings(&snap_streaming(2, &mut read0).await), expected);
+        assert_eq!(strings(&read0.expect_snapshot_and_fetch(2).await), expected);
+
+        // New schema adds nulls (represented by empty string in Strings) in
+        // data written by old schema.
+        let expected = vec![
+            vec!["0 after", ""],
+            vec!["0 before", ""],
+            vec!["1 not", "x"],
+            vec!["1 null", ""],
+        ];
+        assert_eq!(strings(&snap_streaming(2, &mut read1).await), expected);
+        assert_eq!(strings(&read1.expect_snapshot_and_fetch(2).await), expected);
+
+        // Probably too spammy to leave in the logs, but it was useful to have
+        // hooked up while iterating.
+        if false {
+            info_log_non_zero_metrics(&client.metrics.registry.gather());
+        }
     }
 }

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -124,7 +124,7 @@ pub(crate) fn untrimmable_columns(cfg: &ConfigSet) -> UntrimmableColumns {
 
 /// Encodes a [`BlobTraceUpdates`] and calculates [`PartStats`].
 pub(crate) fn encode_updates<K, V>(
-    schemas: &Schemas<K, V>,
+    write_schemas: &Schemas<K, V>,
     updates: &BlobTraceUpdates,
 ) -> Result<(Option<ColumnarRecordsStructuredExt>, PartStats), String>
 where
@@ -136,14 +136,14 @@ where
     let ext = match updates.structured() {
         Some(ext) => ext.clone(),
         None => ColumnarRecordsStructuredExt {
-            key: codec_to_schema2::<K>(schemas.key.as_ref(), records.keys())
+            key: codec_to_schema2::<K>(write_schemas.key.as_ref(), records.keys())
                 .map_err(|e| e.to_string())?,
-            val: codec_to_schema2::<V>(schemas.val.as_ref(), records.vals())
+            val: codec_to_schema2::<V>(write_schemas.val.as_ref(), records.vals())
                 .map_err(|e| e.to_string())?,
         },
     };
 
-    let key_stats = schemas
+    let key_stats = write_schemas
         .key
         .decoder_any(ext.key.as_ref())
         .map_err(|e| e.to_string())?

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -957,14 +957,14 @@ mod tests {
                 &cfg,
                 &client.metrics.user,
                 &client.isolated_runtime,
-                &write.schemas,
+                &write.write_schemas,
             )
             .await;
             b2.flush_to_blob(
                 &cfg,
                 &client.metrics.user,
                 &client.isolated_runtime,
-                &write.schemas,
+                &write.write_schemas,
             )
             .await;
         }

--- a/src/persist-types/src/schema.rs
+++ b/src/persist-types/src/schema.rs
@@ -23,7 +23,7 @@ pub fn backward_compatible(old: &DataType, new: &DataType) -> Option<Migration> 
 }
 
 /// See [backward_compatible].
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Migration(ArrayMigration);
 
 impl Migration {

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -241,6 +241,7 @@ impl BlobTraceUpdates {
                 // compatible schemas... but if it fails we only log, and let some higher-level
                 // code signal the error if it cares.
                 let migrate = |array: &mut ArrayRef, to_type: DataType| {
+                    // TODO: Plumb down the SchemaCache and use it here for the array migrations.
                     let from_type = array.data_type().clone();
                     if from_type != to_type {
                         if let Some(migration) = backward_compatible(&from_type, &to_type) {


### PR DESCRIPTION
We now have both a write schema and a read schema at read time. The
write schema is specified by an id which indexes into a map in durable
persist state, but is sometimes missing because of backward
compatibility. The read schema is always present but might be missing an
id (e.g. if we use this mechanism for projection pushdown, but also for
other various edge cases).

The vast majority common case is that these schemas will be the same and
no migration is necessary. If we're missing the write schema, we _have_
to use the legacy Codec to decode the data. If we have both and they're
not the same, construct (and cache) migration logic for converting from
the write schema to the read schema.

Note that, counter-intuitively, the write schema could be from "after"
the read schema. This is because of the following scenario:

- A persist source is started on some shard at schema 0.
- The shard is migrated to schema 1. We don't want to restart the
  dataflow because it would be too disruptive.
- Data is written at schema 1 and the persist source encounters it.
- We solve this by only allowing migrations that are both backward and
  forward compatible with all registered migrations.
- In practice, this just means a field id cannot be reused after it is
  dropped. Nothing special to implement here right now because we don't
  (yet) support dropping columns in `compare_and_evolve_schema`.

Touches #16625

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

The first commit is pure refactor, so definitely look at the second commit on its own to reduce noise.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
