### PR TITLE
doc/user: fix version shortcode

### DIFF
--- a/doc/user/layouts/shortcodes/version.html
+++ b/doc/user/layouts/shortcodes/version.html
@@ -1,1 +1,5 @@
-{{ (index (index (where $.Site.Sections "Title" "Releases") 0).Pages.ByDate.Reverse 0).File.ContentBaseName -}}
+{{- $releasesPage := (index (where $.Site.Sections "Title" "Releases") 0) -}}
+{{- $publishedReleases := (where $releasesPage.Pages "Params.released" true) -}}
+{{- $latestPublishedRelease := (index $publishedReleases.ByDate.Reverse 0) -}}
+{{- $patch := default 0 $latestPublishedRelease.Params.patch -}}
+{{- $latestPublishedRelease.File.ContentBaseName -}}.{{- $patch -}}


### PR DESCRIPTION
The version shortcode was outdated. Teach it to filter to only published releases, and to stitch in the patch field if set.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
