### PR TITLE
storage/sources: Fix SHOW SOURCE command for sources that may have multiple subsources with the same reference

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3648,7 +3648,7 @@ impl Coordinator {
                     .filter_map(|subsource| {
                         catalog
                             .get_entry(subsource)
-                            .source_export_details()
+                            .subsource_details()
                             .map(|(_id, reference, _details)| reference)
                     })
                     .collect();

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -613,6 +613,10 @@ pub trait CatalogItem {
     /// Returns the IDs of the catalog items that depend upon this catalog item.
     fn used_by(&self) -> &[GlobalId];
 
+    /// Reports whether this catalog entry is a subsource and, if it is, the
+    /// ingestion it is an export of, as well as the item it exports.
+    fn subsource_details(&self) -> Option<(GlobalId, &UnresolvedItemName, &SourceExportDetails)>;
+
     /// Reports whether this catalog entry is a source export and, if it is, the
     /// ingestion it is an export of, as well as the item it exports.
     fn source_export_details(


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

While subsources with the same external reference are not officially supported, they are possible. (A side-effect of the source-versioning work to implement `CREATE TABLE .. FROM SOURCE` statements).

@def- noticed that the `SHOW CREATE SOURCE` might not accurately present the subsource references inside a `CREATE SOURCE` statement when multiple refer to the same upstream reference, so this is a fix for that. Note that this is all going to be deprecated soon once the work in #28430 is completed.

It also fixes a misnamed method on `CatalogEntry` to make it clear when the object is an actual subsource item or a source-export (either a subsource or a source-fed table).

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
