### PR TITLE
version consistency: fix ignore

### DIFF
--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -190,17 +190,24 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("Contains on list and array introduced in PR 27959")
 
-        if (
-            self.lower_version < MZ_VERSION_0_118_0 <= self.higher_version
-            and expression.matches(
+        if self.lower_version < MZ_VERSION_0_118_0 <= self.higher_version:
+            if expression.matches(
+                partial(
+                    involves_data_type_category,
+                    data_type_category=DataTypeCategory.RANGE,
+                ),
+                True,
+            ):
+                return YesIgnore("Changes to array range presentation in PR 29532")
+
+            if expression.matches(
                 partial(
                     involves_data_type_category,
                     data_type_category=DataTypeCategory.BYTEA,
                 ),
                 True,
-            )
-        ):
-            return YesIgnore("Changes to byte array presentation in PR 29591")
+            ):
+                return YesIgnore("Changes to byte array presentation in PR 29591")
 
         return super().shall_ignore_expression(expression, row_selection)
 

--- a/test/version-consistency/mzcompose.py
+++ b/test/version-consistency/mzcompose.py
@@ -13,7 +13,6 @@ Test the consistency with another mz version.
 
 import argparse
 
-from materialize.mz_version import MzVersion
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.materialized import Materialized
@@ -141,11 +140,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
 def resolve_tag(tag: str) -> str:
     if tag == "common-ancestor":
-        ancestor_overrides = {
-            # PR#29532 (repr: Fix printing of array ranges) because of pg8000 version upgrade
-            "4e9eb4e8afb4e9cc8979e574d6bef5437c66bf5e": MzVersion.parse_mz("v0.118.0"),
-        }
-        ancestor_overrides.update(ANCESTOR_OVERRIDES_FOR_CORRECTNESS_REGRESSIONS)
-        return resolve_ancestor_image_tag(ancestor_overrides)
+        return resolve_ancestor_image_tag(
+            ANCESTOR_OVERRIDES_FOR_CORRECTNESS_REGRESSIONS
+        )
 
     return tag


### PR DESCRIPTION
This addresses version consistency failures of https://buildkite.com/materialize/nightly/builds/9640#01920a0d-7ab5-46c8-99a3-23162bb1fb9b.

Explanation of the fix: The ancestor override caused a comparison of v0.118.0.x with v0.118.0.y instead of v0.**117**.0.x with v0.118.0.y so that another ignore entry did no longer match.

```
  Value 1 (Dataflow rendering v0.118.0-dev.0 (2f57a6fa7)): '{n=>"\\x68656c6c6f20f09f918b"}' (type: <class 'str'>)
  Value 2 (Dataflow rendering v0.118.0-dev.0 (53becb0a7)): '{n=>\x68656c6c6f20f09f918b}' (type: <class 'str'>)
```