### PR TITLE
cargo test: Bump timeout in test_timeline_read_holds

### DIFF
--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1795,7 +1795,7 @@ async fn test_timeline_read_holds() {
 
     // Make sure that the table and view are joinable immediately at some timestamp.
     let mz_join_client = server.connect().await.unwrap();
-    let _ = tokio::time::timeout(Duration::from_millis(2_000), async move {
+    let _ = tokio::time::timeout(Duration::from_millis(4_000), async move {
         Ok::<_, anyhow::Error>(
             mz_join_client
                 .query_one(&format!("SELECT COUNT(t.a) FROM t, {view_name};"), &[])


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/test/builds/90515 and https://buildkite.com/materialize/test/builds/90530

@danhhz This seems to have started with https://github.com/MaterializeInc/materialize/pull/29574 being merged

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
