### PR TITLE
controller: move frontier recording into storage controller

### DIFF
--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -694,12 +694,6 @@ pub trait StorageController: Debug {
     async fn inspect_persist_state(&self, id: GlobalId)
         -> Result<serde_json::Value, anyhow::Error>;
 
-    /// Records the current read and write frontiers of all known storage objects.
-    fn record_frontiers(&mut self);
-
-    /// Records the current per-replica write frontiers of all known storage objects.
-    fn record_replica_frontiers(&mut self);
-
     /// Records append-only updates for the given introspection type.
     ///
     /// Rows passed in `updates` MUST have the correct schema for the given


### PR DESCRIPTION
This PR moves the timer that controls when storage frontiers should be recorded in their respective introspection collections from the top-level `Controller` into the storage controller. Since the reporting of compute frontiers has been moved fully into the compute controller (#29399), there is no reason anymore for the top-level `Controller` to be involved.

Inside the storage controller, this PR adds a `maintain` method, akin to the one the compute controller already has. Other periodic tasks can be invoked from there in the future as well. One likely candidate for such a task is wallclock lag reporting (#28097).

This PR also merges `record_frontiers` and `record_replica_frontiers` into one method, to avoid some duplicate work looping through storage collections.


### Motivation

  * This PR adds a known-desirable feature.

Preparation for [adding wallclock lag reporting](https://github.com/MaterializeInc/materialize/pull/29449) for storage collections (#28097)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
