### PR TITLE
Window functions: `Reduce` - `FlatMap UnnestList` fusion

### DIFF
--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -41,6 +41,8 @@ breaking:
     - compute-types/src/dataflows.proto
     # reason: does currently not require backward-compatibility
     - compute-types/src/plan.proto
+    # reason: does currently not require backward-compatibility
+    - compute-types/src/plan/reduce.proto
     # reason: does not currently require backward-compatibility
     - compute-types/src/sinks.proto
     # reason: Ignore because plans are currently not persisted.

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -37,6 +37,8 @@ pub(super) struct Context {
     debug_info: LirDebugInfo,
     /// Whether to enable fusion of MFPs in reductions.
     enable_reduce_mfp_fusion: bool,
+    /// Whether to fuse `Reduce` with `FlatMap UnnestList` for better window function performance.
+    enable_reduce_unnest_list_fusion: bool,
 }
 
 impl Context {
@@ -49,6 +51,7 @@ impl Context {
                 id: GlobalId::Transient(0),
             },
             enable_reduce_mfp_fusion: features.enable_reduce_mfp_fusion,
+            enable_reduce_unnest_list_fusion: features.enable_reduce_unnest_list_fusion,
         }
     }
 

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -587,12 +587,12 @@ This is not expected to cause incorrect results, but could indicate a performanc
                         MapFilterProject::new(mfp.input_arity),
                         group_key.len() + aggregates.len(),
                     );
-                    soft_assert_eq_or_log!(
-                        mfp.input_arity,
-                        output_arity,
-                        "Output arity of reduce must match input arity for MFP on top of it"
-                    );
                 }
