### PR TITLE
coord,compute: decoupled compute controller

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3122,7 +3122,7 @@ impl Coordinator {
     /// Returns the state of the [`Coordinator`] formatted as JSON.
     ///
     /// The returned value is not guaranteed to be stable and may change at any point in time.
-    pub fn dump(&self) -> Result<serde_json::Value, anyhow::Error> {
+    pub async fn dump(&self) -> Result<serde_json::Value, anyhow::Error> {
         // Note: We purposefully use the `Debug` formatting for the value of all fields in the
         // returned object as a tradeoff between usability and stability. `serde_json` will fail
         // to serialize an object if the keys aren't strings, so `Debug` formatting the values
@@ -3190,7 +3190,7 @@ impl Coordinator {
                 "pending_linearize_read_txns".to_string(),
                 serde_json::to_value(pending_linearize_read_txns)?,
             ),
-            ("controller".to_string(), self.controller.dump()?),
+            ("controller".to_string(), self.controller.dump().await?),
         ]);
         Ok(serde_json::Value::Object(map))
     }

--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -52,7 +52,7 @@ impl Coordinator {
         if enable_caught_up_check {
             self.maybe_check_caught_up_new().await
         } else {
-            self.maybe_check_caught_up_legacy()
+            self.maybe_check_caught_up_legacy().await
         }
     }
 
@@ -300,7 +300,7 @@ impl Coordinator {
         Ok(all_caught_up)
     }
 
-    fn maybe_check_caught_up_legacy(&mut self) {
+    async fn maybe_check_caught_up_legacy(&mut self) {
         let Some(ctx) = &self.caught_up_check else {
             return;
         };
@@ -308,7 +308,8 @@ impl Coordinator {
         let compute_hydrated = self
             .controller
             .compute
-            .clusters_hydrated(&ctx.exclude_collections);
+            .clusters_hydrated(&ctx.exclude_collections)
+            .await;
         tracing::info!(%compute_hydrated, "checked hydration status of clusters");
 
         if compute_hydrated {

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -235,7 +235,7 @@ impl Coordinator {
                 }
 
                 Command::Dump { tx } => {
-                    let _ = tx.send(self.dump());
+                    let _ = tx.send(self.dump().await);
                 }
             }
         }

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -417,7 +417,8 @@ impl Coordinator {
                     self.handle_introspection_subscribe_batch(sink_id, response)
                         .await;
                 } else {
-                    tracing::error!(%sink_id, "received SubscribeResponse for nonexistent subscribe");
+                    // Cancellation may cause us to receive responses for subscribes no longer
+                    // tracked, so we quietly ignore them.
                 }
             }
             ControllerResponse::CopyToResponse(sink_id, response) => {
@@ -426,7 +427,8 @@ impl Coordinator {
                         active_copy_to.retire_with_response(response);
                     }
                     _ => {
-                        tracing::error!(%sink_id, "received CopyToResponse for nonexistent copy to");
+                        // Cancellation may cause us to receive responses for subscribes no longer
+                        // tracked, so we quietly ignore them.
                     }
                 }
             }

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -83,20 +83,20 @@ impl From<SetFrontier> for Frontier {
 
 #[async_trait(?Send)]
 impl TimestampProvider for Frontiers {
-    fn compute_read_frontier<'a>(
-        &'a self,
+    fn compute_read_frontier(
+        &self,
         instance: ComputeInstanceId,
         id: GlobalId,
-    ) -> timely::progress::frontier::AntichainRef<'a, Timestamp> {
-        self.compute.get(&(instance, id)).unwrap().read.borrow()
+    ) -> Antichain<Timestamp> {
+        self.compute.get(&(instance, id)).unwrap().read.clone()
     }
 
-    fn compute_write_frontier<'a>(
-        &'a self,
+    fn compute_write_frontier(
+        &self,
         instance: ComputeInstanceId,
         id: GlobalId,
-    ) -> timely::progress::frontier::AntichainRef<'a, Timestamp> {
-        self.compute.get(&(instance, id)).unwrap().write.borrow()
+    ) -> Antichain<Timestamp> {
+        self.compute.get(&(instance, id)).unwrap().write.clone()
     }
 
     fn storage_frontiers(

--- a/src/cluster-client/src/lib.rs
+++ b/src/cluster-client/src/lib.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 pub mod client;
 
 /// A function that computes the lag between the given time and wallclock time.
-pub type WallclockLagFn<T> = Arc<dyn Fn(&T) -> Duration>;
+pub type WallclockLagFn<T> = Arc<dyn Fn(&T) -> Duration + Send + Sync>;
 
 /// Identifier of a replica.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]

--- a/src/compute-client/src/controller/error.rs
+++ b/src/compute-client/src/controller/error.rs
@@ -18,9 +18,10 @@
 //! of each method and make it easy for callers to ensure that all possible errors are handled.
 
 use mz_repr::GlobalId;
+use mz_storage_types::read_holds::ReadHoldError;
 use thiserror::Error;
 
-use crate::controller::{instance, ComputeInstanceId, ReplicaId};
+use crate::controller::{ComputeInstanceId, ReplicaId};
 
 /// The error returned by replica-targeted peeks and subscribes when the target replica
 /// disconnects.
@@ -138,16 +139,17 @@ impl From<InstanceMissing> for DataflowCreationError {
     }
 }
 
