### PR TITLE
ci: Also check incidents-and-escalations for ci-regexp

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -46,6 +46,7 @@ from materialize.buildkite_insights.util.build_step_utils import (
 )
 from materialize.cli.mzcompose import JUNIT_ERROR_DETAILS_SEPARATOR
 from materialize.github import (
+    GROUP_REPO,
     KnownGitHubIssue,
     for_github_re,
     get_known_issues_from_github,
@@ -454,7 +455,14 @@ def annotate_logged_errors(
     step_key: str = os.getenv("BUILDKITE_STEP_KEY", "")
     buildkite_label: str = os.getenv("BUILDKITE_LABEL", "")
 
-    (known_issues, issues_with_invalid_regex) = get_known_issues_from_github()
+    known_issues = []
+    issues_with_invalid_regex = []
+    for repo in GROUP_REPO.values():
+        (known_issues_repo, issues_with_invalid_regex_repo) = (
+            get_known_issues_from_github(repo)
+        )
+        known_issues.extend(known_issues_repo)
+        issues_with_invalid_regex.extend(issues_with_invalid_regex_repo)
     unknown_errors: list[ObservedBaseError] = []
     unknown_errors.extend(issues_with_invalid_regex)
 

--- a/misc/python/materialize/cli/ci_closed_issues_detect.py
+++ b/misc/python/materialize/cli/ci_closed_issues_detect.py
@@ -20,6 +20,7 @@ from typing import IO
 import requests
 
 from materialize import buildkite, spawn
+from materialize.github import GROUP_REPO
 
 ISSUE_RE = re.compile(
     r"""
@@ -31,13 +32,6 @@ ISSUE_RE = re.compile(
     """,
     re.VERBOSE,
 )
-
-GROUP_REPO = {
-    "timelydataflow": "TimelyDataflow/timely-dataflow",
-    "materialize": "MaterializeInc/materialize",
-    "cloud": "MaterializeInc/cloud",
-    "incidentsandescalations": "MaterializeInc/incidents-and-escalations",
-}
 
 REFERENCE_RE = re.compile(
     r"""

--- a/misc/python/materialize/github.py
+++ b/misc/python/materialize/github.py
@@ -21,6 +21,13 @@ from materialize.observed_error import ObservedBaseError, WithIssue
 CI_RE = re.compile("ci-regexp: (.*)")
 CI_APPLY_TO = re.compile("ci-apply-to: (.*)")
 
+GROUP_REPO = {
+    "timelydataflow": "TimelyDataflow/timely-dataflow",
+    "materialize": "MaterializeInc/materialize",
+    "cloud": "MaterializeInc/cloud",
+    "incidentsandescalations": "MaterializeInc/incidents-and-escalations",
+}
+
 
 @dataclass
 class KnownGitHubIssue:
@@ -40,7 +47,7 @@ class GitHubIssueWithInvalidRegexp(ObservedBaseError, WithIssue):
         return f'<a href="{self.issue_url}">{self.issue_title} (#{self.issue_number})</a>: Invalid regex in ci-regexp: {self.regex_pattern}, ignoring'
 
 
-def get_known_issues_from_github_page(page: int = 1) -> Any:
+def get_known_issues_from_github_page(repo: str, page: int = 1) -> Any:
     headers = {
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
@@ -49,7 +56,7 @@ def get_known_issues_from_github_page(page: int = 1) -> Any:
         headers["Authorization"] = f"Bearer {token}"
 
     response = requests.get(
-        f'https://api.github.com/search/issues?q=repo:MaterializeInc/materialize%20type:issue%20in:body%20"ci-regexp%3A"&per_page=100&page={page}',
+        f'https://api.github.com/search/issues?q=repo:{repo}%20type:issue%20in:body%20"ci-regexp%3A"&per_page=100&page={page}',
         headers=headers,
     )
 
@@ -61,14 +68,14 @@ def get_known_issues_from_github_page(page: int = 1) -> Any:
     return issues_json
 
 
-def get_known_issues_from_github() -> (
-    tuple[list[KnownGitHubIssue], list[GitHubIssueWithInvalidRegexp]]
-):
+def get_known_issues_from_github(
+    repo: str,
+) -> tuple[list[KnownGitHubIssue], list[GitHubIssueWithInvalidRegexp]]:
     page = 1
-    issues_json = get_known_issues_from_github_page(page)
+    issues_json = get_known_issues_from_github_page(repo, page)
     while issues_json["total_count"] > len(issues_json["items"]):
         page += 1
-        next_page_json = get_known_issues_from_github_page(page)
+        next_page_json = get_known_issues_from_github_page(repo, page)
         if not next_page_json["items"]:
             break
         issues_json["items"].extend(next_page_json["items"])


### PR DESCRIPTION
Mainly motivated by https://github.com/MaterializeInc/incidents-and-escalations/issues/72 which would have silenced the parallel workload failure here: https://buildkite.com/materialize/nightly/builds/9405#0191bf60-478f-410d-bdba-693f97bee157

    parallel-workload-materialized-1     | thread 'timely:work-0' panicked at /var/lib/buildkite-agent/builds/buildkite-builders-aarch64-585fc7f-i-038ffe6283a5930a9-1/materialize/test/src/persist-client/src/internal/state.rs:1472:17: LeasedReaderId(r7ef9c21d-4778-4cbb-b24b-6e5e1258754f) was expired due to inactivity. Did the machine go to sleep?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
