### PR TITLE
bazel: Fixup build pipeline

### DIFF
--- a/ci/deploy/docker.py
+++ b/ci/deploy/docker.py
@@ -18,7 +18,7 @@ from materialize.xcompile import Arch
 
 
 def main() -> None:
-    bazel = ui.env_is_truthy("CI_BUILD_WITH_BAZEL")
+    bazel = ui.env_is_truthy("CI_BAZEL_BUILD")
     bazel_remote_cache = os.getenv("CI_BAZEL_REMOTE_CACHE")
 
     repos = [

--- a/ci/deploy_mz/docker.py
+++ b/ci/deploy_mz/docker.py
@@ -7,9 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import os
 from pathlib import Path
 
-from materialize import mzbuild
+from materialize import mzbuild, ui
 from materialize.rustc_flags import Sanitizer
 from materialize.xcompile import Arch
 
@@ -18,12 +19,25 @@ from .deploy_util import MZ_CLI_VERSION
 
 
 def main() -> None:
+    bazel = ui.env_is_truthy("CI_BAZEL_BUILD")
+    bazel_remote_cache = os.getenv("CI_BAZEL_REMOTE_CACHE")
+
     repos = [
         mzbuild.Repository(
-            Path("."), Arch.X86_64, coverage=False, sanitizer=Sanitizer.none
+            Path("."),
+            Arch.X86_64,
+            coverage=False,
+            sanitizer=Sanitizer.none,
+            bazel=bazel,
+            bazel_remote_cache=bazel_remote_cache,
         ),
         mzbuild.Repository(
-            Path("."), Arch.AARCH64, coverage=False, sanitizer=Sanitizer.none
+            Path("."),
+            Arch.AARCH64,
+            coverage=False,
+            sanitizer=Sanitizer.none,
+            bazel=bazel,
+            bazel_remote_cache=bazel_remote_cache,
         ),
     ]
 

--- a/ci/deploy_mz/linux.py
+++ b/ci/deploy_mz/linux.py
@@ -10,7 +10,7 @@
 import os
 from pathlib import Path
 
-from materialize import mzbuild, spawn
+from materialize import mzbuild, spawn, ui
 from materialize.mz_version import MzCliVersion
 from materialize.rustc_flags import Sanitizer
 
@@ -19,7 +19,16 @@ from .deploy_util import APT_BUCKET, MZ_CLI_VERSION
 
 
 def main() -> None:
-    repo = mzbuild.Repository(Path("."), coverage=False, sanitizer=Sanitizer.none)
+    bazel = ui.env_is_truthy("CI_BAZEL_BUILD")
+    bazel_remote_cache = os.getenv("CI_BAZEL_REMOTE_CACHE")
+
+    repo = mzbuild.Repository(
+        Path("."),
+        coverage=False,
+        sanitizer=Sanitizer.none,
+        bazel=bazel,
+        bazel_remote_cache=bazel_remote_cache,
+    )
     target = f"{repo.rd.arch}-unknown-linux-gnu"
 
     print("--- Checking version")

--- a/ci/deploy_mz_lsp_server/linux.py
+++ b/ci/deploy_mz_lsp_server/linux.py
@@ -11,7 +11,7 @@ import os
 from pathlib import Path
 
 from ci.deploy.deploy_util import rust_version
-from materialize import mzbuild, spawn
+from materialize import mzbuild, spawn, ui
 from materialize.mz_version import MzLspServerVersion
 from materialize.rustc_flags import Sanitizer
 
@@ -20,7 +20,16 @@ from .deploy_util import MZ_LSP_SERVER_VERSION
 
 
 def main() -> None:
-    repo = mzbuild.Repository(Path("."), coverage=False, sanitizer=Sanitizer.none)
+    bazel = ui.env_is_truthy("CI_BAZEL_BUILD")
+    bazel_remote_cache = os.getenv("CI_BAZEL_REMOTE_CACHE")
+
+    repo = mzbuild.Repository(
+        Path("."),
+        coverage=False,
+        sanitizer=Sanitizer.none,
+        bazel=bazel,
+        bazel_remote_cache=bazel_remote_cache,
+    )
     target = f"{repo.rd.arch}-unknown-linux-gnu"
 
     print("--- Checking version")

--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -91,7 +91,7 @@ so it is executed.""",
     parser.add_argument("pipeline", type=str)
     parser.add_argument(
         "--bazel",
-        default=ui.env_is_truthy("CI_BAZEL_BUILD"),
+        default=ui.env_is_truthy("CI_BAZEL_BUILD", "1"),
         action="store_true",
     )
     parser.add_argument(

--- a/ci/mkpipeline.sh
+++ b/ci/mkpipeline.sh
@@ -44,6 +44,8 @@ steps:
   $bootstrap_steps
   - wait
   - label: mkpipeline
+    env:
+      CI_BUILD_WTIH_BAZEL: 1
     command: bin/ci-builder run stable bin/pyactivate -m ci.mkpipeline $pipeline $@
     priority: 200
     agents:

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -11,7 +11,7 @@
 priority: 0
 
 env:
-  CI_BUILD_WITH_BAZEL: 1
+  CI_BAZEL_BUILD: 1
   CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
 
 steps:
@@ -67,7 +67,7 @@ steps:
     depends_on: []
     timeout_in_minutes: 600
     env:
-      CI_BUILD_WITH_BAZEL: 0
+      CI_BAZEL_BUILD: 0
     plugins:
       - ./ci/plugins/mzcompose:
           composition: cargo-test

--- a/ci/qa-canary/pipeline.template.yml
+++ b/ci/qa-canary/pipeline.template.yml
@@ -10,7 +10,7 @@
 priority: 40
 
 env:
-  CI_BUILD_WITH_BAZEL: 1
+  CI_BAZEL_BUILD: 1
   CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
 
 steps:

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -11,7 +11,7 @@
 priority: 40
 
 env:
-  CI_BUILD_WITH_BAZEL: 1
+  CI_BAZEL_BUILD: 1
   CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
 
 steps:
@@ -38,7 +38,7 @@ steps:
       - id: build-x86_64
         label: ":bazel: Build x86_64"
         env:
-          CI_BUILD_WITH_BAZEL: "1"
+          CI_BAZEL_BUILD: "1"
         command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
         inputs:
           - "*"

--- a/ci/slt/pipeline.template.yml
+++ b/ci/slt/pipeline.template.yml
@@ -11,7 +11,7 @@
 priority: -40
 
 env:
-  CI_BUILD_WITH_BAZEL: 1
+  CI_BAZEL_BUILD: 1
   CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
 
 steps:

--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -31,7 +31,7 @@ DEBUGINFO_BINS = ["environmentd", "clusterd"]
 def main() -> None:
     coverage = ui.env_is_truthy("CI_COVERAGE_ENABLED")
     sanitizer = Sanitizer[os.getenv("CI_SANITIZER", "none")]
-    bazel = ui.env_is_truthy("CI_BUILD_WITH_BAZEL")
+    bazel = ui.env_is_truthy("CI_BAZEL_BUILD")
     bazel_remote_cache = os.getenv("CI_BAZEL_REMOTE_CACHE")
 
     repo = mzbuild.Repository(

--- a/ci/test/dev_tag.py
+++ b/ci/test/dev_tag.py
@@ -18,7 +18,7 @@ from materialize.xcompile import Arch
 
 
 def main() -> None:
-    bazel = ui.env_is_truthy("CI_BUILD_WITH_BAZEL")
+    bazel = ui.env_is_truthy("CI_BAZEL_BUILD")
     bazel_remote_cache = os.getenv("CI_BAZEL_REMOTE_CACHE")
 
     mz_version = ci_util.get_mz_version()

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -16,7 +16,7 @@ dag: true
 
 env:
   CI_BUILDER_SCCACHE: 1
-  CI_BUILD_WITH_BAZEL: 1
+  CI_BAZEL_BUILD: 1
   CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
   # Note: In .cargo/config we set the default build jobs to -1 so on developer machines we keep
   # a single core open when compiling. But we want to use all of CI's resources, hence setting the
@@ -33,7 +33,7 @@ steps:
       - id: rust-build-x86_64
         label: ":rust: Build x86_64"
         env:
-          CI_BUILD_WITH_BAZEL: 0
+          CI_BAZEL_BUILD: 0
         command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
         inputs:
           - "*"
@@ -46,7 +46,7 @@ steps:
       - id: rust-build-aarch64
         label: ":rust: Build aarch64"
         env:
-          CI_BUILD_WITH_BAZEL: 0
+          CI_BAZEL_BUILD: 0
         command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
         inputs:
           - "*"

--- a/misc/python/materialize/benches/avro_ingest.py
+++ b/misc/python/materialize/benches/avro_ingest.py
@@ -93,7 +93,12 @@ def main() -> None:
 
     os.chdir(MZ_ROOT)
     coverage = ui.env_is_truthy("CI_COVERAGE_ENABLED")
-    repo = mzbuild.Repository(MZ_ROOT, coverage=coverage)
+    bazel = ui.env_is_truthy("CI_BAZEL_BUILD")
+    bazel_remote_cache = os.getenv("CI_BAZEL_REMOTE_CACHE")
+
+    repo = mzbuild.Repository(
+        MZ_ROOT, coverage=coverage, bazel=bazel, bazel_remote_cache=bazel_remote_cache
+    )
 
     wait_for_confluent(args.confluent_host)
 

--- a/misc/python/materialize/cloudtest/app/application.py
+++ b/misc/python/materialize/cloudtest/app/application.py
@@ -36,6 +36,12 @@ class Application:
     def sanitizer_mode(self) -> str:
         return os.getenv("CI_SANITIZER", "none")
 
+    def bazel(self) -> bool:
+        return ui.env_is_truthy("CI_BAZEL_BUILD")
+
+    def bazel_remote_cache(self) -> str | None:
+        return os.getenv("CI_BAZEL_REMOTE_CACHE")
+
     def acquire_images(self) -> None:
         raise NotImplementedError
 

--- a/misc/python/materialize/cloudtest/app/cloudtest_application_base.py
+++ b/misc/python/materialize/cloudtest/app/cloudtest_application_base.py
@@ -44,7 +44,11 @@ class CloudtestApplicationBase(Application):
 
     def acquire_images(self) -> None:
         repo = mzbuild.Repository(
-            self.mz_root, release_mode=self.release_mode, coverage=self.coverage_mode()
+            self.mz_root,
+            release_mode=self.release_mode,
+            coverage=self.coverage_mode(),
+            bazel=self.bazel(),
+            bazel_remote_cache=self.bazel_remote_cache(),
         )
         for image in self.images:
             self._acquire_image(repo, image)

--- a/misc/python/materialize/cloudtest/k8s/api/k8s_resource.py
+++ b/misc/python/materialize/cloudtest/k8s/api/k8s_resource.py
@@ -88,11 +88,16 @@ class K8sResource:
         else:
             coverage = ui.env_is_truthy("CI_COVERAGE_ENABLED")
             sanitizer = Sanitizer[os.getenv("CI_SANITIZER", "none")]
+            bazel = ui.env_is_truthy("CI_BAZEL_BUILD")
+            bazel_remote_cache = os.getenv("CI_BAZEL_REMOTE_CACHE")
+
             repo = mzbuild.Repository(
                 MZ_ROOT,
                 release_mode=release_mode,
                 coverage=coverage,
                 sanitizer=sanitizer,
+                bazel=bazel,
+                bazel_remote_cache=bazel_remote_cache,
             )
             deps = repo.resolve_dependencies([repo.images[service]])
             rimage = deps[service]

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -1209,7 +1209,7 @@ class Repository:
         )
         parser.add_argument(
             "--bazel",
-            default=ui.env_is_truthy("CI_BUILD_WITH_BAZEL"),
+            default=ui.env_is_truthy("CI_BAZEL_BUILD"),
             action="store_true",
         )
         parser.add_argument(


### PR DESCRIPTION
This PR makes a few changes to fixup the build pipeline.

* rename `CI_BUILD_WITH_BAZEL` to `CI_BAZEL_BUILD` to align better with `CI_BAZEL_REMOTE_CACHE`
* plumb to all other callers of `Repository(...)`
* add `CI_BAZEL_BUILD: 1` to `mkpipeline.sh`

### Motivation

Fix the build pipeline

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
