### PR TITLE
storage/sinks/kafka: don't wedge on empty progress topics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8292,7 +8292,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.29.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#302aa0e66bdb695abeef3f963d464eb9148e4099"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#4a217ecc7a05d6514c8d18c7e4c1d206605edb6b"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -8308,8 +8308,8 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.3.0+2.4.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#302aa0e66bdb695abeef3f963d464eb9148e4099"
+version = "4.3.0+2.5.0"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#4a217ecc7a05d6514c8d18c7e4c1d206605edb6b"
 dependencies = [
  "cmake",
  "libc",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -901,7 +901,7 @@ version = "0.29.0@git:1e27332856a433235aeba7f82d46d06e3f646b69"
 [[audits.rdkafka]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
-version = "0.29.0@git:302aa0e66bdb695abeef3f963d464eb9148e4099"
+version = "0.29.0@git:4a217ecc7a05d6514c8d18c7e4c1d206605edb6b"
 importable = false
 
 [[audits.rdkafka]]
@@ -932,18 +932,18 @@ version = "4.3.0+2.4.0@git:1e27332856a433235aeba7f82d46d06e3f646b69"
 [[audits.rdkafka-sys]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
-version = "4.3.0+2.4.0@git:302aa0e66bdb695abeef3f963d464eb9148e4099"
-importable = false
-
-[[audits.rdkafka-sys]]
-who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
-criteria = "safe-to-deploy"
 version = "4.3.0+2.4.0@git:80fffc098a94b81b20f1bb3713ac2f96e622b8e9"
 
 [[audits.rdkafka-sys]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "4.3.0+2.4.0@git:f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
+
+[[audits.rdkafka-sys]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "4.3.0+2.5.0@git:4a217ecc7a05d6514c8d18c7e4c1d206605edb6b"
+importable = false
 
 [[audits.redox_syscall]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -995,9 +995,14 @@ async fn determine_sink_progress(
                 Offset::Offset(position) => position,
                 // An invalid offset indicates the consumer has not yet read a
                 // message. Since we assigned the consumer to the beginning of
-                // the topic, it's safe to return 0 here, which indicates the
-                // position before the first possible message.
-                Offset::Invalid => 0,
+                // the topic, it's safe to return the low water mark here, which
+                // indicates the position before the first possible message.
+                //
+                // Note that it's important to return the low water mark and not
+                // the minimum possible offset (i.e., zero) in order to break
+                // out of the loop if the topic is empty but the low water mark
+                // is greater than zero.
+                Offset::Invalid => lo,
                 _ => bail!(
                     "Consumer::position returned offset of wrong type: {:?}",
                     position

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -749,6 +749,7 @@ impl Run for PosCommand {
                     "kafka-add-partitions" => kafka::run_add_partitions(builtin, state).await,
                     "kafka-create-topic" => kafka::run_create_topic(builtin, state).await,
                     "kafka-wait-topic" => kafka::run_wait_topic(builtin, state).await,
+                    "kafka-delete-records" => kafka::run_delete_records(builtin, state).await,
                     "kafka-delete-topic-flaky" => kafka::run_delete_topic(builtin, state).await,
                     "kafka-ingest" => kafka::run_ingest(builtin, state).await,
                     "kafka-verify-data" => kafka::run_verify_data(builtin, state).await,

--- a/src/testdrive/src/action/kafka.rs
+++ b/src/testdrive/src/action/kafka.rs
@@ -9,6 +9,7 @@
 
 mod add_partitions;
 mod create_topic;
+mod delete_records;
 mod delete_topic;
 mod ingest;
 mod verify_commit;
@@ -18,6 +19,7 @@ mod wait_topic;
 
 pub use add_partitions::run_add_partitions;
 pub use create_topic::run_create_topic;
+pub use delete_records::run_delete_records;
 pub use delete_topic::run_delete_topic;
 pub use ingest::run_ingest;
 pub use verify_commit::run_verify_commit;

--- a/src/testdrive/src/action/kafka/delete_records.rs
+++ b/src/testdrive/src/action/kafka/delete_records.rs
@@ -1,0 +1,48 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::{bail, Context};
+use mz_ore::collections::CollectionExt;
+use rdkafka::{Offset, TopicPartitionList};
+
+use crate::action::{ControlFlow, State};
+use crate::parser::BuiltinCommand;
+
+pub async fn run_delete_records(
+    mut cmd: BuiltinCommand,
+    state: &mut State,
+) -> Result<ControlFlow, anyhow::Error> {
+    let topic_prefix = format!("testdrive-{}", cmd.args.string("topic")?);
+    let partition = cmd.args.parse("partition")?;
+    let offset = cmd.args.parse("offset")?;
+    cmd.args.done()?;
+
+    let topic_name = format!("{}-{}", topic_prefix, state.seed);
+    println!(
+        "Deleting records up to offset {offset} from partition {partition} of topic {topic_name}",
+    );
+
+    let mut tpl = TopicPartitionList::new();
+    tpl.add_partition_offset(&topic_name, partition, Offset::Offset(offset))
+        .context("internal error: adding partition to delete records topic partition list")?;
+    let res = state
+        .kafka_admin
+        .delete_records(&tpl, &state.kafka_admin_opts)
+        .await
+        .context("deleting records")?;
+    if res.count() != 1 {
+        bail!(
+            "kafka record deletion returned {} results, but exactly one result was expected",
+            res.count()
+        );
+    }
+    res.elements().into_element().error()?;
+
+    Ok(ControlFlow::Continue)
+}

--- a/test/testdrive/kafka-sink-empty-progress-topic.td
+++ b/test/testdrive/kafka-sink-empty-progress-topic.td
@@ -1,0 +1,101 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test creating a sink when the progress topic is empty but has a non-zero low
+# water mark.
+#
+# Note that, without outside intervention, it's impossible for modern versions
+# of Materialize to get a progress topic into this state because:
+#
+#  * Materialize always creates progress topics with compaction enabled but
+#    time-based retention disabled.
+#
+#  * Materialize never publishes tombstones to the progress topic.
+#
+# So the progress topic will either have a low water mark of zero, or it will
+# have at least one progress message in it.
+#
+# Still, we've observed at least one progress topic in this state in the wild.
+# We believe this occured because the user created the progress topic in an old
+# version of Materialize that did not force disable the retention policy when
+# creating the progress topic.
+#
+# Even though modern versions of Materialize don't leave progress topics in this
+# state naturally, outside intervention can still cause Materialize to observe
+# progress topics in this state:
+#
+#  * A user could enable a retention policy on the progress topic after it's
+#    created. While this is incorrect it won't cause problems in the steady
+#    state in practice as long as the retention window is large enough to never
+#    delete the latest messages. But if all sinks associated with the progress
+#    topic are dropped, and then the progress topic is allowed to sit for a
+#    while ... it will eventually empty out and have a nonzero low water mark.
+#
+#  * A user could manually clear the progress topic out after it's created by
+#    sending DeleteRecords requests to the topic. This is technically valid as
+#    long as there are no sinks actively associated with the progress topic.
+#
+# So it's worth testing that we're handling these sorts of progress topics
+# correctly. Previous versions of Materialize used to get wedged if you created
+# a sink against a progress topic in this state.
+
+$ set-arg-default single-replica-cluster=quickstart
+
+> CREATE MATERIALIZED VIEW mv AS VALUES (1)
+
+# Ensure that sinks can be created against a progress topic that is empty with a
+# low water mark of zero.
+
+$ kafka-create-topic topic=empty-at-zero
+
+> CREATE CONNECTION kafka_conn_empty_at_zero
+  TO KAFKA (
+    BROKER '${testdrive.kafka-addr}',
+    SECURITY PROTOCOL PLAINTEXT,
+    PROGRESS TOPIC 'testdrive-empty-at-zero-${testdrive.seed}'
+  )
+
+> CREATE SINK empty_at_zero
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM mv
+  INTO KAFKA CONNECTION kafka_conn_empty_at_zero (TOPIC 'testdrive-empty-at-zero-${testdrive.seed}')
+  KEY (column1) NOT ENFORCED
+  FORMAT JSON
+  ENVELOPE UPSERT
+
+$ kafka-verify-data sink=materialize.public.empty_at_zero format=json
+{"column1": 1}
+
+# Ensure that sinks can be created against a progress topic that is empty with a
+# low water mark that is nonzero.
+
+$ kafka-create-topic topic=empty-at-nonzero
+$ kafka-ingest topic=empty-at-nonzero format=bytes
+data
+data
+data
+$ kafka-delete-records topic=empty-at-nonzero partition=0 offset=3
+
+> CREATE CONNECTION kafka_conn_empty_at_nonzero
+  TO KAFKA (
+    BROKER '${testdrive.kafka-addr}',
+    SECURITY PROTOCOL PLAINTEXT,
+    PROGRESS TOPIC 'testdrive-empty-at-nonzero-${testdrive.seed}'
+  )
+
+> CREATE SINK empty_at_nonzero
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM mv
+  INTO KAFKA CONNECTION kafka_conn_empty_at_nonzero (TOPIC 'testdrive-empty-at-nonzero-${testdrive.seed}')
+  KEY (column1) NOT ENFORCED
+  FORMAT JSON
+  ENVELOPE UPSERT
+
+$ kafka-verify-data sink=materialize.public.empty_at_nonzero format=json
+{"column1": 1}


### PR DESCRIPTION
Previously, Kafka sinks would wedge on startup if their progress topic was empty but had a nonzero low water mark. It's extremely difficult for a progress topic to get into this state (you need to write one or more messages to the progress topic and then somehow delete *all* of those messages), but we've observed at least one progress topic in this state in the wild.

So, this commit teaches Kafka sinks to handle this case without wedging, and adds a test case to prevent future regressions. See the comments within the patch and the test case for details.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes an issue reported by a customer on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
