### PR TITLE
parallel-benchmark: Introduce disabling tests, work around pg8000's close() failing after a query failed

### DIFF
--- a/misc/python/materialize/mzcompose/services/postgres.py
+++ b/misc/python/materialize/mzcompose/services/postgres.py
@@ -26,6 +26,7 @@ class Postgres(Service):
         volumes: list[str] = [],
         max_wal_senders: int = 100,
         max_replication_slots: int = 100,
+        max_connections: int = 5000,
     ) -> None:
         command: list[str] = [
             "postgres",
@@ -36,7 +37,7 @@ class Postgres(Service):
             "-c",
             f"max_replication_slots={max_replication_slots}",
             "-c",
-            "max_connections=5000",
+            f"max_connections={max_connections}",
         ] + extra_command
         config: ServiceConfig = {"image": image} if image else {"mzbuild": mzbuild}
 

--- a/misc/python/materialize/parallel_benchmark/framework.py
+++ b/misc/python/materialize/parallel_benchmark/framework.py
@@ -19,7 +19,7 @@ from textwrap import dedent
 import pg8000
 
 from materialize.mzcompose.composition import Composition
-from materialize.util import PgConnInfo
+from materialize.util import PgConnInfo, pg8000_close
 
 
 class Measurement:
@@ -104,7 +104,7 @@ class StandaloneQuery(Action):
             if not self.strict_serializable:
                 cur.execute("SET TRANSACTION_ISOLATION TO 'SERIALIZABLE'")
             execute_query(cur, self.query)
-        conn.close()
+        pg8000_close(conn)
 
     def __str__(self) -> str:
         return f"{self.query} (standalone)"
@@ -377,7 +377,7 @@ class Scenario:
     def teardown(self) -> None:
         while not self.conns.empty():
             conn = self.conns.get()
-            conn.close()
+            pg8000_close(conn)
             self.conns.task_done()
         for i in range(len(self.thread_pool)):
             # Indicate to every thread to stop working

--- a/misc/python/materialize/parallel_benchmark/framework.py
+++ b/misc/python/materialize/parallel_benchmark/framework.py
@@ -318,6 +318,9 @@ def run_job(jobs: queue.Queue) -> None:
 
 
 class Scenario:
+    # Has to be set for the class already, not just in the constructor, so that
+    # we can change the value for the entire class in the decorator
+    enabled: bool = True
     phases: list[Phase]
     thread_pool_size: int
     conn_pool_size: int
@@ -382,3 +385,11 @@ class Scenario:
         for thread in self.thread_pool:
             thread.join()
         self.jobs.join()
+
+
+def disabled(ignore_reason: str):
+    def decorator(cls):
+        cls.enabled = False
+        return cls
+
+    return decorator

--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -574,7 +574,7 @@ class CommandQueryResponsibilitySegregation(Scenario):
                                 conn_infos["postgres"],
                                 strict_serializable=False,
                             ),
-                            dist=Periodic(per_second=50),
+                            dist=Periodic(per_second=100),
                             report_regressions=False,
                         ),
                         OpenLoop(
@@ -583,7 +583,7 @@ class CommandQueryResponsibilitySegregation(Scenario):
                                 conn_infos["postgres"],
                                 strict_serializable=False,
                             ),
-                            dist=Periodic(per_second=5),
+                            dist=Periodic(per_second=10),
                             report_regressions=False,
                         ),
                         OpenLoop(
@@ -592,11 +592,9 @@ class CommandQueryResponsibilitySegregation(Scenario):
                                 conn_infos["postgres"],
                                 strict_serializable=False,
                             ),
-                            dist=Periodic(per_second=0.5),
+                            dist=Periodic(per_second=1),
                             report_regressions=False,
                         ),
-                    ]
-                    + [
                         ClosedLoop(
                             action=ReuseConnQuery(
                                 "SELECT * FROM mv_cqrs",
@@ -604,7 +602,7 @@ class CommandQueryResponsibilitySegregation(Scenario):
                                 strict_serializable=True,
                             ),
                             report_regressions=False,  # TODO: Currently not stable enough
-                        )
+                        ),
                     ],
                 ),
             ],

--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -21,6 +21,7 @@ from materialize.parallel_benchmark.framework import (
     StandaloneQuery,
     TdAction,
     TdPhase,
+    disabled,
 )
 from materialize.util import PgConnInfo
 
@@ -529,6 +530,7 @@ class InsertsSelects(Scenario):
 # TODO Try these scenarios' scaling behavior against cc sizes (locally and remote)
 
 
+@disabled("#29572 Currently causes 'network error' with many queries hanging")
 class CommandQueryResponsibilitySegregation(Scenario):
     # TODO: Have one Postgres source with many inserts/updates/deletes and multiple complex materialized view on top of it, read from Mz
     # This should be blocked by materialized view performance

