### PR TITLE
Fix some tests to not rely on unstable Row ordering

### DIFF
--- a/test/cluster/upsert/01-create-sources.td
+++ b/test/cluster/upsert/01-create-sources.td
@@ -50,9 +50,16 @@ $ set schema={
     ]
   }
 
-$ kafka-create-topic topic=dbzupsert partitions=1
+$ kafka-create-topic topic=dbzupsert-broken-key partitions=1
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema}
+$ kafka-ingest format=avro topic=dbzupsert-broken-key key-format=avro key-schema=${keyschema} schema=${schema}
+{"id": 1} {"before": null, "after": {"row": {"id": 1, "creature": "mudskipper"}}}
+{"id": 1} {"before": null, "after": {"row": {"id": 1, "creature": "salamander"}}}
+{"id": 1} {"before": null, "after": {"row": {"id": 1, "creature": "lizard"}}}
+
+$ kafka-create-topic topic=dbzupsert-broken-value partitions=1
+
+$ kafka-ingest format=avro topic=dbzupsert-broken-value key-format=avro key-schema=${keyschema} schema=${schema}
 {"id": 1} {"before": null, "after": {"row": {"id": 1, "creature": "mudskipper"}}}
 {"id": 1} {"before": null, "after": {"row": {"id": 1, "creature": "salamander"}}}
 {"id": 1} {"before": null, "after": {"row": {"id": 1, "creature": "lizard"}}}
@@ -63,33 +70,38 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
     URL '${testdrive.schema-registry-url}'
   );
 
-# With this first source, we verify that we can retract key/value decoding errors.
+# With these first two sources, we verify that we can retract key/value decoding errors.
 
-> CREATE SOURCE upsert
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+> CREATE SOURCE upsert_broken_key
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-broken-key-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
 
-> SELECT * FROM upsert
+> CREATE SOURCE upsert_broken_value
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-broken-value-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+> SELECT * FROM upsert_broken_key
 id creature
 -----------
 1  lizard
 
 # Ingest a broken key/value pair
-$ kafka-ingest format=bytes topic=dbzupsert key-format=bytes
+$ kafka-ingest format=bytes topic=dbzupsert-broken-key key-format=bytes
 broken-key:bar
 
-! SELECT * FROM upsert
+! SELECT * FROM upsert_broken_key
 contains: Key decode
 
 # Ingest a broken value with a good key
-$ kafka-ingest format=bytes topic=dbzupsert key-format=avro key-schema=${keyschema}
+$ kafka-ingest format=bytes topic=dbzupsert-broken-value key-format=avro key-schema=${keyschema}
 {"id": 2}bar2
 
-! SELECT * FROM upsert
+! SELECT * FROM upsert_broken_value
 contains: Value error
 
-# With this second source, we verify that we can retract NULL-key errors by
+# With this third source, we verify that we can retract NULL-key errors by
 # ingesting a NULL:NULL record (a record where both key and value are NULL).
 
 $ kafka-create-topic topic=upsert-nullkey partitions=1

--- a/test/cluster/upsert/02-after-clusterd-restart.td
+++ b/test/cluster/upsert/02-after-clusterd-restart.td
@@ -48,33 +48,45 @@ $ set schema={
 # TODO - we should verify here that the topic is not being re-read from the beginning,
 # but I don't know of any way to do that in Testdrive today.
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema}
+$ kafka-ingest format=avro topic=dbzupsert-broken-key key-format=avro key-schema=${keyschema} schema=${schema}
+{"id": 1} {"before": null, "after": {"row": {"id": 1, "creature": "Tyrannosaurus rex"}}}
+{"id": 1} {"before": null, "after": {"row": {"id": 1, "creature": "dragon"}}}
+
+$ kafka-ingest format=avro topic=dbzupsert-broken-value key-format=avro key-schema=${keyschema} schema=${schema}
 {"id": 1} {"before": null, "after": {"row": {"id": 1, "creature": "Tyrannosaurus rex"}}}
 {"id": 1} {"before": null, "after": {"row": {"id": 1, "creature": "dragon"}}}
 
 # Verify that the errors from before are still there
-! SELECT * FROM upsert
+! SELECT * FROM upsert_broken_key
+contains: Key decode
+
+! SELECT * FROM upsert_broken_value
 contains: Value error
 
 # Retract the bad key
-$ kafka-ingest format=bytes topic=dbzupsert key-format=bytes omit-value=true
+$ kafka-ingest format=bytes topic=dbzupsert-broken-key key-format=bytes omit-value=true
 broken-key:
 
