### PR TITLE
Update timely dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,23 +3,6 @@
 version = 3
 
 [[package]]
-name = "abomonation"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e72913c99b1f927aa7bd59a41518fdd9995f63ffc8760f211609e0241c4fb2"
-
-[[package]]
-name = "abomonation_derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50e2a046af56a864c62d97b7153fda72c596e646be1b0c7963736821f6e1efa"
-dependencies = [
- "proc-macro2",
- "quote",
- "synstructure",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,10 +2036,8 @@ dependencies = [
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#e9128d448ddb4ff28a8f7b8979bb03ccdd14233f"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#7607a2b757394485453343a681df6083872b3f0a"
 dependencies = [
- "abomonation",
- "abomonation_derive",
  "fnv",
  "serde",
  "timely",
@@ -2109,10 +2090,8 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#e9128d448ddb4ff28a8f7b8979bb03ccdd14233f"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#7607a2b757394485453343a681df6083872b3f0a"
 dependencies = [
- "abomonation",
- "abomonation_derive",
  "differential-dataflow",
  "serde",
  "serde_derive",
@@ -9419,18 +9398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
-name = "synstructure"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
- "unicode-xid",
-]
-
-[[package]]
 name = "sysctl"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9723,14 +9690,14 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#5a3a4abb3d7a4f84b499782c579af067b466cb66"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#50f5e056d9ebbad31adb8747ac293c137fcb9ae8"
 dependencies = [
- "abomonation",
- "abomonation_derive",
+ "bincode",
  "crossbeam-channel",
  "getopts",
  "serde",
  "serde_derive",
+ "smallvec",
  "timely_bytes",
  "timely_communication",
  "timely_container",
@@ -9740,15 +9707,13 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#5a3a4abb3d7a4f84b499782c579af067b466cb66"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#50f5e056d9ebbad31adb8747ac293c137fcb9ae8"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#5a3a4abb3d7a4f84b499782c579af067b466cb66"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#50f5e056d9ebbad31adb8747ac293c137fcb9ae8"
 dependencies = [
- "abomonation",
- "abomonation_derive",
  "bincode",
  "byteorder",
  "crossbeam-channel",
@@ -9762,7 +9727,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#5a3a4abb3d7a4f84b499782c579af067b466cb66"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#50f5e056d9ebbad31adb8747ac293c137fcb9ae8"
 dependencies = [
  "columnation",
  "flatcontainer",
@@ -9772,7 +9737,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#5a3a4abb3d7a4f84b499782c579af067b466cb66"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#50f5e056d9ebbad31adb8747ac293c137fcb9ae8"
 
 [[package]]
 name = "tiny-keccak"
@@ -10438,12 +10403,6 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/deny.toml
+++ b/deny.toml
@@ -113,6 +113,10 @@ skip = [
     { name = "sync_wrapper", version = "0.1.2" },
 ]
 
+# We don't want to use abomonation anymore.
+[[bans.deny]]
+name = "abomonation"
+
 # Use `tracing` instead.
 [[bans.deny]]
 name = "env_logger"

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -305,7 +305,8 @@ version = "1.0.5"
 [[audits.differential-dataflow]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:e9128d448ddb4ff28a8f7b8979bb03ccdd14233f"
+version = "0.12.0@git:7607a2b757394485453343a681df6083872b3f0a"
+importable = false
 
 [[audits.domain]]
 who = "Matt Jibson <matt.jibson@gmail.com>"
@@ -1122,22 +1123,26 @@ version = "0.17.0"
 [[audits.timely]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:5a3a4abb3d7a4f84b499782c579af067b466cb66"
+version = "0.12.0@git:50f5e056d9ebbad31adb8747ac293c137fcb9ae8"
+importable = false
 
 [[audits.timely_bytes]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:5a3a4abb3d7a4f84b499782c579af067b466cb66"
+version = "0.12.0@git:50f5e056d9ebbad31adb8747ac293c137fcb9ae8"
+importable = false
 
 [[audits.timely_communication]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:5a3a4abb3d7a4f84b499782c579af067b466cb66"
+version = "0.12.0@git:50f5e056d9ebbad31adb8747ac293c137fcb9ae8"
+importable = false
 
 [[audits.timely_logging]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:5a3a4abb3d7a4f84b499782c579af067b466cb66"
+version = "0.12.0@git:50f5e056d9ebbad31adb8747ac293c137fcb9ae8"
+importable = false
 
 [[audits.tokio]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
@@ -1362,7 +1367,7 @@ delta = "6.0.6 -> 7.0.0"
 
 [[trusted.abomonation]]
 criteria = "safe-to-deploy"
-user-id = 704 # Frank McSherry (frankmcsherry)
+user-id = 704
 start = "2019-05-27"
 end = "2024-11-21"
 
@@ -1608,7 +1613,7 @@ end = "2024-11-16"
 
 [[trusted.differential-dataflow]]
 criteria = "safe-to-deploy"
-user-id = 704 # Frank McSherry (frankmcsherry)
+user-id = 704
 start = "2019-03-31"
 end = "2024-11-21"
 
@@ -1710,7 +1715,7 @@ end = "2024-11-16"
 
 [[trusted.launchdarkly-server-sdk]]
 criteria = "safe-to-deploy"
-user-id = 144672 # LaunchDarklyReleaseBot
+user-id = 144672
 start = "2022-01-22"
 end = "2024-12-24"
 
@@ -2016,31 +2021,31 @@ end = "2024-11-16"
 
 [[trusted.timely]]
 criteria = "safe-to-deploy"
-user-id = 704 # Frank McSherry (frankmcsherry)
+user-id = 704
 start = "2019-03-31"
 end = "2024-11-21"
 
 [[trusted.timely_bytes]]
 criteria = "safe-to-deploy"
-user-id = 704 # Frank McSherry (frankmcsherry)
+user-id = 704
 start = "2019-03-31"
 end = "2024-11-21"
 
 [[trusted.timely_communication]]
 criteria = "safe-to-deploy"
-user-id = 704 # Frank McSherry (frankmcsherry)
+user-id = 704
 start = "2019-03-31"
 end = "2024-11-21"
 
 [[trusted.timely_logging]]
 criteria = "safe-to-deploy"
-user-id = 704 # Frank McSherry (frankmcsherry)
+user-id = 704
 start = "2019-03-31"
 end = "2024-11-21"
 
 [[trusted.tokio-macros]]
 criteria = "safe-to-deploy"
-user-id = 10 # Carl Lerche (carllerche)
+user-id = 10
 start = "2019-04-24"
 end = "2024-11-16"
 

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -102,10 +102,6 @@ audit-as-crates-io = true
 [policy.workspace-hack]
 audit-as-crates-io = true
 
-[[exemptions.abomonation_derive]]
-version = "0.5.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.addr2line]]
 version = "0.17.0"
 criteria = "safe-to-deploy"
@@ -122,24 +118,12 @@ criteria = "safe-to-deploy"
 version = "0.1.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.array-init-cursor]]
-version = "0.2.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.arrayvec]]
 version = "0.5.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.arrow-format]]
-version = "0.8.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.askama_escape]]
 version = "0.10.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.askama_shared]]
-version = "0.12.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.async-compression]]
@@ -152,10 +136,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.auto_impl]]
 version = "1.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.autotools]]
-version = "0.2.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.backoff]]
@@ -182,14 +162,6 @@ criteria = "safe-to-deploy"
 version = "1.3.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.bindgen]]
-version = "0.65.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.bitflags]]
-version = "1.3.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.block-buffer]]
 version = "0.10.0"
 criteria = "safe-to-deploy"
@@ -206,14 +178,6 @@ criteria = "safe-to-deploy"
 version = "0.1.7"
 criteria = "safe-to-deploy"
 
-[[exemptions.bytemuck]]
-version = "1.9.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.bytemuck_derive]]
-version = "1.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.bytes]]
 version = "1.4.0"
 criteria = "safe-to-deploy"
@@ -224,10 +188,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.bytesize]]
 version = "1.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.cargo-lock]]
-version = "7.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.cargo_metadata]]
@@ -370,10 +330,6 @@ criteria = "safe-to-deploy"
 version = "0.3.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.diff]]
-version = "0.1.12"
-criteria = "safe-to-deploy"
-
 [[exemptions.difflib]]
 version = "0.4.0"
 criteria = "safe-to-deploy"
@@ -442,10 +398,6 @@ criteria = "safe-to-deploy"
 version = "0.5.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.enum_dispatch]]
-version = "0.3.11"
-criteria = "safe-to-deploy"
-
 [[exemptions.enumflags2]]
 version = "0.7.7"
 criteria = "safe-to-deploy"
@@ -456,10 +408,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.error-chain]]
 version = "0.12.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.ethnum]]
-version = "1.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.eventsource-client]]
@@ -476,10 +424,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.fallible-iterator]]
 version = "0.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.fallible-streaming-iterator]]
-version = "0.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.fancy-regex]]
@@ -500,10 +444,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.float-cmp]]
 version = "0.9.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.foreign_vec]]
-version = "0.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.fs_extra]]
@@ -562,10 +502,6 @@ criteria = "safe-to-deploy"
 version = "1.6.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.hash_hasher]]
-version = "2.0.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.hdrhistogram]]
 version = "7.4.0"
 criteria = "safe-to-deploy"
@@ -602,16 +538,8 @@ criteria = "safe-to-deploy"
 version = "0.4.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.http-range-header]]
-version = "0.3.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.humantime]]
 version = "2.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.hyper-openssl]]
-version = "0.9.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.hyper-timeout]]
@@ -644,10 +572,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.itertools]]
 version = "0.10.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.jsonpath_lib]]
