### PR TITLE
sql: store SSH TUNNEL public keys in create SQL

### DIFF
--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -18,7 +18,13 @@ use mz_ore::now::NowFn;
 use mz_repr::namespaces::{MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA};
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::ast::display::AstDisplay;
+use mz_sql::ast::{
+    ConnectionOption, ConnectionOptionName, CreateConnectionStatement, CreateConnectionType, Value,
+    WithOptionValue,
+};
 use mz_sql_parser::ast::{Raw, Statement};
+use mz_ssh_util::keys::SshKeyPairSet;
+use mz_storage_types::connections::ConnectionContext;
 use semver::Version;
 use tracing::info;
 // DO NOT add any more imports from `crate` outside of `crate::catalog`.
@@ -96,7 +102,8 @@ pub(crate) async fn migrate(
         catalog_version
     );
 
-    rewrite_ast_items(tx, |_tx, _id, _stmt| {
+    rewrite_ast_items(tx, |_tx, id, stmt| {
+        let connection_context = state.config.connection_context.clone();
         Box::pin(async move {
             // Add per-item AST migrations below.
             //
@@ -106,6 +113,9 @@ pub(crate) async fn migrate(
             //
             // Migration functions may also take `tx` as input to stage
             // arbitrary changes to the catalog.
+
+            migrate_inject_ssh_public_keys_v0118(connection_context, id, stmt).await;
+
             Ok(())
         })
     })
@@ -181,6 +191,46 @@ pub(crate) async fn migrate(
 //
 // Please include the adapter team on any code reviews that add or edit
 // migrations.
+
+async fn migrate_inject_ssh_public_keys_v0118(
+    connection_context: ConnectionContext,
+    id: GlobalId,
+    stmt: &mut Statement<Raw>,
+) {
+    match stmt {
+        Statement::CreateConnection(CreateConnectionStatement {
+            connection_type: CreateConnectionType::Ssh,
+            values,
+            ..
+        }) => {
+            let secret = connection_context
+                .secrets_reader
+                .read(id)
+                .await
+                .unwrap_or_else(|e| panic!("failed reading secret for SSH key {id}: {e}"));
+            let keyset = SshKeyPairSet::from_bytes(&secret)
+                .unwrap_or_else(|e| panic!("failed decoding SSH key {id}: {e}"));
+
+            values.retain(|v| {
+                v.name != ConnectionOptionName::PublicKey1
+                    && v.name != ConnectionOptionName::PublicKey2
+            });
+            values.push(ConnectionOption {
+                name: ConnectionOptionName::PublicKey1,
+                value: Some(WithOptionValue::Value(Value::String(
+                    keyset.primary().ssh_public_key(),
+                ))),
+            });
+            values.push(ConnectionOption {
+                name: ConnectionOptionName::PublicKey2,
+                value: Some(WithOptionValue::Value(Value::String(
+                    keyset.secondary().ssh_public_key(),
+                ))),
+            });
+        }
+        _ => (),
+    }
+}
 
 // Durable migrations
 

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -990,12 +990,12 @@ impl CatalogState {
                 connection:
                     mz_sql::plan::Connection {
                         create_sql,
-                        connection,
+                        details,
                     },
                 ..
             }) => CatalogItem::Connection(Connection {
                 create_sql,
-                connection,
+                details,
                 resolved_ids,
             }),
             _ => {
@@ -2139,8 +2139,8 @@ impl ConnectionResolver for CatalogState {
             .get_entry(&id)
             .connection()
             .expect("catalog out of sync")
-            .connection
-            .clone()
+            .details
+            .to_connection()
         {
             Kafka(conn) => Kafka(conn.into_inline_connection(self)),
             Postgres(conn) => Postgres(conn.into_inline_connection(self)),

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -187,18 +187,14 @@ pub enum Op {
         name: String,
     },
     ResetAllSystemConfiguration,
-    /// Performs updates to weird builtin tables, such as `mz_ssh_tunnel_connections` and
-    /// `mz_cluster_replica_statuses`. Their contents are not fully derived from catalog state.
-    /// `mz_ssh_tunnel_connections` is derived from the secrets controller, however, it still must
-    /// be kept in-sync with the catalog state. Storing the contents of the table in the durable
-    /// catalog would simplify the situation, but then we'd have to somehow encode public keys the
-    /// CREATE SQL of connections, which is annoying. In order to successfully balance all of these
-    /// constraints, we handle all updates to the table separately. `mz_cluster_replica_statuses`
-    /// is ephemeral state and should be a builtin source.
+    /// Performs updates to weird builtin tables, such as
+    /// `mz_cluster_replica_statuses`, which is ephemeral state and should be a
+    /// builtin source.
     ///
-    /// TODO(jkosh44) In a multi-writer or high availability catalog world, this will not work. If
-    /// a process crashes after updating the durable catalog but before updating the builtin table,
-    /// then another listening catalog will never know to update the builtin table.
+    /// TODO(jkosh44) In a multi-writer or high availability catalog world, this
+    /// will not work. If a process crashes after updating the durable catalog
+    /// but before updating the builtin table, then another listening catalog
+    /// will never know to update the builtin table.
     WeirdBuiltinTableUpdates {
         builtin_table_update: BuiltinTableUpdate,
         audit_log: Vec<(EventType, ObjectType, EventDetails)>,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -137,7 +137,10 @@ use mz_secrets::{SecretsController, SecretsReader};
 use mz_sql::ast::{Raw, Statement};
 use mz_sql::catalog::{CatalogCluster, EnvironmentId};
 use mz_sql::optimizer_metrics::OptimizerMetrics;
-use mz_sql::plan::{self, AlterSinkPlan, CreateConnectionPlan, OnTimeoutAction, Params, QueryWhen};
+use mz_sql::plan::{
+    self, AlterSinkPlan, ConnectionDetails, CreateConnectionPlan, OnTimeoutAction, Params,
+    QueryWhen,
+};
 use mz_sql::session::vars::{ConnectionCounter, SystemVars};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::ExplainStage;
@@ -2040,9 +2043,7 @@ impl Coordinator {
                         .unwrap_or_terminate("cannot fail to create exports");
                 }
                 CatalogItem::Connection(catalog_connection) => {
-                    if let mz_storage_types::connections::Connection::AwsPrivatelink(conn) =
-                        &catalog_connection.connection
-                    {
+                    if let ConnectionDetails::AwsPrivatelink(conn) = &catalog_connection.details {
                         privatelink_connections.insert(
                             entry.id(),
                             VpcEndpointConfig {

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -39,6 +39,7 @@ use mz_repr::adt::numeric::Numeric;
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::catalog::{CatalogCluster, CatalogSchema};
 use mz_sql::names::ResolvedDatabaseSpecifier;
+use mz_sql::plan::ConnectionDetails;
 use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::vars::{
     self, SystemVars, Var, MAX_AWS_PRIVATELINK_CONNECTIONS, MAX_CLUSTERS,
@@ -265,19 +266,19 @@ impl Coordinator {
                                     CatalogItem::Secret(_) => {
                                         secrets_to_drop.push(*id);
                                     }
-                                    CatalogItem::Connection(Connection { connection, .. }) => {
-                                        match connection {
-                                        // SSH connections have an associated secret that should be dropped
-                                        mz_storage_types::connections::Connection::Ssh(_) => {
-                                            secrets_to_drop.push(*id);
+                                    CatalogItem::Connection(Connection { details, .. }) => {
+                                        match details {
+                                            // SSH connections have an associated secret that should be dropped
+                                            ConnectionDetails::Ssh { .. } => {
+                                                secrets_to_drop.push(*id);
+                                            }
+                                            // AWS PrivateLink connections have an associated
+                                            // VpcEndpoint K8S resource that should be dropped
+                                            ConnectionDetails::AwsPrivatelink(_) => {
+                                                vpc_endpoints_to_drop.push(*id);
+                                            }
+                                            _ => (),
                                         }
-                                        // AWS PrivateLink connections have an associated
-                                        // VpcEndpoint K8S resource that should be dropped
-                                        mz_storage_types::connections::Connection::AwsPrivatelink(_) => {
-                                            vpc_endpoints_to_drop.push(*id);
-                                        }
-                                        _ => (),
-                                    }
                                     }
                                     _ => (),
                                 }
@@ -1361,18 +1362,17 @@ impl Coordinator {
                         ))
                         .or_insert(0) += 1;
                     match item {
-                        CatalogItem::Connection(connection) => {
-                            use mz_storage_types::connections::Connection;
-                            match connection.connection {
-                                Connection::Kafka(_) => new_kafka_connections += 1,
-                                Connection::Postgres(_) => new_postgres_connections += 1,
-                                Connection::MySql(_) => new_mysql_connections += 1,
-                                Connection::AwsPrivatelink(_) => {
-                                    new_aws_privatelink_connections += 1
-                                }
-                                Connection::Csr(_) | Connection::Ssh(_) | Connection::Aws(_) => {}
+                        CatalogItem::Connection(connection) => match connection.details {
+                            ConnectionDetails::Kafka(_) => new_kafka_connections += 1,
+                            ConnectionDetails::Postgres(_) => new_postgres_connections += 1,
+                            ConnectionDetails::MySql(_) => new_mysql_connections += 1,
+                            ConnectionDetails::AwsPrivatelink(_) => {
+                                new_aws_privatelink_connections += 1
                             }
-                        }
+                            ConnectionDetails::Csr(_)
+                            | ConnectionDetails::Ssh { .. }
+                            | ConnectionDetails::Aws(_) => {}
+                        },
                         CatalogItem::Table(_) => {
                             new_tables += 1;
                         }
@@ -1437,31 +1437,33 @@ impl Coordinator {
                                     ))
                                     .or_insert(0) -= 1;
                                 match entry.item() {
-                            CatalogItem::Connection(connection) => match connection.connection {
-                                mz_storage_types::connections::Connection::AwsPrivatelink(_) => {
-                                    new_aws_privatelink_connections -= 1;
+                                    CatalogItem::Connection(connection) => match connection.details
+                                    {
+                                        ConnectionDetails::AwsPrivatelink(_) => {
+                                            new_aws_privatelink_connections -= 1;
+                                        }
+                                        _ => (),
+                                    },
+                                    CatalogItem::Table(_) => {
+                                        new_tables -= 1;
+                                    }
+                                    CatalogItem::Source(source) => {
+                                        new_sources -=
+                                            source.user_controllable_persist_shard_count()
+                                    }
+                                    CatalogItem::Sink(_) => new_sinks -= 1,
+                                    CatalogItem::MaterializedView(_) => {
+                                        new_materialized_views -= 1;
+                                    }
+                                    CatalogItem::Secret(_) => {
+                                        new_secrets -= 1;
+                                    }
+                                    CatalogItem::Log(_)
+                                    | CatalogItem::View(_)
+                                    | CatalogItem::Index(_)
+                                    | CatalogItem::Type(_)
+                                    | CatalogItem::Func(_) => {}
                                 }
-                                _ => (),
-                            },
-                            CatalogItem::Table(_) => {
-                                new_tables -= 1;
-                            }
-                            CatalogItem::Source(source) => {
-                                new_sources -= source.user_controllable_persist_shard_count()
-                            }
-                            CatalogItem::Sink(_) => new_sinks -= 1,
-                            CatalogItem::MaterializedView(_) => {
-                                new_materialized_views -= 1;
-                            }
-                            CatalogItem::Secret(_) => {
-                                new_secrets -= 1;
-                            }
-                            CatalogItem::Log(_)
-                            | CatalogItem::View(_)
-                            | CatalogItem::Index(_)
-                            | CatalogItem::Type(_)
-                            | CatalogItem::Func(_) => {}
-                        }
                             }
                         }
                     }
@@ -1523,13 +1525,14 @@ impl Coordinator {
                 .connection()
                 .expect("`user_connections()` only returns connection objects");
 
-            use mz_storage_types::connections::Connection;
-            match connection.connection {
-                Connection::AwsPrivatelink(_) => current_aws_privatelink_connections += 1,
-                Connection::Postgres(_) => current_postgres_connections += 1,
-                Connection::MySql(_) => current_mysql_connections += 1,
-                Connection::Kafka(_) => current_kafka_connections += 1,
-                Connection::Csr(_) | Connection::Ssh(_) | Connection::Aws(_) => {}
+            match connection.details {
+                ConnectionDetails::AwsPrivatelink(_) => current_aws_privatelink_connections += 1,
+                ConnectionDetails::Postgres(_) => current_postgres_connections += 1,
+                ConnectionDetails::MySql(_) => current_mysql_connections += 1,
+                ConnectionDetails::Kafka(_) => current_kafka_connections += 1,
+                ConnectionDetails::Csr(_)
+                | ConnectionDetails::Ssh { .. }
+                | ConnectionDetails::Aws(_) => {}
             }
         }
         self.validate_resource_limit(

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 use anyhow::anyhow;
 use futures::future::BoxFuture;
 use futures::stream::FuturesOrdered;
-use futures::{future, Future, FutureExt};
+use futures::{future, Future};
 use itertools::Itertools;
 use maplit::btreeset;
 use mz_adapter_types::compaction::CompactionWindow;
@@ -46,7 +46,7 @@ use mz_sql::names::{
     Aug, ObjectId, QualifiedItemName, ResolvedDatabaseSpecifier, ResolvedIds, ResolvedItemName,
     SchemaSpecifier, SystemObjectId,
 };
-use mz_sql::plan::StatementContext;
+use mz_sql::plan::{ConnectionDetails, StatementContext};
 use mz_sql::pure::{generate_subsource_statements, PurifiedSourceExport};
 use mz_storage_types::sinks::StorageSinkDesc;
 use timely::progress::Timestamp as TimelyTimestamp;
@@ -648,7 +648,7 @@ impl Coordinator {
     pub(super) async fn sequence_create_connection(
         &mut self,
         mut ctx: ExecuteContext,
-        mut plan: plan::CreateConnectionPlan,
+        plan: plan::CreateConnectionPlan,
         resolved_ids: ResolvedIds,
     ) {
         let connection_gid = match self.catalog_mut().allocate_user_id().await {
@@ -656,29 +656,38 @@ impl Coordinator {
             Err(err) => return ctx.retire(Err(err.into())),
         };
 
-        let public_key_set = match plan.connection.connection {
-            mz_storage_types::connections::Connection::Ssh(_) => {
-                let key_set = match SshKeyPairSet::new() {
-                    Ok(key) => key,
-                    Err(err) => return ctx.retire(Err(err.into())),
+        match &plan.connection.details {
+            ConnectionDetails::Ssh { key_1, key_2, .. } => {
+                let key_1 = match key_1.as_key_pair() {
+                    Some(key_1) => key_1.clone(),
+                    None => {
+                        return ctx.retire(Err(AdapterError::Unstructured(anyhow!(
+                            "the PUBLIC KEY 1 option cannot be explicitly specified"
+                        ))))
+                    }
                 };
+
+                let key_2 = match key_2.as_key_pair() {
+                    Some(key_2) => key_2.clone(),
+                    None => {
+                        return ctx.retire(Err(AdapterError::Unstructured(anyhow!(
+                            "the PUBLIC KEY 2 option cannot be explicitly specified"
+                        ))))
+                    }
+                };
+
+                let key_set = SshKeyPairSet::from_parts(key_1, key_2);
                 let secret = key_set.to_bytes();
-                match self
+                if let Err(err) = self
                     .secrets_controller
                     .ensure(connection_gid, &secret)
                     .await
                 {
-                    Ok(()) => Some(key_set.public_keys()),
-                    Err(err) => return ctx.retire(Err(err.into())),
+                    return ctx.retire(Err(err.into()));
                 }
             }
-            _ => None,
+            _ => (),
         };
-        assert_eq!(
-            plan.public_key_set, None,
-            "public key should not be set yet"
-        );
-        plan.public_key_set = public_key_set;
 
         if plan.validate {
             let internal_cmd_tx = self.internal_cmd_tx.clone();
@@ -689,8 +698,8 @@ impl Coordinator {
 
             let connection = plan
                 .connection
-                .connection
-                .clone()
+                .details
+                .to_connection()
                 .into_inline_connection(self.catalog().state());
 
             let current_storage_parameters = self.controller.storage.config().clone();
@@ -745,36 +754,21 @@ impl Coordinator {
         plan: plan::CreateConnectionPlan,
         resolved_ids: ResolvedIds,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let mut ops = vec![catalog::Op::CreateItem {
+        let ops = vec![catalog::Op::CreateItem {
             id: connection_gid,
             name: plan.name.clone(),
             item: CatalogItem::Connection(Connection {
                 create_sql: plan.connection.create_sql,
-                connection: plan.connection.connection.clone(),
+                details: plan.connection.details.clone(),
                 resolved_ids,
             }),
             owner_id: *session.current_role_id(),
         }];
-        if let Some(public_key_set) = plan.public_key_set {
-            let builtin_table_update = self.catalog().state().pack_ssh_tunnel_connection_update(
-                connection_gid,
-                &public_key_set,
-                1,
-            );
-            let builtin_table_update = self
-                .catalog()
-                .state()
-                .resolve_builtin_table_update(builtin_table_update);
-            ops.push(catalog::Op::WeirdBuiltinTableUpdates {
-                builtin_table_update,
-                audit_log: Vec::new(),
-            });
-        }
 
         let transact_result = self
             .catalog_transact_with_side_effects(Some(session), ops, |coord| async {
-                match plan.connection.connection {
-                    mz_storage_types::connections::Connection::AwsPrivatelink(ref privatelink) => {
+                match plan.connection.details {
+                    ConnectionDetails::AwsPrivatelink(ref privatelink) => {
                         let spec = VpcEndpointConfig {
                             aws_service_name: privatelink.service_name.to_owned(),
                             availability_zone_ids: privatelink.availability_zones.to_owned(),
@@ -1260,7 +1254,7 @@ impl Coordinator {
             dropped_active_db,
             dropped_active_cluster,
             dropped_in_use_indexes,
-        } = self.sequence_drop_common(session, drop_ids).await?;
+        } = self.sequence_drop_common(session, drop_ids)?;
 
         self.catalog_transact(Some(session), ops).await?;
 
@@ -1502,7 +1496,7 @@ impl Coordinator {
             dropped_active_db,
             dropped_active_cluster,
             dropped_in_use_indexes,
-        } = self.sequence_drop_common(session, plan.drop_ids).await?;
+        } = self.sequence_drop_common(session, plan.drop_ids)?;
 
         let ops = privilege_revoke_ops
             .chain(default_privilege_revoke_ops)
@@ -1527,7 +1521,7 @@ impl Coordinator {
         Ok(ExecuteResponse::DroppedOwned)
     }
 
-    async fn sequence_drop_common(
+    fn sequence_drop_common(
         &self,
         session: &Session,
         ids: Vec<ObjectId>,
@@ -1548,9 +1542,6 @@ impl Coordinator {
 
         // Clusters we're dropping
         let mut clusters_to_drop = BTreeSet::new();
-
-        // SSH connections we're dropping.
-        let mut ssh_conns_to_drop = Vec::new();
 
         let ids_set = ids.iter().collect::<BTreeSet<_>>();
         for id in &ids {
@@ -1624,12 +1615,6 @@ impl Coordinator {
                                 dependant_objects: dependants,
                             });
                         }
-                    } else if let Ok(connection) = self.catalog().get_entry(id).connection() {
-                        if let mz_storage_types::connections::Connection::Ssh(_) =
-                            &connection.connection
-                        {
-                            ssh_conns_to_drop.push(*id);
-                        }
                     }
                 }
                 _ => {}
@@ -1694,30 +1679,6 @@ impl Coordinator {
             }
         }
 
-        let mut ssh_tunnel_updates = Vec::new();
-        let ssh_conn_secrets = ssh_conns_to_drop.into_iter().map(|ssh_conn| {
-            let secrets_controller = Arc::clone(&self.secrets_controller);
-            async move {
-                let secret = secrets_controller.reader().read(ssh_conn).await?;
-                let key_set = SshKeyPairSet::from_bytes(&secret)?.public_keys();
-                Ok::<_, AdapterError>((ssh_conn, key_set))
-            }
-            .boxed()
-        });
-        let ssh_conn_secrets = future::join_all(ssh_conn_secrets).await;
-        for secret_res in ssh_conn_secrets {
-            let (ssh_conn, key_set) = secret_res?;
-            let ssh_tunnel_update = self
-                .catalog()
-                .state()
-                .pack_ssh_tunnel_connection_update(ssh_conn, &key_set, -1);
-            let ssh_tunnel_update = self
-                .catalog()
-                .state()
-                .resolve_builtin_table_update(ssh_tunnel_update);
-            ssh_tunnel_updates.push(ssh_tunnel_update);
-        }
-
         let ops = role_revokes
             .into_iter()
             .map(|(role_id, member_id, grantor_id)| catalog::Op::RevokeRole {
@@ -1737,12 +1698,6 @@ impl Coordinator {
                     .map(DropObjectInfo::manual_drop_from_object_id)
                     .collect(),
             )))
-            .chain(ssh_tunnel_updates.into_iter().map(|builtin_table_update| {
-                catalog::Op::WeirdBuiltinTableUpdates {
-                    builtin_table_update,
-                    audit_log: Vec::new(),
-                }
-            }))
             .collect();
 
         Ok(DropOps {
@@ -3439,7 +3394,7 @@ impl Coordinator {
 
             Ok(Connection {
                 create_sql: plan.connection.create_sql,
-                connection: plan.connection.connection,
+                details: plan.connection.details,
                 resolved_ids: new_deps,
             })
         };
@@ -3453,8 +3408,8 @@ impl Coordinator {
 
         if validate {
             let connection = conn
-                .connection
-                .clone()
+                .details
+                .to_connection()
                 .into_inline_connection(self.catalog().state());
 
             let internal_cmd_tx = self.internal_cmd_tx.clone();
@@ -3513,8 +3468,9 @@ impl Coordinator {
         match self.catalog.get_entry(&id).item() {
             CatalogItem::Connection(curr_conn) => {
                 curr_conn
-                    .connection
-                    .alter_compatible(id, &connection.connection)
+                    .details
+                    .to_connection()
+                    .alter_compatible(id, &connection.details.to_connection())
                     .map_err(StorageError::from)?;
             }
             _ => unreachable!("known to be a connection"),
@@ -3528,8 +3484,8 @@ impl Coordinator {
 
         self.catalog_transact(Some(session), ops).await?;
 
-        match connection.connection {
-            mz_storage_types::connections::Connection::AwsPrivatelink(ref privatelink) => {
+        match connection.details {
+            ConnectionDetails::AwsPrivatelink(ref privatelink) => {
                 let spec = VpcEndpointConfig {
                     aws_service_name: privatelink.service_name.to_owned(),
                     availability_zone_ids: privatelink.availability_zones.to_owned(),

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -42,7 +42,7 @@ use mz_sql::names::{
     ResolvedDatabaseSpecifier, ResolvedIds, SchemaId, SchemaSpecifier,
 };
 use mz_sql::plan::{
-    ClusterSchedule, ComputeReplicaConfig, ComputeReplicaIntrospectionConfig,
+    ClusterSchedule, ComputeReplicaConfig, ComputeReplicaIntrospectionConfig, ConnectionDetails,
     CreateClusterManagedPlan, CreateClusterPlan, CreateClusterVariant, CreateSourcePlan,
     HirRelationExpr, Ingestion as PlanIngestion, PlanError, WebhookBodyFormat, WebhookHeaders,
     WebhookValidation,
@@ -950,7 +950,7 @@ pub struct Secret {
 #[derive(Debug, Clone, Serialize)]
 pub struct Connection {
     pub create_sql: String,
-    pub connection: mz_storage_types::connections::Connection<ReferencedConnection>,
+    pub details: ConnectionDetails,
     pub resolved_ids: ResolvedIds,
 }
 
@@ -2397,9 +2397,9 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
 
     fn connection(
         &self,
-    ) -> Result<&mz_storage_types::connections::Connection<ReferencedConnection>, SqlCatalogError>
+    ) -> Result<mz_storage_types::connections::Connection<ReferencedConnection>, SqlCatalogError>
     {
-        Ok(&self.connection()?.connection)
+        Ok(self.connection()?.details.to_connection())
     }
 
     fn create_sql(&self) -> &str {

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -327,6 +327,7 @@ Privileges
 Progress
 Protobuf
 Protocol
+Public
 Publication
 Pushdown
 Query

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -728,6 +728,8 @@ pub enum ConnectionOptionName {
     Port,
     ProgressTopic,
     ProgressTopicReplicationFactor,
+    PublicKey1,
+    PublicKey2,
     Region,
     SaslMechanisms,
     SaslPassword,
@@ -763,6 +765,8 @@ impl AstDisplay for ConnectionOptionName {
             ConnectionOptionName::ProgressTopicReplicationFactor => {
                 "PROGRESS TOPIC REPLICATION FACTOR"
             }
+            ConnectionOptionName::PublicKey1 => "PUBLIC KEY 1",
+            ConnectionOptionName::PublicKey2 => "PUBLIC KEY 2",
             ConnectionOptionName::Region => "REGION",
             ConnectionOptionName::AssumeRoleArn => "ASSUME ROLE ARN",
             ConnectionOptionName::AssumeRoleSessionName => "ASSUME ROLE SESSION NAME",
@@ -806,6 +810,8 @@ impl WithOptionName for ConnectionOptionName {
             | ConnectionOptionName::Port
             | ConnectionOptionName::ProgressTopic
             | ConnectionOptionName::ProgressTopicReplicationFactor
+            | ConnectionOptionName::PublicKey1
+            | ConnectionOptionName::PublicKey2
             | ConnectionOptionName::Region
             | ConnectionOptionName::AssumeRoleArn
             | ConnectionOptionName::AssumeRoleSessionName

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2551,6 +2551,7 @@ impl<'a> Parser<'a> {
                 HOST,
                 PASSWORD,
                 PORT,
+                PUBLIC,
                 PROGRESS,
                 REGION,
                 ROLE,
@@ -2596,6 +2597,14 @@ impl<'a> Parser<'a> {
                 HOST => ConnectionOptionName::Host,
                 PASSWORD => ConnectionOptionName::Password,
                 PORT => ConnectionOptionName::Port,
+                PUBLIC => {
+                    self.expect_keyword(KEY)?;
+                    match self.next_token() {
+                        Some(Token::Number(n)) if n == "1" => ConnectionOptionName::PublicKey1,
+                        Some(Token::Number(n)) if n == "2" => ConnectionOptionName::PublicKey2,
+                        t => self.expected(self.peek_prev_pos(), "1 or 2 after PUBLIC KEY", t)?,
+                    }
+                }
                 PROGRESS => {
                     self.expect_keyword(TOPIC)?;
                     match self.parse_keywords(&[REPLICATION, FACTOR]) {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -2635,6 +2635,20 @@ error: Expected one of ACCESS or ASSUME or AVAILABILITY or AWS or BROKER or BROK
 CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL (PUBLIC KEY 3 = nope)
                                                ^
 
+parse-statement
+CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL HOST 'ssh-bastion', PORT 1234, USER 'blah', PUBLIC KEY 3 = 'abc'
+----
+error: Expected 1 or 2 after PUBLIC KEY, found number "3"
+CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL HOST 'ssh-bastion', PORT 1234, USER 'blah', PUBLIC KEY 3 = 'abc'
+                                                                                                      ^
+
+parse-statement
+CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL HOST 'ssh-bastion', PORT 1234, USER 'blah', PUBLIC abc
+----
+error: Expected KEY, found identifier "abc"
+CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL HOST 'ssh-bastion', PORT 1234, USER 'blah', PUBLIC abc
+                                                                                                  ^
+
 parse-statement roundtrip
 CREATE CONNECTION my_ssh_tunnel TO SSH TUNNEL (HOST 'ssh-bastion', PORT 1234, USER 'blah')
 ----

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -2622,11 +2622,18 @@ CREATE SOURCE example FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT CSV WIT
 CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("example")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Csv { columns: Count(5), delimiter: ',' })), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
-CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL HOST 'ssh-bastion', PORT 1234, USER 'blah'
+CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL HOST 'ssh-bastion', PORT 1234, USER 'blah', PUBLIC KEY 1 = 'abc', PUBLIC KEY 2 = 'def'
 ----
-CREATE CONNECTION my_ssh_tunnel TO SSH TUNNEL (HOST = 'ssh-bastion', PORT = 1234, USER = 'blah')
+CREATE CONNECTION my_ssh_tunnel TO SSH TUNNEL (HOST = 'ssh-bastion', PORT = 1234, USER = 'blah', PUBLIC KEY 1 = 'abc', PUBLIC KEY 2 = 'def')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("my_ssh_tunnel")]), connection_type: Ssh, if_not_exists: false, values: [ConnectionOption { name: Host, value: Some(Value(String("ssh-bastion"))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: User, value: Some(Value(String("blah"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("my_ssh_tunnel")]), connection_type: Ssh, if_not_exists: false, values: [ConnectionOption { name: Host, value: Some(Value(String("ssh-bastion"))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: User, value: Some(Value(String("blah"))) }, ConnectionOption { name: PublicKey1, value: Some(Value(String("abc"))) }, ConnectionOption { name: PublicKey2, value: Some(Value(String("def"))) }], with_options: [] })
+
+parse-statement
+CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL (PUBLIC KEY 3 = nope)
+----
+error: Expected one of ACCESS or ASSUME or AVAILABILITY or AWS or BROKER or BROKERS or DATABASE or ENDPOINT or HOST or PASSWORD or PORT or PUBLIC or PROGRESS or REGION or ROLE or SASL or SECRET or SECURITY or SERVICE or SESSION or SSH or SSL or URL or USER or USERNAME, found left parenthesis
+CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL (PUBLIC KEY 3 = nope)
+                                               ^
 
 parse-statement roundtrip
 CREATE CONNECTION my_ssh_tunnel TO SSH TUNNEL (HOST 'ssh-bastion', PORT 1234, USER 'blah')

--- a/src/sql-parser/tests/testdata/error
+++ b/src/sql-parser/tests/testdata/error
@@ -49,7 +49,7 @@ SELECT ALL DISTINCT name FROM customer
 parse-statement
 INSERT public.customer (id, name, active) VALUES (1, 2, 3)
 ----
-error: Expected INTO, found identifier "public"
+error: Expected INTO, found PUBLIC
 INSERT public.customer (id, name, active) VALUES (1, 2, 3)
        ^
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -590,7 +590,7 @@ pub trait CatalogItem {
     /// Returns the resolved connection.
     ///
     /// If the catalog item is not a connection, it returns an error.
-    fn connection(&self) -> Result<&Connection<ReferencedConnection>, CatalogError>;
+    fn connection(&self) -> Result<Connection<ReferencedConnection>, CatalogError>;
 
     /// Returns the type of the catalog item.
     fn item_type(&self) -> CatalogItemType;

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -49,7 +49,13 @@ use mz_sql_parser::ast::{
     SelectStatement, TransactionIsolationLevel, TransactionMode, UnresolvedItemName, Value,
     WithOptionValue,
 };
+use mz_ssh_util::keys::SshKeyPair;
+use mz_storage_types::connections::aws::AwsConnection;
 use mz_storage_types::connections::inline::ReferencedConnection;
+use mz_storage_types::connections::{
+    AwsPrivatelinkConnection, CsrConnection, KafkaConnection, MySqlConnection, PostgresConnection,
+    SshConnection,
+};
 use mz_storage_types::sinks::{
     S3SinkFormat, SinkEnvelope, SinkPartitionStrategy, StorageSinkConnection,
 };
@@ -637,7 +643,6 @@ pub struct CreateConnectionPlan {
     pub if_not_exists: bool,
     pub connection: Connection,
     pub validate: bool,
-    pub public_key_set: Option<(String, String)>,
 }
 
 #[derive(Debug)]
@@ -1470,7 +1475,68 @@ pub struct WebhookValidationSecret {
 #[derive(Clone, Debug)]
 pub struct Connection {
     pub create_sql: String,
-    pub connection: mz_storage_types::connections::Connection<ReferencedConnection>,
+    pub details: ConnectionDetails,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub enum ConnectionDetails {
+    Kafka(KafkaConnection<ReferencedConnection>),
+    Csr(CsrConnection<ReferencedConnection>),
+    Postgres(PostgresConnection<ReferencedConnection>),
+    Ssh {
+        connection: SshConnection,
+        key_1: SshKey,
+        key_2: SshKey,
+    },
+    Aws(AwsConnection),
+    AwsPrivatelink(AwsPrivatelinkConnection),
+    MySql(MySqlConnection<ReferencedConnection>),
+}
+
+impl ConnectionDetails {
+    pub fn to_connection(&self) -> mz_storage_types::connections::Connection<ReferencedConnection> {
+        match self {
+            ConnectionDetails::Kafka(c) => {
+                mz_storage_types::connections::Connection::Kafka(c.clone())
+            }
+            ConnectionDetails::Csr(c) => mz_storage_types::connections::Connection::Csr(c.clone()),
+            ConnectionDetails::Postgres(c) => {
+                mz_storage_types::connections::Connection::Postgres(c.clone())
+            }
+            ConnectionDetails::Ssh { connection, .. } => {
+                mz_storage_types::connections::Connection::Ssh(connection.clone())
+            }
+            ConnectionDetails::Aws(c) => mz_storage_types::connections::Connection::Aws(c.clone()),
+            ConnectionDetails::AwsPrivatelink(c) => {
+                mz_storage_types::connections::Connection::AwsPrivatelink(c.clone())
+            }
+            ConnectionDetails::MySql(c) => {
+                mz_storage_types::connections::Connection::MySql(c.clone())
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub enum SshKey {
+    PublicOnly(String),
+    Both(SshKeyPair),
+}
+
+impl SshKey {
+    pub fn as_key_pair(&self) -> Option<&SshKeyPair> {
+        match self {
+            SshKey::PublicOnly(_) => None,
+            SshKey::Both(key_pair) => Some(key_pair),
+        }
+    }
+
+    pub fn public_key(&self) -> String {
+        match self {
+            SshKey::PublicOnly(s) => s.into(),
+            SshKey::Both(p) => p.ssh_public_key(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/statement/validate.rs
+++ b/src/sql/src/plan/statement/validate.rs
@@ -30,7 +30,7 @@ pub fn plan_validate_connection(
     let item = scx.get_item_by_resolved_name(&stmt.name)?;
 
     // Validate the target of the validate statement.
-    match item.connection().cloned() {
+    match item.connection() {
         Ok(connection) => Ok(Plan::ValidateConnection(ValidateConnectionPlan {
             id: item.id(),
             connection,

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -392,7 +392,6 @@ fn generate_rbac_requirements(
             if_not_exists: _,
             connection: _,
             validate: _,
-            public_key_set: _,
         }) => RbacRequirements {
             privileges: vec![(
                 SystemObjectId::Object(name.qualifiers.clone().into()),

--- a/src/ssh-util/src/keys.rs
+++ b/src/ssh-util/src/keys.rs
@@ -192,12 +192,18 @@ pub struct SshKeyPairSet {
 }
 
 impl SshKeyPairSet {
-    /// Generates a new key pair set with random key pairs.
+    // Generates a new key pair set with random key pairs.
     pub fn new() -> Result<SshKeyPairSet, anyhow::Error> {
-        Ok(SshKeyPairSet {
-            primary: SshKeyPair::new()?,
-            secondary: SshKeyPair::new()?,
-        })
+        Ok(SshKeyPairSet::from_parts(
+            SshKeyPair::new()?,
+            SshKeyPair::new()?,
+        ))
+    }
+
+    /// Creates a new key pair set from an existing primary and secondary key
+    /// pair.
+    pub fn from_parts(primary: SshKeyPair, secondary: SshKeyPair) -> SshKeyPairSet {
+        SshKeyPairSet { primary, secondary }
     }
 
     /// Rotate the key pairs in the set.

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -183,7 +183,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 59  alter  materialized-view  {"id":"u5","new_history":null,"old_history":"FOR␠'5m'"}  materialize
 60  comment  materialized-view  {"id":"MaterializedView(User(5))","name":"materialize.public.v2"}  materialize
 61  create  connection  {"database":"materialize","id":"u16","item":"conn","schema":"public"}  materialize
-62  alter  connection  {"id":"u16","name":"materialize.public.conn"}  materialize
+62  alter  connection  {"database":"materialize","id":"u16","item":"conn","schema":"public"}  materialize
 63  alter  system  {"name":"max_aws_privatelink_connections","value":"10"}  mz_system
 64  alter  system  {"name":"max_aws_privatelink_connections","value":null}  mz_system
 65  alter  system  null  mz_system

--- a/test/ssh-connection/ssh-connections.td
+++ b/test/ssh-connection/ssh-connections.td
@@ -16,6 +16,22 @@ ALTER SYSTEM SET enable_connection_validation_syntax = true
 id public_key_1 public_key_2
 ----------------------------
 
+! CREATE CONNECTION louisoix TO SSH TUNNEL (
+    HOST 'chaos.example.com',
+    USER 'louisoix',
+    PORT 22,
+    PUBLIC KEY 1 = 'bad'
+  );
+contains:the PUBLIC KEY 1 option cannot be explicitly specified
+
+! CREATE CONNECTION louisoix TO SSH TUNNEL (
+    HOST 'chaos.example.com',
+    USER 'louisoix',
+    PORT 22,
+    PUBLIC KEY 2 = 'bad'
+  );
+contains:the PUBLIC KEY 2 option cannot be explicitly specified
+
 > CREATE CONNECTION louisoix TO SSH TUNNEL (
     HOST 'chaos.example.com',
     USER 'louisoix',


### PR DESCRIPTION
This removes one usage of the WeirdBuiltinTableUpdates, which is another step towards the multi-subscriber catalog.

The approach taken is to introduce PUBLIC KEY 1 and PUBLIC KEY 2 options for SSH tunnel connections. Users cannot specify these options directly; rather the the planner automatically injects them with the public keys it generates during planning. These keys can then flow through the normal builtin table update channel, where they get reflected in the mz_ssh_tunnel_connections table.

Private keys, which are sensitive, continue to be handled via the secrets controller, external to the catalog.

Fix #28796.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
