### PR TITLE
frontegg-mock: add internal endpoint to get user passowrds

### DIFF
--- a/src/frontegg-mock/src/handlers/user.rs
+++ b/src/frontegg-mock/src/handlers/user.rs
@@ -515,3 +515,19 @@ pub async fn handle_remove_users_from_group(
         StatusCode::NOT_FOUND
     }
 }
+
+pub async fn internal_handle_get_user_password(
+    State(context): State<Arc<Context>>,
+    Json(request): Json<GetUserPasswordRequest>,
+) -> Result<Json<GetUserPasswordResponse>, StatusCode> {
+    let users = context.users.lock().unwrap();
+
+    if let Some(user) = users.get(&request.email) {
+        Ok(Json(GetUserPasswordResponse {
+            email: user.email.clone(),
+            password: user.password.clone(),
+        }))
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
+}

--- a/src/frontegg-mock/src/models/user.rs
+++ b/src/frontegg-mock/src/models/user.rs
@@ -142,3 +142,14 @@ pub struct RemoveRolesFromGroupParams {
     #[serde(rename = "roleIds")]
     pub role_ids: Vec<String>,
 }
+
+#[derive(Deserialize)]
+pub struct GetUserPasswordRequest {
+    pub email: String,
+}
+
+#[derive(Serialize)]
+pub struct GetUserPasswordResponse {
+    pub email: String,
+    pub password: String,
+}

--- a/src/frontegg-mock/src/server.rs
+++ b/src/frontegg-mock/src/server.rs
@@ -58,6 +58,9 @@ const SSO_CONFIG_GROUP_PATH: &str =
     "/frontegg/team/resources/sso/v1/configurations/:id/groups/:group_id";
 const SSO_CONFIG_ROLES_PATH: &str = "/frontegg/team/resources/sso/v1/configurations/:id/roles";
 
+// Internal endpoints for testing
+const INTERNAL_USER_PASSWORD_PATH: &str = "/api/internal-mock/user-password";
+
 pub struct FronteggMockServer {
     pub base_url: String,
     pub refreshes: Arc<Mutex<u64>>,
@@ -234,6 +237,10 @@ impl FronteggMockServer {
             .route(
                 SCIM_CONFIGURATION_PATH,
                 delete(handle_delete_scim_configuration),
+            )
+            .route(
+                INTERNAL_USER_PASSWORD_PATH,
+                post(internal_handle_get_user_password),
             )
             .layer(middleware::from_fn(logging_middleware))
             .layer(middleware::from_fn_with_state(


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

As discussed in #29331 adding an internal endpoint to allow us to get the user passwords for some internal testing.

To manually test the new endpoint using curl, you could use the following:

```sh
curl -X POST http://localhost:3000/api/internal-mock/user-password \
     -H "Content-Type: application/json" \
     -d '{"email": "mz_system"}'
```

Based on the user data you provided when starting the service, you should get a response like this:

```json
{
  "email": "mz_system",
  "password": "7e8f9a0b-1c2d-3e4f-5a6b-7c8d9e0f1a2b"
}
```