### PR TITLE
environmentd: allow panicking on failed 0dt deployment

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -72,6 +72,7 @@ def get_default_system_parameters(
         "compute_hydration_concurrency": "2",
         "disk_cluster_replicas_default": "true",
         "enable_0dt_deployment": "true" if zero_downtime else "false",
+        "enable_0dt_deployment_panic_after_timeout": "true",
         "enable_alter_swap": "true",
         "enable_assert_not_null": "true",
         "enable_columnation_lgalloc": "true",
@@ -132,7 +133,7 @@ def get_default_system_parameters(
         "storage_use_reclock_v2": "true",
         "timestamp_oracle": "postgres",
         "wait_catalog_consolidation_on_startup": "true",
-        "with_0dt_deployment_max_wait": "100d",  # forever, time out and fail test!
+        "with_0dt_deployment_max_wait": "300s",
         # End of list (ordered by name)
     }
 

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -32,6 +32,12 @@ pub const WITH_0DT_DEPLOYMENT_MAX_WAIT: Config<Duration> = Config::new(
     "How long to wait at most for clusters to be hydrated, when doing a zero-downtime deployment.",
 );
 
+pub const ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT: Config<bool> = Config::new(
+    "enable_0dt_deployment_panic_after_timeout",
+    false,
+    "Whether to panic if the maximum wait time is reached but preflight checks have not succeeded.",
+);
+
 pub const WITH_0DT_DEPLOYMENT_HYDRATION_CHECK_INTERVAL: Config<Duration> = Config::new(
     "0dt_deployment_hydration_check_interval",
     Duration::from_secs(10),
@@ -90,6 +96,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ALLOW_USER_SESSIONS)
         .add(&ENABLE_0DT_DEPLOYMENT)
         .add(&WITH_0DT_DEPLOYMENT_MAX_WAIT)
+        .add(&ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT)
         .add(&WITH_0DT_DEPLOYMENT_HYDRATION_CHECK_INTERVAL)
         .add(&ENABLE_0DT_CAUGHT_UP_CHECK)
         .add(&WITH_0DT_CAUGHT_UP_CHECK_ALLOWED_LAG)

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -14,7 +14,9 @@ use std::time::Duration;
 
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::connection::ConnectionId;
-use mz_adapter_types::dyncfgs::{ENABLE_0DT_DEPLOYMENT, WITH_0DT_DEPLOYMENT_MAX_WAIT};
+use mz_adapter_types::dyncfgs::{
+    ENABLE_0DT_DEPLOYMENT, ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT, WITH_0DT_DEPLOYMENT_MAX_WAIT,
+};
 use mz_audit_log::{
     CreateOrDropClusterReplicaReasonV1, EventDetails, EventType, IdFullNameV1, IdNameV1,
     ObjectType, SchedulingDecisionsWithReasonsV1, VersionedEvent,
@@ -1974,6 +1976,10 @@ impl Catalog {
                         Duration::parse(VarInput::Flat(&parsed_value))
                             .expect("parsing succeeded above");
                     tx.set_0dt_deployment_max_wait(with_0dt_deployment_max_wait)?;
+                } else if name == ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT.name() {
+                    let panic_after_timeout =
+                        strconv::parse_bool(&parsed_value).expect("parsing succeeded above");
+                    tx.set_enable_0dt_deployment_panic_after_timeout(panic_after_timeout)?;
                 }
 
                 CatalogState::add_to_audit_log(

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -157,6 +157,16 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// LaunchDarkly is available.
     async fn get_0dt_deployment_max_wait(&mut self) -> Result<Option<Duration>, CatalogError>;
 
+    /// Get the `enable_0dt_deployment_panic_after_timeout` config value of this
+    /// instance.
+    ///
+    /// This mirrors the `enable_0dt_deployment_panic_after_timeout` "system var"
+    /// so that we can toggle the flag with LaunchDarkly, but use it in boot
+    /// before LaunchDarkly is available.
+    async fn get_enable_0dt_deployment_panic_after_timeout(
+        &mut self,
+    ) -> Result<Option<bool>, CatalogError>;
+
     /// Reports if the remote configuration was synchronized at least once.
     async fn has_system_config_synced_once(&mut self) -> Result<bool, DurableCatalogError>;
 

--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -68,6 +68,13 @@ pub(crate) const ENABLE_0DT_DEPLOYMENT: &str = "enable_0dt_deployment";
 /// NOTE: Weird prefix because we can't start with a `0`.
 pub(crate) const WITH_0DT_DEPLOYMENT_MAX_WAIT: &str = "with_0dt_deployment_max_wait";
 
+/// The key used within the "config" collection where we store a mirror of the
+/// `enable_0dt_deployment_panic_after_timeout` "system var" value. This is
+/// mirrored so that we can toggle the flag with LaunchDarkly, but use it in
+/// boot before LaunchDarkly is available.
+pub(crate) const ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT: &str =
+    "enable_0dt_deployment_panic_after_timeout";
+
 const USER_ID_ALLOC_KEY: &str = "user";
 const SYSTEM_ID_ALLOC_KEY: &str = "system";
 

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -37,7 +37,8 @@ use mz_storage_types::controller::StorageError;
 
 use crate::builtin::BuiltinLog;
 use crate::durable::initialize::{
-    ENABLE_0DT_DEPLOYMENT, SYSTEM_CONFIG_SYNCED_KEY, WITH_0DT_DEPLOYMENT_MAX_WAIT,
+    ENABLE_0DT_DEPLOYMENT, ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT, SYSTEM_CONFIG_SYNCED_KEY,
+    WITH_0DT_DEPLOYMENT_MAX_WAIT,
 };
 use crate::durable::objects::serialization::proto;
 use crate::durable::objects::{
@@ -1616,6 +1617,21 @@ impl<'a> Transaction<'a> {
         )
     }
 
+    /// Updates the catalog `0dt_deployment_panic_after_timeout` "config" value to
+    /// match the `0dt_deployment_panic_after_timeout` "system var" value.
+    ///
+    /// These are mirrored so that we can toggle the flag with Launch Darkly,
+    /// but use it in boot before Launch Darkly is available.
+    pub fn set_enable_0dt_deployment_panic_after_timeout(
+        &mut self,
+        value: bool,
+    ) -> Result<(), CatalogError> {
+        self.set_config(
+            ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT.into(),
+            Some(u64::from(value)),
+        )
+    }
+
     /// Removes the catalog `enable_0dt_deployment` "config" value to
     /// match the `enable_0dt_deployment` "system var" value.
     ///
@@ -1632,6 +1648,16 @@ impl<'a> Transaction<'a> {
     /// but use it in boot before LaunchDarkly is available.
     pub fn reset_0dt_deployment_max_wait(&mut self) -> Result<(), CatalogError> {
         self.set_config(WITH_0DT_DEPLOYMENT_MAX_WAIT.into(), None)
+    }
+
+    /// Removes the catalog `enable_0dt_deployment_panic_after_timeout` "config"
+    /// value to match the `enable_0dt_deployment_panic_after_timeout` "system
+    /// var" value.
+    ///
+    /// These are mirrored so that we can toggle the flag with LaunchDarkly, but
+    /// use it in boot before LaunchDarkly is available.
+    pub fn reset_enable_0dt_deployment_panic_after_timeout(&mut self) -> Result<(), CatalogError> {
+        self.set_config(ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT.into(), None)
     }
 
     /// Updates the catalog `system_config_synced` "config" value to true.

--- a/src/environmentd/src/deployment/preflight.rs
+++ b/src/environmentd/src/deployment/preflight.rs
@@ -36,6 +36,7 @@ pub struct PreflightInput {
     pub openable_adapter_storage: Box<dyn OpenableDurableCatalogState>,
     pub catalog_metrics: Arc<Metrics>,
     pub hydration_max_wait: Duration,
+    pub panic_after_timeout: bool,
 }
 
 /// Output of preflight checks.
@@ -58,6 +59,7 @@ pub async fn preflight_legacy(
         mut openable_adapter_storage,
         catalog_metrics,
         hydration_max_wait: _,
+        panic_after_timeout: _,
     }: PreflightInput,
 ) -> Result<Box<dyn OpenableDurableCatalogState>, CatalogError> {
     tracing::info!("Requested deploy generation {deploy_generation}");
@@ -141,6 +143,7 @@ pub async fn preflight_0dt(
         mut openable_adapter_storage,
         catalog_metrics,
         hydration_max_wait,
+        panic_after_timeout,
     }: PreflightInput,
 ) -> Result<PreflightOutput, CatalogError> {
     info!(%deploy_generation, ?hydration_max_wait, "performing 0dt preflight checks");
@@ -175,6 +178,9 @@ pub async fn preflight_0dt(
                     info!("all clusters hydrated");
                 }
                 () = hydration_max_wait_fut => {
+                    if panic_after_timeout {
+                        panic!("not all clusters hydrated within {:?}", hydration_max_wait);
+                    }
                     info!("not all clusters hydrated within {:?}, proceeding now", hydration_max_wait);
                 }
             }


### PR DESCRIPTION
Add a feature flag, `0dt_deployment_panic_after_timeout`, that causes environmentd to panic if the 0dt maximum wait time is reached and preflight checks have not succeeded.

This will be enabled in 0dt tests, to make the cause of test failures more obvious.

Fix #29328.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
