### PR TITLE
miri test: Disable tests not supported anymore

### DIFF
--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -1322,6 +1322,7 @@ mod tests {
     use prost::Message;
 
     #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `pipe2` on OS `linux`
     fn smoktest_at_version() {
         let desc = RelationDesc::builder()
             .with_column("a", ScalarType::Bool.nullable(true))
@@ -1426,6 +1427,7 @@ mod tests {
     }
 
     #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `pipe2` on OS `linux`
     fn test_dropping_columns_with_keys() {
         let desc = RelationDesc::builder()
             .with_column("a", ScalarType::Bool.nullable(true))
@@ -1509,6 +1511,7 @@ mod tests {
     }
 
     #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `pipe2` on OS `linux`
     fn roundtrip_relation_desc_without_metadata() {
         let typ = ProtoRelationType {
             column_types: vec![
@@ -1572,6 +1575,7 @@ mod tests {
     }
 
     #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `pipe2` on OS `linux`
     fn test_add_column_with_same_name_prev_dropped() {
         let desc = RelationDesc::builder()
             .with_column("a", ScalarType::Bool.nullable(true))
@@ -1616,6 +1620,7 @@ mod tests {
     }
 
     #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // too slow
     fn proptest_relation_desc_roundtrips() {
         fn testcase(og: RelationDesc) {
             let bytes = og.into_proto().encode_to_vec();


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/9315#01919f30-925b-428b-b112-56a530b8ab91

Caused by https://github.com/MaterializeInc/materialize/pull/29231


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
