### PR TITLE
benchmarks: Disable persist_catalog_force_compaction_fuel

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -39,6 +39,15 @@ DEFAULT_MZ_VOLUMES = [
 ]
 
 
+# Parameters which disable systems that periodically/unpredictably impact performance
+ADDITIONAL_BENCHMARKING_SYSTEM_PARAMETERS = {
+    "enable_statement_lifecycle_logging": "false",
+    "persist_catalog_force_compaction_fuel": "0",
+    "statement_logging_default_sample_rate": "0",
+    "statement_logging_max_sample_rate": "0",
+}
+
+
 def get_default_system_parameters(
     version: MzVersion | None = None, zero_downtime: bool = False
 ) -> dict[str, str]:

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -31,6 +31,7 @@ from materialize.feature_benchmark.benchmark_versioning import (
 )
 from materialize.feature_benchmark.report import Report
 from materialize.mz_version import MzVersion
+from materialize.mzcompose import ADDITIONAL_BENCHMARKING_SYSTEM_PARAMETERS
 from materialize.mzcompose.services.mysql import MySql
 from materialize.mzcompose.test_result import (
     FailedTestExecutionError,
@@ -176,7 +177,9 @@ def run_one_scenario(
 
         c.up("testdrive", persistent=True)
 
-        additional_system_parameter_defaults = {"max_clusters": "15"}
+        additional_system_parameter_defaults = (
+            ADDITIONAL_BENCHMARKING_SYSTEM_PARAMETERS | {"max_clusters": "15"}
+        )
 
         if params is not None:
             for param in params.split(";"):

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -23,6 +23,7 @@ import numpy
 from matplotlib.markers import MarkerStyle
 
 from materialize import MZ_ROOT, buildkite
+from materialize.mzcompose import ADDITIONAL_BENCHMARKING_SYSTEM_PARAMETERS
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.balancerd import Balancerd
 from materialize.mzcompose.services.cockroach import Cockroach
@@ -269,11 +270,8 @@ def run_once(
                 external_cockroach=True,
                 external_minio=True,
                 sanity_restart=False,
-                additional_system_parameter_defaults={
-                    "enable_statement_lifecycle_logging": "false",
-                    "statement_logging_default_sample_rate": "0",
-                    "statement_logging_max_sample_rate": "0",
-                },
+                additional_system_parameter_defaults=ADDITIONAL_BENCHMARKING_SYSTEM_PARAMETERS
+                | {"max_connections": "100000"},
             )
         ]
 
@@ -297,11 +295,6 @@ def run_once(
             else:
                 c.up(*service_names)
                 c.up("testdrive", persistent=True)
-                c.sql(
-                    "ALTER SYSTEM SET max_connections = 1000000",
-                    user="mz_system",
-                    port=6877,
-                )
 
                 mz_version = c.query_mz_version()
                 mz_string = f"{mz_version} (docker)"

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -20,6 +20,7 @@ from jupyter_core.command import main as jupyter_core_command_main
 from matplotlib import pyplot as plt
 
 from materialize import buildkite, git
+from materialize.mzcompose import ADDITIONAL_BENCHMARKING_SYSTEM_PARAMETERS
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.balancerd import Balancerd
 from materialize.mzcompose.services.materialized import Materialized
@@ -80,6 +81,7 @@ SERVICES = [
     Materialized(
         image="materialize/materialized:latest",
         sanity_restart=False,
+        additional_system_parameter_defaults=ADDITIONAL_BENCHMARKING_SYSTEM_PARAMETERS,
     ),
     Postgres(),
     Balancerd(),


### PR DESCRIPTION
Fixes: #29653

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
