### PR TITLE
bazel: Expose tools from the Clang toolchain, add `darwin-x86_64` toolchain

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -217,6 +217,9 @@ http_archive(
 # We build our own clang toolchain, see the <https://github.com/MaterializeInc/toolchains> repository.
 LLVM_VERSION = "18.1.8"
 
+# We have a few variants of our clang toolchain, either improving how it's built or adding new tools.
+LLVM_VERSION_SUFFIX = "4"
+
 maybe(
     http_archive,
     name = "toolchains_llvm",
@@ -248,10 +251,10 @@ llvm_toolchain(
         "linux-aarch64": "@linux_sysroot-aarch64//:sysroot",
     },
     urls = {
-        "darwin-aarch64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-4/darwin_aarch64.tar.zst".format(LLVM_VERSION)],
-        "darwin-x86_64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-4/darwin_x86_64.tar.zst".format(LLVM_VERSION)],
-        "linux-aarch64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-4/linux_aarch64.tar.zst".format(LLVM_VERSION)],
-        "linux-x86_64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-4/linux_x86_64.tar.zst".format(LLVM_VERSION)],
+        "darwin-aarch64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-{1}/darwin_aarch64.tar.zst".format(LLVM_VERSION, LLVM_VERSION_SUFFIX)],
+        "darwin-x86_64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-{1}/darwin_x86_64.tar.zst".format(LLVM_VERSION, LLVM_VERSION_SUFFIX)],
+        "linux-aarch64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-{1}/linux_aarch64.tar.zst".format(LLVM_VERSION, LLVM_VERSION_SUFFIX)],
+        "linux-x86_64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-{1}/linux_x86_64.tar.zst".format(LLVM_VERSION, LLVM_VERSION_SUFFIX)],
     },
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -236,7 +236,8 @@ llvm_toolchain(
     name = "llvm_toolchain",
     llvm_version = LLVM_VERSION,
     sha256 = {
-        "darwin-aarch64": "510541536527d9d4264e48e254c231487cdc1631cb30920da8a68adf41fdbb91",
+        "darwin-aarch64": "41d8dea52d18c4e8b90c4fcd31965f9f297df9f40a38a33d60748dbe7f8330b8",
+        "darwin-x86_64": "291b8dd844aa896b98393c5d3beaee57f294768039eacdf9ef5e96ed9d3f62d7",
         "linux-aarch64": "fe8f9e283ab43e963daf9ffb18742e134ad239b56078d61ef9a289ff642784ed",
         "linux-x86_64": "8b725ec14e48bc1cb3698309506e29cd94ff3b823976ebb306e9c3ef84480c16",
     },
@@ -247,7 +248,8 @@ llvm_toolchain(
         "linux-aarch64": "@linux_sysroot-aarch64//:sysroot",
     },
     urls = {
-        "darwin-aarch64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}/darwin_aarch64.tar.zst".format(LLVM_VERSION)],
+        "darwin-aarch64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-4/darwin_aarch64.tar.zst".format(LLVM_VERSION)],
+        "darwin-x86_64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-4/darwin_x86_64.tar.zst".format(LLVM_VERSION)],
         "linux-aarch64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-4/linux_aarch64.tar.zst".format(LLVM_VERSION)],
         "linux-x86_64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-4/linux_x86_64.tar.zst".format(LLVM_VERSION)],
     },
@@ -353,7 +355,13 @@ rust_toolchains(
             "llvm-tools": "86e441024b0e538ed69fa0098be48592caae6fc28097f7630b906be276c79622",
             "rust-std": "e7b766fce1cd89c02bde33f8cc3a81f341c52677258a546df2bee1c7090e9fc5",
         },
-        "x86_64-apple-darwin": {},
+        "x86_64-apple-darwin": {
+            "rustc": "f0adfff86a9d5055f537dab26f6d0b7a81efe087f90b7e16c42698d58af0ffca",
+            "clippy": "5b6e393a7784839a1554188df2d87481696a0e0be242d1d2982e442b43199c08",
+            "cargo": "e3d03157061987be0c7cddf1e708f376929273779a65459a9b3a7ebc6ccadaae",
+            "llvm-tools": "3c443d068464c95a0a02072082bff6661cee5568dbbedbb82dcb6737147f3d6c",
+            "rust-std": "c9e366e76ee470d11afadbd70b200976ef4b34e626b568f19e429d4d23dead86",
+        },
     },
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -237,8 +237,8 @@ llvm_toolchain(
     llvm_version = LLVM_VERSION,
     sha256 = {
         "darwin-aarch64": "510541536527d9d4264e48e254c231487cdc1631cb30920da8a68adf41fdbb91",
-        "linux-aarch64": "738ab939ae9b6351413947758661058c101ff2e4708bf8df984de6035ab29745",
-        "linux-x86_64": "9d72a68e9c3d56fc68af25e8fe95aa2aea1049a135a5b35d395c4fe4aaed6f16",
+        "linux-aarch64": "fe8f9e283ab43e963daf9ffb18742e134ad239b56078d61ef9a289ff642784ed",
+        "linux-x86_64": "8b725ec14e48bc1cb3698309506e29cd94ff3b823976ebb306e9c3ef84480c16",
     },
     sysroot = {
         "darwin-aarch64": "@sysroot_darwin_universal//:sysroot",
@@ -248,8 +248,8 @@ llvm_toolchain(
     },
     urls = {
         "darwin-aarch64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}/darwin_aarch64.tar.zst".format(LLVM_VERSION)],
-        "linux-aarch64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-3/linux_aarch64.tar.zst".format(LLVM_VERSION)],
-        "linux-x86_64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-3/linux_x86_64.tar.zst".format(LLVM_VERSION)],
+        "linux-aarch64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-4/linux_aarch64.tar.zst".format(LLVM_VERSION)],
+        "linux-x86_64": ["https://github.com/MaterializeInc/toolchains/releases/download/clang-{0}-4/linux_x86_64.tar.zst".format(LLVM_VERSION)],
     },
 )
 

