### PR TITLE
Revert "catalog: Combine epoch and deploy generation"

### DIFF
--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -140,8 +140,7 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// NB: We may remove this in later iterations of Pv2.
     async fn epoch(&mut self) -> Result<Epoch, CatalogError>;
 
-    /// Get the most recent deployment generation written to the catalog. Not necessarily the
-    /// deploy generation of this instance.
+    /// Get the most recent deployment generation written to the catalog.
     async fn get_deployment_generation(&mut self) -> Result<u64, CatalogError>;
 
     /// Get the `enable_0dt_deployment` config value of this instance.

--- a/src/catalog/src/durable/error.rs
+++ b/src/catalog/src/durable/error.rs
@@ -138,6 +138,20 @@ pub enum FenceError {
 }
 
 impl FenceError {
+    pub fn deploy_generation(current_generation: u64, fence_generation: u64) -> Self {
+        Self::DeployGeneration {
+            current_generation,
+            fence_generation,
+        }
+    }
+
+    pub fn epoch(current_epoch: Epoch, fence_epoch: Epoch) -> Self {
+        Self::Epoch {
+            current_epoch,
+            fence_epoch,
+        }
+    }
+
     pub fn migration(err: UpperMismatch<Timestamp>) -> Self {
         Self::MigrationUpper {
             expected_upper: antichain_to_timestamp(err.expected),

--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -180,6 +180,7 @@ pub(crate) async fn initialize(
     tx: &mut Transaction<'_>,
     options: &BootstrapArgs,
     initial_ts: EpochMillis,
+    deploy_generation: u64,
     catalog_content_version: String,
 ) -> Result<(), CatalogError> {
     // Collect audit events so we can commit them once at the very end.
@@ -655,6 +656,7 @@ pub(crate) async fn initialize(
 
     for (key, value) in [
         (USER_VERSION_KEY.to_string(), CATALOG_VERSION),
+        (DEPLOY_GENERATION.to_string(), deploy_generation),
         (SYSTEM_CONFIG_SYNCED_KEY.to_string(), 0),
     ] {
         tx.insert_config(key, value)?;

--- a/src/catalog/tests/debug.rs
+++ b/src/catalog/tests/debug.rs
@@ -276,7 +276,6 @@ async fn test_debug_edit_fencing<'a>(state_builder: TestCatalogStateBuilder) {
         .unwrap();
 
     let mut debug_state = state_builder
-        .clone()
         .unwrap_build()
         .await
         .open_debug()
@@ -318,36 +317,6 @@ async fn test_debug_edit_fencing<'a>(state_builder: TestCatalogStateBuilder) {
         ),
         "unexpected err: {err:?}"
     );
-
-    // Open another state to fence the debug state.
-    let _state = state_builder
-        .clone()
-        .with_default_deploy_generation()
-        .unwrap_build()
-        .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args())
-        .await
-        .unwrap();
-
-    // Now debug state should be fenced.
-    let err = debug_state
-        .edit::<SettingCollection>(
-            proto::SettingKey {
-                name: "joe".to_string(),
-            },
-            proto::SettingValue {
-                value: "koshakow".to_string(),
-            },
-        )
-        .await
-        .unwrap_err();
-    assert!(
-        matches!(
-            err,
-            CatalogError::Durable(DurableCatalogError::Fence(FenceError::Epoch { .. }))
-        ),
-        "unexpected err: {err:?}"
-    );
 }
 
 #[mz_ore::test(tokio::test)]
@@ -375,7 +344,6 @@ async fn test_debug_delete_fencing<'a>(state_builder: TestCatalogStateBuilder) {
     txn.commit().await.unwrap();
 
     let mut debug_state = state_builder
-        .clone()
         .unwrap_build()
         .await
         .open_debug()
@@ -405,31 +373,6 @@ async fn test_debug_delete_fencing<'a>(state_builder: TestCatalogStateBuilder) {
     );
 
     let err = state.transaction().await.unwrap_err();
-    assert!(
-        matches!(
-            err,
-            CatalogError::Durable(DurableCatalogError::Fence(FenceError::Epoch { .. }))
-        ),
-        "unexpected err: {err:?}"
-    );
-
-    // Open another state to fence the debug state.
-    let _state = state_builder
-        .clone()
-        .with_default_deploy_generation()
-        .unwrap_build()
-        .await
-        .open(SYSTEM_TIME(), &test_bootstrap_args())
-        .await
-        .unwrap();
-
-    // Now debug state should be fenced.
-    let err = debug_state
-        .delete::<SettingCollection>(proto::SettingKey {
-            name: "joe".to_string(),
-        })
-        .await
-        .unwrap_err();
     assert!(
         matches!(
             err,

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -497,6 +497,77 @@ async fn test_open(state_builder: TestCatalogStateBuilder) {
 
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_persist_unopened_epoch_fencing() {
+    let persist_client = PersistClient::new_for_tests().await;
+    let state_builder = TestCatalogStateBuilder::new(persist_client);
+    test_unopened_epoch_fencing(state_builder).await;
+}
+
+async fn test_unopened_epoch_fencing(state_builder: TestCatalogStateBuilder) {
+    // Initialize catalog.
+    let zdt_deployment_max_wait = Duration::from_millis(666);
+    let state_builder = state_builder.with_default_deploy_generation();
+    {
+        let mut state = state_builder
+            .clone()
+            .unwrap_build()
+            .await
+            .open(SYSTEM_TIME(), &test_bootstrap_args())
+            .await
+            .unwrap();
+        // drain catalog updates.
+        let _ = state.sync_to_current_updates().await.unwrap();
+        let mut txn = state.transaction().await.unwrap();
+        txn.set_0dt_deployment_max_wait(zdt_deployment_max_wait)
+            .unwrap();
+        txn.commit().await.unwrap();
+    }
+    let mut openable_state = state_builder.clone().unwrap_build().await;
+
+    // Read config collection with unopened catalog.
+    assert_eq!(
+        zdt_deployment_max_wait,
+        openable_state
+            .get_0dt_deployment_max_wait()
+            .await
+            .unwrap()
+            .unwrap()
+    );
+
+    // Open catalog, which will bump the epoch.
+    let _state = state_builder
+        .clone()
+        .unwrap_build()
+        .await
+        .open(SYSTEM_TIME(), &test_bootstrap_args())
+        .await
+        .unwrap();
+
+    // Unopened catalog should be fenced now with an epoch fence.
+    let err = openable_state
+        .get_deployment_generation()
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            CatalogError::Durable(DurableCatalogError::Fence(FenceError::Epoch { .. }))
+        ),
+        "unexpected err: {err:?}"
+    );
+
+    let err = openable_state.is_initialized().await.unwrap_err();
+    assert!(
+        matches!(
+            err,
+            CatalogError::Durable(DurableCatalogError::Fence(FenceError::Epoch { .. }))
+        ),
+        "unexpected err: {err:?}"
+    );
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
 async fn test_persist_unopened_deploy_generation_fencing() {
     let persist_client = PersistClient::new_for_tests().await;
     let state_builder = TestCatalogStateBuilder::new(persist_client);

--- a/src/catalog/tests/snapshots/debug__opened_trace.snap
+++ b/src/catalog/tests/snapshots/debug__opened_trace.snap
@@ -628,6 +628,18 @@ Trace {
             (
                 (
                     ConfigKey {
+                        key: "deploy_generation",
+                    },
+                    ConfigValue {
+                        value: 0,
+                    },
+                ),
+                2,
+                1,
+            ),
+            (
+                (
+                    ConfigKey {
                         key: "system_config_synced",
                     },
                     ConfigValue {

--- a/src/catalog/tests/snapshots/open__initial_snapshot.snap
+++ b/src/catalog/tests/snapshots/open__initial_snapshot.snap
@@ -1363,6 +1363,11 @@ Snapshot {
     },
     configs: {
         ConfigKey {
+            key: "deploy_generation",
+        }: ConfigValue {
+            value: 0,
+        },
+        ConfigKey {
             key: "system_config_synced",
         }: ConfigValue {
             value: 0,


### PR DESCRIPTION
This reverts commit fa2c41700e63f054e5bc48428b66a42a912e9ffe.

Fixes: #29432

I'm not sure if we want that.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
