### PR TITLE
ci: Parallelize nightly to run in ~1 hour

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -283,9 +283,10 @@ steps:
               ]
 
       - id: testdrive-in-cloudtest
-        label: Full Testdrive in Cloudtest (K8s)
+        label: "Full Testdrive in Cloudtest (K8s) %N"
         depends_on: build-aarch64
-        timeout_in_minutes: 300
+        timeout_in_minutes: 180
+        parallelism: 2
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
@@ -294,7 +295,8 @@ steps:
           queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/cloudtest:
-              args: [-m=long, test/cloudtest/test_full_testdrive.py]
+              # Uses .td-file based parallelism instead
+              args: [-m=long, test/cloudtest/test_full_testdrive.py, --no-test-parallelism]
         sanitizer: skip
 
       - id: persistence-testdrive
@@ -313,7 +315,7 @@ steps:
     key: limits-group
     steps:
       - id: limits
-        label: "Product limits"
+        label: "Product limits %N"
         depends_on: build-aarch64
         agents:
           queue: hetzner-aarch64-16cpu-32gb
@@ -322,6 +324,7 @@ steps:
               composition: limits
               run: main
         timeout_in_minutes: 180
+        parallelism: 3
         # TODO(def-) Move to larger agents to prevent flakiness
         retry:
           automatic:
@@ -347,7 +350,7 @@ steps:
               limit: 1
 
       - id: bounded-memory
-        label: "Bounded Memory"
+        label: "Bounded Memory %N"
         depends_on: build-aarch64
         timeout_in_minutes: 90
         parallelism: 2
@@ -537,7 +540,7 @@ steps:
     key: platform-checks
     steps:
       - id: checks-restart-entire-mz
