### PR TITLE
adapter: Reduce a `warn!` to an `info!`

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -709,7 +709,10 @@ impl Coordinator {
                             .await;
 
                         if let Err(err) = result {
-                            tracing::warn!(
+                            // Note: it's possible that the secret can be dropped before we have
+                            // a chance to cleanup the replication slot. This is somewhat expected
+                            // so emit a log but there's no reason to have an error.
+                            tracing::info!(
                                 ?replication_slot_name,
                                 ?err,
                                 "failed to drop replication slot"


### PR DESCRIPTION
This PR reduces a `warn!` to an `info!` because previously we've seen getting the backtrace after the warn take a significant amount of time and this scenario is somewhat expected.

### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/8301

The ability for this PR to fix that linked issue is predicated on the idea that for `warn!`s we automatically get a backtrace, which is something I'm not sure about. @def- do you know?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
