### PR TITLE
parallel-workload: Don't wait for potentially hanging threads

### DIFF
--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -13,6 +13,7 @@ mostly find panics and unexpected errors. See zippy for a sequential randomized
 tests which can verify correctness.
 """
 
+import os
 import random
 
 import requests
@@ -124,6 +125,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             c,
             sanity_restart,
         )
+        # Don't wait for potentially hanging threads that we are ignoring
+        os._exit(0)
         # TODO: Only ignore errors that will be handled by parallel-workload, not others
         # except Exception:
         #     print("--- Execution of parallel-workload failed")


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/9428#0191c549-67b6-448a-859a-faeec9812da5
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
