### PR TITLE
platform-checks: Fix PgCdc and MysqlCdc checks

### DIFF
--- a/misc/python/materialize/checks/all_checks/mysql_cdc.py
+++ b/misc/python/materialize/checks/all_checks/mysql_cdc.py
@@ -84,8 +84,7 @@ class MySqlCdcBase:
                   FOR TABLES (public.mysql_source_table{self.suffix} AS mysql_source_tableA{self.suffix});
 
                 >[version>=11700] CREATE SOURCE mysql_source1{self.suffix}
-                  FROM MYSQL CONNECTION mysql1{self.suffix}
-                  (TEXT COLUMNS = (public.mysql_source_table{self.suffix}.f4));
+                  FROM MYSQL CONNECTION mysql1{self.suffix};
                 >[version>=11700] CREATE TABLE mysql_source_tableA{self.suffix} FROM SOURCE mysql_source1{self.suffix} (REFERENCE public.mysql_source_table{self.suffix});
 
                 > CREATE DEFAULT INDEX ON mysql_source_tableA{self.suffix};

--- a/misc/python/materialize/checks/all_checks/pg_cdc.py
+++ b/misc/python/materialize/checks/all_checks/pg_cdc.py
@@ -74,8 +74,7 @@ class PgCdcBase:
 
                 >[version>=11700] CREATE SOURCE postgres_source1{self.suffix}
                   FROM POSTGRES CONNECTION pg1{self.suffix}
-                  (PUBLICATION 'postgres_source{self.suffix}',
-                   TEXT COLUMNS = (postgres_source_table{self.suffix}.f4));
+                  (PUBLICATION 'postgres_source{self.suffix}');
                 >[version>=11700] CREATE TABLE postgres_source_tableA{self.suffix} FROM SOURCE postgres_source1{self.suffix} (REFERENCE postgres_source_table{self.suffix});
 
                 > CREATE DEFAULT INDEX ON postgres_source_tableA{self.suffix};


### PR DESCRIPTION
Broke with https://github.com/MaterializeInc/materialize/pull/29601 being merged

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
