### PR TITLE
[expr] Add a proptest for the is_monotone annotations

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -8672,6 +8672,7 @@ mod test {
 
         let interesting_strs: Vec<Datum<'static>> =
             ScalarType::String.interesting_datums().collect();
+        #[allow(clippy::disallowed_macros)]
         let str_datums = prop_oneof![
             proptest::string::string_regex("[A-Z]{0,10}")
                 .expect("valid regex")
@@ -8681,6 +8682,7 @@ mod test {
 
         let interesting_i32s: Vec<Datum<'static>> =
             ScalarType::Int32.interesting_datums().collect();
+        #[allow(clippy::disallowed_macros)]
         let i32_datums = prop_oneof![
             any::<i32>().prop_map(Datum::from),
             (0..interesting_i32s.len()).prop_map(|i| interesting_i32s[i]),


### PR DESCRIPTION
### Motivation

Why think of counterexamples when the computer can do it?

(We could also add more functions to the abstract interpreter tests, which cover this codepath... but we can test this directly more cheaply for more functions, and this keeps any test failures closer to the problematic code.)

### Tips for reviewer

Inspired by: https://github.com/MaterializeInc/materialize/pull/29514

This sadly produces a counterexample for `left` when passed a negative argument... `'a' < 'aa' < 'z'` but `left(_, -1)` returns `'' < 'a' > ''`. Concat seems fine in the second arg however!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