-        label: "Checks + restart of the entire Mz"
+        label: "Checks + restart of the entire Mz %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         # Sometimes runs into query timeouts or entire test timeouts with parallelism 1, too much state, same in all other platform-checks
@@ -551,7 +554,7 @@ steps:
               args: [--scenario=RestartEntireMz, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-backup-multi
-        label: "Checks + multiple backups/restores"
+        label: "Checks + multiple backups/restores %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -563,7 +566,7 @@ steps:
               args: [--scenario=BackupAndRestoreMulti, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-parallel-drop-create-default-replica
-        label: "Checks parallel + DROP/CREATE replica"
+        label: "Checks parallel + DROP/CREATE replica %N"
         depends_on: build-aarch64
         skip: "Affected by #23882"
         timeout_in_minutes: 180
@@ -576,7 +579,7 @@ steps:
               args: [--scenario=DropCreateDefaultReplica, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-parallel-restart-clusterd-compute
-        label: "Checks parallel + restart compute clusterd"
+        label: "Checks parallel + restart compute clusterd %N"
         depends_on: build-aarch64
         skip: "Affected by #23882"
         timeout_in_minutes: 180
@@ -589,7 +592,7 @@ steps:
               args: [--scenario=RestartClusterdCompute, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-parallel-restart-entire-mz
-        label: "Checks parallel + restart of the entire Mz"
+        label: "Checks parallel + restart of the entire Mz %N"
         depends_on: build-aarch64
         skip: "Affected by #23882"
         timeout_in_minutes: 180
@@ -602,7 +605,7 @@ steps:
               args: [--scenario=RestartEntireMz, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-parallel-restart-environmentd-clusterd-storage
-        label: "Checks parallel + restart of environmentd & storage clusterd"
+        label: "Checks parallel + restart of environmentd & storage clusterd %N"
         depends_on: build-aarch64
         skip: "Affected by #23882"
         timeout_in_minutes: 180
@@ -615,7 +618,7 @@ steps:
               args: [--scenario=RestartEnvironmentdClusterdStorage, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-parallel-kill-clusterd-storage
-        label: "Checks parallel + kill storage clusterd"
+        label: "Checks parallel + kill storage clusterd %N"
         depends_on: build-aarch64
         skip: "Affected by #23882"
         timeout_in_minutes: 180
@@ -628,7 +631,7 @@ steps:
               args: [--scenario=KillClusterdStorage, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-parallel-restart-redpanda
-        label: "Checks parallel + restart Redpanda & Debezium"
+        label: "Checks parallel + restart Redpanda & Debezium %N"
         depends_on: build-aarch64
         skip: "Affected by #23882"
         timeout_in_minutes: 180
@@ -641,7 +644,7 @@ steps:
               args: [--scenario=RestartRedpandaDebezium, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-upgrade-entire-mz
-        label: "Checks upgrade, whole-Mz restart"
+        label: "Checks upgrade, whole-Mz restart %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -653,7 +656,7 @@ steps:
               args: [--scenario=UpgradeEntireMz, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-preflight-check-rollback
-        label: "Checks preflight-check and roll back upgrade"
+        label: "Checks preflight-check and roll back upgrade %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -665,7 +668,7 @@ steps:
               args: [--scenario=PreflightCheckRollback, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-upgrade-entire-mz-two-versions
-        label: "Checks upgrade across two versions"
+        label: "Checks upgrade across two versions %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -677,7 +680,7 @@ steps:
               args: [--scenario=UpgradeEntireMzTwoVersions, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-upgrade-entire-mz-four-versions
-        label: "Checks upgrade across four versions"
+        label: "Checks upgrade across four versions %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2

--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -16,14 +16,24 @@ set -euo pipefail
 
 run_args=(
     "--junitxml=junit_cloudtest_$BUILDKITE_JOB_ID.xml"
-    "--splits=${BUILDKITE_PARALLEL_JOB_COUNT:-1}"
-    "--group=$((${BUILDKITE_PARALLEL_JOB:-0}+1))"
 )
 
+test_parallelism=false
 if read_list BUILDKITE_PLUGIN_CLOUDTEST_ARGS; then
     for arg in "${result[@]}"; do
-        run_args+=("$arg")
+        if [[ "$arg" == "--no-test-parallelism" ]]; then
+            test_parallelism=false
+        else
+          run_args+=("$arg")
+        fi
     done
+fi
+
+if [[ "$test_parallelism" == true ]]; then
+    run_args+=(
+        "--splits=${BUILDKITE_PARALLEL_JOB_COUNT:-1}"
+        "--group=$((${BUILDKITE_PARALLEL_JOB:-0}+1))"
+    )
 fi
 
 date +"%Y-%m-%d %H:%M:%S" > step_start_timestamp

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -302,7 +302,7 @@ steps:
     key: platform-checks
     steps:
       - id: checks-restart-cockroach
-        label: "Checks + restart Cockroach"
+        label: "Checks + restart Cockroach %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         # Sometimes runs into query timeouts or entire test timeouts with parallelism 1, too much state, same in all other platform-checks
@@ -316,7 +316,7 @@ steps:
               args: [--scenario=RestartCockroach, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-backup-restore-before-manipulate
-        label: "Checks backup + restore between the two manipulate()"
+        label: "Checks backup + restore between the two manipulate() %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -328,7 +328,7 @@ steps:
               args: [--scenario=BackupAndRestoreBeforeManipulate, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-backup-restore-after-manipulate
-        label: "Checks backup + restore after manipulate()"
+        label: "Checks backup + restore after manipulate() %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -340,7 +340,7 @@ steps:
               args: [--scenario=BackupAndRestoreAfterManipulate, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-backup-rollback
-        label: "Checks + backup + rollback to previous"
+        label: "Checks + backup + rollback to previous %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -352,7 +352,7 @@ steps:
               args: [--scenario=BackupAndRestoreToPreviousState, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-preflight-check-continue
-        label: "Checks preflight-check and continue upgrade"
+        label: "Checks preflight-check and continue upgrade %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -364,7 +364,7 @@ steps:
               args: [--scenario=PreflightCheckContinue, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-upgrade-clusterd-compute-first
-        label: "Platform checks upgrade, restarting compute clusterd first"
+        label: "Platform checks upgrade, restarting compute clusterd first %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -376,7 +376,7 @@ steps:
               args: [--scenario=UpgradeClusterdComputeFirst, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-upgrade-clusterd-compute-last
-        label: "Platform checks upgrade, restarting compute clusterd last"
+        label: "Platform checks upgrade, restarting compute clusterd last %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -388,7 +388,7 @@ steps:
               args: [--scenario=UpgradeClusterdComputeLast, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-kill-clusterd-storage
-        label: "Checks + kill storage clusterd"
+        label: "Checks + kill storage clusterd %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -400,7 +400,7 @@ steps:
               args: [--scenario=KillClusterdStorage, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-restart-source-postgres
-        label: "Checks + restart source Postgres"
+        label: "Checks + restart source Postgres %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -412,7 +412,7 @@ steps:
               args: [--scenario=RestartSourcePostgres, --check=PgCdc, --check=PgCdcNoWait, --check=PgCdcMzNow, --check=SshPg]
 
       - id: checks-restart-clusterd-compute
-        label: "Checks + restart clusterd compute"
+        label: "Checks + restart clusterd compute %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -424,7 +424,7 @@ steps:
               args: [--scenario=RestartClusterdCompute, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-drop-create-default-replica
-        label: "Checks + DROP/CREATE replica"
+        label: "Checks + DROP/CREATE replica %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