-version = "0.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.junit-report]]
@@ -742,14 +666,6 @@ criteria = "safe-to-deploy"
 version = "0.8.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.multiversion]]
-version = "0.6.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.multiversion-macros]]
-version = "0.6.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.mz-avro]]
 version = "0.7.0"
 criteria = "safe-to-deploy"
@@ -830,10 +746,6 @@ criteria = "safe-to-deploy"
 version = "6.0.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.output_vt100]]
-version = "0.1.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.outref]]
 version = "0.5.1"
 criteria = "safe-to-deploy"
@@ -852,14 +764,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.parking_lot_core]]
 version = "0.9.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.parquet-format-safe]]
-version = "0.2.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.parquet2]]
-version = "0.17.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.parse-zoneinfo]]
@@ -896,10 +800,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.pkg-config]]
 version = "0.3.20"
-criteria = "safe-to-deploy"
-
-[[exemptions.planus]]
-version = "0.3.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.plotters]]
@@ -948,10 +848,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.pretty-hex]]
 version = "0.3.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.pretty_assertions]]
-version = "1.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.proc-macro-crate]]
@@ -1198,10 +1094,6 @@ criteria = "safe-to-deploy"
 version = "1.5.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.simdutf8]]
-version = "0.1.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.similar-asserts]]
 version = "1.4.2"
 criteria = "safe-to-run"
@@ -1246,10 +1138,6 @@ criteria = "safe-to-deploy"
 version = "0.4.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.streaming-decompression]]
-version = "0.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.strip-ansi-escapes]]
 version = "0.2.0"
 criteria = "safe-to-deploy"
@@ -1268,10 +1156,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.symbolic-demangle]]
 version = "10.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.synstructure]]
-version = "0.12.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.sysctl]]
@@ -1358,10 +1242,6 @@ criteria = "safe-to-deploy"
 version = "0.4.13"
 criteria = "safe-to-deploy"
 
