### PR TITLE
bazel: Fix checksums

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -137,7 +137,7 @@ fi
 # *inside* this image. See materialize.git.expand_globs in the Python code for
 # details on this computation.
 files=$(cat \
-        <(git diff --name-only -z 4b825dc642cb6eb9a060e54bf8d69288fbee4904 ci/builder) \
+        <(git diff --name-only -z 4b825dc642cb6eb9a060e54bf8d69288fbee4904 ci/builder .bazelversion) \
         <(git ls-files --others --exclude-standard -z ci/builder) \
     | LC_ALL=C sort -z \
     | xargs -0 "$shasum")

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -287,10 +287,10 @@ ARG BAZEL_VERSION
 
 # Download the bazel binary from the official GitHub releases since the apt repositories do not
 # contain arm64 releases.
-RUN arch_bazel=$(echo "$ARCH_GCC" | sed "s/aarch64/arm64/") bazel_version=$(echo "$BAZEL_VERSION") \
+RUN arch_bazel=$(echo "$ARCH_GCC" | sed -e "s/aarch64/arm64/" -e "s/amd64/x86_64/") bazel_version=$(echo "$BAZEL_VERSION") \
     && curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/$bazel_version/bazel-$bazel_version-linux-$arch_bazel \
-    && if [ "$arch_bazel" = arm64 ]; then echo '37c2d1c8ff917eba88fc68a9fc7ac0b96014f1bed653f1621de0eabc79ed0d2b /usr/local/bin/bazel' | sha256sum --check; fi \
-    && if [ "$arch_bazel" = amd64 ]; then echo 'd93508529d41136065c7b1e5ff555fbfb9d18fd00e768886f2fc7dfb53b05b43 /usr/local/bin/bazel' | sha256sum --check; fi \
+    && if [ "$arch_bazel" = arm64 ]; then echo '5a4cc979353671e438b9469b833924c2361e25a580cc278a75877aedc27c1c53 /usr/local/bin/bazel' | sha256sum --check; fi \
+    && if [ "$arch_bazel" = x86_64 ]; then echo '80ccd1ecb4b88750fbe5d7622d67072fddcba9da7808f13356555e480bf67875 /usr/local/bin/bazel' | sha256sum --check; fi \
     && chmod +x /usr/local/bin/bazel
 
 # Hardcode some known SSH hosts, or else SSH will ask whether the host is


### PR DESCRIPTION
This was broken in https://github.com/MaterializeInc/materialize/pull/28370

But we didn't notice because the bazel files touched didn't cause a rebuild of ci-builder, so fixing that too. @ParkMyCar Are these the correct files to monitor or do we need more?

Seen failing in https://buildkite.com/materialize/test/builds/89528

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
