### PR TITLE
sql: change IGNORE COLUMNS MySQL option to EXCLUDE COLUMNS

### DIFF
--- a/doc/user/content/sql/create-source/mysql.md
+++ b/doc/user/content/sql/create-source/mysql.md
@@ -50,7 +50,7 @@ _src_name_  | The name for the source.
 
 Field                                | Value                           | Description
 -------------------------------------|---------------------------------|-------------------------------------
-`IGNORE COLUMNS`                     | A list of fully-qualified names | Ignore specific columns that cannot be decoded or should not be included in the subsources created in Materialize.
+{{< if-unreleased "v0.117" >}}`IGNORE COLUMNS`{{< /if-unreleased >}} {{< if-released "v0.117" >}}`EXCLUDE COLUMNS`{{< /if-released >}} | A list of fully-qualified names | Exclude specific columns that cannot be decoded or should not be included in the subsources created in Materialize.
 `TEXT COLUMNS`                       | A list of fully-qualified names | Decode data as `text` for specific columns that contain MySQL types that are [unsupported in Materialize](#supported-types).
 
 ## Features
@@ -256,9 +256,17 @@ following types:
 <li><code>year</code></li>
 </ul>
 
+{{< if-unreleased "v0.117" >}}
 The specified columns will be treated as `text`, and will thus not offer the
 expected MySQL type features. For any unsupported data types not listed above,
 use the [`IGNORE COLUMNS`](#ignoring-columns) option.
+{{< /if-unreleased >}}
+
+{{< if-released "v0.117" >}}
+The specified columns will be treated as `text`, and will thus not offer the
+expected MySQL type features. For any unsupported data types not listed above,
+use the [`EXCLUDE COLUMNS`](#excluding-columns) option.
+{{< /if-released >}}
 
 ##### Truncation
 
@@ -372,6 +380,7 @@ CREATE SOURCE mz_source
   FOR ALL TABLES;
 ```
 
+{{< if-unreleased "v0.117" >}}
 #### Ignoring columns
 
 MySQL doesn't provide a way to filter out columns from the replication stream.
@@ -385,6 +394,23 @@ CREATE SOURCE mz_source
   )
   FOR ALL TABLES;
 ```
+{{< /if-unreleased >}}
+
+{{< if-released "v0.117" >}}
+#### Excluding columns
+
+MySQL doesn't provide a way to filter out columns from the replication stream.
+To exclude specific upstream columns from being ingested, use the `EXCLUDE
+COLUMNS` option.
+
+```mzsql
+CREATE SOURCE mz_source
+  FROM MYSQL CONNECTION mysql_connection (
+    EXCLUDE COLUMNS (mydb.table_1.column_to_ignore)
+  )
+  FOR ALL TABLES;
+```
+{{< /if-released >}}
 
 ### Handling errors and schema changes
 

--- a/doc/user/layouts/partials/sql-grammar/create-source-mysql.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-mysql.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="707" height="959">
+<svg xmlns="http://www.w3.org/2000/svg" width="707" height="1101">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -152,119 +152,174 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="608" y="469">)</text>
-   <rect x="45" y="549" width="138" height="32" rx="10"/>
-   <rect x="43"
-         y="547"
-         width="138"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="53" y="567">FOR ALL TABLES</text>
-   <rect x="65" y="637" width="106" height="32" rx="10"/>
-   <rect x="63"
-         y="635"
-         width="106"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="73" y="655">FOR TABLES</text>
-   <rect x="191" y="637" width="26" height="32" rx="10"/>
-   <rect x="189"
-         y="635"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="199" y="655">(</text>
-   <rect x="257" y="637" width="96" height="32"/>
-   <rect x="255" y="635" width="96" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="265" y="655">table_name</text>
-   <rect x="393" y="669" width="40" height="32" rx="10"/>
-   <rect x="391"
-         y="667"
-         width="40"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="401" y="687">AS</text>
-   <rect x="453" y="669" width="106" height="32"/>
-   <rect x="451" y="667" width="106" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="461" y="687">subsrc_name</text>
-   <rect x="257" y="593" width="24" height="32" rx="10"/>
-   <rect x="255"
+   <rect x="78" y="593" width="24" height="32" rx="10"/>
+   <rect x="76"
          y="591"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="265" y="611">,</text>
-   <rect x="65" y="757" width="124" height="32" rx="10"/>
-   <rect x="63"
-         y="755"
-         width="124"
+   <text class="terminal" x="86" y="611">,</text>
+   <rect x="122" y="593" width="162" height="32" rx="10"/>
+   <rect x="120"
+         y="591"
+         width="162"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="73" y="775">FOR SCHEMAS</text>
-   <rect x="209" y="757" width="26" height="32" rx="10"/>
-   <rect x="207"
-         y="755"
+   <text class="terminal" x="130" y="611">EXCLUDE COLUMNS</text>
+   <rect x="324" y="593" width="26" height="32" rx="10"/>
+   <rect x="322"
+         y="591"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="217" y="775">(</text>
-   <rect x="275" y="757" width="114" height="32"/>
-   <rect x="273" y="755" width="114" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="283" y="775">schema_name</text>
-   <rect x="275" y="713" width="24" height="32" rx="10"/>
-   <rect x="273"
-         y="711"
+   <text class="terminal" x="332" y="611">(</text>
+   <rect x="390" y="593" width="110" height="32"/>
+   <rect x="388" y="591" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="398" y="611">column_name</text>
+   <rect x="390" y="549" width="24" height="32" rx="10"/>
+   <rect x="388"
+         y="547"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="283" y="731">,</text>
-   <rect x="639" y="637" width="26" height="32" rx="10"/>
-   <rect x="637"
-         y="635"
+   <text class="terminal" x="398" y="567">,</text>
+   <rect x="540" y="593" width="26" height="32" rx="10"/>
+   <rect x="538"
+         y="591"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="647" y="655">)</text>
-   <rect x="121" y="839" width="76" height="32" rx="10"/>
-   <rect x="119"
-         y="837"
-         width="76"
+   <text class="terminal" x="548" y="611">)</text>
+   <rect x="606" y="593" width="26" height="32" rx="10"/>
+   <rect x="604"
+         y="591"
+         width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="129" y="857">EXPOSE</text>
-   <rect x="217" y="839" width="96" height="32" rx="10"/>
-   <rect x="215"
-         y="837"
-         width="96"
+   <text class="terminal" x="614" y="611">)</text>
+   <rect x="45" y="691" width="138" height="32" rx="10"/>
+   <rect x="43"
+         y="689"
+         width="138"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="225" y="857">PROGRESS</text>
-   <rect x="333" y="839" width="40" height="32" rx="10"/>
-   <rect x="331"
-         y="837"
+   <text class="terminal" x="53" y="709">FOR ALL TABLES</text>
+   <rect x="65" y="779" width="106" height="32" rx="10"/>
+   <rect x="63"
+         y="777"
+         width="106"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="797">FOR TABLES</text>
+   <rect x="191" y="779" width="26" height="32" rx="10"/>
+   <rect x="189"
+         y="777"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="797">(</text>
+   <rect x="257" y="779" width="96" height="32"/>
+   <rect x="255" y="777" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="265" y="797">table_name</text>
+   <rect x="393" y="811" width="40" height="32" rx="10"/>
+   <rect x="391"
+         y="809"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="341" y="857">AS</text>
-   <rect x="393" y="839" width="196" height="32"/>
-   <rect x="391" y="837" width="196" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="401" y="857">progress_subsource_name</text>
-   <rect x="557" y="925" width="102" height="32"/>
-   <rect x="555" y="923" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="565" y="943">with_options</text>
+   <text class="terminal" x="401" y="829">AS</text>
+   <rect x="453" y="811" width="106" height="32"/>
+   <rect x="451" y="809" width="106" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="461" y="829">subsrc_name</text>
+   <rect x="257" y="735" width="24" height="32" rx="10"/>
+   <rect x="255"
+         y="733"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="753">,</text>
+   <rect x="65" y="899" width="124" height="32" rx="10"/>
+   <rect x="63"
+         y="897"
+         width="124"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="917">FOR SCHEMAS</text>
+   <rect x="209" y="899" width="26" height="32" rx="10"/>
+   <rect x="207"
+         y="897"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="217" y="917">(</text>
+   <rect x="275" y="899" width="114" height="32"/>
+   <rect x="273" y="897" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="283" y="917">schema_name</text>
+   <rect x="275" y="855" width="24" height="32" rx="10"/>
+   <rect x="273"
+         y="853"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="283" y="873">,</text>
+   <rect x="639" y="779" width="26" height="32" rx="10"/>
+   <rect x="637"
+         y="777"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="647" y="797">)</text>
+   <rect x="121" y="981" width="76" height="32" rx="10"/>
+   <rect x="119"
+         y="979"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="129" y="999">EXPOSE</text>
+   <rect x="217" y="981" width="96" height="32" rx="10"/>
+   <rect x="215"
+         y="979"
+         width="96"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="225" y="999">PROGRESS</text>
+   <rect x="333" y="981" width="40" height="32" rx="10"/>
+   <rect x="331"
+         y="979"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="341" y="999">AS</text>
+   <rect x="393" y="981" width="196" height="32"/>
+   <rect x="391" y="979" width="196" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="401" y="999">progress_subsource_name</text>
+   <rect x="557" y="1067" width="102" height="32"/>
+   <rect x="555"
+         y="1065"
+         width="102"
+         height="32"
+         class="nonterminal"/>
+   <text class="nonterminal" x="565" y="1085">with_options</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-363 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m70 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-401 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-441 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m0 0 h10 m134 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m110 0 h10 m-150 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m130 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-130 0 h10 m24 0 h10 m0 0 h86 m20 44 h10 m26 0 h10 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v14 m282 0 v-14 m-282 14 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m0 0 h252 m-502 -34 h20 m502 0 h20 m-542 0 q10 0 10 10 m522 0 q0 -10 10 -10 m-532 10 v30 m522 0 v-30 m-522 30 q0 10 10 10 m502 0 q10 0 10 -10 m-512 10 h10 m0 0 h492 m22 -50 l2 0 m2 0 l2 0 m2 0 l2 0 m-596 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m0 0 h10 m150 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m110 0 h10 m-150 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m130 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-130 0 h10 m24 0 h10 m0 0 h86 m20 44 h10 m26 0 h10 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v14 m282 0 v-14 m-282 14 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m0 0 h252 m20 -34 h10 m26 0 h10 m-582 0 h20 m562 0 h20 m-602 0 q10 0 10 10 m582 0 q0 -10 10 -10 m-592 10 v30 m582 0 v-30 m-582 30 q0 10 10 10 m562 0 q10 0 10 -10 m-572 10 h10 m0 0 h552 m22 -50 l2 0 m2 0 l2 0 m2 0 l2 0 m-665 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m138 0 h10 m0 0 h482 m-660 0 h20 m640 0 h20 m-680 0 q10 0 10 10 m660 0 q0 -10 10 -10 m-670 10 v68 m660 0 v-68 m-660 68 q0 10 10 10 m640 0 q10 0 10 -10 m-630 10 h10 m106 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m20 0 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m40 0 h10 m0 0 h10 m106 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m342 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-342 0 h10 m24 0 h10 m0 0 h298 m-554 44 h20 m554 0 h20 m-594 0 q10 0 10 10 m574 0 q0 -10 10 -10 m-584 10 v100 m574 0 v-100 m-574 100 q0 10 10 10 m554 0 q10 0 10 -10 m-564 10 h10 m124 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m114 0 h10 m-154 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m134 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-134 0 h10 m24 0 h10 m0 0 h90 m20 44 h190 m20 -120 h10 m26 0 h10 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-628 258 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h478 m-508 0 h20 m488 0 h20 m-528 0 q10 0 10 10 m508 0 q0 -10 10 -10 m-518 10 v12 m508 0 v-12 m-508 12 q0 10 10 10 m488 0 q10 0 10 -10 m-498 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m196 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-116 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m23 -32 h-3"/>
-   <polygon points="697 907 705 903 705 911"/>
-   <polygon points="697 907 689 903 689 911"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-363 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m70 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-401 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-441 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m0 0 h10 m134 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m110 0 h10 m-150 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m130 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-130 0 h10 m24 0 h10 m0 0 h86 m20 44 h10 m26 0 h10 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v14 m282 0 v-14 m-282 14 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m0 0 h252 m-502 -34 h20 m502 0 h20 m-542 0 q10 0 10 10 m522 0 q0 -10 10 -10 m-532 10 v30 m522 0 v-30 m-522 30 q0 10 10 10 m502 0 q10 0 10 -10 m-512 10 h10 m0 0 h492 m22 -50 l2 0 m2 0 l2 0 m2 0 l2 0 m-596 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m0 0 h10 m150 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m110 0 h10 m-150 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m130 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-130 0 h10 m24 0 h10 m0 0 h86 m20 44 h10 m26 0 h10 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v14 m282 0 v-14 m-282 14 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m0 0 h252 m20 -34 h10 m26 0 h10 m-582 0 h20 m562 0 h20 m-602 0 q10 0 10 10 m582 0 q0 -10 10 -10 m-592 10 v30 m582 0 v-30 m-582 30 q0 10 10 10 m562 0 q10 0 10 -10 m-572 10 h10 m0 0 h552 m22 -50 l2 0 m2 0 l2 0 m2 0 l2 0 m-632 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m0 0 h10 m162 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m110 0 h10 m-150 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m130 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-130 0 h10 m24 0 h10 m0 0 h86 m20 44 h10 m26 0 h10 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v14 m282 0 v-14 m-282 14 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m0 0 h252 m20 -34 h10 m26 0 h10 m-594 0 h20 m574 0 h20 m-614 0 q10 0 10 10 m594 0 q0 -10 10 -10 m-604 10 v30 m594 0 v-30 m-594 30 q0 10 10 10 m574 0 q10 0 10 -10 m-584 10 h10 m0 0 h564 m22 -50 l2 0 m2 0 l2 0 m2 0 l2 0 m-671 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m138 0 h10 m0 0 h482 m-660 0 h20 m640 0 h20 m-680 0 q10 0 10 10 m660 0 q0 -10 10 -10 m-670 10 v68 m660 0 v-68 m-660 68 q0 10 10 10 m640 0 q10 0 10 -10 m-630 10 h10 m106 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m20 0 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m40 0 h10 m0 0 h10 m106 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m342 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-342 0 h10 m24 0 h10 m0 0 h298 m-554 44 h20 m554 0 h20 m-594 0 q10 0 10 10 m574 0 q0 -10 10 -10 m-584 10 v100 m574 0 v-100 m-574 100 q0 10 10 10 m554 0 q10 0 10 -10 m-564 10 h10 m124 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m114 0 h10 m-154 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m134 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-134 0 h10 m24 0 h10 m0 0 h90 m20 44 h190 m20 -120 h10 m26 0 h10 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-628 258 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h478 m-508 0 h20 m488 0 h20 m-528 0 q10 0 10 10 m508 0 q0 -10 10 -10 m-518 10 v12 m508 0 v-12 m-508 12 q0 10 10 10 m488 0 q10 0 10 -10 m-498 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m196 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-116 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m23 -32 h-3"/>
+   <polygon points="697 1049 705 1045 705 1053"/>
+   <polygon points="697 1049 689 1045 689 1053"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -232,6 +232,7 @@ create_source_mysql ::=
   'FROM' 'MYSQL' 'CONNECTION' connection_name
   ( ( '(' 'TEXT COLUMNS' ('(' (column_name) ( ( ',' column_name ) )* ')')? )? )
       ( ( ',' 'IGNORE COLUMNS' ('(' (column_name) ( ( ',' column_name ) )* ')')? ')' )? )
+      ( ( ',' 'EXCLUDE COLUMNS' ('(' (column_name) ( ( ',' column_name ) )* ')')? ')' )? )
   ('FOR ALL TABLES'
     | 'FOR TABLES' '(' table_name ('AS' subsrc_name)?  (',' table_name ('AS' subsrc_name)? )* ')'
     | 'FOR SCHEMAS' '(' schema_name (',' schema_name )* ')'

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3631,7 +3631,7 @@ impl Coordinator {
 
                 let mz_sql::plan::AlterSourceAddSubsourceOptionExtracted {
                     text_columns: mut new_text_columns,
-                    ignore_columns: mut new_ignore_columns,
+                    exclude_columns: mut new_exclude_columns,
                     ..
                 } = options.try_into()?;
 
@@ -3709,7 +3709,7 @@ impl Coordinator {
                     } => {
                         let mz_sql::plan::MySqlConfigOptionExtracted {
                             mut text_columns,
-                            mut ignore_columns,
+                            mut exclude_columns,
                             ..
                         } = curr_options.clone().try_into()?;
 
@@ -3719,28 +3719,28 @@ impl Coordinator {
                             !matches!(
                                 o.name,
                                 MySqlConfigOptionName::TextColumns
-                                    | MySqlConfigOptionName::IgnoreColumns
+                                    | MySqlConfigOptionName::ExcludeColumns
                             )
                         });
 
-                        // Drop all text / ignore columns that are not currently referred to.
+                        // Drop all text / exclude columns that are not currently referred to.
                         let column_referenced =
                             |column_qualified_reference: &UnresolvedItemName| {
                                 mz_ore::soft_assert_eq_or_log!(
                                 column_qualified_reference.0.len(),
                                 3,
-                                "all TEXT COLUMNS & IGNORE COLUMNS values must be column-qualified references"
+                                "all TEXT COLUMNS & EXCLUDE COLUMNS values must be column-qualified references"
                             );
                                 let mut table = column_qualified_reference.clone();
                                 table.0.truncate(2);
                                 curr_references.contains(&table)
                             };
                         text_columns.retain(column_referenced);
-                        ignore_columns.retain(column_referenced);
+                        exclude_columns.retain(column_referenced);
 
-                        // Merge the current text / ignore columns into the new text / ignore columns.
+                        // Merge the current text / exclude columns into the new text / exclude columns.
                         new_text_columns.extend(text_columns);
-                        new_ignore_columns.extend(ignore_columns);
+                        new_exclude_columns.extend(exclude_columns);
 
                         // If we have text columns, add them to the options.
                         if !new_text_columns.is_empty() {
@@ -3755,17 +3755,17 @@ impl Coordinator {
                                 value: Some(WithOptionValue::Sequence(new_text_columns)),
                             });
                         }
-                        // If we have ignore columns, add them to the options.
-                        if !new_ignore_columns.is_empty() {
-                            new_ignore_columns.sort();
-                            let new_ignore_columns = new_ignore_columns
+                        // If we have exclude columns, add them to the options.
+                        if !new_exclude_columns.is_empty() {
+                            new_exclude_columns.sort();
+                            let new_exclude_columns = new_exclude_columns
                                 .into_iter()
                                 .map(WithOptionValue::UnresolvedItemName)
                                 .collect();
 
                             curr_options.push(MySqlConfigOption {
-                                name: MySqlConfigOptionName::IgnoreColumns,
-                                value: Some(WithOptionValue::Sequence(new_ignore_columns)),
+                                name: MySqlConfigOptionName::ExcludeColumns,
+                                value: Some(WithOptionValue::Sequence(new_exclude_columns)),
                             });
                         }
                     }

--- a/src/mysql-util/src/schemas.rs
+++ b/src/mysql-util/src/schemas.rs
@@ -90,14 +90,14 @@ impl MySqlTableSchema {
     }
 
     /// Convert the raw table schema to our MySqlTableDesc representation
-    /// using any provided text_columns and ignore_columns
+    /// using any provided text_columns and exclude_columns
     pub fn to_desc(
         self,
         text_columns: Option<&BTreeSet<&str>>,
-        ignore_columns: Option<&BTreeSet<&str>>,
+        exclude_columns: Option<&BTreeSet<&str>>,
     ) -> Result<MySqlTableDesc, MySqlError> {
-        // Verify there are no duplicates in text_columns and ignore_columns
-        match (&text_columns, &ignore_columns) {
+        // Verify there are no duplicates in text_columns and exclude_columns
+        match (&text_columns, &exclude_columns) {
             (Some(text_cols), Some(ignore_cols)) => {
                 let intersection: Vec<_> = text_cols.intersection(ignore_cols).collect();
                 if !intersection.is_empty() {
@@ -133,7 +133,7 @@ impl MySqlTableSchema {
             }
 
             // If this column is ignored, use None for the column type to signal that it should be.
-            if let Some(ignore_cols) = &ignore_columns {
+            if let Some(ignore_cols) = &exclude_columns {
                 if ignore_cols.contains(&info.column_name.as_str()) {
                     columns.push(MySqlColumnDesc {
                         name: info.column_name,

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -150,6 +150,7 @@ Escape
 Estimate
 Every
 Except
+Exclude
 Execute
 Exists
 Expected

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1092,13 +1092,13 @@ pub enum MySqlConfigOptionName {
     /// fully deprecating that feature and forcing users to use explicit
     /// `CREATE TABLE .. FROM SOURCE` statements
     TextColumns,
-    /// Columns you want to ignore
+    /// Columns you want to exclude
     /// NOTE(roshan): This value is kept around to allow round-tripping a
     /// `CREATE SOURCE` statement while we still allow creating implicit
     /// subsources from `CREATE SOURCE`, but will be removed once
     /// fully deprecating that feature and forcing users to use explicit
     /// `CREATE TABLE .. FROM SOURCE` statements
-    IgnoreColumns,
+    ExcludeColumns,
 }
 
 impl AstDisplay for MySqlConfigOptionName {
@@ -1106,7 +1106,7 @@ impl AstDisplay for MySqlConfigOptionName {
         f.write_str(match self {
             MySqlConfigOptionName::Details => "DETAILS",
             MySqlConfigOptionName::TextColumns => "TEXT COLUMNS",
-            MySqlConfigOptionName::IgnoreColumns => "IGNORE COLUMNS",
+            MySqlConfigOptionName::ExcludeColumns => "EXCLUDE COLUMNS",
         })
     }
 }
@@ -1122,7 +1122,7 @@ impl WithOptionName for MySqlConfigOptionName {
         match self {
             MySqlConfigOptionName::Details
             | MySqlConfigOptionName::TextColumns
-            | MySqlConfigOptionName::IgnoreColumns => false,
+            | MySqlConfigOptionName::ExcludeColumns => false,
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1098,8 +1098,8 @@ pub enum CreateSubsourceOptionName {
     ExternalReference,
     /// Columns whose types you want to unconditionally format as text
     TextColumns,
-    /// Columns you want to ignore when ingesting data
-    IgnoreColumns,
+    /// Columns you want to exclude when ingesting data
+    ExcludeColumns,
     /// `DETAILS` for this subsource, hex-encoded protobuf type
     /// `mz_storage_types::sources::SourceExportStatementDetails`
     Details,
@@ -1111,7 +1111,7 @@ impl AstDisplay for CreateSubsourceOptionName {
             CreateSubsourceOptionName::Progress => "PROGRESS",
             CreateSubsourceOptionName::ExternalReference => "EXTERNAL REFERENCE",
             CreateSubsourceOptionName::TextColumns => "TEXT COLUMNS",
-            CreateSubsourceOptionName::IgnoreColumns => "IGNORE COLUMNS",
+            CreateSubsourceOptionName::ExcludeColumns => "EXCLUDE COLUMNS",
             CreateSubsourceOptionName::Details => "DETAILS",
         })
     }
@@ -1129,7 +1129,7 @@ impl WithOptionName for CreateSubsourceOptionName {
             | CreateSubsourceOptionName::ExternalReference
             | CreateSubsourceOptionName::Details
             | CreateSubsourceOptionName::TextColumns
-            | CreateSubsourceOptionName::IgnoreColumns => false,
+            | CreateSubsourceOptionName::ExcludeColumns => false,
         }
     }
 }
@@ -1510,8 +1510,8 @@ impl_display_for_with_option!(TableOption);
 pub enum TableFromSourceOptionName {
     /// Columns whose types you want to unconditionally format as text
     TextColumns,
-    /// Columns you want to ignore when ingesting data
-    IgnoreColumns,
+    /// Columns you want to exclude when ingesting data
+    ExcludeColumns,
     /// Hex-encoded protobuf of a `ProtoSourceExportStatementDetails`
     /// message, which includes details necessary for planning this
     /// table as a Source Export
@@ -1522,7 +1522,7 @@ impl AstDisplay for TableFromSourceOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
             TableFromSourceOptionName::TextColumns => "TEXT COLUMNS",
-            TableFromSourceOptionName::IgnoreColumns => "IGNORE COLUMNS",
+            TableFromSourceOptionName::ExcludeColumns => "EXCLUDE COLUMNS",
             TableFromSourceOptionName::Details => "DETAILS",
         })
     }
@@ -1539,7 +1539,7 @@ impl WithOptionName for TableFromSourceOptionName {
         match self {
             TableFromSourceOptionName::Details
             | TableFromSourceOptionName::TextColumns
-            | TableFromSourceOptionName::IgnoreColumns => false,
+            | TableFromSourceOptionName::ExcludeColumns => false,
         }
     }
 }
@@ -2534,7 +2534,7 @@ pub enum AlterSourceAddSubsourceOptionName {
     /// Columns whose types you want to unconditionally format as text
     TextColumns,
     /// Columns you want to ignore when ingesting data
-    IgnoreColumns,
+    ExcludeColumns,
     /// Updated `DETAILS` for an ingestion, e.g.
     /// [`crate::ast::PgConfigOptionName::Details`]
     /// or
@@ -2546,7 +2546,7 @@ impl AstDisplay for AlterSourceAddSubsourceOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
             AlterSourceAddSubsourceOptionName::TextColumns => "TEXT COLUMNS",
-            AlterSourceAddSubsourceOptionName::IgnoreColumns => "IGNORE COLUMNS",
+            AlterSourceAddSubsourceOptionName::ExcludeColumns => "EXCLUDE COLUMNS",
             AlterSourceAddSubsourceOptionName::Details => "DETAILS",
         })
     }
@@ -2563,7 +2563,7 @@ impl WithOptionName for AlterSourceAddSubsourceOptionName {
         match self {
             AlterSourceAddSubsourceOptionName::Details
             | AlterSourceAddSubsourceOptionName::TextColumns
-            | AlterSourceAddSubsourceOptionName::IgnoreColumns => false,
+            | AlterSourceAddSubsourceOptionName::ExcludeColumns => false,
         }
     }
 }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -550,16 +550,23 @@ CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source"
 parse-statement
 CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (IGNORE COLUMNS (public.foo.bar)) FOR ALL TABLES;
 ----
-CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (IGNORE COLUMNS = (public.foo.bar)) FOR ALL TABLES
+CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (EXCLUDE COLUMNS = (public.foo.bar)) FOR ALL TABLES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [MySqlConfigOption { name: IgnoreColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(All), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [MySqlConfigOption { name: ExcludeColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(All), progress_subsource: None })
 
 parse-statement
-CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (IGNORE COLUMNS (public.foo.bar), TEXT COLUMNS (public.foo.baz)) FOR ALL TABLES;
+CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (EXCLUDE COLUMNS (public.foo.bar)) FOR ALL TABLES;
 ----
-CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (IGNORE COLUMNS = (public.foo.bar), TEXT COLUMNS = (public.foo.baz)) FOR ALL TABLES
+CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (EXCLUDE COLUMNS = (public.foo.bar)) FOR ALL TABLES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [MySqlConfigOption { name: IgnoreColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))])) }, MySqlConfigOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("baz")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(All), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [MySqlConfigOption { name: ExcludeColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(All), progress_subsource: None })
+
+parse-statement
+CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (EXCLUDE COLUMNS (public.foo.bar), TEXT COLUMNS (public.foo.baz)) FOR ALL TABLES;
+----
+CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (EXCLUDE COLUMNS = (public.foo.bar), TEXT COLUMNS = (public.foo.baz)) FOR ALL TABLES
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [MySqlConfigOption { name: ExcludeColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))])) }, MySqlConfigOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("baz")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(All), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red');
@@ -576,11 +583,11 @@ CREATE SOURCE psychic FROM YUGABYTE CONNECTION pgconn (PUBLICATION = 'red')
 CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: None, col_names: [], connection: Yugabyte { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
-CREATE SUBSOURCE mz_subsource (c int) OF SOURCE public.foo.mz_source WITH (EXTERNAL REFERENCE = public.foo.bar, IGNORE COLUMNS (bar), TEXT COLUMNS (baz, foobar), DETAILS = 'details');
+CREATE SUBSOURCE mz_subsource (c int) OF SOURCE public.foo.mz_source WITH (EXTERNAL REFERENCE = public.foo.bar, EXCLUDE COLUMNS (bar), TEXT COLUMNS (baz, foobar), DETAILS = 'details');
 ----
-CREATE SUBSOURCE mz_subsource (c int4) OF SOURCE public.foo.mz_source WITH (EXTERNAL REFERENCE = public.foo.bar, IGNORE COLUMNS = (bar), TEXT COLUMNS = (baz, foobar), DETAILS = 'details')
+CREATE SUBSOURCE mz_subsource (c int4) OF SOURCE public.foo.mz_source WITH (EXTERNAL REFERENCE = public.foo.bar, EXCLUDE COLUMNS = (bar), TEXT COLUMNS = (baz, foobar), DETAILS = 'details')
 =>
-CreateSubsource(CreateSubsourceStatement { name: UnresolvedItemName([Ident("mz_subsource")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], of_source: Some(Name(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("mz_source")]))), constraints: [], if_not_exists: false, with_options: [CreateSubsourceOption { name: ExternalReference, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))) }, CreateSubsourceOption { name: IgnoreColumns, value: Some(Sequence([Ident(Ident("bar"))])) }, CreateSubsourceOption { name: TextColumns, value: Some(Sequence([Ident(Ident("baz")), Ident(Ident("foobar"))])) }, CreateSubsourceOption { name: Details, value: Some(Value(String("details"))) }] })
+CreateSubsource(CreateSubsourceStatement { name: UnresolvedItemName([Ident("mz_subsource")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], of_source: Some(Name(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("mz_source")]))), constraints: [], if_not_exists: false, with_options: [CreateSubsourceOption { name: ExternalReference, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))) }, CreateSubsourceOption { name: ExcludeColumns, value: Some(Sequence([Ident(Ident("bar"))])) }, CreateSubsourceOption { name: TextColumns, value: Some(Sequence([Ident(Ident("baz")), Ident(Ident("foobar"))])) }, CreateSubsourceOption { name: Details, value: Some(Value(String("details"))) }] })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic', PROGRESS GROUP ID PREFIX 'prefix', COMPRESSION TYPE = gzip, TOPIC METADATA REFRESH INTERVAL = '1s', PARTITION BY = 1 + 2) FORMAT BYTES
@@ -1570,7 +1577,7 @@ AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")])
 parse-statement
 ALTER SOURCE IF EXISTS n ADD SUBSOURCE a, b.c, c, d.e WITH ()
 ----