-impl From<instance::DataflowCreationError> for DataflowCreationError {
-    fn from(error: instance::DataflowCreationError) -> Self {
-        use instance::DataflowCreationError::*;
+impl From<CollectionMissing> for DataflowCreationError {
+    fn from(error: CollectionMissing) -> Self {
+        Self::CollectionMissing(error.0)
+    }
+}
+
+impl From<ReadHoldError> for DataflowCreationError {
+    fn from(error: ReadHoldError) -> Self {
         match error {
-            CollectionMissing(id) => Self::CollectionMissing(id),
-            ReplicaMissing(id) => Self::ReplicaMissing(id),
-            MissingAsOf => Self::MissingAsOf,
-            SinceViolation(id) => Self::SinceViolation(id),
-            EmptyAsOfForSubscribe => Self::EmptyAsOfForSubscribe,
-            EmptyAsOfForCopyTo => Self::EmptyAsOfForCopyTo,
+            ReadHoldError::CollectionMissing(id) => Self::CollectionMissing(id),
+            ReadHoldError::SinceViolation(id) => Self::SinceViolation(id),
         }
     }
 }
@@ -175,13 +177,17 @@ impl From<InstanceMissing> for PeekError {
     }
 }
 
-impl From<instance::PeekError> for PeekError {
-    fn from(error: instance::PeekError) -> Self {
-        use instance::PeekError::*;
+impl From<CollectionMissing> for PeekError {
+    fn from(error: CollectionMissing) -> Self {
+        Self::CollectionMissing(error.0)
+    }
+}
+
+impl From<ReadHoldError> for PeekError {
+    fn from(error: ReadHoldError) -> Self {
         match error {
-            CollectionMissing(id) => Self::CollectionMissing(id),
-            ReplicaMissing(id) => Self::ReplicaMissing(id),
-            SinceViolation(id) => Self::SinceViolation(id),
+            ReadHoldError::CollectionMissing(id) => Self::CollectionMissing(id),
+            ReadHoldError::SinceViolation(id) => Self::SinceViolation(id),
         }
     }
 }

--- a/src/compute-client/src/controller/error.rs
+++ b/src/compute-client/src/controller/error.rs
@@ -79,26 +79,11 @@ pub enum ReplicaCreationError {
     /// TODO(materialize#25239): Add documentation.
     #[error("replica exists already: {0}")]
     ReplicaExists(ReplicaId),
-    /// TODO(materialize#25239): Add documentation.
-    #[error("collection does not exist: {0}")]
-    CollectionMissing(GlobalId),
 }
 
 impl From<InstanceMissing> for ReplicaCreationError {
     fn from(error: InstanceMissing) -> Self {
         Self::InstanceMissing(error.0)
-    }
-}
-
-impl From<instance::ReplicaExists> for ReplicaCreationError {
-    fn from(error: instance::ReplicaExists) -> Self {
-        Self::ReplicaExists(error.0)
-    }
-}
-
-impl From<CollectionMissing> for ReplicaCreationError {
-    fn from(error: CollectionMissing) -> Self {
-        Self::CollectionMissing(error.0)
     }
 }
 
@@ -116,12 +101,6 @@ pub enum ReplicaDropError {
 impl From<InstanceMissing> for ReplicaDropError {
     fn from(error: InstanceMissing) -> Self {
         Self::InstanceMissing(error.0)
-    }
-}
-
-impl From<instance::ReplicaMissing> for ReplicaDropError {
-    fn from(error: instance::ReplicaMissing) -> Self {
-        Self::ReplicaMissing(error.0)
     }
 }
 
@@ -250,13 +229,9 @@ impl From<InstanceMissing> for ReadPolicyError {
     }
 }
 
-impl From<instance::ReadPolicyError> for ReadPolicyError {
-    fn from(error: instance::ReadPolicyError) -> Self {
-        use instance::ReadPolicyError::*;
-        match error {
-            CollectionMissing(id) => Self::CollectionMissing(id),
-            WriteOnlyCollection(id) => Self::WriteOnlyCollection(id),
-        }
+impl From<CollectionMissing> for ReadPolicyError {
+    fn from(error: CollectionMissing) -> Self {
+        Self::CollectionMissing(error.0)
     }
 }
 

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -751,20 +751,6 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
         }
     }
 
-    /// List compute collections that depend on the given collection.
-    pub fn collection_reverse_dependencies(
-        &self,
-        id: GlobalId,
-    ) -> impl Iterator<Item = GlobalId> + '_ {
-        self.collections_iter().filter_map(move |(id2, state)| {
-            if state.compute_dependencies.contains_key(&id) {
-                Some(id2)
-            } else {
-                None
-            }
-        })
-    }
-
     /// Returns the state of the [`Instance`] formatted as JSON.
     ///
     /// The returned value is not guaranteed to be stable and may change at any point in time.

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -276,7 +276,12 @@ where
     }
 
     /// Update task state according to an observed command.
+    #[mz_ore::instrument(level = "debug")]
     fn observe_command(&mut self, command: &ComputeCommand<T>) {
+        if let ComputeCommand::Peek(peek) = command {
+            peek.otel_ctx.attach_as_parent();
+        }
+
         trace!(
             replica = ?self.replica_id,
             command = ?command,
@@ -287,7 +292,12 @@ where
     }
 
     /// Update task state according to an observed response.
+    #[mz_ore::instrument(level = "debug")]
     fn observe_response(&mut self, response: &ComputeResponse<T>) {
+        if let ComputeResponse::PeekResponse(_, _, otel_ctx) = response {
+            otel_ctx.attach_as_parent();
+        }
+
         trace!(
             replica = ?self.replica_id,
             response = ?response,

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -508,6 +508,16 @@ pub enum PeekTarget {
     },
 }
 
+impl PeekTarget {
+    /// Returns the ID of the peeked collection.
+    pub fn id(&self) -> GlobalId {
+        match self {
+            Self::Index { id } => *id,
+            Self::Persist { id, .. } => *id,
+        }
+    }
+}
+
 /// Peek a collection, either in an arrangement or Persist.
 ///
 /// This request elicits data from the worker, by naming the

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -223,7 +223,7 @@ impl<T: ComputeControllerTimestamp> Controller<T> {
     /// Returns the state of the [`Controller`] formatted as JSON.
     ///
     /// The returned value is not guaranteed to be stable and may change at any point in time.
-    pub fn dump(&self) -> Result<serde_json::Value, anyhow::Error> {
+    pub async fn dump(&self) -> Result<serde_json::Value, anyhow::Error> {
         // Note: We purposefully use the `Debug` formatting for the value of all fields in the
         // returned object as a tradeoff between usability and stability. `serde_json` will fail
         // to serialize an object if the keys aren't strings, so `Debug` formatting the values
@@ -252,6 +252,8 @@ impl<T: ComputeControllerTimestamp> Controller<T> {
             immediate_watch_sets,
         } = self;
 
+        let compute = compute.dump().await?;
+
         let unfulfilled_watch_sets: BTreeMap<_, _> = unfulfilled_watch_sets
             .iter()
             .map(|(ws_id, watches)| (format!("{ws_id:?}"), format!("{watches:?}")))
@@ -270,7 +272,7 @@ impl<T: ComputeControllerTimestamp> Controller<T> {
         }
 
         let map = serde_json::Map::from_iter([
-            field("compute", compute.dump()?)?,
+            field("compute", compute)?,
             field("deploy_generation", deploy_generation)?,
             field("read_only", read_only)?,
             field("readiness", format!("{readiness:?}"))?,


### PR DESCRIPTION
This PR moves the compute instance controllers into their own tokio tasks, to decouple the bulk of the compute controller's processing from the coordinator. The top-level `ComputeController` becomes a fat client for the `Instance` tasks that is mostly concerned with pre-validation of controller commands, but is also responsible for acquiring read holds.

To actually decouple the compute controller's processing from the coordinator, it is important that the coordinator doesn't need to block waiting for an `Instance` to process and respond to its commands. This is achieved in a couple ways:

* caching in the `ComputeController` for state that can be inferred solely by observing create/drop commands
* pre-validation, for commands that require waiting only to learn about usage errors
* sharing state through `Arc<Mutex<_>>`, for querying frontiers and acquiring read holds

In a few instances the coordinator still needs to wait for the `Instance` to return some result:
* querying information about cluster/replica hydration
* dumping controller state

None of these instances should affect user query latency though.

### Motivation

  * This PR adds a known-desirable feature.

Closes MaterializeInc/database-issues#8139 

### Tips for reviewer

The PR is split up into sensible commits with extensive commit messages.

The `SharedCollectionState` is a bit of a smell because it introduces blocking on mutexes and shared mutable state. I think that's fine for the first iteration, as that needs to be shared this way is quite small and locks are never held for a long time. Nevertheless, I would like to get rid of `SharedCollectionState` eventually.

* We should be able to avoid sharing `read_capabilities` by requiring callers to pass in all the required read holds upfront. This requires some non-trivial refactoring in the coordinator though, which currently doesn't maintain all required read holds.
* We should be able to avoid sharing frontiers by inventing some broadcast mechanism through which `Instance` task can share frontier updates with interested parties. This mechanism could also be used to share replica frontier updates and hydration statuses, making the hydration-check methods non-`async` as well.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
