### PR TITLE
Revert "catalog: Retry fences  (#29249)"

### DIFF
--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -386,8 +386,6 @@ impl TestCatalogStateBuilder {
 }
 
 /// Creates an openable durable catalog state implemented using persist.
-///
-/// `deploy_generation` MUST be `Some` to initialize a new catalog.
 pub async fn persist_backed_catalog_state(
     persist_client: PersistClient,
     organization_id: Uuid,

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -13,6 +13,7 @@ mod tests;
 use std::cmp::max;
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt::Debug;
+use std::future::Future;
 use std::str::FromStr;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -26,6 +27,7 @@ use mz_audit_log::VersionedEvent;
 use mz_ore::assert::SOFT_ASSERTIONS;
 use mz_ore::metrics::MetricsFutureExt;
 use mz_ore::now::EpochMillis;
+use mz_ore::retry::{Retry, RetryResult};
 use mz_ore::{
     soft_assert_eq_no_log, soft_assert_eq_or_log, soft_assert_ne_or_log, soft_assert_no_log,
     soft_assert_or_log, soft_panic_or_log,
@@ -43,7 +45,7 @@ use mz_storage_types::sources::SourceData;
 use sha2::Digest;
 use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
 use timely::Container;
-use tracing::{debug, warn};
+use tracing::debug;
 use uuid::Uuid;
 
 use crate::durable::debug::{Collection, DebugCatalogState, Trace};
@@ -198,42 +200,6 @@ impl<T: Ord + Copy + Clone + Debug> FenceableToken<T> {
     }
 }
 
-/// An error that can occur while executing [`PersistHandle::compare_and_append`].
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum CompareAndAppendError {
-    #[error(transparent)]
-    Fence(#[from] FenceError),
-    /// Catalog encountered an upper mismatch when trying to write to the catalog. This should only
-    /// happen while trying to fence out other catalogs.
-    #[error(
-        "expected catalog upper {expected_upper:?} did not match actual catalog upper {actual_upper:?}"
-    )]
-    UpperMismatch {
-        expected_upper: Timestamp,
-        actual_upper: Timestamp,
-    },
-}
-
-impl CompareAndAppendError {
-    pub(crate) fn unwrap_fence_error(self) -> FenceError {
-        match self {
-            CompareAndAppendError::Fence(e) => e,
-            e @ CompareAndAppendError::UpperMismatch { .. } => {
-                panic!("unexpected upper mismatch: {e:?}")
-            }
-        }
-    }
-}
-
-impl From<UpperMismatch<Timestamp>> for CompareAndAppendError {
-    fn from(upper_mismatch: UpperMismatch<Timestamp>) -> Self {
-        Self::UpperMismatch {
-            expected_upper: antichain_to_timestamp(upper_mismatch.expected),
-            actual_upper: antichain_to_timestamp(upper_mismatch.current),
-        }
-    }
-}
-
 pub(crate) trait ApplyUpdate<T: IntoStateUpdateKindJson> {
     /// Process and apply `update`.
     ///
@@ -352,7 +318,7 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> PersistHandle<T, U> {
     pub(crate) async fn compare_and_append<S: IntoStateUpdateKindJson>(
         &mut self,
         updates: Vec<(S, Diff)>,
-    ) -> Result<Timestamp, CompareAndAppendError> {
+    ) -> Result<Timestamp, DurableCatalogError> {
         assert_eq!(self.mode, Mode::Writable);
 
         // This awkward code allows us to perform an expensive soft assert that requires cloning
@@ -1018,42 +984,30 @@ impl UnopenedPersistCatalogState {
         self.mode = mode;
         let read_only = matches!(self.mode, Mode::Readonly);
 
+        self.sync_to_current_upper().await?;
+        let prev_epoch = self.epoch.validate()?;
         // Fence out previous catalogs.
-        loop {
-            self.sync_to_current_upper().await?;
-            let prev_epoch = self.epoch.validate()?;
-            let mut fence_updates = Vec::with_capacity(2);
-            if let Some(prev_epoch) = prev_epoch {
-                fence_updates.push((StateUpdateKind::Epoch(prev_epoch), -1));
-            }
-            let mut current_epoch = prev_epoch.unwrap_or(MIN_EPOCH).get();
-            // Only writable catalogs attempt to increment the epoch.
-            if matches!(self.mode, Mode::Writable) {
-                current_epoch = current_epoch + 1;
-            }
-            let current_epoch = Epoch::new(current_epoch).expect("known to be non-zero");
-            fence_updates.push((StateUpdateKind::Epoch(current_epoch), 1));
-            let current_epoch = FenceableToken::new(Some(current_epoch), FenceError::epoch);
-            debug!(
-                ?self.upper,
-                ?prev_epoch,
-                ?current_epoch,
-                "fencing previous catalogs"
-            );
-            self.epoch = current_epoch;
-
-            if matches!(self.mode, Mode::Writable) {
-                match self.compare_and_append(fence_updates).await {
-                    Ok(_) => break,
-                    Err(CompareAndAppendError::Fence(e)) => return Err(e.into()),
-                    Err(e @ CompareAndAppendError::UpperMismatch { .. }) => {
-                        warn!("catalog write failed due to upper mismatch, retrying: {e:?}");
-                        continue;
-                    }
-                }
-            } else {
-                break;
-            }
+        let mut fence_updates = Vec::with_capacity(2);
+        if let Some(prev_epoch) = prev_epoch {
+            fence_updates.push((StateUpdateKind::Epoch(prev_epoch), -1));
+        }
+        let mut current_epoch = prev_epoch.unwrap_or(MIN_EPOCH).get();
+        // Only writable catalogs attempt to increment the epoch.
+        if matches!(self.mode, Mode::Writable) {
+            current_epoch = current_epoch + 1;
+        }
+        let current_epoch = Epoch::new(current_epoch).expect("known to be non-zero");
+        fence_updates.push((StateUpdateKind::Epoch(current_epoch), 1));
+        let current_epoch = FenceableToken::new(Some(current_epoch), FenceError::epoch);
+        debug!(
+            ?self.upper,
+            ?prev_epoch,
+            ?current_epoch,
+            "fencing previous catalogs"
+        );
+        self.epoch = current_epoch;
+        if matches!(self.mode, Mode::Writable) {
+            self.compare_and_append(fence_updates).await?;
         }
 
         let is_initialized = self.is_initialized_inner();
@@ -1544,10 +1498,7 @@ impl DurableCatalogState for PersistCatalogState {
             debug!("committing updates: {updates:?}");
 
             let next_upper = match catalog.mode {
-                Mode::Writable => catalog
-                    .compare_and_append(updates)
-                    .await
-                    .map_err(|e| e.unwrap_fence_error())?,
+                Mode::Writable => catalog.compare_and_append(updates).await?,
                 Mode::Savepoint => {
                     let ts = catalog.upper;
                     let updates =
@@ -1766,44 +1717,55 @@ impl UnopenedPersistCatalogState {
         T::Key: PartialEq + Eq + Debug + Clone,
         T::Value: Debug + Clone,
     {
-        // We must fence out all other catalogs since we are writing.
-        let fence_updates = self.increment_epoch()?;
-        let prev_value = loop {
+        let (_, prev) = retry(self, move |s| {
             let key = key.clone();
             let value = value.clone();
-            let snapshot = self.current_snapshot().await?;
-            let trace = Trace::from_snapshot(snapshot);
-            let collection_trace = T::collection_trace(trace);
-            let prev_values: Vec<_> = collection_trace
-                .values
-                .into_iter()
-                .filter(|((k, _), _, diff)| {
-                    soft_assert_eq_or_log!(*diff, 1, "trace is consolidated");
-                    &key == k
-                })
-                .collect();
-
-            let prev_value = match &prev_values[..] {
-                [] => None,
-                [((_, v), _, _)] => Some(v.clone()),
-                prev_values => panic!("multiple values found for key {key:?}: {prev_values:?}"),
-            };
-
-            let mut updates: Vec<_> = prev_values
-                .into_iter()
-                .map(|((k, v), _, _)| (T::update(k, v), -1))
-                .collect();
-            updates.push((T::update(key, value), 1));
-            updates.extend(fence_updates.clone());
-            match self.compare_and_append(updates).await {
-                Ok(_) => break prev_value,
-                Err(CompareAndAppendError::Fence(e)) => return Err(e.into()),
-                Err(e @ CompareAndAppendError::UpperMismatch { .. }) => {
-                    warn!("catalog write failed due to upper mismatch, retrying: {e:?}");
-                    continue;
-                }
+            async {
+                let prev = s.debug_edit_inner::<T>(key, value).await;
+                (s, prev)
             }
+        })
+        .await;
+        prev
+    }
+
+    #[mz_ore::instrument]
+    pub(crate) async fn debug_edit_inner<T: Collection>(
+        &mut self,
+        key: T::Key,
+        value: T::Value,
+    ) -> Result<Option<T::Value>, CatalogError>
+    where
+        T::Key: PartialEq + Eq + Debug + Clone,
+        T::Value: Debug + Clone,
+    {
+        let snapshot = self.current_snapshot().await?;
+        let trace = Trace::from_snapshot(snapshot);
+        let collection_trace = T::collection_trace(trace);
+        let prev_values: Vec<_> = collection_trace
+            .values
+            .into_iter()
+            .filter(|((k, _), _, diff)| {
+                soft_assert_eq_or_log!(*diff, 1, "trace is consolidated");
+                &key == k
+            })
+            .collect();
+
+        let prev_value = match &prev_values[..] {
+            [] => None,
+            [((_, v), _, _)] => Some(v.clone()),
+            prev_values => panic!("multiple values found for key {key:?}: {prev_values:?}"),
         };
+
+        let mut updates: Vec<_> = prev_values
+            .into_iter()
+            .map(|((k, v), _, _)| (T::update(k, v), -1))
+            .collect();
+        updates.push((T::update(key, value), 1));
+        // We must fence out all other catalogs since we are writing.
+        let fence_updates = self.increment_epoch()?;
+        updates.extend(fence_updates);
+        self.compare_and_append(updates).await?;
         Ok(prev_value)
     }
 
@@ -1817,32 +1779,40 @@ impl UnopenedPersistCatalogState {
         T::Key: PartialEq + Eq + Debug + Clone,
         T::Value: Debug,
     {
+        let (_, res) = retry(self, move |s| {
+            let key = key.clone();
+            async {
+                let res = s.debug_delete_inner::<T>(key).await;
+                (s, res)
+            }
+        })
+        .await;
+        res
+    }
+
+    /// Manually delete `key` from collection `T`.
+    #[mz_ore::instrument]
+    async fn debug_delete_inner<T: Collection>(&mut self, key: T::Key) -> Result<(), CatalogError>
+    where
+        T::Key: PartialEq + Eq + Debug,
+        T::Value: Debug,
+    {
+        let snapshot = self.current_snapshot().await?;
+        let trace = Trace::from_snapshot(snapshot);
+        let collection_trace = T::collection_trace(trace);
+        let mut retractions: Vec<_> = collection_trace
+            .values
+            .into_iter()
+            .filter(|((k, _), _, diff)| {
+                soft_assert_eq_or_log!(*diff, 1, "trace is consolidated");
+                &key == k
+            })
+            .map(|((k, v), _, _)| (T::update(k, v), -1))
+            .collect();
         // We must fence out all other catalogs since we are writing.
         let fence_updates = self.increment_epoch()?;
-        loop {
-            let key = key.clone();
-            let snapshot = self.current_snapshot().await?;
-            let trace = Trace::from_snapshot(snapshot);
-            let collection_trace = T::collection_trace(trace);
-            let mut retractions: Vec<_> = collection_trace
-                .values
-                .into_iter()
-                .filter(|((k, _), _, diff)| {
-                    soft_assert_eq_or_log!(*diff, 1, "trace is consolidated");
-                    &key == k
-                })
-                .map(|((k, v), _, _)| (T::update(k, v), -1))
-                .collect();
-            retractions.extend(fence_updates.clone());
-            match self.compare_and_append(retractions).await {
-                Ok(_) => break,
-                Err(CompareAndAppendError::Fence(e)) => return Err(e.into()),
-                Err(e @ CompareAndAppendError::UpperMismatch { .. }) => {
-                    warn!("catalog write failed due to upper mismatch, retrying: {e:?}");
-                    continue;
-                }
-            }
-        }
+        retractions.extend(fence_updates);
+        self.compare_and_append(retractions).await?;
         Ok(())
     }
 
@@ -1877,4 +1847,18 @@ impl UnopenedPersistCatalogState {
             (StateUpdateKind::Epoch(next_epoch), 1),
         ])
     }
+}
+
+/// Wrapper for [`Retry::retry_async_with_state`] so that all commands share the same retry behavior.
+async fn retry<F, S, U, R, T, E>(state: S, mut f: F) -> (S, Result<T, E>)
+where
+    F: FnMut(S) -> U,
+    U: Future<Output = (S, R)>,
+    R: Into<RetryResult<T, E>>,
+{
+    Retry::default()
+        .max_duration(Duration::from_secs(30))
+        .clamp_backoff(Duration::from_secs(1))
+        .retry_async_with_state(state, |_, s| f(s))
+        .await
 }

--- a/src/catalog/src/durable/upgrade.rs
+++ b/src/catalog/src/durable/upgrade.rs
@@ -329,10 +329,7 @@ async fn run_versioned_upgrade<V1: IntoStateUpdateKindJson, V2: IntoStateUpdateK
 
     // 4. Apply migration to catalog.
     if matches!(unopened_catalog_state.mode, Mode::Writable) {
-        unopened_catalog_state
-            .compare_and_append(updates)
-            .await
-            .map_err(|e| e.unwrap_fence_error())?;
+        unopened_catalog_state.compare_and_append(updates).await?;
     } else {
         let ts = unopened_catalog_state.upper;
         let updates = updates

--- a/src/catalog/tests/debug.rs
+++ b/src/catalog/tests/debug.rs
@@ -8,17 +8,16 @@
 // by the Apache License, Version 2.0.
 
 use std::fmt::{Debug, Formatter};
-use std::time::Duration;
 
 use mz_catalog::durable::debug::{CollectionTrace, ConfigCollection, SettingCollection, Trace};
 use mz_catalog::durable::initialize::USER_VERSION_KEY;
 use mz_catalog::durable::objects::serialization::proto;
 use mz_catalog::durable::{
-    test_bootstrap_args, CatalogError, DurableCatalogError, DurableCatalogState, Epoch, FenceError,
+    test_bootstrap_args, CatalogError, DurableCatalogError, Epoch, FenceError,
     TestCatalogStateBuilder, CATALOG_VERSION,
 };
+use mz_ore::assert_ok;
 use mz_ore::now::{NOW_ZERO, SYSTEM_TIME};
-use mz_ore::{assert_none, assert_ok};
 use mz_persist_client::PersistClient;
 use mz_repr::{Diff, Timestamp};
 
@@ -380,115 +379,4 @@ async fn test_debug_delete_fencing<'a>(state_builder: TestCatalogStateBuilder) {
         ),
         "unexpected err: {err:?}"
     );
-}
-
-#[mz_ore::test(tokio::test)]
-#[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
-async fn test_persist_concurrent_debugs() {
-    let persist_client = PersistClient::new_for_tests().await;
-    let state_builder = TestCatalogStateBuilder::new(persist_client);
-    test_concurrent_debugs(state_builder).await;
-}
-
-async fn test_concurrent_debugs(state_builder: TestCatalogStateBuilder) {
-    let key = proto::ConfigKey {
-        key: "mz".to_string(),
-    };
-    let value = proto::ConfigValue { value: 42 };
-
-    async fn run_state(state: &mut Box<dyn DurableCatalogState>) -> Result<(), CatalogError> {
-        let mut i = 0;
-        loop {
-            // Drain updates.
-            let _ = state.sync_to_current_updates().await?;
-            state.allocate_user_id().await?;
-            // After winning the race 100 times, sleep to give the debug state a chance to win the
-            // race.
-            if i > 100 {
-                tokio::time::sleep(Duration::from_nanos(1)).await;
-            }
-            i += 1;
-        }
-    }
-
-    let mut state = state_builder
-        .clone()
-        .with_default_deploy_generation()
-        .unwrap_build()
-        .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args())
-        .await
-        .unwrap();
-    let state_handle = mz_ore::task::spawn(|| "state", async move {
-        // Eventually this state should get fenced by the edit below.
-        let err = run_state(&mut state).await.unwrap_err();
-        assert!(matches!(
-            err,
-            CatalogError::Durable(DurableCatalogError::Fence(FenceError::Epoch { .. }))
-        ))
-    });
-
-    // Edit should be successful without retrying, even though there is an active state.
-    let mut debug_state = state_builder
-        .clone()
-        .unwrap_build()
-        .await
-        .open_debug()
-        .await
-        .unwrap();
-    debug_state
-        .edit::<ConfigCollection>(key.clone(), value.clone())
-        .await
-        .unwrap();
-
-    state_handle.await.unwrap();
-
-    let mut state = state_builder
-        .clone()
-        .with_default_deploy_generation()
-        .unwrap_build()
-        .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args())
-        .await
-        .unwrap();
-    let configs = state.snapshot().await.unwrap().configs;
-    assert_eq!(configs.get(&key).unwrap(), &value);
-
-    let state_handle = mz_ore::task::spawn(|| "state", async move {
-        // Eventually this state should get fenced by the delete below.
-        let err = run_state(&mut state).await.unwrap_err();
-        assert!(matches!(
-            err,
-            CatalogError::Durable(DurableCatalogError::Fence(FenceError::Epoch { .. }))
-        ))
-    });
-
-    // Delete should be successful without retrying, even though there is an active state.
-    let mut debug_state = state_builder
-        .clone()
-        .unwrap_build()
-        .await
-        .open_debug()
-        .await
-        .unwrap();
-    debug_state
-        .delete::<ConfigCollection>(key.clone())
-        .await
-        .unwrap();
-
-    state_handle.await.unwrap();
-
-    let configs = state_builder
-        .clone()
-        .with_default_deploy_generation()
-        .unwrap_build()
-        .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args())
-        .await
-        .unwrap()
-        .snapshot()
-        .await
-        .unwrap()
-        .configs;
-    assert_none!(configs.get(&key));
 }

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -15,8 +15,8 @@ use mz_catalog::durable::initialize::USER_VERSION_KEY;
 use mz_catalog::durable::objects::serialization::proto;
 use mz_catalog::durable::objects::{DurableType, Snapshot};
 use mz_catalog::durable::{
-    test_bootstrap_args, CatalogError, Database, DurableCatalogError, DurableCatalogState, Epoch,
-    FenceError, Schema, TestCatalogStateBuilder, CATALOG_VERSION,
+    test_bootstrap_args, CatalogError, Database, DurableCatalogError, Epoch, FenceError, Schema,
+    TestCatalogStateBuilder, CATALOG_VERSION,
 };
 use mz_ore::cast::usize_to_u64;
 use mz_ore::collections::HashSet;
@@ -876,58 +876,4 @@ async fn test_persist_version_fencing() {
     testcase("0.10.0", "0.10.0", Ok(())).await;
     testcase("0.10.0", "0.11.0", Ok(())).await;
     testcase("0.10.0", "0.12.0", Err(())).await;
-}
-
-#[mz_ore::test(tokio::test)]
-#[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
-async fn test_persist_concurrent_open() {
-    let persist_client = PersistClient::new_for_tests().await;
-    let state_builder = TestCatalogStateBuilder::new(persist_client);
-    test_concurrent_open(state_builder).await;
-}
-
-async fn test_concurrent_open(state_builder: TestCatalogStateBuilder) {
-    let state_builder = state_builder.with_default_deploy_generation();
-
-    async fn run_state(state: &mut Box<dyn DurableCatalogState>) -> Result<(), CatalogError> {
-        let mut i = 0;
-        loop {
-            // Drain updates.
-            let _ = state.sync_to_current_updates().await?;
-            state.allocate_user_id().await?;
-            // After winning the race 100 times, sleep to give the debug state a chance to win the
-            // race.
-            if i > 100 {
-                tokio::time::sleep(Duration::from_nanos(1)).await;
-            }
-            i += 1;
-        }
-    }
-
-    let mut state = state_builder
-        .clone()
-        .with_default_deploy_generation()
-        .unwrap_build()
-        .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args())
-        .await
-        .unwrap();
-    let state_handle = mz_ore::task::spawn(|| "state", async move {
-        // Eventually this state should get fenced by the open below.
-        let err = run_state(&mut state).await.unwrap_err();
-        assert!(matches!(
-            err,
-            CatalogError::Durable(DurableCatalogError::Fence(FenceError::Epoch { .. }))
-        ))
-    });
-
-    // Open should be successful without retrying, even though there is an active state.
-    let _state = state_builder
-        .unwrap_build()
-        .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args())
-        .await
-        .unwrap();
-
-    state_handle.await.unwrap();
 }

--- a/src/environmentd/src/deployment/preflight.rs
+++ b/src/environmentd/src/deployment/preflight.rs
@@ -186,32 +186,51 @@ pub async fn preflight_0dt(
             // Take over the catalog.
             info!("promoted; attempting takeover");
 
-            let openable_adapter_storage = mz_catalog::durable::persist_backed_catalog_state(
-                persist_client.clone(),
-                environment_id.organization_id(),
-                BUILD_INFO.semver_version(),
-                Some(deploy_generation),
-                Arc::clone(&catalog_metrics),
-            )
-            .await
-            .expect("incompatible catalog/persist version");
-
-            openable_adapter_storage
-                .open(
-                    boot_ts,
-                    &BootstrapArgs {
-                        default_cluster_replica_size: bootstrap_default_cluster_replica_size
-                            .clone(),
-                        bootstrap_role: bootstrap_role.clone(),
-                    },
+            // NOTE: We don't do "smart" retries here, such as retrying at an
+            // interval and/or backing off. We want to get this fence in ASAP
+            // because we have been told to take over as the leader.
+            loop {
+                let openable_adapter_storage = mz_catalog::durable::persist_backed_catalog_state(
+                    persist_client.clone(),
+                    environment_id.organization_id(),
+                    BUILD_INFO.semver_version(),
+                    Some(deploy_generation),
+                    Arc::clone(&catalog_metrics),
                 )
                 .await
-                .unwrap_or_else(|error| {
-                    panic!(
-                        "unexpected error while fencing out old deployment: {:?}",
-                        error
+                .expect("incompatible catalog/persist version");
+
+                let res = openable_adapter_storage
+                    .open(
+                        boot_ts,
+                        &BootstrapArgs {
+                            default_cluster_replica_size: bootstrap_default_cluster_replica_size
+                                .clone(),
+                            bootstrap_role: bootstrap_role.clone(),
+                        },
                     )
-                });
+                    .await;
+
+                match res {
+                    Ok(_catalog) => break,
+                    Err(error) => match error {
+                        CatalogError::Durable(
+                            error @ mz_catalog::durable::DurableCatalogError::UpperMismatch {
+                                ..
+                            },
+                        ) => {
+                            tracing::info!("upper mismatch while trying to fence out old deployment ({}), retrying...", error);
+                            continue;
+                        }
+                        error => {
+                            panic!(
+                                "unexpected error while fencing out old deployment: {:?}",
+                                error
+                            );
+                        }
+                    },
+                }
+            }
 
             // Reboot as the leader.
             halt!("fenced out old deployment; rebooting as leader")


### PR DESCRIPTION
This reverts commit e7cde3508c2019c97f743e6a97df79a960be243b.

Fixes #29293

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
