### PR TITLE
catalog: Add fence token handling

### DIFF
--- a/src/catalog/src/durable/objects.rs
+++ b/src/catalog/src/durable/objects.rs
@@ -1262,7 +1262,10 @@ mod test {
     use mz_proto::{ProtoType, RustType};
     use proptest::prelude::*;
 
-    use super::{DatabaseKey, DatabaseValue, ItemKey, ItemValue, SchemaKey, SchemaValue};
+    use super::{
+        DatabaseKey, DatabaseValue, FenceToken, ItemKey, ItemValue, SchemaKey, SchemaValue,
+    };
+    use crate::durable::Epoch;
 
     proptest! {
         #[mz_ore::test]
@@ -1318,5 +1321,33 @@ mod test {
 
             prop_assert_eq!(value, round);
         }
+    }
+
+    #[mz_ore::test]
+    fn test_fence_token_order() {
+        let ft1 = FenceToken {
+            deploy_generation: 10,
+            epoch: Epoch::new(20).unwrap(),
+        };
+        let ft2 = FenceToken {
+            deploy_generation: 10,
+            epoch: Epoch::new(19).unwrap(),
+        };
+
+        assert!(ft1 > ft2);
+
+        let ft3 = FenceToken {
+            deploy_generation: 11,
+            epoch: Epoch::new(10).unwrap(),
+        };
+
+        assert!(ft3 > ft1);
+
+        let ft4 = FenceToken {
+            deploy_generation: 11,
+            epoch: Epoch::new(30).unwrap(),
+        };
+
+        assert!(ft4 > ft1);
     }
 }

--- a/src/catalog/src/durable/objects.rs
+++ b/src/catalog/src/durable/objects.rs
@@ -1327,25 +1327,25 @@ mod test {
     fn test_fence_token_order() {
         let ft1 = FenceToken {
             deploy_generation: 10,
-            epoch: Epoch::new(20).unwrap(),
+            epoch: Epoch::new(20).expect("non-zero"),
         };
         let ft2 = FenceToken {
             deploy_generation: 10,
-            epoch: Epoch::new(19).unwrap(),
+            epoch: Epoch::new(19).expect("non-zero"),
         };
 
         assert!(ft1 > ft2);
 
         let ft3 = FenceToken {
             deploy_generation: 11,
-            epoch: Epoch::new(10).unwrap(),
+            epoch: Epoch::new(10).expect("non-zero"),
         };
 
         assert!(ft3 > ft1);
 
         let ft4 = FenceToken {
             deploy_generation: 11,
-            epoch: Epoch::new(30).unwrap(),
+            epoch: Epoch::new(30).expect("non-zero"),
         };
 
         assert!(ft4 > ft1);

--- a/src/catalog/src/durable/objects.rs
+++ b/src/catalog/src/durable/objects.rs
@@ -986,6 +986,10 @@ impl Snapshot {
     }
 }
 
+/// Token used to fence out other processes.
+///
+/// Every time a new process takes over, the `epoch` should be incremented.
+/// Every time a new version is deployed, the `deploy` generation should be incremented.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Arbitrary)]
 pub struct FenceToken {
     pub(crate) deploy_generation: u64,


### PR DESCRIPTION
This commit teaches the durable catalog to handle fences that result
from the new fence token update kind. Currently, no processes ever
actually writes this token so the code is technically unreachable.
However, this is need so that the next version can write a fence token
and correctly fence the current version.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
