### PR TITLE
sql: Fix SHOW ROLE MEMBERSHIP filter

### DIFF
--- a/doc/user/content/sql/show-role-membership.md
+++ b/doc/user/content/sql/show-role-membership.md
@@ -42,7 +42,6 @@ SHOW ROLE MEMBERSHIP FOR r2;
 ```nofmt
  role | member |  grantor
 ------+--------+-----------
- r2   | r1     | mz_system
  r3   | r2     | mz_system
  r4   | r3     | mz_system
 ```

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -796,9 +796,7 @@ pub fn show_role_membership<'a>(
     let mut query_filter = Vec::new();
     if let Some(role) = role {
         let name = role.name;
-        query_filter.push(format!(
-            "(pg_has_role('{name}', member, 'USAGE') OR role = '{name}')"
-        ));
+        query_filter.push(format!("pg_has_role('{name}', member, 'USAGE')"));
     }
     let query_filter = if query_filter.len() > 0 {
         format!("WHERE {}", itertools::join(query_filter, " AND "))

--- a/test/sqllogictest/rbac_views.slt
+++ b/test/sqllogictest/rbac_views.slt
@@ -68,7 +68,6 @@ r5  r4  mz_system
 query TTT
 SELECT * FROM (SHOW ROLE MEMBERSHIP FOR r2) ORDER BY role, member
 ----
-r2  r1  mz_system
 r3  r2  mz_system
 
 # SHOW SYSTEM PRIVILEGES


### PR DESCRIPTION
The documentation for `SHOW ROLE MEMBERSHIP` says that the `FOR <role_name>` filter does the following:

> Only shows role memberships granted directly or indirectly to
> role_name.

The implementation outputs these role memberships, but it also outputs role memberships where other roles are members of role_name. This makes the output confusing and not consistent with the documentation. This commit updates the implementation so that it's consistent with the documentation.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
