### PR TITLE
orchestrator-kubernetes: Remove TODO about owner_references

### DIFF
--- a/src/orchestrator-kubernetes/src/cloud_resource_controller.rs
+++ b/src/orchestrator-kubernetes/src/cloud_resource_controller.rs
@@ -50,8 +50,6 @@ impl CloudResourceController for KubernetesOrchestrator {
                 labels: Some(labels),
                 name: Some(name.clone()),
                 namespace: Some(self.kubernetes_namespace.clone()),
-                // TODO owner references #28729
-                //owner_references: todo!(),
                 ..Default::default()
             },
             spec: VpcEndpointSpec {


### PR DESCRIPTION
I'm not sure if more has to be done to actually set the correct values. @pH14 @benesch Can you please check?

Follow-up to #29614 
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
