### PR TITLE
feature-benchmark: Fix comparison

### DIFF
--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -237,19 +237,25 @@ T = TypeVar("T", bound=int | float)
 
 
 class ReportMeasurement(Generic[T]):
-    result: T
-    min: T
-    max: T
-    mean: T
-    variance: float
+    result: T | None
+    min: T | None
+    max: T | None
+    mean: T | None
+    variance: float | None
 
-    def __init__(self, points: list[T]):
+    def __init__(self, points: list[T | None]):
         self.result = points[0]
-        if self.result is not None:
-            self.min = min(points)
-            self.max = max(points)
-            self.mean = mean(points)
-            self.variance = variance(points)
+        set_points = [point for point in points if point is not None]
+        if self.result is not None and set_points:
+            self.min = min(set_points)
+            self.max = max(set_points)
+            self.mean = mean(set_points)
+            self.variance = variance(set_points)
+        else:
+            self.min = None
+            self.max = None
+            self.mean = None
+            self.variance = None
 
 
 class Report:

--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -19,7 +19,7 @@ FEATURE_BENCHMARK_SCENARIOS_DIR = FEATURE_BENCHMARK_FRAMEWORK_DIR / "scenarios"
 # Consider increasing the #FEATURE_BENCHMARK_FRAMEWORK_VERSION if changes are expected to impact results!
 SHA256_OF_FRAMEWORK: dict[str, str] = {}
 SHA256_OF_FRAMEWORK["*"] = (
-    "3833f4d8f9fd24a4f14af873415c4f7b85f28b78a042906c4fb3bfccb1d47e82"
+    "760436d346e0f96824d646c277f02e806187c8360653abb89056ca4df918de0e"
 )
 
 # Consider increasing the scenario's class #version() if changes are expected to impact results!


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/9322#0191a02e-85c1-4bb2-b014-9e14158714e5

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
