### PR TITLE
version consistency: extend ignore to also apply for success mismatches

### DIFF
--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -214,6 +214,17 @@ class VersionPostExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("Evaluation order changed with PR 28144")
 
+        if (
+            self.lower_version < MZ_VERSION_0_117_0 <= self.higher_version
+        ) and query_template.matches_any_expression(
+            is_any_date_time_expression,
+            True,
+        ):
+            # the older version may fail where the newer no longer does
+            return YesIgnore(
+                "Added support for implicit cast from date to mz_timestamp with PR#29494"
+            )
+
         return super()._shall_ignore_success_mismatch(
             error, query_template, contains_aggregation
         )


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/29519. This applies the ignore pattern also to errors of type `SUCCESS_MISMATCH` in addition to `ERROR_MESSAGE_MISMATCH`.

This addresses left-overs in https://buildkite.com/materialize/nightly/builds/9517#0191e958-12e6-4d37-b97a-e8f13052b4ab.