### PR TITLE
compute: remove separate `set_subscribe_target_replica` method

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1979,7 +1979,7 @@ impl Coordinator {
 
                         self.controller
                             .compute
-                            .create_dataflow(idx.cluster_id, df_desc)
+                            .create_dataflow(idx.cluster_id, df_desc, None)
                             .unwrap_or_terminate("cannot fail to create dataflows");
                     }
                 }
@@ -2025,7 +2025,7 @@ impl Coordinator {
                         );
                     }
 
-                    self.ship_dataflow(df_desc, mview.cluster_id).await;
+                    self.ship_dataflow(df_desc, mview.cluster_id, None).await;
                 }
                 CatalogItem::Sink(sink) => {
                     let id = entry.id();
@@ -3049,6 +3049,7 @@ impl Coordinator {
         &mut self,
         dataflow: DataflowDescription<Plan>,
         instance: ComputeInstanceId,
+        subscribe_target_replica: Option<ReplicaId>,
     ) {
         // We must only install read policies for indexes, not for sinks.
         // Sinks are write-only compute collections that don't have read policies.
@@ -3056,7 +3057,7 @@ impl Coordinator {
 
         self.controller
             .compute
-            .create_dataflow(instance, dataflow)
+            .create_dataflow(instance, dataflow, subscribe_target_replica)
             .unwrap_or_terminate("dataflow creation cannot fail");
 
         self.initialize_compute_read_policies(export_ids, instance, CompactionWindow::Default)
@@ -3071,11 +3072,11 @@ impl Coordinator {
         notice_builtin_updates_fut: Option<BuiltinTableAppendNotify>,
     ) {
         if let Some(notice_builtin_updates_fut) = notice_builtin_updates_fut {
-            let ship_dataflow_fut = self.ship_dataflow(dataflow, instance);
+            let ship_dataflow_fut = self.ship_dataflow(dataflow, instance, None);
             let ((), ()) =
                 futures::future::join(notice_builtin_updates_fut, ship_dataflow_fut).await;
         } else {
-            self.ship_dataflow(dataflow, instance).await;
+            self.ship_dataflow(dataflow, instance, None).await;
         }
     }
 
@@ -3383,7 +3384,7 @@ impl Coordinator {
         // this only works because this function will never run.
         let compute_instance = ComputeInstanceId::User(1);
 
-        let _: () = self.ship_dataflow(dataflow, compute_instance).await;
+        let _: () = self.ship_dataflow(dataflow, compute_instance, None).await;
     }
 }
 

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -297,12 +297,8 @@ impl Coordinator {
         // dataflow for it.
         let response = if self.introspection_subscribes.contains_key(&subscribe_id) {
             let (df_desc, _df_meta) = global_lir_plan.unapply();
-            self.ship_dataflow(df_desc, cluster_id).await;
-
-            self.controller
-                .compute
-                .set_subscribe_target_replica(cluster_id, subscribe_id, replica_id)
-                .expect("cannot fail");
+            self.ship_dataflow(df_desc, cluster_id, Some(replica_id))
+                .await;
 
             Ok(StageResult::Response(
                 ExecuteResponse::CreatedIntrospectionSubscribe,

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -568,7 +568,7 @@ impl crate::coord::Coordinator {
                 // Very important: actually create the dataflow (here, so we can destructure).
                 self.controller
                     .compute
-                    .create_dataflow(compute_instance, dataflow)
+                    .create_dataflow(compute_instance, dataflow, None)
                     .unwrap_or_terminate("cannot fail to create dataflows");
                 self.initialize_compute_read_policies(
                     output_ids,

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -973,7 +973,7 @@ impl Coordinator {
         );
 
         // Ship dataflow.
-        self.ship_dataflow(df_desc, cluster_id).await;
+        self.ship_dataflow(df_desc, cluster_id, None).await;
 
         let span = Span::current();
         Ok(StageResult::HandleRetire(mz_ore::task::spawn(

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -12,7 +12,6 @@ use std::fmt::Debug;
 use mz_catalog::durable::{DurableCatalogError, FenceError};
 use mz_compute_client::controller::error::{
     CollectionUpdateError, DataflowCreationError, InstanceMissing, PeekError, ReadPolicyError,
-    SubscribeTargetError,
 };
 use mz_controller_types::ClusterId;
 use mz_ore::tracing::OpenTelemetryContext;
@@ -396,6 +395,7 @@ impl ShouldTerminateGracefully for DataflowCreationError {
             DataflowCreationError::SinceViolation(_)
             | DataflowCreationError::InstanceMissing(_)
             | DataflowCreationError::CollectionMissing(_)
+            | DataflowCreationError::ReplicaMissing(_)
             | DataflowCreationError::MissingAsOf
             | DataflowCreationError::EmptyAsOfForSubscribe
             | DataflowCreationError::EmptyAsOfForCopyTo => false,
@@ -429,17 +429,6 @@ impl ShouldTerminateGracefully for ReadPolicyError {
             ReadPolicyError::InstanceMissing(_)
             | ReadPolicyError::CollectionMissing(_)
             | ReadPolicyError::WriteOnlyCollection(_) => false,
-        }
-    }
-}
-
-impl ShouldTerminateGracefully for SubscribeTargetError {
-    fn should_terminate_gracefully(&self) -> bool {
-        match self {
-            SubscribeTargetError::InstanceMissing(_)
-            | SubscribeTargetError::SubscribeMissing(_)
-            | SubscribeTargetError::ReplicaMissing(_)
-            | SubscribeTargetError::SubscribeAlreadyStarted => false,
         }
     }
 }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -61,7 +61,6 @@ use uuid::Uuid;
 use crate::controller::error::{
     CollectionLookupError, CollectionUpdateError, DataflowCreationError, InstanceExists,
     InstanceMissing, PeekError, ReadPolicyError, ReplicaCreationError, ReplicaDropError,
-    SubscribeTargetError,
 };
 use crate::controller::instance::Instance;
 use crate::controller::replica::ReplicaConfig;
@@ -664,21 +663,6 @@ where
         }
     }
 
-    /// Assign a target replica to the identified subscribe.
-    ///
-    /// If a subscribe has a target replica assigned, only subscribe responses
-    /// sent by that replica are considered.
-    pub fn set_subscribe_target_replica(
-        &mut self,
-        instance_id: ComputeInstanceId,
-        subscribe_id: GlobalId,
-        target_replica: ReplicaId,
-    ) -> Result<(), SubscribeTargetError> {
-        self.instance_mut(instance_id)?
-            .set_subscribe_target_replica(subscribe_id, target_replica)?;
-        Ok(())
-    }
-
     /// Adds replicas of an instance.
     pub fn add_replica_to_instance(
         &mut self,
@@ -730,8 +714,10 @@ where
         &mut self,
         instance_id: ComputeInstanceId,
         dataflow: DataflowDescription<mz_compute_types::plan::Plan<T>, (), T>,
+        subscribe_target_replica: Option<ReplicaId>,
     ) -> Result<(), DataflowCreationError> {
-        self.instance_mut(instance_id)?.create_dataflow(dataflow)?;
+        self.instance_mut(instance_id)?
+            .create_dataflow(dataflow, subscribe_target_replica)?;
         Ok(())
     }
 

--- a/src/compute-client/src/controller/error.rs
+++ b/src/compute-client/src/controller/error.rs
@@ -128,16 +128,19 @@ impl From<instance::ReplicaMissing> for ReplicaDropError {
 /// Errors arising during dataflow creation.
 #[derive(Error, Debug)]
 pub enum DataflowCreationError {
-    /// TODO(#25239): Add documentation.
+    /// The given instance does not exist.
     #[error("instance does not exist: {0}")]
     InstanceMissing(ComputeInstanceId),
-    /// TODO(#25239): Add documentation.
+    /// One of the imported collections does not exist.
     #[error("collection does not exist: {0}")]
     CollectionMissing(GlobalId),
-    /// TODO(#25239): Add documentation.
+    /// The targeted replica does not exist.
+    #[error("replica does not exist: {0}")]
+    ReplicaMissing(ReplicaId),
+    /// The dataflow definition has doesn't have an `as_of` set.
     #[error("dataflow definition lacks an as_of value")]
     MissingAsOf,
-    /// TODO(#25239): Add documentation.
+    /// One of the imported collections has a read frontier greater than the dataflow `as_of`.
     #[error("dataflow has an as_of not beyond the since of collection: {0}")]
     SinceViolation(GlobalId),
     /// We skip dataflow creation for empty `as_of`s, which would be a problem for a SUBSCRIBE,
@@ -161,6 +164,7 @@ impl From<instance::DataflowCreationError> for DataflowCreationError {
         use instance::DataflowCreationError::*;
         match error {
             CollectionMissing(id) => Self::CollectionMissing(id),
+            ReplicaMissing(id) => Self::ReplicaMissing(id),
             MissingAsOf => Self::MissingAsOf,
             SinceViolation(id) => Self::SinceViolation(id),
             EmptyAsOfForSubscribe => Self::EmptyAsOfForSubscribe,
@@ -252,40 +256,6 @@ impl From<instance::ReadPolicyError> for ReadPolicyError {
         match error {
             CollectionMissing(id) => Self::CollectionMissing(id),
             WriteOnlyCollection(id) => Self::WriteOnlyCollection(id),
-        }
-    }
-}
-
-/// Errors arising during subscribe target assignment.
-#[derive(Error, Debug)]
-pub enum SubscribeTargetError {
-    /// TODO(#25239): Add documentation.
-    #[error("instance does not exist: {0}")]
-    InstanceMissing(ComputeInstanceId),
-    /// TODO(#25239): Add documentation.
-    #[error("subscribe does not exist: {0}")]
-    SubscribeMissing(GlobalId),
-    /// TODO(#25239): Add documentation.
-    #[error("replica does not exist: {0}")]
-    ReplicaMissing(ReplicaId),
-    /// TODO(#25239): Add documentation.
-    #[error("subscribe has already produced output")]
-    SubscribeAlreadyStarted,
-}
-
-impl From<InstanceMissing> for SubscribeTargetError {
-    fn from(error: InstanceMissing) -> Self {
-        Self::InstanceMissing(error.0)
-    }
-}
-
-impl From<instance::SubscribeTargetError> for SubscribeTargetError {
-    fn from(error: instance::SubscribeTargetError) -> Self {
-        use instance::SubscribeTargetError::*;
-        match error {
-            SubscribeMissing(id) => Self::SubscribeMissing(id),
-            ReplicaMissing(id) => Self::ReplicaMissing(id),
-            SubscribeAlreadyStarted => Self::SubscribeAlreadyStarted,
         }
     }
 }


### PR DESCRIPTION
Prior to this change, the controller API for creating a replica-targeted subscribe was:

 * call `create_dataflow` to create the subscribe dataflow
 * call `set_subscribe_target_replica` to point the dataflow at a replica

The second call would fail, for sanity reasons, if the subscribe already had responses received.

This API is annoying for compute controller decoupling, i.e., moving the `Instance` controllers into separate tasks. Decoupling will allow the `Instance` to start the subscribe dataflow as soon as the `create_dataflow` command is received, and there is no guarantee that the `set_subscribe_target_replica` command reaches the `Instance` task before the subscribe received its first response.

To avoid this issue, this PR changes the API to pass the target replica already in the `create_dataflow` call. The `set_subscribe_target_replica` method is removed.

For now, the target is ignored for all dataflow exports that are not subscribes. In the future, we might want to change that to avoid running the dataflows of replica-targeted slow-path peeks on replicas that are not targeted by the peek.

### Motivation

  * This PR adds a known-desirable feature.

Part of #27656 
Touches #27399

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
