### PR TITLE
storage/sources: Minor fixes for source table objects

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -535,7 +535,8 @@ impl CatalogState {
                                 // Load generator sources don't have any special
                                 // updates.
                                 "load-generator" => vec![],
-                                // TODO(roshan): Add support for kafka source tables.
+                                // TODO(29373): Add catalog introspection table for kafka source tables.
+                                "kafka" => vec![],
                                 s => unreachable!("{s} sources do not have tables"),
                             }
                         }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -601,12 +601,17 @@ impl Coordinator {
                     assert_eq!(should_be_empty, became_empty, "emptiness did not match!");
                 }
             }
-            if !sources_to_drop.is_empty() {
-                self.drop_sources(sources_to_drop);
-            }
             if !tables_to_drop.is_empty() {
                 let ts = self.get_local_write_ts().await;
                 self.drop_tables(tables_to_drop, ts.timestamp);
+            }
+            // Note that we drop tables before sources since there can be a weak dependency
+            // on sources from tables in the storage controller that will result in error
+            // logging that we'd prefer to avoid. This isn't an actual dependency issue but
+            // we'd like to keep that error logging around to indicate when an actual
+            // dependency error might occur.
+            if !sources_to_drop.is_empty() {
+                self.drop_sources(sources_to_drop);
             }
             if !webhook_sources_to_restart.is_empty() {
                 self.restart_webhook_sources(webhook_sources_to_restart);

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -44,6 +44,7 @@ pub fn create_stmt_rename_schema_refs(
         | stmt @ Statement::CreateView(_)
         | stmt @ Statement::CreateMaterializedView(_)
         | stmt @ Statement::CreateTable(_)
+        | stmt @ Statement::CreateTableFromSource(_)
         | stmt @ Statement::CreateIndex(_)
         | stmt @ Statement::CreateType(_)
         | stmt @ Statement::CreateSecret(_) => {
@@ -208,6 +209,7 @@ pub fn create_stmt_rename_refs(
         Statement::CreateSource(_)
         | Statement::CreateSubsource(_)
         | Statement::CreateTable(_)
+        | Statement::CreateTableFromSource(_)
         | Statement::CreateSecret(_)
         | Statement::CreateConnection(_)
         | Statement::CreateWebhookSource(_) => {}

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -13,6 +13,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use mz_ore::str::StrExt;
 use mz_repr::GlobalId;
+use mz_sql_parser::ast::CreateTableFromSourceStatement;
 
 use crate::ast::visit::{self, Visit};
 use crate::ast::visit_mut::{self, VisitMut};
@@ -147,6 +148,7 @@ pub fn create_stmt_rename(create_stmt: &mut Statement<Raw>, to_item_name: String
         })
         | Statement::CreateMaterializedView(CreateMaterializedViewStatement { name, .. })
         | Statement::CreateTable(CreateTableStatement { name, .. })
+        | Statement::CreateTableFromSource(CreateTableFromSourceStatement { name, .. })
         | Statement::CreateSecret(CreateSecretStatement { name, .. })
         | Statement::CreateConnection(CreateConnectionStatement { name, .. })
         | Statement::CreateWebhookSource(CreateWebhookSourceStatement { name, .. }) => {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug. Fixes https://github.com/MaterializeInc/materialize/issues/29496

Also fixes https://github.com/MaterializeInc/materialize/issues/29562 and fixes https://github.com/MaterializeInc/materialize/issues/29503 and fixes https://github.com/MaterializeInc/materialize/issues/29564

We were error logging whenever source tables were dropped after their corresponding source which was always happening when they are dropped together in a transaction due to the implicit ordering in `src/adapter/src/coord/ddl.rs`. There isn't an actual bug in dropping out-of-order so I could have just removed the error log but I thought that it would be better to keep it since it might be useful in any future issue around dependency ordering.

The error log happens here:
https://github.com/MaterializeInc/materialize/blob/03b586b73d8379be9113fc9fd96fc1d9a71544dc/src/storage-controller/src/lib.rs#L1453-L1461


<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

@MaterializeInc/testing I wasn't actually able to repro https://github.com/MaterializeInc/materialize/issues/29496 using the command in that issue but I believe this is the fix for that issue. If you could try to repro on this branch that would be awesome.


<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
