### PR TITLE
Report hydration before frontiers

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -468,9 +468,11 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                 // Report frontier information back the coordinator.
                 if let Some(mut compute_state) = self.activate_compute(&mut response_tx) {
                     compute_state.compute_state.traces.maintenance();
+                    // Report operator hydration before frontiers, as reporting frontiers may
+                    // affect hydration reporting.
+                    compute_state.report_operator_hydration();
                     compute_state.report_frontiers();
                     compute_state.report_dropped_collections();
-                    compute_state.report_operator_hydration();
                 }
 
                 self.metrics


### PR DESCRIPTION
Report the hydration status before reporting frontiers. Reporting frontiers also updates the collection frontiers, which can advance the frontiers to the empty frontier. If reporting hydration status afterwards, we might observe that the collection has advanced to the empty frontier and hence suppress the hydration update. The fix is to first report hydration status before reporting frontiers.

Fixes #29465.

This is an interim fix until the fix for #26682 changes this implementation again.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
