### PR TITLE
*: escape new lines and tabs in humanized output

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -152,7 +152,7 @@ impl<'a, T: 'a> DisplayText<PlanRenderingContext<'a, T>> for FastPathPlan {
                 if redacted {
                     writeln!(f, "{}Error █", ctx.as_mut())
                 } else {
-                    writeln!(f, "{}Error {}", ctx.as_mut(), err.to_string().quoted())
+                    writeln!(f, "{}Error {}", ctx.as_mut(), err.to_string().escaped())
                 }
             }
             FastPathPlan::PeekExisting(coll_id, idx_id, literal_constraints, mfp) => {

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -313,7 +313,7 @@ impl MirRelationExpr {
                     if mode.redacted() {
                         writeln!(f, "{}Error █", ctx.indent)?;
                     } else {
-                        writeln!(f, "{}Error {}", ctx.indent, err.to_string().quoted())?;
+                        writeln!(f, "{}Error {}", ctx.indent, err.to_string().escaped())?;
                     }
                 }
             },
@@ -1327,7 +1327,7 @@ where
                 if self.mode.redacted() {
                     write!(f, "error(█)")
                 } else {
-                    write!(f, "error({})", err.to_string().quoted())
+                    write!(f, "error({})", err.to_string().escaped())
                 }
             }
         }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3733,7 +3733,7 @@ impl fmt::Display for BinaryFunc {
                 Ok((regex, limit)) => write!(
                     f,
                     "regexp_replace[{}, case_insensitive={}, limit={}]",
-                    regex.pattern.quoted(),
+                    regex.pattern.escaped(),
                     regex.case_insensitive,
                     limit
                 ),

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -896,7 +896,7 @@ impl fmt::Display for IsLikeMatch {
             f,
             "{}like[{}]",
             if self.0.case_insensitive { "i" } else { "" },
-            self.0.pattern.quoted()
+            self.0.pattern.escaped()
         )
     }
 }
@@ -922,7 +922,7 @@ impl fmt::Display for IsRegexpMatch {
         write!(
             f,
             "is_regexp_match[{}, case_insensitive={}]",
-            self.0.pattern.quoted(),
+            self.0.pattern.escaped(),
             self.0.case_insensitive
         )
     }
@@ -980,7 +980,7 @@ impl fmt::Display for RegexpMatch {
         write!(
             f,
             "regexp_match[{}, case_insensitive={}]",
-            self.0.pattern.quoted(),
+            self.0.pattern.escaped(),
             self.0.case_insensitive
         )
     }
@@ -1037,7 +1037,7 @@ impl fmt::Display for RegexpSplitToArray {
         write!(
             f,
             "regexp_split_to_array[{}, case_insensitive={}]",
-            self.0.pattern.quoted(),
+            self.0.pattern.escaped(),
             self.0.case_insensitive
         )
     }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::BTreeMap;
-use std::fmt::{self, Debug, Write};
+use std::fmt::{self, Debug};
 use std::hash::Hash;
 use std::iter;
 use std::ops::Add;
@@ -20,6 +20,7 @@ use enum_kinds::EnumKind;
 use itertools::Itertools;
 use mz_lowertest::MzReflect;
 use mz_ore::cast::CastFrom;
+use mz_ore::str::StrExt;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use ordered_float::OrderedFloat;
 use proptest::prelude::*;
