### PR TITLE
catalog: Optimize item loading on startup

### DIFF
--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -26,7 +26,7 @@ use prost::Message;
 use semver::Version;
 use tracing::info;
 // DO NOT add any more imports from `crate` outside of `crate::catalog`.
-use crate::catalog::open::into_consolidatable_updates;
+use crate::catalog::open::into_consolidatable_updates_startup;
 use crate::catalog::{BuiltinTableUpdate, CatalogState, ConnCatalog};
 
 async fn rewrite_ast_items<F>(tx: &mut Transaction<'_>, mut f: F) -> Result<(), anyhow::Error>
@@ -132,9 +132,9 @@ pub(crate) async fn migrate(
     // Load items into catalog. We make sure to consolidate the old updates with the new updates to
     // avoid trying to apply unmigrated items.
     let commit_ts = tx.commit_ts();
-    let mut item_updates = into_consolidatable_updates(item_updates, commit_ts);
+    let mut item_updates = into_consolidatable_updates_startup(item_updates, commit_ts);
     let op_item_updates = tx.get_and_commit_op_updates();
-    let op_item_updates = into_consolidatable_updates(op_item_updates, commit_ts);
+    let op_item_updates = into_consolidatable_updates_startup(op_item_updates, commit_ts);
     item_updates.extend(op_item_updates);
     differential_dataflow::consolidation::consolidate_updates(&mut item_updates);
     let item_updates = item_updates

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -318,7 +318,7 @@ impl Catalog {
         // Make life easier by consolidating all updates, so that we end up with only positive
         // diffs.
         let commit_ts = txn.commit_ts();
-        let mut updates = into_consolidatable_updates(updates, commit_ts);
+        let mut updates = into_consolidatable_updates_startup(updates, commit_ts);
         differential_dataflow::consolidation::consolidate_updates(&mut updates);
         soft_assert_no_log!(
             updates.iter().all(|(_, _, diff)| *diff == 1),
@@ -1305,7 +1305,9 @@ impl BuiltinBootstrapClusterSizes {
 /// [`mz_catalog::memory::objects::StateUpdateKind`] into an [`BootstrapStateUpdateKind`], which is
 /// identical to [`mz_catalog::memory::objects::StateUpdateKind`] except it doesn't have a
 /// temporary item variant and does implement [`std::cmp::Ord`].
-pub(crate) fn into_consolidatable_updates(
+///
+/// WARNING: Do not call outside of startup.
+pub(crate) fn into_consolidatable_updates_startup(
     updates: Vec<StateUpdate>,
     ts: Timestamp,
 ) -> Vec<(BootstrapStateUpdateKind, Timestamp, Diff)> {


### PR DESCRIPTION
Previously, loading user items into the catalog on startup looked something like this:

  1. Apply AST migrations to the persisted CREATE SQLs for each item.
  2. Load all user items into a temporary in-memory catalog.
  3. Generate item migrations to all user items from the temporary in-memory catalog.
  4. Drop the temporary catalog.
  5. Load all migrated user items into the permanent in-memory catalog.

This process is unnecessarily expensive because we end up parsing, planning, and optimizing all user items twice.

This commit updates the process to look something like this:

  1. Apply AST migrations to the persisted CREATE SQLs for each item.
  2. Load all user items into the permanent in-memory catalog.
  3. Generate item migrations to all user items from the permanent in-memory catalog.
  4. Apply the migrations to the permanent in-memory catalog.

This avoids duplicating the parsing, planning, and optimization work.

Works towards resolving #28722

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
