### PR TITLE
adapter: extract an OptimizerCatalog trait

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -360,16 +360,6 @@ impl Catalog {
         }
         policies
     }
-
-    /// TODO(ct): This exists for continual tasks because they are the first
-    /// self-referential thing in mz. We use this to inject something for the
-    /// optimizer to resolve the CT's own id to before we've saved it to the
-    /// catalog. The one usage of this is careful to destroy this copy of
-    /// catalog immediately after. There are better ways to do this, but it was
-    /// the easiest path to get the skeleton of the feature merged.
-    pub fn hack_add_ct(&mut self, id: GlobalId, entry: CatalogEntry) {
-        self.state.entry_by_id.insert(id, entry);
-    }
 }
 
 #[derive(Debug)]

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2600,7 +2600,7 @@ impl Coordinator {
                     let (optimized_plan, global_lir_plan) = {
                         // Build an optimizer for this MATERIALIZED VIEW.
                         let mut optimizer = optimize::materialized_view::Optimizer::new(
-                            self.owned_catalog(),
+                            self.owned_catalog().as_optimizer_catalog(),
                             compute_instance.clone(),
                             entry.id(),
                             internal_view_id,

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -442,7 +442,7 @@ impl Coordinator {
 
         // Build an optimizer for this MATERIALIZED VIEW.
         let mut optimizer = optimize::materialized_view::Optimizer::new(
-            self.owned_catalog(),
+            self.owned_catalog().as_optimizer_catalog(),
             compute_instance,
             sink_id,
             view_id,

--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -45,7 +45,7 @@ use mz_transform::analysis::DerivedBuilder;
 
 use crate::catalog::CatalogState;
 use crate::coord::id_bundle::CollectionIdBundle;
-use crate::optimize::{view, Optimize, OptimizerConfig, OptimizerError};
+use crate::optimize::{view, Optimize, OptimizerCatalog, OptimizerConfig, OptimizerError};
 use crate::session::{SERVER_MAJOR_VERSION, SERVER_MINOR_VERSION};
 use crate::util::viewable_variables;
 
@@ -87,7 +87,7 @@ impl ComputeInstanceSnapshot {
 /// Borrows of catalog and indexes sufficient to build dataflow descriptions.
 #[derive(Debug)]
 pub struct DataflowBuilder<'a> {
-    pub catalog: &'a CatalogState,
+    pub catalog: &'a dyn OptimizerCatalog,
     /// A handle to the compute abstraction, which describes indexes by identifier.
     ///
     /// This can also be used to grab a handle to the storage abstraction, through
@@ -150,7 +150,7 @@ pub fn dataflow_import_id_bundle<P>(
 }
 
 impl<'a> DataflowBuilder<'a> {
-    pub fn new(catalog: &'a CatalogState, compute: ComputeInstanceSnapshot) -> Self {
+    pub fn new(catalog: &'a dyn OptimizerCatalog, compute: ComputeInstanceSnapshot) -> Self {
         Self {
             catalog,
             compute,

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -29,14 +29,13 @@ use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
 use mz_transform::TransformCtx;
 use timely::progress::Antichain;
 
-use crate::catalog::Catalog;
 use crate::optimize::dataflows::{
     dataflow_import_id_bundle, prep_relation_expr, prep_scalar_expr, ComputeInstanceSnapshot,
     DataflowBuilder, ExprPrepStyle,
 };
 use crate::optimize::{
     optimize_mir_local, trace_plan, LirDataflowDescription, MirDataflowDescription, Optimize,
-    OptimizeMode, OptimizerConfig, OptimizerError,
+    OptimizeMode, OptimizerCatalog, OptimizerConfig, OptimizerError,
 };
 use crate::CollectionIdBundle;
 
@@ -44,7 +43,7 @@ pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.
     typecheck_ctx: TypecheckContext,
     /// A snapshot of the catalog state.
-    catalog: Arc<Catalog>,
+    catalog: Arc<dyn OptimizerCatalog>,
     /// A snapshot of the cluster that will run the dataflows.
     compute_instance: ComputeInstanceSnapshot,
     /// A transient GlobalId to be used for the exported sink.
@@ -83,7 +82,7 @@ impl std::fmt::Debug for Optimizer {
 
 impl Optimizer {
     pub fn new(
-        catalog: Arc<Catalog>,
+        catalog: Arc<dyn OptimizerCatalog>,
         compute_instance: ComputeInstanceSnapshot,
         view_id: GlobalId,
         sink_id: GlobalId,
@@ -184,9 +183,8 @@ impl Optimize<SubscribeFrom> for Optimizer {
         let time = Instant::now();
 
         let mut df_builder = {
-            let catalog = self.catalog.state();
             let compute = self.compute_instance.clone();
-            DataflowBuilder::new(catalog, compute).with_config(&self.config)
+            DataflowBuilder::new(&*self.catalog, compute).with_config(&self.config)
         };
         let mut df_desc = MirDataflowDescription::new(self.debug_name.clone());
         let mut df_meta = DataflowMetainfo::default();
@@ -198,7 +196,6 @@ impl Optimize<SubscribeFrom> for Optimizer {
                     .desc(
                         &self
                             .catalog
-                            .state()
                             .resolve_full_name(from.name(), self.conn_id.as_ref()),
                     )
                     .expect("subscribes can only be run on items with descs")


### PR DESCRIPTION
This will help with continual tasks, which need to inject an entry for
the CT itself before it exists in the catalog, but also it gets us one
step closer to pulling the optimizer into its own crate.

I also switched over a few more `adapter::optimize::*::Optimizer`
structs, but had to leave a few because it gets tricky with
`ExprPrepStyle::OneShot` and `eval_unmaterializable_func`.

Touches MaterializeInc/database-issues#8427

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