-[[exemptions.tower-http]]
-version = "0.4.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.tower-layer]]
 version = "0.3.2"
 criteria = "safe-to-deploy"
@@ -1392,10 +1272,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tracing-serde]]
 version = "0.1.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.treediff]]
-version = "4.0.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.treeline]]
@@ -1556,14 +1432,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.yansi]]
 version = "0.5.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.zerocopy]]
-version = "0.7.32"
-criteria = "safe-to-deploy"
-
-[[exemptions.zerocopy-derive]]
-version = "0.7.32"
 criteria = "safe-to-deploy"
 
 [[exemptions.zeroize]]

--- a/misc/cargo-vet/imports.lock
+++ b/misc/cargo-vet/imports.lock
@@ -1,20 +1,6 @@
 
 # cargo-vet imports lock
 
-[[publisher.abomonation]]
-version = "0.7.3"
-when = "2019-07-11"
-user-id = 704
-user-login = "frankmcsherry"
-user-name = "Frank McSherry"
-
-[[publisher.aho-corasick]]
-version = "0.7.20"
-when = "2022-11-22"
-user-id = 189
-user-login = "BurntSushi"
-user-name = "Andrew Gallant"
-
 [[publisher.assert_cmd]]
 version = "2.0.5"
 when = "2022-10-20"
@@ -53,13 +39,6 @@ user-name = "AWS SDK Rust Bot"
 [[publisher.aws-sdk-s3]]
 version = "1.23.0"
 when = "2024-04-12"
-user-id = 160111
-user-login = "aws-sdk-rust-ci"
-user-name = "AWS SDK Rust Bot"
-
-[[publisher.aws-sdk-secretsmanager]]
-version = "1.7.0"
-when = "2023-12-14"
 user-id = 160111
 user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
@@ -176,33 +155,12 @@ user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
-[[publisher.bstr]]
-version = "1.6.0"
-when = "2023-07-05"
-user-id = 189
-user-login = "BurntSushi"
-user-name = "Andrew Gallant"
-
-[[publisher.bstr]]
-version = "1.10.0"
-when = "2024-07-25"
-user-id = 189
-user-login = "BurntSushi"
-user-name = "Andrew Gallant"
-
 [[publisher.bumpalo]]
 version = "3.12.1"
 when = "2023-04-21"
 user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
-
-[[publisher.byteorder]]
-version = "1.4.3"
-when = "2021-03-10"
-user-id = 189
-user-login = "BurntSushi"
-user-name = "Andrew Gallant"
 
 [[publisher.bzip2-sys]]
 version = "0.1.11+1.0.8"
@@ -245,13 +203,6 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
-[[publisher.cmake]]
-version = "0.1.48"
-when = "2022-01-06"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
 [[publisher.compact_bytes]]
 version = "0.1.2"
 when = "2024-05-31"
@@ -288,22 +239,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.cxx]]
-version = "1.0.63"
-when = "2022-01-18"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
-[[publisher.cxx]]
 version = "1.0.122"
 when = "2024-05-07"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
-[[publisher.cxx-build]]
-version = "1.0.63"
-when = "2022-01-18"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -316,22 +253,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.cxxbridge-flags]]
-version = "1.0.63"
-when = "2022-01-18"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
-[[publisher.cxxbridge-flags]]
 version = "1.0.122"
 when = "2024-05-07"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
-[[publisher.cxxbridge-macro]]
-version = "1.0.63"
-when = "2022-01-18"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -378,20 +301,6 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
-[[publisher.globset]]
-version = "0.4.9"
-when = "2022-06-10"
-user-id = 189
-user-login = "BurntSushi"
-user-name = "Andrew Gallant"
-
-[[publisher.globset]]
-version = "0.4.14"
-when = "2023-11-26"
-user-id = 189
-user-login = "BurntSushi"
-user-name = "Andrew Gallant"
-
 [[publisher.h2]]
 version = "0.3.26"
 when = "2024-04-03"
@@ -435,13 +344,6 @@ user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
 [[publisher.hyper]]
-version = "1.3.1"
-when = "2024-04-16"
-user-id = 359
-user-login = "seanmonstar"
-user-name = "Sean McArthur"
-
-[[publisher.hyper]]
 version = "1.4.1"
 when = "2024-07-09"
 user-id = 359
@@ -465,13 +367,6 @@ user-name = "Sean McArthur"
 [[publisher.indexmap]]
 version = "1.9.1"
 when = "2022-06-21"
-user-id = 539
-user-login = "cuviper"
-user-name = "Josh Stone"
-
-[[publisher.indexmap]]
-version = "2.0.0"
-when = "2023-06-23"
 user-id = 539
 user-login = "cuviper"
 user-name = "Josh Stone"
@@ -511,19 +406,6 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
-[[publisher.launchdarkly-server-sdk]]
-version = "1.0.0"
-when = "2022-12-07"
-user-id = 144672
-user-login = "LaunchDarklyReleaseBot"
-
-[[publisher.link-cplusplus]]
-version = "1.0.6"
-when = "2021-11-13"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
 [[publisher.linux-raw-sys]]
 version = "0.3.4"
 when = "2023-04-22"
@@ -559,27 +441,6 @@ user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
-[[publisher.openssl-src]]
-version = "111.28.1+1.1.1w"
-when = "2023-12-11"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.openssl-src]]
-version = "300.3.1+3.3.1"
-when = "2024-06-04"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.paste]]
-version = "1.0.11"
-when = "2022-12-17"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
 [[publisher.paste]]
 version = "1.0.15"
 when = "2024-05-07"
