### PR TITLE
[persist] Only include the Arrow DataType info at the top level in proto

### DIFF
--- a/src/persist-types/src/arrow.rs
+++ b/src/persist-types/src/arrow.rs
@@ -27,8 +27,10 @@ use std::sync::Arc;
 
 use arrow::array::*;
 use arrow::buffer::{BooleanBuffer, NullBuffer, OffsetBuffer};
-use arrow::datatypes::{ArrowNativeType, DataType, Field, Fields};
+use arrow::datatypes::{ArrowNativeType, DataType, Field, FieldRef, Fields};
+use itertools::Itertools;
 use mz_ore::cast::CastFrom;
+use mz_ore::soft_assert_eq_no_log;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use prost::Message;
 
@@ -38,49 +40,151 @@ mod proto {
 }
 pub use proto::ProtoArrayData;
 
+/// Extract the list of fields for our recursive datatypes.
+fn fields_for_type(data_type: &DataType) -> &[FieldRef] {
+    match data_type {
+        DataType::Struct(fields) => fields,
+        DataType::List(field) => std::slice::from_ref(field),
+        DataType::Map(field, _) => std::slice::from_ref(field),
+        DataType::Null
+        | DataType::Boolean
+        | DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::UInt64
+        | DataType::Float16
+        | DataType::Float32
+        | DataType::Float64
+        | DataType::Timestamp(_, _)
+        | DataType::Date32
+        | DataType::Date64
+        | DataType::Time32(_)
+        | DataType::Time64(_)
+        | DataType::Duration(_)
+        | DataType::Interval(_)
+        | DataType::Binary
+        | DataType::FixedSizeBinary(_)
+        | DataType::LargeBinary
+        | DataType::BinaryView
+        | DataType::Utf8
+        | DataType::LargeUtf8
+        | DataType::Utf8View
+        | DataType::Decimal128(_, _)
+        | DataType::Decimal256(_, _) => &[],
+        DataType::ListView(_)
+        | DataType::FixedSizeList(_, _)
+        | DataType::LargeList(_)
+        | DataType::LargeListView(_)
+        | DataType::Union(_, _)
+        | DataType::Dictionary(_, _)
+        | DataType::RunEndEncoded(_, _) => unimplemented!("not supported"),
+    }
+}
+
+/// Encode the array into proto.
+/// We omit the data type if it matches the expected type, to save space.
+fn into_proto_with_type(data: &ArrayData, expected_type: Option<&DataType>) -> ProtoArrayData {
+    let data_type = match expected_type {
+        Some(expected) => {
+            // Equality is recursive, and this function is itself called recursively,
+            // skip the call in production to avoid a quadratic overhead.
+            soft_assert_eq_no_log!(
+                expected,
+                data.data_type(),
+                "actual type should match expected type"
+            );
+            None
+        }
+        None => Some(data.data_type().into_proto()),
+    };
+
+    ProtoArrayData {
+        data_type,
+        length: u64::cast_from(data.len()),
+        offset: u64::cast_from(data.offset()),
+        buffers: data.buffers().iter().map(|b| b.into_proto()).collect(),
+        children: data
+            .child_data()
+            .iter()
+            .zip_eq(fields_for_type(expected_type.unwrap_or(data.data_type())))
+            .map(|(child, expect)| into_proto_with_type(child, Some(expect.data_type())))
+            .collect(),
+        nulls: data.nulls().map(|n| n.inner().into_proto()),
+    }
+}
+
+/// Decode the array data.
+/// If the data type is omitted from the proto, we decode it as the expected type.
+fn from_proto_with_type(
+    proto: ProtoArrayData,
+    expected_type: Option<&DataType>,
+) -> Result<ArrayData, TryFromProtoError> {
+    let ProtoArrayData {
+        data_type,
+        length,
+        offset,
+        buffers,
+        children,
+        nulls,
+    } = proto;
+    let data_type: Option<DataType> = data_type.into_rust()?;
+    let data_type = match (data_type, expected_type) {
+        (Some(data_type), None) => data_type,
+        (Some(data_type), Some(expected_type)) => {
+            // Equality is recursive, and this function is itself called recursively,
+            // skip the call in production to avoid a quadratic overhead.
+            soft_assert_eq_no_log!(
+                data_type,
+                *expected_type,
+                "expected type should match actual type"
+            );
+            data_type
+        }
+        (None, Some(expected_type)) => expected_type.clone(),
+        (None, None) => {
+            return Err(TryFromProtoError::MissingField(
+                "ProtoArrayData::data_type".to_string(),
+            ))
+        }
+    };
+    let nulls = nulls
+        .map(|n| n.into_rust())
+        .transpose()?
+        .map(NullBuffer::new);
+
+    let mut builder = ArrayDataBuilder::new(data_type.clone())
+        .len(usize::cast_from(length))
+        .offset(usize::cast_from(offset))
+        .nulls(nulls);
+
+    for b in buffers.into_iter().map(|b| b.into_rust()) {
+        builder = builder.add_buffer(b?);
+    }
+    for c in children
+        .into_iter()
+        .zip_eq(fields_for_type(&data_type))
+        .map(|(c, field)| from_proto_with_type(c, Some(field.data_type())))
+    {
+        builder = builder.add_child_data(c?);
+    }
+
+    // Construct the builder which validates all inputs and aligns data.
+    builder
+        .build_aligned()
+        .map_err(|e| TryFromProtoError::RowConversionError(e.to_string()))
+}
+
 impl RustType<ProtoArrayData> for arrow::array::ArrayData {
     fn into_proto(&self) -> ProtoArrayData {
-        ProtoArrayData {
-            data_type: Some(self.data_type().into_proto()),
-            length: u64::cast_from(self.len()),
-            offset: u64::cast_from(self.offset()),
-            buffers: self.buffers().iter().map(|b| b.into_proto()).collect(),
-            children: self.child_data().iter().map(|c| c.into_proto()).collect(),
-            nulls: self.nulls().map(|n| n.inner().into_proto()),
-        }
+        into_proto_with_type(self, None)
     }
 
     fn from_proto(proto: ProtoArrayData) -> Result<Self, TryFromProtoError> {
-        let ProtoArrayData {
-            data_type,
-            length,
-            offset,
-            buffers,
-            children,
-            nulls,
-        } = proto;
-        let data_type = data_type.into_rust_if_some("data_type")?;
-        let nulls = nulls
-            .map(|n| n.into_rust())
-            .transpose()?
-            .map(NullBuffer::new);
-
-        let mut builder = ArrayDataBuilder::new(data_type)
-            .len(usize::cast_from(length))
-            .offset(usize::cast_from(offset))
-            .nulls(nulls);
-
-        for b in buffers.into_iter().map(|b| b.into_rust()) {
-            builder = builder.add_buffer(b?);
-        }
-        for c in children.into_iter().map(|c| c.into_rust()) {
-            builder = builder.add_child_data(c?);
-        }
-
-        // Construct the builder which validates all inputs and aligns data.
-        builder
-            .build_aligned()
-            .map_err(|e| TryFromProtoError::RowConversionError(e.to_string()))
+        from_proto_with_type(proto, None)
     }
 }
 

