### PR TITLE
docs: revert removal of image version

### DIFF
--- a/doc/user/content/get-started/install-materialize-emulator.md
+++ b/doc/user/content/get-started/install-materialize-emulator.md
@@ -62,7 +62,7 @@ not suitable for production deployments</redb>.
    been already downloaded.
 
    ```sh
-   docker run -d -p 6875:6875 -p 6876:6876 materialize/materialized
+   docker run -d -p 6875:6875 -p 6876:6876 materialize/materialized:{{< version >}}
    ```
 
    When running locally:


### PR DESCRIPTION
Can put back with https://github.com/MaterializeInc/materialize/pull/29305 fix. (had accidentally squashed the patches together, so couldn't just do a revert).
 