### PR TITLE
sql-parser: align SUBSCRIBE syntax with CREATE SINK/SELECT

### DIFF
--- a/doc/user/layouts/partials/sql-grammar/subscribe-stmt.svg
+++ b/doc/user/layouts/partials/sql-grammar/subscribe-stmt.svg
@@ -1,355 +1,355 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="851" height="889">
-   <polygon points="11 17 3 13 3 21"/>
-   <polygon points="19 17 11 13 11 21"/>
-   <rect x="33" y="3" width="100" height="32" rx="10"/>
-   <rect x="31"
+<svg xmlns="http://www.w3.org/2000/svg" width="845" height="893">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="100" height="32" rx="10"/>
+   <rect x="29"
          y="1"
          width="100"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="41" y="21">SUBSCRIBE</text>
-   <rect x="173" y="35" width="40" height="32" rx="10"/>
-   <rect x="171"
+   <text class="terminal" x="39" y="21">SUBSCRIBE</text>
+   <rect x="171" y="35" width="40" height="32" rx="10"/>
+   <rect x="169"
          y="33"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="181" y="53">TO</text>
-   <rect x="273" y="3" width="104" height="32"/>
-   <rect x="271" y="1" width="104" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="281" y="21">object_name</text>
-   <rect x="273" y="47" width="26" height="32" rx="10"/>
-   <rect x="271"
+   <text class="terminal" x="179" y="53">TO</text>
+   <rect x="271" y="3" width="104" height="32"/>
+   <rect x="269" y="1" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="279" y="21">object_name</text>
+   <rect x="271" y="47" width="26" height="32" rx="10"/>
+   <rect x="269"
          y="45"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="281" y="65">(</text>
-   <rect x="319" y="47" width="96" height="32"/>
-   <rect x="317" y="45" width="96" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="327" y="65">select_stmt</text>
-   <rect x="435" y="47" width="26" height="32" rx="10"/>
-   <rect x="433"
+   <text class="terminal" x="279" y="65">(</text>
+   <rect x="317" y="47" width="96" height="32"/>
+   <rect x="315" y="45" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="325" y="65">select_stmt</text>
+   <rect x="433" y="47" width="26" height="32" rx="10"/>
+   <rect x="431"
          y="45"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="443" y="65">)</text>
-   <rect x="166" y="189" width="58" height="32" rx="10"/>
-   <rect x="164"
-         y="187"
-         width="58"
+   <text class="terminal" x="441" y="65">)</text>
+   <rect x="141" y="157" width="94" height="32" rx="10"/>
+   <rect x="139"
+         y="155"
+         width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="174" y="207">WITH</text>
-   <rect x="264" y="157" width="26" height="32" rx="10"/>
-   <rect x="262"
+   <text class="terminal" x="149" y="175">ENVELOPE</text>
+   <rect x="255" y="157" width="76" height="32" rx="10"/>
+   <rect x="253"
+         y="155"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="263" y="175">UPSERT</text>
+   <rect x="351" y="157" width="26" height="32" rx="10"/>
+   <rect x="349"
          y="155"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="272" y="175">(</text>
-   <rect x="330" y="157" width="104" height="32"/>
-   <rect x="328" y="155" width="104" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="338" y="175">option_name</text>
-   <rect x="474" y="189" width="28" height="32" rx="10"/>
-   <rect x="472"
-         y="187"
-         width="28"
+   <text class="terminal" x="359" y="175">(</text>
+   <rect x="397" y="157" width="48" height="32" rx="10"/>
+   <rect x="395"
+         y="155"
+         width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="482" y="207">=</text>
-   <rect x="522" y="189" width="102" height="32"/>
-   <rect x="520" y="187" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="530" y="207">option_value</text>
-   <rect x="330" y="113" width="24" height="32" rx="10"/>
-   <rect x="328"
+   <text class="terminal" x="405" y="175">KEY</text>
+   <rect x="465" y="157" width="26" height="32" rx="10"/>
+   <rect x="463"
+         y="155"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="473" y="175">(</text>
+   <rect x="531" y="157" width="64" height="32"/>
+   <rect x="529" y="155" width="64" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="539" y="175">col_ref</text>
+   <rect x="531" y="113" width="24" height="32" rx="10"/>
+   <rect x="529"
          y="111"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="338" y="131">,</text>
-   <rect x="684" y="157" width="26" height="32" rx="10"/>
-   <rect x="682"
+   <text class="terminal" x="539" y="131">,</text>
+   <rect x="635" y="157" width="26" height="32" rx="10"/>
+   <rect x="633"
          y="155"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="692" y="175">)</text>
-   <rect x="192" y="287" width="40" height="32" rx="10"/>
-   <rect x="190"
-         y="285"
-         width="40"
+   <text class="terminal" x="643" y="175">)</text>
+   <rect x="681" y="157" width="26" height="32" rx="10"/>
+   <rect x="679"
+         y="155"
+         width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="200" y="305">AS</text>
-   <rect x="252" y="287" width="38" height="32" rx="10"/>
-   <rect x="250"
-         y="285"
-         width="38"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="260" y="305">OF</text>
-   <rect x="330" y="319" width="40" height="32" rx="10"/>
-   <rect x="328"
-         y="317"
-         width="40"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="338" y="337">AT</text>
-   <rect x="390" y="319" width="66" height="32" rx="10"/>
-   <rect x="388"
-         y="317"
-         width="66"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="398" y="337">LEAST</text>
-   <rect x="496" y="287" width="168" height="32"/>
-   <rect x="494" y="285" width="168" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="504" y="305">timestamp_expression</text>
-   <rect x="285" y="401" width="38" height="32" rx="10"/>
-   <rect x="283"
-         y="399"
-         width="38"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="293" y="419">UP</text>
-   <rect x="343" y="401" width="40" height="32" rx="10"/>
-   <rect x="341"
-         y="399"
-         width="40"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="351" y="419">TO</text>
-   <rect x="403" y="401" width="168" height="32"/>
-   <rect x="401" y="399" width="168" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="411" y="419">timestamp_expression</text>
-   <rect x="145" y="511" width="94" height="32" rx="10"/>
-   <rect x="143"
-         y="509"
+   <text class="terminal" x="689" y="175">)</text>
+   <rect x="133" y="283" width="94" height="32" rx="10"/>
+   <rect x="131"
+         y="281"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="153" y="529">ENVELOPE</text>
-   <rect x="259" y="511" width="76" height="32" rx="10"/>
-   <rect x="257"
-         y="509"
-         width="76"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="267" y="529">UPSERT</text>
-   <rect x="355" y="511" width="26" height="32" rx="10"/>
-   <rect x="353"
-         y="509"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="363" y="529">(</text>
-   <rect x="401" y="511" width="48" height="32" rx="10"/>
-   <rect x="399"
-         y="509"
-         width="48"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="409" y="529">KEY</text>
-   <rect x="469" y="511" width="26" height="32" rx="10"/>
-   <rect x="467"
-         y="509"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="477" y="529">(</text>
-   <rect x="535" y="511" width="64" height="32"/>
-   <rect x="533" y="509" width="64" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="543" y="529">col_ref</text>
-   <rect x="535" y="467" width="24" height="32" rx="10"/>
-   <rect x="533"
-         y="465"
-         width="24"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="543" y="485">,</text>
-   <rect x="639" y="511" width="26" height="32" rx="10"/>
-   <rect x="637"
-         y="509"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="647" y="529">)</text>
-   <rect x="685" y="511" width="26" height="32" rx="10"/>
-   <rect x="683"
-         y="509"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="693" y="529">)</text>
-   <rect x="137" y="637" width="94" height="32" rx="10"/>
-   <rect x="135"
-         y="635"
-         width="94"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="145" y="655">ENVELOPE</text>
-   <rect x="251" y="637" width="92" height="32" rx="10"/>
-   <rect x="249"
-         y="635"
+   <text class="terminal" x="141" y="301">ENVELOPE</text>
+   <rect x="247" y="283" width="92" height="32" rx="10"/>
+   <rect x="245"
+         y="281"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="259" y="655">DEBEZIUM</text>
-   <rect x="363" y="637" width="26" height="32" rx="10"/>
-   <rect x="361"
-         y="635"
+   <text class="terminal" x="255" y="301">DEBEZIUM</text>
+   <rect x="359" y="283" width="26" height="32" rx="10"/>
+   <rect x="357"
+         y="281"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="371" y="655">(</text>
-   <rect x="409" y="637" width="48" height="32" rx="10"/>
-   <rect x="407"
-         y="635"
+   <text class="terminal" x="367" y="301">(</text>
+   <rect x="405" y="283" width="48" height="32" rx="10"/>
+   <rect x="403"
+         y="281"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="417" y="655">KEY</text>
-   <rect x="477" y="637" width="26" height="32" rx="10"/>
-   <rect x="475"
-         y="635"
+   <text class="terminal" x="413" y="301">KEY</text>
+   <rect x="473" y="283" width="26" height="32" rx="10"/>
+   <rect x="471"
+         y="281"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="485" y="655">(</text>
-   <rect x="543" y="637" width="64" height="32"/>
-   <rect x="541" y="635" width="64" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="551" y="655">col_ref</text>
-   <rect x="543" y="593" width="24" height="32" rx="10"/>
-   <rect x="541"
-         y="591"
+   <text class="terminal" x="481" y="301">(</text>
+   <rect x="539" y="283" width="64" height="32"/>
+   <rect x="537" y="281" width="64" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="547" y="301">col_ref</text>
+   <rect x="539" y="239" width="24" height="32" rx="10"/>
+   <rect x="537"
+         y="237"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="551" y="611">,</text>
-   <rect x="647" y="637" width="26" height="32" rx="10"/>
-   <rect x="645"
-         y="635"
+   <text class="terminal" x="547" y="257">,</text>
+   <rect x="643" y="283" width="26" height="32" rx="10"/>
+   <rect x="641"
+         y="281"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="655" y="655">)</text>
-   <rect x="693" y="637" width="26" height="32" rx="10"/>
-   <rect x="691"
-         y="635"
+   <text class="terminal" x="651" y="301">)</text>
+   <rect x="689" y="283" width="26" height="32" rx="10"/>
+   <rect x="687"
+         y="281"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="701" y="655">)</text>
-   <rect x="45" y="763" width="72" height="32" rx="10"/>
+   <text class="terminal" x="697" y="301">)</text>
+   <rect x="45" y="409" width="72" height="32" rx="10"/>
    <rect x="43"
