### PR TITLE
Fix legacy path and re-enable the test

### DIFF
--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -805,6 +805,7 @@ fn apply_diffs_spine<T: Timestamp + Lattice>(
         match apply_compaction_lenient(metrics, batches, &res.output) {
             Ok(batches) => {
                 let mut new_trace = Trace::default();
+                new_trace.roundtrip_structure = trace.roundtrip_structure;
                 new_trace.downgrade_since(trace.since());
                 for batch in batches {
                     // Ignore merge_reqs because whichever process generated
@@ -854,6 +855,7 @@ fn apply_diffs_spine<T: Timestamp + Lattice>(
             // we can try to apply our diffs on top of these new (potentially) merged
             // batches.
             let mut reconstructed_spine = Trace::default();
+            reconstructed_spine.roundtrip_structure = trace.roundtrip_structure;
             trace.map_batches(|b| {
                 // Ignore merge_reqs because whichever process generated this
                 // diff is assigned the work.
@@ -868,6 +870,7 @@ fn apply_diffs_spine<T: Timestamp + Lattice>(
     };
 
     let mut new_trace = Trace::default();
+    new_trace.roundtrip_structure = trace.roundtrip_structure;
     new_trace.downgrade_since(trace.since());
     for (batch, ()) in batches {
         // Ignore merge_reqs because whichever process generated this diff is
@@ -1263,7 +1266,6 @@ mod tests {
     /// is applying those changes as diffs.
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // too slow
-    #[ignore] // TODO: Reenable when #29385 is fixed
     fn test_state_sync() {
         use proptest::prelude::*;
 


### PR DESCRIPTION
This was an interesting test failure! Proptest was finding a sequence of changes that reliably hit the "slow path" state sync code, which involves rebuilding a trace from scratch. My recent change to make the default of trace structured meant that applying diffs also caused the follower to enable structured-data roundtripping, even if the upstream code had not, causing the two states to get out of sync.

This code explicitly sets the flag to match the input trace in the legacy path. (Which is in practice on this codepath always false.)

Fun fact: the smallest repro for this appears to be eight separate operations, including a mix of empty and non-empty appends and compactions. Property testing's great.

### Motivation

Fixes #29385.

### Tips for reviewer

In other circumstances I'd make a constructor that required you to specify the behaviour you wanted explicitly, but this whole codepath is hopefully going away next week, so I tried to keep the changes limited to code that was about to be deleted anyways. I can do the constructor / remove the default impl if this feels less clear however!

The new impl survives 10k iterations via `cargo stress`, which I think is good enough for me.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