+                soft_assert_eq_or_log!(
+                    mfp.input_arity,
+                    output_arity,
+                    "Output arity of reduce must match input arity for MFP on top of it"
+                );
                 let output_keys = reduce_plan.keys(group_key.len(), output_arity);
                 (
                     Plan::Reduce {

--- a/src/compute-types/src/plan/reduce.proto
+++ b/src/compute-types/src/plan/reduce.proto
@@ -9,6 +9,8 @@
 
 // See https://developers.google.com/protocol-buffers for what's going on here.
 
+// buf breaking: ignore (does currently not require backward-compatibility)
+
 syntax = "proto3";
 
 import "expr/src/linear.proto";
@@ -64,12 +66,17 @@ message ProtoBasicPlan {
     message ProtoSingleBasicPlan {
         uint64 index = 1;
         mz_expr.relation.ProtoAggregateExpr expr = 2;
+        bool fused_unnest_list = 3;
+    };
+
+    message ProtoSimpleSingleBasicPlan {
+        uint64 index = 1;
+        mz_expr.relation.ProtoAggregateExpr expr = 2;
     };
 
     message ProtoMultipleBasicPlan {
-        repeated ProtoSingleBasicPlan aggrs = 1;
+        repeated ProtoSimpleSingleBasicPlan aggrs = 1;
     }
-
 
     oneof kind {
         ProtoSingleBasicPlan single = 1;

--- a/src/compute-types/src/plan/reduce.rs
+++ b/src/compute-types/src/plan/reduce.rs
@@ -754,7 +754,7 @@ impl ReducePlan {
     /// that key a single arrangement.
     pub fn keys(&self, key_arity: usize, arity: usize) -> AvailableCollections {
         let key = (0..key_arity)
-            .map(mz_expr::MirScalarExpr::Column)
+            .map(MirScalarExpr::Column)
             .collect::<Vec<_>>();
         let (permutation, thinning) = permutation_for_arrangement(&key, arity);
         AvailableCollections::new_arranged(vec![(key, permutation, thinning)], None)
@@ -863,7 +863,7 @@ impl KeyValPlan {
         input_permutation_and_new_arity: Option<(BTreeMap<usize, usize>, usize)>,
     ) -> Self {
         // Form an operator for evaluating key expressions.
-        let mut key_mfp = mz_expr::MapFilterProject::new(input_arity)
+        let mut key_mfp = MapFilterProject::new(input_arity)
             .map(group_key.iter().cloned())
             .project(input_arity..(input_arity + group_key.len()));
         if let Some((input_permutation, new_arity)) = input_permutation_and_new_arity.clone() {
@@ -871,7 +871,7 @@ impl KeyValPlan {
         }
 
         // Form an operator for evaluating value expressions.
-        let mut val_mfp = mz_expr::MapFilterProject::new(input_arity)
+        let mut val_mfp = MapFilterProject::new(input_arity)
             .map(aggregates.iter().map(|a| a.expr.clone()))
             .project(input_arity..(input_arity + aggregates.len()));
         if let Some((input_permutation, new_arity)) = input_permutation_and_new_arity {

--- a/src/compute-types/src/plan/reduce.rs
+++ b/src/compute-types/src/plan/reduce.rs
@@ -718,11 +718,9 @@ impl ReducePlan {
         expected_group_size: Option<u64>,
         fused_unnest_list: bool,
     ) -> Self {
-        assert!(if fused_unnest_list {
-            matches!(typ, ReductionType::Basic) && aggregates_list.len() == 1
-        } else {
-            true
-        });
+        if fused_unnest_list {
+            assert!(matches!(typ, ReductionType::Basic) && aggregates_list.len() == 1);
+        }
         assert!(
             aggregates_list.len() > 0,
             "error: tried to render a reduce dataflow with no aggregates"

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -27,7 +27,7 @@ where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
 {
-    /// Renders `relation_expr` followed by `map_filter_project` if provided.
+    /// Applies a `TableFunc` to every row, followed by an `mfp`.
     pub fn render_flat_map(
         &mut self,
         input: CollectionBundle<G>,

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -782,8 +782,9 @@ where
         // Allocations for the two closures.
         let mut datums1 = DatumVec::new();
         let mut datums2 = DatumVec::new();
+        let mut datums_key_1 = DatumVec::new();
+        let mut datums_key_2 = DatumVec::new();
         let mfp_after1 = mfp_after.clone();
-        let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
         let func2 = func.clone();
 
         let name = if !fused_unnest_list {
@@ -791,22 +792,21 @@ where
         } else {
             "FusedReduceUnnestList"
         };
-        let arranged =
-            partial.mz_arrange::<RowRowSpine<_, _>>(("Arranged ".to_owned() + name).as_str());
-        let oks = arranged.mz_reduce_abelian::<_, _, _, RowRowSpine<_, _>>(name, {
-            move |key, source, target| {
-                // We respect the multiplicity here (unlike in hierarchical aggregation)
-                // because we don't know that the aggregation method is not sensitive
-                // to the number of records.
-                let iter = source.iter().flat_map(|(v, w)| {
-                    // Note that in the non-positive case, this is wrong, but harmless because
-                    // our other reduction will produce an error.
-                    let count = usize::try_from(*w).unwrap_or(0);
-                    std::iter::repeat(v.to_datum_iter().next().unwrap()).take(count)
-                });
+        let arranged = partial.mz_arrange::<RowRowSpine<_, _>>(&format!("Arranged {name}"));
+        let oks = if !fused_unnest_list {
+            arranged.mz_reduce_abelian::<_, _, _, RowRowSpine<_, _>>(name, {
+                move |key, source, target| {
+                    // We respect the multiplicity here (unlike in hierarchical aggregation)
+                    // because we don't know that the aggregation method is not sensitive
+                    // to the number of records.
+                    let iter = source.iter().flat_map(|(v, w)| {
+                        // Note that in the non-positive case, this is wrong, but harmless because
+                        // our other reduction will produce an error.
+                        let count = usize::try_from(*w).unwrap_or(0);
+                        std::iter::repeat(v.to_datum_iter().next().unwrap()).take(count)
+                    });
 
-                let temp_storage = RowArena::new();
-                if !fused_unnest_list {
+                    let temp_storage = RowArena::new();
                     let datum_iter = key.to_datum_iter();
                     let mut datums_local = datums1.borrow();
                     datums_local.extend(datum_iter);
@@ -825,17 +825,29 @@ where
                     {
                         target.push((row, 1));
                     }
-                } else {
+                }
+            })
+        } else {
+            arranged.mz_reduce_abelian::<_, _, _, RowRowSpine<_, _>>(name, {
+                move |key, source, target| {
+                    // This part is the same as in the `!fused_unnest_list` if branch above.
+                    let iter = source.iter().flat_map(|(v, w)| {
+                        let count = usize::try_from(*w).unwrap_or(0);
+                        std::iter::repeat(v.to_datum_iter().next().unwrap()).take(count)
+                    });
+
+                    // This is the part that is specific to the `fused_unnest_list` branch.
+                    let temp_storage = RowArena::new();
+                    let mut datums_local = datums_key_1.borrow();
+                    datums_local.extend(key.to_datum_iter());
+                    let key_len = datums_local.len();
                     for datum in func
                         .eval_with_unnest_list::<_, window_agg_helpers::OneByOneAggrImpls>(
                             iter,
                             &temp_storage,
                         )
                     {
-                        let datum_iter = key.to_datum_iter();
-                        let mut datums_local = datums1.borrow();
-                        datums_local.extend(datum_iter);
-                        let key_len = datums_local.len();
+                        datums_local.truncate(key_len);
                         datums_local.push(datum);
                         if let Some(row) = evaluate_mfp_after(
                             &mfp_after1,
@@ -847,48 +859,49 @@ where
                         }
                     }
                 }
-            }
-        });
+            })
+        };
 
         // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here, but
         // we then wouldn't be able to do this error check conditionally.  See its documentation for the
         // rationale around using a second reduction here.
         let must_validate = validating && err_output.is_none();
+        let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
         if must_validate || mfp_after2.is_some() {
             let error_logger = self.error_logger();
 
-            let errs = arranged
-                .mz_reduce_abelian::<_, _, _, RowErrSpine<_, _>>(
-                    (name.to_owned() + " Error Check").as_str(),
-                    move |key, source, target| {
-                        // Negative counts would be surprising, but until we are 100% certain we won't
-                        // see them, we should report when we do. We may want to bake even more info
-                        // in here in the future.
-                        if must_validate {
-                            for (value, count) in source.iter() {
-                                if count.is_positive() {
-                                    continue;
+            let errs = if !fused_unnest_list {
+                arranged
+                    .mz_reduce_abelian::<_, _, _, RowErrSpine<_, _>>(
+                        &format!("{name} Error Check"),
+                        move |key, source, target| {
+                            // Negative counts would be surprising, but until we are 100% certain we won't
+                            // see them, we should report when we do. We may want to bake even more info
+                            // in here in the future.
+                            if must_validate {
+                                for (value, count) in source.iter() {
+                                    if count.is_positive() {
+                                        continue;
+                                    }
+                                    let value = value.into_owned();
+                                    let message = "Non-positive accumulation in ReduceInaccumulable";
+                                    error_logger
+                                        .log(message, &format!("value={value:?}, count={count}"));
+                                    target.push((EvalError::Internal(message.to_string()).into(), 1));
+                                    return;
                                 }
-                                let value = value.into_owned();
-                                let message = "Non-positive accumulation in ReduceInaccumulable";
-                                error_logger
-                                    .log(message, &format!("value={value:?}, count={count}"));
-                                target.push((EvalError::Internal(message.to_string()).into(), 1));
-                                return;
                             }
-                        }
 
-                        // We know that `mfp_after` can error if it exists, so try to evaluate it here.
-                        let Some(mfp) = &mfp_after2 else { return };
-                        let iter = source.iter().flat_map(|(mut v, w)| {
-                            let count = usize::try_from(*w).unwrap_or(0);
-                            // This would ideally use `to_datum_iter` but we cannot as it needs to
-                            // borrow `v` and only presents datums with that lifetime, not any longer.
-                            std::iter::repeat(v.next().unwrap()).take(count)
-                        });
+                            // We know that `mfp_after` can error if it exists, so try to evaluate it here.
+                            let Some(mfp) = &mfp_after2 else { return };
+                            let iter = source.iter().flat_map(|(mut v, w)| {
+                                let count = usize::try_from(*w).unwrap_or(0);
+                                // This would ideally use `to_datum_iter` but we cannot as it needs to
+                                // borrow `v` and only presents datums with that lifetime, not any longer.
+                                std::iter::repeat(v.next().unwrap()).take(count)
+                            });
 
-                        let temp_storage = RowArena::new();
-                        if !fused_unnest_list {
+                            let temp_storage = RowArena::new();
                             let datum_iter = key.to_datum_iter();
                             let mut datums_local = datums2.borrow();
                             datums_local.extend(datum_iter);
@@ -898,25 +911,56 @@ where
                                     &temp_storage,
                                 ),
                             );
-                            if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage)
+                            if let Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage)
                             {
                                 target.push((e.into(), 1));
                             }
-                        } else {
-                            for datum in func2.eval_with_unnest_list::<_, window_agg_helpers::OneByOneAggrImpls>(iter, &temp_storage) {
-                                let datum_iter = key.to_datum_iter();
-                                let mut datums_local = datums2.borrow();
-                                datums_local.extend(datum_iter);
+                        },
+                    )
+                    .as_collection(|_, v| v.into_owned())
+            } else {
+                // `render_reduce_plan_inner` doesn't request validation when `fused_unnest_list`.
+                assert!(!must_validate);
+                // We couldn't have got into this if branch due to `must_validate`, so it must be
+                // because of the `mfp_after2.is_some()`.
+                let Some(mfp) = mfp_after2 else {
+                    unreachable!()
+                };
+                arranged
+                    .mz_reduce_abelian::<_, _, _, RowErrSpine<_, _>>(
+                        &format!("{name} Error Check"),
+                        move |key, source, target| {
+                            let iter = source.iter().flat_map(|(mut v, w)| {
+                                let count = usize::try_from(*w).unwrap_or(0);
+                                // This would ideally use `to_datum_iter` but we cannot as it needs to
+                                // borrow `v` and only presents datums with that lifetime, not any longer.
+                                std::iter::repeat(v.next().unwrap()).take(count)
+                            });
+
+                            let temp_storage = RowArena::new();
+                            let mut datums_local = datums_key_2.borrow();
+                            datums_local.extend(key.to_datum_iter());
+                            let key_len = datums_local.len();
+                            for datum in func2
+                                .eval_with_unnest_list::<_, window_agg_helpers::OneByOneAggrImpls>(
+                                    iter,
+                                    &temp_storage,
+                                )
+                            {
+                                datums_local.truncate(key_len);
                                 datums_local.push(datum);
-                                if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage)
+                                // We know that `mfp` can error (because of the `could_error` call
+                                // above), so try to evaluate it here.
+                                if let Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage)
                                 {
                                     target.push((e.into(), 1));
                                 }
                             }
-                        }
-                    },
-                )
-                .as_collection(|_, v| v.into_owned());
+                        },
+                    )
+                    .as_collection(|_, v| v.into_owned())
+            };
+
             if let Some(e) = err_output {
                 err_output = Some(e.concat(&errs));
             } else {

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -26,7 +26,7 @@ use differential_dataflow::trace::{Batch, Batcher, Builder, Trace, TraceReader};
 use differential_dataflow::{Collection, Diff as _};
 use mz_compute_types::plan::reduce::{
     reduction_type, AccumulablePlan, BasicPlan, BucketedPlan, HierarchicalPlan, KeyValPlan,
-    MonotonicPlan, ReducePlan, ReductionType,
+    MonotonicPlan, ReducePlan, ReductionType, SingleBasicPlan,
 };
 use mz_expr::{
     AggregateExpr, AggregateFunc, EvalError, MapFilterProject, MirScalarExpr, SafeMfpPlan,
@@ -230,10 +230,27 @@ where
                 errors.push(errs);
                 MzArrangement::RowRow(output)
             }
-            ReducePlan::Basic(BasicPlan::Single(index, aggr)) => {
-                let (output, errs) = self
-                    .build_basic_aggregate(collection, index, &aggr, true, key_arity, mfp_after);
-                errors.push(errs.expect("validation should have occurred as it was requested"));
+            ReducePlan::Basic(BasicPlan::Single(SingleBasicPlan {
+                index,
+                expr,
+                fused_unnest_list,
+            })) => {
+                // Note that we skip validating for negative diffs when we have a fused unnest list,
+                // because this is already a CPU-intensive situation due to the non-incrementalness
+                // of window functions.
+                let validating = !fused_unnest_list;
+                let (output, errs) = self.build_basic_aggregate(
+                    collection,
+                    index,
+                    &expr,
+                    validating,
+                    key_arity,
+                    mfp_after,
+                    fused_unnest_list,
+                );
+                if validating {
+                    errors.push(errs.expect("validation should have occurred as it was requested"));
+                }
                 MzArrangement::RowRow(output)
             }
             ReducePlan::Basic(BasicPlan::Multiple(aggrs)) => {
@@ -628,6 +645,7 @@ where
                 err_output.is_none(),
                 key_arity,
                 None,
+                false,
             );
             if errs.is_some() {
                 err_output = errs
@@ -711,6 +729,7 @@ where
         validating: bool,
         key_arity: usize,
         mfp_after: Option<SafeMfpPlan>,
+        fused_unnest_list: bool,
     ) -> (
         RowRowArrangement<S>,
         Option<Collection<S, DataflowError, Diff>>,
@@ -767,21 +786,27 @@ where
         let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
         let func2 = func.clone();
 
-        let arranged = partial.mz_arrange::<RowRowSpine<_, _>>("Arranged ReduceInaccumulable");
-        let oks =
-            arranged.mz_reduce_abelian::<_, _, _, RowRowSpine<_, _>>("ReduceInaccumulable", {
-                move |key, source, target| {
-                    // We respect the multiplicity here (unlike in hierarchical aggregation)
-                    // because we don't know that the aggregation method is not sensitive
-                    // to the number of records.
-                    let iter = source.iter().flat_map(|(v, w)| {
-                        // Note that in the non-positive case, this is wrong, but harmless because
-                        // our other reduction will produce an error.
-                        let count = usize::try_from(*w).unwrap_or(0);
-                        std::iter::repeat(v.to_datum_iter().next().unwrap()).take(count)
-                    });
+        let name = if !fused_unnest_list {
+            "ReduceInaccumulable"
+        } else {
+            "FusedReduceUnnestList"
+        };
+        let arranged =
+            partial.mz_arrange::<RowRowSpine<_, _>>(("Arranged ".to_owned() + name).as_str());
+        let oks = arranged.mz_reduce_abelian::<_, _, _, RowRowSpine<_, _>>(name, {
+            move |key, source, target| {
+                // We respect the multiplicity here (unlike in hierarchical aggregation)
+                // because we don't know that the aggregation method is not sensitive
+                // to the number of records.
+                let iter = source.iter().flat_map(|(v, w)| {
+                    // Note that in the non-positive case, this is wrong, but harmless because
+                    // our other reduction will produce an error.
+                    let count = usize::try_from(*w).unwrap_or(0);
+                    std::iter::repeat(v.to_datum_iter().next().unwrap()).take(count)
+                });
 
-                    let temp_storage = RowArena::new();
+                let temp_storage = RowArena::new();
+                if !fused_unnest_list {
                     let datum_iter = key.to_datum_iter();
                     let mut datums_local = datums1.borrow();
                     datums_local.extend(datum_iter);
@@ -800,8 +825,30 @@ where
                     {
                         target.push((row, 1));
                     }
+                } else {
+                    for datum in func
+                        .eval_with_unnest_list::<_, window_agg_helpers::OneByOneAggrImpls>(
+                            iter,
+                            &temp_storage,
+                        )
+                    {
+                        let datum_iter = key.to_datum_iter();
+                        let mut datums_local = datums1.borrow();
+                        datums_local.extend(datum_iter);
+                        let key_len = datums_local.len();
+                        datums_local.push(datum);
+                        if let Some(row) = evaluate_mfp_after(
+                            &mfp_after1,
+                            &mut datums_local,
+                            &temp_storage,
+                            key_len,
+                        ) {
+                            target.push((row, 1));
+                        }
+                    }
                 }
-            });
+            }
+        });
 
         // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here, but
         // we then wouldn't be able to do this error check conditionally.  See its documentation for the
@@ -812,7 +859,7 @@ where
 
             let errs = arranged
                 .mz_reduce_abelian::<_, _, _, RowErrSpine<_, _>>(
-                    "ReduceInaccumulable Error Check",
+                    (name.to_owned() + " Error Check").as_str(),
                     move |key, source, target| {
                         // Negative counts would be surprising, but until we are 100% certain we won't
                         // see them, we should report when we do. We may want to bake even more info
@@ -841,18 +888,31 @@ where
                         });
 
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.to_datum_iter();
-                        let mut datums_local = datums2.borrow();
-                        datums_local.extend(datum_iter);
-                        datums_local.push(
-                            func2.eval_with_fast_window_agg::<_, window_agg_helpers::OneByOneAggrImpls>(
-                                iter,
-                                &temp_storage,
-                            ),
-                        );
-                        if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage)
-                        {
-                            target.push((e.into(), 1));
+                        if !fused_unnest_list {
+                            let datum_iter = key.to_datum_iter();
+                            let mut datums_local = datums2.borrow();
+                            datums_local.extend(datum_iter);
+                            datums_local.push(
+                                func2.eval_with_fast_window_agg::<_, window_agg_helpers::OneByOneAggrImpls>(
+                                    iter,
+                                    &temp_storage,
+                                ),
+                            );
+                            if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage)
+                            {
+                                target.push((e.into(), 1));
+                            }
+                        } else {
+                            for datum in func2.eval_with_unnest_list::<_, window_agg_helpers::OneByOneAggrImpls>(iter, &temp_storage) {
+                                let datum_iter = key.to_datum_iter();
+                                let mut datums_local = datums2.borrow();
+                                datums_local.extend(datum_iter);
+                                datums_local.push(datum);
+                                if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage)
+                                {
+                                    target.push((e.into(), 1));
+                                }
+                            }
                         }
                     },
                 )

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -13,6 +13,7 @@ use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Datum, Row};
 use proptest::prelude::*;
 use serde::{Deserialize, Serialize};
+
 use crate::linear::proto_map_filter_project::ProtoPredicate;
 use crate::visit::Visit;
 use crate::{MirRelationExpr, MirScalarExpr};

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -13,7 +13,6 @@ use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Datum, Row};
 use proptest::prelude::*;
 use serde::{Deserialize, Serialize};
-
 use crate::linear::proto_map_filter_project::ProtoPredicate;
 use crate::visit::Visit;
 use crate::{MirRelationExpr, MirScalarExpr};
@@ -814,7 +813,7 @@ impl MapFilterProject {
     /// with the expectation that `shuffle` describes all input columns, and so the
     /// intermediate results will be able to start at position `shuffle.len()`.
     ///
-    /// The supplied `shuffle` may not list columns that are not "demanded" by the
+    /// The supplied `shuffle` might not list columns that are not "demanded" by the
     /// instance, and so we should ensure that `self` is optimized to not reference
     /// columns that are not demanded.
     pub fn permute(&mut self, mut shuffle: BTreeMap<usize, usize>, new_input_arity: usize) {

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -274,17 +274,25 @@ where
     })
 }
 
-// Assuming datums is a List, sort them by the 2nd through Nth elements
-// corresponding to order_by, then return the 1st element.
-pub fn order_aggregate_datums<'a, I>(
+/// Assuming datums is a List, sort them by the 2nd through Nth elements
+/// corresponding to order_by, then return the 1st element.
+///
+/// Near the usages of this function, we sometimes want to produce Datums with a shorter lifetime
+/// than 'a. We have to actually perform the shortening of the lifetime here, inside this function,
+/// because if we were to simply return `impl Iterator<Item = Datum<'a>>`, that wouldn't be
+/// covariant in the item type, because opaque types are always invariant. (Contrast this with how
+/// we perform the shortening _inside_ this function: the input of the `map` is known to
+/// specifically be `std::vec::IntoIter`, which is known to be covariant.)
+pub fn order_aggregate_datums<'a: 'b, 'b, I>(
     datums: I,
     order_by: &[ColumnOrder],
-) -> impl Iterator<Item = Datum<'a>>
+) -> impl Iterator<Item = Datum<'b>>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
     order_aggregate_datums_with_rank_inner(datums, order_by)
         .into_iter()
+        // (`payload` is coerced here to `Datum<'b>` in the argument of the closure)
         .map(|(payload, _order_datums)| payload)
 }
 
@@ -393,36 +401,65 @@ fn row_number<'a, I>(
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
-    let datums = order_aggregate_datums(datums, order_by);
-
-    let temp_storage = RowArena::with_capacity(datums.size_hint().0);
-    let datums = datums
-        .into_iter()
-        .map(|d| d.unwrap_list().iter())
-        .flatten()
-        .zip(1i64..)
-        .map(|(d, i)| {
-            temp_storage.make_datum(|packer| {
-                packer.push_list_with(|packer| {
-                    packer.push(Datum::Int64(i));
-                    packer.push(d);
-                });
-            })
-        });
+    // We want to use our own temp_storage here, to avoid flooding `callers_temp_storage` with a
+    // large number of new datums. This is because we don't want to make an assumption about
+    // whether the caller creates a new temp_storage between window partitions.
+    let temp_storage = RowArena::new();
+    let datums = row_number_no_list(datums, &temp_storage, order_by);
 
     callers_temp_storage.make_datum(|packer| {
         packer.push_list(datums);
     })
 }
 
+fn row_number_no_list<'a: 'b, 'b, I>(
+    datums: I,
+    callers_temp_storage: &'b RowArena,
+    order_by: &[ColumnOrder],
+) -> impl Iterator<Item = Datum<'b>>
+where
+    I: IntoIterator<Item = Datum<'a>>,
+{
+    let datums = order_aggregate_datums(datums, order_by);
+
+    callers_temp_storage.reserve(datums.size_hint().0);
+    datums
+        .into_iter()
+        .map(|d| d.unwrap_list().iter())
+        .flatten()
+        .zip(1i64..)
+        .map(|(d, i)| {
+            callers_temp_storage.make_datum(|packer| {
+                packer.push_list_with(|packer| {
+                    packer.push(Datum::Int64(i));
+                    packer.push(d);
+                });
+            })
+        })
+}
+
 fn rank<'a, I>(datums: I, callers_temp_storage: &'a RowArena, order_by: &[ColumnOrder]) -> Datum<'a>
+where
+    I: IntoIterator<Item = Datum<'a>>,
+{
+    let temp_storage = RowArena::new();
+    let datums = rank_no_list(datums, &temp_storage, order_by);
+
+    callers_temp_storage.make_datum(|packer| {
+        packer.push_list(datums);
+    })
+}
+
+fn rank_no_list<'a: 'b, 'b, I>(
+    datums: I,
+    callers_temp_storage: &'b RowArena,
+    order_by: &[ColumnOrder],
+) -> impl Iterator<Item = Datum<'b>>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
     // Keep the row used for ordering around, as it is used to determine the rank
     let datums = order_aggregate_datums_with_rank(datums, order_by);
-
-    let temp_storage = RowArena::with_capacity(datums.size_hint().0);
 
     let mut datums = datums
         .into_iter()
@@ -433,7 +470,8 @@ where
         })
         .flatten();
 
