### PR TITLE
tests: Retry docker hub searches

### DIFF
--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -149,7 +149,7 @@ def _resolve_image_name_by_commit_hash(commit_hash: str) -> str:
 
 
 def _search_docker_hub_for_image_name(
-    search_value: str, remaining_retries: int = 1
+    search_value: str, remaining_retries: int = 3
 ) -> list[str]:
     try:
         json_response = requests.get(
@@ -159,9 +159,9 @@ def _search_docker_hub_for_image_name(
         requests.exceptions.ConnectionError,
         requests.exceptions.JSONDecodeError,
     ) as _:
-        print("Searching Docker Hub for image name failed, retrying in 5 seconds")
-        time.sleep(5)
         if remaining_retries > 0:
+            print("Searching Docker Hub for image name failed, retrying in 5 seconds")
+            time.sleep(5)
             return _search_docker_hub_for_image_name(
                 search_value, remaining_retries - 1
             )


### PR DESCRIPTION
Can sometimes fail, currently defaults to no retries in feature-benchmark for example: https://buildkite.com/materialize/test/builds/89615#0191b332-48ad-4c56-9704-c4cf6c457a51

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
