### PR TITLE
test-analytics: Sanitize literals everywhere

### DIFF
--- a/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
+++ b/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
@@ -17,6 +17,7 @@ import pg8000
 from pg8000 import Connection, Cursor
 
 from materialize.test_analytics.config.mz_db_config import MzDbConfig
+from materialize.test_analytics.util.mz_sql_util import as_sanitized_literal
 
 
 class TestAnalyticsUploadError(Exception):
@@ -93,7 +94,7 @@ class DatabaseConnector:
         connection.autocommit = autocommit
         connection.run(f"SET database = {self.config.database}")
         connection.run(f"SET search_path = {self.config.search_path}")
-        connection.run(f"SET cluster = '{self.config.cluster}'")
+        connection.run(f"SET cluster = {as_sanitized_literal(self.config.cluster)}")
         connection.run("SET transaction_isolation = serializable")
 
         return connection
@@ -114,7 +115,9 @@ class DatabaseConnector:
                 connection = self.create_connection(autocommit=autocommit)
 
         cursor = connection.cursor()
-        cursor.execute(f"SET statement_timeout = '{statement_timeout}'")
+        cursor.execute(
+            f"SET statement_timeout = {as_sanitized_literal(statement_timeout)}"
+        )
         return cursor
 
     def set_read_only(self) -> None:

--- a/misc/python/materialize/test_analytics/data/build/build_history_analysis.py
+++ b/misc/python/materialize/test_analytics/data/build/build_history_analysis.py
@@ -20,6 +20,7 @@ from materialize.test_analytics.connector.test_analytics_connector import (
     DatabaseConnector,
 )
 from materialize.test_analytics.data.base_data_storage import BaseDataStorage
+from materialize.test_analytics.util.mz_sql_util import as_sanitized_literal
 
 
 class BuildHistoryAnalysis(BaseDataStorage):
@@ -46,8 +47,8 @@ class BuildHistoryAnalysis(BaseDataStorage):
                 FROM
                     mv_recent_build_job_success_on_main_v2
                 WHERE
-                    pipeline = '{pipeline}' AND
-                    build_step_key = '{step_key}' AND
+                    pipeline = {as_sanitized_literal(pipeline)} AND
+                    build_step_key = {as_sanitized_literal(step_key)} AND
                     {shard_index_comparison}
                 ORDER BY
                     build_number DESC

--- a/misc/python/materialize/test_analytics/data/build_annotation/build_annotation_storage.py
+++ b/misc/python/materialize/test_analytics/data/build_annotation/build_annotation_storage.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from materialize import buildkite
 from materialize.buildkite import BuildkiteEnvVar
 from materialize.test_analytics.data.base_data_storage import BaseDataStorage
-from materialize.test_analytics.util import mz_sql_util
+from materialize.test_analytics.util.mz_sql_util import as_sanitized_literal
 
 
 @dataclass
@@ -53,9 +53,9 @@ class BuildAnnotationStorage(BaseDataStorage):
                 insert_date
             )
             SELECT
-                '{build_id}',
-                '{job_id}',
-                {mz_sql_util.as_sanitized_literal(annotation.test_suite)},
+                {as_sanitized_literal(build_id)},
+                {as_sanitized_literal(job_id)},
+                {as_sanitized_literal(annotation.test_suite)},
                 {annotation.test_retry_count},
                 {annotation.is_failure},
                 now()
@@ -75,10 +75,10 @@ class BuildAnnotationStorage(BaseDataStorage):
                     occurrence_count
                 )
                 SELECT
