### PR TITLE
storage: support ingesting from yugabyte

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -454,6 +454,17 @@ steps:
         agents:
           queue: hetzner-aarch64-4cpu-8gb
 
+  - id: yugabyte-cdc
+    label: "Yugabyte CDC tests"
+    depends_on: build-aarch64
+    timeout_in_minutes: 30
+    inputs: [test/yugabyte-cdc]
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: yugabyte-cdc
+    agents:
+      queue: hetzner-aarch64-4cpu-8gb
+
   - group: "Connection tests"
     key: connection-tests
     steps:

--- a/misc/python/materialize/mzcompose/services/yugabyte.py
+++ b/misc/python/materialize/mzcompose/services/yugabyte.py
@@ -1,0 +1,65 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.mzcompose.service import (
+    Service,
+    ServiceConfig,
+)
+
+YUGABYTE_VERSION = "2.23.0.0-b710"
+
+
+class Yugabyte(Service):
+    def __init__(
+        self,
+        name: str = "yugabyte",
+        version: str = YUGABYTE_VERSION,
+        image: str | None = None,
+        ports: list[int] | None = None,
+    ) -> None:
+        if image is None:
+            image = f"yugabytedb/yugabyte:{version}"
+
+        if ports is None:
+            ports = [5433]
+
+        command_list = [
+            "bin/yugabyted",
+            "start",
+            "--background=false",
+            "--master_flags",
+            ",".join(
+                [
+                    "ysql_yb_enable_replication_commands=true",
+                    "ysql_cdc_active_replication_slot_window_ms=0",
+                    "allowed_preview_flags_csv={ysql_yb_enable_replication_commands}",
+                ]
+            ),
+            "--tserver_flags",
+            "ysql_pg_conf=wal_level=logical",
+        ]
+
+        config: ServiceConfig = {
+            "image": image,
+            "ports": ports,
+            "command": command_list,
+            "healthcheck": {
+                "test": [
+                    "CMD",
+                    "bash",
+                    "-c",
+                    '/home/yugabyte/bin/ysqlsh -h $(hostname) -p 5433 -U yugabyte -c "\\conninfo"',
+                ],
+                "interval": "1s",
+                "start_period": "30s",
+            },
+        }
+
+        super().__init__(name=name, config=config)

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -34,6 +34,7 @@ use mz_ore::now::to_datetime;
 use mz_ore::retry::Retry;
 use mz_ore::str::StrExt;
 use mz_ore::task;
+use mz_postgres_util::tunnel::PostgresFlavor;
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::catalog::{CatalogCluster, CatalogSchema};
@@ -697,10 +698,18 @@ impl Coordinator {
                                         )
                                     })?;
 
