### PR TITLE
test-analytics: Use new instance type of hetzner agents

### DIFF
--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -26,6 +26,7 @@ T = TypeVar("T")
 class BuildkiteEnvVar(Enum):
     # environment
     BUILDKITE_AGENT_META_DATA_AWS_INSTANCE_TYPE = auto()
+    BUILDKITE_AGENT_META_DATA_INSTANCE_TYPE = auto()
 
     # build
     BUILDKITE_PULL_REQUEST = auto()

--- a/misc/python/materialize/test_analytics/data/build/build_data_storage.py
+++ b/misc/python/materialize/test_analytics/data/build/build_data_storage.py
@@ -89,9 +89,9 @@ class BuildDataStorage(BaseDataStorage):
             BuildkiteEnvVar.BUILDKITE_PARALLEL_JOB, "NULL::INT"
         )
         retry_count = buildkite.get_var(BuildkiteEnvVar.BUILDKITE_RETRY_COUNT)
-        aws_instance_type = buildkite.get_var(
+        instance_type = buildkite.get_var(
             BuildkiteEnvVar.BUILDKITE_AGENT_META_DATA_AWS_INSTANCE_TYPE
-        )
+        ) or buildkite.get_var(BuildkiteEnvVar.BUILDKITE_AGENT_META_DATA_INSTANCE_TYPE)
 
         start_time_with_tz = os.getenv("STEP_START_TIMESTAMP_WITH_TZ")
         if buildkite.is_in_buildkite():
@@ -134,7 +134,7 @@ class BuildDataStorage(BaseDataStorage):
               now(),
               TRUE,
               {was_successful},
-              {as_sanitized_literal(aws_instance_type)}
+              {as_sanitized_literal(instance_type)}
             WHERE NOT EXISTS
             (
                 SELECT 1


### PR DESCRIPTION
Requires https://github.com/MaterializeInc/i2/pull/2156
(I didn't want to go through the trouble of renaming the column from `aws_instance_type` to `instance_type`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
