### PR TITLE
persist: hook up dropped metric for schema cache, too

### DIFF
--- a/src/persist-client/src/schema.rs
+++ b/src/persist-client/src/schema.rs
@@ -290,6 +290,13 @@ impl<I: Clone + Ord, S: PartialEq + Debug> SchemaCacheMap<I, S> {
     }
 }
 
+impl<I, K> Drop for SchemaCacheMap<I, K> {
+    fn drop(&mut self) {
+        let map = self.map.read().expect("lock");
+        self.metrics.dropped_count.inc_by(u64::cast_from(map.len()));
+    }
+}
+
 #[derive(Debug, Clone)]
 struct MigrationCacheMap {
     metrics: SchemaCacheMetrics,


### PR DESCRIPTION
I only hooked it up for the migrations cache initially because my mental
model was that the schema cache would be tied to the process lifetime.
But, of course, that's only true if there's a long lived handle. Hooking
this up allows us to correct the graph for the total number of entries
in the cache.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
