### PR TITLE
0dt: add administrator override to skip catchup

### DIFF
--- a/src/environmentd/src/deployment/preflight.rs
+++ b/src/environmentd/src/deployment/preflight.rs
@@ -173,9 +173,14 @@ pub async fn preflight_0dt(
                 ()
             };
 
+            let skip_catchup = deployment_state.set_catching_up();
+
             tokio::select! {
                 () = clusters_hydrated_receiver => {
                     info!("all clusters hydrated");
+                }
+                () = skip_catchup => {
+                    info!("skipping waiting for clusters to hydrate due to administrator request");
                 }
                 () = hydration_max_wait_fut => {
                     if panic_after_timeout {


### PR DESCRIPTION
For unhealthy environments, it's useful to allow the release manager to skip the catchup phase of the 0dt deployment process and force the deployment to become ready for promotion. Add a new HTTP endpoint for this purpose.

Touches #27406.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
