### PR TITLE
tests: Move longer Zippys back to AWS

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -45,7 +45,8 @@ steps:
       # 48h
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        # TODO: Move back to Hetzner when agent lost issues are fixed
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -58,7 +59,8 @@ steps:
       # 24h
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        # TODO: Move back to Hetzner when agent lost issues are fixed
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -70,7 +72,8 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        # TODO: Move back to Hetzner when agent lost issues are fixed
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -82,7 +85,8 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        # TODO: Move back to Hetzner when agent lost issues are fixed
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -93,7 +97,8 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        # TODO: Move back to Hetzner when agent lost issues are fixed
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -105,7 +110,8 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        # TODO: Move back to Hetzner when agent lost issues are fixed
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -116,7 +122,8 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        # TODO: Move back to Hetzner when agent lost issues are fixed
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -128,8 +135,8 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        # Runs out of disk
-        queue: hetzner-aarch64-16cpu-32gb
+        # TODO: Move back to Hetzner when agent lost issues are fixed
+        queue: linux-aarch64
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -142,7 +149,8 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        # TODO: Move back to Hetzner when agent lost issues are fixed
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy


### PR DESCRIPTION
See https://github.com/buildkite/agent/issues/2969
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
