### PR TITLE
output consistency: do not fail on "possibly invalid operation specification"

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -92,7 +92,7 @@ ERROR_RE = re.compile(
     # non-greedy using ? so that we don't match all the result comparison issues into one block
     | ----------\ RESULT\ COMPARISON\ ISSUE\ START\ ----------[\s\S]*?----------\ RESULT\ COMPARISON\ ISSUE\ END\ ------------
     # output consistency tests
-    | possibly\ invalid\ operation\ specification
+    # | possibly\ invalid\ operation\ specification # disabled
     # for miri test summary
     | (FAIL|TIMEOUT)\s+\[\s*\d+\.\d+s\]
     # parallel-workload


### PR DESCRIPTION
Disable this error cause, which became unreliable.

This addresses errors like
```
-- * function 'row(AnyOperationParam)': 3 top level, 0 nested, 0 generation failed, not included in any query that was successfully executed in all strategies (possibly invalid operation specification)!
```
observed for example in https://buildkite.com/materialize/nightly/builds/9341#0191a459-8f9f-460e-919d-2035c2d9422f.