### PR TITLE
Micro-optimizations around window functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5051,6 +5051,7 @@ dependencies = [
  "proptest-derive",
  "prost",
  "prost-build",
+ "rand",
  "regex",
  "regex-syntax 0.8.3",
  "seahash",

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -13,6 +13,10 @@ workspace = true
 name = "like_pattern"
 harness = false
 
+[[bench]]
+name = "window_functions"
+harness = false
+
 [dependencies]
 aho-corasick = "1.1.3"
 anyhow = "1.0.66"
@@ -69,6 +73,7 @@ datadriven = "0.8.0"
 mz-expr-test-util = { path = "../expr-test-util" }
 mz-ore = { path = "../ore" }
 proc-macro2 = "1.0.60"
+rand = "0.8.5"
 
 [build-dependencies]
 mz-build-tools = { path = "../build-tools", default-features = false }

--- a/src/expr/benches/window_functions.rs
+++ b/src/expr/benches/window_functions.rs
@@ -1,0 +1,120 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::hint::black_box;
+
+use chrono::DateTime;
+use criterion::{criterion_group, criterion_main, Criterion};
+use mz_expr::ColumnOrder;
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::{Datum, RowArena};
+use rand::distributions::{Distribution, Uniform};
+
+/// Microbenchmark to test an important part of window function evaluation.
+///
+/// Run with
+/// ```
+/// cargo bench window_function_benches
+/// ```
+/// (It's good to go into this directory, to avoid building also all other things in release mode.)
+///
+/// A similar end-to-end test:
+/// ```
+/// CREATE SOURCE counter FROM LOAD GENERATOR COUNTER;
+///
+/// create table t3(t timestamptz, d1 int, d2 text, d3 int, d4 int, d5 int, d6 text);
+///
+/// insert into t3
+/// select generate_series(1,300000)::mz_timestamp::timestamptz, 5, 'aaa', 7, 8, 9, 'bbb';
+///
+/// create view v1 as
+/// select counter::mz_timestamp::timestamptz as t, 5 as d1, 'aaa' as d2, 7 as d3, 8 as d4, 9 as d5, 'bbb' as d6 from counter
+/// union all
+/// select t, d1, d2, EXTRACT(MILLISECOND FROM t) * 91 % 1223 as d3, d4, d5, d6 from t3;
+///
+/// create index v1_ind on v1(t);
+///
+/// create view v2 as
+/// select t, d1, d2, lag(t) over (order by t) as r
+/// from v1;
+///
+/// create index v2_ind on v2(r);
+/// ```
+/// and then vary the size of the `generate_series`, and watch whether `v2_ind` is able to keep up.
+fn order_aggregate_datums_benchmark(c: &mut Criterion) {
+
+    let mut group = c.benchmark_group("window_function_benches");
+
+    let scale = 1000000;
+
+    group.bench_function("order_aggregate_datums", |b| {
+
+        let mut rng = rand::thread_rng();
+        let temp_storage = RowArena::new();
+
+        let order_by = vec![ColumnOrder {
+            column: 0,
+            desc: false,
+            nulls_last: false,
+        }];
+
+        // Simulate a lag/lead, e.g.
+        // row(
+        //   row(
+        //     row(#0, #1, #2, #3), // original row
+        //     row(#1, 1, null) // args to lag/lead
+        //   ),
+        //   <order_by_col_1>,
+        // )
+        let distr = Uniform::new(0, 1000000000);
+        let mut datums = Vec::with_capacity(scale);
+        for _i in 0..scale {
+            datums.push(temp_storage.make_datum(|packer| {
+                let orig_row_and_args = temp_storage.make_datum(|packer| {
+                    packer.push(Datum::Int32(3));
+                    packer.push(Datum::Int32(545577777));
+                    packer.push(Datum::Int32(123456789));
+                    packer.push(Datum::String("aaaaaaaaaa"));
+                });
+
+                // An early version had non-random stuff here, but surprisingly this is much faster
+                // to sort, so it's not representative.
+                //let order_by_col_1 = Datum::Int32((scale - i) as i32);
+                // This is faster, probably because Int32 is easier to decode than a Timestamp.
+                //let order_by_col_1 = Datum::Int32(distr.sample(&mut rng));
+                // So, we generate a random timestamp. Timestamps are a common thing to order by in
+                // window functions.
+                let order_by_col_1 = Datum::TimestampTz(
+                    CheckedTimestamp::from_timestamplike(
+                        DateTime::from_timestamp_millis(distr.sample(&mut rng)).unwrap(),
+                    )
+                    .unwrap(),
+                );
+
+                packer.push_list_with(|packer| {
+                    packer.push(orig_row_and_args);
+                    packer.push(order_by_col_1);
+                });
+            }));
+        }
+
+        b.iter(|| {
+            black_box(mz_expr::order_aggregate_datums_exported_for_benchmarking(
+                black_box(datums.clone()),
+                black_box(&order_by),
+            ))
+            // Do something with the result to force the iterator.
+            .for_each(|d| assert!(!d.is_null()));
+        })
+
+    });
+}
+
+criterion_group!(window_function_benches, order_aggregate_datums_benchmark);
+criterion_main!(window_function_benches);

--- a/src/expr/benches/window_functions.rs
+++ b/src/expr/benches/window_functions.rs
@@ -48,13 +48,11 @@ use rand::distributions::{Distribution, Uniform};
 /// ```
 /// and then vary the size of the `generate_series`, and watch whether `v2_ind` is able to keep up.
 fn order_aggregate_datums_benchmark(c: &mut Criterion) {
-
     let mut group = c.benchmark_group("window_function_benches");
 
     let scale = 1000000;
 
     group.bench_function("order_aggregate_datums", |b| {
-
         let mut rng = rand::thread_rng();
         let temp_storage = RowArena::new();
 
@@ -112,7 +110,6 @@ fn order_aggregate_datums_benchmark(c: &mut Criterion) {
             // Do something with the result to force the iterator.
             .for_each(|d| assert!(!d.is_null()));
         })
-
     });
 }
 

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -34,6 +34,7 @@ pub use linear::util::{join_permutations, permutation_for_arrangement};
 pub use linear::{
     memoize_expr, MapFilterProject, ProtoMapFilterProject, ProtoMfpPlan, ProtoSafeMfpPlan,
 };
