### PR TITLE
Fix ignore nulls performance problem with long runs of nulls

### DIFF
--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -2276,7 +2276,7 @@ create table t6(x int, y int);
 statement ok
 insert into t6 values (1,2), (3,null), (5,6), (7,8), (9, null), (11, null), (13, 14), (15, 16), (17, 18);
 
-query IIIIIIIIIIIIIII
+query IIIIIIIIIIIIIIIII
 select
   x,
   y,
@@ -2292,23 +2292,25 @@ select
   lag(y, 2, -1) ignore nulls over (order by x) as lag2_ign_def,
   lead(y, 2, -1) ignore nulls over (order by x) as lead2_ign_def,
   lag(y, 2, 16) ignore nulls over (order by x) as lag2_ign_def16,
-  lead(y, 2, 16) ignore nulls over (order by x) as lead2_ign_def16
+  lead(y, 2, 16) ignore nulls over (order by x) as lead2_ign_def16,
+  lag(y, -1, 100) ignore nulls over (order by x) as lag_neg_offset,
+  lead(y, -2, 100) ignore nulls over (order by x) as lead_neg_offset
 from t6
 order by x;
 ----
-1  2  NULL  NULL  NULL  NULL  6  NULL  NULL  6  8  -1  8  16  8
-3  NULL  2  2  2  6  6  NULL  NULL  8  8  -1  8  16  8
-5  6  NULL  NULL  2  8  8  2  NULL  NULL  14  -1  14  16  14
-7  8  6  6  6  NULL  14  NULL  2  NULL  16  2  16  2  16
-9  NULL  8  8  8  NULL  14  6  6  14  16  6  16  6  16
-11  NULL  NULL  NULL  8  14  14  8  6  16  16  6  16  6  16
-13  14  NULL  NULL  8  16  16  NULL  6  18  18  6  18  6  18
-15  16  14  14  14  18  18  NULL  8  NULL  NULL  8  -1  8  16
-17  18  16  16  16  NULL  NULL  14  14  NULL  NULL  14  -1  14  16
+1  2  NULL  NULL  NULL  NULL  6  NULL  NULL  6  8  -1  8  16  8  6  100
+3  NULL  2  2  2  6  6  NULL  NULL  8  8  -1  8  16  8  6  100
+5  6  NULL  NULL  2  8  8  2  NULL  NULL  14  -1  14  16  14  8  100
+7  8  6  6  6  NULL  14  NULL  2  NULL  16  2  16  2  16  14  2
+9  NULL  8  8  8  NULL  14  6  6  14  16  6  16  6  16  14  6
+11  NULL  NULL  NULL  8  14  14  8  6  16  16  6  16  6  16  14  6
+13  14  NULL  NULL  8  16  16  NULL  6  18  18  6  18  6  18  16  6
+15  16  14  14  14  18  18  NULL  8  NULL  NULL  8  -1  8  16  18  8
+17  18  16  16  16  NULL  NULL  14  14  NULL  NULL  14  -1  14  16  100  14
 
 # Same as above, but with a `partition by`
 
-query IIIIIIIIIIIIIII
+query IIIIIIIIIIIIIIIII
 select
   x,
   y,
@@ -2324,19 +2326,21 @@ select
   lag(y, 2, -1) ignore nulls over (partition by x%4 order by x) as lag2_ign_def,
   lead(y, 2, -1) ignore nulls over (partition by x%4 order by x) as lead2_ign_def,
   lag(y, 2, 16) ignore nulls over (partition by x%4 order by x) as lag2_ign_def16,
-  lead(y, 2, 16) ignore nulls over (partition by x%4 order by x) as lead2_ign_def16
+  lead(y, 2, 16) ignore nulls over (partition by x%4 order by x) as lead2_ign_def16,
+  lag(y, -1, 100) ignore nulls over (partition by x%4 order by x) as lag_neg_offset,
+  lead(y, -2, 100) ignore nulls over (partition by x%4 order by x) as lead_neg_offset
 from t6
 order by x%4, x;
 ----
