### PR TITLE
output consistency: adapt to psycopg and byte array changes

### DIFF
--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -1213,6 +1213,7 @@ def _error_message_is_about_zero_or_value_ranges(message: str) -> bool:
 def is_unknown_function_or_operation_invocation(error_msg: str) -> bool:
     return (
         "No function matches the given name and argument types" in error_msg
+        or re.search("(function|operator) (.*?) does not exist", error_msg) is not None
         or "No operator matches the given name and argument types" in error_msg
         or ("WHERE clause error: " in error_msg and "does not exist" in error_msg)
     )


### PR DESCRIPTION
This is a follow-up to https://github.com/MaterializeInc/materialize/pull/29591 and addresses https://buildkite.com/materialize/nightly/builds/9634.

### Commits
c98eaa987a postgres consistency: adapt error matching to adapt to move to psycopg
b53026bf27 version consistency: add ignore