@@ -593,20 +454,6 @@ when = "2022-12-02"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
-
-[[publisher.prettyplease]]
-version = "0.1.25"
-when = "2023-03-15"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
-[[publisher.prettyplease]]
-version = "0.2.4"
-when = "2023-03-25"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
 
 [[publisher.prettyplease]]
 version = "0.2.20"
@@ -637,13 +484,6 @@ user-login = "cuviper"
 user-name = "Josh Stone"
 
 [[publisher.regex]]
-version = "1.7.0"
-when = "2022-11-05"
-user-id = 189
-user-login = "BurntSushi"
-user-name = "Andrew Gallant"
-
-[[publisher.regex]]
 version = "1.10.5"
 when = "2024-06-09"
 user-id = 189
@@ -653,13 +493,6 @@ user-name = "Andrew Gallant"
 [[publisher.regex-automata]]
 version = "0.1.9"
 when = "2020-03-09"
-user-id = 189
-user-login = "BurntSushi"
-user-name = "Andrew Gallant"
-
-[[publisher.regex-automata]]
-version = "0.3.9"
-when = "2023-09-30"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
@@ -721,13 +554,6 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.scratch]]
-version = "1.0.1"
-when = "2021-12-23"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
-[[publisher.scratch]]
 version = "1.0.7"
 when = "2023-07-15"
 user-id = 3618
@@ -742,22 +568,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.serde]]
-version = "1.0.164"
-when = "2023-06-08"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
-[[publisher.serde]]
 version = "1.0.203"
 when = "2024-05-25"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
-[[publisher.serde_derive]]
-version = "1.0.164"
-when = "2023-06-08"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -772,20 +584,6 @@ user-name = "David Tolnay"
 [[publisher.serde_derive_internals]]
 version = "0.26.0"
 when = "2021-04-09"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
-[[publisher.serde_json]]
-version = "1.0.99"
-when = "2023-06-24"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
-[[publisher.serde_json]]
-version = "1.0.117"
-when = "2024-05-08"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -840,13 +638,6 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.syn]]
-version = "2.0.39"
-when = "2023-11-06"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
-[[publisher.syn]]
 version = "2.0.63"
 when = "2024-05-11"
 user-id = 3618
@@ -867,33 +658,12 @@ user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
-[[publisher.tokio-macros]]
-version = "1.7.0"
-when = "2021-12-15"
-user-id = 10
-user-login = "carllerche"
-user-name = "Carl Lerche"
-
-[[publisher.tokio-macros]]
-version = "2.3.0"
-when = "2024-05-30"
-user-id = 10
-user-login = "carllerche"
-user-name = "Carl Lerche"
-
 [[publisher.tokio-test]]
 version = "0.4.2"
 when = "2021-05-14"
 user-id = 6741
 user-login = "Darksonn"
 user-name = "Alice Ryhl"
-
-[[publisher.toml]]
-version = "0.5.7"
-when = "2020-10-11"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
 
 [[publisher.toml]]
 version = "0.8.2"
@@ -930,13 +700,6 @@ user-id = 1060
 user-login = "shepmaster"
 user-name = "Jake Goulding"
 
-[[publisher.unicode-ident]]
-version = "1.0.0"
-when = "2022-05-16"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
 [[publisher.unicode-normalization]]
 version = "0.1.23"
 when = "2024-02-20"
@@ -954,13 +717,6 @@ user-name = "Manish Goregaokar"
 [[publisher.unicode-width]]
 version = "0.1.10"
 when = "2022-09-13"
-user-id = 1139
-user-login = "Manishearth"
-user-name = "Manish Goregaokar"
-
-[[publisher.unicode-xid]]
-version = "0.2.2"
-when = "2021-04-29"
 user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
@@ -1288,12 +1044,6 @@ criteria = "safe-to-deploy"
 version = "0.1.1"
 notes = "small crate, only defines macro-rules!, nicely documented as well"
 
