### PR TITLE
ci: Include test command and description in annotation

### DIFF
--- a/ci/builder/pyright-version.sh
+++ b/ci/builder/pyright-version.sh
@@ -11,4 +11,4 @@
 # pyright-version.sh — specifies version of Pyright typechecker we use
 # as a string printed to stdout, for use from other tools
 
-printf "1.1.323"
+printf "1.1.324"

--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -49,5 +49,8 @@ rm -f kubectl-*.log
 ci_collapsed_heading "kail: Start a new instance"
 NO_COLOR=1 bin/ci-builder run stable --detach --name "kail" kail --context "$K8S_CONTEXT" --log-level info
 
-ci_uncollapsed_heading "cloudtest: Running \`bin/pytest ${run_args[*]}\`"
+TEST_CMD="bin/pytest ${run_args[*]}"
+echo "$TEST_CMD" > test_cmd
+
+ci_uncollapsed_heading "cloudtest: Running \`$TEST_CMD\`"
 stdbuf --output=L --error=L bin/ci-builder run stable bin/pytest "${run_args[@]}" |& tee run.log

--- a/ci/plugins/cloudtest/hooks/post-command
+++ b/ci/plugins/cloudtest/hooks/post-command
@@ -91,7 +91,7 @@ unset CI_EXTRA_ARGS # We don't want extra args for the annotation
 CI_ANNOTATE_ERRORS_RESULT=0
 # We have to upload artifacts before ci-annotate-errors, so that the annotations can link to the artifacts
 buildkite-agent artifact upload "$artifacts_str"
-bin/ci-builder run stable bin/ci-annotate-errors "${artifacts[@]}" > ci-annotate-errors.log || CI_ANNOTATE_ERRORS_RESULT=$?
+bin/ci-builder run stable bin/ci-annotate-errors --test-cmd="$(cat test_cmd)" "${artifacts[@]}" > ci-annotate-errors.log || CI_ANNOTATE_ERRORS_RESULT=$?
 buildkite-agent artifact upload "ci-annotate-errors.log"
 
 # File should not be empty, see #25369

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -97,7 +97,13 @@ if is_truthy "${CI_HEAP_PROFILES:-}"; then
     ) &
 fi
 
-ci_uncollapsed_heading ":docker: Running \`bin/mzcompose --find $BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION run ${run_args[*]}\`"
+TEST_CMD="bin/mzcompose --find $BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION run ${run_args[*]}"
+echo "$TEST_CMD" > test_cmd
+TEST_DESC="$(mzcompose description)"
+echo "$TEST_DESC" > test_desc
+
+ci_uncollapsed_heading ":docker: Running \`$TEST_CMD\`"
+echo "$TEST_DESC"
 
 mzcompose run "${run_args[@]}" |& tee run.log
 RESULT=$?

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -82,7 +82,7 @@ CI_ANNOTATE_ERRORS_RESULT=0
 # Uploading large files currently sometimes hangs, as a temporary workaround
 # timeout and don't fail, TODO(def-) Remove timeout again
 timeout 300 buildkite-agent artifact upload "$artifacts_str" || true
-bin/ci-builder run stable bin/ci-annotate-errors "${artifacts[@]}" > ci-annotate-errors.log || CI_ANNOTATE_ERRORS_RESULT=$?
+bin/ci-builder run stable bin/ci-annotate-errors --test-cmd="$(cat test_cmd)" --test-desc="$(cat test_desc)" "${artifacts[@]}" > ci-annotate-errors.log || CI_ANNOTATE_ERRORS_RESULT=$?
 buildkite-agent artifact upload "ci-annotate-errors.log"
 
 if [ ! -s services.log ] && [ "$BUILDKITE_LABEL" != "Maelstrom coverage of persist" ] && [ "$BUILDKITE_LABEL" != "Long single-node Maelstrom coverage of persist" ] && [ "$BUILDKITE_LABEL" != "Maelstrom coverage of txn-wal" ] && [ "$BUILDKITE_LABEL" != "Mz E2E Test" ] && [ "$BUILDKITE_LABEL" != "Output consistency (version for DFR)" ] && [ "$BUILDKITE_LABEL" != "Output consistency (version for CTF)" ] && [ "$BUILDKITE_LABEL" != "QA Canary Environment Base Load" ]; then

