### PR TITLE
controller: make `Controller::process` non-`async`

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -647,7 +647,7 @@ impl Coordinator {
             if !cluster_replicas_to_drop.is_empty() {
                 fail::fail_point!("after_catalog_drop_replica");
                 for (cluster_id, replica_id) in cluster_replicas_to_drop {
-                    self.drop_replica(cluster_id, replica_id).await;
+                    self.drop_replica(cluster_id, replica_id);
                 }
             }
             if !clusters_to_drop.is_empty() {
@@ -792,7 +792,7 @@ impl Coordinator {
         Ok(builtin_update_notify)
     }
 
-    async fn drop_replica(&mut self, cluster_id: ClusterId, replica_id: ReplicaId) {
+    fn drop_replica(&mut self, cluster_id: ClusterId, replica_id: ReplicaId) {
         if let Some(Some(ReplicaMetadata { metrics })) =
             self.transient_replica_metadata.insert(replica_id, None)
         {
@@ -811,7 +811,7 @@ impl Coordinator {
             self.builtin_table_update().background(updates);
         }
 
-        self.drop_introspection_subscribes(replica_id).await;
+        self.drop_introspection_subscribes(replica_id);
 
         self.controller
             .drop_replica(cluster_id, replica_id)

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -72,7 +72,6 @@ impl Coordinator {
                 let storage_metadata = catalog.state().storage_metadata();
                 if let Some(m) = controller
                     .process(storage_metadata)
-                    .await
                     .expect("`process` never returns an error")
                 {
                     self.message_controller(m).boxed_local().await

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -177,7 +177,7 @@ impl Coordinator {
                 self.sequence_staged(ctx, span, stage).boxed_local().await;
             }
             Message::DrainStatementLog => {
-                self.drain_statement_log().boxed_local().await;
+                self.drain_statement_log();
             }
             Message::PrivateLinkVpcEndpointEvents(events) => {
                 if !self.controller.read_only() {
@@ -189,8 +189,7 @@ impl Coordinator {
                                     .into_iter()
                                     .map(|e| (mz_repr::Row::from(e), 1))
                                     .collect(),
-                            )
-                            .boxed_local().await;
+                            );
                 }
             }
             Message::CheckSchedulingPolicies => {

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -223,7 +223,7 @@ impl Coordinator {
     }
 
     #[mz_ore::instrument(level = "debug")]
-    pub(crate) async fn drain_statement_log(&mut self) {
+    pub(crate) fn drain_statement_log(&mut self) {
         let session_updates = std::mem::take(&mut self.statement_logging.pending_session_events)
             .into_iter()
             .map(|update| (update, 1))
@@ -257,8 +257,7 @@ impl Coordinator {
             if !updates.is_empty() && !self.controller.read_only() {
                 self.controller
                     .storage
-                    .append_introspection_updates(type_, updates)
-                    .await;
+                    .append_introspection_updates(type_, updates);
             }
         }
     }

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -28,7 +28,6 @@ use std::num::NonZeroI64;
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
-use futures::stream::{Peekable, StreamExt};
 use mz_build_info::BuildInfo;
 use mz_cluster_client::ReplicaId;
 use mz_compute_client::controller::{
@@ -63,9 +62,8 @@ use mz_storage_types::controller::StorageError;
 use mz_txn_wal::metrics::Metrics as TxnMetrics;
 use serde::Serialize;
 use timely::progress::{Antichain, Timestamp};
-use tokio::sync::mpsc::{self, UnboundedSender};
+use tokio::sync::mpsc;
 use tokio::time::{self, Duration, Interval, MissedTickBehavior};
-use tokio_stream::wrappers::UnboundedReceiverStream;
 use uuid::Uuid;
 
 pub mod clusters;
@@ -140,8 +138,8 @@ enum Readiness<T> {
     Storage,
     /// The compute controller is ready.
     Compute,
-    /// The metrics channel is ready.
-    Metrics,
+    /// A batch of metric data is ready.
+    Metrics((ReplicaId, Vec<ServiceProcessMetrics>)),
     /// Frontiers are ready for recording.
     Frontiers,
     /// An internally-generated message is ready to be returned.
@@ -172,9 +170,9 @@ pub struct Controller<T: Timestamp = mz_repr::Timestamp> {
     /// Tasks for collecting replica metrics.
     metrics_tasks: BTreeMap<ReplicaId, AbortOnDropHandle<()>>,
     /// Sender for the channel over which replica metrics are sent.
-    metrics_tx: UnboundedSender<(ReplicaId, Vec<ServiceProcessMetrics>)>,
+    metrics_tx: mpsc::UnboundedSender<(ReplicaId, Vec<ServiceProcessMetrics>)>,
     /// Receiver for the channel over which replica metrics are sent.
-    metrics_rx: Peekable<UnboundedReceiverStream<(ReplicaId, Vec<ServiceProcessMetrics>)>>,
+    metrics_rx: mpsc::UnboundedReceiver<(ReplicaId, Vec<ServiceProcessMetrics>)>,
     /// Periodic notification to record frontiers.
     frontiers_ticker: Interval,
     /// A function providing the current wallclock time.
@@ -375,8 +373,8 @@ where
                     () = self.compute.ready() => {
                         self.readiness = Readiness::Compute;
                     }
-                    _ = Pin::new(&mut self.metrics_rx).peek() => {
-                        self.readiness = Readiness::Metrics;
+                    Some(metrics) = self.metrics_rx.recv() => {
+                        self.readiness = Readiness::Metrics(metrics);
                     }
                     _ = self.frontiers_ticker.tick() => {
                         self.readiness = Readiness::Frontiers;
@@ -529,7 +527,7 @@ where
     /// This method is **not** guaranteed to be cancellation safe. It **must**
     /// be awaited to completion.
     #[mz_ore::instrument(level = "debug")]
-    pub async fn process(
+    pub fn process(
         &mut self,
         storage_metadata: &StorageMetadata,
     ) -> Result<Option<ControllerResponse<T>>, anyhow::Error> {
@@ -537,7 +535,7 @@ where
             Readiness::NotReady => Ok(None),
             Readiness::Storage => self.process_storage_response(storage_metadata),
             Readiness::Compute => self.process_compute_response(),
-            Readiness::Metrics => self.process_replica_metrics().await,
+            Readiness::Metrics((id, metrics)) => self.process_replica_metrics(id, metrics),
             Readiness::Frontiers => {
                 self.record_frontiers();
                 Ok(None)
@@ -587,13 +585,11 @@ where
         (!(finished.is_empty())).then(|| ControllerResponse::WatchSetFinished(finished))
     }
 
-    async fn process_replica_metrics(
+    fn process_replica_metrics(
         &mut self,
+        id: ReplicaId,
+        metrics: Vec<ServiceProcessMetrics>,
     ) -> Result<Option<ControllerResponse<T>>, anyhow::Error> {
-        let Some((id, metrics)) = self.metrics_rx.next().await else {
-            return Ok(None);
-        };
-
         self.record_replica_metrics(id, &metrics);
         Ok(Some(ControllerResponse::ComputeReplicaMetrics(id, metrics)))
     }
@@ -758,7 +754,7 @@ where
             readiness: Readiness::NotReady,
             metrics_tasks: BTreeMap::new(),
             metrics_tx,
-            metrics_rx: UnboundedReceiverStream::new(metrics_rx).peekable(),
+            metrics_rx,
             frontiers_ticker,
             now: config.now,
             persist_pubsub_url: config.persist_pubsub_url,

--- a/src/storage-controller/src/collection_status.rs
+++ b/src/storage-controller/src/collection_status.rs
@@ -58,11 +58,7 @@ where
         self.previous_statuses.extend(previous_statuses)
     }
 
-    pub(super) async fn append_updates(
-        &mut self,
-        updates: Vec<StatusUpdate>,
-        type_: IntrospectionType,
-    ) {
+    pub(super) fn append_updates(&mut self, updates: Vec<StatusUpdate>, type_: IntrospectionType) {
         let source_status_history_id = *self
             .introspection_ids
             .lock()
@@ -84,14 +80,12 @@ where
             .extend(new.iter().map(|r| (r.id, r.status)));
 
         if !new.is_empty() {
-            self.collection_manager
-                .blind_write(
-                    source_status_history_id,
-                    new.into_iter()
-                        .map(|update| (Row::from(update), 1))
-                        .collect(),
-                )
-                .await;
+            self.collection_manager.blind_write(
+                source_status_history_id,
+                new.into_iter()
+                    .map(|update| (Row::from(update), 1))
+                    .collect(),
+            );
         }
     }
 }

--- a/src/storage-controller/src/statistics.rs
+++ b/src/storage-controller/src/statistics.rs
@@ -149,9 +149,7 @@ where
         if !correction.is_empty() {
             current_metrics.extend(correction.iter().cloned());
 
-            collection_mgmt
-                .differential_append(statistics_collection_id, correction)
-                .await;
+            collection_mgmt.differential_append(statistics_collection_id, correction);
         }
 
         let mut interval = tokio::time::interval(initial_interval);
@@ -202,8 +200,7 @@ where
                     if !correction.is_empty() {
                         current_metrics.extend(correction.iter().cloned());
                         collection_mgmt
-                            .differential_append(statistics_collection_id, correction)
-                            .await;
+                            .differential_append(statistics_collection_id, correction);
                     }
                 }
             }


### PR DESCRIPTION
This PR makes converts the `Controller::process` method to a non-`async` one, removing one potential source of blocking from the coordinator main loop.

The most significant change here is making the channel on which updates are sent to the `CollectionManager` unbounded. This does introduce the risk of higher memory usage on envd. This is not the first use of an unbounded channel in envd and in the past it has actually been helpful seeing their memory usage grow to realize that something was wrong with the system. Anecdotically, we seem to be better at debugging increased memory usage than blockage in the coordinator loop.

### Motivation

  * This PR fixes a previously unreported bug.

The coordinator main loop can be blocked at various places if the channels feeding the `CollectionManager` run full.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
