### PR TITLE
version consistency: add ignore for changed order of array_agg and string_agg

### DIFF
--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -50,6 +50,7 @@ MZ_VERSION_0_95_0 = MzVersion.parse_mz("v0.95.0")
 MZ_VERSION_0_99_0 = MzVersion.parse_mz("v0.99.0")
 MZ_VERSION_0_107_0 = MzVersion.parse_mz("v0.107.0")
 MZ_VERSION_0_109_0 = MzVersion.parse_mz("v0.109.0")
+MZ_VERSION_0_117_0 = MzVersion.parse_mz("v0.117.0")
 
 
 class VersionConsistencyIgnoreFilter(GenericInconsistencyIgnoreFilter):
@@ -177,6 +178,18 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
             )
         ):
             return YesIgnore("Contains on list and array introduced in PR 27959")
+
+        if (
+            self.lower_version < MZ_VERSION_0_117_0 <= self.higher_version
+            and expression.matches(
+                partial(
+                    matches_fun_by_any_name,
+                    function_names_in_lower_case={"array_agg", "string_agg"},
+                ),
+                True,
+            )
+        ):
+            return YesIgnore("Order changes with PR#29422 for both DFR and CTF")
 
         return super().shall_ignore_expression(expression, row_selection)
 


### PR DESCRIPTION
This addresses https://buildkite.com/materialize/nightly/builds/9456#0191c9b1-a3fa-44b9-a589-baeecb4e4723 and other builds caused by https://github.com/MaterializeInc/materialize/pull/29422.