### PR TITLE
output consistency: remove string_agg and array_agg without ordering

### DIFF
--- a/misc/python/materialize/output_consistency/ignore_filter/internal_output_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/internal_output_inconsistency_ignore_filter.py
@@ -38,7 +38,6 @@ from materialize.output_consistency.input_data.return_specs.number_return_spec i
 )
 from materialize.output_consistency.operation.operation import (
     DbFunction,
-    DbFunctionWithCustomPattern,
     DbOperation,
     DbOperationOrFunction,
 )
@@ -110,13 +109,6 @@ class PreExecutionInternalOutputInconsistencyIgnoreFilter(
                 and ExpressionCharacteristics.TINY_VALUE in all_involved_characteristics
             ):
                 return YesIgnore("#15186")
-
-        if db_function.function_name_in_lower_case in {
-            "array_agg",
-            "string_agg",
-        } and not isinstance(db_function, DbFunctionWithCustomPattern):
-            # The unordered variants are to be ignored.
-            return YesIgnore("#19832")
 
         return NoIgnore()
 

--- a/misc/python/materialize/output_consistency/input_data/operations/aggregate_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/aggregate_operations_provider.py
@@ -146,17 +146,6 @@ AGGREGATE_OPERATION_TYPES.append(
 )
 
 AGGREGATE_OPERATION_TYPES.append(
-    DbFunction(
-        "string_agg",
-        [StringOperationParam(), StringOperationParam()],
-        StringReturnTypeSpec(),
-        is_aggregation=True,
-        relevance=OperationRelevance.LOW,
-        comment="without ordering",
-    ),
-)
-
-AGGREGATE_OPERATION_TYPES.append(
     DbFunctionWithCustomPattern(
         "string_agg",
         {3: "string_agg($, $ ORDER BY row_index, $)"},
@@ -168,6 +157,5 @@ AGGREGATE_OPERATION_TYPES.append(
         StringReturnTypeSpec(),
         is_aggregation=True,
         relevance=OperationRelevance.LOW,
-        comment="with ordering",
     ),
 )

--- a/misc/python/materialize/output_consistency/input_data/operations/array_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/array_operations_provider.py
@@ -170,22 +170,12 @@ ARRAY_OPERATION_TYPES.append(
     )
 )
 ARRAY_OPERATION_TYPES.append(
-    DbFunction(
-        "array_agg",
-        [AnyOperationParam()],
-        ArrayReturnTypeSpec(array_value_type_category=DataTypeCategory.DYNAMIC),
-        is_aggregation=True,
-        comment="without ordering",
-    ),
-)
-ARRAY_OPERATION_TYPES.append(
     DbFunctionWithCustomPattern(
         "array_agg",
         {2: "array_agg($ ORDER BY row_index, $)"},
         [AnyOperationParam(), SameOperationParam(index_of_previous_param=0)],
         ArrayReturnTypeSpec(array_value_type_category=DataTypeCategory.DYNAMIC),
         is_aggregation=True,
-        comment="with ordering",
     ),
 )
 ARRAY_OPERATION_TYPES.append(

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -232,15 +232,6 @@ class PgPreExecutionInconsistencyIgnoreFilter(
         expression: ExpressionWithArgs,
         all_involved_characteristics: set[ExpressionCharacteristics],
     ) -> IgnoreVerdict:
-        inconsistent_value_ordering_functions = ["array_agg", "string_agg"]
-        if (
-            db_function.function_name_in_lower_case
-            in inconsistent_value_ordering_functions
-            # only exclude unordered variant
-            and "ORDER BY" not in db_function.to_pattern(db_function.max_param_count)
-        ):
-            return YesIgnore("inconsistent ordering, not an error")
-
         if db_function.function_name_in_lower_case == "jsonb_pretty":
             return YesIgnore("Accepted")
 


### PR DESCRIPTION
This replaces https://github.com/MaterializeInc/materialize/pull/29444 and addresses https://buildkite.com/materialize/nightly/builds/9456#0191c9b1-a3fa-44b9-a589-baeecb4e4723.