### PR TITLE
persist: Always update opaque value on success

### DIFF
--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1378,9 +1378,9 @@ where
             )));
         }
 
+        reader_state.opaque = OpaqueState(Codec64::encode(new_opaque));
         if PartialOrder::less_equal(&reader_state.since, new_since) {
             reader_state.since.clone_from(new_since);
-            reader_state.opaque = OpaqueState(Codec64::encode(new_opaque));
             self.update_since();
             Continue(Ok(Since(new_since.clone())))
         } else {


### PR DESCRIPTION
`StateCollections::compare_and_downgrade_since` would return `Ok` if the shard is finalized or the expected opaque value matches the actual opaque value. However, the opaque value was only updated to the new opaque value iff the expected opaque value matched the actual opaque value, AND the shard was not finalized, AND the actual since was less than or equal to the new since.

Many callers, including `SinceHandle::compare_and_downgrade_since`, assumed that if `StateCollections::compare_and_downgrade_since` returned `Ok`, then the opaque value would be updated. This assumption is not always true, as described above.

This commit updates `StateCollections::compare_and_downgrade_since`, so that the opaque value is always updated if the expected opaque value matches the actual opaque value and the shard is not finalized, regardless of the since.

The opaque value is still NOT updated if the shard is finalized, which may still break some callers expectations.

Works towards resolving #29432

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
