### PR TITLE
[persist] Allow reading back data in structured order

### DIFF
--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use mz_build_info::BuildInfo;
-use mz_dyncfg::{Config, ConfigSet, ConfigType, ConfigUpdates};
+use mz_dyncfg::{Config, ConfigDefault, ConfigSet, ConfigUpdates};
 use mz_ore::instrument;
 use mz_ore::now::NowFn;
 use mz_persist::cfg::BlobKnobs;
@@ -222,7 +222,7 @@ impl PersistConfig {
         }
     }
 
-    pub(crate) fn set_config<T: ConfigType>(&self, cfg: &Config<T>, val: T) {
+    pub(crate) fn set_config<T: ConfigDefault>(&self, cfg: &Config<T>, val: T) {
         let mut updates = ConfigUpdates::default();
         updates.add(cfg, val);
         updates.apply(self)

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -21,11 +21,13 @@ use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
 use futures::Stream;
+use itertools::Either;
 use mz_dyncfg::Config;
 use mz_ore::instrument;
 use mz_ore::now::EpochMillis;
 use mz_ore::task::{AbortOnDropHandle, JoinHandle, RuntimeExt};
 use mz_persist::location::{Blob, SeqNo};
+use mz_persist_types::columnar::{ColumnDecoder, Schema2};
 use mz_persist_types::{Codec, Codec64};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -35,6 +37,7 @@ use tokio::runtime::Handle;
 use tracing::{debug_span, warn, Instrument};
 use uuid::Uuid;
 
+use crate::batch::{BLOB_TARGET_SIZE, STRUCTURED_ORDER};
 use crate::cfg::RetryParameters;
 use crate::fetch::{fetch_leased_part, FetchBatchFilter, FetchedPart, Lease, LeasedBatchPart};
 use crate::internal::encoding::Schemas;
@@ -42,7 +45,7 @@ use crate::internal::machine::{ExpireFn, Machine};
 use crate::internal::metrics::Metrics;
 use crate::internal::state::{BatchPart, HollowBatch};
 use crate::internal::watch::StateWatch;
-use crate::iter::{CodecSort, Consolidator};
+use crate::iter::{CodecSort, Consolidator, StructuredSort};
 use crate::schema::SchemaCache;
 use crate::stats::{SnapshotPartStats, SnapshotPartsStats, SnapshotStats};
 use crate::{parse_id, GarbageCollector, PersistConfig, ShardId};
@@ -904,9 +907,21 @@ pub(crate) struct UnexpiredReadHandleState {
 /// but it's also free to abandon the instance at any time if it eg. only needs a few entries.
 #[derive(Debug)]
 pub struct Cursor<K: Codec, V: Codec, T: Timestamp + Codec64, D: Codec64> {
-    consolidator: Consolidator<T, D>,
+    consolidator: CursorConsolidator<K, V, T, D>,
     _lease: Lease,
     read_schemas: Schemas<K, V>,
+}
+
+#[derive(Debug)]
+enum CursorConsolidator<K: Codec, V: Codec, T: Timestamp + Codec64, D: Codec64> {
+    Codec {
+        consolidator: Consolidator<T, D, CodecSort<T, D>>,
+    },
+    Structured {
+        consolidator: Consolidator<T, D, StructuredSort<K, V, T, D>>,
+        max_len: usize,
+        max_bytes: usize,
+    },
 }
 
 impl<K, V, T, D> Cursor<K, V, T, D>
@@ -920,17 +935,56 @@ where
     pub async fn next(
         &mut self,
     ) -> Option<impl Iterator<Item = ((Result<K, String>, Result<V, String>), T, D)> + '_> {
-        let iter = self
-            .consolidator
-            .next()
-            .await
-            .expect("fetching a leased part")?;
-        let iter = iter.map(|((k, v), t, d)| {
-            let key = K::decode(k, &self.read_schemas.key);
-            let val = V::decode(v, &self.read_schemas.val);
-            ((key, val), t, d)
-        });
-        Some(iter)
+        match &mut self.consolidator {
+            CursorConsolidator::Structured {
+                consolidator,
+                max_len,
+                max_bytes,
+            } => {
+                let mut iter = consolidator
+                    .next_chunk(*max_len, *max_bytes)
+                    .await
+                    .expect("fetching a leased part")?;
+                let structured = iter.get_or_make_structured::<K, V>(
+                    self.read_schemas.key.as_ref(),
+                    self.read_schemas.val.as_ref(),
+                );
+                let key_decoder = self
+                    .read_schemas
+                    .key
+                    .decoder_any(structured.key.as_ref())
+                    .expect("ok");
+                let val_decoder = self
+                    .read_schemas
+                    .val
+                    .decoder_any(structured.val.as_ref())
+                    .expect("ok");
+                let iter = (0..iter.len()).map(move |i| {
+                    let mut k = K::default();
+                    let mut v = V::default();
+                    key_decoder.decode(i, &mut k);
+                    val_decoder.decode(i, &mut v);
+                    let t = T::decode(iter.records().timestamps().value(i).to_le_bytes());
+                    let d = D::decode(iter.records().diffs().value(i).to_le_bytes());
+                    ((Ok(k), Ok(v)), t, d)
+                });
+
+                Some(Either::Left(iter))
+            }
+            CursorConsolidator::Codec { consolidator } => {
+                let iter = consolidator
+                    .next()
+                    .await
+                    .expect("fetching a leased part")?
+                    .map(|((k, v), t, d)| {
+                        let key = K::decode(k, &self.read_schemas.key);
+                        let val = V::decode(v, &self.read_schemas.val);
+                        ((key, val), t, d)
+                    });
+
+                Some(Either::Right(iter))
+            }
+        }
     }
 }
 
@@ -993,32 +1047,68 @@ where
     ) -> Result<Cursor<K, V, T, D>, Since<T>> {
         let batches = self.machine.snapshot(&as_of).await?;
 
-        let mut consolidator = Consolidator::new(
-            format!("{}[as_of={:?}]", self.shard_id(), as_of.elements()),
-            self.shard_id(),
-            CodecSort::default(),
-            Arc::clone(&self.blob),
-            Arc::clone(&self.metrics),
-            Arc::clone(&self.machine.applier.shard_metrics),
-            self.metrics.read.snapshot.clone(),
-            FetchBatchFilter::Snapshot {
-                as_of: as_of.clone(),
-            },
-            self.cfg.dynamic.compaction_memory_bound_bytes(),
-        );
-
+        let context = format!("{}[as_of={:?}]", self.shard_id(), as_of.elements());
+        let filter = FetchBatchFilter::Snapshot {
+            as_of: as_of.clone(),
+        };
         let lease = self.lease_seqno();
-        for batch in batches {
-            for (meta, run) in batch.runs() {
-                consolidator.enqueue_run(
-                    &batch.desc,
-                    meta,
-                    run.into_iter()
-                        .filter(|p| should_fetch_part(p.stats()))
-                        .cloned(),
-                );
+
+        let consolidator = if STRUCTURED_ORDER.get(&self.cfg) {
+            let mut consolidator = Consolidator::new(
+                context,
+                self.shard_id(),
+                StructuredSort::new(self.read_schemas.clone()),
+                Arc::clone(&self.blob),
+                Arc::clone(&self.metrics),
+                Arc::clone(&self.machine.applier.shard_metrics),
+                self.metrics.read.snapshot.clone(),
+                filter,
+                self.cfg.dynamic.compaction_memory_bound_bytes(),
+            );
+            for batch in batches {
+                for (meta, run) in batch.runs() {
+                    consolidator.enqueue_run(
+                        &batch.desc,
+                        meta,
+                        run.into_iter()
+                            .filter(|p| should_fetch_part(p.stats()))
+                            .cloned(),
+                    );
+                }
             }
-        }
+            CursorConsolidator::Structured {
+                consolidator,
+                // This default may end up consolidating more records than previously
+                // for cases like fast-path peeks, where only the first few entries are used.
+                // If this is a noticeable performance impact, thread the max-len in from the caller.
+                max_len: self.cfg.compaction_yield_after_n_updates,
+                max_bytes: BLOB_TARGET_SIZE.get(&self.cfg).max(1),
+            }
+        } else {
+            let mut consolidator = Consolidator::new(
+                context,
+                self.shard_id(),
+                CodecSort::default(),
+                Arc::clone(&self.blob),
+                Arc::clone(&self.metrics),
+                Arc::clone(&self.machine.applier.shard_metrics),
+                self.metrics.read.snapshot.clone(),
+                filter,
+                self.cfg.dynamic.compaction_memory_bound_bytes(),
+            );
+            for batch in batches {
+                for (meta, run) in batch.runs() {
+                    consolidator.enqueue_run(
+                        &batch.desc,
+                        meta,
+                        run.into_iter()
+                            .filter(|p| should_fetch_part(p.stats()))
+                            .cloned(),
+                    );
+                }
+            }
+            CursorConsolidator::Codec { consolidator }
+        };
 
         Ok(Cursor {
             consolidator,

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -107,7 +107,7 @@ pub trait Schema2<T>: Debug + Send + Sync {
     type Statistics: DynStats + 'static;
 
     /// Type that is able to decode values of `T` from [`Self::ArrowColumn`].
-    type Decoder: ColumnDecoder<T> + Debug;
+    type Decoder: ColumnDecoder<T> + Debug + Send + Sync;
     /// Type that is able to encoder values of `T`.
     type Encoder: ColumnEncoder<T, FinishedColumn = Self::ArrowColumn> + Debug;
 

--- a/test/sqllogictest/persist-fast-path.slt
+++ b/test/sqllogictest/persist-fast-path.slt
@@ -9,8 +9,21 @@
 
 mode cockroach
 
+# To make ordering deterministic for fast-path peeks, enable the
+# structured part format and set Persist to use that ordering.
+
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET persist_fast_path_limit = 100
+ALTER SYSTEM SET persist_batch_columnar_format = 'both_v2'
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET persist_batch_columnar_format_percent = 100
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET persist_batch_structured_order = true
 ----
 COMPLETE 0
 
@@ -68,10 +81,9 @@ INSERT INTO numbers SELECT generate_series(1, 3);
 statement ok
 INSERT INTO numbers SELECT generate_series(1, 10);
 
-# The ordering here is technically nondeterministic, but in practice unlikely to change.
-# Feel free to rewrite or remove if this causes trouble.
+# We should deterministically return the first N values.
 
-query T
+query T valuesort
 SELECT value from numbers LIMIT 20;
 ----
 1
@@ -103,22 +115,22 @@ statement ok
 INSERT INTO numbers SELECT generate_series(5, 100);
 
 statement ok
-INSERT INTO numbers SELECT generate_series(50, 1000);
+INSERT INTO numbers SELECT generate_series(-1, 10);
 
 statement ok
 INSERT INTO numbers SELECT generate_series(500, 10000);
 
-# Since we don't guarantee which of the rows are returned, transform the results
-# in a way that doesn't depend on the specific values.
+# Since we order the data in terms of its structured representation, we see the
+# smallest values regardless of which order they were inserted in.
 
-query T
-SELECT value < 999999 from numbers LIMIT 5;
+query T valuesort
+SELECT value from numbers LIMIT 5;
 ----
-true
-true
-true
-true
-true
+-1
+0
+1
+1
+1
 
 # Errors should always be returned even when the limit is small
 statement ok


### PR DESCRIPTION
### Motivation

Part of MaterializeInc/database-issues#7411 - allows reading back data in the structured-data order.

Before this change, we could configure Persist to compact data in the new structured-data order, but when we were consolidating at read time we'd reorder it back to the codec order. This is inefficient, and we'd like to allow callers to rely on the sorted order of data in the future for things like `PARTITION BY`.

### Tips for reviewer

This uses the same ordering flag as the compaction side, which is a little weird: when we first flip the flag, we'll start using the new order for the fast-path peeks before there's any meaningful percentage of batch parts in the new order. It's possible we'll want to add fancier knobs for the true rollout, but this is enough to toggle things in CI / staging for now.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