-                    '{job_id}',
-                    '{error.error_type}',
-                    {mz_sql_util.as_sanitized_literal(error.message)},
-                    {mz_sql_util.as_sanitized_literal(error.issue)},
+                    {as_sanitized_literal(job_id)},
+                    {as_sanitized_literal(error.error_type)},
+                    {as_sanitized_literal(error.message)},
+                    {as_sanitized_literal(error.issue)},
                     {error.occurrence_count}
             ;
             """

--- a/misc/python/materialize/test_analytics/data/feature_benchmark/feature_benchmark_result_storage.py
+++ b/misc/python/materialize/test_analytics/data/feature_benchmark/feature_benchmark_result_storage.py
@@ -12,6 +12,7 @@ from materialize import buildkite
 from materialize.buildkite import BuildkiteEnvVar
 from materialize.feature_benchmark.benchmark import ReportMeasurement
 from materialize.test_analytics.data.base_data_storage import BaseDataStorage
+from materialize.test_analytics.util.mz_sql_util import as_sanitized_literal
 
 
 @dataclass
@@ -61,13 +62,13 @@ class FeatureBenchmarkResultStorage(BaseDataStorage):
                     wallclock_variance
                 )
                 SELECT
-                    '{job_id}',
-                    '{framework_version}',
-                    '{result_entry.scenario_name}',
-                    '{result_entry.scenario_group}',
-                    '{result_entry.scenario_version}',
+                    {as_sanitized_literal(job_id)},
+                    {as_sanitized_literal(framework_version)},
+                    {as_sanitized_literal(result_entry.scenario_name)},
+                    {as_sanitized_literal(result_entry.scenario_group)},
+                    {as_sanitized_literal(result_entry.scenario_version)},
                     {result_entry.cycle},
-                    '{result_entry.scale}',
+                    {as_sanitized_literal(result_entry.scale)},
                     {result_entry.wallclock.result or 'NULL::DOUBLE'},
                     {result_entry.messages.result or 'NULL::INT'},
                     {result_entry.memory_mz.result or 'NULL::DOUBLE'},
@@ -112,8 +113,8 @@ class FeatureBenchmarkResultStorage(BaseDataStorage):
                     wallclock_variance
                 )
                 SELECT
-                    '{job_id}',
-                    '{discarded_entry.scenario_name}',
+                    {as_sanitized_literal(job_id)},
+                    {as_sanitized_literal(discarded_entry.scenario_name)},
                     {discarded_entry.cycle},
                     {discarded_entry.wallclock.result or 'NULL::DOUBLE'},
                     {discarded_entry.messages.result or 'NULL::INT'},

--- a/misc/python/materialize/test_analytics/data/known_issues/known_issues_storage.py
+++ b/misc/python/materialize/test_analytics/data/known_issues/known_issues_storage.py
@@ -9,7 +9,7 @@
 
 from materialize.github import KnownGitHubIssue
 from materialize.test_analytics.data.base_data_storage import BaseDataStorage
-from materialize.test_analytics.util import mz_sql_util
+from materialize.test_analytics.util.mz_sql_util import as_sanitized_literal
 
 
 class KnownIssuesStorage(BaseDataStorage):
@@ -23,20 +23,20 @@ class KnownIssuesStorage(BaseDataStorage):
         sql_statements = [
             f"""
             UPDATE issue
-            SET title = {mz_sql_util.as_sanitized_literal(issue.info["title"])},
-                ci_regexp = {mz_sql_util.as_sanitized_literal(issue.regex.pattern.decode("utf-8"))},
-                state = {mz_sql_util.as_sanitized_literal(issue.info["state"])}
-            WHERE issue_id = {mz_sql_util.as_sanitized_literal(issue_str)}
+            SET title = {as_sanitized_literal(issue.info["title"])},
+                ci_regexp = {as_sanitized_literal(issue.regex.pattern.decode("utf-8"))},
+                state = {as_sanitized_literal(issue.info["state"])}
+            WHERE issue_id = {as_sanitized_literal(issue_str)}
             ;
             """,
             f"""
             INSERT INTO issue (issue_id, title, ci_regexp, state)
