### PR TITLE
platform-checks: Only read new version after promotion succeeded

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -413,11 +413,11 @@ class PromoteMz(MzcomposeAction):
         )
         assert result["result"] == "Success", f"Unexpected result {result}"
 
-        mz_version = MzVersion.parse_mz(c.query_mz_version(service=self.mz_service))
-        e.current_mz_version = mz_version
-
         # Wait until new Materialize is ready to handle queries
         c.await_mz_deployment_status(DeploymentStatus.IS_LEADER, self.mz_service)
+
+        mz_version = MzVersion.parse_mz(c.query_mz_version(service=self.mz_service))
+        e.current_mz_version = mz_version
 
 
 class SystemVarChange(MzcomposeAction):


### PR DESCRIPTION
Fixes `bin/mzcompose --find platform-checks down && bin/mzcompose --find platform-checks run default --scenario=ZeroDowntimeRestartEntireMz --check=DebeziumPostgres` for me on macOS.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
