### PR TITLE
bazel: Release configuration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,13 +6,6 @@ common --enable_platform_specific_config
 common --compiler=clang++
 common --cxxopt=-stdlib=libc++
 
-# LLVM's libc++ has different assertion modes which can be configured to catch
-# undefined behavior. See: <https://libcxx.llvm.org/Hardening.html>
-#
-# TODO(parkmycar): Configure this differently for Debug and CI builds.
-build --cxxopt="-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST"
-build --host_cxxopt="-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST"
-
 # Required for remote caching to be effective.
 #
 # Otherwise Bazel will passthrough the current system's PATH in the execution
@@ -74,3 +67,47 @@ common --experimental_remote_merkle_tree_cache
 common --experimental_remote_merkle_tree_cache_size=5000
 # Tells `xz` to use all available cores.
 action_env=XZ_OPT=-T0
+
+
+# LLVM's libc++ has different assertion modes which can be configured to catch
+# undefined behavior. See: <https://libcxx.llvm.org/Hardening.html>
+build:debug --cxxopt="-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG"
+build:debug --host_cxxopt="-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG"
+build:debug --@rules_rust//:extra_rustc_flag="-Csplit-debuginfo=unpacked"
+
+# Common Build Configuration
+build --linkopt="-Wl,-O2"
+build --linkopt="-fuse-ld=lld"
+build --@rules_rust//:extra_rustc_flag="-Clink-arg=-Wl,-O2"
+build --@rules_rust//:extra_rustc_flag="-Clink-arg=-fuse-ld=lld"
+build --@rules_rust//:extra_rustc_flag="-Csymbol-mangling-version=v0"
+
+# TODO(parkmycar): toolchains_llvm uses ld64 for macOS which doesn't support
+# compressing debug sections.
+build:linux --linkopt="-Wl,--compress-debug-sections=zlib"
+build:linux --@rules_rust//:extra_rustc_flag="-Clink-arg=-Wl,--compress-debug-sections=zlib"
+
+# As of Jan 2024 all of the x86-64 and aarch64 hardware we run on support these
+# CPU targets.
+build:linux-amd64 --copt="-march=x86-64-v3"
+build:linux-amd64 --@rules_rust//:extra_rustc_flag="-Ctarget-cpu=x86-64-v3"
+build:linux-arm64 --copt="-mcpu=neoverse-n1"
+build:linux-arm64 --@rules_rust//:extra_rustc_flag="-Ctarget-cpu=neoverse-n1"
+
+# Release Build Configuration
+build:release --cxxopt="-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST"
+build:release --copt="-O3"
+build:release --copt="-DNDEBUG"
+build:release --copt="-flto=thin"
+build:release --linkopt="-flto=thin"
+build:release --@rules_rust//:extra_rustc_flag="-Clto=thin"
+build:release -c opt
+
+# Cross Language LTO
+#
+# <https://blog.llvm.org/2019/09/closing-gap-cross-language-lto-between.html>
+#
+# TODO(parkmycar): Measure the tradeoff between compile time and runtime performance.
+# TODO(parkmycar): Experiment with a different number of codegen units.
+build:x-lang-lto --@rules_rust//:extra_rustc_flag="-Clinker-plugin-lto"
+build:x-lang-lto --@rules_rust//:extra_rustc_flag="-Clinker=external/llvm_toolchain_llvm/bin/clang"

--- a/bin/bazel-temp
+++ b/bin/bazel-temp
@@ -28,4 +28,4 @@ bin/bazel build \
     //src/sqllogictest:sqllogictest \
     //src/testdrive:testdrive \
     //src/fivetran-destination:mz_fivetran_destination_bin \
-    -c opt --remote_cache=https://bazel-remote.dev.materialize.com 2>&1 | sed -e 's/INFO/--- INFO/'
+    --config release --remote_cache=https://bazel-remote.dev.materialize.com 2>&1 | sed -e 's/INFO/--- INFO/'


### PR DESCRIPTION
This PR adds a Bazel config named `release` that is the same as our existing release configuration. It also adds a `x-lang-lto` config that enables cross language inlining, which is now possible since all of our C dependencies are built with clang.

### Motivation

Fixes: https://github.com/MaterializeInc/materialize/issues/27033

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
