### PR TITLE
ci: Further nightly speedups

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -335,7 +335,7 @@ steps:
               composition: limits
               run: main
         timeout_in_minutes: 180
-        parallelism: 3
+        parallelism: 2
         # TODO(def-) Move to larger agents to prevent flakiness
         retry:
           automatic:
@@ -1273,7 +1273,8 @@ steps:
   - id: data-ingest
     label: "Data Ingest"
     depends_on: build-aarch64
-    timeout_in_minutes: 120
+    timeout_in_minutes: 90
+    parallelism: 2
     retry:
       automatic:
         - exit_status: 75
@@ -1473,7 +1474,8 @@ steps:
   - id: txn-wal-fencing
     label: Txn-wal fencing
     depends_on: build-aarch64
-    timeout_in_minutes: 180
+    timeout_in_minutes: 120
+    parallelism: 2
     plugins:
       - ./ci/plugins/mzcompose:
           composition: txn-wal-fencing

--- a/misc/python/materialize/scalability/executor/benchmark_executor.py
+++ b/misc/python/materialize/scalability/executor/benchmark_executor.py
@@ -129,7 +129,7 @@ class BenchmarkExecutor:
         endpoint: Endpoint,
         workload: Workload,
     ) -> WorkloadResult:
-        print(f"Running workload {workload.name()} on {endpoint}")
+        print(f"--- Running workload {workload.name()} on {endpoint}")
         self.result.record_workload_metadata(workload)
 
         df_totals = DfTotals()

--- a/misc/python/materialize/scalability/scalability_versioning.py
+++ b/misc/python/materialize/scalability/scalability_versioning.py
@@ -19,7 +19,7 @@ SCALABILITY_WORKLOADS_DIR = SCALABILITY_FRAMEWORK_DIR / "workload" / "workloads"
 # Consider increasing the #SCALABILITY_FRAMEWORK_VERSION if changes are expected to impact results!
 SHA256_OF_FRAMEWORK: dict[str, str] = {}
 SHA256_OF_FRAMEWORK["*"] = (
-    "f275bb082ff0427e48c2216abdf493adf95f288a1c167092974a853d5ca28ceb"
+    "1d0fa12d738b686e62d0fa2612656a1b4a0ac43cbfb377f1ffa5c7952ec4314d"
 )
 
 # Consider increasing the workload's class #version() if changes are expected to impact results!

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1506,6 +1506,8 @@ class MySqlSources(Generator):
 
 
 class WebhookSources(Generator):
+    COUNT = 100  # TODO: Remove when #29358 is fixed
+
     @classmethod
     def body(cls) -> None:
         print("$ postgres-execute connection=mz_system")

--- a/test/txn-wal-fencing/mzcompose.py
+++ b/test/txn-wal-fencing/mzcompose.py
@@ -18,6 +18,7 @@ from concurrent import futures
 from dataclasses import dataclass
 from enum import Enum
 
+from materialize import buildkite
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.materialized import Materialized
@@ -94,7 +95,12 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    for workload in WORKLOADS:
+    workloads = buildkite.shard_list(WORKLOADS, lambda w: w.name)
+    print(
+        f"Workloads in shard with index {buildkite.get_parallelism_index()}: {[w.name for w in workloads]}"
+    )
+
+    for workload in workloads:
         run_workload(c, workload)
 
 


### PR DESCRIPTION
Based on the results from https://buildkite.com/materialize/nightly/builds/9380/waterfall

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
