### PR TITLE
Arc cached plans in the catalog

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -144,8 +144,8 @@ impl Clone for Catalog {
 
 #[derive(Default, Debug, Clone)]
 pub struct CatalogPlans {
-    optimized_plan_by_id: BTreeMap<GlobalId, DataflowDescription<OptimizedMirRelationExpr>>,
-    physical_plan_by_id: BTreeMap<GlobalId, DataflowDescription<mz_compute_types::plan::Plan>>,
+    optimized_plan_by_id: BTreeMap<GlobalId, Arc<DataflowDescription<OptimizedMirRelationExpr>>>,
+    physical_plan_by_id: BTreeMap<GlobalId, Arc<DataflowDescription<mz_compute_types::plan::Plan>>>,
     dataflow_metainfos: BTreeMap<GlobalId, DataflowMetainfo<Arc<OptimizerNotice>>>,
     notices_by_dep_id: BTreeMap<GlobalId, SmallVec<[Arc<OptimizerNotice>; 4]>>,
 }
@@ -158,7 +158,7 @@ impl Catalog {
         id: GlobalId,
         plan: DataflowDescription<OptimizedMirRelationExpr>,
     ) {
-        self.plans.optimized_plan_by_id.insert(id, plan);
+        self.plans.optimized_plan_by_id.insert(id, plan.into());
     }
 
     /// Set the optimized plan for the item identified by `id`.
@@ -168,7 +168,7 @@ impl Catalog {
         id: GlobalId,
         plan: DataflowDescription<mz_compute_types::plan::Plan>,
     ) {
-        self.plans.physical_plan_by_id.insert(id, plan);
+        self.plans.physical_plan_by_id.insert(id, plan.into());
     }
 
     /// Try to get the optimized plan for the item identified by `id`.
@@ -177,7 +177,7 @@ impl Catalog {
         &self,
         id: &GlobalId,
     ) -> Option<&DataflowDescription<OptimizedMirRelationExpr>> {
-        self.plans.optimized_plan_by_id.get(id)
+        self.plans.optimized_plan_by_id.get(id).map(AsRef::as_ref)
     }
 
     /// Try to get the optimized plan for the item identified by `id`.
@@ -186,7 +186,7 @@ impl Catalog {
         &self,
         id: &GlobalId,
     ) -> Option<&DataflowDescription<mz_compute_types::plan::Plan>> {
-        self.plans.physical_plan_by_id.get(id)
+        self.plans.physical_plan_by_id.get(id).map(AsRef::as_ref)
     }
 
     /// Set the `DataflowMetainfo` for the item identified by `id`.

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1413,14 +1413,14 @@ mod builtin_migration_tests {
                                 column_types: Vec::new(),
                                 keys: Vec::new(),
                             },
-                        ),
+                        ).into(),
                         optimized_expr: OptimizedMirRelationExpr(MirRelationExpr::Constant {
                             rows: Ok(Vec::new()),
                             typ: RelationType {
                                 column_types: Vec::new(),
                                 keys: Vec::new(),
                             },
-                        }),
+                        }).into(),
                         desc: RelationDesc::builder()
                             .with_column("a", ScalarType::Int32.nullable(true))
                             .with_key(vec![0])

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1438,7 +1438,7 @@ mod builtin_migration_tests {
                     CatalogItem::Index(Index {
                         create_sql: format!("CREATE INDEX idx ON materialize.public.{on} (a)"),
                         on: on_id,
-                        keys: Vec::new(),
+                        keys: Default::default(),
                         conn_id: None,
                         resolved_ids: ResolvedIds(BTreeSet::from_iter([on_id])),
                         cluster_id: ClusterId::User(1),

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -945,7 +945,7 @@ impl CatalogState {
             Plan::CreateIndex(CreateIndexPlan { index, .. }) => CatalogItem::Index(Index {
                 create_sql: index.create_sql,
                 on: index.on,
-                keys: index.keys,
+                keys: index.keys.into(),
                 conn_id: None,
                 resolved_ids,
                 cluster_id: index.cluster_id,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -902,9 +902,9 @@ impl CatalogState {
 
                 CatalogItem::View(View {
                     create_sql: view.create_sql,
-                    raw_expr,
+                    raw_expr: raw_expr.into(),
                     desc: RelationDesc::new(optimized_expr.typ(), view.column_names),
-                    optimized_expr,
+                    optimized_expr: optimized_expr.into(),
                     conn_id: None,
                     resolved_ids,
                 })
@@ -931,8 +931,8 @@ impl CatalogState {
 
                 CatalogItem::MaterializedView(MaterializedView {
                     create_sql: materialized_view.create_sql,
-                    raw_expr,
-                    optimized_expr,
+                    raw_expr: raw_expr.into(),
+                    optimized_expr: optimized_expr.into(),
                     desc,
                     resolved_ids,
                     cluster_id: materialized_view.cluster_id,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2601,7 +2601,8 @@ impl Coordinator {
                         );
 
                         // MIR ⇒ MIR optimization (global)
-                        let global_mir_plan = optimizer.optimize(mv.optimized_expr.clone())?;
+                        let global_mir_plan =
+                            optimizer.optimize(mv.optimized_expr.as_ref().clone())?;
                         let optimized_plan = global_mir_plan.df_desc().clone();
 
                         // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2543,8 +2543,11 @@ impl Coordinator {
                         );
 
                         // MIR ⇒ MIR optimization (global)
-                        let index_plan =
-                            optimize::index::Index::new(entry.name(), &idx.on, &idx.keys);
+                        let index_plan = optimize::index::Index::new(
+                            entry.name().clone(),
+                            idx.on,
+                            idx.keys.to_vec(),
+                        );
                         let global_mir_plan = optimizer.optimize(index_plan)?;
                         let optimized_plan = global_mir_plan.df_desc().clone();
 

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -90,7 +90,7 @@ impl IndexOracle for DataflowBuilder<'_> {
     ) -> Box<dyn Iterator<Item = (GlobalId, &[MirScalarExpr])> + '_> {
         Box::new(
             self.indexes_on(id)
-                .map(|(idx_id, idx)| (idx_id, idx.keys.as_slice())),
+                .map(|(idx_id, idx)| (idx_id, idx.keys.as_ref())),
         )
     }
 }

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -332,7 +332,7 @@ impl Coordinator {
                     let _dispatch_guard = explain_ctx.dispatch_guard();
 
                     let index_plan =
-                        optimize::index::Index::new(&plan.name, &plan.index.on, &plan.index.keys);
+                        optimize::index::Index::new(plan.name.clone(), plan.index.on, plan.index.keys.clone());
 
                     // MIR ⇒ MIR optimization (global)
                     let global_mir_plan = optimizer.catch_unwind_optimize(index_plan)?;
@@ -426,7 +426,7 @@ impl Coordinator {
             name: name.clone(),
             item: CatalogItem::Index(Index {
                 create_sql,
-                keys,
+                keys: keys.into(),
                 on,
                 conn_id: None,
                 resolved_ids,

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -254,7 +254,7 @@ impl Coordinator {
 
         let explain = match stage {
             ExplainStage::RawPlan => explain_plan(
-                view.raw_expr.clone(),
+                view.raw_expr.as_ref().clone(),
                 format,
                 &config,
                 &features,
@@ -623,8 +623,8 @@ impl Coordinator {
                 name: name.clone(),
                 item: CatalogItem::MaterializedView(MaterializedView {
                     create_sql,
-                    raw_expr,
-                    optimized_expr: local_mir_plan.expr(),
+                    raw_expr: raw_expr.into(),
+                    optimized_expr: local_mir_plan.expr().into(),
                     desc: global_lir_plan.desc().clone(),
                     resolved_ids,
                     cluster_id,

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -212,7 +212,7 @@ impl Coordinator {
 
         let explain = match stage {
             ExplainStage::RawPlan => explain_plan(
-                view.raw_expr.clone(),
+                view.raw_expr.as_ref().clone(),
                 format,
                 &config,
                 &features,
@@ -397,9 +397,9 @@ impl Coordinator {
                 name: name.clone(),
                 item: CatalogItem::View(View {
                     create_sql: create_sql.clone(),
-                    raw_expr,
+                    raw_expr: raw_expr.into(),
                     desc: RelationDesc::new(optimized_expr.typ(), column_names.clone()),
-                    optimized_expr,
+                    optimized_expr: optimized_expr.into(),
                     conn_id: if temporary {
                         Some(session.conn_id().clone())
                     } else {

--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -217,8 +217,8 @@ impl<'a> DataflowBuilder<'a> {
                         dataflow.import_source(*id, source.desc.typ().clone(), monotonic);
                     }
                     CatalogItem::View(view) => {
-                        let expr = view.optimized_expr.clone();
-                        self.import_view_into_dataflow(id, &expr, dataflow, features)?;
+                        let expr = view.optimized_expr.as_ref();
+                        self.import_view_into_dataflow(id, expr, dataflow, features)?;
                     }
                     CatalogItem::MaterializedView(mview) => {
                         dataflow.import_source(*id, mview.desc.typ().clone(), monotonic);

--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -282,7 +282,7 @@ impl<'a> DataflowBuilder<'a> {
                 .entered();
 
                 // Reoptimize the view and update the resulting `desc.plan`.
-                desc.plan = view_optimizer.optimize(view.raw_expr.clone())?;
+                desc.plan = view_optimizer.optimize(view.raw_expr.as_ref().clone())?;
 
                 // Report the optimized plan under this span.
                 trace_plan(desc.plan.as_inner());
@@ -338,7 +338,7 @@ impl<'a> DataflowBuilder<'a> {
             match self.catalog.get_entry(&id).item() {
                 CatalogItem::Source(source) => Ok(self.monotonic_source(source)),
                 CatalogItem::View(View { optimized_expr, .. }) => {
-                    let view_expr = optimized_expr.clone().into_inner();
+                    let view_expr = optimized_expr.as_ref().clone().into_inner();
 
                     // Inspect global ids that occur in the Gets in view_expr, and collect the ids
                     // of monotonic dependees.

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -94,16 +94,8 @@ pub struct Index {
 }
 
 impl Index {
-    pub fn new(
-        name: &QualifiedItemName,
-        on: &GlobalId,
-        keys: &Vec<mz_expr::MirScalarExpr>,
-    ) -> Self {
-        Self {
-            name: name.clone(),
-            on: on.clone(),
-            keys: keys.clone(),
-        }
+    pub fn new(name: QualifiedItemName, on: GlobalId, keys: Vec<mz_expr::MirScalarExpr>) -> Self {
+        Self { name, on, keys }
     }
 }
 
@@ -204,11 +196,11 @@ impl Optimize<Index> for Optimizer {
         // currently optimizing.
         for (index_id, idx) in df_builder
             .indexes_on(index.on)
-            .filter(|(_id, idx)| idx.keys == index.keys)
+            .filter(|(_id, idx)| idx.keys.as_ref() == &index.keys)
         {
             df_meta.push_optimizer_notice_dedup(IndexAlreadyExists {
                 index_id,
-                index_key: idx.keys.clone(),
+                index_key: idx.keys.to_vec(),
                 index_on_id: idx.on,
                 exported_index_id: self.exported_index_id,
             });

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -900,7 +900,7 @@ pub struct MaterializedView {
 pub struct Index {
     pub create_sql: String,
     pub on: GlobalId,
-    pub keys: Vec<MirScalarExpr>,
+    pub keys: Arc<[MirScalarExpr]>,
     pub conn_id: Option<ConnectionId>,
     pub resolved_ids: ResolvedIds,
     pub cluster_id: ClusterId,

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -14,7 +14,7 @@
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ops::{Deref, DerefMut};
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use chrono::{DateTime, Utc};
 use mz_adapter_types::compaction::CompactionWindow;
@@ -872,8 +872,8 @@ impl Sink {
 #[derive(Debug, Clone, Serialize)]
 pub struct View {
     pub create_sql: String,
-    pub raw_expr: HirRelationExpr,
-    pub optimized_expr: OptimizedMirRelationExpr,
+    pub raw_expr: Arc<HirRelationExpr>,
+    pub optimized_expr: Arc<OptimizedMirRelationExpr>,
     pub desc: RelationDesc,
     pub conn_id: Option<ConnectionId>,
     pub resolved_ids: ResolvedIds,
@@ -882,8 +882,8 @@ pub struct View {
 #[derive(Debug, Clone, Serialize)]
 pub struct MaterializedView {
     pub create_sql: String,
-    pub raw_expr: HirRelationExpr,
-    pub optimized_expr: OptimizedMirRelationExpr,
+    pub raw_expr: Arc<HirRelationExpr>,
+    pub optimized_expr: Arc<OptimizedMirRelationExpr>,
     pub desc: RelationDesc,
     pub resolved_ids: ResolvedIds,
     pub cluster_id: ClusterId,


### PR DESCRIPTION
Most of the cost of cloning the catalog come from cloning the HIR and MIR
plans for (materialized) views. To avoid the cost, we wrap them in an Arc.

Part of #28720.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
