### PR TITLE
storage: infrastructure for reclocking to latest frontier

### DIFF
--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -205,6 +205,14 @@ pub const STORAGE_USE_RECLOCK_V2: Config<bool> = Config::new(
     "Whether to use the new reclock implementation.",
 );
 
+/// Whether to mint reclock bindings based on the latest probed frontier or the currently ingested
+/// frontier.
+pub const STORAGE_RECLOCK_TO_LATEST: Config<bool> = Config::new(
+    "storage_reclock_to_latest",
+    false,
+    "Whether to mint reclock bindings based on the latest probed offset or the latest ingested offset."
+);
+
 /// Adds the full set of all storage `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -227,4 +235,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&STORAGE_ROCKSDB_CLEANUP_TRIES)
         .add(&STORAGE_SUSPEND_AND_RESTART_DELAY)
         .add(&STORAGE_USE_RECLOCK_V2)
+        .add(&STORAGE_RECLOCK_TO_LATEST)
 }

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -113,6 +113,15 @@ pub struct SourceMessage {
     pub metadata: Row,
 }
 
+/// The result of probing an upstream system for its write frontier.
+#[derive(Debug, Clone)]
+pub struct Probe<T> {
+    /// The timestamp at which this probe was initiated.
+    pub probe_ts: mz_repr::Timestamp,
+    /// The frontier obtain from the upstream system.
+    pub upstream_frontier: Antichain<T>,
+}
+
 mod columnation {
     use columnation::{Columnation, Region};
     use mz_repr::Row;


### PR DESCRIPTION
This PR adds the infrastructure to support minting reclock bindings according to the latest probed upstream frontier. This lives side by side the current strategy which mints based on a local timer and the frontier we have ingested so far. Which one is used is controlled by an LD flag.

Note that this PR only implements the necessary plumbing to suppored probed frontier minting but no source is currently connected so turning the flag on will effectively result in no bindings to be minted. I will connect the sources to the mechanism introduced here in a follow up PR.

The way in which this is implemented is by removing the decision of the binding timestamps from the `ReclockOperator` which now expects them as an argument. Under the new semantics whoever is using calling the `mint` function is effectively proposing a new binding to be minted which is only accepted if both the mz frontier and the recorded source frontier are advancing.

The calling code calls the new mint function based on probed or ingested uppers depending on a feature flag. When using the ingested frontier the associated binding timestamp is taken from the current wall clock as before. When using the probed froniter the associated binding timestamp is the initiation time of the probe.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
