### PR TITLE
persist: Try removing condition

### DIFF
--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -139,20 +139,13 @@ impl Row {
             }
         }
 
-        // HACK(parkmycar): Only validate that the decoded Row matches the RelationDesc if it was
-        // non-empty. We have an optimization for queries like COUNT(*) that returns a fake empty
-        // Part instead of decoding the data, which this assertion will fail on.
-        //
-        // TODO(#28146): Remove the check for if the num_columns is 0.
-        if num_columns != 0 && col_idx != 0 {
-            mz_ore::soft_assert_eq_or_log!(
-                col_idx,
-                num_columns,
-                "wrong number of columns when decoding a Row!, got {row:?}, expected {desc:?}",
-                row = self,
-                desc = desc,
-            );
-        }
+        mz_ore::soft_assert_eq_or_log!(
+            col_idx,
+            num_columns,
+            "wrong number of columns when decoding a Row!, got {row:?}, expected {desc:?}",
+            row = self,
+            desc = desc,
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Removes the if-condition on the consistency check when decoding a `ProtoRow` so we always validate the number of datums == the number of columns.

### Motivation

Closes https://github.com/MaterializeInc/materialize/issues/28146

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
