### PR TITLE
parallel-benchmark: Don't use strict serializable

### DIFF
--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -302,7 +302,7 @@ class LoadPhase(Phase):
         for i in range(self.duration):
             assert (
                 jobs.qsize() < 100
-            ), "Too many jobs in queue, can't keep up: {jobs.qsize()}"
+            ), f"Too many jobs in queue, can't keep up: {jobs.qsize()}"
             time.sleep(1)
         for thread in threads:
             thread.join()
@@ -428,7 +428,7 @@ class Kafka(Scenario):
                             action=StandaloneQuery(
                                 "SELECT * FROM kafka_mv",
                                 conn_infos["materialized"],
-                                strict_serializable=True,
+                                strict_serializable=False,
                             ),
                         )
                         for i in range(10)
@@ -488,7 +488,7 @@ class PgReadReplica(Scenario):
                             action=StandaloneQuery(
                                 "SELECT * FROM mv_sum",
                                 conn_infos["materialized"],
-                                strict_serializable=True,
+                                strict_serializable=False,
                             ),
                         )
                         for i in range(10)
@@ -611,7 +611,7 @@ class MySQLReadReplica(Scenario):
                             action=StandaloneQuery(
                                 "SELECT * FROM mv_sum_mysql",
                                 conn_info=conn_infos["materialized"],
-                                strict_serializable=True,
+                                strict_serializable=False,
                             ),
                         )
                         for i in range(10)


### PR DESCRIPTION
This was seen in [Parallel Benchmark](https://buildkite.com/materialize/nightly/builds/9390#0191bcf9-9a77-46d1-98eb-27a676e00ca4), but I have seen similar occurrences on main too:
![image](https://github.com/user-attachments/assets/9eaa4bbe-b51a-4d1f-b8d0-ffe922c3e542)
Meanwhile good runs look like this:
![Kafka2](https://github.com/user-attachments/assets/e77cee05-b6dd-4f1e-bf56-c58bd247895f)
We ingest data once per second, which looks suspiciously like the 1 s latency. My best guess is that this is expected when you use strict serializable, so I'll change the scenario to use serializable. But I'd also appreciate if @rjobanp or @petrosagg can confirm that this is reasonable.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