--- a/src/persist-types/src/arrow.rs
+++ b/src/persist-types/src/arrow.rs
@@ -97,7 +97,8 @@ fn into_proto_with_type(data: &ArrayData, expected_type: Option<&DataType>) -> P
                 data.data_type(),
                 "actual type should match expected type"
             );
-            None
+            // TODO(bkirwi): return None here in a future release, assuming the types match
+            Some(expected.into_proto())
         }
         None => Some(data.data_type().into_proto()),
     };


### PR DESCRIPTION
Arrow types are recursive, and they're present at all levels of a hierarchical data type. For example, if I have a struct array, I'll have a list of fields which include the data types of each child... and a separate list of children, each of which track their own datatype.

In general this doesn't explode in size for arrow because many types contain `Arc`s and can be shared. But we lose this sharing when encoding to proto.

This changes our encoding to pass an "expected" type to encoding and decoding. Encoding is allowed to omit the type if it matches the expected type, and decoding is allowed to assume an omitted type is the expected type. In practice this means that we only need to include the type info at the top level.

This can be very significant for small arrays. For example, some single-row arrays I've been testing have their size cut down by about a third. (And as a side benefit, this improves sharing at decode time by cloning potentically-`Arc` types instead of re-decoding them.)

### Motivation

Previously unspecified refactoring.

This is not mandatory but very nice for #29412 - we're looking at adding a trimmed/encoded array to every part, and the smaller the encoding the less trimming we'll have to do for any particular threshold. (And it should have a similar benefit for inline parts.)

### Tips for reviewer

I've added a second commit that disables the optimization, but keeps the more-flexible read path. Like other proto migrations, we don't want to change the data we write until the previous version knows how to read it; normally we'd add a flag, but this is deep enough to make that tricky, and since I'm AFK for most of the week I'm relatively happy to wait a release for the full version. The expectation is that next week, I'll come back and revert this second commit.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