+pub use relation::func::order_aggregate_datums as order_aggregate_datums_exported_for_benchmarking;
 pub use relation::func::{
     AggregateFunc, AnalyzedRegex, CaptureGroupDesc, LagLeadType, NaiveOneByOneAggr, OneByOneAggr,
     TableFunc,

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -276,7 +276,7 @@ where
 
 // Assuming datums is a List, sort them by the 2nd through Nth elements
 // corresponding to order_by, then return the 1st element.
-fn order_aggregate_datums<'a, I>(
+pub fn order_aggregate_datums<'a, I>(
     datums: I,
     order_by: &[ColumnOrder],
 ) -> impl Iterator<Item = Datum<'a>>
@@ -3491,11 +3491,12 @@ impl fmt::Display for TableFunc {
 
 #[cfg(test)]
 mod tests {
+    use super::{
+        AggregateFunc, ProtoAggregateFunc, ProtoTableFunc, TableFunc,
+    };
     use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
-
-    use super::{AggregateFunc, ProtoAggregateFunc, ProtoTableFunc, TableFunc};
 
     proptest! {
        #[mz_ore::test]

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -385,11 +385,17 @@ where
     })
 }
 
-fn row_number<'a, I>(datums: I, temp_storage: &'a RowArena, order_by: &[ColumnOrder]) -> Datum<'a>
+fn row_number<'a, I>(
+    datums: I,
+    callers_temp_storage: &'a RowArena,
+    order_by: &[ColumnOrder],
+) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
     let datums = order_aggregate_datums(datums, order_by);
+
+    let temp_storage = RowArena::with_capacity(datums.size_hint().0);
     let datums = datums
         .into_iter()
         .map(|d| d.unwrap_list().iter())
@@ -401,17 +407,19 @@ where
             })
         });
 
-    temp_storage.make_datum(|packer| {
+    callers_temp_storage.make_datum(|packer| {
         packer.push_list(datums);
     })
 }
 
-fn rank<'a, I>(datums: I, temp_storage: &'a RowArena, order_by: &[ColumnOrder]) -> Datum<'a>
+fn rank<'a, I>(datums: I, callers_temp_storage: &'a RowArena, order_by: &[ColumnOrder]) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
     // Keep the row used for ordering around, as it is used to determine the rank
     let datums = order_aggregate_datums_with_rank(datums, order_by);
+
+    let temp_storage = RowArena::with_capacity(datums.size_hint().0);
 
     let mut datums = datums
         .into_iter()
@@ -444,17 +452,23 @@ where
         })
     });
 
