### PR TITLE
ci: Bump cockroach version and add workaround

### DIFF
--- a/misc/images/materialized-base/Dockerfile
+++ b/misc/images/materialized-base/Dockerfile
@@ -10,7 +10,7 @@
 # This is a separate mzimage so that we don't have to re-install the apt things
 # every time we get a CI builder with a cold cache.
 
-FROM cockroachdb/cockroach:v23.1.11 AS crdb
+FROM cockroachdb/cockroach:v24.2.0 AS crdb
 
 MZFROM ubuntu-base
 

--- a/misc/images/materialized/entrypoint.sh
+++ b/misc/images/materialized/entrypoint.sh
@@ -45,6 +45,11 @@ if [ -z "${MZ_NO_BUILTIN_COCKROACH:-}" ]; then
       --background \
       --store=/mzdata/cockroach
 
+  # See: https://github.com/cockroachdb/cockroach/issues/130011
+  while ! cockroach sql --insecure -e "SELECT 1"; do
+      echo "Reaching CRDB failed, retrying..."
+  done
+
   # See: https://github.com/cockroachdb/cockroach/issues/93892
   # See: https://github.com/MaterializeInc/materialize/issues/16726
   cockroach sql --insecure -e "SET CLUSTER SETTING sql.stats.forecasts.enabled = false"

--- a/misc/python/materialize/mzcompose/services/cockroach.py
+++ b/misc/python/materialize/mzcompose/services/cockroach.py
@@ -21,7 +21,7 @@ from materialize.mzcompose.service import (
 
 
 class Cockroach(Service):
-    DEFAULT_COCKROACH_TAG = "v23.1.11"
+    DEFAULT_COCKROACH_TAG = "v24.2.0"
 
     def __init__(
         self,


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/test/builds/89635#0191b6d7-9684-4202-87b2-f88668b59fce

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