-         y="761"
+         y="407"
          width="72"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="781">WITHIN</text>
-   <rect x="137" y="763" width="106" height="32" rx="10"/>
+   <text class="terminal" x="53" y="427">WITHIN</text>
+   <rect x="137" y="409" width="106" height="32" rx="10"/>
    <rect x="135"
-         y="761"
+         y="407"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="145" y="781">TIMESTAMP</text>
-   <rect x="263" y="763" width="68" height="32" rx="10"/>
+   <text class="terminal" x="145" y="427">TIMESTAMP</text>
+   <rect x="263" y="409" width="68" height="32" rx="10"/>
    <rect x="261"
-         y="761"
+         y="407"
          width="68"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="271" y="781">ORDER</text>
-   <rect x="351" y="763" width="40" height="32" rx="10"/>
+   <text class="terminal" x="271" y="427">ORDER</text>
+   <rect x="351" y="409" width="40" height="32" rx="10"/>
    <rect x="349"
-         y="761"
+         y="407"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="359" y="781">BY</text>
-   <rect x="431" y="763" width="64" height="32"/>
-   <rect x="429" y="761" width="64" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="439" y="781">col_ref</text>
-   <rect x="535" y="795" width="50" height="32" rx="10"/>
+   <text class="terminal" x="359" y="427">BY</text>
+   <rect x="431" y="409" width="64" height="32"/>
+   <rect x="429" y="407" width="64" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="439" y="427">col_ref</text>
+   <rect x="535" y="441" width="50" height="32" rx="10"/>
    <rect x="533"