--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -191,15 +191,14 @@ class PgReadReplicaRTR(Scenario):
                                 "INSERT INTO t2 VALUES (1)",
                                 conn_infos["postgres"],
                             ),
-                            dist=Periodic(per_second=100),
+                            dist=Periodic(per_second=10),
                         ),
-                        OpenLoop(
-                            action=StandaloneQuery(
+                        ClosedLoop(
+                            action=ReuseConnQuery(
                                 "SET REAL_TIME_RECENCY TO TRUE; SELECT * FROM mv_sum",
                                 conn_infos["materialized"],
                                 strict_serializable=False,
                             ),
-                            dist=Periodic(per_second=125),
                             report_regressions=False,  # TODO: Currently not stable enough, reenable when RTR becomes more consistent
                         ),
                     ],
@@ -574,7 +573,7 @@ class CommandQueryResponsibilitySegregation(Scenario):
                                 conn_infos["postgres"],
                                 strict_serializable=False,
                             ),
-                            dist=Periodic(per_second=100),
+                            dist=Periodic(per_second=50),
                             report_regressions=False,
                         ),
                         OpenLoop(
@@ -583,7 +582,7 @@ class CommandQueryResponsibilitySegregation(Scenario):
                                 conn_infos["postgres"],
                                 strict_serializable=False,
                             ),
-                            dist=Periodic(per_second=10),
+                            dist=Periodic(per_second=5),
                             report_regressions=False,
                         ),
                         OpenLoop(

--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -21,7 +21,6 @@ from materialize.parallel_benchmark.framework import (
     StandaloneQuery,
     TdAction,
     TdPhase,
-    disabled,
 )
 from materialize.util import PgConnInfo
 
@@ -530,7 +529,6 @@ class InsertsSelects(Scenario):
 # TODO Try these scenarios' scaling behavior against cc sizes (locally and remote)
 
 
-@disabled("#29572 Currently causes 'network error' with many queries hanging")
 class CommandQueryResponsibilitySegregation(Scenario):
     # TODO: Have one Postgres source with many inserts/updates/deletes and multiple complex materialized view on top of it, read from Mz
     # This should be blocked by materialized view performance
@@ -576,7 +574,7 @@ class CommandQueryResponsibilitySegregation(Scenario):
                                 conn_infos["postgres"],
                                 strict_serializable=False,
                             ),
-                            dist=Periodic(per_second=100),
+                            dist=Periodic(per_second=50),
                             report_regressions=False,
                         ),
                         OpenLoop(
@@ -585,7 +583,7 @@ class CommandQueryResponsibilitySegregation(Scenario):
                                 conn_infos["postgres"],
                                 strict_serializable=False,
                             ),
-                            dist=Periodic(per_second=10),
+                            dist=Periodic(per_second=5),
                             report_regressions=False,
                         ),
                         OpenLoop(
@@ -594,7 +592,7 @@ class CommandQueryResponsibilitySegregation(Scenario):
                                 conn_infos["postgres"],
                                 strict_serializable=False,
                             ),
-                            dist=Periodic(per_second=1),
+                            dist=Periodic(per_second=0.5),
                             report_regressions=False,
                         ),
                     ]

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -35,7 +35,7 @@ from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.mysql import MySql
 from materialize.parallel_workload.executor import Executor
 from materialize.parallel_workload.settings import Complexity, Scenario
-from materialize.util import naughty_strings
+from materialize.util import naughty_strings, pg8000_close
 
 MAX_COLUMNS = 5
 MAX_INCLUDE_HEADERS = 5
@@ -1049,11 +1049,11 @@ class Database:
             db.drop(exe)
 
         for src in self.kafka_sources:
-            src.executor.mz_conn.close()
+            pg8000_close(src.executor.mz_conn)
         for src in self.postgres_sources:
-            src.executor.mz_conn.close()
+            pg8000_close(src.executor.mz_conn)
         for src in self.mysql_sources:
-            src.executor.mz_conn.close()
+            pg8000_close(src.executor.mz_conn)
 
     def update_sqlsmith_state(self, composition: Composition) -> None:
         if False:  # Questionable use

--- a/misc/python/materialize/parallel_workload/worker.py
+++ b/misc/python/materialize/parallel_workload/worker.py
@@ -25,6 +25,7 @@ from materialize.parallel_workload.action import (
 )
 from materialize.parallel_workload.database import Database
 from materialize.parallel_workload.executor import Executor
+from materialize.util import pg8000_close
 
 
 class Worker:
@@ -132,6 +133,6 @@ class Worker:
                 self.occurred_exception = e
                 raise e
 
-        self.exe.cur._c.close()
+        pg8000_close(self.exe.cur._c)
         if self.exe.ws:
             self.exe.ws.close()

--- a/test/canary-environment/mzcompose.py
+++ b/test/canary-environment/mzcompose.py
@@ -17,6 +17,7 @@ import pg8000
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.dbt import Dbt
 from materialize.mzcompose.services.testdrive import Testdrive