-    let datums = datums
+    callers_temp_storage.reserve(datums.size_hint().0);
+    datums
         .next()
         .map_or(vec![], |(first_datum, first_order_row)| {
             // Folding with (last order_by row, last assigned rank, row number, output vec)
@@ -450,16 +488,12 @@ where
                 acc
             })
         }.3).into_iter().map(|(d, i)| {
-        temp_storage.make_datum(|packer| {
+        callers_temp_storage.make_datum(|packer| {
             packer.push_list_with(|packer| {
                 packer.push(Datum::Int64(i));
                 packer.push(d);
             });
         })
-    });
-
-    callers_temp_storage.make_datum(|packer| {
-        packer.push_list(datums);
     })
 }
 
@@ -471,10 +505,24 @@ fn dense_rank<'a, I>(
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
+    let temp_storage = RowArena::new();
+    let datums = dense_rank_no_list(datums, &temp_storage, order_by);
+
+    callers_temp_storage.make_datum(|packer| {
+        packer.push_list(datums);
+    })
+}
+
+fn dense_rank_no_list<'a: 'b, 'b, I>(
+    datums: I,
+    callers_temp_storage: &'b RowArena,
+    order_by: &[ColumnOrder],
+) -> impl Iterator<Item = Datum<'b>>
+where
+    I: IntoIterator<Item = Datum<'a>>,
+{
     // Keep the row used for ordering around, as it is used to determine the rank
     let datums = order_aggregate_datums_with_rank(datums, order_by);
-
-    let temp_storage = RowArena::with_capacity(datums.size_hint().0);
 
     let mut datums = datums
         .into_iter()
@@ -485,7 +533,8 @@ where
         })
         .flatten();
 
-    let datums = datums
+    callers_temp_storage.reserve(datums.size_hint().0);
+    datums
         .next()
         .map_or(vec![], |(first_datum, first_order_row)| {
             // Folding with (last order_by row, last assigned rank, output vec)
@@ -501,16 +550,12 @@ where
                 acc
             })
         }.2).into_iter().map(|(d, i)| {
-            temp_storage.make_datum(|packer| {
-                packer.push_list_with(|packer| {
-                    packer.push(Datum::Int64(i));
-                    packer.push(d);
-                });
-            })
-        });
-
-    callers_temp_storage.make_datum(|packer| {
-        packer.push_list(datums);
+        callers_temp_storage.make_datum(|packer| {
+            packer.push_list_with(|packer| {
+                packer.push(Datum::Int64(i));
+                packer.push(d);
+            });
+        })
     })
 }
 
@@ -545,6 +590,25 @@ fn lag_lead<'a, I>(
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
+    let temp_storage = RowArena::new();
+    let iter = lag_lead_no_list(datums, &temp_storage, order_by, lag_lead_type, ignore_nulls);
+    callers_temp_storage.make_datum(|packer| {
+        packer.push_list(iter);
+    })
+}
+
+/// Like `lag_lead`, but doesn't perform the final wrapping in a list, returning an Iterator
+/// instead.
+fn lag_lead_no_list<'a: 'b, 'b, I>(
+    datums: I,
+    callers_temp_storage: &'b RowArena,
+    order_by: &[ColumnOrder],
+    lag_lead_type: &LagLeadType,
+    ignore_nulls: &bool,
+) -> impl Iterator<Item = Datum<'b>>
+where
+    I: IntoIterator<Item = Datum<'a>>,
+{
     // Sort the datums according to the ORDER BY expressions and return the (OriginalRow, EncodedArgs) record
     let datums = order_aggregate_datums(datums, order_by);
 
@@ -562,24 +626,20 @@ where
         })
         .unzip();
 
-    let result = lag_lead_inner(unwrapped_args, lag_lead_type, ignore_nulls);
+    let result: Vec<Datum<'a>> = lag_lead_inner(unwrapped_args, lag_lead_type, ignore_nulls);
 
