### PR TITLE
frontegg-mock: add password to user create route

### DIFF
--- a/src/frontegg-mock/src/handlers/user.rs
+++ b/src/frontegg-mock/src/handlers/user.rs
@@ -292,7 +292,9 @@ pub async fn handle_create_user(
     let user_config = UserConfig {
         id: user_id,
         email: new_user.email.clone(),
-        password: Uuid::new_v4().to_string(),
+        password: new_user
+            .password
+            .unwrap_or_else(|| Uuid::new_v4().to_string()),
         tenant_id: default_tenant_id,
         initial_api_tokens: vec![],
         roles: role_names.clone(),

--- a/src/frontegg-mock/src/models/user.rs
+++ b/src/frontegg-mock/src/models/user.rs
@@ -61,6 +61,7 @@ impl UserConfig {
 #[derive(Deserialize, Clone, Serialize)]
 pub struct UserCreate {
     pub email: String,
+    pub password: Option<String>,
     #[serde(rename = "roleIds")]
     pub role_ids: Option<Vec<String>>,
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
As pointed out by @pH14 there isn't currently a way to create a new user with a predefined password. This PR extends the user-create functionality to allow us to pass the password in the create user payload.

UPDATE: I now remember why I did not initially implement this on the Terraform side, if you were to try and create a user with a pre-defined password using the staging Frontegg API you would get:

```
Failed to create user: Frontegg API error (HTTP 400): unexpected status code: 400 - {"errors":["User creation with password is forbidden"]}
```

We could still have this supported in the mock service, but it will diverge from the staging/prod Frontegg API.