--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Runs the Rust-based unit tests in Debug mode.
+"""
+
 import json
 import multiprocessing
 import os

--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Basic test for the Data build tool (dbt) integration of Materialize
+"""
+
 from dataclasses import dataclass
 from textwrap import dedent
 from typing import Dict, List, Optional

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -112,6 +112,7 @@ For additional details on mzcompose, consult doc/developer/mzbuild.md.""",
     CpCommand.register(parser, subparsers)
     CreateCommand.register(parser, subparsers)
     DescribeCommand().register(parser, subparsers)
+    DescriptionCommand().register(parser, subparsers)
     DownCommand().register(parser, subparsers)
     EventsCommand.register(parser, subparsers)
     ExecCommand.register(parser, subparsers)
@@ -336,6 +337,11 @@ class DescribeCommand(Command):
 
         name_width = min(max(len(name) for name, _ in workflows), 16)
 
+        if composition.description:
+            print("Description:")
+            print(composition.description)
+            print()
+
         print("Services:")
         for name in sorted(composition.compose["services"]):
             print(f"    {name}")
@@ -356,6 +362,15 @@ class DescribeCommand(Command):
     $ ./mzcompose run WORKFLOW --help
 """
         )
+
+
+class DescriptionCommand(Command):
+    name = "description"
+    help = "fetch the Python code description from mzcompose.py"
+
+    def run(self, args: argparse.Namespace) -> None:
+        composition = load_composition(args)
+        print(composition.description)
 
 
 class SqlCommand(Command):

--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -15,6 +15,7 @@ from typing import Any
 import confluent_kafka  # type: ignore
 import pg8000
 import pymysql
+import pymysql.cursors
 from confluent_kafka.admin import AdminClient  # type: ignore
 from confluent_kafka.schema_registry import Schema, SchemaRegistryClient  # type: ignore
 from confluent_kafka.schema_registry.avro import AvroSerializer  # type: ignore
@@ -85,7 +86,7 @@ class Executor:
     def run(self, transaction: Transaction, logging_exe: Any | None = None) -> None:
         raise NotImplementedError
 
-    def execute(self, cur: pg8000.Cursor, query: str) -> None:
+    def execute(self, cur: pg8000.Cursor | pymysql.cursors.Cursor, query: str) -> None:
         if self.logging_exe is not None:
             self.logging_exe.log(query)
 

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Explicit deterministic tests for read-only mode and zero downtime deploys (same
+version, no upgrade).
+"""
+
 import time
 from textwrap import dedent
 

--- a/test/backup-restore/mzcompose.py
+++ b/test/backup-restore/mzcompose.py
@@ -6,6 +6,11 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+
+"""
+Basic Backup & Restore test with a table
+"""
+
 from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition

--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Tests using the balancerd service instead of connecting to materialized directly.
+Uses the frontegg-mock instead of a real frontend backend.
+"""
+
 import json
 import ssl
 import uuid

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -6,6 +6,12 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+
+"""
+Tests with limited amount of memory, makes sure that the scenarios keep working
+and do not regress. Contains tests for large data ingestions.
+"""
+
 import math
 from dataclasses import dataclass
 from string import ascii_lowercase

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -7,6 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Deploy the current version on a real Staging Cloud, and run some basic
+verifications, like ingesting data from Kafka and Redpanda Cloud using AWS
+Privatelink. Runs only on main and release branches.
+"""
+
 import argparse
 import glob
 import itertools

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test cluster isolation by introducing faults of various kinds in cluster1 and
+then making sure that cluster2 continues to operate properly
+"""
+
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -94,9 +99,6 @@ contains: statement timeout
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    """Test cluster isolation by introducing faults of various kinds in cluster1
-    and then making sure that cluster2 continues to operate properly
-    """
 
     parser.add_argument("disruptions", nargs="*", default=[d.name for d in disruptions])
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Functional tests which require separate clusterd containers (intead of the
+usual clusterd included in the materialized container).
+"""
+
 import json
 import random
 import re

--- a/test/copy-to-s3/mzcompose.py
+++ b/test/copy-to-s3/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Functional tests for the COPY TO S3 command against a local minio service
+instead of a real AWS S3.
+"""
 
 import csv
 import json