-    let temp_storage = RowArena::with_capacity(result.len());
-    let result = result
+    callers_temp_storage.reserve(result.len());
+    result
         .into_iter()
         .zip_eq(orig_rows)
         .map(|(result_value, original_row)| {
-            temp_storage.make_datum(|packer| {
+            callers_temp_storage.make_datum(|packer| {
                 packer.push_list_with(|packer| {
                     packer.push(result_value);
                     packer.push(original_row);
                 });
             })
-        });
-
-    callers_temp_storage.make_datum(|packer| {
-        packer.push_list(result);
-    })
+        })
 }
 
 /// lag/lead's arguments are in a record. This function unwraps this record.
@@ -777,6 +837,24 @@ fn first_value<'a, I>(
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
+    let temp_storage = RowArena::new();
+    let iter = first_value_no_list(datums, &temp_storage, order_by, window_frame);
+    callers_temp_storage.make_datum(|packer| {
+        packer.push_list(iter);
+    })
+}
+
+/// Like `first_value`, but doesn't perform the final wrapping in a list, returning an Iterator
+/// instead.
+fn first_value_no_list<'a: 'b, 'b, I>(
+    datums: I,
+    callers_temp_storage: &'b RowArena,
+    order_by: &[ColumnOrder],
+    window_frame: &WindowFrame,
+) -> impl Iterator<Item = Datum<'b>>
+where
+    I: IntoIterator<Item = Datum<'a>>,
+{
     // Sort the datums according to the ORDER BY expressions and return the (OriginalRow, InputValue) record
     let datums = order_aggregate_datums(datums, order_by);
 
@@ -794,23 +872,18 @@ where
 
     let results = first_value_inner(args, window_frame);
 
-    let temp_storage = RowArena::with_capacity(results.len());
-    let results_with_orig_rows =
-        results
-            .into_iter()
-            .zip_eq(orig_rows)
-            .map(|(result_value, original_row)| {
-                temp_storage.make_datum(|packer| {
-                    packer.push_list_with(|packer| {
-                        packer.push(result_value);
-                        packer.push(original_row);
-                    });
-                })
-            });
-
-    callers_temp_storage.make_datum(|packer| {
-        packer.push_list(results_with_orig_rows);
-    })
+    callers_temp_storage.reserve(results.len());
+    results
+        .into_iter()
+        .zip_eq(orig_rows)
+        .map(|(result_value, original_row)| {
+            callers_temp_storage.make_datum(|packer| {
+                packer.push_list_with(|packer| {
+                    packer.push(result_value);
+                    packer.push(original_row);
+                });
+            })
+        })
 }
 
 fn first_value_inner<'a>(datums: Vec<Datum<'a>>, window_frame: &WindowFrame) -> Vec<Datum<'a>> {
@@ -885,6 +958,24 @@ fn last_value<'a, I>(
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
+    let temp_storage = RowArena::new();
+    let iter = last_value_no_list(datums, &temp_storage, order_by, window_frame);
+    callers_temp_storage.make_datum(|packer| {
+        packer.push_list(iter);
+    })
+}
+
+/// Like `last_value`, but doesn't perform the final wrapping in a list, returning an Iterator
+/// instead.
+fn last_value_no_list<'a: 'b, 'b, I>(
+    datums: I,
+    callers_temp_storage: &'b RowArena,
+    order_by: &[ColumnOrder],
+    window_frame: &WindowFrame,
+) -> impl Iterator<Item = Datum<'b>>
+where
+    I: IntoIterator<Item = Datum<'a>>,
+{
     // Sort the datums according to the ORDER BY expressions and return the ((OriginalRow, InputValue), OrderByRow) record
     // The OrderByRow is kept around because it is required to compute the peer groups in RANGE mode
     let datums = order_aggregate_datums_with_rank(datums, order_by);
@@ -905,22 +996,18 @@ where
 
     let results = last_value_inner(args, &order_by_rows, window_frame);
 
-    let temp_storage = RowArena::with_capacity(results.len());
-    let result = results
+    callers_temp_storage.reserve(results.len());
+    results
         .into_iter()
         .zip_eq(original_rows)
         .map(|(result_value, original_row)| {
-            temp_storage.make_datum(|packer| {
+            callers_temp_storage.make_datum(|packer| {
                 packer.push_list_with(|packer| {
                     packer.push(result_value);
                     packer.push(original_row);
                 });
             })
-        });
-
-    callers_temp_storage.make_datum(|packer| {
-        packer.push_list(result);
-    })
+        })
 }
 
 fn last_value_inner<'a>(
@@ -1026,6 +1113,24 @@ fn fused_value_window_func<'a, I>(
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
+    let temp_storage = RowArena::new();
+    let iter = fused_value_window_func_no_list(input_datums, &temp_storage, funcs, order_by);
+    callers_temp_storage.make_datum(|packer| {
+        packer.push_list(iter);
+    })
+}
+
+/// Like `fused_value_window_func`, but doesn't perform the final wrapping in a list, returning an
+/// Iterator instead.
+fn fused_value_window_func_no_list<'a: 'b, 'b, I>(
+    input_datums: I,
+    callers_temp_storage: &'b RowArena,
+    funcs: &Vec<AggregateFunc>,
+    order_by: &Vec<ColumnOrder>,
+) -> impl Iterator<Item = Datum<'b>>
+where
+    I: IntoIterator<Item = Datum<'a>>,
+{
     let has_last_value = funcs
         .iter()
         .any(|f| matches!(f, AggregateFunc::LastValue { .. }));
@@ -1090,22 +1195,19 @@ where
         }
     }
 
-    // Let's create a new RowArena, to avoid flooding the caller's arena with stuff proportional to
-    // the window partition size. We will use our own arena for internal evaluations, and will use
-    // the caller's at the very end to return the final result Datum.
-    let temp_storage = RowArena::with_capacity(2 * original_rows.len());
-    let results_with_orig_rows = results_per_row.into_iter().enumerate().map(|(i, results)| {
-        temp_storage.make_datum(|packer| {
-            packer.push_list_with(|packer| {
-                packer.push(temp_storage.make_datum(|packer| packer.push_list(results)));
-                packer.push(original_rows[i]);
-            });
+    callers_temp_storage.reserve(2 * original_rows.len());
+    results_per_row
+        .into_iter()
+        .enumerate()
+        .map(move |(i, results)| {
+            callers_temp_storage.make_datum(|packer| {
+                packer.push_list_with(|packer| {
+                    packer
+                        .push(callers_temp_storage.make_datum(|packer| packer.push_list(results)));
+                    packer.push(original_rows[i]);
+                });
+            })
         })
-    });
-
-    callers_temp_storage.make_datum(|packer| {
-        packer.push_list(results_with_orig_rows);
-    })
 }
 
 /// The expected input is in the format of `[((OriginalRow, InputValue), OrderByExprs...)]`
@@ -1119,6 +1221,34 @@ fn window_aggr<'a, I, A>(
     order_by: &[ColumnOrder],
     window_frame: &WindowFrame,
 ) -> Datum<'a>
+where
+    I: IntoIterator<Item = Datum<'a>>,
+    A: OneByOneAggr,
+{
+    let temp_storage = RowArena::new();
+    let iter = window_aggr_no_list::<I, A>(
+        input_datums,
+        &temp_storage,
+        wrapped_aggregate,
+        order_by,
+        window_frame,
+    );
+    callers_temp_storage.make_datum(|packer| {
+        packer.push_list(iter);
+    })
+}
+
+/// Like `window_aggr`, but doesn't perform the final wrapping in a list, returning an Iterator
+/// instead.
+fn window_aggr_no_list<'a: 'b, 'b, I, A>(
+    input_datums: I, // An entire window partition.
+    callers_temp_storage: &'b RowArena,
+    wrapped_aggregate: &AggregateFunc, // E.g., for `sum(...) OVER (...)`, this is the `sum(...)`.
+    // Note that this `order_by` doesn't have expressions, only `ColumnOrder`s. For an explanation,
+    // see the comment on `WindowExprType`.
+    order_by: &[ColumnOrder],
+    window_frame: &WindowFrame,
+) -> impl Iterator<Item = Datum<'b>>
 where
     I: IntoIterator<Item = Datum<'a>>,
     A: OneByOneAggr,
@@ -1142,10 +1272,7 @@ where
     let length = input_datums.len();
     let mut result: Vec<(Datum, Datum)> = Vec::with_capacity(length);
 
-    // Let's create a new RowArena, to avoid flooding the caller's arena with stuff proportional to
-    // the window partition size. We will use our own arena for internal evaluations, and will use
-    // the caller's at the very end to return the final result Datum.
-    let temp_storage = RowArena::with_capacity(length);
+    callers_temp_storage.reserve(length);
 
     // In this degenerate case, all results would be `wrapped_aggregate.default()` (usually null).
     // However, this currently can't happen, because
@@ -1178,7 +1305,7 @@ where
             .iter()
             .map(|(input_value, _original_row, _order_by_row)| input_value.clone())
             .collect_vec(); // I'm open to suggestions on how to remove this `collect_vec()`...
-        let result_value = wrapped_aggregate.eval(input_values, &temp_storage);
+        let result_value = wrapped_aggregate.eval(input_values, callers_temp_storage);
         // Every row will get the above aggregate as result.
         for (_current_datum, original_row, _order_by_row) in input_datums.iter() {
             result.push((result_value, *original_row));
@@ -1309,7 +1436,7 @@ where
                     input_datums,
                     &mut result,
                     A::new(wrapped_aggregate, false),
-                    &temp_storage,
+                    callers_temp_storage,
                 );
             }
             (Rows, CurrentRow, UnboundedFollowing) => {
@@ -1319,7 +1446,7 @@ where
                     input_datums,
                     &mut result,
                     A::new(wrapped_aggregate, true),
-                    &temp_storage,
+                    callers_temp_storage,
                 );
                 result.reverse();
             }
@@ -1330,7 +1457,7 @@ where
                     input_datums,
                     &mut result,
                     A::new(wrapped_aggregate, false),
-                    &temp_storage,
+                    callers_temp_storage,
                 );
             }
             // The next several cases all call `rows_between_offset_and_offset`. Note that the
@@ -1347,7 +1474,7 @@ where
                     input_datums,
                     &mut result,
                     wrapped_aggregate,
-                    &temp_storage,
+                    callers_temp_storage,
                     -start_prec,
                     -end_prec,
                 );
@@ -1363,7 +1490,7 @@ where
                     input_datums,
                     &mut result,
                     wrapped_aggregate,
