### PR TITLE
platform-checks: Mark checks as non-idempotent

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -574,8 +574,8 @@ steps:
               composition: platform-checks
               args: [--scenario=RestartEntireMz, "--seed=$BUILDKITE_JOB_ID"]
 
-      - id: checks-backup-multi
-        label: "Checks + multiple backups/restores %N"
+      - id: checks-backup-rollback
+        label: "Checks + backup + rollback to previous %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -584,7 +584,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=BackupAndRestoreMulti, "--seed=$BUILDKITE_JOB_ID"]
+              args: [--scenario=BackupAndRestoreToPreviousState, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-parallel-drop-create-default-replica
         label: "Checks parallel + DROP/CREATE replica %N"

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -379,8 +379,8 @@ steps:
               composition: platform-checks
               args: [--scenario=BackupAndRestoreAfterManipulate, "--seed=$BUILDKITE_JOB_ID"]
 
-      - id: checks-backup-rollback
-        label: "Checks + backup + rollback to previous %N"
+      - id: checks-backup-multi
+        label: "Checks + multiple backups/restores %N"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -389,7 +389,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=BackupAndRestoreToPreviousState, "--seed=$BUILDKITE_JOB_ID"]
+              args: [--scenario=BackupAndRestoreMulti, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-preflight-check-continue
         label: "Checks preflight-check and continue upgrade %N"

--- a/misc/python/materialize/checks/all_checks/source_tables.py
+++ b/misc/python/materialize/checks/all_checks/source_tables.py
@@ -9,7 +9,7 @@
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import Check, externally_idempotent
 from materialize.checks.executors import Executor
 from materialize.mz_version import MzVersion
 from materialize.mzcompose.services.mysql import MySql
@@ -29,6 +29,7 @@ class TableFromSourceBase(Check):
         )
 
 
+@externally_idempotent(False)
 class TableFromPgSource(TableFromSourceBase):
     suffix = "tbl_from_pg_source"
 
@@ -129,6 +130,7 @@ class TableFromPgSource(TableFromSourceBase):
         )
 
 
+@externally_idempotent(False)
 class TableFromMySqlSource(TableFromSourceBase):
     suffix = "tbl_from_mysql_source"
 


### PR DESCRIPTION
Fixes: #29548

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
