### PR TITLE
output consistency: reproduction printer: do not remove data sources that are unreferenced but needed

### DIFF
--- a/misc/python/materialize/output_consistency/output/reproduction_code_printer.py
+++ b/misc/python/materialize/output_consistency/output/reproduction_code_printer.py
@@ -146,20 +146,11 @@ class ReproductionCodePrinter(BaseOutputPrinter):
         row_selection = (
             query_template.row_selection if apply_row_filter else ALL_ROWS_SELECTION
         )
-        data_sources_of_non_select_expressions = (
-            self._collect_data_sources_of_non_select_expressions(query_template)
-        )
 
         setup_code_lines = []
         for data_source in query_template.get_all_data_sources():
             if data_source.custom_db_object_name is not None:
                 # we assume that the custom object already exists
-                continue
-
-            if (
-                not table_column_selection.requires_data_source(data_source)
-                and data_source not in data_sources_of_non_select_expressions
-            ):
                 continue
 
             setup_code_lines.extend(


### PR DESCRIPTION
Observed in https://buildkite.com/materialize/nightly/builds/9341#0191a459-8f9f-460e-919d-2035c2d9422f.

For queries like

```
SELECT convert_from(sha256(s0.bytea_val), 'utf8')
FROM t_dfr_vert_0 s0
INNER JOIN t_dfr_vert_1 s1 ON (NOT (s1.bool_val))
INNER JOIN t_dfr_vert_2 s2 ON TRUE::BOOL
ORDER BY s0.row_index ASC, s1.row_index ASC, s2.row_index ASC
OFFSET 4;
```

`t_dfr_vert_2` is unused (not referenced) but can still influence the result (e.g., in particular when the join condition is `FALSE::BOOL`).