### PR TITLE
balancerd: fix LaunchDarkly syncing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6163,6 +6163,7 @@ dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "mz-dyncfg",
  "mz-ore",
  "openssl",
  "scopeguard",

--- a/src/dyncfg-launchdarkly/src/lib.rs
+++ b/src/dyncfg-launchdarkly/src/lib.rs
@@ -148,11 +148,11 @@ impl<F: Fn(&ConfigUpdates, &ConfigSet) + Send> SyncedConfigSet<F> {
     }
 
     /// Reads current values from LaunchDarkly and updates the ConfigSet.
-    fn sync(&self) -> Result<ConfigUpdates, anyhow::Error> {
+    fn sync(&self) -> Result<(), anyhow::Error> {
         let mut updates = ConfigUpdates::default();
         let Some(ld_client) = &self.ld_client else {
             (self.on_update)(&updates, &self.set);
-            return Ok(updates);
+            return Ok(());
         };
         for entry in self.set.entries() {
             let val = dyn_into_flag(entry.val()).expect("new() verifies all configs can convert");
@@ -190,7 +190,7 @@ impl<F: Fn(&ConfigUpdates, &ConfigSet) + Send> SyncedConfigSet<F> {
         }
         updates.apply(&self.set);
         (self.on_update)(&updates, &self.set);
-        Ok(updates)
+        Ok(())
     }
 }
 

--- a/src/dyncfg/src/lib.rs
+++ b/src/dyncfg/src/lib.rs
@@ -195,8 +195,19 @@ impl<T: ConfigType> ConfigDefault for fn() -> T {
     }
 }
 
-/// An set of [Config]s with values independent of other [ConfigSet]s (even if
-/// they contain the same configs).
+/// An set of [Config]s with values that may or may not be independent of other
+/// [ConfigSet]s.
+///
+/// When constructing a ConfigSet from scratch with [ConfigSet::default]
+/// followed by [ConfigSet::add], the values added to the ConfigSet will be
+/// independent of the values in all other ConfigSets.
+///
+/// When constructing a ConfigSet by cloning an existing ConfigSet, any values
+/// cloned from the original ConfigSet will be shared with the original
+/// ConfigSet. Updates to these values in one ConfigSet will be seen in the
+/// other ConfigSet, and vice versa. Any value added to the new ConfigSet via
+/// ConfigSet::add will be independent of values in the original ConfigSet,
+/// unless the new ConfigSet is later cloned.
 #[derive(Clone, Default)]
 pub struct ConfigSet {
     configs: BTreeMap<String, ConfigEntry>,

--- a/src/server-core/BUILD.bazel
+++ b/src/server-core/BUILD.bazel
@@ -28,7 +28,10 @@ rust_library(
     rustc_env = {},
     rustc_flags = [],
     version = "0.0.0",
-    deps = ["//src/ore:mz_ore"] + all_crate_deps(normal = True),
+    deps = [
+        "//src/dyncfg:mz_dyncfg",
+        "//src/ore:mz_ore",
+    ] + all_crate_deps(normal = True),
 )
 
 rust_test(
@@ -52,7 +55,10 @@ rust_test(
     rustc_env = {},
     rustc_flags = [],
     version = "0.0.0",
-    deps = ["//src/ore:mz_ore"] + all_crate_deps(
+    deps = [
+        "//src/dyncfg:mz_dyncfg",
+        "//src/ore:mz_ore",
+    ] + all_crate_deps(
         normal = True,
         normal_dev = True,
     ),
@@ -61,7 +67,10 @@ rust_test(
 rust_doc_test(
     name = "mz_server_core_doc_test",
     crate = ":mz_server_core",
-    deps = ["//src/ore:mz_ore"] + all_crate_deps(
+    deps = [
+        "//src/dyncfg:mz_dyncfg",
+        "//src/ore:mz_ore",
+    ] + all_crate_deps(
         normal = True,
         normal_dev = True,
     ),

--- a/src/server-core/Cargo.toml
+++ b/src/server-core/Cargo.toml
@@ -19,6 +19,7 @@ socket2 = "0.5.3"
 tokio-stream = "0.1.11"
 tracing = "0.1.37"
 futures = "0.3.25"
+mz-dyncfg = { path = "../dyncfg" }
 mz-ore = { path = "../ore", default-features = false, features = ["test"] }
 tokio = "1.38.0"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }


### PR DESCRIPTION
Plumb a dyncfg `ConfigSet` into `mz_server_core::serve` so that changes to the graceful termination period are dynamically updated.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a TODO flagged by @jubrad on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
