### PR TITLE
cargo test: Fix nextest.toml order

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,6 +13,10 @@ threads-required = 8
 slow-timeout = { period = "300s", terminate-after = 2 }
 
 [[profile.default.overrides]]
+filter = "package(mz-environmentd) and test(test_storage_usage_collection_interval)"
+slow-timeout = { period = "300s", terminate-after = 2 }
+
+[[profile.default.overrides]]
 filter = "package(mz-environmentd)"
 threads-required = 8
 slow-timeout = { period = "120s", terminate-after = 2 }
@@ -31,10 +35,6 @@ slow-timeout = { period = "300s", terminate-after = 2 }
 
 [[profile.default.overrides]]
 filter = "package(mz-adapter) and test(test_smoketest_all_builtins)"
-slow-timeout = { period = "300s", terminate-after = 2 }
-
-[[profile.default.overrides]]
-filter = "package(mz-environmentd) and test(test_storage_usage_collection_interval)"
 slow-timeout = { period = "300s", terminate-after = 2 }
 
 [profile.ci]


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/test/builds/90445
Mistakenly used the wrong order in https://github.com/MaterializeInc/materialize/pull/29534

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