-    temp_storage.make_datum(|packer| {
+    callers_temp_storage.make_datum(|packer| {
         packer.push_list(datums);
     })
 }
 
-fn dense_rank<'a, I>(datums: I, temp_storage: &'a RowArena, order_by: &[ColumnOrder]) -> Datum<'a>
+fn dense_rank<'a, I>(
+    datums: I,
+    callers_temp_storage: &'a RowArena,
+    order_by: &[ColumnOrder],
+) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
     // Keep the row used for ordering around, as it is used to determine the rank
     let datums = order_aggregate_datums_with_rank(datums, order_by);
+
+    let temp_storage = RowArena::with_capacity(datums.size_hint().0);
 
     let mut datums = datums
         .into_iter()
@@ -486,7 +500,7 @@ where
             })
         });
 
-    temp_storage.make_datum(|packer| {
+    callers_temp_storage.make_datum(|packer| {
         packer.push_list(datums);
     })
 }
@@ -514,7 +528,7 @@ where
 /// )
 fn lag_lead<'a, I>(
     datums: I,
-    temp_storage: &'a RowArena,
+    callers_temp_storage: &'a RowArena,
     order_by: &[ColumnOrder],
     lag_lead_type: &LagLeadType,
     ignore_nulls: &bool,
@@ -541,6 +555,7 @@ where
 
     let result = lag_lead_inner(unwrapped_args, lag_lead_type, ignore_nulls);
 
+    let temp_storage = RowArena::with_capacity(result.len());
     let result = result
         .into_iter()
         .zip_eq(orig_rows)
@@ -550,7 +565,7 @@ where
             })
         });
 
-    temp_storage.make_datum(|packer| {
+    callers_temp_storage.make_datum(|packer| {
         packer.push_list(result);
     })
 }
@@ -743,7 +758,7 @@ fn lag_lead_inner_ignore_nulls<'a>(
 /// The expected input is in the format of [((OriginalRow, InputValue), OrderByExprs...)]
 fn first_value<'a, I>(
     datums: I,
-    temp_storage: &'a RowArena,
+    callers_temp_storage: &'a RowArena,
     order_by: &[ColumnOrder],
     window_frame: &WindowFrame,
 ) -> Datum<'a>
@@ -767,6 +782,7 @@ where
 
     let results = first_value_inner(args, window_frame);
 
+    let temp_storage = RowArena::with_capacity(results.len());
     let results_with_orig_rows =
         results
             .into_iter()
@@ -777,7 +793,7 @@ where
                 })
             });
 
-    temp_storage.make_datum(|packer| {
+    callers_temp_storage.make_datum(|packer| {
         packer.push_list(results_with_orig_rows);
     })
 }
@@ -847,7 +863,7 @@ fn first_value_inner<'a>(datums: Vec<Datum<'a>>, window_frame: &WindowFrame) -> 
 /// The expected input is in the format of [((OriginalRow, InputValue), OrderByExprs...)]
 fn last_value<'a, I>(
     datums: I,
-    temp_storage: &'a RowArena,
+    callers_temp_storage: &'a RowArena,
     order_by: &[ColumnOrder],
     window_frame: &WindowFrame,
 ) -> Datum<'a>
@@ -874,6 +890,7 @@ where
 
     let results = last_value_inner(args, &order_by_rows, window_frame);
 
+    let temp_storage = RowArena::with_capacity(results.len());
     let result = results
         .into_iter()
         .zip_eq(original_rows)
@@ -883,7 +900,7 @@ where
             })
         });
 
-    temp_storage.make_datum(|packer| {
+    callers_temp_storage.make_datum(|packer| {
         packer.push_list(result);
     })
 }
@@ -991,11 +1008,6 @@ fn fused_value_window_func<'a, I>(
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
-    // Let's create a new RowArena, to avoid flooding the caller's arena with stuff proportional to
-    // the window partition size. We will use our own arena for internal evaluations, and will use
-    // the caller's at the very end to return the final result Datum.
-    let temp_storage = RowArena::new();
-
     let has_last_value = funcs
         .iter()
         .any(|f| matches!(f, AggregateFunc::LastValue { .. }));
@@ -1060,6 +1072,10 @@ where
         }
     }
 
