### PR TITLE
bazel: Tweak build settings, reduce debug info for non-tagged builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -73,27 +73,18 @@ build:debug --cxxopt="-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG"
 build:debug --host_cxxopt="-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG"
 build:debug --@rules_rust//:extra_rustc_flag="-Csplit-debuginfo=unpacked"
 
-
-# Common Build Configuration
-build --linkopt="-fuse-ld=lld"
-build --@rules_rust//:extra_rustc_flag="-Clink-arg=-fuse-ld=lld"
-build --@rules_rust//:extra_rustc_flag="-Csymbol-mangling-version=v0"
-# We use 64 because it's enough to totally saturate a CI builder so our builds
-# are as fast as possible, and it's less than the default of 256 used with
-# Cargo when incremental compilation is enabled.
 #
-# TODO(parkmycar): Investigate a "super release" build with codegen-units=1
-build --@rules_rust//:extra_rustc_flag="-Ccodegen-units=64"
-# Enabling pipelined builds allows dependent libraries to begin compiling with
-# just `.rmeta` instead of the full `.rlib`.
-build --@rules_rust//rust/settings:pipelined_compilation=True
+# Debug Info Configuration
+#
 
-# TODO(parkmycar): toolchains_llvm uses ld64 for macOS which doesn't support
-# compressing debug sections.
+# TODO(parkmycar): Enable this for macOS. `toolchains_llvm` defaults to ld64 which
+# doesn't support zlib compression.
 build:linux --linkopt="-Wl,--compress-debug-sections=zlib"
-build:linux --linkopt="-Wl,-O2"
 build:linux --@rules_rust//:extra_rustc_flag="-Clink-arg=-Wl,--compress-debug-sections=zlib"
+# Specifying "-O2" uses level 6 zlib compression.
+build:linux --linkopt="-Wl,-O2"
 build:linux --@rules_rust//:extra_rustc_flag="-Clink-arg=-Wl,-O2"
+build:linux --copt="-gz=zlib"
 
 # Match the DWARF version used by Rust
 #
@@ -102,6 +93,28 @@ build:linux --copt="-gdwarf-4"
 build:linux --linkopt="-gdwarf-4"
 build:macos --copt="-gdwarf-2"
 build:macos --linkopt="-gdwarf-2"
+
+# Emit full debug info, allowing us to easily analyze core dumps from staging
+# (and, in an emergency, also prod).
+build:debuginfo-full --@rules_rust//:extra_rustc_flag=-Cdebuginfo=2
+build:debuginfo-full --copt=-g2
+
+build:debuginfo-limited --@rules_rust//:extra_rustc_flag=-Cdebuginfo=line-tables-only
+build:debuginfo-limited --copt=-gline-tables-only
+
+#
+# Common Build Configuration
+#
+build --linkopt="-fuse-ld=lld"
+build --@rules_rust//:extra_rustc_flag="-Clink-arg=-fuse-ld=lld"
+build --@rules_rust//:extra_rustc_flag="-Csymbol-mangling-version=v0"
+# We use 64 because it's enough to totally saturate a CI builder so our builds
+# are as fast as possible, and it's less than the default of 256 used with
+# Cargo when incremental compilation is enabled.
+build --@rules_rust//:extra_rustc_flag="-Ccodegen-units=64"
+# Enabling pipelined builds allows dependent libraries to begin compiling with
+# just `.rmeta` instead of the full `.rlib`.
+build --@rules_rust//rust/settings:pipelined_compilation=True
 
 # As of Jan 2024 all of the x86-64 and aarch64 hardware we run on support these
 # CPU targets.
@@ -118,11 +131,9 @@ build:linux-arm64 --@rules_rust//:extra_rustc_flag="-Ctarget-cpu=neoverse-n1"
 #
 # `/dev/shm` is a RAM backed temporary filesystem, it should speedup sandbox creation.
 build:ci --sandbox_base=/dev/shm
-# Only downloads the "necessary" output files from the remote cache, recommended for CI
-# builds.
-build:ci --remote_download_minimal
 
 # Release Build Configuration
+#
 build:release --cxxopt=-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST
 build:release --copt=-O3
 build:release --copt=-DNDEBUG
@@ -130,13 +141,19 @@ build:release --compilation_mode=opt
 build:release --copt=-flto=thin
 build:release --linkopt=-flto=thin
 build:release --@rules_rust//:extra_rustc_flag=-Clto=thin
-# Emit full debug info, allowing us to easily analyze core dumps from staging
-# (and, in an emergency, also prod).
-build:release --@rules_rust//:extra_rustc_flag=-Cdebuginfo=2
-build:release --copt=-g
 # `rules_rust` defaults to stripping debug symbols for release builds, undo that.
 build:release --strip=never
 build:release --@rules_rust//:extra_rustc_flag=-Cstrip=none
+
+# Builds from `main` or tagged builds.
+#
+# Note: We don't use a ramdisk for tagged builds because the full debuginfo is
+# too large and we OOD/OOM.
+build:release-tagged --config=release --config=release-stamp --config=debuginfo-full
+# Local builds and from PRs in CI.
+#
+# Not doing a full stamp nor omitting full debug info, greatly speeds up compile times.
+build:release-dev --config=release --config=debuginfo-limited
 
 # Build with the Rust Nightly Toolchain
 build:rust-nightly --@rules_rust//rust/toolchain/channel=nightly

