### PR TITLE
bazel build: Update hashes for Clang

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -198,9 +198,9 @@ llvm_toolchain(
         "linux-x86_64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}/linux_x86_64.tar.zst".format(LLVM_VERSION)],
     },
     sha256 = {
-        "darwin-aarch64": "c538f0a8e359f6fec68f4fb6a7e1a36cbb1e7fd1d74640d6b413c204c599d4f4",
-        "linux-aarch64": "e899e3e40748d4c9e704316f0e14b565b2646a0d2d2525a5d9cbe3dcf5389842",
-        "linux-x86_64": "737b3eaf4d0247bc7a29411906b8f55a779928803847b2a3f754c038c782a7d3",
+        "darwin-aarch64": "510541536527d9d4264e48e254c231487cdc1631cb30920da8a68adf41fdbb91",
+        "linux-aarch64": "bdab5b24cb44f121c82378503afdf55052931c8a26a86f16dad4405a3626a23d",
+        "linux-x86_64": "c44046d74e491661e53fc409add8eb7bdcca4b13decde9aa4adb9b8dc8ef1fa4",
     },
 )
 


### PR DESCRIPTION
Failed in https://buildkite.com/materialize/test/builds/89599

Someone updates the files uploaded in
https://github.com/MaterializeInc/toolchains/releases/tag/clang-18.1.8 yesterday, since
https://github.com/MaterializeInc/materialize/pull/29320 is actively being worked on, I guess @ParkMyCar updated it accidentally without bumping the version. I'd suggest to disallow overriding artifacts if that can be configured.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
