### PR TITLE
adapter: Fetch table snapshots in parallel

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2369,16 +2369,10 @@ impl Coordinator {
                 self.catalog().resolve_full_name(system_table.name(), None),
                 id,
             );
-            let current_contents_fut = self
-                .controller
-                .storage
-                .snapshot_async(id, read_ts)
-                .await
-                .unwrap_or_terminate("cannot fail to fetch snapshot");
+            let current_contents_fut = self.controller.storage.snapshot(id, read_ts);
             let task = spawn(|| format!("snapshot-{}", id), async move {
                 let current_contents = current_contents_fut
                     .await
-                    .expect("sender hung up")
                     .unwrap_or_terminate("cannot fail to fetch snapshot");
                 debug!(
                     "coordinator init: table ({}) size {}",

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2196,8 +2196,15 @@ impl Coordinator {
             futures::future::ready(()).boxed()
         };
 
+        info!(
+            "startup: coordinator init: bootstrap: postamble complete in {:?}",
+            postamble_start.elapsed()
+        );
+
+        let builtin_update_start = Instant::now();
+        info!("startup: coordinator init: bootstrap: generate builtin updates beginning");
         let builtin_updates_fut = if self.controller.read_only() {
-            info!("startup: coordinator init: bootstrap: stashing builtin table updates while in read-only mode");
+            info!("coordinator init: bootstrap: stashing builtin table updates while in read-only mode");
 
             self.buffered_builtin_table_updates
                 .as_mut()
@@ -2208,7 +2215,13 @@ impl Coordinator {
         } else {
             self.bootstrap_tables(&entries, builtin_table_updates).await
         };
+        info!(
+            "startup: coordinator init: bootstrap: generate builtin updates complete in {:?}",
+            builtin_update_start.elapsed()
+        );
 
+        let cleanup_secrets_start = Instant::now();
+        info!("startup: coordinator init: bootstrap: generate secret cleanup beginning");
         // Cleanup orphaned secrets. Errors during list() or delete() do not
         // need to prevent bootstrap from succeeding; we will retry next
         // startup.
@@ -2270,10 +2283,9 @@ impl Coordinator {
                 }
             }
         };
-
         info!(
-            "startup: coordinator init: bootstrap: postamble complete in {:?}",
-            postamble_start.elapsed()
+            "startup: coordinator init: bootstrap: generate secret cleanup complete in {:?}",
+            cleanup_secrets_start.elapsed()
         );
 
         // Run all of our final steps concurrently.
@@ -2347,28 +2359,47 @@ impl Coordinator {
             entry.name.item == MZ_STORAGE_USAGE_BY_SHARD.name
                 && entry.name.qualifiers.schema_spec == mz_storage_usage_by_shard_schema
         };
+        let mut retraction_tasks = Vec::new();
         for system_table in entries.iter().filter(|entry| {
             entry.is_table() && entry.id().is_system() && !is_storage_usage_by_shard(entry)
         }) {
+            let id = system_table.id();
             debug!(
                 "coordinator init: resetting system table {} ({})",
                 self.catalog().resolve_full_name(system_table.name(), None),
-                system_table.id()
+                id,
             );
-            let current_contents = self
+            let current_contents_fut = self
                 .controller
                 .storage
-                .snapshot(system_table.id(), read_ts)
+                .snapshot_async(id, read_ts)
                 .await
                 .unwrap_or_terminate("cannot fail to fetch snapshot");
-            debug!("coordinator init: table size {}", current_contents.len());
-            let retractions = current_contents
-                .into_iter()
-                .map(|(row, diff)| BuiltinTableUpdate {
-                    id: system_table.id(),
-                    row,
-                    diff: diff.neg(),
-                });
+            let task = spawn(|| format!("snapshot-{}", id), async move {
+                let current_contents = current_contents_fut
+                    .await
+                    .expect("sender hung up")
+                    .unwrap_or_terminate("cannot fail to fetch snapshot");
+                debug!(
+                    "coordinator init: table ({}) size {}",
+                    id,
+                    current_contents.len()
+                );
+                current_contents
+                    .into_iter()
+                    .map(|(row, diff)| BuiltinTableUpdate {
+                        id,
+                        row,
+                        diff: diff.neg(),
+                    })
+                    .collect::<Vec<_>>()
+            });
+            retraction_tasks.push(task);
+        }
+
+        let retractions_res = futures::future::join_all(retraction_tasks).await;
+        for retractions in retractions_res {
+            let retractions = retractions.expect("cannot fail to fetch snapshot");
             builtin_table_updates.extend(retractions);
         }
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -593,22 +593,11 @@ pub trait StorageController: Debug {
     ) -> Result<Arc<WebhookStatistics>, StorageError<Self::Timestamp>>;
 
     /// Returns the snapshot of the contents of the local input named `id` at `as_of`.
-    async fn snapshot(
+    fn snapshot(
         &mut self,
         id: GlobalId,
         as_of: Self::Timestamp,
-    ) -> Result<Vec<(Row, Diff)>, StorageError<Self::Timestamp>>;
-
-    /// Returns a future that returns the snapshot of the contents of the local input named `id` at
-    /// `as_of`.
-    async fn snapshot_async(
-        &mut self,
-        id: GlobalId,
-        as_of: Self::Timestamp,
-    ) -> Result<
-        oneshot::Receiver<Result<Vec<(Row, Diff)>, StorageError<Self::Timestamp>>>,
-        StorageError<Self::Timestamp>,
-    >;
+    ) -> BoxFuture<Result<Vec<(Row, Diff)>, StorageError<Self::Timestamp>>>;
 
     /// Returns the snapshot of the contents of the local input named `id` at
     /// the largest readable `as_of`.

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -599,6 +599,17 @@ pub trait StorageController: Debug {
         as_of: Self::Timestamp,
     ) -> Result<Vec<(Row, Diff)>, StorageError<Self::Timestamp>>;
 
+    /// Returns a future that returns the snapshot of the contents of the local input named `id` at
+    /// `as_of`.
+    async fn snapshot_async(
+        &mut self,
+        id: GlobalId,
+        as_of: Self::Timestamp,
+    ) -> Result<
+        oneshot::Receiver<Result<Vec<(Row, Diff)>, StorageError<Self::Timestamp>>>,
+        StorageError<Self::Timestamp>,
+    >;
+
     /// Returns the snapshot of the contents of the local input named `id` at
     /// the largest readable `as_of`.
     async fn snapshot_latest(


### PR DESCRIPTION
This commit speeds up the startup process by fetching snapshots of all builtin tables in parallel instead of sequentially.

Works towards resolving #28722

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