-                SELECT {mz_sql_util.as_sanitized_literal(issue_str)},
-                       {mz_sql_util.as_sanitized_literal(issue.info["title"])},
-                       {mz_sql_util.as_sanitized_literal(issue.regex.pattern.decode("utf-8"))},
-                       {mz_sql_util.as_sanitized_literal(issue.info["state"])}
+                SELECT {as_sanitized_literal(issue_str)},
+                       {as_sanitized_literal(issue.info["title"])},
+                       {as_sanitized_literal(issue.regex.pattern.decode("utf-8"))},
+                       {as_sanitized_literal(issue.info["state"])}
                 WHERE NOT EXISTS (
-                    SELECT 1 FROM issue WHERE issue_id = {mz_sql_util.as_sanitized_literal(issue_str)}
+                    SELECT 1 FROM issue WHERE issue_id = {as_sanitized_literal(issue_str)}
                 )
             ;
             """,

--- a/misc/python/materialize/test_analytics/data/output_consistency/output_consistency_stats_storage.py
+++ b/misc/python/materialize/test_analytics/data/output_consistency/output_consistency_stats_storage.py
@@ -10,6 +10,7 @@
 from materialize import buildkite
 from materialize.buildkite import BuildkiteEnvVar
 from materialize.test_analytics.data.base_data_storage import BaseDataStorage
+from materialize.test_analytics.util.mz_sql_util import as_sanitized_literal
 
 
 class OutputConsistencyStatsStorage(BaseDataStorage):
@@ -51,8 +52,8 @@ class OutputConsistencyStatsStorage(BaseDataStorage):
                 count_used_ops
             )
             SELECT
-                '{job_id}',
-                '{step_key}',
+                {as_sanitized_literal(job_id)},
+                {as_sanitized_literal(step_key)},
                 {count_generated_select_expressions},
                 {count_ignored_select_expressions},
                 {count_executed_queries},

--- a/misc/python/materialize/test_analytics/data/scalability_framework/scalability_framework_result_storage.py
+++ b/misc/python/materialize/test_analytics/data/scalability_framework/scalability_framework_result_storage.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from materialize import buildkite
 from materialize.buildkite import BuildkiteEnvVar
 from materialize.test_analytics.data.base_data_storage import BaseDataStorage
+from materialize.test_analytics.util.mz_sql_util import as_sanitized_literal
 
 
 @dataclass
@@ -49,11 +50,11 @@ class ScalabilityFrameworkResultStorage(BaseDataStorage):
                         tps
                     )
                     SELECT
-                        '{job_id}',
-                        '{framework_version}',
-                        '{result_entry.workload_name}',
-                        '{result_entry.workload_group}',
-                        '{result_entry.workload_version}',
+                        {as_sanitized_literal(job_id)},
+                        {as_sanitized_literal(framework_version)},
+                        {as_sanitized_literal(result_entry.workload_name)},
+                        {as_sanitized_literal(result_entry.workload_group)},
+                        {as_sanitized_literal(result_entry.workload_version)},
                         {result_entry.concurrency},
                         {result_entry.count},
                         {result_entry.tps}

--- a/misc/python/materialize/test_analytics/setup/test_analytics_setup.py
+++ b/misc/python/materialize/test_analytics/setup/test_analytics_setup.py
@@ -12,6 +12,7 @@ import os
 from pg8000 import Cursor
 
 from materialize import MZ_ROOT
+from materialize.test_analytics.util.mz_sql_util import as_sanitized_literal
 
 
 def setup_all_structures(cursor: Cursor) -> None:
@@ -44,7 +45,7 @@ def setup_structures(cursor: Cursor, directory: str) -> None:
 def exist_structures(cursor: Cursor) -> bool:
     table_name_to_test = "build"
     cursor.execute(
-        f"SELECT exists(SELECT 1 FROM mz_tables WHERE name = '{table_name_to_test}');"
+        f"SELECT exists(SELECT 1 FROM mz_tables WHERE name = {as_sanitized_literal(table_name_to_test)});"
     )
     return cursor.fetchall()[0][0]
 


### PR DESCRIPTION

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