+                                // Yugabyte does not support waiting for the replication to become
+                                // inactive before dropping it. That is fine though because in that
+                                // case dropping will fail and we'll go around the retry loop which
+                                // is effectively the same as waiting 60 seconds.
+                                let should_wait = match connection.flavor {
+                                    PostgresFlavor::Vanilla => true,
+                                    PostgresFlavor::Yugabyte => false,
+                                };
                                 mz_postgres_util::drop_replication_slots(
                                     &ssh_tunnel_manager,
                                     config.clone(),
-                                    &[&replication_slot_name],
+                                    &[(&replication_slot_name, should_wait)],
                                 )
                                 .await?;
 

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -354,7 +354,7 @@ pub async fn run_fail_sql(
     cmd: FailSqlCommand,
     state: &State,
 ) -> Result<ControlFlow, anyhow::Error> {
-    use Statement::{AlterSink, Commit, Fetch, Rollback};
+    use Statement::{AlterSink, Commit, CreateConnection, Fetch, Rollback};
 
     let stmts = mz_sql_parser::parser::parse_statements(&cmd.query)
         .map_err(|e| format!("unable to parse SQL: {}: {}", cmd.query, e));
@@ -393,6 +393,7 @@ pub async fn run_fail_sql(
         // FETCH should not be retried because it consumes data on each response.
         Some(Fetch(_)) => false,
         Some(AlterSink(_)) => false,
+        Some(CreateConnection(_)) => false,
         Some(_) => true,
     };
 

--- a/test/yugabyte-cdc/mzcompose
+++ b/test/yugabyte-cdc/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/yugabyte-cdc/mzcompose.py
+++ b/test/yugabyte-cdc/mzcompose.py
@@ -1,0 +1,40 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""
+Native Yugabyte source tests, functional.
+"""
+
+import random
+
+from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.testdrive import Testdrive
+from materialize.mzcompose.services.yugabyte import Yugabyte
+
+SERVICES = [
+    Yugabyte(),
+    Materialized(),
+    Testdrive(),
+]
+
+
+#
+# Test that Yugabyte ingestion works
+#
+def workflow_default(c: Composition) -> None:
+    c.up("yugabyte", "materialized")
+    seed = random.getrandbits(16)
+    c.run_testdrive_files(
+        "--no-reset",
+        "--max-errors=1",
+        f"--seed={seed}",
+        f"--var=default-replica-size={Materialized.Size.DEFAULT_SIZE}-{Materialized.Size.DEFAULT_SIZE}",
+        "yugabyte-cdc.td",
+    )

--- a/test/yugabyte-cdc/yugabyte-cdc.td
+++ b/test/yugabyte-cdc/yugabyte-cdc.td
@@ -1,0 +1,699 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_yugabyte_connection = true;
+
+> CREATE SECRET pgpass AS 'yugabyte'
+
+> CREATE CONNECTION yb TO YUGABYTE (
+    HOST yugabyte,
+    PORT 5433,
+    DATABASE yugabyte,
+    USER yugabyte,
+    PASSWORD SECRET pgpass
+  )
+
+> CREATE CLUSTER cdc_cluster SIZE '${arg.default-replica-size}'
+
+$ postgres-execute connection=postgres://yugabyte:yugabyte@yugabyte:5433/yugabyte
+ALTER USER yugabyte WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+CREATE TABLE pk_table (pk INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO pk_table VALUES (1, 'one');
+ALTER TABLE pk_table REPLICA IDENTITY FULL;
+INSERT INTO pk_table VALUES (2, 'two');
+INSERT INTO pk_table VALUES (3, 'three');
+
+CREATE TABLE types_table (pk INTEGER PRIMARY KEY, char_col char(3), date_col DATE, time_col TIME, timestamp_col TIMESTAMP, uuid_col UUID, double_col DOUBLE PRECISION, numeric NUMERIC(8,4), int4range_col INT4RANGE, int8range_col INT8RANGE, daterange_col DATERANGE, numrange_col NUMRANGE);
+INSERT INTO types_table VALUES (1, 'foo', '2011-11-11', '11:11:11', '2011-11-11 11:11:11', 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11', 1234.56768, 1234.5678, '(,)', '(,)', '(,)', '(,)');
+ALTER TABLE types_table REPLICA IDENTITY FULL;
+
+CREATE TABLE array_types_table (pk INTEGER PRIMARY KEY, date_col DATE[], time_col TIME[], timestamp_col TIMESTAMP[], uuid_col UUID[], double_col DOUBLE PRECISION[], numeric NUMERIC[], int4range_col INT4RANGE[], int8range_col INT8RANGE[], daterange_col DATERANGE[], numrange_col NUMRANGE[]);
+INSERT INTO array_types_table VALUES (1, '{2011-11-11}', '{11:11:11}', '{2011-11-11 11:11:11}', '{A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11}', '{1234.56768}', '{1234.5678}', '{"(,)"}', '{"(,)"}', '{"(,)"}', '{"(,)"}');
+ALTER TABLE array_types_table REPLICA IDENTITY FULL;
+
+CREATE TABLE large_text (pk INTEGER PRIMARY KEY, f1 TEXT, f2 TEXT);
+INSERT INTO large_text VALUES (1, REPEAT('x', 16 * 1024 * 1024), REPEAT('y', 1 * 1024 * 1024));
+INSERT INTO large_text VALUES (2, REPEAT('a', 3 * 1024 * 1024),  REPEAT('b', 2 * 1024 * 1024));
+ALTER TABLE large_text REPLICA IDENTITY FULL;
+
+CREATE TABLE trailing_space_pk (f1 TEXT PRIMARY KEY);
+INSERT INTO trailing_space_pk VALUES ('abc   ');
+ALTER TABLE trailing_space_pk REPLICA IDENTITY FULL;
+
+CREATE TABLE multipart_pk(f1 INTEGER, f2 TEXT, f3 TEXT, PRIMARY KEY (f1, f2));
+INSERT INTO multipart_pk VALUES (1, 'abc', 'xyz');
+ALTER TABLE multipart_pk REPLICA IDENTITY FULL;
+
+CREATE TABLE nulls_table (pk INTEGER PRIMARY KEY, f2 TEXT, f3 INTEGER);
+INSERT INTO nulls_table VALUES (1, NULL, NULL);
+ALTER TABLE nulls_table REPLICA IDENTITY FULL;
+
+CREATE TABLE utf8_table (f1 TEXT PRIMARY KEY, f2 TEXT);
+INSERT INTO utf8_table VALUES ('това е текст', 'това ''е'' "текст"');
+ALTER TABLE utf8_table REPLICA IDENTITY FULL;
+
+CREATE TABLE "таблица" ("колона" TEXT PRIMARY KEY);
+ALTER TABLE "таблица" REPLICA IDENTITY FULL;
+INSERT INTO "таблица" VALUES ('стойност');
+
+CREATE TABLE tstzrange_table (pk INTEGER PRIMARY KEY, a TSTZRANGE);
+ALTER TABLE tstzrange_table REPLICA IDENTITY FULL;
+INSERT INTO tstzrange_table VALUES (1, '["2024-02-13 17:01:58.37848+00!?!",)');
+
+CREATE TABLE """literal_quotes""" (a TEXT PRIMARY KEY);
+ALTER TABLE """literal_quotes""" REPLICA IDENTITY FULL;
+INSERT INTO """literal_quotes""" VALUES ('v');
+ALTER TABLE """literal_quotes""" REPLICA IDENTITY FULL;
+
+CREATE TABLE "create" (a TEXT PRIMARY KEY);
+ALTER TABLE "create" REPLICA IDENTITY FULL;
+INSERT INTO "create" VALUES ('v');
+
+CREATE TABLE escaped_text_table (pk INTEGER PRIMARY KEY, f1 TEXT, f2 TEXt);
+ALTER TABLE escaped_text_table REPLICA IDENTITY FULL;
+INSERT INTO escaped_text_table VALUES (1, 'escaped\ntext\twith\nnewlines\tand\ntabs', 'more\tescaped\ntext');
+INSERT INTO escaped_text_table VALUES (2, 'second\nrow\twith\tmore\ttabs', 'and\nmore\n\nnewlines\n');
+
+CREATE TABLE conflict_table (f1 INTEGER PRIMARY KEY);
+ALTER TABLE conflict_table REPLICA IDENTITY FULL;
+INSERT INTO conflict_table VALUES (123);
+
+DROP SCHEMA IF EXISTS conflict_schema CASCADE;
+CREATE SCHEMA conflict_schema;
+CREATE TABLE conflict_schema.conflict_table (f1 TEXT PRIMARY KEY);
+ALTER TABLE conflict_schema.conflict_table REPLICA IDENTITY FULL;
+INSERT INTO conflict_schema.conflict_table VALUES ('234');
+
+CREATE TABLE "space table" ("space column" INTEGER PRIMARY KEY);
+ALTER TABLE "space table" REPLICA IDENTITY FULL;
+
+CREATE TYPE an_enum AS ENUM ('var0', 'var1');
+CREATE TABLE enum_table (pk INTEGER PRIMARY KEY, a an_enum);
+INSERT INTO enum_table VALUES (1, 'var0'), (2, 'var1');
+ALTER TABLE enum_table REPLICA IDENTITY FULL;
+
+CREATE TYPE another_enum AS ENUM ('var2', 'var3');
+CREATE TABLE another_enum_table (pk INTEGER PRIMARY KEY, "колона" another_enum);
+INSERT INTO another_enum_table VALUES (1, 'var2'), (2, 'var3');
+ALTER TABLE another_enum_table REPLICA IDENTITY FULL;
+
+CREATE TABLE conflict_schema.another_enum_table (pk INTEGER PRIMARY KEY, "колона" another_enum);
+INSERT INTO conflict_schema.another_enum_table VALUES (1, 'var2'), (2, 'var3');
+ALTER TABLE conflict_schema.another_enum_table REPLICA IDENTITY FULL;
+
+DROP PUBLICATION IF EXISTS mz_source_narrow;
+
+CREATE PUBLICATION mz_source_narrow FOR TABLE enum_table, public.another_enum_table, pk_table;
+
+DROP SCHEMA IF EXISTS another_schema CASCADE;
+CREATE SCHEMA another_schema;
+CREATE TABLE another_schema.another_table (f1 TEXT PRIMARY KEY);
+ALTER TABLE another_schema.another_table REPLICA IDENTITY FULL;
+INSERT INTO another_schema.another_table VALUES ('123');
+
+DROP PUBLICATION IF EXISTS another_publication;
+
+CREATE PUBLICATION another_publication FOR TABLE another_schema.another_table;
+
+#
+# Error checking
+#
+
+! CREATE CONNECTION no_such_host TO YUGABYTE (
+    HOST 'no_such_postgres.mtrlz.com',
+    PORT 5433,
+    DATABASE yugabyte,
+    USER yugabyte,
+    PASSWORD SECRET pgpass
+  )
+contains:failed to lookup address information
+
+! CREATE CONNECTION no_such_port TO YUGABYTE (
+    HOST yugabyte,
+    PORT 65534,
+    DATABASE yugabyte,
+    USER yugabyte,
+    PASSWORD SECRET pgpass
+  )
+contains:error connecting to server: Connection refused
+
+! CREATE CONNECTION no_such_user TO YUGABYTE (
+    HOST yugabyte,
+    PORT 5433,
+    DATABASE yugabyte,
+    USER no_such_user,
+    PASSWORD SECRET pgpass
+  )
+contains:role "no_such_user" does not exist
+
+! CREATE CONNECTION no_such_dbname TO YUGABYTE (
+    HOST yugabyte,
+    PORT 5433,
+    DATABASE no_such_dbname,
+    USER yugabyte,
+    PASSWORD SECRET pgpass
+  )
+contains:database "no_such_dbname" does not exist
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET storage_enforce_external_addresses = true
+
+! CREATE CONNECTION private_address TO YUGABYTE (
+    HOST yugabyte,
+    PORT 5433,
+    DATABASE yugabyte,
+    USER yugabyte,
+    PASSWORD SECRET pgpass
+  )
+contains:Address resolved to a private IP
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET storage_enforce_external_addresses = false
+
+! CREATE SOURCE "no_such_publication"
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (PUBLICATION 'no_such_publication');
+# TODO: assert on `detail` here.
+contains:failed to connect to PostgreSQL database
+
+! CREATE SOURCE "mz_source"
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (PUBLICATION 'mz_source')
+  FOR TABLES (
+    "enum_table"
+  );
+contains:referenced tables use unsupported types
+
+! CREATE SOURCE "mz_source"
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (PUBLICATION 'mz_source')
+  FOR TABLES (
+    "enum_table",
+    public.another_enum_table
+  );
+contains:referenced tables use unsupported types
+
+! CREATE SOURCE mz_source
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (
+    PUBLICATION 'mz_source',
+    DETAILS 'abc'
+  )
+  FOR TABLES (
+    pk_table
+  );
+contains: CREATE SOURCE specifies DETAILS option
+
+#
+# Establish direct replication
+#
+#
+# Note: This implicitly tests that enum_table being part of the publication does not
+# prevent us from using other tables as subsources.
+#
+> CREATE SOURCE "mz_source"
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (PUBLICATION 'mz_source')
+  FOR TABLES (
+    "pk_table",
+    "types_table",
+    "array_types_table",
+    "large_text",
+    "trailing_space_pk",
+    "multipart_pk",
+    "nulls_table",
+    "utf8_table",
+    "таблица",
+    "escaped_text_table",
+    conflict_schema.conflict_table AS public.conflict_table,
+    "space table",
+    """literal_quotes""",
+    "create",
+    tstzrange_table
+  );
+
+> SHOW SOURCES
+array_types_table     subsource  cdc_cluster  ""
+conflict_table        subsource  cdc_cluster  ""
+create                subsource  cdc_cluster  ""
+escaped_text_table    subsource  cdc_cluster  ""
+large_text            subsource  cdc_cluster  ""
+multipart_pk          subsource  cdc_cluster  ""
+mz_source             postgres   cdc_cluster  ""
+mz_source_progress    progress   <null>       ""
+nulls_table           subsource  cdc_cluster  ""
+pk_table              subsource  cdc_cluster  ""
+"space table"         subsource  cdc_cluster  ""
+trailing_space_pk     subsource  cdc_cluster  ""
+"\"literal_quotes\""  subsource  cdc_cluster  ""
+tstzrange_table       subsource  cdc_cluster  ""
+types_table           subsource  cdc_cluster  ""
+utf8_table            subsource  cdc_cluster  ""
+таблица               subsource  cdc_cluster  ""
+
+> SELECT schema_name, table_name FROM mz_internal.mz_postgres_source_tables
+public          create
+public          pk_table
+public          large_text
+public          utf8_table
+public          types_table
+public          nulls_table
+public          multipart_pk
+public          "\"space table\""
+public          tstzrange_table
+public          "\"таблица\""
+public          array_types_table
+public          trailing_space_pk
+public          escaped_text_table
+public          "\"\"\"literal_quotes\"\"\""
+conflict_schema conflict_table
+
+# Ensure all ingestion export subsources have an ID greater than the primary source ID
+> SELECT bool_and(primary_source_id < subsource_id)
+  FROM
+      (SELECT id AS primary_source_id FROM mz_sources WHERE type = 'postgres')
+          CROSS JOIN (SELECT id AS subsource_id FROM mz_sources WHERE type = 'subsource');
+true
+
+# Ensure progress subsources have an ID less than the primary source ID
+> SELECT progress_source_id < primary_source_id
+    FROM (
+        SELECT
+            (SELECT id FROM mz_sources WHERE type = 'postgres') AS primary_source_id,
+            (SELECT id FROM mz_sources WHERE type = 'progress') AS progress_source_id
+    );
+true
+
+> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
+running
+
+> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mz_source_progress';
+running
+
+> SELECT lsn > 0 FROM mz_source_progress
+true
+
+# Ensure we report the write frontier of the progress subsource
+$ set-regex match=(\s{12}0|\d{13,20}|u\d{1,5}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d\.\d\d\d\)|true|false) replacement=<>
+> EXPLAIN TIMESTAMP FOR SELECT * FROM mz_source_progress
+"                query timestamp: <> <>\n          oracle read timestamp: <> <>\nlargest not in advance of upper: <> <>\n                          upper:[<> <>]\n                          since:[<> <>]\n        can respond immediately: <>\n                       timeline: Some(EpochMilliseconds)\n              session wall time: <> <>\n\nsource materialize.public.mz_source_progress (<>, storage):\n                  read frontier:[<> <>]\n                 write frontier:[<> <>]\n"
+
+$ set-regex match=[0-9]+|_[a-f0-9]+ replacement=<SUPPRESSED>
+
+> SELECT * FROM mz_internal.mz_postgres_sources
+id             replication_slot         timeline_id
+---------------------------------------------------
+u<SUPPRESSED>  materialize<SUPPRESSED>  <SUPPRESSED>
+
+$ unset-regex
+
+#
+# Perform sanity checks of the initial snapshot
+#
+
+> SELECT * FROM pk_table;
+1 one
+2 two
+3 three
+
+> SELECT * FROM types_table;
+1 "foo" "2011-11-11" "11:11:11" "2011-11-11 11:11:11" "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11" "1234.56768" "1234.5678" "(,)" "(,)" "(,)" "(,)"
+
+> SELECT pg_typeof(numeric) FROM types_table;
+"numeric"
+
+> SELECT * FROM array_types_table;
+1 "{2011-11-11}" "{11:11:11}" "{2011-11-11 11:11:11}" "{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}" "{1234.56768}" "{1234.5678}" "{(,)}" "{(,)}" "{(,)}" "{(,)}"
+
+> SELECT LENGTH(f1), LENGTH(f2) FROM large_text;
+16777216 1048576
+3145728  2097152
+
+> SELECT LENGTH(f1), f1 FROM trailing_space_pk;
+"6" "abc   "
+
+> SELECT * FROM multipart_pk;
+1 abc xyz
+
+> SELECT f2, f3, f2 IS NULL, f3 IS NULL FROM nulls_table;
+<null> <null> true true
+
+> SELECT * FROM utf8_table;
+"това е текст" "това \'е\' \"текст\""
+
+> SELECT * FROM "таблица";
+стойност
+
+> SELECT * FROM escaped_text_table;
+1 "escaped\\ntext\\twith\\nnewlines\\tand\\ntabs" "more\\tescaped\\ntext"
+2 "second\\nrow\\twith\\tmore\\ttabs" "and\\nmore\\n\\nnewlines\\n"
+
+> SELECT * FROM conflict_table;
+234
+
+> SELECT * FROM """literal_quotes"""
+v
+
+> SELECT * FROM "create"
+v
+
+> SELECT * FROM tstzrange_table
+1 "[2024-02-13 17:01:58.378480 UTC,)"
+
+#
+# Basic sanity check that the timestamps are reasonable
+#
+
+> SELECT COUNT(*) > 0 FROM pk_table;
+true
+
+#
+# Modify the tables on the Yugabyte side
+#
+
+$ postgres-execute connection=postgres://yugabyte:yugabyte@yugabyte:5433/yugabyte
+INSERT INTO pk_table VALUES (4, 'four');
+INSERT INTO pk_table VALUES (5, 'five');
+DELETE FROM pk_table WHERE pk = 1;
+UPDATE pk_table SET f2 = 'two_two' WHERE pk = 2;
+UPDATE pk_table SET pk = pk + 10 WHERE pk BETWEEN 3 AND 4;
+
+INSERT INTO types_table VALUES (2, 'foo', '2011-11-11', '11:11:11', '2011-11-11 11:11:11', 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11', 1234.56768, 1234.5678, 'empty', 'empty', 'empty', 'empty');
+
+INSERT INTO array_types_table VALUES (2, '{2011-11-11}', '{11:11:11}', '{2011-11-11 11:11:11}', '{A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11}', '{1234.56768}', '{1234.5678}', '{"(,)"}', '{"(,)"}', '{"(,)"}', '{"(,)"}');
+
+INSERT INTO large_text VALUES (3, REPEAT('x', 16 * 1024 * 1024), 'abc');
+
+INSERT INTO trailing_space_pk VALUES ('klm   ');
+UPDATE trailing_space_pk SET f1 = 'xyz   ' WHERE f1 = 'klm   ';
+DELETE FROM trailing_space_pk WHERE f1 = 'abc   ';
+
+INSERT INTO multipart_pk VALUES (2, 'klm', 'xyz');
+DELETE FROM multipart_pk WHERE f1 = 1;
+
+UPDATE nulls_table SET f3 = 3 WHERE f3 IS NULL;
+INSERT INTO nulls_table VALUES (2, NULL, 1), (3, NULL, 2);
+UPDATE nulls_table SET f3 = NULL WHERE f3 = 2;
+
+INSERT INTO utf8_table VALUES ('това е текст 2', 'това ''е'' "текст" 2');
+UPDATE utf8_table SET f1 = f1 || f1 , f2 = f2 || f2;
+
+INSERT INTO "таблица" VALUES ('наздраве');
+
+#
+# Check the updated data on the Materialize side
+#
+
+> SELECT * FROM pk_table;
+13 three
+14 four
+2 two_two
+5 five
+
+> SELECT * FROM types_table;
+1 "foo" "2011-11-11" "11:11:11" "2011-11-11 11:11:11" "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11" "1234.56768" "1234.5678" "(,)" "(,)" "(,)" "(,)"
+2 "foo" "2011-11-11" "11:11:11" "2011-11-11 11:11:11" "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11" "1234.56768" "1234.5678" "empty" "empty" "empty" "empty"
+
+> SELECT * FROM array_types_table;
+1 "{2011-11-11}" "{11:11:11}" "{2011-11-11 11:11:11}" "{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}" "{1234.56768}" "{1234.5678}" "{(,)}" "{(,)}" "{(,)}" "{(,)}"
+2 "{2011-11-11}" "{11:11:11}" "{2011-11-11 11:11:11}" "{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}" "{1234.56768}" "{1234.5678}" "{(,)}" "{(,)}" "{(,)}" "{(,)}"
+
+> SELECT LENGTH(f1), LENGTH(f2) FROM large_text;
+16777216 1048576
+3145728  2097152
+16777216 3
+
+> SELECT LENGTH(f1), f1 FROM trailing_space_pk;
+"6" "xyz   "
+
+> SELECT * FROM multipart_pk;
+"2" "klm" "xyz"
+
+> SELECT f2, f3, f2 IS NULL, f3 IS NULL FROM nulls_table;
+"<null>" "1" "true" "false"
+"<null>" "3" "true" "false"
+"<null>" "<null>" "true" "true"
+
+> SELECT * FROM utf8_table;
+"това е текст 2това е текст 2" "това \'е\' \"текст\" 2това \'е\' \"текст\" 2"
+"това е тексттова е текст" "това \'е\' \"текст\"това \'е\' \"текст\""
+
+> SELECT * FROM "таблица";
+стойност
+наздраве
+
+#
+# Check that the timestamps continue to be reasonable in the face of incoming updates
+#
+
+> SELECT COUNT(*) > 0 FROM pk_table;
+true
+
+#
+# Ensure we can start a source with more workers than the default max_wal_senders param (10)
+#
+
+> CREATE CLUSTER large_cluster SIZE '16';
+
+> CREATE SOURCE large_cluster_source
+  IN CLUSTER large_cluster
+  FROM YUGABYTE CONNECTION yb (PUBLICATION 'mz_source')
+  FOR TABLES ("pk_table" AS large_cluster_source_pk_table);
+
+> SELECT * FROM large_cluster_source_pk_table;
+13 three
+14 four
+2 two_two
+5 five
+
+> SELECT status = 'running' FROM mz_internal.mz_source_statuses WHERE name = 'large_cluster_source_pk_table';
+true
+
+> DROP SOURCE large_cluster_source CASCADE;
+
+#
+# Remove all data on the Yugabyte side
+#
+
+$ postgres-execute connection=postgres://yugabyte:yugabyte@yugabyte:5433/yugabyte
+DELETE FROM pk_table;
+DELETE FROM large_text;
+DELETE FROM trailing_space_pk;
+DELETE FROM multipart_pk;
+DELETE FROM nulls_table;
+DELETE FROM utf8_table;
+DELETE FROM "таблица";
+DELETE FROM conflict_schema.conflict_table;
+DELETE FROM tstzrange_table;
+
+#
+# Check that all data sources empty out on the Materialize side
+#
+
+> SELECT COUNT(*) FROM pk_table;
+0
+
+> SELECT COUNT(*) FROM large_text;
+0
+
+> SELECT COUNT(*) FROM trailing_space_pk;
+0
+
+> SELECT COUNT(*) FROM multipart_pk;
+0
+
+> SELECT COUNT(*) FROM nulls_table;
+0
+
+> SELECT COUNT(*) FROM utf8_table;
+0
+
+> SELECT COUNT(*) FROM "таблица";
+0
+
+> SELECT COUNT(*) FROM conflict_table;
+0
+
+> SELECT COUNT(*) FROM tstzrange_table;
+0
+
+#
+# Support enum values as strings
+#
+#
+! CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [pk_table.col_dne]
+  )
+  FOR TABLES (
+    "enum_table"
+  );
+contains: invalid TEXT COLUMNS option value: column "pk_table.col_dne" does not exist
+
+! CREATE SOURCE case_sensitive_names
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [pk_table."F2"]
+  )
+  FOR TABLES (
+    "enum_table"
+  );
+contains: invalid TEXT COLUMNS option value: column "pk_table.F2" does not exist
+hint: The similarly named column "pk_table.f2" does exist.
+
+! CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [table_dne.col_dne]
+  )
+  FOR TABLES (
+    "enum_table"
+  );
+contains: invalid TEXT COLUMNS option value: reference to table_dne not found in source
+
+# Reference exists in two schemas, so is not unambiguous
+! CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [another_enum_table."колона"]
+  )
+  FOR TABLES(
+    conflict_schema.another_enum_table AS conflict_enum,
+    public.another_enum_table AS public_enum
+  );
+contains: invalid TEXT COLUMNS option value: reference to another_enum_table is ambiguous, consider specifying an additional layer of qualification
+
+! CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [foo]
+  )
+  FOR TABLES (pk_table);
+contains: invalid TEXT COLUMNS option value: column name 'foo' must have at least a table qualification
+
+! CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [foo.bar.qux.qax.foo]
+  )
+  FOR TABLES (pk_table);
+contains: invalid TEXT COLUMNS option value: reference to foo.bar.qux.qax not found in source
+
+! CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [enum_table.a, enum_table.a]
+  )
+  FOR TABLES (enum_table);
+contains: invalid TEXT COLUMNS option value: unexpected multiple references to yugabyte.public.enum_table.a
+
+# utf8_table is not part of mz_source_narrow publication
+! CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (
+    PUBLICATION 'mz_source_narrow',
+    TEXT COLUMNS [enum_table.a, utf8_table.f1]
+  )
+  FOR TABLES (enum_table);
+contains: invalid TEXT COLUMNS option value: reference to utf8_table not found in source
+
+# n.b includes a reference to pk_table, which is not a table that's part of the
+# source, but is part of the publication.
+
+! CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [
+      enum_table.a,
+      public.another_enum_table."колона",
+      pk_table.pk
+    ]
+  )
+  FOR TABLES (
+    "enum_table",
+    public.another_enum_table
+  );
+contains:TEXT COLUMNS refers to table not currently being added
+
+> CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [
+      enum_table.a,
+      public.another_enum_table."колона"
+    ]
+  )
+  FOR TABLES (
+    "enum_table",
+    public.another_enum_table
+  );
+
+> SELECT * FROM (SHOW SOURCES) WHERE name LIKE '%enum%';
+another_enum_table      subsource cdc_cluster  ""
+enum_source             postgres  cdc_cluster  ""
+enum_source_progress    progress  <null>       ""
+enum_table              subsource cdc_cluster  ""
+
+> SELECT * FROM enum_table
+1 var0
+2 var1
+
+> SHOW CREATE SOURCE enum_table
+materialize.public.enum_table "CREATE SUBSOURCE \"materialize\".\"public\".\"enum_table\" (\"pk\" \"pg_catalog\".\"int4\" NOT NULL, \"a\" \"pg_catalog\".\"text\", CONSTRAINT \"enum_table_pkey\" PRIMARY KEY (\"pk\")) OF SOURCE \"materialize\".\"public\".\"enum_source\" WITH (EXTERNAL REFERENCE = \"yugabyte\".\"public\".\"enum_table\", TEXT COLUMNS = (\"a\"))"
+
+> SELECT "колона" FROM another_enum_table
+var2
+var3
+
+#
+# Cleanup
+#
+#
+
+> DROP SOURCE enum_source CASCADE;
+> DROP SOURCE "mz_source" CASCADE;
+
+#
+# Check schema scoped tables
+
+> CREATE SOURCE another_source
+  IN CLUSTER cdc_cluster
+  FROM YUGABYTE CONNECTION yb (
+    PUBLICATION 'another_publication'
+  )
+  FOR SCHEMAS (
+    another_schema
+  );
+
+> SHOW SOURCES
+another_source          postgres  cdc_cluster  ""
+another_source_progress progress  <null>       ""
+another_table           subsource cdc_cluster  ""
+
+> DROP SOURCE another_source CASCADE
+
+$ postgres-execute connection=postgres://yugabyte:yugabyte@yugabyte:5433/yugabyte
+DROP SCHEMA conflict_schema CASCADE;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR changes the way we snapshot tables in the postgres operator such that it uses the main replication slot for setting the transaction snapshot. Doing it this way means that we can successfully snapshot and replicate from Yugabyte since no temporary replications slots are created.

Beyond that this PR adjust a couple more parts to behave slightly differently when we talk to a Yugabyte source and also sets up an mzcompose functional test that goes over the most common patterns.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

The first commit contains the code changes and the second commit contains the tests

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