+    // Let's create a new RowArena, to avoid flooding the caller's arena with stuff proportional to
+    // the window partition size. We will use our own arena for internal evaluations, and will use
+    // the caller's at the very end to return the final result Datum.
+    let temp_storage = RowArena::with_capacity(2 * original_rows.len());
     let results_with_orig_rows = results_per_row.into_iter().enumerate().map(|(i, results)| {
         temp_storage.make_datum(|packer| {
             packer.push_list(vec![
@@ -1074,8 +1090,8 @@ where
     })
 }
 
-// The expected input is in the format of [((OriginalRow, InputValue), OrderByExprs...)]
-// See also in the comment in `window_func_applied_to`.
+/// The expected input is in the format of `[((OriginalRow, InputValue), OrderByExprs...)]`
+/// See also in the comment in `window_func_applied_to`.
 fn window_aggr<'a, I, A>(
     input_datums: I, // An entire window partition.
     callers_temp_storage: &'a RowArena,
@@ -1089,11 +1105,6 @@ where
     I: IntoIterator<Item = Datum<'a>>,
     A: OneByOneAggr,
 {
-    // Let's create a new RowArena, to avoid flooding the caller's arena with stuff proportional to
-    // the window partition size. We will use our own arena for internal evaluations, and will use
-    // the caller's at the very end to return the final result Datum.
-    let temp_storage = RowArena::new();
-
     // Sort the datums according to the ORDER BY expressions and return the ((OriginalRow, InputValue), OrderByRow) record
     // The OrderByRow is kept around because it is required to compute the peer groups in RANGE mode
     let datums = order_aggregate_datums_with_rank(input_datums, order_by);
@@ -1112,6 +1123,11 @@ where
 
     let length = input_datums.len();
     let mut result: Vec<(Datum, Datum)> = Vec::with_capacity(length);
+
+    // Let's create a new RowArena, to avoid flooding the caller's arena with stuff proportional to
+    // the window partition size. We will use our own arena for internal evaluations, and will use
+    // the caller's at the very end to return the final result Datum.
+    let temp_storage = RowArena::with_capacity(length);
 
     // In this degenerate case, all results would be `wrapped_aggregate.default()` (usually null).
     // However, this currently can't happen, because

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -859,9 +859,10 @@ where
     let datums = order_aggregate_datums_with_rank(datums, order_by);
 
     // Decode the input (OriginalRow, InputValue) into separate datums, while keeping the OrderByRow
-    let mut args = Vec::new();
-    let mut original_rows = Vec::new();
-    let mut order_by_rows = Vec::new();
+    let size_hint = datums.size_hint().0;
+    let mut args = Vec::with_capacity(size_hint);
+    let mut original_rows = Vec::with_capacity(size_hint);
+    let mut order_by_rows = Vec::with_capacity(size_hint);
     for (d, order_by_row) in datums.into_iter() {
         let mut iter = d.unwrap_list().iter();
         let original_row = iter.next().unwrap();
@@ -1001,10 +1002,10 @@ where
 
     let input_datums_with_ranks = order_aggregate_datums_with_rank(input_datums, order_by);
 
-    // TODO: `with_capacity`
-    let mut encoded_argsss = vec![Vec::new(); funcs.len()];
-    let mut original_rows = Vec::new();
-    let mut order_by_rows = Vec::new();
+    let size_hint = input_datums_with_ranks.size_hint().0;
+    let mut encoded_argsss = vec![Vec::with_capacity(size_hint); funcs.len()];
+    let mut original_rows = Vec::with_capacity(size_hint);
+    let mut order_by_rows = Vec::with_capacity(size_hint);
     for (d, order_by_row) in input_datums_with_ranks {
         let mut iter = d.unwrap_list().iter();
         let original_row = iter.next().unwrap();
@@ -1019,8 +1020,7 @@ where
         }
     }
 
-    // TODO: `with_capacity`
-    let mut results_per_row = vec![Vec::new(); original_rows.len()];
+    let mut results_per_row = vec![Vec::with_capacity(funcs.len()); original_rows.len()];
     for (func, encoded_argss) in funcs.iter().zip_eq(encoded_argsss) {
         let results = match func {
             AggregateFunc::LagLead {

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -403,7 +403,10 @@ where
         .zip(1i64..)
         .map(|(d, i)| {
             temp_storage.make_datum(|packer| {
-                packer.push_list(vec![Datum::Int64(i), d]);
+                packer.push_list_with(|packer| {
+                    packer.push(Datum::Int64(i));
+                    packer.push(d);
+                });
             })
         });
 
@@ -448,7 +451,10 @@ where
             })
         }.3).into_iter().map(|(d, i)| {
         temp_storage.make_datum(|packer| {
-            packer.push_list(vec![Datum::Int64(i), d]);
+            packer.push_list_with(|packer| {
+                packer.push(Datum::Int64(i));
+                packer.push(d);
+            });
         })
     });
 
@@ -496,7 +502,10 @@ where
             })
         }.2).into_iter().map(|(d, i)| {
             temp_storage.make_datum(|packer| {
-                packer.push_list(vec![Datum::Int64(i), d]);
+                packer.push_list_with(|packer| {
+                    packer.push(Datum::Int64(i));
+                    packer.push(d);
+                });
             })
         });
 
