### PR TITLE
bazel: Add `bazelisk` to scratch instances

### DIFF
--- a/misc/scratch/provision.bash
+++ b/misc/scratch/provision.bash
@@ -14,6 +14,9 @@
 
 set -euo pipefail
 
+arch=$(uname -m)
+arch=$(echo $arch | sed -e "s/aarch64/arm64/" -e "s/x86_64/amd64/" )
+
 # Install APT dependencies.
 apt-get update
 apt-get install -y \
@@ -53,6 +56,12 @@ sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plu
 
 # Install Rust.
 sudo -u ubuntu sh -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q -y"
+
+# Install Bazel.
+sudo sh -c "curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-$arch" \
+    && if [[ "$arch" = arm64 ]]; then echo '467ec3821aca5e278c8570b7c25e0dfc1a061d2873be89e4a266aaf488148426 /usr/local/bin/bazel' | sha256sum --check; fi \
+    && if [[ "$arch" = amd64 ]]; then echo 'd9af1fa808c0529753c3befda75123236a711d971d3485a390507122148773a3 /usr/local/bin/bazel' | sha256sum --check; fi \
+    && sudo sh -c "chmod +x /usr/local/bin/bazel"
 
 # Install the AWS CLI.
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" > awscliv2.zip


### PR DESCRIPTION
This PR adds `bazelisk` (our `bazel` runner) to instances spawned by `bin/scratch`

### Motivation

Progress towards https://github.com/MaterializeInc/materialize/issues/26796

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
