### PR TITLE
adapter: promote mz_cluster_replica_frontiers

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -63,6 +63,32 @@ Field          | Type       | Meaning
 ---------------|------------|----------
 `id`           | [`text`]   | The ID of the type.
 
+### `mz_cluster_replica_frontiers`
+
+{{< warn-if-unreleased "v0.118" >}}
+
+The `mz_cluster_replica_frontiers` table describes the per-replica frontiers of
+sources, sinks, materialized views, indexes, and subscriptions in the system,
+as observed from the coordinator.
+
+[`mz_compute_frontiers`](../mz_introspection/#mz_compute_frontiers) is similar to
+`mz_cluster_replica_frontiers`, but `mz_compute_frontiers` reports the
+frontiers known to the active compute replica, while
+`mz_cluster_replica_frontiers` reports the frontiers of all replicas. Note also
+that `mz_compute_frontiers` is restricted to compute objects (indexes,
+materialized views, and subscriptions) while `mz_cluster_replica_frontiers`
+contains storage objects that are installed on replicas (sources, sinks) as
+well.
+
+At this time, we do not make any guarantees about the freshness of these numbers.
+
+<!-- RELATION_SPEC mz_catalog.mz_cluster_replica_frontiers -->
+| Field            | Type             | Meaning                                                                |
+| -----------------| ---------------- | --------                                                               |
+| `object_id`      | [`text`]         | The ID of the source, sink, index, materialized view, or subscription. |
+| `replica_id`     | [`text`]         | The ID of a cluster replica.                                           |
+| `write_frontier` | [`mz_timestamp`] | The next timestamp at which the output may change.                     |
+
 ### `mz_cluster_replica_sizes`
 
 The `mz_cluster_replica_sizes` table contains a mapping of logical sizes
@@ -266,7 +292,7 @@ Field                | Type     | Meaning
 `id`                 | [`text`] | The ID of the sink.
 `topic`              | [`text`] | The name of the Kafka topic into which the sink is writing.
 
-## `mz_kafka_sources`
+### `mz_kafka_sources`
 
 {{< warn-if-unreleased v0.115 >}}
 The `mz_kafka_sources` table contains a row for each Kafka source in the system.
@@ -636,6 +662,7 @@ Field          | Type                 | Meaning
 [`jsonb`]: /sql/types/jsonb
 [`mz_aclitem`]: /sql/types/mz_aclitem
 [`mz_aclitem array`]: /sql/types/mz_aclitem
+[`mz_timestamp`]: /sql/types/mz_timestamp
 [`numeric`]: /sql/types/numeric/
 [`oid`]: /sql/types/oid
 [`record`]: /sql/types/record

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -141,30 +141,6 @@ The `mz_cluster_schedules` table shows the `SCHEDULE` option specified for each 
 | `type`                              | [`text`]     | `on-refresh`, or `manual`. Default: `manual`                   |
 | `refresh_hydration_time_estimate`   | [`interval`] | The interval given in the `HYDRATION TIME ESTIMATE` option.    |
 
-## `mz_cluster_replica_frontiers`
-
-The `mz_cluster_replica_frontiers` table describes the per-replica frontiers of
-sources, sinks, materialized views, indexes, and subscriptions in the system,
-as observed from the coordinator.
-
-[`mz_compute_frontiers`](../mz_introspection/#mz_compute_frontiers) is similar to
-`mz_cluster_replica_frontiers`, but `mz_compute_frontiers` reports the
-frontiers known to the active compute replica, while
-`mz_cluster_replica_frontiers` reports the frontiers of all replicas. Note also
-that `mz_compute_frontiers` is restricted to compute objects (indexes,
-materialized views, and subscriptions) while `mz_cluster_replica_frontiers`
-contains storage objects that are installed on replicas (sources, sinks) as
-well.
-
-At this time, we do not make any guarantees about the freshness of these numbers.
-
-<!-- RELATION_SPEC mz_internal.mz_cluster_replica_frontiers -->
-| Field            | Type             | Meaning                                                                |
-| -----------------| ---------------- | --------                                                               |
-| `object_id`      | [`text`]         | The ID of the source, sink, index, materialized view, or subscription. |
-| `replica_id`     | [`text`]         | The ID of a cluster replica.                                           |
-| `write_frontier` | [`mz_timestamp`] | The next timestamp at which the output may change.                     |
-
 ## `mz_cluster_replica_metrics`
 
 The `mz_cluster_replica_metrics` table gives the last known CPU and RAM utilization statistics

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -3264,7 +3264,7 @@ pub static MZ_CLUSTER_REPLICA_METRICS_HISTORY: LazyLock<BuiltinSource> =
 pub static MZ_CLUSTER_REPLICA_FRONTIERS: LazyLock<BuiltinSource> =
     LazyLock::new(|| BuiltinSource {
         name: "mz_cluster_replica_frontiers",
-        schema: MZ_INTERNAL_SCHEMA,
+        schema: MZ_CATALOG_SCHEMA,
         oid: oid::SOURCE_MZ_CLUSTER_REPLICA_FRONTIERS_OID,
         data_source: IntrospectionType::ReplicaFrontiers,
         desc: RelationDesc::builder()
@@ -5094,7 +5094,7 @@ WITH
             true AS hydrated,
             NULL::interval AS hydration_time
         FROM mz_materialized_views mv
-        JOIN mz_internal.mz_cluster_replica_frontiers f ON f.object_id = mv.id
+        JOIN mz_catalog.mz_cluster_replica_frontiers f ON f.object_id = mv.id
         WHERE f.write_frontier IS NULL
     )
 SELECT * FROM dataflows
@@ -7154,7 +7154,7 @@ sinks AS (
     LEFT JOIN mz_internal.mz_sink_statuses ss USING (id)
     JOIN mz_catalog.mz_cluster_replicas r
         ON (r.cluster_id = s.cluster_id)
-    LEFT JOIN mz_internal.mz_cluster_replica_frontiers f
+    LEFT JOIN mz_catalog.mz_cluster_replica_frontiers f
         ON (f.object_id = s.id AND f.replica_id = r.id)
 )
 SELECT * FROM indexes

--- a/test/sqllogictest/autogenerated/mz_catalog.slt
+++ b/test/sqllogictest/autogenerated/mz_catalog.slt
@@ -57,6 +57,13 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 1  id  text
 
 query ITT
+SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_cluster_replica_frontiers' ORDER BY position
+----
+1  object_id  text
+2  replica_id  text
+3  write_frontier  mz_timestamp
+
+query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_cluster_replica_sizes' ORDER BY position
 ----
 1  size  text
@@ -419,6 +426,7 @@ mz_array_types
 mz_audit_events
 mz_aws_privatelink_connections
 mz_base_types
+mz_cluster_replica_frontiers
 mz_cluster_replica_sizes
 mz_cluster_replicas
 mz_clusters

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -102,13 +102,6 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 3  refresh_hydration_time_estimate  interval
 
 query ITT
-SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_cluster_replica_frontiers' ORDER BY position
-----
-1  object_id  text
-2  replica_id  text
-3  write_frontier  mz_timestamp
-
-query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_cluster_replica_metrics' ORDER BY position
 ----
 1  replica_id  text
@@ -604,7 +597,6 @@ mz_aggregates
 mz_aws_connections
 mz_aws_privatelink_connection_status_history
 mz_aws_privatelink_connection_statuses
-mz_cluster_replica_frontiers
 mz_cluster_replica_history
 mz_cluster_replica_metrics
 mz_cluster_replica_metrics_history

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -109,6 +109,10 @@ mz_base_types
 BASE TABLE
 materialize
 mz_catalog
+mz_cluster_replica_frontiers
+SOURCE
+materialize
+mz_catalog
 mz_cluster_replica_sizes
 BASE TABLE
 materialize
@@ -275,10 +279,6 @@ materialize
 mz_internal
 mz_aws_privatelink_connection_statuses
 VIEW
-materialize
-mz_internal
-mz_cluster_replica_frontiers
-SOURCE
 materialize
 mz_internal
 mz_cluster_replica_history

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -499,8 +499,9 @@ name    comment
 # Check default sources, tables, and views in mz_catalog.
 
 > SHOW SOURCES FROM mz_catalog
-name  type  cluster  comment
-----------------------------
+name                                         type    cluster  comment
+---------------------------------------------------------------------
+mz_cluster_replica_frontiers                 source  <null>   ""
 
 > SHOW TABLES FROM mz_catalog
 name                           comment
@@ -565,7 +566,6 @@ mz_timezone_names          ""
 name                                         type    cluster    comment
 -----------------------------------------------------------------------
 mz_aws_privatelink_connection_status_history source  <null>     ""
-mz_cluster_replica_frontiers                 source  <null>     ""
 mz_cluster_replica_metrics_history           source  <null>     ""
 mz_cluster_replica_status_history            source  <null>     ""
 mz_compute_dependencies                      source  <null>     ""

--- a/test/testdrive/controller-frontiers.td
+++ b/test/testdrive/controller-frontiers.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 # Test reporting of controller frontiers through `mz_internal.mz_frontiers` and
-# `mz_internal.mz_cluster_replica_frontiers`.
+# `mz_cluster_replica_frontiers`.
 #
 # These tests rely on testdrive's retry feature, as they query introspection
 # sources whose data might not be immediately available.
@@ -36,7 +36,7 @@
 > SELECT
     mvs.name,
     replicas.name
-  FROM mz_internal.mz_cluster_replica_frontiers frontiers
+  FROM mz_cluster_replica_frontiers frontiers
   JOIN mz_materialized_views mvs
     ON frontiers.object_id = mvs.id
   LEFT JOIN mz_cluster_replicas replicas
@@ -66,7 +66,7 @@ mv1
 > SELECT
     indexes.name,
     replicas.name
-  FROM mz_internal.mz_cluster_replica_frontiers frontiers
+  FROM mz_cluster_replica_frontiers frontiers
   JOIN mz_indexes indexes
     ON frontiers.object_id = indexes.id
   LEFT JOIN mz_cluster_replicas replicas
@@ -98,7 +98,7 @@ idx1
 > SELECT
     sources.name,
     replicas.name
-  FROM mz_internal.mz_cluster_replica_frontiers frontiers
+  FROM mz_cluster_replica_frontiers frontiers
   JOIN mz_sources sources
     ON frontiers.object_id = sources.id
   LEFT JOIN mz_cluster_replicas replicas
@@ -139,7 +139,7 @@ source1_progress
 > SELECT
     sinks.name,
     replicas.name
-  FROM mz_internal.mz_cluster_replica_frontiers frontiers
+  FROM mz_cluster_replica_frontiers frontiers
   JOIN mz_sinks sinks
     ON frontiers.object_id = sinks.id
   LEFT JOIN mz_cluster_replicas replicas
@@ -164,7 +164,7 @@ sink1
 
 > SELECT
     replicas.name
-  FROM mz_internal.mz_cluster_replica_frontiers frontiers
+  FROM mz_cluster_replica_frontiers frontiers
   JOIN mz_indexes indexes
     ON frontiers.object_id = indexes.id
   JOIN mz_clusters clusters
@@ -223,7 +223,7 @@ mz_frontiers
 > SELECT
     objects.name,
     replicas.name
-  FROM mz_internal.mz_cluster_replica_frontiers frontiers
+  FROM mz_cluster_replica_frontiers frontiers
   JOIN mz_objects objects
     ON frontiers.object_id = objects.id
   JOIN mz_cluster_replicas replicas
@@ -244,7 +244,7 @@ mv1  r2
 > SELECT
     objects.name,
     replicas.name
-  FROM mz_internal.mz_cluster_replica_frontiers frontiers
+  FROM mz_cluster_replica_frontiers frontiers
   JOIN mz_objects objects
     ON frontiers.object_id = objects.id
   JOIN mz_cluster_replicas replicas
@@ -269,7 +269,7 @@ mv1  r3
 > SELECT
     objects.name,
     replicas.name
-  FROM mz_internal.mz_cluster_replica_frontiers frontiers
+  FROM mz_cluster_replica_frontiers frontiers
   JOIN mz_objects objects
     ON frontiers.object_id = objects.id
   JOIN mz_cluster_replicas replicas
@@ -292,7 +292,7 @@ mv1  r3
 > SELECT
     replicas.name,
     frontiers.write_frontier
-  FROM mz_internal.mz_cluster_replica_frontiers frontiers
+  FROM mz_cluster_replica_frontiers frontiers
   JOIN mz_materialized_views mvs
     ON frontiers.object_id = mvs.id
   JOIN mz_cluster_replicas replicas
@@ -322,7 +322,7 @@ r3 <null>
 > DROP TABLE t1
 
 > SELECT *
-  FROM mz_internal.mz_cluster_replica_frontiers frontiers
+  FROM mz_cluster_replica_frontiers frontiers
   WHERE object_id LIKE 'u%'
 
 > SELECT *

--- a/test/testdrive/github-15095.td
+++ b/test/testdrive/github-15095.td
@@ -18,6 +18,6 @@ SELECT mz_now()::text
 # the first frontiers message to arrive.
 
 > SELECT bool_and(f.write_frontier > ${now})
-  FROM mz_cluster_replicas r, mz_internal.mz_cluster_replica_frontiers f
+  FROM mz_cluster_replicas r, mz_cluster_replica_frontiers f
   WHERE r.id = f.replica_id AND r.name = 'r'
 true


### PR DESCRIPTION
This was on our list of relations to promote in August, but it requires a bit of special care due to the way the relation is used by the 0dt machinery.

Fix (eventually) #29233 (leaving issue open to track the removal of the migration).

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