@@ -561,7 +570,10 @@ where
         .zip_eq(orig_rows)
         .map(|(result_value, original_row)| {
             temp_storage.make_datum(|packer| {
-                packer.push_list(vec![result_value, original_row]);
+                packer.push_list_with(|packer| {
+                    packer.push(result_value);
+                    packer.push(original_row);
+                });
             })
         });
 
@@ -789,7 +801,10 @@ where
             .zip_eq(orig_rows)
             .map(|(result_value, original_row)| {
                 temp_storage.make_datum(|packer| {
-                    packer.push_list(vec![result_value, original_row]);
+                    packer.push_list_with(|packer| {
+                        packer.push(result_value);
+                        packer.push(original_row);
+                    });
                 })
             });
 
@@ -896,7 +911,10 @@ where
         .zip_eq(original_rows)
         .map(|(result_value, original_row)| {
             temp_storage.make_datum(|packer| {
-                packer.push_list(vec![result_value, original_row]);
+                packer.push_list_with(|packer| {
+                    packer.push(result_value);
+                    packer.push(original_row);
+                });
             })
         });
 
@@ -1078,10 +1096,10 @@ where
     let temp_storage = RowArena::with_capacity(2 * original_rows.len());
     let results_with_orig_rows = results_per_row.into_iter().enumerate().map(|(i, results)| {
         temp_storage.make_datum(|packer| {
-            packer.push_list(vec![
-                temp_storage.make_datum(|packer| packer.push_list(results)),
-                original_rows[i],
-            ]);
+            packer.push_list_with(|packer| {
+                packer.push(temp_storage.make_datum(|packer| packer.push_list(results)));
+                packer.push(original_rows[i]);
+            });
         })
     });
 
@@ -1450,7 +1468,10 @@ where
 
     let result = result.into_iter().map(|(result_value, original_row)| {
         temp_storage.make_datum(|packer| {
-            packer.push_list(vec![result_value, original_row]);
+            packer.push_list_with(|packer| {
+                packer.push(result_value);
+                packer.push(original_row);
+            });
         })
     });
 

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -2457,6 +2457,14 @@ impl RowArena {
         }
     }
 
+    /// Creates a `RowArena` with a hint of how many rows will be created in the arena, to avoid
+    /// reallocations of its internal vector.
+    pub fn with_capacity(capacity: usize) -> Self {
+        RowArena {
+            inner: RefCell::new(Vec::with_capacity(capacity)),
+        }
+    }
+
     /// Take ownership of `bytes` for the lifetime of the arena.
     #[allow(clippy::transmute_ptr_to_ptr)]
     pub fn push_bytes<'a>(&'a self, bytes: Vec<u8>) -> &'a [u8] {


### PR DESCRIPTION
This PR does a number of micro-optimizations in the window function code. https://github.com/MaterializeInc/accounts/issues/3 's new use case will push our window functions quite a bit, so we need all the performance we can get.

If this is deemed too many things in one PR, I could break it up!

~The 1st commit actually fixes a very minor bug, see commit msg.~ Edit: This was split off into a separate PR in the meantime: https://github.com/MaterializeInc/materialize/pull/29422

The ~2nd~ 1st commit adds a micro-benchmark, which can measure the effect of commits 3, 4, 5, ~6~. These commits give a ~6.5x~ 3.2x speedup in total on this benchmark. Edit: One of these commits were removed in the meantime, so there is 2x less speedup now.

Commits ~7, 8, 9~ 5, 6, 7 are just minor things (outside of the realm of the above micro-benchmark), with only a modest speedup.

(After this PR, the most CPU-consuming thing when executing window functions is by far the maintenance of Reduce's output arrangement. I'll work on this next, as discussed in the Tuesday hangout.)

### Motivation

* https://github.com/MaterializeInc/accounts/issues/3 's new use case will need all the window function performance we can get! https://github.com/MaterializeInc/materialize/issues/20741
* https://github.com/MaterializeInc/materialize/issues/29479

### Tips for reviewer

Review commit by commit. (Some commit msgs mention more details and/or speedups.)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