-error: Expected one of TEXT or IGNORE, found right parenthesis
+error: Expected one of TEXT or EXCLUDE or IGNORE, found right parenthesis
 ALTER SOURCE IF EXISTS n ADD SUBSOURCE a, b.c, c, d.e WITH ()
                                                             ^
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -454,7 +454,7 @@ generate_extracted_config!(
     MySqlConfigOption,
     (Details, String),
     (TextColumns, Vec::<UnresolvedItemName>, Default(vec![])),
-    (IgnoreColumns, Vec::<UnresolvedItemName>, Default(vec![]))
+    (ExcludeColumns, Vec::<UnresolvedItemName>, Default(vec![]))
 );
 
 pub fn plan_create_webhook_source(
@@ -845,11 +845,11 @@ pub fn plan_create_source(
             };
             let MySqlConfigOptionExtracted {
                 details,
-                // text/ignore columns are already part of the source-exports and are only included
+                // text/exclude columns are already part of the source-exports and are only included
                 // in these options for round-tripping of a `CREATE SOURCE` statement. This should
                 // be removed once we drop support for implicitly created subsources.
                 text_columns: _,
-                ignore_columns: _,
+                exclude_columns: _,
                 seen: _,
             } = options.clone().try_into()?;
 
@@ -1333,7 +1333,7 @@ generate_extracted_config!(
     (Progress, bool, Default(false)),
     (ExternalReference, UnresolvedItemName),
     (TextColumns, Vec::<Ident>, Default(vec![])),
-    (IgnoreColumns, Vec::<Ident>, Default(vec![])),
+    (ExcludeColumns, Vec::<Ident>, Default(vec![])),
     (Details, String)
 );
 
@@ -1354,7 +1354,7 @@ pub fn plan_create_subsource(
         progress,
         external_reference,
         text_columns,
-        ignore_columns,
+        exclude_columns,
         details,
         seen: _,
     } = with_options.clone().try_into()?;
@@ -1404,7 +1404,7 @@ pub fn plan_create_subsource(
                 table,
                 initial_gtid_set,
                 text_columns: text_columns.into_iter().map(|c| c.into_string()).collect(),
-                ignore_columns: ignore_columns
+                exclude_columns: exclude_columns
                     .into_iter()
                     .map(|c| c.into_string())
                     .collect(),
@@ -1448,7 +1448,7 @@ pub fn plan_create_subsource(
 generate_extracted_config!(
     TableFromSourceOption,
     (TextColumns, Vec::<Ident>, Default(vec![])),
-    (IgnoreColumns, Vec::<Ident>, Default(vec![])),
+    (ExcludeColumns, Vec::<Ident>, Default(vec![])),
     (Details, String)
 );
 
@@ -1470,7 +1470,7 @@ pub fn plan_create_table_from_source(
 
     let TableFromSourceOptionExtracted {
         text_columns,
-        ignore_columns,
+        exclude_columns,
         details,
         seen: _,
     } = with_options.clone().try_into()?;
@@ -1508,7 +1508,7 @@ pub fn plan_create_table_from_source(
             table,
             initial_gtid_set,
             text_columns: text_columns.into_iter().map(|c| c.into_string()).collect(),
-            ignore_columns: ignore_columns
+            exclude_columns: exclude_columns
                 .into_iter()
                 .map(|c| c.into_string())
                 .collect(),
@@ -6053,7 +6053,7 @@ pub fn describe_alter_source(
 generate_extracted_config!(
     AlterSourceAddSubsourceOption,
     (TextColumns, Vec::<UnresolvedItemName>, Default(vec![])),
-    (IgnoreColumns, Vec::<UnresolvedItemName>, Default(vec![])),
+    (ExcludeColumns, Vec::<UnresolvedItemName>, Default(vec![])),
     (Details, String)
 );
 

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -1021,7 +1021,7 @@ fn humanize_sql_for_show_create(
                             // COLUMNS` values that refer to the table it
                             // ingests, which we'll handle below.
                             MySqlConfigOptionName::TextColumns
-                            | MySqlConfigOptionName::IgnoreColumns => {}
+                            | MySqlConfigOptionName::ExcludeColumns => {}
                             // Drop details, which does not rountrip.
                             MySqlConfigOptionName::Details => return false,
                         };
@@ -1036,13 +1036,13 @@ fn humanize_sql_for_show_create(
                                         curr_references.contains_key(&name)
                                     }
                                     _ => unreachable!(
-                                        "TEXT COLUMNS + IGNORE COLUMNS must be sequence of unresolved item names"
+                                        "TEXT COLUMNS + EXCLUDE COLUMNS must be sequence of unresolved item names"
                                     ),
                                 });
                                 !seq_unresolved_item_names.is_empty()
                             }
                             _ => unreachable!(
-                                "TEXT COLUMNS + IGNORE COLUMNS must be sequence of unresolved item names"
+                                "TEXT COLUMNS + EXCLUDE COLUMNS must be sequence of unresolved item names"
                             ),
                         }
                     });
