### PR TITLE
k8s: reduce client timeouts

### DIFF
--- a/test/cloudtest/test_metrics.py
+++ b/test/cloudtest/test_metrics.py
@@ -9,12 +9,9 @@
 
 from textwrap import dedent
 
-import pytest
-
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
 
 
-@pytest.mark.skip(reason="Fails occasionally, see database-issues#8472")
 def test_replica_metrics(mz: MaterializeApplication) -> None:
     mz.testdrive.run(
         input=dedent(


### PR DESCRIPTION
The [default timeouts](https://docs.rs/kube-client/latest/src/kube_client/config/mod.rs.html#387-390) for the k8s client are:

 * connect:  30s
 * read:    295s
 * write:   295s

We always connect to a k8s cluster that's running in the same region as we do, so there is no reason we'd need such long timeouts.

Reducing them lets us react faster to network issues, by retrying the request. In particular, it seems to fix a test flake where sometimes the command to create the service for a new cluster would get stuck until the test timed out.

### Motivation

  * This PR fixes a recognized bug.

Fixes MaterializeInc/database-issues#8472

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
