### PR TITLE
compute: decouple frontier introspection reporting

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -412,26 +412,6 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
             .map_err(|e| e.into())
     }
 
-    /// Returns a map with the read and write frontiers of each collection.
-    pub fn collect_collection_frontiers(&self) -> BTreeMap<GlobalId, (Antichain<T>, Antichain<T>)> {
-        let collections = self.instances.values().flat_map(|i| i.collections_iter());
-        collections
-            .map(|(id, collection)| {
-                let since = collection.read_frontier().to_owned();
-                let upper = collection.write_frontier().to_owned();
-                (id, (since, upper))
-            })
-            .collect()
-    }
-
-    /// Returns a map with the write frontier of each collection installed on each replica.
-    pub fn collect_replica_write_frontiers(&self) -> BTreeMap<(GlobalId, ReplicaId), Antichain<T>> {
-        self.instances
-            .values()
-            .flat_map(|i| i.replica_write_frontiers())
-            .collect()
-    }
-
     /// Returns the state of the [`ComputeController`] formatted as JSON.
     ///
     /// The returned value is not guaranteed to be stable and may change at any point in time.

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -53,7 +53,7 @@ use mz_storage_types::read_policy::ReadPolicy;
 use prometheus::proto::LabelPair;
 use serde::{Deserialize, Serialize};
 use timely::progress::frontier::AntichainRef;
-use timely::progress::{Antichain, Timestamp};
+use timely::progress::Antichain;
 use tokio::time::{self, MissedTickBehavior};
 use tracing::warn;
 use uuid::Uuid;
@@ -142,7 +142,7 @@ impl ComputeReplicaLogging {
 }
 
 /// A controller for the compute layer.
-pub struct ComputeController<T: Timestamp> {
+pub struct ComputeController<T: ComputeControllerTimestamp> {
     instances: BTreeMap<ComputeInstanceId, Instance<T>>,
     /// A map from an instance ID to an arbitrary string that describes the
     /// class of the workload that compute instance is running (e.g.,

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -344,19 +344,6 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
         self.collections.remove(&id);
     }
 
-    /// Returns the write frontier for each collection installed on each replica.
-    pub fn replica_write_frontiers(
-        &self,
-    ) -> impl Iterator<Item = ((GlobalId, ReplicaId), Antichain<T>)> + '_ {
-        self.replicas.iter().flat_map(|(replica_id, replica)| {
-            let collections = replica.collections.iter();
-            collections.map(|(collection_id, collection)| {
-                let frontier = collection.write_frontier.clone();
-                ((*collection_id, *replica_id), frontier)
-            })
-        })
-    }
-
     fn add_replica_state(
         &mut self,
         id: ReplicaId,

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -147,7 +147,7 @@ enum Readiness<T> {
 }
 
 /// A client that maintains soft state and validates commands, in addition to forwarding them.
-pub struct Controller<T: Timestamp = mz_repr::Timestamp> {
+pub struct Controller<T: ComputeControllerTimestamp = mz_repr::Timestamp> {
     pub storage: Box<dyn StorageController<Timestamp = T>>,
     pub storage_collections: Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
     pub compute: ComputeController<T>,

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -625,12 +625,10 @@ where
     }
 
     fn record_frontiers(&mut self) {
-        let compute_frontiers = self.compute.collect_collection_frontiers();
-        self.storage.record_frontiers(compute_frontiers);
-
-        let compute_replica_frontiers = self.compute.collect_replica_write_frontiers();
-        self.storage
-            .record_replica_frontiers(compute_replica_frontiers);
+        // TODO(teskje): There is no need for the global `Controller` to be what's ticking the
+        // frontier recording. We should do this inside the storage controller instead.
+        self.storage.record_frontiers();
+        self.storage.record_replica_frontiers();
     }
 
     /// Determine the "real-time recency" timestamp for all `ids`.

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -699,33 +699,10 @@ pub trait StorageController: Debug {
         -> Result<serde_json::Value, anyhow::Error>;
 
     /// Records the current read and write frontiers of all known storage objects.
-    ///
-    /// The provided `external_frontiers` are merged with the frontiers known to
-    /// the storage controller. If `external_frontiers` contains entries with
-    /// object IDs that are known to storage controller, the storage
-    /// controller's frontiers take precedence. The rationale is that the
-    /// storage controller should be the authority on frontiers of storage
-    /// objects, not the caller of this method.
-    fn record_frontiers(
-        &mut self,
-        external_frontiers: BTreeMap<
-            GlobalId,
-            (Antichain<Self::Timestamp>, Antichain<Self::Timestamp>),
-        >,
-    );
+    fn record_frontiers(&mut self);
 
     /// Records the current per-replica write frontiers of all known storage objects.
-    ///
-    /// The provided `external_frontiers` are merged with the frontiers known to
-    /// the storage controller. If `external_frontiers` contains entries with
-    /// object IDs that are known to storage controller, the storage
-    /// controller's frontiers take precedence. The rationale is that the
-    /// storage controller should be the authority on frontiers of storage
-    /// objects, not the caller of this method.
-    fn record_replica_frontiers(
-        &mut self,
-        external_frontiers: BTreeMap<(GlobalId, ReplicaId), Antichain<Self::Timestamp>>,
-    );
+    fn record_replica_frontiers(&mut self);
 
     /// Records append-only updates for the given introspection type.
     ///

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2059,14 +2059,8 @@ where
         Ok(json_state)
     }
 
-    fn record_frontiers(
-        &mut self,
-        external_frontiers: BTreeMap<
-            GlobalId,
-            (Antichain<Self::Timestamp>, Antichain<Self::Timestamp>),
-        >,
-    ) {
-        let mut frontiers = external_frontiers;
+    fn record_frontiers(&mut self) {
+        let mut frontiers = BTreeMap::new();
 
         // Enrich `frontiers` with storage frontiers.
         for CollectionFrontiers {
@@ -2119,11 +2113,8 @@ where
         self.collection_manager.differential_append(id, updates);
     }
 
-    fn record_replica_frontiers(
-        &mut self,
-        external_frontiers: BTreeMap<(GlobalId, ReplicaId), Antichain<Self::Timestamp>>,
-    ) {
-        let mut frontiers = external_frontiers;
+    fn record_replica_frontiers(&mut self) {
+        let mut frontiers = BTreeMap::new();
 
         // Enrich `frontiers` with storage frontiers.
         let mut uppers: BTreeMap<GlobalId, Antichain<Self::Timestamp>> = self


### PR DESCRIPTION
This PR changes the way frontier introspection (what populated `mz_frontiers` and `mz_cluster_replica_frontiers`) works for compute frontiers. Previously, the top-level `Controller` would wake up once a second, fetch the current global and replica frontiers from the compute controller, and send them to the storage controller, which would add its own frontiers and write everything to the introspection collections.

With this change, the top-level `Controller` still wakes up every second, but it now only tells the storage controller to record its own frontiers. The compute frontiers are now recorded inside the compute controller, using the existing infrastructure for maintaining introspection data (`CollectionIntrospection` and `introspecton_tx`). The reporting of storage frontiers can now be moved in the storage controller too, but to limit the scope of this PR this is left as future work.

This change is motivated by the work of decoupling the compute controller from the coordinator (#27656). Once the `Instance` controllers run in their own task, the top-level `Controller` won't be able to reach in and collect compute frontiers anymore, but the `Instance` tasks will still be able to send updates through the `introspection_tx`.

### Motivation

  * This PR adds a known-desirable feature.

Part of #27656

### Tips for reviewer

The PR is split into sensible commits with detailed commit messages.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