--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -162,7 +162,7 @@ so it is executed.""",
                 elif agent == "linux-aarch64-medium":
                     agent = "linux-aarch64-large"
                 elif agent == "linux-aarch64-large":
-                    agent = "builder-linux-aarch64"
+                    agent = "builder-linux-aarch64-mem"
                 elif agent == "linux-x86_64-small":
                     agent = "linux-x86_64"
                 elif agent == "linux-x86_64":

--- a/ci/mkpipeline.sh
+++ b/ci/mkpipeline.sh
@@ -27,7 +27,7 @@ for arch in x86_64 aarch64; do
         if ! MZ_DEV_CI_BUILDER_ARCH=$arch bin/ci-builder exists $toolchain; then
             queue=builder-linux-x86_64
             if [[ $arch = aarch64 ]]; then
-                queue=builder-linux-aarch64
+                queue=builder-linux-aarch64-mem
             fi
             bootstrap_steps+="
   - label: bootstrap $toolchain $arch

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -38,7 +38,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-aarch64
+          queue: builder-linux-aarch64-mem
 
   - group: Linters
     key: linters
@@ -74,7 +74,7 @@ steps:
           args: [--miri-full]
     agents:
       # TODO(def-) Switch back to Hetzner
-      queue: builder-linux-aarch64
+      queue: builder-linux-aarch64-mem
     sanitizer: skip
 
   - group: Benchmarks
@@ -848,7 +848,7 @@ steps:
         timeout_in_minutes: 240
         agents:
           # TODO(def-): Switch back to hetzner
-          queue: builder-linux-aarch64
+          queue: builder-linux-aarch64-mem
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks

--- a/ci/qa-canary/pipeline.template.yml
+++ b/ci/qa-canary/pipeline.template.yml
@@ -23,7 +23,7 @@ steps:
     depends_on: []
     timeout_in_minutes: 60
     agents:
-      queue: builder-linux-aarch64
+      queue: builder-linux-aarch64-mem
 
   - wait: ~
 

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -27,7 +27,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-aarch64
+          queue: builder-linux-aarch64-mem
         # Don't build for "trigger_job" source, which indicates that this release
         # qualification pipeline was triggered automatically by the tests pipeline
         # because there is a new tag on a v* branch. In this case we want to make

--- a/ci/slt/pipeline.template.yml
+++ b/ci/slt/pipeline.template.yml
@@ -24,7 +24,7 @@ steps:
     depends_on: []
     timeout_in_minutes: 60
     agents:
-      queue: builder-linux-aarch64
+      queue: builder-linux-aarch64-mem
 
   - wait: ~
 

--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -93,7 +93,7 @@ def maybe_upload_debuginfo(
 
     for bin in bins:
         if repo.rd.bazel:
-            options = ["--config=release"] if repo.rd.release_mode else []
+            options = repo.rd.bazel_config()
             paths = bazel.output_paths(bazel_bins[bin], options)
             assert len(paths) == 1, f"{bazel_bins[bin]} output more than 1 file"
             bin_path = paths[0]

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -54,7 +54,7 @@ steps:
         priority: 50
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-aarch64
+          queue: builder-linux-aarch64-mem
 
       - id: build-x86_64
         label: ":bazel: Build x86_64"
@@ -273,7 +273,7 @@ steps:
           composition: cargo-test
     agents:
       # Because of scratch-aws-access
-      queue: builder-linux-aarch64
+      queue: builder-linux-aarch64-mem
 
   - id: testdrive
     label: "Testdrive %N"

--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -15,7 +15,6 @@ import sys
 from enum import Enum
 
 from materialize import MZ_ROOT, spawn
-from materialize import bazel as bazel_utils
 from materialize.rustc_flags import Sanitizer
 
 
@@ -89,7 +88,6 @@ def target_features(arch: Arch) -> list[str]:
 def bazel(
     arch: Arch,
     subcommand: str,
-    is_tagged_build: bool,
     rustflags: list[str],
     extra_env: dict[str, str] = {},
 ) -> list[str]:
@@ -115,13 +113,6 @@ def bazel(
     bazel_flags = ["--config=linux"]
     if sys.platform != "darwin":
         bazel_flags += [f"--config=linux-{arch.go_str()}"]
-
-    # If we're a tagged build, then we'll use stamping to update our build info, otherwise we'll
-    # use our side channel/best-effort approach to update it.
-    if is_tagged_build:
-        bazel_flags += ["--config=release-stamp"]
-    else:
-        bazel_utils.write_git_hash()
 
     rustc_flags = [
         f"--@rules_rust//:extra_rustc_flag={flag}"


### PR DESCRIPTION
This PR improves the speed of builds by reducing the amount of debug info we keep for non tagged builds. Instead of [full debug info](https://doc.rust-lang.org/rustc/codegen-options/index.html#debuginfo) we generate `line-tables-only`. 

~~I also tried using `/dev/shm` (a temporary filesystem on top of a Ramdisk) for the Bazel sandbox, which improves the startup speed for Bazel actions. While this works when I test on the same EC2 instances it fails in CI. Presumably because CI instances have more running and thus less RAM available.~~ I was able to enable `/dev/shm`, it turns out the CI Builder Docker image by default only mounts a ramdisk with 64MB of space, tuning this fixed the issue.

### Motivation

* This PR adds a feature that has not yet been specified.

Improves speed of CI

### Tips for reviewer

Review only the last commit, the others are from https://github.com/MaterializeInc/materialize/pull/29402

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
