### PR TITLE
Revert "ci: Also check incidents-and-escalations for ci-regexp"

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -46,7 +46,6 @@ from materialize.buildkite_insights.util.build_step_utils import (
 )
 from materialize.cli.mzcompose import JUNIT_ERROR_DETAILS_SEPARATOR
 from materialize.github import (
-    GROUP_REPO,
     KnownGitHubIssue,
     for_github_re,
     get_known_issues_from_github,
@@ -455,14 +454,7 @@ def annotate_logged_errors(
     step_key: str = os.getenv("BUILDKITE_STEP_KEY", "")
     buildkite_label: str = os.getenv("BUILDKITE_LABEL", "")
 
-    known_issues = []
-    issues_with_invalid_regex = []
-    for repo in GROUP_REPO.values():
-        (known_issues_repo, issues_with_invalid_regex_repo) = (
-            get_known_issues_from_github(repo)
-        )
-        known_issues.extend(known_issues_repo)
-        issues_with_invalid_regex.extend(issues_with_invalid_regex_repo)
+    (known_issues, issues_with_invalid_regex) = get_known_issues_from_github()
     unknown_errors: list[ObservedBaseError] = []
     unknown_errors.extend(issues_with_invalid_regex)
 

--- a/misc/python/materialize/cli/ci_closed_issues_detect.py
+++ b/misc/python/materialize/cli/ci_closed_issues_detect.py
@@ -20,7 +20,6 @@ from typing import IO
 import requests
 
 from materialize import buildkite, spawn
-from materialize.github import GROUP_REPO
 
 ISSUE_RE = re.compile(
     r"""
@@ -32,6 +31,13 @@ ISSUE_RE = re.compile(
     """,
     re.VERBOSE,
 )
+
+GROUP_REPO = {
+    "timelydataflow": "TimelyDataflow/timely-dataflow",
+    "materialize": "MaterializeInc/materialize",
+    "cloud": "MaterializeInc/cloud",
+    "incidentsandescalations": "MaterializeInc/incidents-and-escalations",
+}
 
 REFERENCE_RE = re.compile(
     r"""

--- a/misc/python/materialize/github.py
+++ b/misc/python/materialize/github.py
@@ -21,13 +21,6 @@ from materialize.observed_error import ObservedBaseError, WithIssue
 CI_RE = re.compile("ci-regexp: (.*)")
 CI_APPLY_TO = re.compile("ci-apply-to: (.*)")
 
-GROUP_REPO = {
-    "timelydataflow": "TimelyDataflow/timely-dataflow",
-    "materialize": "MaterializeInc/materialize",
-    "cloud": "MaterializeInc/cloud",
-    "incidentsandescalations": "MaterializeInc/incidents-and-escalations",
-}
-
 
 @dataclass
 class KnownGitHubIssue:
@@ -47,7 +40,7 @@ class GitHubIssueWithInvalidRegexp(ObservedBaseError, WithIssue):
         return f'<a href="{self.issue_url}">{self.issue_title} (#{self.issue_number})</a>: Invalid regex in ci-regexp: {self.regex_pattern}, ignoring'
 
 
-def get_known_issues_from_github_page(repo: str, page: int = 1) -> Any:
+def get_known_issues_from_github_page(page: int = 1) -> Any:
     headers = {
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
@@ -56,7 +49,7 @@ def get_known_issues_from_github_page(repo: str, page: int = 1) -> Any:
         headers["Authorization"] = f"Bearer {token}"
 
     response = requests.get(
-        f'https://api.github.com/search/issues?q=repo:{repo}%20type:issue%20in:body%20"ci-regexp%3A"&per_page=100&page={page}',
+        f'https://api.github.com/search/issues?q=repo:MaterializeInc/materialize%20type:issue%20in:body%20"ci-regexp%3A"&per_page=100&page={page}',
         headers=headers,
     )
 
@@ -68,14 +61,14 @@ def get_known_issues_from_github_page(repo: str, page: int = 1) -> Any:
     return issues_json
 
 
-def get_known_issues_from_github(
-    repo: str,
-) -> tuple[list[KnownGitHubIssue], list[GitHubIssueWithInvalidRegexp]]:
+def get_known_issues_from_github() -> (
+    tuple[list[KnownGitHubIssue], list[GitHubIssueWithInvalidRegexp]]
+):
     page = 1
-    issues_json = get_known_issues_from_github_page(repo, page)
+    issues_json = get_known_issues_from_github_page(page)
     while issues_json["total_count"] > len(issues_json["items"]):
         page += 1
-        next_page_json = get_known_issues_from_github_page(repo, page)
+        next_page_json = get_known_issues_from_github_page(page)
         if not next_page_json["items"]:
             break
         issues_json["items"].extend(next_page_json["items"])


### PR DESCRIPTION
Reverts MaterializeInc/materialize#29389

We probably have to give the token necessary permissions first, seems to cause CI failures.

> Uploading results failed! Bad return code from GitHub: 422