### PR TITLE
Minor code improvements

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -801,20 +801,13 @@ impl Coordinator {
                 new_process_status,
             );
 
-            let mut builtin_table_updates = vec![builtin_table_retraction, builtin_table_addition];
+            let builtin_table_updates = vec![builtin_table_retraction, builtin_table_addition];
 
-            if self.controller.read_only() {
-                self.buffered_builtin_table_updates
-                    .as_mut()
-                    .expect("in read-only mode")
-                    .append(&mut builtin_table_updates);
-            } else {
-                self.builtin_table_update()
-                    .execute(builtin_table_updates)
-                    .await
-                    .instrument(info_span!("coord::message_cluster_event::table_updates"))
-                    .await;
-            }
+            self.builtin_table_update()
+                .execute(builtin_table_updates)
+                .await
+                .instrument(info_span!("coord::message_cluster_event::table_updates"))
+                .await;
 
             let cluster = self.catalog().get_cluster(event.cluster_id);
             let replica = cluster.replica(event.replica_id).expect("Replica exists");

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -593,10 +593,10 @@ impl Coordinator {
     pub fn pack_statement_ended_execution_updates(
         began_record: &StatementBeganExecutionRecord,
         ended_record: &StatementEndedExecutionRecord,
-    ) -> Vec<(Row, Diff)> {
+    ) -> [(Row, Diff); 2] {
         let retraction = Self::pack_statement_began_execution_update(began_record);
         let new = Self::pack_full_statement_execution_update(began_record, ended_record);
-        vec![(retraction, -1), (new, 1)]
+        [(retraction, -1), (new, 1)]
     }
 
     /// Mutate a statement execution record via the given function `f`.


### PR DESCRIPTION
Avoid an allocation when packing an update, remove redundant check for
sending builtin table updates in read-only mode.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
