### PR TITLE
docs: tweak windows functions examples to include order by

### DIFF
--- a/doc/user/content/transform-data/patterns/top-k.md
+++ b/doc/user/content/transform-data/patterns/top-k.md
@@ -24,7 +24,8 @@ query looks like this:
 SELECT key_col, ... FROM
     (SELECT DISTINCT key_col FROM tbl) grp,
     LATERAL (
-        SELECT col1, col2..., order_col FROM tbl
+        SELECT col1, col2..., order_col
+        FROM tbl
         WHERE key_col = grp.key_col
         ORDER BY order_col LIMIT k
     )
@@ -61,7 +62,8 @@ To fetch the three most populous cities in each state:
 SELECT state, city FROM
     (SELECT DISTINCT state FROM cities) grp,
     LATERAL (
-        SELECT city, pop FROM cities
+        SELECT city, pop
+        FROM cities
         WHERE state = grp.state
         ORDER BY pop DESC LIMIT 3
     )
@@ -119,7 +121,8 @@ specifying [query hints](/sql/select/#query-hints) to improve memory usage. For 
 SELECT state, city FROM
     (SELECT DISTINCT state FROM cities) grp,
     LATERAL (
-        SELECT city, pop FROM cities
+        SELECT city, pop
+        FROM cities
         WHERE state = grp.state
         OPTIONS (LIMIT INPUT GROUP SIZE = 1000)
         ORDER BY pop DESC LIMIT 3

--- a/doc/user/content/transform-data/patterns/top-k.md
+++ b/doc/user/content/transform-data/patterns/top-k.md
@@ -21,13 +21,14 @@ databases, you might use window functions. In Materialize, we recommend using a
 query looks like this:
 
 ```mzsql
-SELECT * FROM
+SELECT key_col, ... FROM
     (SELECT DISTINCT key_col FROM tbl) grp,
     LATERAL (
-        SELECT col1, col2... FROM tbl
+        SELECT col1, col2..., order_col FROM tbl
         WHERE key_col = grp.key_col
         ORDER BY order_col LIMIT k
     )
+ORDER BY key_col, order_col
 ```
 
 For example, suppose you have a relation containing the population of various
@@ -35,7 +36,7 @@ U.S. cities.
 
 ```mzsql
 CREATE TABLE cities (
-    name text NOT NULL,
+    city text NOT NULL,
     state text NOT NULL,
     pop int NOT NULL
 );
@@ -57,37 +58,45 @@ INSERT INTO cities VALUES
 To fetch the three most populous cities in each state:
 
 ```mzsql
-SELECT state, name FROM
+SELECT state, city FROM
     (SELECT DISTINCT state FROM cities) grp,
     LATERAL (
-        SELECT name FROM cities
+        SELECT city, pop FROM cities
         WHERE state = grp.state
         ORDER BY pop DESC LIMIT 3
-    );
+    )
+ORDER BY state, pop DESC;
 ```
-```nofmt
-AZ  Phoenix
-CA  Los_Angeles
-CA  San_Diego
-CA  San_Jose
-IL  Chicago
-NY  New_York
-TX  Houston
-TX  San_Antonio
-TX  Dallas
-```
+
+The query returns the following results:
+
+| state | city        |
+| ----- | ----------- |
+| AZ    | Phoenix     |
+| CA    | Los_Angeles |
+| CA    | San_Diego   |
+| CA    | San_Jose    |
+| IL    | Chicago     |
+| NY    | New_York    |
+| TX    | Houston     |
+| TX    | San_Antonio |
+| TX    | Dallas      |
 
 Despite the verbosity of the above query, Materialize produces a straightforward
 plan:
 
 ```mzsql
-EXPLAIN SELECT state, name FROM ...
+EXPLAIN SELECT state, city FROM ...
 ```
+
+The explain returns the following:
+
 ```nofmt
 Explained Query:
-  Project (#1, #0)
-    TopK group_by=[#1] order_by=[#2 desc nulls_first] limit=3
-      ReadStorage materialize.public.cities
+  Finish order_by=[#0{state} asc nulls_last, #2{pop} desc nulls_first] output=[#0..=#2]
+    TopK group_by=[#0{state}] order_by=[#2{pop} desc nulls_first] limit=3 // { arity: 3 }
+      Project (#1{city}, #0{state}, #2{pop}) // { arity: 3 }
+        ReadStorage materialize.public.cities // { arity: 3 }
 ```
 
 ## Top 1 using `DISTINCT ON`
@@ -95,7 +104,7 @@ Explained Query:
 If _K_ = 1, i.e., you would like to see only the most populous city in each state, another approach is to use `DISTINCT ON`:
 
 ```mzsql
-SELECT DISTINCT ON(state) state, name
+SELECT DISTINCT ON(state) state, city
 FROM cities
 ORDER BY state, pop DESC;
 ```
@@ -107,20 +116,21 @@ When using either the above `LATERAL` subquery pattern or `DISTINCT ON`, we reco
 specifying [query hints](/sql/select/#query-hints) to improve memory usage. For example:
 
 ```mzsql
-SELECT state, name FROM
+SELECT state, city FROM
     (SELECT DISTINCT state FROM cities) grp,
     LATERAL (
-        SELECT name FROM cities
+        SELECT city, pop FROM cities
         WHERE state = grp.state
         OPTIONS (LIMIT INPUT GROUP SIZE = 1000)
         ORDER BY pop DESC LIMIT 3
-    );
+    )
+ORDER BY state, pop DESC;
 ```
 
 or
 
 ```mzsql
-SELECT DISTINCT ON(state) state, name
+SELECT DISTINCT ON(state) state, city
 FROM cities
 OPTIONS (DISTINCT ON INPUT GROUP SIZE = 1000)
 ORDER BY state, pop DESC;

--- a/doc/user/content/transform-data/patterns/window-functions.md
+++ b/doc/user/content/transform-data/patterns/window-functions.md
@@ -60,7 +60,8 @@ If there are states that have many cities, a more performant way to express this
 SELECT state, city FROM
     (SELECT DISTINCT state FROM cities) grp,
     LATERAL (
-        SELECT city, pop FROM cities
+        SELECT city, pop
+        FROM cities
         WHERE state = grp.state
         ORDER BY pop DESC LIMIT 3
     )
@@ -74,7 +75,7 @@ Suppose that you want to compute the ratio of each city's population vs. the mos
 ```mzsql
 SELECT state, city,
        CAST(pop AS float) / FIRST_VALUE(pop)
-         OVER (PARTITION BY state ORDER BY pop DESC) as pop_ratio
+         OVER (PARTITION BY state ORDER BY pop DESC) AS pop_ratio
 FROM cities
 ORDER BY state, pop_ratio DESC;
 ```
@@ -82,7 +83,7 @@ ORDER BY state, pop_ratio DESC;
 For better performance, you can rewrite this query to first compute the largest population of each state using an aggregation, and then join against that:
 
 ```mzsql
-SELECT cities.state, city, CAST(pop as float) / max_pops.max_pop pop_ratio
+SELECT cities.state, city, CAST(pop as float) / max_pops.max_pop AS pop_ratio
 FROM cities,
      (SELECT state, MAX(pop) as max_pop
       FROM cities
@@ -107,7 +108,7 @@ INSERT INTO measurements VALUES
 
 You can compute the differences between consecutive measurements using `LAG()`:
 ```mzsql
-SELECT time, value - LAG(value) OVER (ORDER BY time) as diff_w_prev
+SELECT time, value - LAG(value) OVER (ORDER BY time) AS diff
 FROM measurements
 ORDER BY time;
 ```
@@ -115,7 +116,7 @@ ORDER BY time;
 For better performance, you can rewrite this query using an equi-join:
 
 ```mzsql
-SELECT m2.time, m2.value - m1.value as diff_w_prev
+SELECT m2.time, m2.value - m1.value AS diff
 FROM measurements m1, measurements m2
 WHERE m2.time = m1.time + INTERVAL '1' MINUTE
 ORDER BY m2.time;
@@ -125,7 +126,7 @@ Note that these queries differ in whether they include the first timestamp (with
 a `NULL` difference).  A `RIGHT JOIN` would make the outputs match exactly.
 
 ```mzsql
-SELECT m2.time, m2.value - m1.value as diff_w_prev
+SELECT m2.time, m2.value - m1.value AS diff
 FROM measurements m1
 RIGHT JOIN measurements m2
 ON m2.time = m1.time + INTERVAL '1' MINUTE

--- a/doc/user/content/transform-data/patterns/window-functions.md
+++ b/doc/user/content/transform-data/patterns/window-functions.md
@@ -85,7 +85,7 @@ For better performance, you can rewrite this query to first compute the largest 
 ```mzsql
 SELECT cities.state, city, CAST(pop as float) / max_pops.max_pop AS pop_ratio
 FROM cities,
-     (SELECT state, MAX(pop) as max_pop
+     (SELECT state, MAX(pop) AS max_pop
       FROM cities
       GROUP BY state) max_pops
 WHERE cities.state = max_pops.state
@@ -116,19 +116,18 @@ ORDER BY time;
 For better performance, you can rewrite this query using an equi-join:
 
 ```mzsql
-SELECT m2.time, m2.value - m1.value AS diff
+SELECT m1.time, m1.value - m2.value AS diff
 FROM measurements m1, measurements m2
-WHERE m2.time = m1.time + INTERVAL '1' MINUTE
-ORDER BY m2.time;
+WHERE m1.time = m2.time + INTERVAL '1' MINUTE ORDER BY m1.time;
 ```
 
 Note that these queries differ in whether they include the first timestamp (with
-a `NULL` difference).  A `RIGHT JOIN` would make the outputs match exactly.
+a `NULL` difference).  A `LEFT JOIN` would make the outputs match exactly.
 
 ```mzsql
-SELECT m2.time, m2.value - m1.value AS diff
+SELECT m1.time, m1.value - m2.value AS diff
 FROM measurements m1
-RIGHT JOIN measurements m2
-ON m2.time = m1.time + INTERVAL '1' MINUTE
-ORDER BY m2.time;
+LEFT JOIN measurements m2
+ON m1.time = m2.time + INTERVAL '1' MINUTE
+ORDER BY m1.time;
 ```


### PR DESCRIPTION
Add order by clause and a small fix to the lag example suggestion to use RIGHT join instead of LEFT join.
- Also, small tweak to change `name` to `city` in the table.