### PR TITLE
replica isolation test: Disable restart-replica disruption

### DIFF
--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -369,14 +369,15 @@ disruptions = [
             ArrangedIntro("cluster1.replica2", "clusterd_2_1"),
         ],
     ),
-    Disruption(
-        name="restart-replica",
-        disruption=lambda c: restart_replica(c),
-        compaction_checks=AllowCompactionCheck.all_checks(
-            "cluster1.replica1", "clusterd_1_1"
-        )
-        + AllowCompactionCheck.all_checks("cluster1.replica2", "clusterd_2_1"),
-    ),
+    # TODO: Reenable when #28997 is fixed
+    # Disruption(
+    #     name="restart-replica",
+    #     disruption=lambda c: restart_replica(c),
+    #     compaction_checks=AllowCompactionCheck.all_checks(
+    #         "cluster1.replica1", "clusterd_1_1"
+    #     )
+    #     + AllowCompactionCheck.all_checks("cluster1.replica2", "clusterd_2_1"),
+    # ),
     Disruption(
         name="pause-one-clusterd",
         disruption=lambda c: c.pause("clusterd_1_1"),


### PR DESCRIPTION
16 failures in CI is too much: https://ci-failures.dev.materialize.com/?key=test-failures&tfFilters=%5B%7B%22id%22%3A%22build_date%22%2C%22value%22%3A%5Bnull%2Cnull%5D%7D%5D&tfGlobalFilter=Someone%20claimed%20to%20be%20us

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