@@ -1077,7 +1077,7 @@ fn humanize_sql_for_show_create(
             stmt.with_options.retain_mut(|o| {
                 match o.name {
                     CreateSubsourceOptionName::TextColumns => true,
-                    CreateSubsourceOptionName::IgnoreColumns => true,
+                    CreateSubsourceOptionName::ExcludeColumns => true,
                     // Drop details, which does not rountrip.
                     CreateSubsourceOptionName::Details => false,
                     CreateSubsourceOptionName::ExternalReference => true,

--- a/src/sql/src/pure/error.rs
+++ b/src/sql/src/pure/error.rs
@@ -316,7 +316,7 @@ impl MySqlSourcePurificationError {
             ),
             Self::UnrecognizedTypes { cols: _ } => Some(
                 "Check the docs -- some types can be supported using the TEXT COLUMNS option to \
-                ingest their values as text, or ignored using IGNORE COLUMNS."
+                ingest their values as text, or ignored using EXCLUDE COLUMNS."
                     .into(),
             ),
             Self::EmptyDatabase => Some(

--- a/src/storage-types/src/sources/mysql.proto
+++ b/src/storage-types/src/sources/mysql.proto
@@ -30,7 +30,7 @@ message ProtoMySqlSourceExportDetails {
     mz_mysql_util.ProtoMySqlTableDesc table = 1;
     string initial_gtid_set = 2;
     repeated string text_columns = 3;
-    repeated string ignore_columns = 4;
+    repeated string exclude_columns = 4;
 }
 
 // NOTE: this message is encoded and stored as part of source export

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -240,7 +240,7 @@ pub struct MySqlSourceExportDetails {
     #[proptest(strategy = "any_gtidset()")]
     pub initial_gtid_set: String,
     pub text_columns: Vec<String>,
-    pub ignore_columns: Vec<String>,
+    pub exclude_columns: Vec<String>,
 }
 
 impl RustType<ProtoMySqlSourceExportDetails> for MySqlSourceExportDetails {
@@ -249,7 +249,7 @@ impl RustType<ProtoMySqlSourceExportDetails> for MySqlSourceExportDetails {
             table: Some(self.table.into_proto()),
             initial_gtid_set: self.initial_gtid_set.clone(),
             text_columns: self.text_columns.clone(),
-            ignore_columns: self.ignore_columns.clone(),
+            exclude_columns: self.exclude_columns.clone(),
         }
     }
 
@@ -260,7 +260,7 @@ impl RustType<ProtoMySqlSourceExportDetails> for MySqlSourceExportDetails {
                 .into_rust_if_some("ProtoMySqlSourceExportDetails::table")?,
             initial_gtid_set: proto.initial_gtid_set,
             text_columns: proto.text_columns,
-            ignore_columns: proto.ignore_columns,
+            exclude_columns: proto.exclude_columns,
         })
     }
 }
@@ -277,7 +277,7 @@ impl AlterCompatible for MySqlSourceExportDetails {
             table: _,
             initial_gtid_set: _,
             text_columns: _,
-            ignore_columns: _,
+            exclude_columns: _,
         } = self;
         Ok(())
     }

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -144,7 +144,7 @@ impl SourceRender for MySqlSourceConnection {
                 output_index: *ingestion_output,
                 desc,
                 text_columns: details.text_columns.clone(),
-                ignore_columns: details.ignore_columns.clone(),
+                exclude_columns: details.exclude_columns.clone(),
                 initial_gtid_set: gtid_set_frontier(&initial_gtid_set).expect("invalid gtid set"),
                 resume_upper,
             });