-                    &temp_storage,
+                    callers_temp_storage,
                     -start_prec,
                     end_fol,
                 );
@@ -1379,7 +1506,7 @@ where
                     input_datums,
                     &mut result,
                     wrapped_aggregate,
-                    &temp_storage,
+                    callers_temp_storage,
                     start_fol,
                     end_fol,
                 );
@@ -1396,7 +1523,7 @@ where
                     input_datums,
                     &mut result,
                     wrapped_aggregate,
-                    &temp_storage,
+                    callers_temp_storage,
                     -start_prec,
                     end_fol,
                 );
@@ -1410,7 +1537,7 @@ where
                     input_datums,
                     &mut result,
                     wrapped_aggregate,
-                    &temp_storage,
+                    callers_temp_storage,
                     start_fol,
                     end_fol,
                 );
@@ -1424,7 +1551,7 @@ where
                     input_datums,
                     &mut result,
                     wrapped_aggregate,
-                    &temp_storage,
+                    callers_temp_storage,
                     start_fol,
                     end_fol,
                 );
@@ -1466,17 +1593,13 @@ where
         }
     }
 
-    let result = result.into_iter().map(|(result_value, original_row)| {
-        temp_storage.make_datum(|packer| {
+    result.into_iter().map(|(result_value, original_row)| {
+        callers_temp_storage.make_datum(|packer| {
             packer.push_list_with(|packer| {
                 packer.push(result_value);
                 packer.push(original_row);
             });
         })
-    });
-
-    callers_temp_storage.make_datum(|packer| {
-        packer.push_list(result);
     })
 }
 
@@ -2199,6 +2322,61 @@ impl AggregateFunc {
         }
     }
 
+    pub fn eval_with_unnest_list<'a, I, W>(
+        &self,
+        datums: I,
+        temp_storage: &'a RowArena,
+    ) -> impl Iterator<Item = Datum<'a>>
+    where
+        I: IntoIterator<Item = Datum<'a>>,
+        W: OneByOneAggr,
+    {
+        // TODO: Use use `enum_dispatch` to construct a unified iterator instead of `collect_vec`.
+        assert!(self.can_fuse_with_unnest_list());
+        match self {
+            AggregateFunc::RowNumber { order_by } => {
+                row_number_no_list(datums, temp_storage, order_by).collect_vec()
+            }
+            AggregateFunc::Rank { order_by } => {
+                rank_no_list(datums, temp_storage, order_by).collect_vec()
+            }
+            AggregateFunc::DenseRank { order_by } => {
+                dense_rank_no_list(datums, temp_storage, order_by).collect_vec()
+            }
+            AggregateFunc::LagLead {
+                order_by,
+                lag_lead: lag_lead_type,
+                ignore_nulls,
+            } => lag_lead_no_list(datums, temp_storage, order_by, lag_lead_type, ignore_nulls)
+                .collect_vec(),
+            AggregateFunc::FirstValue {
+                order_by,
+                window_frame,
+            } => first_value_no_list(datums, temp_storage, order_by, window_frame).collect_vec(),
+            AggregateFunc::LastValue {
+                order_by,
+                window_frame,
+            } => last_value_no_list(datums, temp_storage, order_by, window_frame).collect_vec(),
+            AggregateFunc::FusedValueWindowFunc { funcs, order_by } => {
+                fused_value_window_func_no_list(datums, temp_storage, funcs, order_by).collect_vec()
+            }
+            AggregateFunc::WindowAggregate {
+                wrapped_aggregate,
+                order_by,
+                window_frame,
+            } => window_aggr_no_list::<_, W>(
+                datums,
+                temp_storage,
+                wrapped_aggregate,
+                order_by,
+                window_frame,
+            )
+            .collect_vec(),
+            _ => unreachable!("asserted above that `can_fuse_with_unnest_list`"),
+        }
+        .into_iter()
+    }
+
     /// Returns the output of the aggregation function when applied on an empty
     /// input relation.
     pub fn default(&self) -> Datum<'static> {
@@ -2276,6 +2454,72 @@ impl AggregateFunc {
             | AggregateFunc::JsonbObjectAgg { .. }
             | AggregateFunc::MapAgg { .. }
             | AggregateFunc::StringAgg { .. } => Datum::Null,
+        }
+    }
+
+    pub fn can_fuse_with_unnest_list(&self) -> bool {
+        match self {
+            AggregateFunc::RowNumber { .. }
+            | AggregateFunc::Rank { .. }
+            | AggregateFunc::DenseRank { .. }
+            | AggregateFunc::LagLead { .. }
+            | AggregateFunc::FirstValue { .. }
+            | AggregateFunc::LastValue { .. }
+            | AggregateFunc::WindowAggregate { .. }
+            | AggregateFunc::FusedValueWindowFunc { .. } => true,
+            AggregateFunc::ArrayConcat { .. }
+            | AggregateFunc::ListConcat { .. }
+            | AggregateFunc::Any
+            | AggregateFunc::All
+            | AggregateFunc::Dummy
+            | AggregateFunc::MaxNumeric
+            | AggregateFunc::MaxInt16
+            | AggregateFunc::MaxInt32
+            | AggregateFunc::MaxInt64
+            | AggregateFunc::MaxUInt16
+            | AggregateFunc::MaxUInt32
+            | AggregateFunc::MaxUInt64
+            | AggregateFunc::MaxMzTimestamp
+            | AggregateFunc::MaxFloat32
+            | AggregateFunc::MaxFloat64
+            | AggregateFunc::MaxBool
+            | AggregateFunc::MaxString
+            | AggregateFunc::MaxDate
+            | AggregateFunc::MaxTimestamp
+            | AggregateFunc::MaxTimestampTz
+            | AggregateFunc::MaxInterval
+            | AggregateFunc::MaxTime
+            | AggregateFunc::MinNumeric
+            | AggregateFunc::MinInt16
+            | AggregateFunc::MinInt32
+            | AggregateFunc::MinInt64
+            | AggregateFunc::MinUInt16
+            | AggregateFunc::MinUInt32
+            | AggregateFunc::MinUInt64
+            | AggregateFunc::MinMzTimestamp
+            | AggregateFunc::MinFloat32
+            | AggregateFunc::MinFloat64
+            | AggregateFunc::MinBool
+            | AggregateFunc::MinString
+            | AggregateFunc::MinDate
+            | AggregateFunc::MinTimestamp
+            | AggregateFunc::MinTimestampTz
+            | AggregateFunc::MinInterval
+            | AggregateFunc::MinTime
+            | AggregateFunc::SumInt16
+            | AggregateFunc::SumInt32
+            | AggregateFunc::SumInt64
+            | AggregateFunc::SumUInt16
+            | AggregateFunc::SumUInt32
+            | AggregateFunc::SumUInt64
+            | AggregateFunc::SumFloat32
+            | AggregateFunc::SumFloat64
+            | AggregateFunc::SumNumeric
+            | AggregateFunc::Count
+            | AggregateFunc::JsonbAgg { .. }
+            | AggregateFunc::JsonbObjectAgg { .. }
+            | AggregateFunc::MapAgg { .. }
+            | AggregateFunc::StringAgg { .. } => false,
         }
     }
 

--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -119,6 +119,7 @@ optimizer_feature_flags!({
     reoptimize_imported_views: bool,
     // Enables the value window function fusion optimization.
     enable_value_window_function_fusion: bool,
+    // See the feature flag of the same name.
     enable_reduce_unnest_list_fusion: bool,
 });
 

--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -119,6 +119,7 @@ optimizer_feature_flags!({
     reoptimize_imported_views: bool,
     // Enables the value window function fusion optimization.
     enable_value_window_function_fusion: bool,
+    enable_reduce_unnest_list_fusion: bool,
 });
 
 /// A trait used to implement layered config construction.

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -2458,6 +2458,8 @@ impl RowArena {
         }
     }
 
+    /// Does a `reserve` on the underlying `Vec`. Call this when you expect `additional` more datums
+    /// to be created in this arena.
     pub fn reserve(&self, additional: usize) {
         self.inner.borrow_mut().reserve(additional);
     }

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -2458,6 +2458,10 @@ impl RowArena {
         }
     }
 
+    pub fn reserve(&self, additional: usize) {
+        self.inner.borrow_mut().reserve(additional);
+    }
+
     /// Take ownership of `bytes` for the lifetime of the arena.
     #[allow(clippy::transmute_ptr_to_ptr)]
     pub fn push_bytes<'a>(&'a self, bytes: Vec<u8>) -> &'a [u8] {

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -342,6 +342,7 @@ Reassign
 Recursion
 Recursive
 Redacted
+Reduce
 Reference
 References
 Refresh
@@ -451,6 +452,7 @@ Uncommitted
 Union
 Unique
 Unknown
+Unnest
 Until
 Up
 Update

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2047,6 +2047,7 @@ pub enum ClusterFeatureName {
     EnableLetrecFixpointAnalysis,
     EnableOuterJoinNullFilter,
     EnableValueWindowFunctionFusion,
+    EnableReduceUnnestListFusion,
 }
 
 impl WithOptionName for ClusterFeatureName {
@@ -2063,7 +2064,8 @@ impl WithOptionName for ClusterFeatureName {
             | Self::EnableVariadicLeftJoinLowering
             | Self::EnableLetrecFixpointAnalysis
             | Self::EnableOuterJoinNullFilter
-            | Self::EnableValueWindowFunctionFusion => false,
+            | Self::EnableValueWindowFunctionFusion
+            | Self::EnableReduceUnnestListFusion => false,
         }
     }
 }