--- a/test/crdb-restarts/mzcompose.py
+++ b/test/crdb-restarts/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Disrupt Cockroach and verify that Materialize recovers from it.
+"""
+
 from collections.abc import Callable
 from dataclasses import dataclass
 from textwrap import dedent

--- a/test/data-ingest/mzcompose.py
+++ b/test/data-ingest/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test that ingests large amounts of data from Kafka/Postgres/MySQL and verifies
+that Materialize can handle it correctly by comparing the results.
+"""
+
 import random
 import time
 import traceback

--- a/test/debezium/mzcompose.py
+++ b/test/debezium/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Connect Postgres/SQL Server/MySQL to Materialize using Kafka+Debezium
+"""
+
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.debezium import Debezium
 from materialize.mzcompose.services.kafka import Kafka

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -7,6 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Simple benchmark of mostly individual queries using testdrive. Can find
+wallclock/memory/messages regressions in single-connection query executions,
+not suitable for concurrency.
+"""
+
 import argparse
 import os
 import sys

--- a/test/feature-flag-consistency/mzcompose.py
+++ b/test/feature-flag-consistency/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Verify that Materialize has the same results with different sets of feature flags.
+"""
+
 from materialize.feature_flag_consistency.feature_flag_consistency_test import (
     FeatureFlagConsistencyTest,
 )

--- a/test/kafka-auth/mzcompose.py
+++ b/test/kafka-auth/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Tests that Materialize can connect to Kafka's various connection modes:
+plaintext, ssl, mssl, sasl_plaintext, sasl_ssl, sasl_mssl
+"""
+
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized

--- a/test/kafka-exactly-once/mzcompose.py
+++ b/test/kafka-exactly-once/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Verify that data from Kafka is only ingested exactly once, there should be no
+duplicates, even after restarting Materialize.
+"""
+
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test various Confluent Platform d Redpanda versions to make sure they are all
+working with Materialize.
+"""
+
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.localstack import Localstack

--- a/test/kafka-multi-broker/mzcompose.py
+++ b/test/kafka-multi-broker/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Functional test against Kafka with 3 brokers, most of our other tests only use
+a single Broker.
+"""
+
 import time
 
 from materialize.mzcompose.composition import Composition

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test that the Kafka <-> Materialize connection (source + sink) can survive
+network problems and interruptions using Toxiyproxy.
+"""
+
 import argparse
 import random
 

--- a/test/kafka-rtr/mzcompose.py
+++ b/test/kafka-rtr/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Functional test for Kafka with real-time recency enabled. Queries should block
+until results are available instead of returning out of date results.
+"""
+
 import random
 import threading
 import time

--- a/test/lang/csharp/mzcompose.py
+++ b/test/lang/csharp/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Basic test for Postgres-compatible connections from C# programming language.
+"""
+
 from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.materialized import Materialized
 

--- a/test/lang/java/mzcompose.py
+++ b/test/lang/java/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Basic test for Postgres-compatible connections from Java programming language.
+"""
+
 from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.materialized import Materialized
 

--- a/test/lang/js/mzcompose.py
+++ b/test/lang/js/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Basic test for Postgres-compatible connections from JavaScript programming language.
+"""
+
 from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.materialized import Materialized
 

