### PR TITLE
ci: Speed up cloudtest & large-scale backup+restore

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -154,7 +154,7 @@ steps:
         - ./ci/plugins/mzcompose:
             composition: zippy
             # Runs out of disk
-            args: [--scenario=BackupAndRestoreLarge, --actions=500000]
+            args: [--scenario=BackupAndRestoreLarge, --actions=250000]
 
     - id: zippy-kafka-parallel-insert
       label: "Longer Zippy Kafka Parallel Insert"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -588,7 +588,7 @@ steps:
   - id: cloudtest
     label: Cloudtest %N
     depends_on: build-aarch64
-    parallelism: 6
+    parallelism: 8
     timeout_in_minutes: 60
     inputs:
       - test/cloudtest


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/release-qualification/builds/600#0191f45f-70e2-4251-a5b7-e980ba841ea0

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
