### PR TITLE
bazel: add a Linux sysroot and support cross compilation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,10 +2,6 @@
 # `build:[ linux | macos | windows | freebsd | openbsd ]`
 common --enable_platform_specific_config
 
-# C Toolchain Configuration
-common --compiler=clang++
-common --cxxopt=-stdlib=libc++
-
 # Required for remote caching to be effective.
 #
 # Otherwise Bazel will passthrough the current system's PATH in the execution

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -237,16 +237,8 @@ llvm_toolchain(
     llvm_version = LLVM_VERSION,
     sha256 = {
         "darwin-aarch64": "510541536527d9d4264e48e254c231487cdc1631cb30920da8a68adf41fdbb91",
-        "linux-aarch64": "bdab5b24cb44f121c82378503afdf55052931c8a26a86f16dad4405a3626a23d",
-        "linux-x86_64": "c44046d74e491661e53fc409add8eb7bdcca4b13decde9aa4adb9b8dc8ef1fa4",
-    },
-    # Default behavior is to link against LLVM's libc++ which is included with our Clang
-    # toolchain. But when cross-compiling, libc++ isn't available so we link against
-    # GNU's libstdc++. Instead we just always link against libstdc++ so the behavior is
-    # the same whether cross-compiling or not.
-    stdlib = {
-        "linux-aarch64": "stdc++",
-        "linux-x86_64": "stdc++",
+        "linux-aarch64": "6117a28376d91d331fbacbac3cf9ef4e21ad255e3cbd6fcbfc260e3f437be533",
+        "linux-x86_64": "6aa8a3c61de78e95134261b6d0e3a1907e1fee5b41a3baa62b185ec8326c0753",
     },
     sysroot = {
         "darwin-aarch64": "@sysroot_darwin_universal//:sysroot",
@@ -256,8 +248,8 @@ llvm_toolchain(
     },
     urls = {
         "darwin-aarch64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}/darwin_aarch64.tar.zst".format(LLVM_VERSION)],
-        "linux-aarch64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}/linux_aarch64.tar.zst".format(LLVM_VERSION)],
-        "linux-x86_64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}/linux_x86_64.tar.zst".format(LLVM_VERSION)],
+        "linux-aarch64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-1/linux_aarch64.tar.zst".format(LLVM_VERSION)],
+        "linux-x86_64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-1/linux_x86_64.tar.zst".format(LLVM_VERSION)],
     },
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,7 +32,9 @@ included by calling a `*_dependencies()` macro.
 # Note: In an ideal world the two rule sets would be combined into one.
 
 BAZEL_SKYLIB_VERSION = "1.6.1"
+
 BAZEL_SKYLIB_INTEGRITY = "sha256-nziIakBUjG6WwQa3UvJCEw7hGqoGila6flb0UR8z5PI="
