### PR TITLE
ci: Handle panics and logging interleaving

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -725,13 +725,16 @@ def _collect_service_panics_in_logs(data: Any, log_file_name: str) -> list[Error
                 # Handling every services.log line here, filter to
                 # handle only the ones which are currently in a panic
                 # handler:
-                if panic_start := open_panics.get(match.group("service")):
-                    del open_panics[match.group("service")]
-                    if IGNORE_RE.search(match.group(0)):
-                        continue
-                    collected_panics.append(
-                        ErrorLog(panic_start + b" " + match.group("msg"), log_file_name)
-                    )
+                if panic_msg := open_panics.get(match.group("service")):
+                    if b"stack backtrace:" in line:
+                        del open_panics[match.group("service")]
+                        if IGNORE_RE.search(panic_msg):
+                            continue
+                        collected_panics.append(ErrorLog(panic_msg, log_file_name))
+                    else:
+                        open_panics[match.group("service")] = (
+                            panic_msg + b" " + match.group("msg")
+                        )
     assert not open_panics, f"Panic log never finished: {open_panics}"
 
     return collected_panics


### PR DESCRIPTION
Does not fix, but works around #24088

So that we can at least ignore known panics relatively reliably and don't fail tests for them.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