-         y="793"
+         y="439"
          width="50"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="543" y="813">ASC</text>
-   <rect x="535" y="839" width="58" height="32" rx="10"/>
+   <text class="terminal" x="543" y="459">ASC</text>
+   <rect x="535" y="485" width="58" height="32" rx="10"/>
    <rect x="533"
-         y="837"
+         y="483"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="543" y="857">DESC</text>
-   <rect x="653" y="795" width="106" height="32" rx="10"/>
+   <text class="terminal" x="543" y="503">DESC</text>
+   <rect x="653" y="441" width="106" height="32" rx="10"/>
    <rect x="651"
-         y="793"
+         y="439"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="661" y="813">NULLS LAST</text>
-   <rect x="653" y="839" width="110" height="32" rx="10"/>
+   <text class="terminal" x="661" y="459">NULLS LAST</text>
+   <rect x="653" y="485" width="110" height="32" rx="10"/>
    <rect x="651"
-         y="837"
+         y="483"
          width="110"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="661" y="857">NULLS FIRST</text>
-   <rect x="431" y="719" width="24" height="32" rx="10"/>
+   <text class="terminal" x="661" y="503">NULLS FIRST</text>
+   <rect x="431" y="365" width="24" height="32" rx="10"/>
    <rect x="429"
-         y="717"
+         y="363"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="439" y="737">,</text>
+   <text class="terminal" x="439" y="383">,</text>
+   <rect x="162" y="643" width="58" height="32" rx="10"/>
+   <rect x="160"
+         y="641"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="170" y="661">WITH</text>
+   <rect x="260" y="611" width="26" height="32" rx="10"/>
+   <rect x="258"
+         y="609"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="268" y="629">(</text>
+   <rect x="326" y="611" width="104" height="32"/>
+   <rect x="324" y="609" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="334" y="629">option_name</text>
+   <rect x="470" y="643" width="28" height="32" rx="10"/>
+   <rect x="468"
+         y="641"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="478" y="661">=</text>
+   <rect x="518" y="643" width="102" height="32"/>
+   <rect x="516" y="641" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="526" y="661">option_value</text>
+   <rect x="326" y="567" width="24" height="32" rx="10"/>
+   <rect x="324"
+         y="565"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="334" y="585">,</text>
+   <rect x="680" y="611" width="26" height="32" rx="10"/>
+   <rect x="678"
+         y="609"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="688" y="629">)</text>
+   <rect x="188" y="741" width="40" height="32" rx="10"/>
+   <rect x="186"
+         y="739"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="196" y="759">AS</text>
+   <rect x="248" y="741" width="38" height="32" rx="10"/>
+   <rect x="246"
+         y="739"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="256" y="759">OF</text>
+   <rect x="326" y="773" width="40" height="32" rx="10"/>
+   <rect x="324"
+         y="771"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="334" y="791">AT</text>
+   <rect x="386" y="773" width="66" height="32" rx="10"/>
+   <rect x="384"
+         y="771"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="394" y="791">LEAST</text>
+   <rect x="492" y="741" width="168" height="32"/>
+   <rect x="490" y="739" width="168" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="500" y="759">timestamp_expression</text>
+   <rect x="511" y="859" width="38" height="32" rx="10"/>
+   <rect x="509"
+         y="857"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="519" y="877">UP</text>
+   <rect x="569" y="859" width="40" height="32" rx="10"/>
+   <rect x="567"
+         y="857"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="577" y="877">TO</text>
+   <rect x="629" y="859" width="168" height="32"/>
+   <rect x="627" y="857" width="168" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="637" y="877">timestamp_expression</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m100 0 h10 m20 0 h10 m0 0 h50 m-80 0 h20 m60 0 h20 m-100 0 q10 0 10 10 m80 0 q0 -10 10 -10 m-90 10 v12 m80 0 v-12 m-80 12 q0 10 10 10 m60 0 q10 0 10 -10 m-70 10 h10 m40 0 h10 m40 -32 h10 m104 0 h10 m0 0 h84 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v24 m228 0 v-24 m-228 24 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m26 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m26 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-399 154 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m104 0 h10 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m28 0 h10 m0 0 h10 m102 0 h10 m-334 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m334 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-334 0 h10 m24 0 h10 m0 0 h290 m20 44 h10 m26 0 h10 m-604 0 h20 m584 0 h20 m-624 0 q10 0 10 10 m604 0 q0 -10 10 -10 m-614 10 v46 m604 0 v-46 m-604 46 q0 10 10 10 m584 0 q10 0 10 -10 m-594 10 h10 m0 0 h574 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-602 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h482 m-512 0 h20 m492 0 h20 m-532 0 q10 0 10 10 m512 0 q0 -10 10 -10 m-522 10 v12 m512 0 v-12 m-512 12 q0 10 10 10 m492 0 q10 0 10 -10 m-502 10 h10 m40 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m0 0 h136 m-166 0 h20 m146 0 h20 m-186 0 q10 0 10 10 m166 0 q0 -10 10 -10 m-176 10 v12 m166 0 v-12 m-166 12 q0 10 10 10 m146 0 q10 0 10 -10 m-156 10 h10 m40 0 h10 m0 0 h10 m66 0 h10 m20 -32 h10 m168 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-463 114 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h296 m-326 0 h20 m306 0 h20 m-346 0 q10 0 10 10 m326 0 q0 -10 10 -10 m-336 10 v12 m326 0 v-12 m-326 12 q0 10 10 10 m306 0 q10 0 10 -10 m-316 10 h10 m38 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m168 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-510 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m94 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m64 0 h10 m-104 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m84 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-84 0 h10 m24 0 h10 m0 0 h40 m20 44 h10 m26 0 h10 m0 0 h10 m26 0 h10 m-606 0 h20 m586 0 h20 m-626 0 q10 0 10 10 m606 0 q0 -10 10 -10 m-616 10 v14 m606 0 v-14 m-606 14 q0 10 10 10 m586 0 q10 0 10 -10 m-596 10 h10 m0 0 h576 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-658 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m94 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m64 0 h10 m-104 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m84 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-84 0 h10 m24 0 h10 m0 0 h40 m20 44 h10 m26 0 h10 m0 0 h10 m26 0 h10 m-622 0 h20 m602 0 h20 m-642 0 q10 0 10 10 m622 0 q0 -10 10 -10 m-632 10 v14 m622 0 v-14 m-622 14 q0 10 10 10 m602 0 q10 0 10 -10 m-612 10 h10 m0 0 h592 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-758 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m72 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m64 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m50 0 h10 m0 0 h8 m-88 -10 v20 m98 0 v-20 m-98 20 v24 m98 0 v-24 m-98 24 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m40 -76 h10 m0 0 h120 m-150 0 h20 m130 0 h20 m-170 0 q10 0 10 10 m150 0 q0 -10 10 -10 m-160 10 v12 m150 0 v-12 m-150 12 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m106 0 h10 m0 0 h4 m-140 -10 v20 m150 0 v-20 m-150 20 v24 m150 0 v-24 m-150 24 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m110 0 h10 m-372 -76 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m372 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-372 0 h10 m24 0 h10 m0 0 h328 m-778 44 h20 m778 0 h20 m-818 0 q10 0 10 10 m798 0 q0 -10 10 -10 m-808 10 v90 m798 0 v-90 m-798 90 q0 10 10 10 m778 0 q10 0 10 -10 m-788 10 h10 m0 0 h768 m23 -110 h-3"/>
-   <polygon points="841 777 849 773 849 781"/>
-   <polygon points="841 777 833 773 833 781"/>
+         d="m17 17 h2 m0 0 h10 m100 0 h10 m20 0 h10 m0 0 h50 m-80 0 h20 m60 0 h20 m-100 0 q10 0 10 10 m80 0 q0 -10 10 -10 m-90 10 v12 m80 0 v-12 m-80 12 q0 10 10 10 m60 0 q10 0 10 -10 m-70 10 h10 m40 0 h10 m40 -32 h10 m104 0 h10 m0 0 h84 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v24 m228 0 v-24 m-228 24 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m26 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m26 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-402 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m94 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m64 0 h10 m-104 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m84 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-84 0 h10 m24 0 h10 m0 0 h40 m20 44 h10 m26 0 h10 m0 0 h10 m26 0 h10 m-606 0 h20 m586 0 h20 m-626 0 q10 0 10 10 m606 0 q0 -10 10 -10 m-616 10 v14 m606 0 v-14 m-606 14 q0 10 10 10 m586 0 q10 0 10 -10 m-596 10 h10 m0 0 h576 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-658 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m94 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m64 0 h10 m-104 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m84 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-84 0 h10 m24 0 h10 m0 0 h40 m20 44 h10 m26 0 h10 m0 0 h10 m26 0 h10 m-622 0 h20 m602 0 h20 m-642 0 q10 0 10 10 m622 0 q0 -10 10 -10 m-632 10 v14 m622 0 v-14 m-622 14 q0 10 10 10 m602 0 q10 0 10 -10 m-612 10 h10 m0 0 h592 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-754 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m72 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m64 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m50 0 h10 m0 0 h8 m-88 -10 v20 m98 0 v-20 m-98 20 v24 m98 0 v-24 m-98 24 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m40 -76 h10 m0 0 h120 m-150 0 h20 m130 0 h20 m-170 0 q10 0 10 10 m150 0 q0 -10 10 -10 m-160 10 v12 m150 0 v-12 m-150 12 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m106 0 h10 m0 0 h4 m-140 -10 v20 m150 0 v-20 m-150 20 v24 m150 0 v-24 m-150 24 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m110 0 h10 m-372 -76 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m372 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-372 0 h10 m24 0 h10 m0 0 h328 m-778 44 h20 m778 0 h20 m-818 0 q10 0 10 10 m798 0 q0 -10 10 -10 m-808 10 v90 m798 0 v-90 m-798 90 q0 10 10 10 m778 0 q10 0 10 -10 m-788 10 h10 m0 0 h768 m22 -110 l2 0 m2 0 l2 0 m2 0 l2 0 m-745 202 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m104 0 h10 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m28 0 h10 m0 0 h10 m102 0 h10 m-334 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m334 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-334 0 h10 m24 0 h10 m0 0 h290 m20 44 h10 m26 0 h10 m-604 0 h20 m584 0 h20 m-624 0 q10 0 10 10 m604 0 q0 -10 10 -10 m-614 10 v46 m604 0 v-46 m-604 46 q0 10 10 10 m584 0 q10 0 10 -10 m-594 10 h10 m0 0 h574 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-602 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h482 m-512 0 h20 m492 0 h20 m-532 0 q10 0 10 10 m512 0 q0 -10 10 -10 m-522 10 v12 m512 0 v-12 m-512 12 q0 10 10 10 m492 0 q10 0 10 -10 m-502 10 h10 m40 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m0 0 h136 m-166 0 h20 m146 0 h20 m-186 0 q10 0 10 10 m166 0 q0 -10 10 -10 m-176 10 v12 m166 0 v-12 m-166 12 q0 10 10 10 m146 0 q10 0 10 -10 m-156 10 h10 m40 0 h10 m0 0 h10 m66 0 h10 m20 -32 h10 m168 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-233 118 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h296 m-326 0 h20 m306 0 h20 m-346 0 q10 0 10 10 m326 0 q0 -10 10 -10 m-336 10 v12 m326 0 v-12 m-326 12 q0 10 10 10 m306 0 q10 0 10 -10 m-316 10 h10 m38 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m168 0 h10 m23 -32 h-3"/>
+   <polygon points="835 841 843 837 843 845"/>
+   <polygon points="835 841 827 837 827 845"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -537,12 +537,12 @@ string_agg ::=
 subscribe_stmt ::=
     'SUBSCRIBE' 'TO'?
     ( object_name | '(' select_stmt ')' )