@@ -225,7 +225,7 @@ struct SourceOutputInfo {
     table_name: MySqlTableName,
     desc: MySqlTableDesc,
     text_columns: Vec<String>,
-    ignore_columns: Vec<String>,
+    exclude_columns: Vec<String>,
     initial_gtid_set: Antichain<GtidPartition>,
     resume_upper: Antichain<GtidPartition>,
 }

--- a/src/storage/src/source/mysql/schemas.rs
+++ b/src/storage/src/source/mysql/schemas.rs
@@ -60,7 +60,7 @@ where
                                 output.text_columns.iter().map(|s| s.as_str()),
                             )),
                             Some(&BTreeSet::from_iter(
-                                output.ignore_columns.iter().map(|s| s.as_str()),
+                                output.exclude_columns.iter().map(|s| s.as_str()),
                             )),
                         );
                         match new_desc {

--- a/test/mysql-cdc/35-exclude-columns.td
+++ b/test/mysql-cdc/35-exclude-columns.td
@@ -37,14 +37,14 @@ contains: unsupported type
 
 ! CREATE SOURCE da
   FROM MYSQL CONNECTION mysqc (
-    IGNORE COLUMNS (t1.f2, t1.f3)
+    EXCLUDE COLUMNS (t1.f2, t1.f3)
   )
   FOR TABLES (public.t1);
-contains:invalid IGNORE COLUMNS option value: column name 't1.f2' must have at least a table qualification
+contains:invalid EXCLUDE COLUMNS option value: column name 't1.f2' must have at least a table qualification
 
 > CREATE SOURCE da
   FROM MYSQL CONNECTION mysqc (
-    IGNORE COLUMNS (public.t1.f2, public.t1.f3)
+    EXCLUDE COLUMNS (public.t1.f2, public.t1.f3)
   )
   FOR TABLES (public.t1);
 
@@ -62,7 +62,7 @@ INSERT INTO t1 SELECT * FROM t1;
 "test"
 
 > SHOW CREATE SOURCE t1;
-materialize.public.t1 "CREATE SUBSOURCE \"materialize\".\"public\".\"t1\" (\"f1\" \"pg_catalog\".\"int4\", \"f4\" \"pg_catalog\".\"varchar\"(64)) OF SOURCE \"materialize\".\"public\".\"da\" WITH (EXTERNAL REFERENCE = \"public\".\"t1\", IGNORE COLUMNS = (\"f2\", \"f3\"))"
+materialize.public.t1 "CREATE SUBSOURCE \"materialize\".\"public\".\"t1\" (\"f1\" \"pg_catalog\".\"int4\", \"f4\" \"pg_catalog\".\"varchar\"(64)) OF SOURCE \"materialize\".\"public\".\"da\" WITH (EXTERNAL REFERENCE = \"public\".\"t1\", EXCLUDE COLUMNS = (\"f2\", \"f3\"))"
 
 ! SELECT f2 FROM t1;
 contains:column "f2" does not exist

--- a/test/mysql-cdc/alter-source.td
+++ b/test/mysql-cdc/alter-source.td
@@ -395,27 +395,27 @@ detail:the following columns are referenced but not added: public.table_f.f2
 
 
 #
-# Can add tables with ignore columns
+# Can add tables with exclude columns
 #
-! ALTER SOURCE mz_source ADD SUBSOURCE public.table_f WITH (IGNORE COLUMNS [public.table_f.f2, public.table_f.f2]);
-contains: invalid IGNORE COLUMNS option value: unexpected multiple references to public.table_f.f2
+! ALTER SOURCE mz_source ADD SUBSOURCE public.table_f WITH (EXCLUDE COLUMNS [public.table_f.f2, public.table_f.f2]);
+contains: invalid EXCLUDE COLUMNS option value: unexpected multiple references to public.table_f.f2
 
-> ALTER SOURCE mz_source ADD SUBSOURCE public.table_f WITH (IGNORE COLUMNS [public.table_f.f2]);
+> ALTER SOURCE mz_source ADD SUBSOURCE public.table_f WITH (EXCLUDE COLUMNS [public.table_f.f2]);
 
 > SELECT * FROM table_f
 1
 2
 3
 
-> SELECT regexp_match(create_sql, 'IGNORE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+> SELECT regexp_match(create_sql, 'EXCLUDE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
 "\"public\".\"table_f\".\"f2\""
 
-> ALTER SOURCE mz_source ADD SUBSOURCE public.table_i WITH (IGNORE COLUMNS [public.table_i.f2]);
+> ALTER SOURCE mz_source ADD SUBSOURCE public.table_i WITH (EXCLUDE COLUMNS [public.table_i.f2]);
 
-> SELECT regexp_match(create_sql, 'IGNORE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+> SELECT regexp_match(create_sql, 'EXCLUDE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
 "\"public\".\"table_f\".\"f2\", \"public\".\"table_i\".\"f2\""
 
-> SELECT regexp_match(create_sql, 'IGNORE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE table_i);
+> SELECT regexp_match(create_sql, 'EXCLUDE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE table_i);
 "\"f2\""
 
 > SELECT * FROM table_i
@@ -424,28 +424,28 @@ contains: invalid IGNORE COLUMNS option value: unexpected multiple references to
 
 > DROP SOURCE table_f, table_i;
 
-> SELECT regexp_match(create_sql, 'IGNORE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+> SELECT regexp_match(create_sql, 'EXCLUDE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
 <null>
 
-! ALTER SOURCE mz_source ADD SUBSOURCE public.table_e WITH (IGNORE COLUMNS (public.table_z.a));
+! ALTER SOURCE mz_source ADD SUBSOURCE public.table_e WITH (EXCLUDE COLUMNS (public.table_z.a));
 contains:Reference to columns not currently being added
 
-! ALTER SOURCE mz_source ADD SUBSOURCE public.table_e WITH (IGNORE COLUMNS [public.table_f.f2]);
+! ALTER SOURCE mz_source ADD SUBSOURCE public.table_e WITH (EXCLUDE COLUMNS [public.table_f.f2]);
 contains:Reference to columns not currently being added
 detail:the following columns are referenced but not added: public.table_f.f2
 
-# Test adding ignore cols w/o original IGNORE COLUMNS
+# Test adding exclude cols w/o original EXCLUDE COLUMNS
 
-> CREATE SOURCE "mz_source_wo_init_ignore_cols"
+> CREATE SOURCE "mz_source_wo_init_exclude_cols"
   FROM MYSQL CONNECTION mysql_conn
   FOR TABLES (public.table_a AS t_a2);
 
-> SELECT regexp_match(create_sql, 'IGNORE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source_wo_init_ignore_cols);
+> SELECT regexp_match(create_sql, 'EXCLUDE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source_wo_init_exclude_cols);
 <null>
 
-> ALTER SOURCE mz_source_wo_init_ignore_cols ADD SUBSOURCE public.table_f AS t_f2 WITH (IGNORE COLUMNS [public.table_f.f2]);
+> ALTER SOURCE mz_source_wo_init_exclude_cols ADD SUBSOURCE public.table_f AS t_f2 WITH (EXCLUDE COLUMNS [public.table_f.f2]);
 
-> SELECT regexp_match(create_sql, 'IGNORE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source_wo_init_ignore_cols);
+> SELECT regexp_match(create_sql, 'EXCLUDE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source_wo_init_exclude_cols);
 "\"public\".\"table_f\".\"f2\""
 
 # Add a table after having created the source


### PR DESCRIPTION
We want to align this option with the forthcoming analogous option for sinks (#27758). In the context of sinks, "EXCLUDE" reads better than "IGNORE", because the columns aren't wholly ignored. Rather, they're allowed to be referenced in the PARTITION BY expression and the HEADERS option--they're just *excluded* from the final value.

EXCLUDE also nicely aligns with the `SELECT ... EXCLUDE` syntax that was recently added to DuckDB and Snowflake.

For backwards compatibility, the `IGNORE COLUMNS` option for the MySQL source continues to be accepted as an alias for `EXCLUDE COLUMNS`.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
