### PR TITLE
storage: remove some minor bits of duplication

### DIFF
--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -738,6 +738,22 @@ pub trait StorageController: Debug {
     >;
 }
 
+impl DataSource {
+    /// Returns true if the storage controller manages the data shard for this
+    /// source using txn-wal.
+    pub fn in_txns(&self) -> bool {
+        match self {
+            DataSource::Other(DataSourceOther::TableWrites) => true,
+            DataSource::Other(DataSourceOther::Compute)
+            | DataSource::Ingestion(_)
+            | DataSource::IngestionExport { .. }
+            | DataSource::Introspection(_)
+            | DataSource::Progress
+            | DataSource::Webhook => false,
+        }
+    }
+}
+
 /// A wrapper struct that presents the adapter token to a format that is understandable by persist
 /// and also allows us to differentiate between a token being present versus being set for the
 /// first time.

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1405,17 +1405,10 @@ where
                 // If the shard is being managed by txn-wal (initially,
                 // tables), then we need to pass along the shard id for the txns
                 // shard to dataflow rendering.
-                let txns_shard = match description.data_source {
-                    DataSource::Other(DataSourceOther::TableWrites) => {
-                        Some(*self.txns_read.txns_id())
-                    }
-                    DataSource::Ingestion(_)
-                    | DataSource::IngestionExport { .. }
-                    | DataSource::Introspection(_)
-                    | DataSource::Progress
-                    | DataSource::Webhook
-                    | DataSource::Other(DataSourceOther::Compute) => None,
-                };
+                let txns_shard = description
+                    .data_source
+                    .in_txns()
+                    .then(|| *self.txns_read.txns_id());
 
                 let metadata = CollectionMetadata {
                     persist_location: self.persist_location.clone(),

--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -104,6 +104,11 @@ type AppendOnlyWriteChannel<T> = mpsc::UnboundedSender<(
 type WriteTask = AbortOnDropHandle<()>;
 type ShutdownSender = oneshot::Sender<()>;
 
+pub enum CollectionManagerKind {
+    AppendOnly,
+    Differential,
+}
+
 #[derive(Debug, Clone)]
 pub struct CollectionManager<T>
 where

--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -104,6 +104,18 @@ type AppendOnlyWriteChannel<T> = mpsc::UnboundedSender<(
 type WriteTask = AbortOnDropHandle<()>;
 type ShutdownSender = oneshot::Sender<()>;
 
+/// Types of storage-managed/introspection collections:
+///
+/// Append-only: Only accepts blind writes, writes that can be applied at any
+/// timestamp and don’t depend on current collection contents.
+///
+/// Pseudo append-only: We treat them largely as append-only collections but
+/// periodically (currently on bootstrap) retract old updates from them.
+///
+/// Differential: at any given time `t` , collection contents mirrors some
+/// (small cardinality) state. The cardinality of the collection stays constant
+/// if the thing that is mirrored doesn’t change in cardinality. At steady
+/// state, updates always come in pairs of retractions/additions.
 pub enum CollectionManagerKind {
     AppendOnly,
     Differential,

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -89,6 +89,7 @@ use tokio::time::error::Elapsed;
 use tokio::time::MissedTickBehavior;
 use tracing::{debug, info, warn};
 
+use crate::collection_mgmt::CollectionManagerKind;
 use crate::instance::{Instance, ReplicaConfig};
 use crate::statistics::StatsState;
 
@@ -574,17 +575,10 @@ where
 
                 // If the shard is being managed by txn-wal (initially, tables), then we need to
                 // pass along the shard id for the txns shard to dataflow rendering.
-                let txns_shard = match description.data_source {
-                    DataSource::Other(DataSourceOther::TableWrites) => {
-                        Some(*self.txns_read.txns_id())
-                    }
-                    DataSource::Ingestion(_)
-                    | DataSource::IngestionExport { .. }
-                    | DataSource::Introspection(_)
-                    | DataSource::Progress
-                    | DataSource::Webhook
-                    | DataSource::Other(DataSourceOther::Compute) => None,
-                };
+                let txns_shard = description
+                    .data_source
+                    .in_txns()
+                    .then(|| *self.txns_read.txns_id());
 
                 let metadata = CollectionMetadata {
                     persist_location: self.persist_location.clone(),
@@ -2819,31 +2813,8 @@ where
 
         let recent_upper = write_handle.shared_upper();
 
-        // Types of storage-managed/introspection collections:
-        //
-        // Append-only: Only accepts blind writes, writes that can
-        // be applied at any timestamp and don’t depend on current
-        // collection contents.
-        //
-        // Pseudo append-only: We treat them largely as append-only
-        // collections but periodically (currently on bootstrap)
-        // retract old updates from them.
-        //
-        // Differential: at any given time `t` , collection contents
-        // mirrors some (small cardinality) state. The cardinality
-        // of the collection stays constant if the thing that is
-        // mirrored doesn’t change in cardinality. At steady state,
-        // updates always come in pairs of retractions/additions.
-        match introspection_type {
-            // For these, we first register the collection and then prepare it,
-            // because the code that prepares differential collection expects to
-            // be able to update desired state via the collection manager
-            // already.
-            IntrospectionType::ShardMapping
-            | IntrospectionType::Frontiers
-            | IntrospectionType::ReplicaFrontiers
-            | IntrospectionType::StorageSourceStatistics
-            | IntrospectionType::StorageSinkStatistics => {
+        match CollectionManagerKind::from(&introspection_type) {
+            CollectionManagerKind::Differential => {
                 self.collection_manager.register_differential_collection(
                     id,
                     write_handle,
@@ -2861,69 +2832,7 @@ where
                     .await?;
                 }
             }
-
-            // For these, we first have to prepare and then register with
-            // collection manager, because the preparation logic wants to read
-            // the shard's contents and then do uncontested writes.
-            //
-            // TODO(aljoscha): We should make the truncation/cleanup work that
-            // happens when we take over instead be a periodic thing, and make
-            // it resilient to the upper moving concurrently.
-            IntrospectionType::SourceStatusHistory
-            | IntrospectionType::SinkStatusHistory
-            | IntrospectionType::PrivatelinkConnectionStatusHistory
-            | IntrospectionType::ReplicaStatusHistory
-            | IntrospectionType::ReplicaMetricsHistory
-            | IntrospectionType::WallclockLagHistory => {
-                if !self.read_only {
-                    self.prepare_introspection_collection(
-                        id,
-                        introspection_type,
-                        recent_upper,
-                        Some(&mut write_handle),
-                    )
-                    .await?;
-                }
-
-                self.collection_manager.register_append_only_collection(
-                    id,
-                    write_handle,
-                    force_writable,
-                );
-            }
-
-            // Same as our other differential collections, but for these the
-            // preparation logic currently doesn't do anything.
-            IntrospectionType::ComputeDependencies
-            | IntrospectionType::ComputeOperatorHydrationStatus
-            | IntrospectionType::ComputeMaterializedViewRefreshes
-            | IntrospectionType::ComputeErrorCounts
-            | IntrospectionType::ComputeHydrationTimes => {
-                self.collection_manager.register_differential_collection(
-                    id,
-                    write_handle,
-                    read_handle_fn,
-                    force_writable,
-                );
-
-                if !self.read_only {
-                    self.prepare_introspection_collection(
-                        id,
-                        introspection_type,
-                        recent_upper,
-                        None,
-                    )
-                    .await?;
-                }
-            }
-
-            // Note [btv] - we don't truncate these, because that uses
-            // a huge amount of memory on environmentd startup.
-            IntrospectionType::PreparedStatementHistory
-            | IntrospectionType::StatementExecutionHistory
-            | IntrospectionType::SessionHistory
-            | IntrospectionType::StatementLifecycleHistory
-            | IntrospectionType::SqlText => {
+            CollectionManagerKind::AppendOnly => {
                 if !self.read_only {
                     self.prepare_introspection_collection(
                         id,
@@ -3881,6 +3790,67 @@ where
     fn maintain(&mut self) {
         self.update_frontier_introspection();
         self.update_wallclock_lag_introspection();
+    }
+}
+
+impl From<&IntrospectionType> for CollectionManagerKind {
+    fn from(value: &IntrospectionType) -> Self {
+        // Types of storage-managed/introspection collections:
+        //
+        // Append-only: Only accepts blind writes, writes that can
+        // be applied at any timestamp and don’t depend on current
+        // collection contents.
+        //
+        // Pseudo append-only: We treat them largely as append-only
+        // collections but periodically (currently on bootstrap)
+        // retract old updates from them.
+        //
+        // Differential: at any given time `t` , collection contents
+        // mirrors some (small cardinality) state. The cardinality
+        // of the collection stays constant if the thing that is
+        // mirrored doesn’t change in cardinality. At steady state,
+        // updates always come in pairs of retractions/additions.
+        match value {
+            // For these, we first register the collection and then prepare it,
+            // because the code that prepares differential collection expects to
+            // be able to update desired state via the collection manager
+            // already.
+            IntrospectionType::ShardMapping
+            | IntrospectionType::Frontiers
+            | IntrospectionType::ReplicaFrontiers
+            | IntrospectionType::StorageSourceStatistics
+            | IntrospectionType::StorageSinkStatistics => CollectionManagerKind::Differential,
+
+            // Same as our other differential collections, but for these the
+            // preparation logic currently doesn't do anything.
+            IntrospectionType::ComputeDependencies
+            | IntrospectionType::ComputeOperatorHydrationStatus
+            | IntrospectionType::ComputeMaterializedViewRefreshes
+            | IntrospectionType::ComputeErrorCounts
+            | IntrospectionType::ComputeHydrationTimes => CollectionManagerKind::Differential,
+
+            // For these, we first have to prepare and then register with
+            // collection manager, because the preparation logic wants to read
+            // the shard's contents and then do uncontested writes.
+            //
+            // TODO(aljoscha): We should make the truncation/cleanup work that
+            // happens when we take over instead be a periodic thing, and make
+            // it resilient to the upper moving concurrently.
+            IntrospectionType::SourceStatusHistory
+            | IntrospectionType::SinkStatusHistory
+            | IntrospectionType::PrivatelinkConnectionStatusHistory
+            | IntrospectionType::ReplicaStatusHistory
+            | IntrospectionType::ReplicaMetricsHistory
+            | IntrospectionType::WallclockLagHistory => CollectionManagerKind::AppendOnly,
+
+            // Note [btv] - we don't truncate these, because that uses
+            // a huge amount of memory on environmentd startup.
+            IntrospectionType::PreparedStatementHistory
+            | IntrospectionType::StatementExecutionHistory
+            | IntrospectionType::SessionHistory
+            | IntrospectionType::StatementLifecycleHistory
+            | IntrospectionType::SqlText => CollectionManagerKind::AppendOnly,
+        }
     }
 }
 


### PR DESCRIPTION
Pure refactor, no behavior change.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