-[[audits.bytecode-alliance.audits.peeking_take_while]]
-who = "Nick Fitzgerald <fitzgen@gmail.com>"
-criteria = "safe-to-deploy"
-version = "1.0.0"
-notes = "I am the author of this crate."
-
 [[audits.bytecode-alliance.audits.percent-encoding]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -1308,17 +1058,6 @@ as correct and otherwise this crate is good to go.
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.1.0"
-
-[[audits.bytecode-alliance.audits.quote]]
-who = "Pat Hickey <phickey@fastly.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.23 -> 1.0.27"
-
-[[audits.bytecode-alliance.audits.semver]]
-who = "Pat Hickey <phickey@fastly.com>"
-criteria = "safe-to-deploy"
-version = "1.0.17"
-notes = "plenty of unsafe pointer and vec tricks, but in well-structured and commented code that appears to be correct"
 
 [[audits.bytecode-alliance.audits.sharded-slab]]
 who = "Pat Hickey <phickey@fastly.com>"
@@ -1364,12 +1103,6 @@ This crate, while it implements collections, does so without `std::*` APIs and
 without `unsafe`. Skimming the crate everything looks reasonable and what one
 would expect from idiomatic safe collections in Rust.
 """
-
-[[audits.bytecode-alliance.audits.tokio-macros]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "1.7.0 -> 2.1.0"
-notes = "A number of updates to parsed syntax and such but nothing unexpected and entirely what one would expect a Rust procedural macro to do."
 
 [[audits.bytecode-alliance.audits.tokio-util]]
 who = "Pat Hickey <phickey@fastly.com>"
@@ -1431,12 +1164,6 @@ criteria = "safe-to-deploy"
 delta = "0.15.4 -> 0.17.0"
 notes = "No notable changes"
 
-[[audits.embark-studios.audits.headers]]
-who = "Johan Andersson <opensource@embark-studios.com>"
-criteria = "safe-to-deploy"
-version = "0.3.8"
-notes = "HTTP type definitions. Single sound unsafe usage, no ambient capabilities used"
-
 [[audits.embark-studios.audits.ident_case]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
@@ -1484,18 +1211,6 @@ criteria = "safe-to-deploy"
 version = "1.0.1"
 notes = "No unsafe usage or ambient capabilities"
 
-[[audits.embark-studios.audits.thiserror]]
-who = "Johan Andersson <opensource@embark-studios.com>"
-criteria = "safe-to-deploy"
-version = "1.0.40"
-notes = "Wrapper over implementation crate, found no unsafe or ambient capabilities used"
-
-[[audits.embark-studios.audits.thiserror-impl]]
-who = "Johan Andersson <opensource@embark-studios.com>"
-criteria = "safe-to-deploy"
-version = "1.0.40"
-notes = "Found no unsafe or ambient capabilities used"
-
 [[audits.embark-studios.audits.tinyvec_macros]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
@@ -1526,39 +1241,27 @@ criteria = "safe-to-deploy"
 version = "0.4.5"
 notes = "No unsafe usage or ambient capabilities"
 
-[[audits.google.audits.async-stream]]
-who = "Tyler Mandry <tmandry@google.com>"
-criteria = "safe-to-deploy"
-version = "0.3.4"
-notes = "Reviewed on https://fxrev.dev/761470"
-aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.async-stream]]
-who = "David Koloski <dkoloski@google.com>"
-criteria = "safe-to-deploy"
-delta = "0.3.4 -> 0.3.5"
-notes = "Reviewed on https://fxrev.dev/906795"
-aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.async-stream-impl]]
-who = "Tyler Mandry <tmandry@google.com>"
-criteria = "safe-to-deploy"
-version = "0.3.4"
-notes = "Reviewed on https://fxrev.dev/761470"
-aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.async-stream-impl]]
-who = "David Koloski <dkoloski@google.com>"
-criteria = "safe-to-deploy"
-delta = "0.3.4 -> 0.3.5"
-notes = "Reviewed on https://fxrev.dev/906795"
-aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
-
 [[audits.google.audits.base64]]
 who = "Adam Langley <agl@chromium.org>"
 criteria = "safe-to-deploy"
 version = "0.13.1"
 notes = "Skimmed the uses of `std` to ensure that nothing untoward is happening. Code uses `forbid(unsafe_code)` and, indeed, there are no uses of `unsafe`"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.bitflags]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.3.2"
+notes = """
+Security review of earlier versions of the crate can be found at
+(Google-internal, sorry): go/image-crate-chromium-security-review
+
+The crate exposes a function marked as `unsafe`, but doesn't use any
+`unsafe` blocks (except for tests of the single `unsafe` function).  I
+think this justifies marking this crate as `ub-risk-1`.
+
+Additional review comments can be found at https://crrev.com/c/4723145/31
+"""
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.cfg-if]]
@@ -1771,15 +1474,6 @@ end = "2024-05-03"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.wildcard-audits.unicode-xid]]
-who = "Manish Goregaokar <manishsmail@gmail.com>"
-criteria = "safe-to-deploy"
-user-id = 1139 # Manish Goregaokar (Manishearth)
-start = "2019-07-25"
-end = "2024-05-03"
-notes = "All code written or reviewed by Manish"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.android_system_properties]]
 who = "Nicolas Silva <nical@fastmail.com>"
 criteria = "safe-to-deploy"
@@ -1797,16 +1491,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.1.4 -> 0.1.5"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.askama]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-deploy"
-version = "0.11.1"
-notes = """
-Just contains some traits and re-exports for use by a broader package of related
-crates. No unsafe code or ambient capability usage.
-"""
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.autocfg]]
@@ -1953,13 +1637,6 @@ version = "0.12.3"
 notes = "This version is used in rust's libstd, so effectively we're already trusting it"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.headers-core]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-deploy"
-version = "0.2.0"
-notes = "Trivial crate, no unsafe code."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.hex]]
 who = "Simon Friedberger <simon@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -1991,12 +1668,6 @@ who = "Alex Franchuk <afranchuk@mozilla.com>"
 criteria = "safe-to-deploy"
 delta = "0.5.4 -> 0.5.6"
 notes = "New unsafe code has debug assertions and meets invariants. All other changes are formatting-related."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.log]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-version = "0.4.17"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.mach2]]
@@ -2031,13 +1702,6 @@ criteria = "safe-to-deploy"
 delta = "1.16.0 -> 1.17.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.peeking_take_while]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.0 -> 0.1.2"
-notes = "Small refactor of some simple iterator logic, no unsafe code or capabilities."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.percent-encoding]]
 who = "Valentin Gosu <valentin.gosu@gmail.com>"
 criteria = "safe-to-deploy"
@@ -2049,41 +1713,6 @@ who = "Valentin Gosu <valentin.gosu@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "2.3.0 -> 2.3.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quote]]
-who = "Nika Layzell <nika@thelayzells.com>"
-criteria = "safe-to-deploy"
-version = "1.0.18"
-notes = """
-`quote` is a utility crate used by proc-macros to generate TokenStreams
-conveniently from source code. The bulk of the logic is some complex
-interlocking `macro_rules!` macros which are used to parse and build the
-`TokenStream` within the proc-macro.
-
-This crate contains no unsafe code, and the internal logic, while difficult to
-read, is generally straightforward. I have audited the the quote macros, ident
-formatter, and runtime logic.
-"""
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quote]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.18 -> 1.0.21"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quote]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.21 -> 1.0.23"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quote]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.27 -> 1.0.28"
-notes = "Enabled on wasm targets"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.rustc-hash]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -2102,12 +1731,6 @@ at enough to convince myself it wasn't going to do anything dramatically wrong.
 I don't think logic bugs in the version parsing etc can realistically introduce
 a security vulnerability.
 """
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.semver]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.17 -> 1.0.16"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.sha1]]
@@ -2152,12 +1775,6 @@ criteria = "safe-to-deploy"
 version = "0.2.6"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.toml]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.5.7 -> 0.5.9"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.unicode-bidi]]
 who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
 criteria = "safe-to-deploy"
