### PR TITLE
catalog: Remove old migrations

### DIFF
--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -7,25 +7,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use futures::future::BoxFuture;
-use mz_adapter_types::dyncfgs::DEFAULT_SINK_PARTITION_STRATEGY;
 use mz_catalog::durable::Item;
 use mz_catalog::memory::objects::{StateDiff, StateUpdate};
 use mz_catalog::{durable::Transaction, memory::objects::StateUpdateKind};
-use mz_dyncfg::ConfigSet;
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::NowFn;
 use mz_proto::RustType;
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::visit_mut::VisitMut;
-use mz_sql::ast::{
-    CreateSinkConnection, CreateSinkOption, CreateSinkOptionName, CreateSinkStatement,
-    CreateSourceStatement, KafkaSinkConfigOption, KafkaSinkConfigOptionName, UnresolvedItemName,
-    Value, WithOptionValue,
-};
+use mz_sql::ast::{CreateSourceStatement, UnresolvedItemName, Value};
 use mz_sql_parser::ast::{Raw, Statement};
 use mz_storage_types::connections::ConnectionContext;
 use prost::Message;
@@ -116,8 +110,6 @@ pub(crate) async fn migrate(
     );
 
     rewrite_ast_items(tx, |_tx, _id, stmt, all_items_and_statements| {
-        let catalog_version = catalog_version.clone();
-        let configs = state.system_config().dyncfgs().clone();
         Box::pin(async move {
             // Add per-item AST migrations below.
             //
@@ -128,11 +120,7 @@ pub(crate) async fn migrate(
             // Migration functions may also take `tx` as input to stage
             // arbitrary changes to the catalog.
             ast_rewrite_create_postgres_subsource_text_columns(stmt, all_items_and_statements)?;
-            ast_rewrite_create_sink_partition_strategy(&configs, stmt)?;
             ast_rewrite_create_load_gen_subsource_details(stmt)?;
-            if catalog_version < Version::parse("0.112.0-dev").expect("known to be valid") {
-                ast_rewrite_create_sink_default_compression(stmt)?;
-            }
             Ok(())
         })
     })
@@ -198,29 +186,6 @@ pub(crate) async fn migrate(
 //
 // Please include the adapter team on any code reviews that add or edit
 // migrations.
-
-fn ast_rewrite_create_sink_partition_strategy(
-    configs: &ConfigSet,
-    stmt: &mut Statement<Raw>,
-) -> Result<(), anyhow::Error> {
-    let Statement::CreateSink(stmt) = stmt else {
-        return Ok(());
-    };
-
-    if !stmt
-        .with_options
-        .iter()
-        .any(|op| op.name == CreateSinkOptionName::PartitionStrategy)
-    {
-        let default_strategy = DEFAULT_SINK_PARTITION_STRATEGY.get(configs);
-        stmt.with_options.push(CreateSinkOption {
-            name: CreateSinkOptionName::PartitionStrategy,
-            value: Some(WithOptionValue::Value(Value::String(default_strategy))),
-        });
-    }
-
-    Ok(())
-}
 
 /// Copies the 'TEXT COLUMNS' option from the relevant `CREATE SOURCE` statement to each
 /// `CREATE SUBSOURCE` statement for Postgres subsources.
@@ -499,43 +464,13 @@ fn ast_rewrite_create_load_gen_subsource_details(
     Ok(())
 }
 
-/// Inject `COMPRESSION TYPE = NONE` into existing sinks, to preserve the
-/// default compression type for sinks pre-v112.
-fn ast_rewrite_create_sink_default_compression(
-    stmt: &mut Statement<Raw>,
-) -> Result<(), anyhow::Error> {
-    match stmt {
-        Statement::CreateSink(CreateSinkStatement {
-            connection: CreateSinkConnection::Kafka { options, .. },
-            ..
-        }) => {
-            if !options
-                .iter()
-                .any(|op| op.name == KafkaSinkConfigOptionName::CompressionType)
-            {
-                options.push(KafkaSinkConfigOption {
-                    name: KafkaSinkConfigOptionName::CompressionType,
-                    value: Some(WithOptionValue::Value(Value::String("none".into()))),
-                });
-            }
-        }
-        _ => (),
-    }
-
-    Ok(())
-}
-
 // Durable migrations
 
 /// Migrations that run only on the durable catalog before any data is loaded into memory.
 pub(crate) fn durable_migrate(
-    tx: &mut Transaction,
+    _tx: &mut Transaction,
     _boot_ts: Timestamp,
 ) -> Result<(), anyhow::Error> {
-    catalog_add_new_unstable_schemas_v_0_106_0(tx)?;
-    catalog_remove_wait_catalog_consolidation_on_startup_v_0_108_0(tx);
-    catalog_remove_txn_wal_toggle_v_0_109_0(tx)?;
-
     Ok(())
 }
 
@@ -548,68 +483,3 @@ pub(crate) fn durable_migrate(
 //
 // Please include the adapter team on any code reviews that add or edit
 // migrations.
-
-/// This migration applies the rename of the built-in `mz_introspection` cluster to
-/// `mz_catalog_server` to the durable catalog state.
-fn catalog_add_new_unstable_schemas_v_0_106_0(tx: &mut Transaction) -> Result<(), anyhow::Error> {
-    use mz_catalog::durable::initialize::{
-        MZ_CATALOG_UNSTABLE_SCHEMA_ID, MZ_INTROSPECTION_SCHEMA_ID,
-    };
-    use mz_pgrepr::oid::{SCHEMA_MZ_CATALOG_UNSTABLE_OID, SCHEMA_MZ_INTROSPECTION_OID};
-    use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
-    use mz_repr::namespaces::{MZ_CATALOG_UNSTABLE_SCHEMA, MZ_INTROSPECTION_SCHEMA};
-    use mz_sql::names::SchemaId;
-    use mz_sql::rbac;
-    use mz_sql::session::user::{MZ_SUPPORT_ROLE_ID, MZ_SYSTEM_ROLE_ID};
-
-    let schema_ids: BTreeSet<_> = tx
-        .get_schemas()
-        .filter_map(|schema| match schema.id {
-            SchemaId::User(_) => None,
-            SchemaId::System(id) => Some(id),
-        })
-        .collect();
-    let schema_privileges = vec![
-        rbac::default_builtin_object_privilege(mz_sql::catalog::ObjectType::Schema),
-        MzAclItem {
-            grantee: MZ_SUPPORT_ROLE_ID,
-            grantor: MZ_SYSTEM_ROLE_ID,
-            acl_mode: AclMode::USAGE,
-        },
-        rbac::owner_privilege(mz_sql::catalog::ObjectType::Schema, MZ_SYSTEM_ROLE_ID),
-    ];
-
-    if !schema_ids.contains(&MZ_CATALOG_UNSTABLE_SCHEMA_ID) {
-        tx.insert_system_schema(
-            MZ_CATALOG_UNSTABLE_SCHEMA_ID,
-            MZ_CATALOG_UNSTABLE_SCHEMA,
-            MZ_SYSTEM_ROLE_ID,
-            schema_privileges.clone(),
-            SCHEMA_MZ_CATALOG_UNSTABLE_OID,
-        )?;
-    }
-    if !schema_ids.contains(&MZ_INTROSPECTION_SCHEMA_ID) {
-        tx.insert_system_schema(
-            MZ_INTROSPECTION_SCHEMA_ID,
-            MZ_INTROSPECTION_SCHEMA,
-            MZ_SYSTEM_ROLE_ID,
-            schema_privileges.clone(),
-            SCHEMA_MZ_INTROSPECTION_OID,
-        )?;
-    }
-
-    Ok(())
-}
-
-/// This migration removes the server configuration parameter
-/// "wait_catalog_consolidation_on_startup" which is no longer used.
-fn catalog_remove_wait_catalog_consolidation_on_startup_v_0_108_0(tx: &mut Transaction) {
-    tx.remove_system_config("wait_catalog_consolidation_on_startup");
-}
-
-/// This migration removes the txn wal feature flag.
-fn catalog_remove_txn_wal_toggle_v_0_109_0(tx: &mut Transaction) -> Result<(), anyhow::Error> {
-    tx.set_config("persist_txn_tables".to_string(), None)?;
-    tx.remove_system_config("persist_txn_tables");
-    Ok(())
-}


### PR DESCRIPTION
This commit removes migrations that are older than 4 versions.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