-# There is still an error, due to the bad value.
-! SELECT * FROM upsert
+> SELECT * FROM upsert_broken_key
+id creature
+-----------
+1  dragon
+
+# There is still an error in the other source, due to the bad value.
+! SELECT * FROM upsert_broken_value
 contains: Value error
 
 # Update the bad value
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema}
+$ kafka-ingest format=avro topic=dbzupsert-broken-value key-format=avro key-schema=${keyschema} schema=${schema}
 {"id": 2} {"before": null, "after": {"row": {"id": 2, "creature": "cow"}}}
 
-> SELECT * FROM upsert
+> SELECT * FROM upsert_broken_value
 id creature
 -----------
 1  dragon
 2  cow
 
-# Verify that we still can't query, because of the NULL-key error.
+# Verify that we still can't query the third source, because of the NULL-key error.
 ! select * from upsert_nullkey
 contains: record with NULL key in UPSERT source
 

--- a/test/testdrive/copy-to-s3-minio.td
+++ b/test/testdrive/copy-to-s3-minio.td
@@ -160,22 +160,22 @@ contains:S3 bucket path is not empty
 $ set-from-sql var=key-1
 SELECT TO_CHAR(now(), 'YYYY-MM-DD')
 
-$ s3-verify-data bucket=copytos3 key=test/1/${key-1}
+$ s3-verify-data bucket=copytos3 key=test/1/${key-1} sort-rows=true
 1
 2
 
-$ s3-verify-data bucket=copytos3 key=test/2
+$ s3-verify-data bucket=copytos3 key=test/2 sort-rows=true
 1
 2
 
-$ s3-verify-data bucket=copytos3 key=test/2_5
+$ s3-verify-data bucket=copytos3 key=test/2_5 sort-rows=true
 a
 1
 
-$ s3-verify-data bucket=copytos3 key=test/3
+$ s3-verify-data bucket=copytos3 key=test/3 sort-rows=true
 "{1,2}",f,Infinity,"{""s"":""abc""}",1,32767,2147483647,9223372036854775807,12345678901234567890123.4567890123456789,2010-10-10,10:10:10,2010-10-10 10:10:10,2010-10-10 08:10:10+00,00:00:00,aaaa,\x5c7841414141,това е,\xd182d0b5d0bad181d182
 
-$ s3-verify-data bucket=copytos3 key=test/4_5
+$ s3-verify-data bucket=copytos3 key=test/4_5 sort-rows=true
 array;int4;jsonb;timestamp
 {1,2};83647;`{"s":"ab``c"}`;2010-10-10 10:10:10
 
@@ -212,15 +212,15 @@ array;int4;jsonb;timestamp
     FORMAT = 'parquet'
   );
 
-$ s3-verify-data bucket=copytos3 key=parquet_test/1/${key-1}
+$ s3-verify-data bucket=copytos3 key=parquet_test/1/${key-1} sort-rows=true
 1
 2
 
-$ s3-verify-data bucket=copytos3 key=parquet_test/2
+$ s3-verify-data bucket=copytos3 key=parquet_test/2 sort-rows=true
 1
 2
 
-$ s3-verify-data bucket=copytos3 key=parquet_test/3
+$ s3-verify-data bucket=copytos3 key=parquet_test/3 sort-rows=true
 {items: [1, 2], dimensions: 1} {items: [1, 2, , 4], dimensions: 2} false inf {"s":"abc"} 85907cb9ac9b4e3584b860dc69368aca 1 32767 2147483647 9223372036854775807 1234567890123456789012.4567890123456789 2010-10-10 10:10:10 2010-10-10T10:10:10 2010-10-10T08:10:10Z aaaa 5c7841414141 това е d182d0b5d0bad181d182
 
 # Confirm that unimplemented types will early exit before writing to s3
@@ -240,7 +240,7 @@ contains:Cannot encode the following columns/types: ["interval: Interval"]
     FORMAT = 'parquet'
   );
 
-$ s3-verify-data bucket=copytos3 key=parquet_test/5
+$ s3-verify-data bucket=copytos3 key=parquet_test/5 sort-rows=true
 1
 
 # Tests for decimal / numeric type


### PR DESCRIPTION
This fixes two tests to not rely on unstable Row ordering, see discussions [here](https://materializeinc.slack.com/archives/C01LKF361MZ/p1725905144170379) and [here](https://materializeinc.slack.com/archives/C01LKF361MZ/p1725910128130889). In the cluster test, I've split the `dbzupsert` topic into two topics, so that the two errors can be tested separately.

This PR is split off from https://github.com/MaterializeInc/materialize/pull/29454. That PR changes the row ordering, and these tests were failing without this PR.

### Motivation

  * This PR fixes a test issue.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
