### PR TITLE
test: fix wallclock lag tests for sources

### DIFF
--- a/test/testdrive/wallclock-lag.td
+++ b/test/testdrive/wallclock-lag.td
@@ -46,7 +46,7 @@ ALTER SYSTEM SET wallclock_lag_refresh_interval = '1s'
   ENVELOPE DEBEZIUM
 
 > SELECT DISTINCT ON(o.name, r.name)
-    o.name, r.name, l.lag > 0, l.lag < '5s'
+    o.name, r.name, l.lag >= 0, l.lag < '5s'
   FROM mz_internal.mz_wallclock_lag_history l
   JOIN mz_objects o ON o.id = l.object_id
   LEFT JOIN mz_cluster_replicas r ON r.id = l.replica_id
@@ -54,43 +54,45 @@ ALTER SYSTEM SET wallclock_lag_refresh_interval = '1s'
   ORDER BY o.name, r.name, l.occurred_at DESC
 idx          r1     true  true
 idx          r2     true  true
-idx_const    r1     false true
-idx_const    r2     false true
+idx_const    r1     true  true
+idx_const    r2     true  true
 mv           r1     true  true
 mv           r2     true  true
 mv           <null> true  true
-mv_const     r1     false true
-mv_const     r2     false true
-mv_const     <null> false true
+mv_const     r1     true  true
+mv_const     r2     true  true
+mv_const     <null> true  true
 snk          <null> true  true
 src          <null> true  true
 src_progress <null> true  true
 tbl          <null> true  true
 
 > SELECT DISTINCT ON(o.name)
-    o.name, l.lag > 0, l.lag < '5s'
+    o.name, l.lag >= 0, l.lag < '5s'
   FROM mz_internal.mz_wallclock_global_lag_history l
   JOIN mz_objects o ON o.id = l.object_id
   WHERE l.object_id LIKE 'u%'
-  AND o.name NOT LIKE 'src%'
   ORDER BY o.name, l.occurred_at DESC
 idx          true  true
-idx_const    false true
+idx_const    true  true
 mv           true  true
-mv_const     false true
+mv_const     true  true
 snk          true  true
+src          true  true
+src_progress true  true
 tbl          true  true
 
 > SELECT DISTINCT ON(o.name)
-    o.name, l.lag > 0, l.lag < '5s'
+    o.name, l.lag >= 0, l.lag < '5s'
   FROM mz_internal.mz_wallclock_global_lag_recent_history l
   JOIN mz_objects o ON o.id = l.object_id
   WHERE l.object_id LIKE 'u%'
-  AND o.name NOT LIKE 'src%'
   ORDER BY o.name, l.occurred_at DESC
 idx          true  true
-idx_const    false true
+idx_const    true  true
 mv           true  true
-mv_const     false true
+mv_const     true  true
 snk          true  true
+src          true  true
+src_progress true  true
 tbl          true  true


### PR DESCRIPTION
Apparently sources can sometimes have a frontier that's in advance of the wallclock time (and my guess is that this is also true for other objects). Unflake the test by allowing a zero lag for all objects, not just constant collections.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
