### PR TITLE
testdrive: Bump global wallclock lag in test

### DIFF
--- a/test/testdrive/wallclock-lag.td
+++ b/test/testdrive/wallclock-lag.td
@@ -72,14 +72,13 @@ tbl          <null> true  true
   FROM mz_internal.mz_wallclock_global_lag_history l
   JOIN mz_objects o ON o.id = l.object_id
   WHERE l.object_id LIKE 'u%'
+  AND o.name NOT LIKE 'src%'
   ORDER BY o.name, l.occurred_at DESC
 idx          true  true
 idx_const    false true
 mv           true  true
 mv_const     false true
 snk          true  true
-src          true  true
-src_progress true  true
 tbl          true  true
 
 > SELECT DISTINCT ON(o.name)
@@ -87,12 +86,11 @@ tbl          true  true
   FROM mz_internal.mz_wallclock_global_lag_recent_history l
   JOIN mz_objects o ON o.id = l.object_id
   WHERE l.object_id LIKE 'u%'
+  AND o.name NOT LIKE 'src%'
   ORDER BY o.name, l.occurred_at DESC
 idx          true  true
 idx_const    false true
 mv           true  true
 mv_const     false true
 snk          true  true
-src          true  true
-src_progress true  true
 tbl          true  true


### PR DESCRIPTION
Seen flaking in CI 6 times: https://ci-failures.dev.materialize.com/?key=test-failures&tfFilters=%5B%7B%22id%22%3A%22build_date%22%2C%22value%22%3A%5Bnull%2Cnull%5D%7D%2C%7B%22id%22%3A%22content%22%2C%22value%22%3A%22wallclock-lag.td%3A%22%7D%5D

Was introduced in https://github.com/MaterializeInc/materialize/pull/29449

Edit: Even with 10 s I'm still seeing it fail locally:
```
wallclock-lag.td:70:1: error: non-matching rows: expected:
[["idx", "true", "true"], ["idx_const", "false", "true"], ["mv", "true", "true"], ["mv_const", "false", "true"], ["snk", "true", "true"], ["src", "true", "true"], ["src_progress", "true", "true"], ["tbl", "true", "true"]]
got:
[["idx", "true", "true"], ["idx_const", "false", "true"], ["mv", "true", "true"], ["mv_const", "false", "true"], ["snk", "true", "true"], ["src", "false", "true"], ["src_progress", "false", "true"], ["tbl", "true", "true"]]
Poor diff:
+ src false true
- src true true
+ src_progress false true
- src_progress true true

     |
  15 | $ postgres-connect n ... [rest of line truncated for security]
  17 | $ postgres-execute c ... [rest of line truncated for security]
  40 |   TO CONFLUENT SCHEM ... [rest of line truncated for security]
  69 |
  70 | > SELECT DISTINCT ON(o.name)
     | ^
+++ !!! Error Report
```
Edit2: 20 s too, I'll remove the src and src_progress instead.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