@@ -2193,4 +1810,24 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Valentin Gosu <valentin.gosu@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "2.4.1 -> 2.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerocopy]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.7.32"
+notes = """
+This crate is `no_std` so doesn't use any side-effectful std functions. It
+contains quite a lot of `unsafe` code, however. I verified portions of this. It
+also has a large, thorough test suite. The project claims to run tests with
+Miri to have stronger soundness checks, and also claims to use formal
+verification tools to prove correctness.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerocopy-derive]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.7.32"
+notes = "Clean, safe macros for zerocopy."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"

--- a/src/adapter-types/Cargo.toml
+++ b/src/adapter-types/Cargo.toml
@@ -15,7 +15,7 @@ mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }
 mz-storage-types = { path = "../storage-types" }
 serde = "1.0.152"
-timely = { version = "0.12.0", default-features = false }
+timely = "0.12.0"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -93,9 +93,7 @@ serde_plain = "1.0.1"
 sha2 = "0.10.6"
 smallvec = { version = "1.10.0", features = ["union"] }
 static_assertions = "1.1"
-timely = { version = "0.12.0", default-features = false, features = [
-    "bincode",
-] }
+timely = "0.12.0"
 tokio = { version = "1.38.0", features = ["rt", "time"] }
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = "0.1.11"

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -56,7 +56,7 @@ serde_json = "1.0.125"
 serde_plain = "1.0.1"
 static_assertions = "1.1"
 sha2 = "0.10.6"
-timely = { version = "0.12.0", default-features = false }
+timely = "0.12.0"
 tracing = "0.1.37"
 thiserror = "1.0.37"
 uuid = "1.2.2"

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -33,7 +33,7 @@ rocksdb = { version = "0.22.0", default-features = false, features = ["snappy", 
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -37,7 +37,7 @@ mz-storage-client = { path = "../storage-client" }
 mz-storage-types = { path = "../storage-types" }
 mz-timely-util = { path = "../timely-util" }
 mz-txn-wal = { path = "../txn-wal" }
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util"] }
 tower = "0.4.13"
 tracing = "0.1.37"

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -46,7 +46,7 @@ regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.125"
 thiserror = "1.0.37"
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tonic = "0.12.1"

--- a/src/compute-types/Cargo.toml
+++ b/src/compute-types/Cargo.toml
@@ -23,7 +23,7 @@ proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -43,7 +43,7 @@ prometheus = { version = "0.13.3", default-features = false }
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -930,7 +930,7 @@ impl PendingPeek {
             let chosen_index = usize::cast_from(peek.uuid.hashed()) % timely_worker.peers();
             chosen_index == timely_worker.index()
         };
-        let activator = timely_worker.sync_activator_for(&[]);
+        let activator = timely_worker.sync_activator_for([].into());
         let peek_uuid = peek.uuid;
 
         let (result_tx, result_rx) = oneshot::channel();

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -109,7 +109,7 @@ pub enum ComputeEvent {
         /// Operator index
         operator: usize,
         /// The address of the operator.
-        address: Vec<usize>,
+        address: Rc<[usize]>,
     },
     /// Arrangement size operator dropped
     ArrangementHeapSizeOperatorDrop {
@@ -907,8 +907,8 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
     }
 
     /// Indicate that a new arrangement exists, start maintaining the heap size state.
-    fn handle_arrangement_heap_size_operator(&mut self, operator_id: usize, address: Vec<usize>) {
-        let activator = self.state.worker.activator_for(&address);
+    fn handle_arrangement_heap_size_operator(&mut self, operator_id: usize, address: Rc<[usize]>) {
+        let activator = self.state.worker.activator_for(address);
         let existing = self
             .state
             .arrangement_size

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -1260,7 +1260,7 @@ where
         self.unary(Pipeline, "StartSignal", |_cap, info| {
             let token = Box::new(ActivateOnDrop::new(
                 (),
-                Rc::new(info.address.clone()),
+                info.address,
                 self.scope().activations(),
             ));
             signal.drop_on_fire(token);

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -100,7 +100,7 @@ where
         compute_state: &ComputeState,
     ) -> Self {
         use mz_ore::collections::CollectionExt as IteratorExt;
-        let dataflow_id = scope.addr().into_first();
+        let dataflow_id = *scope.addr().into_first();
         let as_of_frontier = dataflow
             .as_of
             .clone()
@@ -845,9 +845,7 @@ where
             .stream
             .unary::<CB<_>, _, _, _>(Pipeline, &name, move |_, info| {
                 // Acquire an activator to reschedule the operator when it has unfinished work.
-                use timely::scheduling::Activator;
-                let activations = trace.stream.scope().activations();
-                let activator = Activator::new(&info.address[..], activations);
+                let activator = trace.stream.scope().activator_for(info.address);
                 // Maintain a list of work to do, cursor to navigate and process.
                 let mut todo = std::collections::VecDeque::new();
                 move |input, output| {

--- a/src/compute/src/render/join/mz_join_core.rs
+++ b/src/compute/src/render/join/mz_join_core.rs
@@ -56,7 +56,6 @@ use timely::dataflow::operators::generic::OutputHandleCore;
 use timely::dataflow::operators::{Capability, Operator};
 use timely::dataflow::{Scope, StreamCore};
 use timely::progress::timestamp::Timestamp;
-use timely::scheduling::Activator;
 use timely::PartialOrder;
 use tracing::trace;
 
@@ -99,8 +98,7 @@ where
             let operator_id = info.global_id;
 
             // Acquire an activator to reschedule the operator when it has unfinished work.
-            let activations = arranged1.stream.scope().activations();
-            let activator = Activator::new(&info.address[..], activations);
+            let activator = arranged1.stream.scope().activator_for(info.address);
 
             // Our initial invariants are that for each trace, physical compaction is less or equal the trace's upper bound.
             // These invariants ensure that we can reference observed batch frontiers from `_start_upper` onward, as long as

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -354,7 +354,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                 let mut container = Default::default();
                 source(scope, "CmdSource", |capability, info| {
                     // Send activator for this operator back.
-                    let activator = scope.sync_activator_for(&info.address[..]);
+                    let activator = scope.sync_activator_for(info.address.to_vec());
                     // This might fail if the client has already shut down, which is fine. The rest
                     // of the operator implementation knows how to handle a disconnected client.
                     let _ = activator_tx.send(activator);

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -33,7 +33,7 @@ mz-txn-wal = { path = "../txn-wal" }
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.125"
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tracing = "0.1.37"

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -147,9 +147,7 @@ reqwest = { version = "0.11.13", features = ["blocking"] }
 serde_json = "1.0.125"
 serde_urlencoded = "0.7.1"
 similar-asserts = "1.4"
-timely = { version = "0.12.0", default-features = false, features = [
-    "bincode",
-] }
+timely = "0.12.0"
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4"] }
 
 [build-dependencies]

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -55,9 +55,7 @@ serde_json = "1.0.125"
 sha1 = "0.10.5"
 sha2 = "0.10.6"
 subtle = "2.4.1"
-timely = { version = "0.12.0", default-features = false, features = [
-    "bincode",
-] }
+timely = "0.12.0"
 tracing = "0.1.37"
 uncased = "0.9.7"
 uuid = { version = "1.7.0", features = ["v5"] }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -33,7 +33,7 @@ prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 prost-reflect = "0.14.2"
 seahash = "4"
 serde_json = "1.0.125"
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 tokio = { version = "1.38.0", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde"] }

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -40,7 +40,7 @@ num_enum = "0.5.7"
 prometheus = { version = "0.13.3", default-features = false }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.125"
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 url = "2.3.1"

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -59,7 +59,7 @@ sentry-tracing = "0.29.1"
 semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.125"
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 thiserror = "1.0.37"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tokio-metrics = "0.3.0"

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -26,7 +26,7 @@ proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
-timely = { version = "0.12.0", default-features = false, features = ["bincode", "getopts"] }
+timely = "0.12.0"
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -53,7 +53,7 @@ proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.152", features = ["derive"] }
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 tokio = { version = "1.38.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -69,7 +69,7 @@ serde_json = { version = "1.0.125", features = ["arbitrary_precision", "preserve
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
 static_assertions = "1.1"
 strsim = "0.10"
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 tokio-postgres = { version = "0.7.8" }
 tracing-core = "0.1.30"
 url = { version = "2.3.1", features = ["serde"] }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -35,7 +35,7 @@ prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 semver = "1.0.16"
 serde = { version = "1.0.152", features = ["derive"] }
 sysinfo = "0.27.2"
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tonic = "0.12.1"

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -45,9 +45,7 @@ rdkafka = { version = "0.29.0", features = [
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
 static_assertions = "1.1"
-timely = { version = "0.12.0", default-features = false, features = [
-    "bincode",
-] }
+timely = "0.12.0"
 tokio = { version = "1.38.0", features = [
     "fs",
     "rt",

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1054,7 +1054,7 @@ where
 
             let (changes, frontier) = collections_net
                 .entry(id)
-                .or_insert_with(|| (ChangeBatch::new(), Antichain::new()));
+                .or_insert_with(|| (<ChangeBatch<_>>::new(), Antichain::new()));
 
             changes.extend(update.drain());
             *frontier = collection.read_capabilities.frontier().to_owned();

--- a/src/storage-controller/Cargo.toml
+++ b/src/storage-controller/Cargo.toml
@@ -36,7 +36,7 @@ proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2638,7 +2638,11 @@ where
 
                 let (changes, frontier, _cluster_id) =
                     collections_net.entry(key).or_insert_with(|| {
-                        (ChangeBatch::new(), Antichain::new(), ingestion.instance_id)
+                        (
+                            <ChangeBatch<_>>::new(),
+                            Antichain::new(),
+                            ingestion.instance_id,
+                        )
                     });
 
                 changes.extend(update.drain());
@@ -2654,9 +2658,14 @@ where
 
                 // Make sure we also send `AllowCompaction` commands for sinks,
                 // which drives updating the sink's `as_of`, among other things.
-                let (changes, frontier, _cluster_id) = exports_net
-                    .entry(key)
-                    .or_insert_with(|| (ChangeBatch::new(), Antichain::new(), export.cluster_id()));
+                let (changes, frontier, _cluster_id) =
+                    exports_net.entry(key).or_insert_with(|| {
+                        (
+                            <ChangeBatch<_>>::new(),
+                            Antichain::new(),
+                            export.cluster_id(),
+                        )
+                    });
 
                 changes.extend(update.drain());
                 *frontier = staged_read_hold.frontier().to_owned();

--- a/src/storage-controller/src/statistics.rs
+++ b/src/storage-controller/src/statistics.rs
@@ -120,7 +120,7 @@ where
         //
         // We assume that `shared_stats` is kept up-to-date (and initialized)
         // by the controller.
-        let mut current_metrics = ChangeBatch::new();
+        let mut current_metrics = <ChangeBatch<_>>::new();
 
         let mut correction = Vec::new();
         {

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -35,7 +35,7 @@ prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 sentry = { version = "0.29.1" }
 serde = { version = "1.0.152", features = ["derive"] }
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 thiserror = "1.0.37"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tracing = "0.1.37"

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -439,7 +439,7 @@ where
         let name = name.to_owned();
         // Acquire an activator to reschedule the operator when it has unfinished work.
         let activations = scope.activations();
-        let activator = Activator::new(&operator_info.address[..], activations);
+        let activator = Activator::new(operator_info.address, activations);
         // Maintain a list of work to do
         let mut pending_work = std::collections::VecDeque::new();
         let mut buffer = Default::default();

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -64,7 +64,7 @@ regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125", features = ["preserve_order"] }
 thiserror = "1.0.37"
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tracing = "0.1.37"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -85,9 +85,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
 serde_bytes = { version = "0.11.14" }
 sha2 = "0.10.6"
-timely = { version = "0.12.0", default-features = false, features = [
-    "bincode",
-] }
+timely = "0.12.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -16,7 +16,7 @@ lgalloc = "0.3"
 columnation = { git = "https://github.com/frankmcsherry/columnation" }
 futures-util = "0.3.25"
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 serde = { version = "1.0.152", features = ["derive"] }
 mz-ore = { path = "../ore", features = ["async", "process", "tracing_", "test"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -413,14 +413,14 @@ impl<G: Scope> OperatorBuilder<G> {
     pub fn new(name: String, mut scope: G) -> Self {
         let builder = OperatorBuilderRc::new(name, scope.clone());
         let info = builder.operator_info();
-        let activator = scope.activator_for(&info.address);
-        let sync_activator = scope.sync_activator_for(&info.address);
+        let activator = scope.activator_for(Rc::clone(&info.address));
+        let sync_activator = scope.sync_activator_for(info.address.to_vec());
         let operator_waker = TimelyWaker {
             activator: sync_activator,
             active: AtomicBool::new(false),
             task_ready: AtomicBool::new(true),
         };
-        let (shutdown_handle, shutdown_button) = button(&mut scope, &info.address);
+        let (shutdown_handle, shutdown_button) = button(&mut scope, info.address);
 
         OperatorBuilder {
             builder,
@@ -694,7 +694,7 @@ impl<G: Scope> OperatorBuilder<G> {
 }
 
 /// Creates a new coordinated button the worker configuration described by `scope`.
-pub fn button<G: Scope>(scope: &mut G, addr: &[usize]) -> (ButtonHandle, Button) {
+pub fn button<G: Scope>(scope: &mut G, addr: Rc<[usize]>) -> (ButtonHandle, Button) {
     let index = scope.new_identifier();
     let (pushers, puller) = scope.allocate(index, addr);
 

--- a/src/timely-util/src/pact.rs
+++ b/src/timely-util/src/pact.rs
@@ -9,6 +9,7 @@
 
 //! Parallelization contracts, describing requirements for data movement along dataflow edges.
 
+use std::rc::Rc;
 use timely::communication::{Data, Pull, Push};
 use timely::dataflow::channels::pact::{LogPuller, LogPusher, ParallelizationContract};
 use timely::dataflow::channels::{Bundle, Message};
@@ -29,7 +30,7 @@ impl<T: Timestamp, C: Container + Data> ParallelizationContract<T, C> for Distri
         self,
         allocator: &mut A,
         identifier: usize,
-        address: &[usize],
+        address: Rc<[usize]>,
         logging: Option<TimelyLogger>,
     ) -> (Self::Pusher, Self::Puller) {
         let (senders, receiver) = allocator.allocate::<Message<T, C>>(identifier, address);

--- a/src/timely-util/src/reclock.rs
+++ b/src/timely-util/src/reclock.rs
@@ -219,7 +219,7 @@ where
     let info = builder.operator_info();
     let channel_id = scope.new_identifier();
     let (pusher, mut events) =
-        scope.pipeline::<Event<FromTime, Vec<(D, FromTime, R)>>>(channel_id, &info.address);
+        scope.pipeline::<Event<FromTime, Vec<(D, FromTime, R)>>>(channel_id, info.address);
 
     let mut remap_input = builder.new_input(&remap_collection.inner, Pipeline);
     let (mut output, reclocked) = builder.new_output();

--- a/src/timely-util/src/replay.rs
+++ b/src/timely-util/src/replay.rs
@@ -85,7 +85,7 @@ where
         let mut builder = OperatorBuilder::new(name, scope.clone());
 
         let address = builder.operator_info().address;
-        let periodic_activator = scope.activator_for(&address[..]);
+        let periodic_activator = scope.activator_for(Rc::clone(&address));
 
         let (targets, stream) = builder.new_output();
 
@@ -96,15 +96,15 @@ where
         let mut last_active = Instant::now();
 
         let mut progress_sofar =
-            timely::progress::ChangeBatch::new_from(S::Timestamp::minimum(), 1);
+            <timely::progress::ChangeBatch<_>>::new_from(S::Timestamp::minimum(), 1);
         let token = Rc::new(ActivateOnDrop::new(
             (),
-            Rc::new(address.clone()),
+            Rc::clone(&address),
             scope.activations(),
         ));
         let weak_token = Rc::downgrade(&token);
 
-        activator.register(scope, &address[..]);
+        activator.register(scope, address);
 
         builder.build(move |progress| {
             activator.ack();

--- a/src/txn-wal/Cargo.toml
+++ b/src/txn-wal/Cargo.toml
@@ -23,7 +23,7 @@ mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = "0.12.0"
 tokio = { version = "1.38.0", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }


### PR DESCRIPTION
Update timely and differential dependencies

Noteworthy changes include:
* We're not depending on abomonation anymore.
* Timely avoids several temporary memory allocations during dataflow rendering.
* Timely's `ChangeBatch` and `Antichain` types use a `SmallVec` to provide inline storage capacity. This should benefit all instances of totally-ordered times as they can avoid a heap allocation.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