--- a/test/lang/python/mzcompose.py
+++ b/test/lang/python/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Basic test for Postgres-compatible connections from Python programming language.
+"""
+
 from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.materialized import Materialized
 

--- a/test/lang/ruby/mzcompose.py
+++ b/test/lang/ruby/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Basic test for Postgres-compatible connections from Ruby programming language.
+"""
+
 from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.materialized import Materialized
 

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test the LaunchDarkly integration, get configuration flags from LD.
+"""
+
 from itertools import chain
 from os import environ
 from textwrap import dedent

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -7,8 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-"""Verifies that objects created in previous versions of Materialize are still
-operational after an upgrade.
+"""
+Verifies that objects created in previous versions of Materialize are still
+operational after an upgrade. See also the newer platform-checks' upgrade scenarios.
 """
 
 import random

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Stresses Materialize with large number of objects, large ingestions, etc. Good
+to prevent regressions in basic functionality for larger installations.
+"""
+
 import contextlib
 import json
 import sys

--- a/test/metabase/mzcompose.py
+++ b/test/metabase/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Smoketest that Metabase can connect to Materialize
+"""
+
 from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.metabase import Metabase

--- a/test/mysql-cdc-resumption/mzcompose.py
+++ b/test/mysql-cdc-resumption/mzcompose.py
@@ -7,6 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Functional test for the native (non-Debezium) MySQL sources, using Toxiproxy to
+simulate bad network as well as checking how Materialize handles binary log
+corruptions.
+"""
+
 import time
 from typing import Any
 

--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Functional test for the native (non-Debezium) MySQL sources.
+"""
+
 import threading
 from textwrap import dedent
 

--- a/test/mysql-rtr/mzcompose.py
+++ b/test/mysql-rtr/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Functional test for MySQL source with real-time recency enabled. Queries should
+block until results are available instead of returning out of date results.
+"""
+
 import random
 
 from materialize.mzcompose.composition import Composition

--- a/test/mz-e2e/mzcompose.py
+++ b/test/mz-e2e/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Tests the mz command line tool against a real Cloud instance
+"""
+
 import argparse
 import csv
 import json

--- a/test/output-consistency/mzcompose.py
+++ b/test/output-consistency/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test the output consistency of different query evaluation strategies (e.g.,
+dataflow rendering and constant folding).
+"""
+
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.materialized import Materialized
@@ -26,10 +31,6 @@ SERVICES = [
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    """
-    Test the output consistency of different query evaluation strategies (e.g., dataflow rendering and constant folding).
-    """
-
     c.down(destroy_volumes=True)
 
     c.up("materialized")

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Runs a randomized parallel workload stressing all parts of Materialize, can
+mostly find panics and unexpected errors. See zippy for a sequential randomized
+tests which can verify correctness.
+"""
 
 import random
 

--- a/test/persist/mzcompose.py
+++ b/test/persist/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Maelstrom test against the Persist subsystem.
+"""
+
 import argparse
 
 from materialize.mzcompose.composition import (

--- a/test/persistence/mzcompose.py
+++ b/test/persistence/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Basic tests for Persistence layer.
+"""
+
 import os
 import time
 from argparse import Namespace

