### PR TITLE
adapter,controller: more principled handling of read holds

### DIFF
--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -297,7 +297,7 @@ impl Coordinator {
         // dataflow for it.
         let response = if self.introspection_subscribes.contains_key(&subscribe_id) {
             let (df_desc, _df_meta) = global_lir_plan.unapply();
-            self.ship_dataflow(df_desc, cluster_id, Some(replica_id))
+            self.ship_dataflow(df_desc, cluster_id, read_holds.into(), Some(replica_id))
                 .await;
 
             Ok(StageResult::Response(
@@ -310,7 +310,6 @@ impl Coordinator {
             ))
         };
 
-        drop(read_holds);
         response
     }
 

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -562,15 +562,13 @@ impl crate::coord::Coordinator {
                 permutation: index_permutation,
                 thinned_arity: index_thinned_arity,
             }) => {
-                let output_ids = dataflow.export_ids().collect();
-
                 // Very important: actually create the dataflow (here, so we can destructure).
                 self.controller
                     .compute
                     .create_dataflow(compute_instance, dataflow, None)
                     .unwrap_or_terminate("cannot fail to create dataflows");
-                self.initialize_compute_read_policies(
-                    output_ids,
+                self.initialize_compute_read_policy(
+                    index_id,
                     compute_instance,
                     // Disable compaction so that nothing can compact before the peek occurs below.
                     CompactionWindow::DisableCompaction,

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -32,6 +32,7 @@ use mz_expr::{
     OptimizedMirRelationExpr, RowSetFinishing,
 };
 use mz_ore::cast::CastFrom;
+use mz_ore::collections::CollectionExt;
 use mz_ore::str::{separated, StrExt};
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::explain::text::DisplayText;
@@ -584,16 +585,12 @@ impl crate::coord::Coordinator {
                     let import_read_holds = read_holds.clone_for(&id_bundle).into();
 
                     // Very important: actually create the dataflow (here, so we can destructure).
-                    self.controller
-                        .compute
-                        .create_dataflow(compute_instance, dataflow, import_read_holds, None)
-                        .unwrap_or_terminate("cannot fail to create dataflows");
-
                     let read_hold = self
                         .controller
                         .compute
-                        .acquire_read_hold(compute_instance, index_id)
-                        .expect("collection just created");
+                        .create_dataflow(compute_instance, dataflow, import_read_holds, None)
+                        .unwrap_or_terminate("cannot fail to create dataflows")
+                        .into_element();
 
                     self.initialize_compute_read_policy(
                         index_id,

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -593,7 +593,7 @@ impl crate::coord::Coordinator {
                         .into_element();
 
                     self.initialize_compute_read_policy(
-                        index_id,
+                        read_hold.clone(),
                         compute_instance,
                         // Disable compaction so that nothing can compact before the peek occurs below.
                         CompactionWindow::DisableCompaction,

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -390,13 +390,9 @@ impl Coordinator {
             self.create_cluster_replica(cluster_id, replica_id).await;
         }
 
-        if !introspection_source_ids.is_empty() {
-            self.initialize_compute_read_policies(
-                introspection_source_ids,
-                cluster_id,
-                CompactionWindow::Default,
-            )
-            .await;
+        for id in introspection_source_ids {
+            self.initialize_compute_read_policy(id, cluster_id, CompactionWindow::Default)
+                .await;
         }
     }
 

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -371,11 +371,8 @@ impl Coordinator {
             ..
         } = self;
         let cluster = catalog.get_cluster(cluster_id);
-        let cluster_id = cluster.id;
-        let introspection_source_ids: Vec<_> =
-            cluster.log_indexes.iter().map(|(_, id)| *id).collect();
 
-        controller
+        let log_read_holds = controller
             .create_cluster(
                 cluster_id,
                 mz_controller::clusters::ClusterConfig {
@@ -390,8 +387,8 @@ impl Coordinator {
             self.create_cluster_replica(cluster_id, replica_id).await;
         }
 
-        for id in introspection_source_ids {
-            self.initialize_compute_read_policy(id, cluster_id, CompactionWindow::Default)
+        for hold in log_read_holds {
+            self.initialize_compute_read_policy(hold, cluster_id, CompactionWindow::Default)
                 .await;
         }
     }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -593,12 +593,15 @@ impl Coordinator {
 
                 let storage_metadata = coord.catalog.state().storage_metadata();
 
-                coord
+                let read_holds = coord
                     .controller
                     .storage
                     .create_collections(storage_metadata, None, collections)
                     .await
                     .unwrap_or_terminate("cannot fail to create collections");
+
+                let mut read_holds: BTreeMap<_, _> =
+                    read_holds.into_iter().map(|r| (r.id(), r)).collect();
 
                 // It is _very_ important that we only initialize read policies
                 // after we have created all the sources/collections. Some of
@@ -620,9 +623,12 @@ impl Coordinator {
                     .state()
                     .source_compaction_windows(source_ids);
                 for (compaction_window, ids) in read_policies {
-                    coord
-                        .initialize_storage_read_policies(ids, compaction_window)
-                        .await;
+                    for id in ids {
+                        let hold = read_holds.remove(&id).expect("collection just created");
+                        coord
+                            .initialize_storage_read_policy(hold, compaction_window)
+                            .await;
+                    }
                 }
             })
             .await;
@@ -956,7 +962,7 @@ impl Coordinator {
                             DataSourceOther::TableWrites,
                         );
                         let storage_metadata = coord.catalog.state().storage_metadata();
-                        coord
+                        let read_hold = coord
                             .controller
                             .storage
                             .create_collections(
@@ -965,17 +971,14 @@ impl Coordinator {
                                 vec![(table_id, collection_desc)],
                             )
                             .await
-                            .unwrap_or_terminate("cannot fail to create collections");
+                            .unwrap_or_terminate("cannot fail to create collections")
+                            .into_element();
                         coord.apply_local_write(register_ts).await;
 
-                        coord
-                            .initialize_storage_read_policy(
-                                table_id,
-                                table
-                                    .custom_logical_compaction_window
-                                    .unwrap_or(CompactionWindow::Default),
-                            )
-                            .await;
+                        let cw = table
+                            .custom_logical_compaction_window
+                            .unwrap_or(CompactionWindow::Default);
+                        coord.initialize_storage_read_policy(read_hold, cw).await;
                     }
                     TableDataSource::DataSource(data_source) => {
                         match data_source {
@@ -1004,7 +1007,7 @@ impl Coordinator {
                                     status_collection_id,
                                 };
                                 let storage_metadata = coord.catalog.state().storage_metadata();
-                                coord
+                                let read_holds = coord
                                     .controller
                                     .storage
                                     .create_collections(
@@ -1015,14 +1018,22 @@ impl Coordinator {
                                     .await
                                     .unwrap_or_terminate("cannot fail to create collections");
 
+                                let mut read_holds: BTreeMap<_, _> =
+                                    read_holds.into_iter().map(|r| (r.id(), r)).collect();
+
                                 let read_policies = coord
                                     .catalog()
                                     .state()
                                     .source_compaction_windows(vec![table_id]);
                                 for (compaction_window, ids) in read_policies {
-                                    coord
-                                        .initialize_storage_read_policies(ids, compaction_window)
-                                        .await;
+                                    for id in ids {
+                                        let hold = read_holds
+                                            .remove(&id)
+                                            .expect("collection just created");
+                                        coord
+                                            .initialize_storage_read_policy(hold, compaction_window)
+                                            .await;
+                                    }
                                 }
                             }
                             _ => unreachable!("CREATE TABLE data source got {:?}", data_source),
@@ -3895,14 +3906,15 @@ impl Coordinator {
 
                 let storage_metadata = self.catalog.state().storage_metadata();
 
-                self.controller
+                let read_holds = self
+                    .controller
                     .storage
                     .create_collections(storage_metadata, None, collections)
                     .await
                     .unwrap_or_terminate("cannot fail to create collections");
 
                 self.initialize_storage_read_policies(
-                    source_ids,
+                    read_holds,
                     source_compaction_window.unwrap_or(CompactionWindow::Default),
                 )
                 .await;

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -10,7 +10,6 @@
 use anyhow::anyhow;
 use differential_dataflow::lattice::Lattice;
 use maplit::btreemap;
-use maplit::btreeset;
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_catalog::memory::objects::{CatalogItem, MaterializedView};
 use mz_expr::{CollectionPlan, ResultSpec};
@@ -686,8 +685,8 @@ impl Coordinator {
                     .unwrap_or_terminate("cannot fail to append");
 
                 coord
-                    .initialize_storage_read_policies(
-                        btreeset![sink_id],
+                    .initialize_storage_read_policy(
+                        sink_id,
                         compaction_window.unwrap_or(CompactionWindow::Default),
                     )
                     .await;

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -662,7 +662,7 @@ impl Coordinator {
                 let storage_metadata = coord.catalog.state().storage_metadata();
 
                 // Announce the creation of the materialized view source.
-                coord
+                let read_hold = coord
                     .controller
                     .storage
                     .create_collections(
@@ -679,11 +679,12 @@ impl Coordinator {
                         )],
                     )
                     .await
-                    .unwrap_or_terminate("cannot fail to append");
+                    .unwrap_or_terminate("cannot fail to append")
+                    .into_element();
 
                 coord
                     .initialize_storage_read_policy(
-                        sink_id,
+                        read_hold,
                         compaction_window.unwrap_or(CompactionWindow::Default),
                     )
                     .await;

--- a/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
+++ b/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
@@ -313,7 +313,7 @@ impl Coordinator {
 
         let oracle_read_ts = self.oracle_read_ts(session, &timeline_context, &when).await;
 
-        let determination = self.sequence_peek_timestamp(
+        let (determination, _read_holds) = self.sequence_peek_timestamp(
             session,
             &when,
             cluster_id,

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -404,13 +404,14 @@ impl<T> ShouldTerminateGracefully for StorageError<T> {
 impl ShouldTerminateGracefully for DataflowCreationError {
     fn should_terminate_gracefully(&self) -> Terminate {
         match self {
-            DataflowCreationError::SinceViolation(_)
-            | DataflowCreationError::InstanceMissing(_)
+            DataflowCreationError::InstanceMissing(_)
             | DataflowCreationError::CollectionMissing(_)
             | DataflowCreationError::ReplicaMissing(_)
             | DataflowCreationError::MissingAsOf
             | DataflowCreationError::EmptyAsOfForSubscribe
-            | DataflowCreationError::EmptyAsOfForCopyTo => Terminate::Panic,
+            | DataflowCreationError::EmptyAsOfForCopyTo
+            | DataflowCreationError::ReadHoldMissing(_)
+            | DataflowCreationError::ReadHoldInsufficient(_) => Terminate::Panic,
         }
     }
 }
@@ -427,10 +428,10 @@ impl ShouldTerminateGracefully for CollectionUpdateError {
 impl ShouldTerminateGracefully for PeekError {
     fn should_terminate_gracefully(&self) -> Terminate {
         match self {
-            PeekError::SinceViolation(_)
-            | PeekError::InstanceMissing(_)
-            | PeekError::CollectionMissing(_)
-            | PeekError::ReplicaMissing(_) => Terminate::Panic,
+            PeekError::InstanceMissing(_)
+            | PeekError::ReplicaMissing(_)
+            | PeekError::ReadHoldIdMismatch(_)
+            | PeekError::ReadHoldInsufficient(_) => Terminate::Panic,
         }
     }
 }

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -847,7 +847,7 @@ mod tests {
             _register_ts: Option<Self::Timestamp>,
             _collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
             _migrated_storage_collections: &BTreeSet<GlobalId>,
-        ) -> Result<(), StorageError<Self::Timestamp>> {
+        ) -> Result<Vec<ReadHold<Self::Timestamp>>, StorageError<Self::Timestamp>> {
             unimplemented!()
         }
 

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -508,6 +508,16 @@ pub enum PeekTarget {
     },
 }
 
+impl PeekTarget {
+    /// Returns the ID of the peeked collection.
+    pub fn id(&self) -> GlobalId {
+        match self {
+            Self::Index { id } => *id,
+            Self::Persist { id, .. } => *id,
+        }
+    }
+}
+
 /// Peek a collection, either in an arrangement or Persist.
 ///
 /// This request elicits data from the worker, by naming the

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -415,12 +415,14 @@ pub trait StorageController: Debug {
     /// might later give non-tables the same treatment, but hold off on that initially.) Callers
     /// must provide a Some if any of the collections is a table. A None may be given if none of the
     /// collections are a table (i.e. all materialized views, sources, etc).
+    ///
+    /// Returns a [`ReadHold`] for each created collection.
     async fn create_collections(
         &mut self,
         storage_metadata: &StorageMetadata,
         register_ts: Option<Self::Timestamp>,
         collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    ) -> Result<Vec<ReadHold<Self::Timestamp>>, StorageError<Self::Timestamp>> {
         self.create_collections_for_bootstrap(
             storage_metadata,
             register_ts,
@@ -440,7 +442,7 @@ pub trait StorageController: Debug {
         register_ts: Option<Self::Timestamp>,
         collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
         migrated_storage_collections: &BTreeSet<GlobalId>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<Vec<ReadHold<Self::Timestamp>>, StorageError<Self::Timestamp>>;
 
     /// Check that the ingestion associated with `id` can use the provided
     /// [`SourceDesc`].

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -519,11 +519,12 @@ where
         register_ts: Option<Self::Timestamp>,
         mut collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
         migrated_storage_collections: &BTreeSet<GlobalId>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    ) -> Result<Vec<ReadHold<T>>, StorageError<Self::Timestamp>> {
         self.migrated_storage_collections
             .clone_from(migrated_storage_collections);
 
-        self.storage_collections
+        let read_holds = self
+            .storage_collections
             .create_collections_for_bootstrap(
                 storage_metadata,
                 register_ts.clone(),
@@ -914,7 +915,7 @@ where
             };
         }
 
-        Ok(())
+        Ok(read_holds)
     }
 
     fn check_alter_ingestion_source_desc(


### PR DESCRIPTION
This commit changes how read holds are handled in the coordinator and the controller:

* controller methods that create storage/compute collections return initial `ReadHold`s for them
* controller methods that initiate reads from storage/compute collections expect the appropriate `ReadHold`s to be passed by the caller, instead of acquiring new ones
* `Coordinator::initialize_{storage,compute}_read_policy` expects a `ReadHold` to be passed by the caller, instead of acquiring a new one

As a result the code becomes easier to reason about wrt. to read holds. We are less likely to forget to acquire read holds when reading methods require them to be passed.

More importantly, this prepares the code for compute controller decoupling (#27656). Once the compute controller lives in a separate tasks, calls to `acquire_read_hold` will become `async` and blocking, so we want to avoid them as much as possible. There are still some calls to `acquire_read_hold` left, but they are all in a place where we can use the staged-sequencing mechanism to move them off the coordinator's main thread.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
