### PR TITLE
postgres consistency: add ignores

### DIFF
--- a/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
@@ -118,6 +118,15 @@ def matches_any_expression_arg(
     return False
 
 
+def matches_recursively(
+    expression: Expression, matcher: Callable[[Expression], bool]
+) -> bool:
+    if isinstance(expression, ExpressionWithArgs):
+        for arg_expression in expression.args:
+            return matches_recursively(arg_expression, matcher)
+    return matcher(expression)
+
+
 def matches_nested_expression(expression: Expression) -> bool:
     return not matches_expression_with_only_plain_arguments(expression)
 

--- a/misc/python/materialize/output_consistency/input_data/operations/number_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/number_operations_provider.py
@@ -30,6 +30,7 @@ from materialize.output_consistency.operation.operation import (
     OperationRelevance,
 )
 
+TAG_BASIC_ARITHMETIC_OP = "basic_arithmetic"
 TAG_BITWISE_OP = "bitwise"
 
 NUMERIC_OPERATION_TYPES: list[DbOperationOrFunction] = []
@@ -40,6 +41,7 @@ NUMERIC_OPERATION_TYPES.append(
         [NumericOperationParam(), NumericOperationParam()],
         NumericReturnTypeSpec(),
         {MultiParamValueGrowsArgsValidator()},
+        tags={TAG_BASIC_ARITHMETIC_OP},
     )
 )
 NUMERIC_OPERATION_TYPES.append(
@@ -48,6 +50,7 @@ NUMERIC_OPERATION_TYPES.append(
         [NumericOperationParam(), NumericOperationParam()],
         NumericReturnTypeSpec(),
         {MaxMinusNegMaxArgsValidator()},
+        tags={TAG_BASIC_ARITHMETIC_OP},
     )
 )
 NUMERIC_OPERATION_TYPES.append(
@@ -56,6 +59,7 @@ NUMERIC_OPERATION_TYPES.append(
         [NumericOperationParam(), NumericOperationParam()],
         NumericReturnTypeSpec(),
         {MultiParamValueGrowsArgsValidator()},
+        tags={TAG_BASIC_ARITHMETIC_OP},
     )
 )
 NUMERIC_OPERATION_TYPES.append(
@@ -67,6 +71,7 @@ NUMERIC_OPERATION_TYPES.append(
         ],
         NumericReturnTypeSpec(),
         relevance=OperationRelevance.HIGH,
+        tags={TAG_BASIC_ARITHMETIC_OP},
     )
 )
 NUMERIC_OPERATION_TYPES.append(

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -808,6 +808,10 @@ class PgPostExecutionInconsistencyIgnoreFilter(
                 "Different evaluation order of join clause and where filter"
             )
 
+        if query_template.uses_join():
+            # more generic catch
+            return YesIgnore("#29347: eager evaluation of select expression in mz")
+
         if (
             "invalid input syntax for type jsonb" in mz_error_msg
             and "is out of range" in mz_error_msg

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -63,6 +63,9 @@ from materialize.output_consistency.input_data.operations.jsonb_operations_provi
     TAG_JSONB_TO_TEXT,
     TAG_JSONB_VALUE_ACCESS,
 )
+from materialize.output_consistency.input_data.operations.number_operations_provider import (
+    TAG_BASIC_ARITHMETIC_OP,
+)
 from materialize.output_consistency.input_data.operations.record_operations_provider import (
     TAG_RECORD_CREATION,
 )
@@ -1137,7 +1140,7 @@ class PgPostExecutionInconsistencyIgnoreFilter(
             )
 
         if query_template.matches_specific_select_or_filter_expression(
-            col_index, partial(matches_op_by_pattern, pattern="$ / $"), True
+            col_index, partial(is_operation_tagged, tag=TAG_BASIC_ARITHMETIC_OP), True
         ):
             return YesIgnore("#28852: numeric return type inconsistency")
 

--- a/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
+++ b/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
@@ -92,6 +92,11 @@ class PostgresResultComparator(ResultComparator):
         if isinstance(value1, str) and isinstance(value2, str):
             return self.is_str_equal(value1, value2, is_tolerant)
 
+        if is_tolerant and isinstance(value1, int) and isinstance(value2, int):
+            # This is needed for imprecise results of floating type operations that are returned as int values in dicts
+            # of JSONB data.
+            return self.is_float_equal(float(value1), float(value2))
+
         return False
 
     def is_decimal_equal(self, value1: Decimal, value2: Decimal) -> bool:


### PR DESCRIPTION
This addresses issues observed in:
* https://buildkite.com/materialize/nightly/builds/9341
* https://buildkite.com/materialize/nightly/builds/9246
* https://buildkite.com/materialize/nightly/builds/9235
* https://buildkite.com/materialize/nightly/builds/9250
* https://buildkite.com/materialize/nightly/builds/9315

### Filed issues
* https://github.com/MaterializeInc/materialize/issues/29347
* https://github.com/MaterializeInc/materialize/issues/29350

#### Commits
9888d242ee postgres consistency: add ignore regarding eager evaluation of select expression
1b3c157934 postgres consistency: extend ignore regarding return type of arithmetic operation
01aba742b0 postgres consistency: move ignore regarding pg_size_pretty to match all error types
196d46e12e postgres consistency: special handling for float operation results in JSONB
1b6794f703 postgres consistency: add ignore regarding eager evaluation of table functions
a372c57ffb output consistency: matchers: add matches_recursively
6aad351b19 postgres consistency: add ignore regarding floating point issues in JSONB
