### PR TITLE
[persist] Add a few more knobs to drive compactions

### DIFF
--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -348,6 +348,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::internal::compact::COMPACTION_MINIMUM_TIMEOUT)
         .add(&crate::internal::machine::CLAIM_UNCLAIMED_COMPACTIONS)
         .add(&crate::internal::machine::CLAIM_COMPACTION_PERCENT)
+        .add(&crate::internal::machine::CLAIM_COMPACTION_MIN_VERSION)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_CLAMP)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_FIXED_SLEEP)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF)

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -347,6 +347,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::internal::cache::BLOB_CACHE_MEM_LIMIT_BYTES)
         .add(&crate::internal::compact::COMPACTION_MINIMUM_TIMEOUT)
         .add(&crate::internal::machine::CLAIM_UNCLAIMED_COMPACTIONS)
+        .add(&crate::internal::machine::CLAIM_COMPACTION_PERCENT)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_CLAMP)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_FIXED_SLEEP)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF)

--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -272,7 +272,7 @@ where
                 state
                     .collections
                     .trace
-                    .fueled_merge_reqs_before_ms(u64::MAX)
+                    .fueled_merge_reqs_before_ms(u64::MAX, None)
                     .collect()
             })
     }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -30,6 +30,7 @@ use mz_ore::task::JoinHandle;
 use mz_persist::location::{ExternalError, Indeterminate, SeqNo};
 use mz_persist::retry::Retry;
 use mz_persist_types::{Codec, Codec64, Opaque};
+use semver::Version;
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 use tracing::{debug, info, trace_span, warn, Instrument};
@@ -54,7 +55,6 @@ use crate::internal::state::{
 use crate::internal::state_versions::StateVersions;
 use crate::internal::trace::{ApplyMergeResult, FueledMergeRes};
 use crate::internal::watch::StateWatch;
-use crate::iter::MINIMUM_CONSOLIDATED_VERSION;
 use crate::read::{LeasedReaderId, READER_LEASE_DURATION};
 use crate::rpc::PubSubSender;
 use crate::schema::{CaESchema, SchemaId};
@@ -96,6 +96,12 @@ pub(crate) const CLAIM_COMPACTION_PERCENT: Config<usize> = Config::new(
     "Claim a compaction with the given percent chance, if claiming compactions is enabled. \
     (If over 100, we'll always claim at least one; for example, if set to 365, we'll claim at least \
     three and have a 65% chance of claiming a fourth.)",
+);
+
+pub(crate) const CLAIM_COMPACTION_MIN_VERSION: Config<String> = Config::new(
+    "persist_claim_compaction_min_version",
+    String::new(),
+    "If set to a valid version string, compact away any earlier versions if possible.",
 );
 
 impl<K, V, T, D> Machine<K, V, T, D>
@@ -438,6 +444,9 @@ where
                         } else {
                             0
                         },
+                        Version::parse(&CLAIM_COMPACTION_MIN_VERSION.get(cfg))
+                            .ok()
+                            .as_ref(),
                     )
                 })
                 .await;

--- a/src/persist-client/src/internal/paths.rs
+++ b/src/persist-client/src/internal/paths.rs
@@ -134,8 +134,8 @@ impl PartialBatchKey {
         PartialBatchKey(format!("{}/{}", version, part_id))
     }
 
-    pub fn split(&self) -> (WriterKey, PartId) {
-        split_batch_key(&self.0).expect("valid partial batch key")
+    pub fn split(&self) -> Option<(WriterKey, PartId)> {
+        split_batch_key(&self.0).ok()
     }
 
     pub fn complete(&self, shard_id: &ShardId) -> BlobKey {

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1196,7 +1196,7 @@ where
         let all_empty_reqs = merge_reqs
             .iter()
             .all(|req| req.inputs.iter().all(|b| b.batch.is_empty()));
-        if record_compactions && all_empty_reqs {
+        if record_compactions && all_empty_reqs && !batch.is_empty() {
             let mut reqs_to_take = claim_compaction_percent / 100;
             if (usize::cast_from(idempotency_token.hashed()) % 100)
                 < (claim_compaction_percent % 100)

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1206,6 +1206,8 @@ where
             let threshold_ms = heartbeat_timestamp_ms.saturating_sub(lease_duration_ms);
             let min_writer = claim_compaction_min_version.map(WriterKey::for_version);
             merge_reqs.extend(
+                // We keep the oldest `reqs_to_take` batches, under the theory that they're least
+                // likely to be compacted soon for other reasons.
                 self.trace
                     .fueled_merge_reqs_before_ms(threshold_ms, min_writer)
                     .take(reqs_to_take),

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -537,7 +537,7 @@ impl<T: Timestamp + Lattice> Trace<T> {
     }
 
     /// Obtain all fueled merge reqs that either have no active compaction, or the previous
-    /// compaction was started at or before the threshold time.
+    /// compaction was started at or before the threshold time, in order from oldest to newest.
     pub(crate) fn fueled_merge_reqs_before_ms(
         &self,
         threshold_ms: u64,
@@ -1100,10 +1100,12 @@ struct Spine<T> {
 }
 
 impl<T> Spine<T> {
+    /// All batches in the spine, oldest to newest.
     pub fn spine_batches(&self) -> impl Iterator<Item = &SpineBatch<T>> {
         self.merging.iter().rev().flat_map(|m| &m.batches)
     }
 
+    /// All (mutable) batches in the spine, oldest to newest.
     pub fn spine_batches_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut SpineBatch<T>> {
         self.merging.iter_mut().rev().flat_map(|m| &mut m.batches)
     }


### PR DESCRIPTION
### Motivation

We've discussed wanting a similar thing a few times now.

### Tips for reviewer

This only works for shards that are regularly getting appends, since that's the only time we have the opportunity to generate merge reqs at the moment. I suspect we probably want a way to be even more aggressive, but all the ideas I have there are more invasive and need some team discussion, so I'd rather take them in a followup PR.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
