### PR TITLE
ci: Only build once with bazel when multiple pipelines are running

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -625,29 +625,30 @@ def trim_builds(
                 # hash at least don't run concurrently, leading to wasted
                 # resources.
                 step["concurrency"] = 1
-                step["concurrency_group"] = f"build-x86_64/{hash(deps)}"
+                step["concurrency_group"] = f"rust-build-x86_64/{hash(deps)}"
         elif step.get("id") == "rust-build-aarch64":
             (deps, check) = get_deps(Arch.AARCH64)
             if check:
                 step["skip"] = True
             else:
-                # Make sure that builds in different pipelines for the same
-                # hash at least don't run concurrently, leading to wasted
-                # resources.
                 step["concurrency"] = 1
                 step["concurrency_group"] = f"rust-build-aarch64/{hash(deps)}"
         elif step.get("id") == "build-x86_64":
-            (_deps, check) = get_deps(Arch.X86_64)
+            (deps, check) = get_deps(Arch.X86_64)
             inputs = step.get("inputs") or []
             if check and not have_paths_changed(inputs):
                 step["skip"] = True
-            # Bazel builds are not uploaded yet, so no concurrency group
+            else:
+                step["concurrency"] = 1
+                step["concurrency_group"] = f"build-x86_64/{hash(deps)}"
         elif step.get("id") == "build-aarch64":
-            (_deps, check) = get_deps(Arch.AARCH64)
+            (deps, check) = get_deps(Arch.AARCH64)
             inputs = step.get("inputs") or []
             if check and not have_paths_changed(inputs):
                 step["skip"] = True
-            # Bazel builds are not uploaded yet, so no concurrency group
+            else:
+                step["concurrency"] = 1
+                step["concurrency_group"] = f"build-aarch64/{hash(deps)}"
 
 
 def have_paths_changed(globs: Iterable[str]) -> bool:


### PR DESCRIPTION
Since we upload the Bazel result to Dockerhub now.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