+from materialize.util import pg8000_close
 
 # The actual values are stored as Pulumi secrets in the i2 repository
 MATERIALIZE_PROD_SANDBOX_HOSTNAME = os.environ["MATERIALIZE_PROD_SANDBOX_HOSTNAME"]
@@ -213,7 +214,7 @@ def workflow_test(c: Composition, parser: WorkflowArgumentParser) -> None:
             result[0][0] == 1
         ), f"RDS Postgres has wrong number of pg_replication_slots {result[0][0]}, please fix manually to prevent Postgres from going out of disk from stalled Materialize connections"
     finally:
-        con.close()
+        pg8000_close(con)
 
     c.exec("dbt", "dbt", "test", workdir="/workdir")
 

--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -31,6 +31,7 @@ from materialize.mzcompose.test_result import (
     TestFailureDetails,
 )
 from materialize.ui import CommandFailureCausedUIError
+from materialize.util import pg8000_close
 
 SERVICES = [
     Testdrive(),  # Overridden below
@@ -219,7 +220,7 @@ def close_connection_and_cursor(
     cursor.execute(f"CLOSE {object_to_close}")
     cursor.execute("ROLLBACK")
     cursor.close()
-    connection.close()
+    pg8000_close(connection)
 
 
 def perform_test(

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -40,6 +40,7 @@ from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.redpanda_cloud import RedpandaCloud
 from materialize.ui import UIError
+from materialize.util import pg8000_close
 
 REDPANDA_RESOURCE_GROUP = "ci-resource-group"
 REDPANDA_NETWORK = "ci-network"
@@ -160,7 +161,7 @@ class Redpanda:
         )
         privatelink_principal = cloud_cursor.fetchone()[0]
         cloud_cursor.close()
-        cloud_conn.close()
+        pg8000_close(cloud_conn)
 
         result = self.cloud.patch(
             f"clusters/{self.cluster_info['id']}",

--- a/test/cloudtest/test_replica_restart.py
+++ b/test/cloudtest/test_replica_restart.py
@@ -16,6 +16,7 @@ import pytest
 from pg8000 import Connection
 
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
+from materialize.util import pg8000_close
 
 
 def query(conn: Connection, sql: str) -> None:
@@ -172,6 +173,6 @@ def test_crash_clusterd(mz: MaterializeApplication) -> None:
     # We need all the above threads to finish for the test to succeed.Close the
     # connections from this thread because pg8000 doesn't support cancellation
     # and dropping the table in mz doesn't complete the queries either.
-    c_select.close()
-    c_subscribe.close()
-    c_copy.close()
+    pg8000_close(c_select)
+    pg8000_close(c_subscribe)
+    pg8000_close(c_copy)

--- a/test/data-ingest/mzcompose.py
+++ b/test/data-ingest/mzcompose.py
@@ -37,6 +37,7 @@ from materialize.mzcompose.services.mysql import MySql
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.zookeeper import Zookeeper
+from materialize.util import pg8000_close
 
 SERVICES = [
     Postgres(),
@@ -133,7 +134,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                URL 'http://schema-registry:8081'"""
         )
     conn.autocommit = False
-    conn.close()
+    pg8000_close(conn)
 
     ports = {s: c.default_port(s) for s in services}
     ports["materialized2"] = 26875

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -97,7 +97,7 @@ SERVICES = [
     Cockroach(setup_materialize=True),
     Minio(setup_materialize=True),
     KgenService(),
-    Postgres(),
+    Postgres(max_connections=10000),
     MySql(),
     Balancerd(),
     # Overridden below

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -55,7 +55,12 @@ from materialize.test_analytics.data.parallel_benchmark import (
     parallel_benchmark_result_storage,
 )
 from materialize.test_analytics.test_analytics_db import TestAnalyticsDb
-from materialize.util import PgConnInfo, all_subclasses, parse_pg_conn_string
+from materialize.util import (
+    PgConnInfo,
+    all_subclasses,
+    parse_pg_conn_string,
+    pg8000_close,
+)
 from materialize.version_list import resolve_ancestor_image_tag
 
 PARALLEL_BENCHMARK_FRAMEWORK_VERSION = "1.1.0"
@@ -290,7 +295,7 @@ def run_once(
                 with conn.cursor() as cur:
                     cur.execute("SELECT mz_version()")
                     mz_version = cur.fetchall()[0][0]
-                conn.close()
+                pg8000_close(conn)
                 mz_string = f"{mz_version} ({target.host})"
             else:
                 c.up(*service_names)

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -584,7 +584,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             globals()[scenario] for scenario in args.scenario
         ]
     else:
-        scenarios = list(all_subclasses(Scenario))
+        scenarios = [
+            scenario for scenario in all_subclasses(Scenario) if scenario.enabled
+        ]
 
     sharded_scenarios = buildkite.shard_list(scenarios, lambda s: s.name())
 


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