@@ -1350,15 +1351,7 @@ impl fmt::Display for Datum<'_> {
                 Ok(())
             }
             Datum::String(s) => {
-                f.write_str("\"")?;
-                for c in s.chars() {
-                    if c == '"' {
-                        f.write_str("\\\"")?;
-                    } else {
-                        f.write_char(c)?;
-                    }
-                }
-                f.write_str("\"")
+                write!(f, "{}", s.escaped())
             }
             Datum::Uuid(u) => write!(f, "{}", u),
             Datum::Array(array) => {

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -155,8 +155,7 @@ SELECT replace(s, E'\n', '<newline>') FROM t WHERE s~'a.*';
 Explained Query:
   Project (#3)
     Filter is_regexp_match["a.*", case_insensitive=false](#0)
-      Map (replace(#0, "
-", "<newline>"))
+      Map (replace(#0, "\n", "<newline>"))
         ReadStorage materialize.public.t
 
 Source materialize.public.t
@@ -178,8 +177,7 @@ SELECT replace(s, E'\n', '<newline>') FROM t WHERE s~*'a.*';
 Explained Query:
   Project (#3)
     Filter is_regexp_match["a.*", case_insensitive=true](#0)
-      Map (replace(#0, "
-", "<newline>"))
+      Map (replace(#0, "\n", "<newline>"))
         ReadStorage materialize.public.t
 
 Source materialize.public.t
@@ -201,8 +199,7 @@ SELECT replace(s, E'\n', '<newline>'), regexp_match(s, 'a.*') FROM t;
 ----
 Explained Query:
   Project (#3, #4)
-    Map (replace(#0, "
-", "<newline>"), regexp_match["a.*", case_insensitive=false](#0))
+    Map (replace(#0, "\n", "<newline>"), regexp_match["a.*", case_insensitive=false](#0))
       ReadStorage materialize.public.t
 
 Source materialize.public.t
@@ -229,8 +226,7 @@ SELECT replace(s, E'\n', '<newline>'), regexp_match(s, 'a.*', 'i') FROM t;
 ----
 Explained Query:
   Project (#3, #4)
-    Map (replace(#0, "
-", "<newline>"), regexp_match["a.*", case_insensitive=true](#0))
+    Map (replace(#0, "\n", "<newline>"), regexp_match["a.*", case_insensitive=true](#0))
       ReadStorage materialize.public.t
 
 Source materialize.public.t
@@ -287,8 +283,7 @@ SELECT replace(s, E'\n', '<newline>') FROM t WHERE s ~ regex_pat;
 Explained Query:
   Project (#3)
     Filter (#0 ~ #2)
-      Map (replace(#0, "
-", "<newline>"))
+      Map (replace(#0, "\n", "<newline>"))
         ReadStorage materialize.public.t
 
 Source materialize.public.t
@@ -311,8 +306,7 @@ SELECT replace(s, E'\n', '<newline>') FROM t WHERE s ~* regex_pat;
 Explained Query:
   Project (#3)
     Filter (#0 ~* #2)
-      Map (replace(#0, "
-", "<newline>"))
+      Map (replace(#0, "\n", "<newline>"))
         ReadStorage materialize.public.t
 
 Source materialize.public.t
@@ -335,8 +329,7 @@ SELECT replace(s, E'\n', '<newline>'), regex_pat, regexp_match(s, regex_pat) FRO
 ----
 Explained Query:
   Project (#3, #2, #4)
-    Map (replace(#0, "
-", "<newline>"), regexp_match(#0, #2))
+    Map (replace(#0, "\n", "<newline>"), regexp_match(#0, #2))
       ReadStorage materialize.public.t
 
 Source materialize.public.t
@@ -368,8 +361,7 @@ SELECT replace(s, E'\n', '<newline>'), regex_pat, regexp_match(s, regex_pat, 'i'
 ----
 Explained Query:
   Project (#3, #2, #4)
-    Map (replace(#0, "
-", "<newline>"), regexp_match(#0, #2, "i"))
+    Map (replace(#0, "\n", "<newline>"), regexp_match(#0, #2, "i"))
       ReadStorage materialize.public.t
 
 Source materialize.public.t
@@ -440,10 +432,7 @@ EXPLAIN
 SELECT *, s~'\' FROM t;
 ----
 Explained Query:
-  Map (error("invalid regular expression: regex parse error:
-    \
-    ^
-error: incomplete escape sequence, reached end of pattern prematurely"))
+  Map (error("invalid regular expression: regex parse error:\n    \\n    ^\nerror: incomplete escape sequence, reached end of pattern prematurely"))
     ReadStorage materialize.public.t
 
 Source materialize.public.t
@@ -714,10 +703,7 @@ EXPLAIN
 SELECT regexp_replace('foobarbaz', 'b(..', 'X', 'ig');
 ----
 Explained Query (fast path):
-  Error "invalid regular expression: regex parse error:
-    b(..
-     ^
-error: unclosed group"
+  Error "invalid regular expression: regex parse error:\n    b(..\n     ^\nerror: unclosed group"
 
 Target cluster: quickstart
 


### PR DESCRIPTION
Update string formatting to also escape new lines and tabs, such that these characters are not rendered as is.

### Motivation

Fixes #27355. Note the resulting change in the test outputs.

### Tips for reviewer

* Added a new String wrapper variant `EscapedStr`. Open to other names for this Struct.
* The `pattern.escaped()` changes should only affect humanized output.
* The change for rending `Datum::String` is more contentious and might have a risk of a backward incompatible change.
  * From a cursory look, Datum::String.to_string() is only used in tests and error messages.
  * The important uses directly access the inner `str` without using `to_string()`.
  * Worth taking a good second look here.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
