### PR TITLE
feature-benchmark: Fix variance calculation

### DIFF
--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -250,7 +250,7 @@ class ReportMeasurement(Generic[T]):
             self.min = min(set_points)
             self.max = max(set_points)
             self.mean = mean(set_points)
-            self.variance = variance(set_points)
+            self.variance = variance(set_points) if len(set_points) > 1 else None
         else:
             self.min = None
             self.max = None

--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -19,7 +19,7 @@ FEATURE_BENCHMARK_SCENARIOS_DIR = FEATURE_BENCHMARK_FRAMEWORK_DIR / "scenarios"
 # Consider increasing the #FEATURE_BENCHMARK_FRAMEWORK_VERSION if changes are expected to impact results!
 SHA256_OF_FRAMEWORK: dict[str, str] = {}
 SHA256_OF_FRAMEWORK["*"] = (
-    "760436d346e0f96824d646c277f02e806187c8360653abb89056ca4df918de0e"
+    "9a9435308923d4ddec0d1057c5f14a19c15e2fe3038ea9c755d4561414dedc2b"
 )
 
 # Consider increasing the scenario's class #version() if changes are expected to impact results!


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/9339

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
