### PR TITLE
kafka-util: only complain when true misconfiguration happens

### DIFF
--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1881,7 +1881,7 @@ impl SystemVars {
     }
 
     /// Returns the `kafka_socket_timeout` configuration parameter.
-    pub fn kafka_socket_timeout(&self) -> Duration {
+    pub fn kafka_socket_timeout(&self) -> Option<Duration> {
         *self.expect_value(&KAFKA_SOCKET_TIMEOUT)
     }
 
@@ -1901,7 +1901,7 @@ impl SystemVars {
     }
 
     /// Returns the `kafka_progress_record_fetch_timeout` configuration parameter.
-    pub fn kafka_progress_record_fetch_timeout(&self) -> Duration {
+    pub fn kafka_progress_record_fetch_timeout(&self) -> Option<Duration> {
         *self.expect_value(&KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT)
     }
 

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1081,9 +1081,10 @@ pub static KAFKA_SOCKET_KEEPALIVE: VarDefinition = VarDefinition::new(
 /// `kafka_transaction_timeout`, or less than 10ms.
 pub static KAFKA_SOCKET_TIMEOUT: VarDefinition = VarDefinition::new(
     "kafka_socket_timeout",
-    value!(Duration; mz_kafka_util::client::DEFAULT_SOCKET_TIMEOUT),
+    value!(Option<Duration>; None),
     "Controls `socket.timeout.ms` for rdkafka \
-        client connections. Defaults to the rdkafka default (60000ms). \
+        client connections. Defaults to the rdkafka default (60000ms) or \
+        the set transaction timeout + 100ms, whichever one is smaller. \
         Cannot be greater than 300000ms, more than 100ms greater than \
         `kafka_transaction_timeout`, or less than 10ms.",
     false,
@@ -1123,9 +1124,9 @@ pub static KAFKA_FETCH_METADATA_TIMEOUT: VarDefinition = VarDefinition::new(
 /// Controls the timeout when fetching kafka progress records. Defaults to 60s.
 pub static KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT: VarDefinition = VarDefinition::new(
     "kafka_progress_record_fetch_timeout",
-    value!(Duration; mz_kafka_util::client::DEFAULT_PROGRESS_RECORD_FETCH_TIMEOUT),
+    value!(Option<Duration>; None),
     "Controls the timeout when fetching kafka progress records. \
-        Defaults to 60s.",
+        Defaults to 60s or the transaction timeout, whichever one is larger.",
     false,
 );
 


### PR DESCRIPTION
The code as it was would produce an error report if someone set the kafka transaction timeout to a value that is above the default progress record fetch timeout, even though it's the system that chose the problematic default in the first place. So in some sense, it was complaining about a problem it caused to itself.

This PR makes it so that configurations whose defaults are derived from other values have an `Option<_>` type so that we can differenciate between "the user does not have an opinion" and the "the user has an opinion". We then only produce an error if the user had the wrong opinion.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