@@ -3591,6 +3593,7 @@ pub enum ExplainPlanOptionName {
     EnableLetrecFixpointAnalysis,
     EnableOuterJoinNullFilter,
     EnableValueWindowFunctionFusion,
+    EnableReduceUnnestListFusion,
 }
 
 impl WithOptionName for ExplainPlanOptionName {
@@ -3626,7 +3629,8 @@ impl WithOptionName for ExplainPlanOptionName {
             | Self::EnableVariadicLeftJoinLowering
             | Self::EnableLetrecFixpointAnalysis
             | Self::EnableOuterJoinNullFilter
-            | Self::EnableValueWindowFunctionFusion => false,
+            | Self::EnableValueWindowFunctionFusion
+            | Self::EnableReduceUnnestListFusion => false,
         }
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3822,7 +3822,8 @@ generate_extracted_config!(
     (EnableVariadicLeftJoinLowering, Option<bool>, Default(None)),
     (EnableLetrecFixpointAnalysis, Option<bool>, Default(None)),
     (EnableOuterJoinNullFilter, Option<bool>, Default(None)),
-    (EnableValueWindowFunctionFusion, Option<bool>, Default(None))
+    (EnableValueWindowFunctionFusion, Option<bool>, Default(None)),
+    (EnableReduceUnnestListFusion, Option<bool>, Default(None))
 );
 
 /// Convert a [`CreateClusterStatement`] into a [`Plan`].
@@ -3961,6 +3962,7 @@ pub fn plan_create_cluster_inner(
             enable_letrec_fixpoint_analysis,
             enable_outer_join_null_filter,
             enable_value_window_function_fusion,
+            enable_reduce_unnest_list_fusion,
             seen: _,
         } = ClusterFeatureExtracted::try_from(features)?;
         let optimizer_feature_overrides = OptimizerFeatureOverrides {
@@ -3971,6 +3973,7 @@ pub fn plan_create_cluster_inner(
             enable_letrec_fixpoint_analysis,
             enable_outer_join_null_filter,
             enable_value_window_function_fusion,
+            enable_reduce_unnest_list_fusion,
             ..Default::default()
         };
 
@@ -4067,6 +4070,7 @@ pub fn unplan_create_cluster(
                 enable_letrec_fixpoint_analysis,
                 enable_outer_join_null_filter,
                 enable_value_window_function_fusion,
+                enable_reduce_unnest_list_fusion,
             } = optimizer_feature_overrides;
             let features_extracted = ClusterFeatureExtracted {
                 // Seen is ignored when unplanning.
@@ -4078,6 +4082,7 @@ pub fn unplan_create_cluster(
                 enable_letrec_fixpoint_analysis,
                 enable_outer_join_null_filter,
                 enable_value_window_function_fusion,
+                enable_reduce_unnest_list_fusion,
             };
             let features = features_extracted.into_values(scx.catalog);
             let availability_zones = if availability_zones.is_empty() {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -370,7 +370,8 @@ generate_extracted_config!(
     (EnableVariadicLeftJoinLowering, Option<bool>, Default(None)),
     (EnableLetrecFixpointAnalysis, Option<bool>, Default(None)),
     (EnableOuterJoinNullFilter, Option<bool>, Default(None)),
-    (EnableValueWindowFunctionFusion, Option<bool>, Default(None))
+    (EnableValueWindowFunctionFusion, Option<bool>, Default(None)),
+    (EnableReduceUnnestListFusion, Option<bool>, Default(None))
 );
 
 impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
@@ -423,6 +424,7 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 persist_fast_path_limit: Default::default(),
                 reoptimize_imported_views: v.reoptimize_imported_views,
                 enable_value_window_function_fusion: v.enable_value_window_function_fusion,
+                enable_reduce_unnest_list_fusion: v.enable_reduce_unnest_list_fusion,
             },
         })
     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2116,6 +2116,12 @@ feature_flags!(
         default: true,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_reduce_unnest_list_fusion,
+        desc: "Enables fusing `Reduce` with `FlatMap UnnestList` for better window function performance",
+        default: false,
+        enable_for_item_parsing: false,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {
@@ -2132,6 +2138,7 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_value_window_function_fusion: vars.enable_value_window_function_fusion(),
             persist_fast_path_limit: vars.persist_fast_path_limit(),
             reoptimize_imported_views: false,
+            enable_reduce_unnest_list_fusion: vars.enable_reduce_unnest_list_fusion(),
         }
     }
 }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2119,7 +2119,7 @@ feature_flags!(
     {
         name: enable_reduce_unnest_list_fusion,
         desc: "Enables fusing `Reduce` with `FlatMap UnnestList` for better window function performance",
-        default: false,
+        default: true,
         enable_for_item_parsing: false,
     },
 );
@@ -2136,9 +2136,9 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_cardinality_estimates: vars.enable_cardinality_estimates(),
             enable_outer_join_null_filter: vars.enable_outer_join_null_filter(),
             enable_value_window_function_fusion: vars.enable_value_window_function_fusion(),
+            enable_reduce_unnest_list_fusion: vars.enable_reduce_unnest_list_fusion(),
             persist_fast_path_limit: vars.persist_fast_path_limit(),
             reoptimize_imported_views: false,
-            enable_reduce_unnest_list_fusion: vars.enable_reduce_unnest_list_fusion(),
         }
     }
 }

--- a/test/sqllogictest/explain/physical_plan_aggregates.slt
+++ b/test/sqllogictest/explain/physical_plan_aggregates.slt
@@ -433,13 +433,12 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, dense_rank() OVER (ORDER BY a), array_agg(b) FROM t GROUP BY a;
 ----
 Explained Query:
