### PR TITLE
security: Ignore lexical-core advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -228,10 +228,10 @@ ignore = [
     "RUSTSEC-2021-0145",
     # Consider `encoding_rs` instead of `encoding` (unmaintained)
     "RUSTSEC-2021-0153",
-    # abomonation transmutes &T to and from &[u8] without sufficient constraints
-    "RUSTSEC-2021-0120",
     # proc-macro-error is unmaintained, possible alternative: proc-macro-error2
     "RUSTSEC-2024-0370",
+    # lexical-core: Multiple soundness issues, depends on arrow upgrading
+    "RUSTSEC-2023-0086",
 ]
 
 # Must be manually kept in sync with about.toml.


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2023-0086

Seen in https://buildkite.com/materialize/security/builds/1306#01920049-5920-416c-b917-7067acf48669

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