--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -162,7 +162,7 @@ def maybe_upload_debuginfo(
             print(f"Constructing source tarball for {bin}...")
             with tempfile.NamedTemporaryFile() as tarball:
                 p1 = subprocess.Popen(
-                    ["llvm-dwarfdump", "--show-sources", bin_path],
+                    [*repo.rd.tool("llvm-dwarfdump"), "--show-sources", bin_path],
                     stdout=subprocess.PIPE,
                 )
                 p2 = subprocess.Popen(

--- a/misc/bazel/tools/BUILD.bazel
+++ b/misc/bazel/tools/BUILD.bazel
@@ -32,3 +32,36 @@ sh_binary(
         no_match_error = "`buildifier` is not supported on the current platform.",
     ),
 )
+
+# We alias some tools from the Clang toolchain for easy consumption from other
+# parts of our build system, e.g. `mzbuild.py`.
+#
+# To see all of the available tools, run `bazel cquery @llvm_toolchain_llvm//:bin --output=files`
+#
+# Note: In a _perfect_ Bazel world, we would have some rule that invokes these
+# tools and removes the need for the wrapper, but this is an incremental step.
+
+alias(
+    name = "dwarfdump",
+    actual = "@llvm_toolchain_llvm//:bin/llvm-dwarfdump",
+)
+
+alias(
+    name = "objcopy",
+    actual = "@llvm_toolchain_llvm//:bin/llvm-objcopy",
+)
+
+alias(
+    name = "objdump",
+    actual = "@llvm_toolchain_llvm//:bin/llvm-objdump",
+)
+
+alias(
+    name = "profdata",
+    actual = "@llvm_toolchain_llvm//:bin/llvm-profdata",
+)
+
+alias(
+    name = "strip",
+    actual = "@llvm_toolchain_llvm//:bin/llvm-strip",
+)

--- a/misc/bazel/tools/BUILD.bazel
+++ b/misc/bazel/tools/BUILD.bazel
@@ -42,26 +42,51 @@ sh_binary(
 # tools and removes the need for the wrapper, but this is an incremental step.
 
 alias(
-    name = "dwarfdump",
+    name = "llvm-dwarfdump",
     actual = "@llvm_toolchain_llvm//:bin/llvm-dwarfdump",
 )
 
 alias(
-    name = "objcopy",
+    name = "dwarfdump",
+    actual = ":llvm-dwarfdump",
+)
+
+alias(
+    name = "llvm-objcopy",
     actual = "@llvm_toolchain_llvm//:bin/llvm-objcopy",
 )
 
 alias(
-    name = "objdump",
+    name = "objcopy",
+    actual = ":llvm-objcopy",
+)
+
+alias(
+    name = "llvm-objdump",
     actual = "@llvm_toolchain_llvm//:bin/llvm-objdump",
 )
 
 alias(
-    name = "profdata",
+    name = "objdump",
+    actual = ":llvm-objdump",
+)
+
+alias(
+    name = "llvm-profdata",
     actual = "@llvm_toolchain_llvm//:bin/llvm-profdata",
 )
 
 alias(
-    name = "strip",
+    name = "profdata",
+    actual = ":llvm-profdata",
+)
+
+alias(
+    name = "llvm-strip",
     actual = "@llvm_toolchain_llvm//:bin/llvm-strip",
+)
+
+alias(
+    name = "strip",
+    actual = ":llvm-strip",
 )

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -128,7 +128,10 @@ class RepositoryDetails:
 
     def tool(self, name: str) -> list[str]:
         """Start a binutils tool invocation for the configured architecture."""
-        return xcompile.tool(self.arch, name)
+        if self.bazel:
+            return ["bazel", "run", f"@//misc/bazel/tools:{name}", "--"]
+        else:
+            return xcompile.tool(self.arch, name)
 
     def cargo_target_dir(self) -> Path:
         """Determine the path to the target directory for Cargo."""


### PR DESCRIPTION
This PR makes some of the tools from our Clang toolchain more easily accessible so things like `mzbuild` can use them. It also updates `mzbuild.py` to use these tools when Bazel is enabled.

### Motivation

* This PR refactors existing code.

Exposing the necessary tools from Bazel will allow us to remove them from the CI builder image and slim it down.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
