### PR TITLE
cargo-test: Bump timeout for long-running test_storage_usage_collection_interval

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -33,6 +33,10 @@ slow-timeout = { period = "300s", terminate-after = 2 }
 filter = "package(mz-adapter) and test(test_smoketest_all_builtins)"
 slow-timeout = { period = "300s", terminate-after = 2 }
 
+[[profile.default.overrides]]
+filter = "package(mz-environmentd) and test(test_storage_usage_collection_interval)"
+slow-timeout = { period = "300s", terminate-after = 2 }
+
 [profile.ci]
 junit = { path = "junit_cargo-test.xml" }
 fail-fast = false


### PR DESCRIPTION
Seen timing out in https://buildkite.com/materialize/test/builds/90318#0191e775-e18e-4711-95e0-1a69276f7ad8
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