-    ( 'WITH'? '(' (option_name ('=' option_value)?) ( ',' (option_name ('=' option_value)?) )* ')' )?
-    ('AS' 'OF' ( 'AT' 'LEAST' )? timestamp_expression)?
-    ( 'UP' 'TO' timestamp_expression )?
     ('ENVELOPE' 'UPSERT' '(' 'KEY' '(' col_ref ( ',' col_ref )* ')' ')' )?
     ('ENVELOPE' 'DEBEZIUM' '(' 'KEY' '(' col_ref ( ',' col_ref )* ')' ')' )?
     ('WITHIN' 'TIMESTAMP' 'ORDER' 'BY' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? ( ',' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? )*)?
+    ( 'WITH'? '(' (option_name ('=' option_value)?) ( ',' (option_name ('=' option_value)?) )* ')' )?
+    ('AS' 'OF' ( 'AT' 'LEAST' )? timestamp_expression)?
+    ( 'UP' 'TO' timestamp_expression )?
 table_ref ::=
   (
     table_name

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1222,6 +1222,62 @@ SUBSCRIBE foo.bar WITHIN TIMESTAMP ORDER BY
                                            ^
 
 parse-statement
+SUBSCRIBE foo.bar ENVELOPE UPSERT (KEY (a)) AS OF 1 UP TO 2
+----
+SUBSCRIBE foo.bar AS OF 1 UP TO 2 ENVELOPE UPSERT (KEY (a))
+=>
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Value(Number("1")))), up_to: Some(Value(Number("2"))), output: EnvelopeUpsert { key_columns: [Ident("a")] } })
+
+parse-statement
+SUBSCRIBE foo.bar ENVELOPE UPSERT (KEY (a)) AS OF 1
+----
+SUBSCRIBE foo.bar AS OF 1 ENVELOPE UPSERT (KEY (a))
+=>
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Value(Number("1")))), up_to: None, output: EnvelopeUpsert { key_columns: [Ident("a")] } })
+
+parse-statement
+SUBSCRIBE foo.bar ENVELOPE UPSERT (KEY (a)) WITH (SNAPSHOT = true)
+----
+SUBSCRIBE foo.bar WITH (SNAPSHOT = true) ENVELOPE UPSERT (KEY (a))
+=>
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [SubscribeOption { name: Snapshot, value: Some(Value(Boolean(true))) }], as_of: None, up_to: None, output: EnvelopeUpsert { key_columns: [Ident("a")] } })
+
+parse-statement
+SUBSCRIBE foo.bar ENVELOPE UPSERT (KEY (a)) WITH (SNAPSHOT = true) WITHIN TIMESTAMP ORDER BY a
+----
+error: Expected end of statement, found WITHIN
+SUBSCRIBE foo.bar ENVELOPE UPSERT (KEY (a)) WITH (SNAPSHOT = true) WITHIN TIMESTAMP ORDER BY a
+                                                                   ^
+
+parse-statement
+SUBSCRIBE foo.bar ENVELOPE UPSERT (KEY (a)) UP TO 2
+----
+SUBSCRIBE foo.bar UP TO 2 ENVELOPE UPSERT (KEY (a))
+=>
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [], as_of: None, up_to: Some(Value(Number("2"))), output: EnvelopeUpsert { key_columns: [Ident("a")] } })
+
+parse-statement
+SUBSCRIBE foo.bar AS OF 1 ENVELOPE UPSERT (KEY (a, b, c, d, e)) AS OF 1
+----
+error: Expected end of statement, found AS
+SUBSCRIBE foo.bar AS OF 1 ENVELOPE UPSERT (KEY (a, b, c, d, e)) AS OF 1
+                                                                ^
+
+parse-statement
+SUBSCRIBE foo.bar AS OF 1 ENVELOPE UPSERT (KEY (a)) UP TO 2
+----
+error: Expected end of statement, found UP
+SUBSCRIBE foo.bar AS OF 1 ENVELOPE UPSERT (KEY (a)) UP TO 2
+                                                    ^
+
+parse-statement
+SUBSCRIBE foo.bar AS OF 1 AS OF 1
+----
+error: Expected end of statement, found AS
+SUBSCRIBE foo.bar AS OF 1 AS OF 1
+                          ^
+
+parse-statement
 CREATE TABLE public.customer (
         customer_id integer DEFAULT nextval(public.customer_customer_id_seq),
         store_id smallint NOT NULL,

--- a/test/sqllogictest/subscribe_outputs.slt
+++ b/test/sqllogictest/subscribe_outputs.slt
@@ -86,6 +86,20 @@ statement ok
 BEGIN
 
 statement ok
+DECLARE c CURSOR FOR SUBSCRIBE t ENVELOPE UPSERT (KEY (a)) WITH (PROGRESS)
+
+query IIIII colnames
+FETCH 0 c
+----
+mz_timestamp mz_progressed mz_state a b
+
+statement ok
+COMMIT
+
+statement ok
+BEGIN
+
+statement ok
 DECLARE c CURSOR FOR SUBSCRIBE t ENVELOPE UPSERT (KEY (b))
 
 query IIII colnames


### PR DESCRIPTION
The "output options" for `SUBSCRIBE` (i.e., the `ENVELOPE` and `WITHIN TIMESTAMP ORDER BY` clauses) were jammed in at the end of the statement, as in:

    SUBSCRIBE t WITH (SNAPSHOT) AS OF 1 UP TO 2 ENVELOPE UPSERT KEY (a)

This was inconsistent with our other SQL statements. In particular, CREATE SOURCE and CREATE SINK always put the WITH options at the very end of the statement:

    CREATE SINK ... WITH (SNAPSHOT)

And SELECT always puts the AS OF clause at the very end of the statement:

    SELECT * FROM t WHERE ... AS OF 1

This commit restores the consistency that used to be present in `SUBSCRIBE` by moving the output options to *before* the `AS OF`, `UP TO`, and `WITH` options:

    SUBSCRIBE t ENVELOPE UPSERT KEY (a) WITH (SNAPSHOT) AS OF 1 UP TO 2

The old syntax remains supported for backwards compatibility, but is softly deprecated. Only the new syntax will be mentioned in the docs going forward.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
