### PR TITLE
adapter: Remove old log line

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3774,18 +3774,10 @@ pub fn serve(
                         .await
                         .map_err(AdapterError::Orchestrator)?;
 
-                    // TODO(jkosh44) Kick this off as a background task in
-                    // `serve` instead of blocking startup on the pruning.
                     if let Some(retention_period) = storage_usage_retention_period {
-                        let prune_start = Instant::now();
-                        info!("startup: coord serve: storage usage prune beginning");
                         coord
                             .prune_storage_usage_events_on_startup(retention_period)
                             .await;
-                        info!(
-                            "startup: coord serve: storage usage prune complete in {:?}",
-                            prune_start.elapsed()
-                        );
                     }
 
                     Ok(())


### PR DESCRIPTION
This commit removes the log for timing storage usage pruning, since it happens in the background.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