-1  2  NULL  NULL  NULL  6  6  NULL  NULL  NULL  14  -1  14  16  14
-5  6  2  2  2  NULL  14  NULL  NULL  14  18  -1  18  16  18
-9  NULL  6  6  6  14  14  2  2  18  18  2  18  2  18
-13  14  NULL  NULL  6  18  18  6  2  NULL  NULL  2  -1  2  16
-17  18  14  14  14  NULL  NULL  NULL  6  NULL  NULL  6  -1  6  16
-3  NULL  NULL  NULL  NULL  8  8  NULL  NULL  NULL  16  -1  16  16  16
-7  8  NULL  NULL  NULL  NULL  16  NULL  NULL  16  NULL  -1  -1  16  16
-11  NULL  8  8  8  16  16  NULL  NULL  NULL  NULL  -1  -1  16  16
-15  16  NULL  NULL  8  NULL  NULL  8  NULL  NULL  NULL  -1  -1  16  16
+1  2  NULL  NULL  NULL  6  6  NULL  NULL  NULL  14  -1  14  16  14  6  100
+5  6  2  2  2  NULL  14  NULL  NULL  14  18  -1  18  16  18  14  100
+9  NULL  6  6  6  14  14  2  2  18  18  2  18  2  18  14  2
+13  14  NULL  NULL  6  18  18  6  2  NULL  NULL  2  -1  2  16  18  2
+17  18  14  14  14  NULL  NULL  NULL  6  NULL  NULL  6  -1  6  16  100  6
+3  NULL  NULL  NULL  NULL  8  8  NULL  NULL  NULL  16  -1  16  16  16  8  100
+7  8  NULL  NULL  NULL  NULL  16  NULL  NULL  16  NULL  -1  -1  16  16  16  100
+11  NULL  8  8  8  16  16  NULL  NULL  NULL  NULL  -1  -1  16  16  16  100
+15  16  NULL  NULL  8  NULL  NULL  8  NULL  NULL  NULL  -1  -1  16  16  100  100
 
 query error db error: ERROR: IGNORE NULLS and RESPECT NULLS options for functions other than LAG and LEAD not yet supported
 select first_value(x) ignore nulls over() from t6;

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -2342,6 +2342,36 @@ order by x%4, x;
 11  NULL  8  8  8  16  16  NULL  NULL  NULL  NULL  -1  -1  16  16  16  100
 15  16  NULL  NULL  8  NULL  NULL  8  NULL  NULL  NULL  -1  -1  16  16  100  100
 
+statement ok
+CREATE VIEW t6_more_nulls AS
+SELECT
+  x,
+  CASE WHEN y < 15 AND y > 7 THEN null ELSE y END AS y
+FROM t6;
+
+query IIIIIIII
+select
+  x,
+  y,
+  lag(y) ignore nulls over (order by x) as lag1,
+  lag(y,2) ignore nulls over (order by x) as lag2,
+  lag(y,3) ignore nulls over (order by x) as lag3,
+  lead(y) ignore nulls over (order by x) as lead1,
+  lead(y,2) ignore nulls over (order by x) as lead2,
+  lead(y,3) ignore nulls over (order by x) as lead3
+from t6_more_nulls
+order by x;
+----
+1  2  NULL  NULL  NULL  6  16  18
+3  NULL  2  NULL  NULL  6  16  18
+5  6  2  NULL  NULL  16  18  NULL
+7  NULL  6  2  NULL  16  18  NULL
+9  NULL  6  2  NULL  16  18  NULL
+11  NULL  6  2  NULL  16  18  NULL
+13  NULL  6  2  NULL  16  18  NULL
+15  16  6  2  NULL  18  NULL  NULL
+17  18  16  6  2  NULL  NULL  NULL
+
 query error db error: ERROR: IGNORE NULLS and RESPECT NULLS options for functions other than LAG and LEAD not yet supported
 select first_value(x) ignore nulls over() from t6;
 


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/29243

Look at the commits separately:
1. Fixes a bug with negative offsets.
2. lag/lead IGNORE NULLS: panic on 0 offset instead of an infinite loop. Started a Council thread on what should actually be the result for this: https://materializeinc.slack.com/archives/C063H5S7NKE/p1724962369706729 In the meantime, panicking is better than freezing.
3. Split IGNORE NULLS true/false code paths into separate functions. This is a preparation before making the IGNORE NULLS case more complicated.
4. Refactor to step over a run of nulls in an isolated loop. This is another preparatory step for the main commit, which will eliminate this loop.
5. The main commit: step over a run of nulls in constant time. This unblocks https://github.com/MaterializeInc/accounts/issues/3, [who has very long runs of nulls](https://materializeinc.slack.com/archives/C04SN4BEQ0N/p1724762264011989?thread_ts=1724712432.820019&cid=C04SN4BEQ0N) in their new use case.

### Motivation

  * This PR adds a known-desirable feature: lag/lead IGNORE NULLS with long runs of nulls: https://github.com/MaterializeInc/materialize/issues/29243

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
