### PR TITLE
0dt: in caught-up checks, ignore collections whose write frontier is too far behind

### DIFF
--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -56,6 +56,12 @@ pub const WITH_0DT_CAUGHT_UP_CHECK_ALLOWED_LAG: Config<Duration> = Config::new(
     "Maximum allowed lag when determining whether collections are caught up for 0dt deployments.",
 );
 
+pub const WITH_0DT_CAUGHT_UP_CHECK_CUTOFF: Config<Duration> = Config::new(
+    "with_0dt_caught_up_check_cutoff",
+    Duration::from_secs(2 * 60 * 60), // 2 hours
+    "Collections whose write frontier is behind 'now' by more than the cutoff are ignored when doing caught-up checks for 0dt deployments.",
+);
+
 /// Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history.
 pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: Config<bool> = Config::new(
     "enable_statement_lifecycle_logging",
@@ -100,6 +106,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&WITH_0DT_DEPLOYMENT_HYDRATION_CHECK_INTERVAL)
         .add(&ENABLE_0DT_CAUGHT_UP_CHECK)
         .add(&WITH_0DT_CAUGHT_UP_CHECK_ALLOWED_LAG)
+        .add(&WITH_0DT_CAUGHT_UP_CHECK_CUTOFF)
         .add(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
         .add(&ENABLE_INTROSPECTION_SUBSCRIBES)
         .add(&PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION)

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3301,17 +3301,9 @@ impl Coordinator {
                     &ctx.exclude_collections,
                 );
 
-                // We also check that we're "hydrated", meaning all collections
-                // have reported an upper at _some_ frontier. This acts as a
-                // back-stop to the case where `mz_cluster_replica_frontiers` is
-                // migrated and we report `0` for a collection frontier.
-                let compute_hydrated = self
-                    .controller
-                    .compute
-                    .clusters_hydrated(&ctx.exclude_collections);
-                tracing::info!(%compute_caught_up, %compute_hydrated, "checked caught-up status of collections");
+                tracing::info!(%compute_caught_up, "checked caught-up status of collections");
 
-                if compute_caught_up && compute_hydrated {
+                if compute_caught_up {
                     let ctx = self.hydration_check.take().expect("known to exist");
                     ctx.trigger.fire();
                 }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -372,19 +372,29 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
     /// reported by a currently running `environmentd` deployment, during a 0dt
     /// upgrade.
     ///
+    /// Collections whose write frontier is behind `now` by more than the cutoff
+    /// are ignored.
+    ///
     /// For this check, zero-replica clusters are always considered caught up.
     /// Their collections would never normally be considered caught up but it's
     /// clearly intentional that they have no replicas.
     pub fn clusters_caught_up(
         &self,
         allowed_lag: T,
+        cutoff: T,
+        now: T,
         live_frontiers: &BTreeMap<GlobalId, Antichain<T>>,
         exclude_collections: &BTreeSet<GlobalId>,
     ) -> bool {
         let mut result = true;
         for (instance_id, i) in &self.instances {
-            let instance_hydrated =
-                i.collections_caught_up(allowed_lag.clone(), live_frontiers, exclude_collections);
+            let instance_hydrated = i.collections_caught_up(
+                allowed_lag.clone(),
+                cutoff.clone(),
+                now.clone(),
+                live_frontiers,
+                exclude_collections,
+            );
 
             if !instance_hydrated {
                 result = false;

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -673,8 +673,6 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
 
             let write_frontier = collection.write_frontier();
 
-            // WIP: Assumes that the String representation remains stable. Is
-            // that okay?
             let live_write_frontier = match live_frontiers.get(&id) {
                 Some(frontier) => frontier,
                 None => {


### PR DESCRIPTION
Touches MaterializeInc/materialize#29329

The thinking is that these collections reside on a crash-looping (or
otherwise unhealthy) cluster and should not hold up doing an upgrade.

There are still cases that we will not support well with this:

- A crash-looping cluster manages to re-hydrate some collections before
  crashing. And the set of collections it manages to hydrate changes
  between attempts. In that case, the upper of all collections would
  slowly creep forward and not be caught by this new check.


### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