+
 maybe(
     http_archive,
     name = "bazel_skylib",
@@ -44,7 +46,9 @@ maybe(
 )
 
 ASPECT_BAZEL_LIB_VERSION = "2.7.0"
+
 ASPECT_BAZEL_LIB_INTEGRITY = "sha256-NX2tnSEjJ8NdkkQZDvAQqtMV5z/6G+0aKeIMNy+co0Y="
+
 maybe(
     http_archive,
     name = "aspect_bazel_lib",
@@ -52,10 +56,12 @@ maybe(
     strip_prefix = "bazel-lib-{0}".format(ASPECT_BAZEL_LIB_VERSION),
     url = "https://github.com/aspect-build/bazel-lib/releases/download/v{0}/bazel-lib-v{0}.tar.gz".format(ASPECT_BAZEL_LIB_VERSION),
 )
+
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "aspect_bazel_lib_register_toolchains")
 
 # Required bazel-lib dependencies
 aspect_bazel_lib_dependencies()
+
 # Register bazel-lib toolchains
 aspect_bazel_lib_register_toolchains()
 
@@ -66,7 +72,9 @@ aspect_bazel_lib_register_toolchains()
 # rule set.
 
 RULES_CC_VERSION = "0.0.9"
+
 RULES_CC_INTEGRITY = "sha256-IDeHW5pEVtzkp50RKorohbvEqtlo5lh9ym5k86CQDN8="
+
 maybe(
     http_archive,
     name = "rules_cc",
@@ -82,7 +90,9 @@ maybe(
 # Rules for building archives, e.g. `tar` or `zip`, for packages.
 
 RULES_PKG_VERSION = "0.7.0"
+
 RULES_PKG_INTEGRITY = "sha256-iimOgydi7aGDBZfWT+fbWBeKqEzVkm121bdE1lWJQcI="
+
 maybe(
     http_archive,
     name = "rules_pkg",
@@ -117,7 +127,9 @@ maybe(
 #    See: <https://github.com/MaterializeInc/rules_foreign_cc/commit/de4a79280f54d8796e86b7ab0b631939b7b44d05>
 
 RULES_FOREIGN_CC_VERSION = "de4a79280f54d8796e86b7ab0b631939b7b44d05"
+
 RULES_FOREIGN_CC_INTEGRITY = "sha256-WwRg/GJuUjT3SMJEagTni2ZH+g3szIkHaqGgbYCN1u0="
+
 maybe(
     http_archive,
     name = "rules_foreign_cc",
@@ -125,6 +137,7 @@ maybe(
     strip_prefix = "rules_foreign_cc-{0}".format(RULES_FOREIGN_CC_VERSION),
     url = "https://github.com/MaterializeInc/rules_foreign_cc/archive/{0}.tar.gz".format(RULES_FOREIGN_CC_VERSION),
 )
+
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 rules_foreign_cc_dependencies(make_version = "4.2")
@@ -140,6 +153,7 @@ rules_foreign_cc_dependencies(make_version = "4.2")
 
 # Version of the "toolchains_llvm" rule set, _not_ the version of clang/llvm.
 TOOLCHAINS_LLVM_VERSION = "1.0.0"
+
 TOOLCHAINS_LLVM_INTEGRITY = "sha256-6RxDYfmQEaVIFOGvvlxDbg0ymHEUajzVjCOitK+1Bzc="
 
 # System roots that we use, this is where clang will search for things like libc.
@@ -156,6 +170,7 @@ filegroup(
 """
 
 DARWIN_SYSROOT_VERSION = "14.5"
+
 DARWIN_SYSROOT_INTEGRITY = "sha256-k8OxF+DSVq0L1dy1S9TPqhFxDHF/bT32Ust3a1ldat8="
 
 http_archive(
@@ -212,9 +227,11 @@ maybe(
 )
 
 load("@toolchains_llvm//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+
 bazel_toolchain_dependencies()
 
 load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
+
 llvm_toolchain(
     name = "llvm_toolchain",
     llvm_version = LLVM_VERSION,
@@ -245,6 +262,7 @@ llvm_toolchain(
 )
 
 load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
+
 llvm_register_toolchains()
 
 # `rules_perl`
@@ -252,6 +270,7 @@ llvm_register_toolchains()
 # Provides a `perl` toolchain which is required to build some libraries (e.g. openssl).
 
 RULES_PERL_VERISON = "0.1.0"
+
 RULES_PERL_INTEGRITY = "sha256-XO+tvypJvzQh7eAJ8sWiyYNquueSYg7S/5kYQTN1UyU="
 
 maybe(
@@ -263,9 +282,11 @@ maybe(
         "https://github.com/bazelbuild/rules_perl/archive/refs/tags/{0}.tar.gz".format(RULES_PERL_VERISON),
     ],
 )
+
 load("@rules_perl//perl:deps.bzl", "perl_register_toolchains", "perl_rules_dependencies")
 
 perl_rules_dependencies()
+
 perl_register_toolchains()
 
 # Extra setup.
@@ -274,12 +295,14 @@ perl_register_toolchains()
 # specific to a single library we move their definitions into separate files
 # to avoid cluter.
 load("//misc/bazel/c_deps:extra_setup.bzl", "protoc_setup")
+
 protoc_setup()
 
 # C Repositories
 #
 # Loads all of the C dependencies that we rely on.
 load("//misc/bazel/c_deps:repositories.bzl", "c_repositories")
+
 c_repositories()
 
 # `rules_rust`
@@ -288,6 +311,7 @@ c_repositories()
 # dependencies.
 
 RULES_RUST_VERSION = "0.49.3"
+
 RULES_RUST_INTEGRITY = "sha256-3QBrdyIdWeTRQSB8DnrfEbH7YNFEC4/KA7+SVheTKmA="
 
 maybe(
@@ -301,6 +325,7 @@ maybe(
 )
 
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies")
+
 rules_rust_dependencies()
 
 # `rustc`
@@ -311,6 +336,7 @@ rules_rust_dependencies()
 RUST_VERSION = "1.80.1"
 
 load("//misc/bazel/toolchains:rust.bzl", "rust_toolchains")
+
 rust_toolchains(
     RUST_VERSION,
     {
@@ -336,27 +362,24 @@ rust_toolchains(
             "rust-std": "e7b766fce1cd89c02bde33f8cc3a81f341c52677258a546df2bee1c7090e9fc5",
         },
         "x86_64-apple-darwin": {},
-    }
+    },
 )
 
 # Load all dependencies for crate_universe.
 load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
+
 crate_universe_dependencies()
 
-load("@rules_rust//crate_universe:defs.bzl", "crates_repository", "crate")
+load("@rules_rust//crate_universe:defs.bzl", "crate", "crates_repository")
+
 crates_repository(
     name = "crates_io",
-    rust_version = RUST_VERSION,
     annotations = {
         "decnumber-sys": [crate.annotation(
-            gen_build_script = False,
             additive_build_file = "@//misc/bazel/c_deps:rust-sys/BUILD.decnumber.bazel",
+            gen_build_script = False,
             # Note: This is a target we add from the additive build file above.
-            compile_data = [":decnumber_static_lib"],
-            rustc_flags = [
-                "-Lnative=$(execpath :decnumber_static_lib)",
-                "-lstatic=decnumber",
-            ]
+            deps = [":decnumber"],
         )],
         "librocksdb-sys": [crate.annotation(
             additive_build_file = "@//misc/bazel/c_deps:rust-sys/BUILD.rocksdb.bazel",
@@ -388,24 +411,20 @@ crates_repository(
                 ":snappy_lib",
             ],
         )],
-        "rdkafka-sys": [crate.annotation(
+        "tikv-jemalloc-sys": [crate.annotation(
             gen_build_script = False,
+            rustc_flags = ["--cfg=prefixed"],
+            deps = ["@jemalloc"],
+        )],
+        "rdkafka-sys": [crate.annotation(
             additive_build_file = "@//misc/bazel/c_deps:rust-sys/BUILD.librdkafka.bazel",
+            gen_build_script = False,
             # Note: This is a target we add from the additive build file above.
             deps = [":librdkafka"],
-            compile_data = [":rdkafka_lib"],
-            rustc_flags = [
-                "-Lnative=$(execpath :rdkafka_lib)",
-                "-lstatic=rdkafka",
-            ]
         )],
         "libz-sys": [crate.annotation(
             gen_build_script = False,
-            compile_data = ["@zlib//:zlib_static_lib"],
-            rustc_flags = [
-                "-Lnative=$(execpath @zlib//:zlib_static_lib)",
-                "-lstatic=zlib",
-            ]
+            deps = ["@zlib"],
         )],
         "openssl-sys": [crate.annotation(
             build_script_data = [
@@ -425,11 +444,11 @@ crates_repository(
             # Note: We shouldn't ever depend on protobuf-src, but if we do, don't try to bootstrap
             # `protoc`.
             gen_build_script = False,
-            rustc_env = { "INSTALL_DIR": "fake" },
+            rustc_env = {"INSTALL_DIR": "fake"},
         )],
         "protobuf-native": [crate.annotation(
-            gen_build_script = False,
             additive_build_file = "@//misc/bazel/c_deps:rust-sys/BUILD.protobuf-native.bazel",
+            gen_build_script = False,
             deps = [":protobuf-native-bridge"],
         )],
         "psm": [crate.annotation(
@@ -579,14 +598,15 @@ crates_repository(
         "//:test/test-util/Cargo.toml",
         "//:misc/bazel/cargo-gazelle/Cargo.toml",
     ],
+    rust_version = RUST_VERSION,
     # Only used if developing rules_rust.
     # generator = "@cargo_bazel_bootstrap//:cargo-bazel",
 )
 
 load("@crates_io//:defs.bzl", "crate_repositories")
+
 crate_repositories()
 
-load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
 crate_universe_dependencies()
 
 # Third-Party Rust Tools
@@ -595,6 +615,7 @@ crate_universe_dependencies()
 # with Bazel we need to include the `cxx` command line binary.
 
 load("//misc/bazel/rust_deps:repositories.bzl", "rust_repositories")
+
 rust_repositories()
 
 # Load and include any dependencies the third-party Rust binaries require.
@@ -606,6 +627,7 @@ rust_repositories()
 # TODO(parkmycar): This should get better when we switch to bzlmod.
 
 load("@cxxbridge//:defs.bzl", cxxbridge_cmd_deps = "crate_repositories")
+
 cxxbridge_cmd_deps()
 
 # git Submodules
@@ -615,6 +637,6 @@ cxxbridge_cmd_deps()
 
 new_local_repository(
     name = "fivetran_sdk",
-    path = "misc/fivetran-sdk",
     build_file = "//misc/bazel:git_submodules/BUILD.fivetran_sdk.bazel",
+    path = "misc/fivetran-sdk",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -361,28 +361,33 @@ crates_repository(
         "librocksdb-sys": [crate.annotation(
             additive_build_file = "@//misc/bazel/c_deps:rust-sys/BUILD.rocksdb.bazel",
             # Note: The below targets are from the additive build file.
+            #
+            # HACK(parkmycar): The `librocksdb-sys` build script runs bindgen for us, and to
+            # support cross compiling we need to provide the sysroot to the build script so
+            # bindgen can find it. Providing the sysroot and relying on the raw paths is quite
+            # fragile, the fix is to use `@rules_rust//bindgen/...` rules with our Clang toolchain.
+            build_script_data = [
+                ":rocksdb_lib",
+                ":rocksdb_include",
+                ":snappy_lib",
+                "@linux_sysroot-aarch64//:sysroot",
+                "@linux_sysroot-x86_64//:sysroot",
+            ],
             build_script_env = {
                 "ROCKSDB_STATIC": "true",
                 "ROCKSDB_LIB_DIR": "$(execpath :rocksdb_lib)",
                 "ROCKSDB_INCLUDE_DIR": "$(execpath :rocksdb_include)",
                 "SNAPPY_STATIC": "true",
                 "SNAPPY_LIB_DIR": "$(execpath :snappy_lib)",
+                "BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu": "--sysroot=external/linux_sysroot-aarch64",
+                "BINDGEN_EXTRA_CLANG_ARGS_x86_64-unknown-linux-gnu": "--sysroot=external/linux_sysroot-x86_64",
             },
-            build_script_data = [
+            compile_data = [
                 ":rocksdb_lib",
                 ":rocksdb_include",
                 ":snappy_lib",
             ],
-            compile_data = [":rocksdb_lib", ":rocksdb_include", ":snappy_lib"],
         )],
-        # TODO(parkmycar): Re-enable linking with a jemalloc built by Bazel.
-        # "tikv-jemalloc-sys": [crate.annotation(
-        #     build_script_env = {
-        #         "JEMALLOC_OVERRIDE": "$(execpath @jemalloc//:libjemalloc)",
-        #     },
-        #     build_script_data = ["@jemalloc//:libjemalloc"],
-        #     compile_data = ["@jemalloc//:libjemalloc"],
-        # )],
         "rdkafka-sys": [crate.annotation(
             gen_build_script = False,
             additive_build_file = "@//misc/bazel/c_deps:rust-sys/BUILD.librdkafka.bazel",
@@ -426,6 +431,20 @@ crates_repository(
             gen_build_script = False,
             additive_build_file = "@//misc/bazel/c_deps:rust-sys/BUILD.protobuf-native.bazel",
             deps = [":protobuf-native-bridge"],
+        )],
+        "psm": [crate.annotation(
+            additive_build_file = "@//misc/bazel/c_deps:rust-sys/BUILD.psm.bazel",
+            gen_build_script = False,
+            # Note: All of the targets we build for support switching stacks, if we ever want to
+            # support Windows we'll have to revist this.
+            rustc_flags = [
+                "--check-cfg=cfg(switchable_stack,asm,link_asm)",
+                "--cfg=asm",
+                "--cfg=link_asm",
+                "--cfg=switchable_stack",
+            ],
+            # Note: This is a target we add from the additive build file above.
+            deps = ["psm_s"],
         )],
         "launchdarkly-server-sdk": [crate.annotation(
             build_script_env = {

--- a/misc/bazel/c_deps/BUILD.jemalloc.bazel
+++ b/misc/bazel/c_deps/BUILD.jemalloc.bazel
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
-load("@bazel_skylib//rules:select_file.bzl", "select_file")
 
 """Builds jemalloc."""
 
@@ -39,12 +38,14 @@ CONFIGURE_OPTIONS = [
     "--enable-prof",
     "--enable-stats",
     "--with-malloc-conf=background_thread:true",
+    # We build with clang.
+    "--enable-prof-libunwind",
+    "--disable-prof-libgcc",
+    "--disable-prof-gcc",
 ]
 
 configure_make(
     name = "jemalloc",
-    autogen = True,
-    configure_in_place = True,
     # TODO(parkmycar): Do we want to customize page sizes?
     configure_options = CONFIGURE_OPTIONS + select({
         "@//misc/bazel/platforms:linux_arm": ["--host=aarch64-unknown-linux-gnu"],
@@ -58,7 +59,7 @@ configure_make(
     # macOS we use llvm-ar instead.
     build_data = select({
         "@platforms//os:macos": ["@llvm_toolchain_llvm//:ar"],
-        "//conditions:default": {},
+        "//conditions:default": [],
     }),
     env = select({
         "@platforms//os:macos": {"AR": "$(execpath @llvm_toolchain_llvm//:ar)"},
@@ -75,12 +76,5 @@ configure_make(
         "install_include",
     ],
     copts = ["-lpthread"],
-    visibility = ["//visibility:public"],
-)
-
-select_file(
-    name = "libjemalloc",
-    srcs = ":jemalloc",
-    subpath = "libjemalloc.a",
     visibility = ["//visibility:public"],
 )

--- a/misc/bazel/c_deps/BUILD.openssl.bazel
+++ b/misc/bazel/c_deps/BUILD.openssl.bazel
@@ -20,11 +20,10 @@ Adapted from the OpenSSL build file in the `rules_rust` examples:
 https://github.com/bazelbuild/rules_rust/blob/21eed19188c0359d72f9a508a0c0e7040ff20070/examples/crate_universe/multi_package/3rdparty/BUILD.openssl.bazel
 """
 
-load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
-
-load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
+load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@bazel_skylib//rules:select_file.bzl", "select_file")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 
 # Read https://wiki.openssl.org/index.php/Compilation_and_Installation
 
@@ -74,24 +73,32 @@ MAKE_TARGETS = [
 
 configure_make(
     name = "openssl",
-    configure_command = "config",
-    configure_in_place = True,
-    configure_options = CONFIGURE_OPTIONS + select({
-        "@platforms//os:macos": ["ARFLAGS=r"],
-        "//conditions:default": [],
-    }),
+    # TODO(parkmycar): Figure out how to dynamically provide a number of jobs to foreign_cc rules.
+    args = ["-j8"],
     # darwin/macOS defaults to using libtool but openSSL3 fails linking with
     # the generated archive, so we switch to `llvm-ar`.
     build_data = select({
         "@platforms//os:macos": ["@llvm_toolchain_llvm//:ar"],
         "//conditions:default": {},
     }),
+    configure_command = "config",
+    configure_in_place = True,
+    configure_options = CONFIGURE_OPTIONS + select(
+        {
+            "@//misc/bazel/platforms:linux_arm": ["linux-aarch64"],
+            "@//misc/bazel/platforms:linux_x86_64": ["linux-x86_64"],
+            "@//misc/bazel/platforms:macos_arm": ["darwin64-arm64-cc"],
+            "@//misc/bazel/platforms:macos_x86_64": ["darwin64-x86_64-cc"],
+        },
+        no_match_error = "The specified platform is not supported.",
+    ) + select({
+        "@platforms//os:macos": ["ARFLAGS=r"],
+        "//conditions:default": [],
+    }),
     env = select({
         "@platforms//os:macos": {"AR": "$(execpath @llvm_toolchain_llvm//:ar)"},
         "//conditions:default": {},
     }),
-    # TODO(parkmycar): Figure out how to dynamically provide a number of jobs to foreign_cc rules.
-    args = ["-j8"],
     lib_name = LIB_NAME,
     lib_source = ":all_srcs",
     # Note that for Linux builds, libssl must come before libcrypto on the linker command-line.
@@ -126,6 +133,7 @@ select_file(
     srcs = ":out_dir",
     subpath = "libssl.a",
 )
+
 copy_file(
     name = "libssl_copy",
     src = ":libssl",
@@ -138,6 +146,7 @@ select_file(
     srcs = ":out_dir",
     subpath = "libcrypto.a",
 )
+
 copy_file(
     name = "libcrypto_copy",
     src = ":libcrypto",
@@ -148,8 +157,8 @@ copy_file(
 copy_to_directory(
     name = "openssl_lib",
     srcs = [
-        ":libssl_copy",
         ":libcrypto_copy",
+        ":libssl_copy",
     ],
     visibility = ["//visibility:public"],
 )
@@ -165,10 +174,13 @@ select_file(
 copy_to_directory(
     name = "openssl_root",
     srcs = [
-        ":libssl_copy",
         ":libcrypto_copy",
+        ":libssl_copy",
         ":openssl_include",
     ],
-    root_paths = [".", "openssl"],
+    root_paths = [
+        ".",
+        "openssl",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/misc/bazel/c_deps/BUILD.zlib.bazel
+++ b/misc/bazel/c_deps/BUILD.zlib.bazel
@@ -20,7 +20,6 @@ Copied from https://github.com/protocolbuffers/protobuf/blob/v3.9.1/third_party/
 """
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 
 _ZLIB_HEADERS = [
     "crc32.h",
@@ -77,13 +76,6 @@ cc_library(
         ],
     }),
     includes = ["zlib/include/"],
-    visibility = ["//visibility:public"],
-)
-
-# Place the compiled static library in the right place so rustc can find it.
-copy_to_directory(
-    name = "zlib_static_lib",
-    srcs = [":zlib"],
     visibility = ["//visibility:public"],
 )
 

--- a/misc/bazel/c_deps/extra_setup.bzl
+++ b/misc/bazel/c_deps/extra_setup.bzl
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-
 load("@//misc/bazel/rules:utils.bzl", "maybe_github_archive")
 
 def protoc_setup():

--- a/misc/bazel/c_deps/rust-sys/BUILD.decnumber.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.decnumber.bazel
@@ -7,10 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
-load("@bazel_skylib//rules:select_file.bzl", "select_file")
-
 """Additive BUILD file for the decimal-sys Rust crate."""
 
 cc_library(
@@ -60,12 +56,5 @@ cc_library(
         # correctly define `DECLITEND`.
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    visibility = ["//visibility:public"],
-)
-
-# Place the compiled static library in the right place so rustc can find it.
-copy_to_directory(
-    name = "decnumber_static_lib",
-    srcs = [":decnumber"],
     visibility = ["//visibility:public"],
 )

--- a/misc/bazel/c_deps/rust-sys/BUILD.librdkafka.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.librdkafka.bazel
@@ -17,10 +17,6 @@
 
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 
-load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
-load("@bazel_skylib//rules:select_file.bzl", "select_file")
-
 filegroup(
     name = "all_srcs",
     srcs = glob(["librdkafka/**"]),
@@ -72,21 +68,4 @@ cmake(
     ],
     build_data = ["@openssl//:openssl_root"],
     out_static_libs = ["librdkafka.a"],
-)
-
-select_file(
-    name = "librdkafka_a",
-    srcs = ":librdkafka",
-    subpath = "librdkafka.a",
-)
-copy_file(
-    name = "librdkafka_copy",
-    src = ":librdkafka_a",
-    out = "librdkafka.a",
-    allow_symlink = False,
-)
-copy_to_directory(
-    name = "rdkafka_lib",
-    srcs = [":librdkafka_copy"],
-    visibility = ["//visibility:public"],
 )

--- a/misc/bazel/c_deps/rust-sys/BUILD.psm.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.psm.bazel
@@ -1,0 +1,54 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Builds the assembly coded included with `psm`"""
+
+# Note: `psm` supports more platforms and OS's than we configure for here.
+# They're omitted because we have no use for them.
+cc_library(
+    name = "psm_s",
+    srcs = select(
+        {
+            "@platforms//cpu:x86_64": ["src/arch/x86_64.s"],
+            "@platforms//cpu:aarch64": ["src/arch/aarch_aapcs64.s"],
+        },
+        no_match_error = "The specified cpu is not supported.",
+    ),
+    hdrs = ["src/arch/psm.h"],
+    # Always optimize `psm` since it's small and in some very hot code paths.
+    copts = [
+        "-xassembler-with-cpp",
+        "-O3",
+    ] + select(
+        {
+            "@platforms//os:linux": [
+                "-DCFG_TARGET_OS_linux",
+                "-DCFG_TARGET_ENV_gnu",
+            ],
+            "@platforms//os:macos": [
+                "-DCFG_TARGET_OS_macos",
+                "-DCFG_TARGET_ENV_",
+            ],
+        },
+        no_match_error = "The specified OS is not supported.",
+    ) + select(
+        {
+            "@platforms//cpu:x86_64": ["-DCFG_TARGET_ARCH_x86_64"],
+            "@platforms//cpu:aarch64": ["-DCFG_TARGET_ARCH_aarch64"],
+        },
+        no_match_error = "The specified cpu is not supported.",
+    ),
+    visibility = ["//visibility:public"],
+)

--- a/misc/bazel/c_deps/rust-sys/BUILD.rocksdb.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.rocksdb.bazel
@@ -13,11 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
-
-load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
+load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@bazel_skylib//rules:select_file.bzl", "select_file")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 
 """Additive BUILD file for the librocksdb-sys Rust crate."""
 
@@ -37,9 +36,8 @@ cc_library(
         ":snappy_stubs_public_h",
     ],
     hdrs = [
-        "snappy/snappy.h"
+        "snappy/snappy.h",
     ],
-    includes = ["snappy/."],
     copts = [
         "-DHAVE_CONFIG_H",
         "-fno-exceptions",
@@ -48,6 +46,7 @@ cc_library(
         "-Wno-implicit-function-declaration",
     ],
     defines = ["HAVE_SYS_UIO_H"],
+    includes = ["snappy/."],
 )
 
 genrule(
@@ -123,7 +122,6 @@ filegroup(
 
 cmake(
     name = "rocksdb",
-    working_directory = "rocksdb/",
     build_args = ["-j8"],
     generate_args = [
         "-DWITH_SNAPPY=1",
@@ -146,19 +144,32 @@ cmake(
         "-DCMAKE_FIND_USE_CMAKE_SYSTEM_PATH=0",
         # Uncomment this if you ever need to debug what library cmake is resolving.
         # "-DCMAKE_FIND_DEBUG_MODE=TRUE",
-    ] + select({
-        "@platforms//os:macos": ["-DCMAKE_OSX_DEPLOYMENT_TARGET=14.0"],
-        "//conditions:default": [],
-    }),
+    ] + select(
+        {
+            "@platforms//os:macos": [
+                "-DCMAKE_OSX_DEPLOYMENT_TARGET=14.0",
+                "-DCMAKE_SYSTEM_NAME=Darwin",
+            ],
+            "@platforms//os:linux": ["-DCMAKE_SYSTEM_NAME=Linux"],
+        },
+        no_match_error = "Building rocksdb for the specified OS is not supported.",
+    ) + select(
+        {
+            "@platforms//cpu:x86_64": ["-DCMAKE_SYSTEM_PROCESSOR=x86_64"],
+            "@platforms//cpu:aarch64": ["-DCMAKE_SYSTEM_PROCESSOR=aarch64"],
+        },
+        no_match_error = "Building rocksdb for the specified CPU is not supported.",
+    ),
     lib_source = ":rocksdb_srcs",
-    targets = ["rocksdb"],
     out_static_libs = ["librocksdb.a"],
+    targets = ["rocksdb"],
+    visibility = ["//visibility:public"],
+    working_directory = "rocksdb/",
     deps = [
         ":snappy",
-        "@lz4//:lz4",
-        "@zstd//:zstd",
+        "@lz4",
+        "@zstd",
     ],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
@@ -172,6 +183,7 @@ select_file(
     srcs = ":out_dir",
     subpath = "librocksdb.a",
 )
+
 copy_file(
     name = "librocksdb_copy",
     src = ":librocksdb",
@@ -198,6 +210,7 @@ select_file(
     srcs = ":snappy",
     subpath = "libsnappy.a",
 )
+
 copy_to_directory(
     name = "snappy_lib",
     srcs = [":libsnappy"],

--- a/misc/bazel/c_deps/rust-sys/BUILD.rocksdb.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.rocksdb.bazel
@@ -197,11 +197,15 @@ copy_to_directory(
     visibility = ["//visibility:public"],
 )
 
-# Select the include folder so we can specify `ROCKSDB_INCLUDE_DIR`
-select_file(
+# Copy the include folder so we can specify `ROCKSDB_INCLUDE_DIR`
+#
+# Note: We used to use `select_file` here but it generated symlinks that
+# overlapped with others and spammed the logs with WARNINGs.
+copy_to_directory(
     name = "rocksdb_include",
-    srcs = ":out_dir",
-    subpath = "include",
+    out = "include",
+    srcs = [":out_dir"],
+    root_paths = ["rocksdb/include"],
     visibility = ["//visibility:public"],
 )
 

--- a/misc/bazel/toolchains/rust.bzl
+++ b/misc/bazel/toolchains/rust.bzl
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_rust//rust:repositories.bzl", "rust_repository_set", "DEFAULT_TOOLCHAIN_TRIPLES")
+load("@rules_rust//rust:repositories.bzl", "DEFAULT_TOOLCHAIN_TRIPLES", "rust_repository_set")
 
 def rust_toolchains(version, targets):
     """
@@ -35,6 +35,15 @@ def rust_toolchains(version, targets):
             key = "{0}-{1}-{2}".format(resource, version, target)
             integrity[key] = sha256
 
+        CROSS_COMPILING_COMPONENTS = ["rust-std"]
+        for extra_target in extra_targets:
+            for component in CROSS_COMPILING_COMPONENTS:
+                sha256 = targets[extra_target].get(component)
+                if not sha256:
+                    continue
+                key = "{0}-{1}-{2}".format(component, version, extra_target)
+                integrity[key] = sha256
+
         rust_repository_set(
             name = DEFAULT_TOOLCHAIN_TRIPLES[target],
             edition = "2021",
@@ -43,6 +52,6 @@ def rust_toolchains(version, targets):
             versions = [version],
             sha256s = integrity,
             urls = [
-                "https://github.com/MaterializeInc/toolchains/releases/download/rust-{VERSION}/{{}}.tar.zst".format(VERSION=version)
+                "https://github.com/MaterializeInc/toolchains/releases/download/rust-{VERSION}/{{}}.tar.zst".format(VERSION = version),
             ],
         )


### PR DESCRIPTION
This PR does several things to add support for cross compilation and better remote caching for Linux.

1. It adds a Linux sysroot so we no longer depend on any libraries from the host
    1. This should also allow us to slim down the ci_builder Docker image
2. Makes a few changes to the `BUILD` files for C dependencies to support cross compiling
    1. `rocksdb`
    2. `jemalloc`, we now also link the Bazel built `jemalloc` instead of relying on `tikv-jemalloc-sys` crates build script
    3. `openssl`
    4. [`psm`](https://crates.io/crates/psm) the Rust crate used to grow the stack
3. General cleanup of `BUILD` files. Instead of specifying `-Lnative=<path>` and `-lstatic=<libname>` linker flags for Rust system crates, we add them as `deps` to the corresponding Rust crate where `rules_rust` will add these flags for us.

### Motivation

Progress towards https://github.com/MaterializeInc/materialize/issues/26796

This also unlocks the ability to have `mzbuild` (and thus `mzcompose`) use Bazel on macOS.

### Tips for reviewer

The PR is split into three separate commits which should make it easier to review.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