--- a/test/pg-cdc-resumption/mzcompose.py
+++ b/test/pg-cdc-resumption/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Postgres source tests with interruptions, test that Materialize can recover.
+"""
+
 import time
 
 from materialize import buildkite

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -6,6 +6,11 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+
+"""
+Native Postgres source tests, functional.
+"""
+
 import time
 
 import pg8000

--- a/test/pg-rtr/mzcompose.py
+++ b/test/pg-rtr/mzcompose.py
@@ -7,6 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Functional test for Postgres source with real-time recency enabled. Queries
+should block until results are available instead of returning out of date
+results.
+"""
+
 import random
 
 from materialize.mzcompose.composition import Composition

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -7,6 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Write a single set of .td fragments for a particular feature or functionality
+and then have Zippy execute them in upgrade, 0dt-upgrade, restart, recovery and
+failure contexts.
+"""
+
 import os
 from enum import Enum
 

--- a/test/postgres-consistency/mzcompose.py
+++ b/test/postgres-consistency/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test the consistency of Materialize against Postgres as an oracle.
+"""
+
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.materialized import Materialized
@@ -30,9 +34,6 @@ SERVICES = [
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    """
-    Test the consistency with Postgres.
-    """
 
     c.down(destroy_volumes=True)
 

--- a/test/pubsub-disruption/mzcompose.py
+++ b/test/pubsub-disruption/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test toxiproxy disruptions in the persist pubsub connection.
+"""
+
 from collections.abc import Callable
 from dataclasses import dataclass
 from textwrap import dedent

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -7,6 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test replica isolation by introducing faults of various kinds in replica1 and
+then making sure that the cluster continues to operate properly
+"""
+
+
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -404,10 +410,6 @@ disruptions = [
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    """Test replica isolation by introducing faults of various kinds in replica1
-    and then making sure that the cluster continues to operate properly
-    """
-
     parser.add_argument("disruptions", nargs="*", default=[d.name for d in disruptions])
 
     args = parser.parse_args()

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -7,6 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Testdrive-based tests involving restarting materialized (including its clusterd
+processes). See cluster tests for separate clusterds, see platform-checks for
+further restart scenarios.
+"""
+
 import json
 import time
 from textwrap import dedent

--- a/test/retain-history/mzcompose.py
+++ b/test/retain-history/mzcompose.py
@@ -6,6 +6,9 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+
+"""Test the retain history feature."""
+
 import time
 from datetime import datetime
 from textwrap import dedent
@@ -23,7 +26,6 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    """Test the retain history feature."""
     setup(c)
     run_test_with_mv_on_table(c)
     run_test_with_mv_on_table_with_altered_retention(c)

--- a/test/rqg/mzcompose.py
+++ b/test/rqg/mzcompose.py
@@ -7,6 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test Materialize with the Random Query Generator (grammar-based):
+https://github.com/MaterializeInc/RQG/ Can find query errors and panics, but
+not correctness.
+"""
+
 import argparse
 from dataclasses import dataclass
 from enum import Enum

--- a/test/rtr-combined/mzcompose.py
+++ b/test/rtr-combined/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test that real-time recency works w/ slow ingest of upstream data from Kafka+MySQL+Postgres
+"""
+
 import random
 import threading
 import time
@@ -36,9 +40,6 @@ SERVICES = [
 ]
 
 
-#
-# Test that real-time recency works w/ slow ingest of upstream data.
-#
 def workflow_default(c: Composition) -> None:
     c.down(destroy_volumes=True)
     c.up("zookeeper", "kafka", "schema-registry", "postgres", "mysql", "materialized")

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Benchmark for how various queries scale, compares against old Materialize versions.
+"""
+
 import argparse
 import sys
 from pathlib import Path

--- a/test/secrets-local-file/mzcompose.py
+++ b/test/secrets-local-file/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test that `CREATE SECRET` and using secrets works using a local file for storage.
+"""
+
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.testdrive import Testdrive

--- a/test/skip-version-upgrade/mzcompose.py
+++ b/test/skip-version-upgrade/mzcompose.py
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test that skipping versions when upgrading will fail.
+"""
 
 from materialize.mz_version import MzVersion
 from materialize.mzcompose.composition import Composition
@@ -34,10 +37,6 @@ def workflow_default(c: Composition) -> None:
 
 
 def workflow_test_version_skips(c: Composition) -> None:
-    """
-    Test that skipping versions when upgrading will fail.
-    """
-
     current_version = MzVersion.parse_cargo()
 
     # If the current version is `v0.X.0-dev`, two_minor_releases_before will be `v0.X-2.Y`.

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test the detection and reporting of source/sink errors by introducing a
+Disruption and then checking the mz_internal.mz_*_statuses tables
+"""
+
 import random
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -540,10 +545,6 @@ disruptions: list[Disruption] = [
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    """Test the detection and reporting of source/sink errors by
-    introducing a Disruption and then checking the mz_internal.mz_*_statuses tables
-    """
-
     parser.add_argument("disruptions", nargs="*", default=[d.name for d in disruptions])
 
     args = parser.parse_args()

--- a/test/sql-feature-flags/mzcompose.py
+++ b/test/sql-feature-flags/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test that setting feature flags works
+"""
+
 import argparse
 from textwrap import dedent, indent
 

--- a/test/sqlancer/mzcompose.py
+++ b/test/sqlancer/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Run SQLancer against Materialize: Automated testing to find logic bugs in
+database systems: https://github.com/sqlancer/sqlancer
+"""
+
 import argparse
 import random
 from threading import Thread

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -6,6 +6,13 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+
+"""
+Run SQL tests using an instance of Mz that is embedded in the sqllogic binary
+itself. Good for basic SQL tests, but can't interact with sources like
+MySQL/Kafka, see Testdrive for that.
+"""
+
 from __future__ import annotations
 
 import argparse

--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -7,6 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Use SQLsmith to generate random queries (AST/code based) and run them against
+Materialize: https://github.com/MaterializeInc/sqlsmith The queries can be
+complex, but we can't verify correctness or performance.
+"""
+
 import json
 import random
 import time

--- a/test/ssh-connection/mzcompose.py
+++ b/test/ssh-connection/mzcompose.py
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Test sources with SSH connections using an SSH bastion host.
+"""
+
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized

--- a/test/storage-usage/mzcompose.py
+++ b/test/storage-usage/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Verify how much storage is being used, based on mz_storage_usage and
+mz_recent_storage_usage.
+"""
+
 import time
 from dataclasses import dataclass
 from textwrap import dedent

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -7,6 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Testdrive is the basic framework and language for defining product tests under
+the expected-result/actual-result (aka golden testing) paradigm. A query is
+retried until it produces the desired result.
+"""
+
 from pathlib import Path
 
 from materialize import ci_util

--- a/test/tracing/mzcompose.py
+++ b/test/tracing/mzcompose.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""Tests the dynamic tracing setup on environmentd"""
+
 import os
 import time
 
@@ -31,7 +33,6 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    """Tests the dynamic tracing setup on environmentd"""
     for name in c.workflows:
         if name != "default":
             with c.test_case(name):

--- a/test/txn-wal-fencing/mzcompose.py
+++ b/test/txn-wal-fencing/mzcompose.py
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Introduce a second Mz instance while a concurrent workload is running for the
+purpose of exercising fencing.
+"""
+
 import random
 import time
 from concurrent import futures
@@ -89,7 +94,6 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    """Introduce a second Mz instance while a concurrent workload is running for the purpose of exercising fencing."""
     for workload in WORKLOADS:
         run_workload(c, workload)
 

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -10,6 +10,10 @@
 # This mzcompose currently tests `UPSERT` sources with `DISK` configured.
 # TODO(guswynn): move ALL upsert-related tests into this directory.
 
+"""
+Test Kafka Upsert sources using Testdrive.
+"""
+
 from pathlib import Path
 from textwrap import dedent
 

--- a/test/version-consistency/mzcompose.py
+++ b/test/version-consistency/mzcompose.py
@@ -6,6 +6,11 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+
+"""
+Test the consistency with another mz version.
+"""
+
 import argparse
 
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
@@ -45,10 +50,6 @@ SERVICES = [
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    """
-    Test the consistency with another mz version.
-    """
-
     c.down(destroy_volumes=True)
 
     test = VersionConsistencyTest()

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -7,6 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+"""
+Zippy generates a pseudo-random sequence of DDLs, DMLs, failures, data
+validation and other events and runs it sequentially. By keeping track of the
+expected state it can verify results for correctness.
+"""
+
 import random
 import re
 from datetime import timedelta


### PR DESCRIPTION
Extended descriptions

Had to bump pyright because of https://github.com/microsoft/pyright/issues/5737

Thanks to Joe for suggesting

Example run: https://buildkite.com/materialize/test/builds/89581
![Screenshot 2024-08-31 at 10 21 31](https://github.com/user-attachments/assets/bb8d2f79-72b3-4466-b5ee-cd3eac276552)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
