### PR TITLE
test-analytics: Add qa group, grant it ownership of all tables and views

### DIFF
--- a/misc/python/materialize/test_analytics/setup/tables/00-config.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/00-config.sql
@@ -26,4 +26,7 @@ VALUES
     FALSE
 );
 
+CREATE ROLE qa;
+GRANT qa TO "dennis.felsing@materialize.com", "rainer@materialize.com";
+ALTER TABLE config OWNER TO qa;
 GRANT SELECT ON TABLE config TO "hetzner-ci";

--- a/misc/python/materialize/test_analytics/setup/tables/01-build.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/01-build.sql
@@ -22,4 +22,5 @@ CREATE TABLE build (
 
 CREATE INDEX IN CLUSTER test_analytics ON build (build_id);
 
+ALTER TABLE build OWNER TO qa;
 GRANT SELECT, INSERT, UPDATE ON TABLE build TO "hetzner-ci";

--- a/misc/python/materialize/test_analytics/setup/tables/02-build-job.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/02-build-job.sql
@@ -25,4 +25,5 @@ CREATE TABLE build_job (
     agent_type TEXT -- will eventually be changed to not null
 );
 
+ALTER TABLE build_job OWNER TO qa;
 GRANT SELECT, INSERT, UPDATE ON TABLE build_job TO "hetzner-ci";

--- a/misc/python/materialize/test_analytics/setup/tables/10-feature-benchmark.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/10-feature-benchmark.sql
@@ -42,5 +42,7 @@ CREATE TABLE feature_benchmark_discarded_result (
    wallclock_variance DOUBLE
 );
 
+ALTER TABLE feature_benchmark_result OWNER TO qa;
+ALTER TABLE feature_benchmark_discarded_result OWNER TO qa;
 GRANT SELECT, INSERT, UPDATE ON TABLE feature_benchmark_result TO "hetzner-ci";
 GRANT SELECT, INSERT, UPDATE ON TABLE feature_benchmark_discarded_result TO "hetzner-ci";

--- a/misc/python/materialize/test_analytics/setup/tables/11-scalability-framework.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/11-scalability-framework.sql
@@ -20,4 +20,5 @@ CREATE TABLE scalability_framework_result (
    tps DOUBLE
 );
 
+ALTER TABLE scalability_framework_result OWNER TO qa;
 GRANT SELECT, INSERT, UPDATE ON TABLE scalability_framework_result TO "hetzner-ci";

--- a/misc/python/materialize/test_analytics/setup/tables/12-parallel-benchmark.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/12-parallel-benchmark.sql
@@ -34,4 +34,5 @@ CREATE TABLE parallel_benchmark_result (
    slope DOUBLE NOT NULL
 );
 
+ALTER TABLE parallel_benchmark_result OWNER TO qa;
 GRANT SELECT, INSERT, UPDATE ON TABLE parallel_benchmark_result TO "hetzner-ci";

--- a/misc/python/materialize/test_analytics/setup/tables/20-build-annotation.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/20-build-annotation.sql
@@ -24,5 +24,7 @@ CREATE TABLE build_annotation_error (
    occurrence_count UINT4 NOT NULL
 );
 
+ALTER TABLE build_annotation OWNER TO qa;
+ALTER TABLE build_annotation_error OWNER TO qa;
 GRANT SELECT, INSERT, UPDATE ON TABLE build_annotation TO "hetzner-ci";
 GRANT SELECT, INSERT, UPDATE ON TABLE build_annotation_error TO "hetzner-ci";

--- a/misc/python/materialize/test_analytics/setup/tables/40-issues.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/40-issues.sql
@@ -14,4 +14,5 @@ CREATE TABLE issue (
     state TEXT NOT NULL
 );
 
+ALTER TABLE issue OWNER TO qa;
 GRANT SELECT, INSERT, UPDATE ON TABLE issue TO "hetzner-ci";

--- a/misc/python/materialize/test_analytics/setup/tables/50-output-consistency-stats.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/50-output-consistency-stats.sql
@@ -22,4 +22,5 @@ CREATE TABLE output_consistency_stats (
    count_used_ops UINT4 NOT NULL
 );
 
+ALTER TABLE output_consistency_stats OWNER TO qa;
 GRANT SELECT, INSERT, UPDATE ON TABLE output_consistency_stats TO "hetzner-ci";

--- a/misc/python/materialize/test_analytics/setup/views/01-build.sql
+++ b/misc/python/materialize/test_analytics/setup/views/01-build.sql
@@ -84,3 +84,9 @@ GROUP BY
     b.branch,
     b.build_id,
     b.build_number;
+
+ALTER VIEW v_count_builds_per_week OWNER TO qa;
+ALTER VIEW v_count_builds_per_mz_version OWNER TO qa;
+ALTER VIEW v_last_build_per_week OWNER TO qa;
+ALTER VIEW v_most_recent_build OWNER TO qa;
+ALTER VIEW v_build_success OWNER TO qa;

--- a/misc/python/materialize/test_analytics/setup/views/02-build-job.sql
+++ b/misc/python/materialize/test_analytics/setup/views/02-build-job.sql
@@ -108,4 +108,8 @@ SELECT * FROM (
 ) WHERE row_number <= 5
 ;
 
+ALTER VIEW v_successful_build_jobs OWNER TO qa;
+ALTER VIEW v_build_step_success OWNER TO qa;
+ALTER VIEW v_build_step_success_unsharded OWNER TO qa;
+ALTER MATERIALIZED VIEW mv_recent_build_job_success_on_main_v2 OWNER TO qa;
 GRANT SELECT ON TABLE mv_recent_build_job_success_on_main_v2 TO "hetzner-ci";

--- a/misc/python/materialize/test_analytics/setup/views/10-feature-benchmark.sql
+++ b/misc/python/materialize/test_analytics/setup/views/10-feature-benchmark.sql
@@ -136,3 +136,7 @@ CREATE OR REPLACE VIEW v_feature_benchmark_result_per_month AS
         res.scale,
         date_trunc('month', b.date)
 ;
+
+ALTER VIEW v_feature_benchmark_result_per_day OWNER TO qa;
+ALTER VIEW v_feature_benchmark_result_per_week OWNER TO qa;
+ALTER VIEW v_feature_benchmark_result_per_month OWNER TO qa;

--- a/misc/python/materialize/test_analytics/setup/views/100-data-integrity.sql
+++ b/misc/python/materialize/test_analytics/setup/views/100-data-integrity.sql
@@ -82,3 +82,5 @@ CREATE OR REPLACE VIEW v_data_integrity (table_name, own_item_key, referenced_it
     GROUP BY issue_id
     HAVING count(*) > 1
 ;
+
+ALTER VIEW v_data_integrity OWNER TO qa;

--- a/misc/python/materialize/test_analytics/setup/views/11-scalability-framework.sql
+++ b/misc/python/materialize/test_analytics/setup/views/11-scalability-framework.sql
@@ -116,3 +116,7 @@ CREATE OR REPLACE VIEW v_scalability_framework_result_per_month AS
         res.concurrency,
         date_trunc('month', b.date)
 ;
+
+ALTER VIEW v_scalability_framework_result_per_day OWNER TO qa;
+ALTER VIEW v_scalability_framework_result_per_week OWNER TO qa;
+ALTER VIEW v_scalability_framework_result_per_month OWNER TO qa;

--- a/misc/python/materialize/test_analytics/setup/views/20-build-annotation.sql
+++ b/misc/python/materialize/test_analytics/setup/views/20-build-annotation.sql
@@ -60,3 +60,6 @@ CREATE OR REPLACE VIEW v_build_annotation_overview AS
       bae.test_suite,
       bae.test_retry_count
 ;
+
+ALTER VIEW v_build_annotation_error OWNER TO qa;
+ALTER VIEW v_build_annotation_overview OWNER TO qa;

--- a/misc/python/materialize/test_analytics/setup/views/30-ci-failures.sql
+++ b/misc/python/materialize/test_analytics/setup/views/30-ci-failures.sql
@@ -45,4 +45,5 @@ IN CLUSTER test_analytics AS
 
 CREATE INDEX IN CLUSTER test_analytics ON mv_ci_failures (branch, build_date, issue);
 
+ALTER MATERIALIZED VIEW mv_ci_failures OWNER TO qa;
 GRANT SELECT ON mv_ci_failures TO "ci-failures";

--- a/misc/python/materialize/test_analytics/setup/views/31-ci-issues.sql
+++ b/misc/python/materialize/test_analytics/setup/views/31-ci-issues.sql
@@ -24,4 +24,5 @@ IN CLUSTER test_analytics AS
     JOIN issue AS i ON a.issue = i.issue_id
 ;
 
+ALTER MATERIALIZED VIEW mv_ci_issues OWNER TO qa;
 GRANT SELECT ON mv_ci_issues TO "ci-failures";

--- a/misc/python/materialize/test_analytics/setup/views/50-output-consistency-stats.sql
+++ b/misc/python/materialize/test_analytics/setup/views/50-output-consistency-stats.sql
@@ -18,3 +18,5 @@ INNER JOIN build_job bj
 ON ocs.build_job_id = bj.build_job_id
 INNER JOIN build b
 ON bj.build_id = b.build_id;
+
+ALTER VIEW v_output_consistency_stats OWNER TO qa;


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