-  FlatMap unnest_list(#0)
-    mfp_after
-      project=(#3, #5, #4)
-      map=(record_get[1](#1), record_get[0](#2), record_get[1](#2), record_get[0](#1))
+  Mfp
+    project=(#2, #4, #3)
+    map=(record_get[1](#0), record_get[0](#1), record_get[1](#1), record_get[0](#0))
     input_key=
     Reduce::Basic
-      aggr=(0, dense_rank[order_by=[#0 asc nulls_last]](row(list[row(#0, #1)], #0)))
+      aggr=(0, dense_rank[order_by=[#0 asc nulls_last]](row(list[row(#0, #1)], #0)), fused_unnest_list=true)
       val_plan
         project=(#2)
         map=(row(list[row(#0, #1)], #0))

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -1364,13 +1364,12 @@ SELECT lead(b, 3, -5) IGNORE NULLS OVER () as l
 FROM t;
 ----
 Explained Query:
-  FlatMap unnest_list(#0)
-    mfp_after
-      project=(#2)
-      map=(record_get[0](#1))
+  Mfp
+    project=(#1)
+    map=(record_get[0](#0))
     input_key=
     Reduce::Basic
-      aggr=(0, lead[ignore_nulls=true, order_by=[]](row(row(row(#0, #1), row(#1, 3, -5)))))
+      aggr=(0, lead[ignore_nulls=true, order_by=[]](row(row(row(#0, #1), row(#1, 3, -5)))), fused_unnest_list=true)
       val_plan
         project=(#2)
         map=(row(row(row(#0, #1), row(#1, 3, -5))))
@@ -1395,25 +1394,22 @@ SELECT lag(b, 3, -5) IGNORE NULLS OVER (PARTITION BY b, a ORDER BY b+8, a-7) as 
 FROM t;
 ----
 Explained Query:
-  FlatMap unnest_list(#0)
-    mfp_after
-      project=(#2)
-      map=(record_get[0](#1))
-    Mfp
-      project=(#2)
-      input_key=#0, #1
-      Reduce::Basic
-        aggr=(0, lag[ignore_nulls=true, order_by=[#0 asc nulls_last, #1 asc nulls_last]](row(row(row(#0, #1), row(#1, 3, -5)), (#1 + 8), (#0 - 7))))
-        val_plan
-          project=(#2)
-          map=(row(row(row(#0, #1), row(#1, 3, -5)), (#1 + 8), (#0 - 7)))
-        key_plan
-          project=(#1, #0)
-        input_key=#0
-        Get::PassArrangements materialize.public.t
-          raw=false
-          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
+  Mfp
+    project=(#3)
+    map=(record_get[0](#2))
+    input_key=#0, #1
+    Reduce::Basic
+      aggr=(0, lag[ignore_nulls=true, order_by=[#0 asc nulls_last, #1 asc nulls_last]](row(row(row(#0, #1), row(#1, 3, -5)), (#1 + 8), (#0 - 7))), fused_unnest_list=true)
+      val_plan
+        project=(#2)
+        map=(row(row(row(#0, #1), row(#1, 3, -5)), (#1 + 8), (#0 - 7)))
+      key_plan
+        project=(#1, #0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)

--- a/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
@@ -1349,13 +1349,12 @@ SELECT lead(b, 3, -5) IGNORE NULLS OVER () as l
 FROM t;
 ----
 Explained Query:
-  FlatMap unnest_list(#0)
-    mfp_after
-      project=(#2)
-      map=(record_get[0](#1))
+  Mfp
+    project=(#1)
+    map=(record_get[0](#0))
     input_key=
     Reduce::Basic
-      aggr=(0, lead[ignore_nulls=true, order_by=[]](row(row(row(#0, #1), row(#1, █, █)))))
+      aggr=(0, lead[ignore_nulls=true, order_by=[]](row(row(row(#0, #1), row(#1, █, █)))), fused_unnest_list=true)
       val_plan
         project=(#2)
         map=(row(row(row(#0, #1), row(#1, █, █))))
@@ -1380,25 +1379,22 @@ SELECT lag(b, 3, -5) IGNORE NULLS OVER (PARTITION BY b, a ORDER BY b+8, a-7) as 
 FROM t;
 ----
 Explained Query:
-  FlatMap unnest_list(#0)
-    mfp_after
-      project=(#2)
-      map=(record_get[0](#1))
-    Mfp
-      project=(#2)
-      input_key=#0, #1
-      Reduce::Basic
-        aggr=(0, lag[ignore_nulls=true, order_by=[#0 asc nulls_last, #1 asc nulls_last]](row(row(row(#0, #1), row(#1, █, █)), (#1 + █), (#0 - █))))
-        val_plan
-          project=(#2)
-          map=(row(row(row(#0, #1), row(#1, █, █)), (#1 + █), (#0 - █)))
-        key_plan
-          project=(#1, #0)
-        input_key=#0
-        Get::PassArrangements materialize.public.t
-          raw=false
-          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
+  Mfp
+    project=(#3)
+    map=(record_get[0](#2))
+    input_key=#0, #1
+    Reduce::Basic
+      aggr=(0, lag[ignore_nulls=true, order_by=[#0 asc nulls_last, #1 asc nulls_last]](row(row(row(#0, #1), row(#1, █, █)), (#1 + █), (#0 - █))), fused_unnest_list=true)
+      val_plan
+        project=(#2)
+        map=(row(row(row(#0, #1), row(#1, █, █)), (#1 + █), (#0 - █)))
+      key_plan
+        project=(#1, #0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -12,6 +12,11 @@
 
 mode cockroach
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_reduce_unnest_list_fusion = true
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE t(x string);
 
@@ -7608,3 +7613,208 @@ Source materialize.public.t7
 Target cluster: quickstart
 
 EOF
+
+# Test the situation when the MFP above is fused into the Reduce.
+query III
+SELECT *
+FROM (
+  SELECT *, lag(x) OVER (ORDER BY x) AS l
+  FROM t7
+)
+WHERE l/2 < 7
+ORDER BY x,y,l;
+----
+3  NULL  1
+5  6  3
+7  8  5
+9  NULL  7
+10  -50  9
+10  -40  10
+11  NULL  10
+13  14  11
+15  16  13
+
+## Run some tests also with `enable_reduce_unnest_list_fusion` disabled.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_reduce_unnest_list_fusion = true
+----
+COMPLETE 0
+
+# This is a new test.
+query IIIIIIIIIIIII
+SELECT
+  *,
+  first_value(
+    lag(x*x,y,1111) OVER (PARTITION BY x ORDER BY y)
+  ) OVER (PARTITION BY x ORDER BY y),
+  x*y,
+  last_value(
+    lag(x*x,y,2222) OVER (PARTITION BY x ORDER BY y)
+  ) OVER (PARTITION BY x ORDER BY y+y),
+  last_value(x+y) OVER (PARTITION BY x ORDER BY y+y),
+  lag(y)          OVER (ORDER BY x),
+  row_number() OVER (ORDER BY x),
+  rank()       OVER (ORDER BY x),
+  dense_rank() OVER (ORDER BY x),
+  sum(y+3)     OVER (ORDER BY x),
+  min(y+4)     OVER (PARTITION BY x%2 ORDER BY x),
+  x+y
+FROM t7
+ORDER BY x,y;
+----
+1  2  1111  2  2222  3  NULL  1  1  1  5  6  3
+3  NULL  NULL  NULL  NULL  NULL  2  2  2  2  5  6  NULL
+5  6  1111  30  2222  11  NULL  3  3  3  14  6  11
+7  8  1111  56  2222  15  6  4  4  4  25  6  15
+9  NULL  NULL  NULL  NULL  NULL  8  5  5  5  25  6  NULL
+10  -50  1111  -500  2222  -40  NULL  6  6  6  -59  -46  -40
+10  -40  1111  -400  2222  -30  -50  7  6  6  -59  -46  -30
+11  NULL  NULL  NULL  NULL  NULL  -40  8  8  7  -59  6  NULL
+13  14  1111  182  2222  27  NULL  9  9  8  -42  6  27
+15  16  1111  240  2222  31  14  10  10  9  -23  6  31
+17  18  1111  306  2222  35  16  11  11  10  -2  6  35
+
+# These are copied from above.
+query III
+SELECT *
+FROM (
+  SELECT *, lag(x) OVER (ORDER BY x) AS l
+  FROM t7
+)
+WHERE l/2 < 7
+ORDER BY x,y,l;
+----
+3  NULL  1
+5  6  3
+7  8  5
+9  NULL  7
+10  -50  9
+10  -40  10
+11  NULL  10
+13  14  11
+15  16  13
+
+query IRRB
+WITH
+  simple AS (
+    SELECT
+      x%5 AS x5_simple,
+      avg(y) OVER (PARTITION BY x%5) AS avg_simple
+    FROM t7
+  ),
+  complicated AS ( -- array_agg, then do an unnest and global agg in a subquery in a SELECT
+    WITH
+      array_agg AS (
+        SELECT
+          x%5 AS x5,
+          array_agg(y) OVER (PARTITION BY x%5) AS l
+        FROM t7
+      )
+    SELECT
+      x5 AS x5_complicated,
+      (
+        SELECT avg(uy)
+        FROM unnest(l) AS uy
+      ) AS avg_complicated
+    FROM array_agg
+  )
+SELECT DISTINCT
+  x5_simple,
+  avg_simple,
+  avg_complicated,
+  avg_simple = avg_complicated
+FROM simple, complicated
+WHERE x5_simple = x5_complicated
+ORDER BY x5_simple;
+----
+0  -17  -17  true
+1  2  2  true
+2  13  13  true
+3  14  14  true
+4  NULL  NULL  NULL
+
+query IIIIIIIIIIIIIIIIIIII
+select
+  x,
+  y,
+  lag(y) over (partition by x%4 order by x) as lag1,
+  lag(y) respect nulls over (partition by x%4 order by x) as lag1_resp,
+  lag(y) ignore nulls over (partition by x%4 order by x) as lag1_ign,
+  lead(y) over (partition by x%4 order by x) as lead1,
+  lead(y) ignore nulls over (partition by x%4 order by x) as lead1_ign,
+  lag(y, 2) over (partition by x%4 order by x) as lag2,
+  lag(y, 2) ignore nulls over (partition by x%4 order by x) as lag2_ign,
+  lead(y, 2) over (partition by x%4 order by x) as lead2,
+  lead(y, 2) ignore nulls over (partition by x%4 order by x) as lead2_ign,
+  lag(y, 2, -1) ignore nulls over (partition by x%4 order by x) as lag2_ign_def,
+  lead(y, 2, -1) ignore nulls over (partition by x%4 order by x) as lead2_ign_def,
+  lag(y, 2, 16) ignore nulls over (partition by x%4 order by x) as lag2_ign_def16,
+  lead(y, 2, 16) ignore nulls over (partition by x%4 order by x) as lead2_ign_def16,
+  lag(y, -1, 100) ignore nulls over (partition by x%4 order by x) as lag_neg_offset,
+  lead(y, -2, 100) ignore nulls over (partition by x%4 order by x) as lead_neg_offset,
+  lag(y, y/5+1) ignore nulls over (partition by x%4 order by x) as lag_dynamic_offset,
+  lead(y, y/5+1) ignore nulls over (partition by x%4 order by x) as lead_dynamic_offset,
+  lag(y, null) ignore nulls over (partition by x%4 order by x) as lag_literal_null_offset
+from t6
+order by x%4, x;
+----
+1  2  NULL  NULL  NULL  6  6  NULL  NULL  NULL  14  -1  14  16  14  6  100  NULL  6  NULL
+5  6  2  2  2  NULL  14  NULL  NULL  14  18  -1  18  16  18  14  100  NULL  18  NULL
+9  NULL  6  6  6  14  14  2  2  18  18  2  18  2  18  14  2  NULL  NULL  NULL
+13  14  NULL  NULL  6  18  18  6  2  NULL  NULL  2  -1  2  16  18  2  NULL  NULL  NULL
+17  18  14  14  14  NULL  NULL  NULL  6  NULL  NULL  6  -1  6  16  100  6  NULL  NULL  NULL
+3  NULL  NULL  NULL  NULL  8  8  NULL  NULL  NULL  16  -1  16  16  16  8  100  NULL  NULL  NULL
+7  8  NULL  NULL  NULL  NULL  16  NULL  NULL  16  NULL  -1  -1  16  16  16  100  NULL  NULL  NULL
+11  NULL  8  8  8  16  16  NULL  NULL  NULL  NULL  -1  -1  16  16  16  100  NULL  NULL  NULL
+15  16  NULL  NULL  8  NULL  NULL  8  NULL  NULL  NULL  -1  -1  16  16  100  100  NULL  NULL  NULL
+
+# Run the same test with also `enable_value_window_function_fusion` disabled.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_value_window_function_fusion = false
+----
+COMPLETE 0
+
+query IIIIIIIIIIIIIIIIIIII
+select
+  x,
+  y,
+  lag(y) over (partition by x%4 order by x) as lag1,
+  lag(y) respect nulls over (partition by x%4 order by x) as lag1_resp,
+  lag(y) ignore nulls over (partition by x%4 order by x) as lag1_ign,
+  lead(y) over (partition by x%4 order by x) as lead1,
+  lead(y) ignore nulls over (partition by x%4 order by x) as lead1_ign,
+  lag(y, 2) over (partition by x%4 order by x) as lag2,
+  lag(y, 2) ignore nulls over (partition by x%4 order by x) as lag2_ign,
+  lead(y, 2) over (partition by x%4 order by x) as lead2,
+  lead(y, 2) ignore nulls over (partition by x%4 order by x) as lead2_ign,
+  lag(y, 2, -1) ignore nulls over (partition by x%4 order by x) as lag2_ign_def,
+  lead(y, 2, -1) ignore nulls over (partition by x%4 order by x) as lead2_ign_def,
+  lag(y, 2, 16) ignore nulls over (partition by x%4 order by x) as lag2_ign_def16,
+  lead(y, 2, 16) ignore nulls over (partition by x%4 order by x) as lead2_ign_def16,
+  lag(y, -1, 100) ignore nulls over (partition by x%4 order by x) as lag_neg_offset,
+  lead(y, -2, 100) ignore nulls over (partition by x%4 order by x) as lead_neg_offset,
+  lag(y, y/5+1) ignore nulls over (partition by x%4 order by x) as lag_dynamic_offset,
+  lead(y, y/5+1) ignore nulls over (partition by x%4 order by x) as lead_dynamic_offset,
+  lag(y, null) ignore nulls over (partition by x%4 order by x) as lag_literal_null_offset
+from t6
+order by x%4, x;
+----
+1  2  NULL  NULL  NULL  6  6  NULL  NULL  NULL  14  -1  14  16  14  6  100  NULL  6  NULL
+5  6  2  2  2  NULL  14  NULL  NULL  14  18  -1  18  16  18  14  100  NULL  18  NULL
+9  NULL  6  6  6  14  14  2  2  18  18  2  18  2  18  14  2  NULL  NULL  NULL
+13  14  NULL  NULL  6  18  18  6  2  NULL  NULL  2  -1  2  16  18  2  NULL  NULL  NULL
+17  18  14  14  14  NULL  NULL  NULL  6  NULL  NULL  6  -1  6  16  100  6  NULL  NULL  NULL
+3  NULL  NULL  NULL  NULL  8  8  NULL  NULL  NULL  16  -1  16  16  16  8  100  NULL  NULL  NULL
+7  8  NULL  NULL  NULL  NULL  16  NULL  NULL  16  NULL  -1  -1  16  16  16  100  NULL  NULL  NULL
+11  NULL  8  8  8  16  16  NULL  NULL  NULL  NULL  -1  -1  16  16  16  100  NULL  NULL  NULL
+15  16  NULL  NULL  8  NULL  NULL  8  NULL  NULL  NULL  -1  -1  16  16  100  100  NULL  NULL  NULL
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_value_window_function_fusion = true
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_reduce_unnest_list_fusion = true
+----
+COMPLETE 0

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -7614,7 +7614,7 @@ Target cluster: quickstart
 
 EOF
 
-# Test the situation when the MFP above is fused into the Reduce.
+# Test the situation when the MFP above is fused into the Reduce, and the MFP can error.
 query III
 SELECT *
 FROM (
@@ -7634,9 +7634,216 @@ ORDER BY x,y,l;
 13  14  11
 15  16  13
 
+# Test the situation when the MFP above is fused into the Reduce, but the MFP can't error.
+query III
+SELECT *
+FROM (
+  SELECT *, lag(x) OVER (ORDER BY x) AS l
+  FROM t7
+)
+WHERE l < 14
+ORDER BY x,y,l;
+----
+3  NULL  1
+5  6  3
+7  8  5
+9  NULL  7
+10  -50  9
+10  -40  10
+11  NULL  10
+13  14  11
+15  16  13
+
+## Check some LIR plans that the optimization guarded by `enable_reduce_unnest_list_fusion` happens.
+## These should show `fused_unnest_list=true`.
+
+# Simple situation
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR
+SELECT
+  lead(x,y-2,120) OVER (ORDER BY x)
+FROM t9;
+----
+Explained Query:
+  Mfp
+    project=(#1)
+    map=(record_get[0](#0))
+    input_key=
+    Reduce::Basic
+      aggr=(0, lead[order_by=[#0 asc nulls_last]](row(row(row(#0, #1), row(#0, (#1 - 2), 120)), #0)), fused_unnest_list=true)
+      val_plan
+        project=(#2)
+        map=(row(row(row(#0, #1), row(#0, (#1 - 2), 120)), #0))
+      key_plan
+        project=()
+      Get::PassArrangements materialize.public.t9
+        raw=true
+
+Source materialize.public.t9
+
+Target cluster: quickstart
+
+EOF
+
+# PARTITION BY
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR
+SELECT
+  lead(x,y-2,120) OVER (PARTITION BY x/2 ORDER BY x)
+FROM t9;
+----
+Explained Query:
+  Mfp
+    project=(#2)
+    map=(record_get[0](#1))
+    input_key=#0
+    Reduce::Basic
+      aggr=(0, lead[order_by=[#0 asc nulls_last]](row(row(row(#0, #1), row(#0, (#1 - 2), 120)), #0)), fused_unnest_list=true)
+      val_plan
+        project=(#2)
+        map=(row(row(row(#0, #1), row(#0, (#1 - 2), 120)), #0))
+      key_plan
+        project=(#2)
+        map=((#0 / 2))
+      Get::PassArrangements materialize.public.t9
+        raw=true
+
+Source materialize.public.t9
+
+Target cluster: quickstart
+
+EOF
+
+# PARTITION BY multiple columns
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR
+SELECT
+  lead(x,y-2,120) OVER (PARTITION BY x/2, y ORDER BY x)
+FROM t9;
+----
+Explained Query:
+  Mfp
+    project=(#3)
+    map=(record_get[0](#2))
+    input_key=#0, #1
+    Reduce::Basic
+      aggr=(0, lead[order_by=[#0 asc nulls_last]](row(row(row(#0, #1), row(#0, (#1 - 2), 120)), #0)), fused_unnest_list=true)
+      val_plan
+        project=(#2)
+        map=(row(row(row(#0, #1), row(#0, (#1 - 2), 120)), #0))
+      key_plan
+        project=(#2, #1)
+        map=((#0 / 2))
+      Get::PassArrangements materialize.public.t9
+        raw=true
+
+Source materialize.public.t9
+
+Target cluster: quickstart
+
+EOF
+
+# row_number()
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR
+SELECT
+  row_number() OVER (ORDER BY x),
+  x
+FROM t7
+ORDER BY row_number
+----
+Explained Query:
+  Finish order_by=[#0 asc nulls_last] output=[#0, #1]
+    Mfp
+      project=(#2, #1)
+      map=(record_get[0](record_get[1](#0)), record_get[0](#0))
+      input_key=
+      Reduce::Basic
+        aggr=(0, row_number[order_by=[#0 asc nulls_last]](row(list[row(#0, #1)], #0)), fused_unnest_list=true)
+        val_plan
+          project=(#2)
+          map=(row(list[row(#0, #1)], #0))
+        key_plan
+          project=()
+        Get::PassArrangements materialize.public.t7
+          raw=true
+
+Source materialize.public.t7
+
+Target cluster: quickstart
+
+EOF
+
+# MFP after is fused into the Reduce
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR
+SELECT *
+FROM (
+  SELECT *, lag(x) OVER (ORDER BY x) AS l
+  FROM t7
+)
+WHERE l < 14
+ORDER BY x,y,l;
+----
+Explained Query:
+  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last, #2 asc nulls_last] output=[#0..=#2]
+    Mfp
+      project=(#3, #4, #1)
+      map=(record_get[0](#0), record_get[1](#0), record_get[0](#2), record_get[1](#2))
+      input_key=
+      Reduce::Basic
+        aggr=(0, lag[order_by=[#0 asc nulls_last]](row(row(row(#0, #1), row(#0, 1, null)), #0)), fused_unnest_list=true)
+        val_plan
+          project=(#2)
+          map=(row(row(row(#0, #1), row(#0, 1, null)), #0))
+        key_plan
+          project=()
+        mfp_after
+          filter=((record_get[0](#0) < 14))
+        Get::PassArrangements materialize.public.t7
+          raw=true
+
+Source materialize.public.t7
+
+Target cluster: quickstart
+
+EOF
+
+# Two lags fused with each other + Reduce-FlatMap fusion.
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR
+SELECT
+  *,
+  lag(x) OVER (),
+  lag(y) OVER ()
+FROM t7
+ORDER BY x,y;
+----
+Explained Query:
+  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#3]
+    Mfp
+      project=(#2, #3, #6, #5)
+      map=(record_get[1](#0), record_get[0](#1), record_get[1](#1), record_get[0](#0), record_get[0](#4), record_get[1](#4))
+      input_key=
+      Reduce::Basic
+        aggr=(0, fused_value_window_func[lag[order_by=[]], lag[order_by=[]] order_by=[]](row(row(row(#0, #1), row(row(#1, 1, null), row(#0, 1, null))))), fused_unnest_list=true)
+        val_plan
+          project=(#2)
+          map=(row(row(row(#0, #1), row(row(#1, 1, null), row(#0, 1, null)))))
+        key_plan
+          project=()
+        Get::PassArrangements materialize.public.t7
+          raw=true
+
+Source materialize.public.t7
+
+Target cluster: quickstart
+
+EOF
+
 ## Run some tests also with `enable_reduce_unnest_list_fusion` disabled.
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_reduce_unnest_list_fusion = true
+ALTER SYSTEM SET enable_reduce_unnest_list_fusion = false
 ----
 COMPLETE 0
 

--- a/test/testdrive/negative-multiplicities.td
+++ b/test/testdrive/negative-multiplicities.td
@@ -88,20 +88,23 @@ contains:Invalid data in source, saw non-positive accumulation
 contains:on-positive accumulation
 
 # Window aggregations
-! SELECT list_agg(data) OVER ()[1] FROM data;
-contains:Non-positive accumulation in ReduceInaccumulable
+# These are currently commented out, because window functions currently don't check their inputs for negative
+# multiplicities, see https://github.com/MaterializeInc/materialize/issues/29624
 
-! SELECT sum(data) OVER () FROM data;
-contains:Non-positive accumulation in ReduceInaccumulable
+#! SELECT list_agg(data) OVER ()[1] FROM data;
+#contains:Non-positive accumulation in ReduceInaccumulable
 
-! SELECT max(data) OVER () FROM data;
-contains:Non-positive accumulation in ReduceInaccumulable
+#! SELECT sum(data) OVER () FROM data;
+#contains:Non-positive accumulation in ReduceInaccumulable
 
-! SELECT list_agg(unsigned_data) OVER ()[1] FROM data;
-contains:Non-positive accumulation in ReduceInaccumulable
+#! SELECT max(data) OVER () FROM data;
+#contains:Non-positive accumulation in ReduceInaccumulable
 
-! SELECT sum(unsigned_data) OVER () FROM data;
-contains:Non-positive accumulation in ReduceInaccumulable
+#! SELECT list_agg(unsigned_data) OVER ()[1] FROM data;
+#contains:Non-positive accumulation in ReduceInaccumulable
 
-! SELECT max(unsigned_data) OVER () FROM data;
-contains:Non-positive accumulation in ReduceInaccumulable
+#! SELECT sum(unsigned_data) OVER () FROM data;
+#contains:Non-positive accumulation in ReduceInaccumulable
+
+#! SELECT max(unsigned_data) OVER () FROM data;
+#contains:Non-positive accumulation in ReduceInaccumulable


### PR DESCRIPTION
This PR implements fusing `Reduce` with `FlatMap UnnestList`, to improve window function performance (https://github.com/MaterializeInc/materialize/issues/29426) to unblock https://github.com/MaterializeInc/accounts/issues/3.

The first two commits are just minor refactorings in preparation for the main thing.

The third commit adds a feature flag (but doesn't wire it up to any actual functionality yet).

The fourth commit is the main thing.

We'll probably want to backport this to the release that is coming out this Thursday, because https://github.com/MaterializeInc/accounts/issues/3 is [quite blocked](https://materializeinc.slack.com/archives/C04SN4BEQ0N/p1726241272433609?thread_ts=1725913543.246879&cid=C04SN4BEQ0N) at the moment.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/29426 This is currently blocking https://github.com/MaterializeInc/accounts/issues/3 with their prototyping of a new use case.

### Tips for reviewer

Review commit by commit.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
  - `window_funcs.slt` has 7000+ lines of window function tests, and most of those exercise the new code when the feature flag is enabled.
    - I've run the entire slt locally with the feature flag enabled and disabled.
    - The feature flag is explicitly enabled at the beginning of the slt.
    - Added some new tests at the end of the slt where the feature flag is explicitly disabled.
    - I've checked locally that when the feature flag is enabled, then all (non-const-folding) tests in the slt run the new code, i.e., that the pattern matching in the lowering always succeeds for window functions.
  - Nightly:
    - https://buildkite.com/materialize/nightly/builds/9539
    - New run, after adding the pattern match soft_assert: https://buildkite.com/materialize/nightly/builds/9618
  - Locally ran RQG `window-functions` with the feature flag enabled and disabled.
  - Did some benchmarking: there is an 1.5x speedup on [this benchmark](https://github.com/MaterializeInc/materialize/pull/29379#issuecomment-2333941357).
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
