### PR TITLE
parallel-benchmark: Switch to psycopg instead of pg8000

### DIFF
--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -157,12 +157,14 @@ def find_modified_lines() -> set[tuple[str, int]]:
     return modified_lines
 
 
-def upload_artifact(path: Path | str, cwd: Path | None = None):
+def upload_artifact(path: Path | str, cwd: Path | None = None, quiet: bool = False):
     spawn.runv(
         [
             "buildkite-agent",
             "artifact",
             "upload",
+            "--log-level",
+            "fatal" if quiet else "notice",
             path,
         ],
         cwd=cwd,

--- a/misc/python/materialize/parallel_benchmark/framework.py
+++ b/misc/python/materialize/parallel_benchmark/framework.py
@@ -16,7 +16,7 @@ from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from textwrap import dedent
 
-import pg8000
+import psycopg
 
 from materialize.mzcompose.composition import Composition
 from materialize.util import PgConnInfo
@@ -41,10 +41,10 @@ class State:
     periodic_dists: dict[str, int]
 
 
-def execute_query(cur: pg8000.Cursor, query: str) -> None:
+def execute_query(cur: psycopg.Cursor, query: str) -> None:
     while True:
         try:
-            cur.execute(query)
+            cur.execute(query.encode("utf-8"))
             break
         except Exception as e:
             if "deadlock detected" in str(e):

--- a/misc/python/materialize/parallel_benchmark/framework.py
+++ b/misc/python/materialize/parallel_benchmark/framework.py
@@ -318,6 +318,9 @@ def run_job(jobs: queue.Queue) -> None:
 
 
 class Scenario:
+    # Has to be set for the class already, not just in the constructor, so that
+    # we can change the value for the entire class in the decorator
+    enabled: bool = True
     phases: list[Phase]
     thread_pool_size: int
     conn_pool_size: int
@@ -382,3 +385,11 @@ class Scenario:
         for thread in self.thread_pool:
             thread.join()
         self.jobs.join()
+
+
+def disabled(ignore_reason: str):
+    def decorator(cls):
+        cls.enabled = False
+        return cls
+
+    return decorator

--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -21,6 +21,7 @@ from materialize.parallel_benchmark.framework import (
     StandaloneQuery,
     TdAction,
     TdPhase,
+    disabled,
 )
 from materialize.util import PgConnInfo
 
@@ -749,6 +750,9 @@ class OperationalDataMesh(Scenario):
         )
 
 
+@disabled(
+    "Not well suited to measure regressions since too many queries are running at once"
+)
 class ReadReplicaBenchmark(Scenario):
     # We might want to run a full version of rr-bench instead, this is not a
     # very realistic representation of it but might already help us catch some

--- a/misc/python/materialize/util.py
+++ b/misc/python/materialize/util.py
@@ -17,7 +17,6 @@ import json
 import os
 import pathlib
 import random
-import ssl
 import subprocess
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -27,7 +26,7 @@ from threading import Thread
 from typing import Protocol, TypeVar
 from urllib.parse import parse_qs, unquote, urlparse
 
-import pg8000
+import psycopg
 import xxhash
 import zstandard
 
@@ -159,14 +158,14 @@ class PgConnInfo:
     password: str | None = None
     ssl: bool = False
 
-    def connect(self) -> pg8000.Connection:
-        return pg8000.connect(
+    def connect(self) -> psycopg.Connection:
+        return psycopg.connect(
             host=self.host,
             port=self.port,
             user=self.user,
             password=self.password,
-            database=self.database,
-            ssl_context=ssl.SSLContext() if self.ssl else None,
+            dbname=self.database,
+            sslmode="require" if self.ssl else None,
         )
 
 

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -155,7 +155,7 @@ def upload_plot(
     variant: str,
 ):
     if buildkite.is_in_buildkite():
-        buildkite.upload_artifact(plot_path, cwd=MZ_ROOT)
+        buildkite.upload_artifact(plot_path, cwd=MZ_ROOT, quiet=True)
         print(f"+++ Plot for {scenario_name} ({variant})")
         print(
             buildkite.inline_image(
@@ -221,12 +221,14 @@ def report(
     plt.yscale("log")
     plt.ylabel("CCDF")
     plt.xlabel("latency [ms]")
+    plt.title(f"{scenario_name} against {mz_string}")
     for key, m in measurements.items():
         durations = [x.duration * 1000.0 for x in m]
         durations.sort()
         (uniqu_durations, counts) = numpy.unique(durations, return_counts=True)
         counts = numpy.cumsum(counts)
         plt.plot(uniqu_durations, 1 - counts / counts.max(), label=key)
+    plt.legend(loc="best")
 
     plot_path = f"plots/{scenario_name}_{suffix}_ccdf.png"
     plt.savefig(MZ_ROOT / plot_path, dpi=300)

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -584,7 +584,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             globals()[scenario] for scenario in args.scenario
         ]
     else:
-        scenarios = list(all_subclasses(Scenario))
+        scenarios = [
+            scenario for scenario in all_subclasses(Scenario) if scenario.enabled
+        ]
 
     sharded_scenarios = buildkite.shard_list(scenarios, lambda s: s.name())
 


### PR DESCRIPTION
Way higher performance, removes bottleneck from testing, don't have to investigate pg8000 weirdness with many connections (sudden network errors)

If this works well, I think we should consider using psycopg everywhere, we had other mystery network errors before, and more performance doesn't hurt. I didn't realize we already had psycopg as a dependency anyway.

Replaces: https://github.com/MaterializeInc/materialize/pull/29573

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
