### PR TITLE
Plot CCDFs in parallel-benchmark

### DIFF
--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -222,11 +222,11 @@ def report(
     plt.ylabel("CCDF")
     plt.xlabel("latency [ms]")
     for key, m in measurements.items():
-        durations = numpy.array([x.duration * 1000.0 for x in m])
+        durations = [x.duration * 1000.0 for x in m]
         durations.sort()
-        (durations, counts) = numpy.unique(durations, return_counts=True)
+        (uniqu_durations, counts) = numpy.unique(durations, return_counts=True)
         counts = numpy.cumsum(counts)
-        plt.plot(durations, 1 - counts / counts.max())
+        plt.plot(uniqu_durations, 1 - counts / counts.max(), label=key)
 
     plot_path = f"plots/{scenario_name}_{suffix}_ccdf.png"
     plt.savefig(MZ_ROOT / plot_path, dpi=300)


### PR DESCRIPTION
Plot CCDFs as part of the parallel benchmark framework.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
