### PR TITLE
ci: Fix heap profiles for clusterds & minor parallel-workload fixes

### DIFF
--- a/misc/python/materialize/cli/ci_upload_heap_profiles.py
+++ b/misc/python/materialize/cli/ci_upload_heap_profiles.py
@@ -18,7 +18,7 @@ import time
 from threading import Thread
 
 CLUSTERD_COMMAND_RE = re.compile(
-    r"--internal-http-listen-addr=(?P<socket>[^ ]*).*--opentelemetry-resource=cluster_id=(?P<cluster_id>[^ ]*).*--opentelemetry-resource=replica_id=(?P<replica_id>[^ ]*).*/(?P<process>[0-9]+)\.pid"
+    r"--internal-http-listen-addr=(?P<socket>[^ ]*).*--log-prefix=(?P<logprefix>[^ ]*)"
 )
 
 
@@ -100,7 +100,7 @@ def main() -> int:
                                     match.group("socket"),
                                     "http:/prof/heap",
                                 ],
-                                f"-cluster-{match.group('cluster_id')}-replica-{match.group('replica_id')}-process-{match.group('process')}",
+                                f"-{match.group('logprefix')}",
                             ),
                         )
                     )

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -996,7 +996,11 @@ class Database:
 
         exe.execute("SELECT name FROM mz_roles WHERE name LIKE 'r%'")
         for row in exe.cur.fetchall():
-            exe.execute(f"DROP ROLE {identifier(row[0])} CASCADE")
+            exe.execute(f"DROP ROLE {identifier(row[0])}")
+
+        exe.execute("DROP SECRET IF EXISTS pgpass CASCADE")
+        exe.execute("DROP SECRET IF EXISTS mypass CASCADE")
+        exe.execute("DROP SECRET IF EXISTS minio CASCADE")
 
         print("Creating connections")
 


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
