### PR TITLE
testdrive: Fix new kafka-sink-empty-progress-topic.td

### DIFF
--- a/test/testdrive/kafka-sink-empty-progress-topic.td
+++ b/test/testdrive/kafka-sink-empty-progress-topic.td
@@ -52,7 +52,7 @@ $ set-arg-default single-replica-cluster=quickstart
 # Ensure that sinks can be created against a progress topic that is empty with a
 # low water mark of zero.
 
-$ kafka-create-topic topic=empty-at-zero
+$ kafka-create-topic topic=empty-at-zero partitions=1
 
 > CREATE CONNECTION kafka_conn_empty_at_zero
   TO KAFKA (
@@ -75,7 +75,7 @@ $ kafka-verify-data sink=materialize.public.empty_at_zero format=json
 # Ensure that sinks can be created against a progress topic that is empty with a
 # low water mark that is nonzero.
 
-$ kafka-create-topic topic=empty-at-nonzero
+$ kafka-create-topic topic=empty-at-nonzero partitions=1
 $ kafka-ingest topic=empty-at-nonzero format=bytes
 data
 data


### PR DESCRIPTION
with `--kafka-default-partitions 5`

Seen failing in https://buildkite.com/materialize/nightly/builds/9364#0191b3ce-8119-4260-920e-c1895e58fb2b
```
cluster-u1-replica-u1-gen-0: 2024-09-02T18:19:23.249860Z  INFO mz_storage::healthcheck: Health transition for sink u1169: Some(Running) -> Some(Stalled { error: "kafka: Progress topic testdrive-empty-at-zero-3107866228 should contain a single partition, but instead contains 5 partitions", hints: {}, namespaced_errors: {Kafka: "Progress topic testdrive-empty-at-zero-3107866228 should contain a single partition, but instead contains 5 partitions"} })
```
Just introduced in https://github.com/MaterializeInc/materialize/pull/29321

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
