### PR TITLE
adapter: synthesize and apply side effects (aka. controller commands) from catalog changes

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -16,6 +16,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::convert;
 use std::sync::Arc;
 
+#[cfg(test)]
+use crate::catalog::side_effects::CatalogSideEffect;
 use futures::Future;
 use itertools::Itertools;
 use mz_adapter_types::connection::ConnectionId;
@@ -93,6 +95,7 @@ use crate::{AdapterError, AdapterNotice, ExecuteResponse};
 mod builtin_table_updates;
 pub(crate) mod consistency;
 mod migrate;
+pub(crate) mod side_effects;
 
 mod apply;
 mod open;
@@ -1263,13 +1266,20 @@ impl Catalog {
     /// Listen for and apply all unconsumed updates to the durable catalog state.
     // TODO(jkosh44) When this method is actually used outside of a test we can remove the
     // `#[cfg(test)]` annotation.
+    // WIP: Structured return type?
     #[cfg(test)]
     async fn sync_to_current_updates(
         &mut self,
-    ) -> Result<Vec<BuiltinTableUpdate<&'static BuiltinTable>>, CatalogError> {
+    ) -> Result<
+        (
+            Vec<BuiltinTableUpdate<&'static BuiltinTable>>,
+            Vec<CatalogSideEffect>,
+        ),
+        CatalogError,
+    > {
         let updates = self.storage().await.sync_to_current_updates().await?;
-        let builtin_table_updates = self.state.apply_updates(updates)?;
-        Ok(builtin_table_updates)
+        let (builtin_table_updates, side_effects) = self.state.apply_updates(updates)?;
+        Ok((builtin_table_updates, side_effects))
     }
 }
 

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -58,6 +58,7 @@ use mz_sql_parser::ast::Expr;
 use mz_storage_types::sources::Timeline;
 use tracing::{error, info_span, warn, Instrument};
 
+use crate::catalog::side_effects::CatalogSideEffect;
 use crate::catalog::{BuiltinTableUpdate, CatalogState};
 use crate::util::index_sql;
 use crate::AdapterError;
@@ -97,8 +98,12 @@ impl CatalogState {
     pub(crate) async fn apply_updates_for_bootstrap(
         &mut self,
         updates: Vec<StateUpdate>,
-    ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
+    ) -> (
+        Vec<BuiltinTableUpdate<&'static BuiltinTable>>,
+        Vec<CatalogSideEffect>,
+    ) {
         let mut builtin_table_updates = Vec::with_capacity(updates.len());
+        let mut side_effects = Vec::with_capacity(updates.len());
         let updates = sort_updates(updates);
 
         let mut groups: Vec<Vec<_>> = Vec::new();
@@ -111,18 +116,22 @@ impl CatalogState {
 
             for update in updates {
                 let next_apply_state = BootstrapApplyState::new(update);
-                let (next_apply_state, builtin_table_update) = apply_state
+                let (next_apply_state, (builtin_table_update, side_effect)) = apply_state
                     .step(next_apply_state, self, &mut retractions)
                     .await;
                 apply_state = next_apply_state;
                 builtin_table_updates.extend(builtin_table_update);
+                side_effects.extend(side_effect);
             }
 
             // Apply remaining state.
-            let builtin_table_update = apply_state.apply(self, &mut retractions).await;
+            let (builtin_table_update, side_effect) =
+                apply_state.apply(self, &mut retractions).await;
             builtin_table_updates.extend(builtin_table_update);
+            side_effects.extend(side_effect);
         }
-        builtin_table_updates
+
+        (builtin_table_updates, side_effects)
     }
 
     /// Update in-memory catalog state from a list of updates made to the durable catalog state.
@@ -132,18 +141,26 @@ impl CatalogState {
     pub(crate) fn apply_updates(
         &mut self,
         updates: Vec<StateUpdate>,
-    ) -> Result<Vec<BuiltinTableUpdate<&'static BuiltinTable>>, CatalogError> {
+    ) -> Result<
+        (
+            Vec<BuiltinTableUpdate<&'static BuiltinTable>>,
+            Vec<CatalogSideEffect>,
+        ),
+        CatalogError,
+    > {
         let mut builtin_table_updates = Vec::with_capacity(updates.len());
+        let mut side_effects = Vec::with_capacity(updates.len());
         let updates = sort_updates(updates);
 
         for (_, updates) in &updates.into_iter().group_by(|update| update.ts) {
             let mut retractions = InProgressRetractions::default();
-            let builtin_table_update =
+            let (builtin_table_update, side_effect) =
                 self.apply_updates_inner(updates.collect(), &mut retractions)?;
             builtin_table_updates.extend(builtin_table_update);
+            side_effects.extend(side_effect);
         }
 
-        Ok(builtin_table_updates)
+        Ok((builtin_table_updates, side_effects))
     }
 
     #[must_use]
@@ -152,16 +169,28 @@ impl CatalogState {
         &mut self,
         updates: Vec<StateUpdate>,
         retractions: &mut InProgressRetractions,
-    ) -> Result<Vec<BuiltinTableUpdate<&'static BuiltinTable>>, CatalogError> {
+    ) -> Result<
+        (
+            Vec<BuiltinTableUpdate<&'static BuiltinTable>>,
+            Vec<CatalogSideEffect>,
+        ),
+        CatalogError,
+    > {
         soft_assert_no_log!(
             updates.iter().map(|update| update.ts).all_equal(),
             "all timestamps should be equal: {updates:?}"
         );
 
         let mut builtin_table_updates = Vec::with_capacity(updates.len());
+        let mut side_effects = Vec::new();
+
         for StateUpdate { kind, ts: _, diff } in updates {
             match diff {
                 StateDiff::Retraction => {
+                    // We want the side effect to match the state of the catalog
+                    // _before_ applying the update.
+                    side_effects.extend(self.generate_side_effects(kind.clone(), diff));
+
                     // We want the builtin table retraction to match the state of the catalog
                     // before applying the update.
                     builtin_table_updates
@@ -174,10 +203,14 @@ impl CatalogState {
                     // after applying the update.
                     builtin_table_updates
                         .extend(self.generate_builtin_table_update(kind.clone(), diff));
+
+                    // We want the side effect to match the state of the catalog
+                    // _after_ applying the update.
+                    side_effects.extend(self.generate_side_effects(kind.clone(), diff));
                 }
             }
         }
-        Ok(builtin_table_updates)
+        Ok((builtin_table_updates, side_effects))
     }
 
     #[instrument(level = "debug")]
@@ -1813,7 +1846,10 @@ impl BootstrapApplyState {
         self,
         state: &mut CatalogState,
         retractions: &mut InProgressRetractions,
-    ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
+    ) -> (
+        Vec<BuiltinTableUpdate<&'static BuiltinTable>>,
+        Vec<CatalogSideEffect>,
+    ) {
         match self {
             BootstrapApplyState::BuiltinViewAdditions(builtin_view_additions) => {
                 let restore = state.system_configuration.clone();
@@ -1821,7 +1857,7 @@ impl BootstrapApplyState {
                 let builtin_table_updates =
                     CatalogState::parse_builtin_views(state, builtin_view_additions).await;
                 state.system_configuration = restore;
-                builtin_table_updates
+                (builtin_table_updates, Vec::new())
             }
             BootstrapApplyState::Items(updates) => state.with_enable_for_item_parsing(|state| {
                 state
@@ -1841,7 +1877,10 @@ impl BootstrapApplyState {
         retractions: &mut InProgressRetractions,
     ) -> (
         BootstrapApplyState,
-        Vec<BuiltinTableUpdate<&'static BuiltinTable>>,
+        (
+            Vec<BuiltinTableUpdate<&'static BuiltinTable>>,
+            Vec<CatalogSideEffect>,
+        ),
     ) {
         match (self, next) {
             (
@@ -1852,13 +1891,16 @@ impl BootstrapApplyState {
                 builtin_view_additions.extend(next_builtin_view_additions);
                 (
                     BootstrapApplyState::BuiltinViewAdditions(builtin_view_additions),
-                    Vec::new(),
+                    (Vec::new(), Vec::new()),
                 )
             }
             (BootstrapApplyState::Items(mut updates), BootstrapApplyState::Items(next_updates)) => {
                 // Continue batching item updates.
                 updates.extend(next_updates);
-                (BootstrapApplyState::Items(updates), Vec::new())
+                (
+                    BootstrapApplyState::Items(updates),
+                    (Vec::new(), Vec::new()),
+                )
             }
             (
                 BootstrapApplyState::Updates(mut updates),
@@ -1866,12 +1908,15 @@ impl BootstrapApplyState {
             ) => {
                 // Continue batching updates.
                 updates.extend(next_updates);
-                (BootstrapApplyState::Updates(updates), Vec::new())
+                (
+                    BootstrapApplyState::Updates(updates),
+                    (Vec::new(), Vec::new()),
+                )
             }
             (apply_state, next_apply_state) => {
                 // Apply the current batch and start batching new apply state.
-                let builtin_table_update = apply_state.apply(state, retractions).await;
-                (next_apply_state, builtin_table_update)
+                let updates = apply_state.apply(state, retractions).await;
+                (next_apply_state, updates)
             }
         }
     }

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -23,6 +23,7 @@ use semver::Version;
 use tracing::info;
 // DO NOT add any more imports from `crate` outside of `crate::catalog`.
 use crate::catalog::open::into_consolidatable_updates_startup;
+use crate::catalog::side_effects::CatalogSideEffect;
 use crate::catalog::{BuiltinTableUpdate, CatalogState, ConnCatalog};
 
 async fn rewrite_ast_items<F>(tx: &mut Transaction<'_>, mut f: F) -> Result<(), anyhow::Error>
@@ -84,7 +85,13 @@ pub(crate) async fn migrate(
     item_updates: Vec<StateUpdate>,
     _now: NowFn,
     _boot_ts: Timestamp,
-) -> Result<Vec<BuiltinTableUpdate<&'static BuiltinTable>>, anyhow::Error> {
+) -> Result<
+    (
+        Vec<BuiltinTableUpdate<&'static BuiltinTable>>,
+        Vec<CatalogSideEffect>,
+    ),
+    anyhow::Error,
+> {
     let catalog_version = tx.get_catalog_content_version();
     let catalog_version = match catalog_version {
         Some(v) => Version::parse(&v)?,
@@ -127,7 +134,8 @@ pub(crate) async fn migrate(
             diff: diff.try_into().expect("valid diff"),
         })
         .collect();
-    let mut ast_builtin_table_updates = state.apply_updates_for_bootstrap(item_updates).await;
+    let (mut ast_builtin_table_updates, mut ast_side_effects) =
+        state.apply_updates_for_bootstrap(item_updates).await;
 
     info!("migrating from catalog version {:?}", catalog_version);
 
@@ -161,15 +169,17 @@ pub(crate) async fn migrate(
     // input and stages arbitrary transformations to the catalog on `tx`.
 
     let op_item_updates = tx.get_and_commit_op_updates();
-    let item_builtin_table_updates = state.apply_updates_for_bootstrap(op_item_updates).await;
+    let (item_builtin_table_updates, item_side_effects) =
+        state.apply_updates_for_bootstrap(op_item_updates).await;
 
     ast_builtin_table_updates.extend(item_builtin_table_updates);
+    ast_side_effects.extend(item_side_effects);
 
     info!(
         "migration from catalog version {:?} complete",
         catalog_version
     );
-    Ok(ast_builtin_table_updates)
+    Ok((ast_builtin_table_updates, ast_side_effects))
 }
 
 // Add new migrations below their appropriate heading, and precede them with a

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -365,7 +365,12 @@ impl Catalog {
             }
         }
 
-        let builtin_table_update = state.apply_updates_for_bootstrap(pre_item_updates).await;
+        // When initializing/bootstrapping, we don't use the side effects but
+        // instead load the catalog fully and then go ahead and apply the side
+        // effects. Maybe we _should_ instead use the same logic and return and
+        // use the side effects from here.
+        let (builtin_table_update, _side_effects) =
+            state.apply_updates_for_bootstrap(pre_item_updates).await;
         builtin_table_updates.extend(builtin_table_update);
 
         let last_seen_version = txn
@@ -373,7 +378,7 @@ impl Catalog {
             .unwrap_or_else(|| "new".to_string());
 
         // Migrate item ASTs.
-        let builtin_table_update = if !config.skip_migrations {
+        let (builtin_table_update, _side_effect) = if !config.skip_migrations {
             migrate::migrate(
                 &mut state,
                 &mut txn,
@@ -394,7 +399,8 @@ impl Catalog {
         };
         builtin_table_updates.extend(builtin_table_update);
 
-        let builtin_table_update = state.apply_updates_for_bootstrap(post_item_updates).await;
+        let (builtin_table_update, _side_effect) =
+            state.apply_updates_for_bootstrap(post_item_updates).await;
         builtin_table_updates.extend(builtin_table_update);
 
         // Migrate builtin items.
@@ -552,8 +558,9 @@ impl Catalog {
             .map_err(mz_catalog::durable::DurableCatalogError::from)?;
 
         let updates = txn.get_and_commit_op_updates();
-        let builtin_updates = state.apply_updates(updates)?;
+        let (builtin_updates, side_effects) = state.apply_updates(updates)?;
         assert_eq!(builtin_updates, Vec::new());
+        assert!(side_effects.is_empty());
         txn.commit().await?;
         drop(storage);
 
@@ -819,7 +826,12 @@ impl Catalog {
                 }),
         )?;
         let updates = txn.get_and_commit_op_updates();
-        let builtin_table_update = state.apply_updates_for_bootstrap(updates).await;
+
+        // When initializing/bootstrapping, we don't use the side effects but
+        // instead load the catalog fully and then go ahead and apply the side
+        // effects. Maybe we _should_ instead use the same logic and return and
+        // use the side effects from here.
+        let (builtin_table_update, _side_effect) = state.apply_updates_for_bootstrap(updates).await;
         builtin_table_updates.extend(builtin_table_update);
         for CreateOp {
             id,
@@ -843,7 +855,13 @@ impl Catalog {
                 privileges.all_values_owned().collect(),
             )?;
             let updates = txn.get_and_commit_op_updates();
-            let builtin_table_update = state.apply_updates_for_bootstrap(updates).await;
+
+            // When initializing/bootstrapping, we don't use the controller
+            // updates but instead load the catalog fully and then go ahead and
+            // apply the side effects. Maybe we _should_ instead use the same
+            // logic and return and use the side effects from here.
+            let (builtin_table_update, _side_effect) =
+                state.apply_updates_for_bootstrap(updates).await;
             builtin_table_updates.extend(builtin_table_update);
         }
         Ok(builtin_table_updates)

--- a/src/adapter/src/catalog/open/builtin_item_migration.rs
+++ b/src/adapter/src/catalog/open/builtin_item_migration.rs
@@ -409,7 +409,11 @@ async fn migrate_builtin_items_0dt(
     };
 
     let updates = txn.get_and_commit_op_updates();
-    let builtin_table_updates = state.apply_updates_for_bootstrap(updates).await;
+    // When initializing/bootstrapping, we don't use the side effects but
+    // instead load the catalog fully and then go ahead and apply the controller
+    // updates. Maybe we _should_ instead use the same logic and return and use
+    // the side effects from here.
+    let (builtin_table_updates, _side_effects) = state.apply_updates_for_bootstrap(updates).await;
 
     let cleanup_action = async move {
         if !read_only {

--- a/src/adapter/src/catalog/side_effects.rs
+++ b/src/adapter/src/catalog/side_effects.rs
@@ -1,0 +1,65 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Side effects derived from catalog changes that can be applied to a
+//! controller.
+
+use mz_catalog::memory::objects::{CatalogItem, StateDiff, StateUpdateKind, Table};
+use mz_ore::instrument;
+use mz_repr::GlobalId;
+
+// DO NOT add any more imports from `crate` outside of `crate::catalog`.
+use crate::catalog::CatalogState;
+
+/// An update that needs to be applied to a controller.
+#[derive(Debug, Clone)]
+pub enum CatalogSideEffect {
+    CreateTable(GlobalId, Table),
+    DropTable(GlobalId),
+}
+
+impl CatalogState {
+    /// Generate a list of [CatalogSideEffects](CatalogSideEffect) that
+    /// correspond to a single update made to the durable catalog.
+    #[instrument(level = "debug")]
+    pub(crate) fn generate_side_effects(
+        &self,
+        kind: StateUpdateKind,
+        diff: StateDiff,
+    ) -> Vec<CatalogSideEffect> {
+        // WIP: Exhaustive match?
+        match kind {
+            StateUpdateKind::Item(item) => self.generate_item_update(item.id, diff),
+            _ => Vec::new(),
+        }
+    }
+
+    fn generate_item_update(&self, id: GlobalId, diff: StateDiff) -> Vec<CatalogSideEffect> {
+        let entry = self.get_entry(&id);
+        let id = entry.id();
+
+        // WIP: Exhaustive match?
+        let updates = match entry.item() {
+            CatalogItem::Table(table) => match diff {
+                StateDiff::Addition => {
+                    vec![CatalogSideEffect::CreateTable(id, table.clone())]
+                }
+                StateDiff::Retraction => {
+                    vec![CatalogSideEffect::DropTable(id)]
+                }
+            },
+            _ => {
+                // WIP!
+                Vec::new()
+            }
+        };
+
+        updates
+    }
+}

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -53,6 +53,7 @@ use mz_sql_parser::ast::{QualifiedReplica, Value};
 use mz_storage_client::controller::StorageController;
 use tracing::{info, trace};
 
+use crate::catalog::side_effects::CatalogSideEffect;
 use crate::catalog::{
     catalog_type_to_audit_object_type, comment_id_to_audit_object_type, is_reserved_name,
     is_reserved_role_name, object_type_to_audit_object_type,
@@ -296,6 +297,7 @@ impl ReplicaCreateDropReason {
 
 pub struct TransactionResult {
     pub builtin_table_updates: Vec<BuiltinTableUpdate>,
+    pub side_effects: Vec<CatalogSideEffect>,
     pub audit_events: Vec<VersionedEvent>,
 }
 
@@ -383,6 +385,7 @@ impl Catalog {
             .collect();
         let temporary_ids = self.temporary_ids(&ops, temporary_drops)?;
         let mut builtin_table_updates = vec![];
+        let mut side_effects = vec![];
         let mut audit_events = vec![];
         let mut storage = self.storage().await;
         let mut tx = storage
@@ -399,6 +402,7 @@ impl Catalog {
             ops,
             temporary_ids,
             &mut builtin_table_updates,
+            &mut side_effects,
             &mut audit_events,
             &mut tx,
             &mut state,
@@ -432,6 +436,7 @@ impl Catalog {
 
         Ok(TransactionResult {
             builtin_table_updates,
+            side_effects,
             audit_events,
         })
     }
@@ -450,6 +455,7 @@ impl Catalog {
         mut ops: Vec<Op>,
         temporary_ids: Vec<GlobalId>,
         builtin_table_updates: &mut Vec<BuiltinTableUpdate>,
+        side_effects: &mut Vec<CatalogSideEffect>,
         audit_events: &mut Vec<VersionedEvent>,
         tx: &mut Transaction<'_>,
         state: &mut CatalogState,
@@ -510,10 +516,12 @@ impl Catalog {
 
             let mut updates: Vec<_> = tx.get_and_commit_op_updates();
             updates.extend(temporary_item_updates);
-            let op_builtin_table_updates = state.apply_updates(updates)?;
+            let (op_builtin_table_updates, op_side_effects) =
+                state.apply_updates(updates.clone())?;
             let op_builtin_table_updates =
                 state.resolve_builtin_table_updates(op_builtin_table_updates);
             builtin_table_updates.extend(op_builtin_table_updates);
+            side_effects.extend(op_side_effects);
         }
 
         if dry_run_ops.is_empty() {
@@ -528,10 +536,12 @@ impl Catalog {
             }
 
             let updates = tx.get_and_commit_op_updates();
-            let op_builtin_table_updates = state.apply_updates(updates)?;
+            let (op_builtin_table_updates, op_side_effects) =
+                state.apply_updates(updates.clone())?;
             let op_builtin_table_updates =
                 state.resolve_builtin_table_updates(op_builtin_table_updates);
             builtin_table_updates.extend(op_builtin_table_updates);
+            side_effects.extend(op_side_effects);
 
             Ok(())
         } else {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -205,6 +205,7 @@ mod catalog_serving;
 pub mod cluster_scheduling;
 mod command_handler;
 pub mod consistency;
+mod controller_apply;
 mod ddl;
 mod indexes;
 mod introspection;

--- a/src/adapter/src/coord/controller_apply.rs
+++ b/src/adapter/src/coord/controller_apply.rs
@@ -21,12 +21,13 @@ use tracing::{info_span, Instrument};
 
 use crate::catalog::side_effects::CatalogSideEffect;
 use crate::coord::Coordinator;
-use crate::{AdapterError, ResultExt};
+use crate::{AdapterError, ExecuteContext, ResultExt};
 
 impl Coordinator {
     #[instrument(level = "debug")]
     pub async fn controller_apply_side_effects(
         &mut self,
+        mut ctx: Option<&mut ExecuteContext>,
         updates: Vec<CatalogSideEffect>,
     ) -> Result<(), AdapterError> {
         let mut tables_to_drop = Vec::new();
@@ -35,7 +36,7 @@ impl Coordinator {
             tracing::info!(?update, "have to apply!");
             match update {
                 CatalogSideEffect::CreateTable(id, table) => {
-                    self.controller_create_table(id, table).await?
+                    self.controller_create_table(&mut ctx, id, table).await?
                 }
                 CatalogSideEffect::DropTable(id) => {
                     tables_to_drop.push(id);
@@ -62,6 +63,7 @@ impl Coordinator {
     #[instrument(level = "debug")]
     async fn controller_create_table(
         &mut self,
+        ctx: &mut Option<&mut ExecuteContext>,
         table_id: GlobalId,
         table: Table,
     ) -> Result<(), AdapterError> {
@@ -84,9 +86,9 @@ impl Coordinator {
                     .await
                     .unwrap_or_terminate("unable to confirm leadership");
 
-                //if let Some(id) = ctx.as_ref().and_then(|ctx| ctx.extra().contents()) {
-                //    self.set_statement_execution_timestamp(id, register_ts);
-                //}
+                if let Some(id) = ctx.as_ref().and_then(|ctx| ctx.extra().contents()) {
+                    self.set_statement_execution_timestamp(id, register_ts);
+                }
 
                 let collection_desc = CollectionDescription::from_desc(
                     table.desc.clone(),

--- a/src/adapter/src/coord/controller_apply.rs
+++ b/src/adapter/src/coord/controller_apply.rs
@@ -1,0 +1,178 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Logic related to applying [CatalogSideEffects](CatalogSideEffect) to
+//! controller(s).
+
+use maplit::btreeset;
+use mz_adapter_types::compaction::CompactionWindow;
+use mz_catalog::memory::objects::{DataSourceDesc, Table, TableDataSource};
+use mz_ore::instrument;
+use mz_repr::{GlobalId, Timestamp};
+use mz_storage_client::controller::{CollectionDescription, DataSource, DataSourceOther};
+use mz_storage_types::connections::inline::IntoInlineConnection;
+use tracing::{info_span, Instrument};
+
+use crate::catalog::side_effects::CatalogSideEffect;
+use crate::coord::Coordinator;
+use crate::{AdapterError, ResultExt};
+
+impl Coordinator {
+    #[instrument(level = "debug")]
+    pub async fn controller_apply_side_effects(
+        &mut self,
+        updates: Vec<CatalogSideEffect>,
+    ) -> Result<(), AdapterError> {
+        let mut tables_to_drop = Vec::new();
+
+        for update in updates {
+            tracing::info!(?update, "have to apply!");
+            match update {
+                CatalogSideEffect::CreateTable(id, table) => {
+                    self.controller_create_table(id, table).await?
+                }
+                CatalogSideEffect::DropTable(id) => {
+                    tables_to_drop.push(id);
+                }
+            }
+        }
+
+        // No error returns are allowed after this point. Enforce this at compile time
+        // by using this odd structure so we don't accidentally add a stray `?`.
+        //
+        // WIP: Do we need to cargo cult this structure?
+        let _: () = async {
+            if !tables_to_drop.is_empty() {
+                let ts = self.get_local_write_ts().await;
+                self.drop_tables(tables_to_drop, ts.timestamp);
+            }
+        }
+        .instrument(info_span!("coord::controller_apply_updates::finalize"))
+        .await;
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug")]
+    async fn controller_create_table(
+        &mut self,
+        table_id: GlobalId,
+        table: Table,
+    ) -> Result<(), AdapterError> {
+        // The table data_source determines whether this table will be written to
+        // by environmentd (e.g. with INSERT INTO statements) or by the storage layer
+        // (e.g. a source-fed table).
+        match table.data_source {
+            TableDataSource::TableWrites { defaults: _ } => {
+                // Determine the initial validity for the table.
+                let register_ts = self.get_local_write_ts().await.timestamp;
+
+                // After acquiring `register_ts` but before using it, we need to
+                // be sure we're still the leader. Otherwise a new generation
+                // may also be trying to use `register_ts` for a different
+                // purpose.
+                //
+                // See #28216.
+                self.catalog
+                    .confirm_leadership()
+                    .await
+                    .unwrap_or_terminate("unable to confirm leadership");
+
+                //if let Some(id) = ctx.as_ref().and_then(|ctx| ctx.extra().contents()) {
+                //    self.set_statement_execution_timestamp(id, register_ts);
+                //}
+
+                let collection_desc = CollectionDescription::from_desc(
+                    table.desc.clone(),
+                    DataSourceOther::TableWrites,
+                );
+                let storage_metadata = self.catalog.state().storage_metadata();
+                self.controller
+                    .storage
+                    .create_collections(
+                        storage_metadata,
+                        Some(register_ts),
+                        vec![(table_id, collection_desc)],
+                    )
+                    .await
+                    .unwrap_or_terminate("cannot fail to create collections");
+                self.apply_local_write(register_ts).await;
+
+                self.initialize_storage_read_policies(
+                    btreeset![table_id],
+                    table
+                        .custom_logical_compaction_window
+                        .unwrap_or(CompactionWindow::Default),
+                )
+                .await;
+            }
+            TableDataSource::DataSource(data_source) => {
+                match data_source {
+                    DataSourceDesc::IngestionExport {
+                        ingestion_id,
+                        external_reference: _,
+                        details,
+                        data_config,
+                    } => {
+                        // TODO: It's a little weird that a table will be present in this
+                        // source status collection, we might want to split out into a separate
+                        // status collection.
+                        let status_collection_id =
+                            Some(self.catalog().resolve_builtin_storage_collection(
+                                &mz_catalog::builtin::MZ_SOURCE_STATUS_HISTORY,
+                            ));
+                        let collection_desc = CollectionDescription::<Timestamp> {
+                            desc: table.desc.clone(),
+                            data_source: DataSource::IngestionExport {
+                                ingestion_id,
+                                details,
+                                data_config: data_config
+                                    .into_inline_connection(self.catalog.state()),
+                            },
+                            since: None,
+                            status_collection_id,
+                        };
+                        let storage_metadata = self.catalog.state().storage_metadata();
+                        self.controller
+                            .storage
+                            .create_collections(
+                                storage_metadata,
+                                None,
+                                vec![(table_id, collection_desc)],
+                            )
+                            .await
+                            .unwrap_or_terminate("cannot fail to create collections");
+
+                        let read_policies = self
+                            .catalog()
+                            .state()
+                            .source_compaction_windows(vec![table_id]);
+                        for (compaction_window, storage_policies) in read_policies {
+                            self.initialize_storage_read_policies(
+                                storage_policies,
+                                compaction_window,
+                            )
+                            .await;
+                        }
+                    }
+                    _ => unreachable!("CREATE TABLE data source got {:?}", data_source),
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn drop_tables(&mut self, tables: Vec<GlobalId>, ts: Timestamp) {
+        let storage_metadata = self.catalog.state().storage_metadata();
+        self.controller
+            .storage
+            .drop_tables(storage_metadata, tables, ts)
+            .unwrap_or_terminate("cannot fail to drop tables");
+    }
+}

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -65,7 +65,7 @@ use crate::session::{Session, Transaction, TransactionOps};
 use crate::statement_logging::StatementEndedExecutionReason;
 use crate::telemetry::{EventDetails, SegmentClientExt};
 use crate::util::ResultExt;
-use crate::{catalog, flags, AdapterError, TimestampProvider};
+use crate::{catalog, flags, AdapterError, ExecuteContext, TimestampProvider};
 
 impl Coordinator {
     /// Same as [`Self::catalog_transact_conn`] but takes a [`Session`].
@@ -133,14 +133,14 @@ impl Coordinator {
     #[instrument(name = "coord::catalog_transact_and_apply_side_effects")]
     pub(crate) async fn catalog_transact_and_apply_side_effects(
         &mut self,
-        session: Option<&Session>,
+        ctx: Option<&mut ExecuteContext>,
         ops: Vec<catalog::Op>,
     ) -> Result<(), AdapterError> {
-        let (table_updates, derived_side_effects) = self
-            .catalog_transact_inner(session.map(|session| session.conn_id()), ops)
-            .await?;
+        let conn_id = ctx.as_ref().map(|ctx| ctx.session().conn_id());
+        let (table_updates, derived_side_effects) =
+            self.catalog_transact_inner(conn_id, ops).await?;
 
-        let side_effects_fut = self.controller_apply_side_effects(derived_side_effects);
+        let side_effects_fut = self.controller_apply_side_effects(ctx, derived_side_effects);
 
         // Run our side effects concurrently with the table updates.
         let (side_effects_res, ()) = futures::future::join(

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -56,6 +56,7 @@ use serde_json::json;
 use tracing::{event, info_span, warn, Instrument, Level};
 
 use crate::active_compute_sink::{ActiveComputeSink, ActiveComputeSinkRetireReason};
+use crate::catalog::side_effects::CatalogSideEffect;
 use crate::catalog::{DropObjectInfo, Op, ReplicaCreateDropReason, TransactionResult};
 use crate::coord::appends::BuiltinTableAppendNotify;
 use crate::coord::timeline::{TimelineContext, TimelineState};
@@ -68,6 +69,9 @@ use crate::{catalog, flags, AdapterError, TimestampProvider};
 
 impl Coordinator {
     /// Same as [`Self::catalog_transact_conn`] but takes a [`Session`].
+    ///
+    /// This asserts that there are no side effects being generated from
+    /// applying the given `ops`.
     #[instrument(name = "coord::catalog_transact")]
     pub(crate) async fn catalog_transact(
         &mut self,
@@ -81,6 +85,14 @@ impl Coordinator {
     /// Same as [`Self::catalog_transact_conn`] but takes a [`Session`] and runs
     /// builtin table updates concurrently with any side effects (e.g. creating
     /// collections).
+    ///
+    /// This asserts that there are no side effects being generated from
+    /// applying the given `ops`.
+    // TODO(aljoscha): Remove this method once all call-sites have been migrated
+    // to the newer catalog_transact_and_apply_side_effects. The latter is what
+    // allows us to apply side effects to the controller either when initially
+    // applying the ops to the catalog _or_ when following catalog changes from
+    // another process.
     #[instrument(name = "coord::catalog_transact_with_side_effects")]
     pub(crate) async fn catalog_transact_with_side_effects<'c, F, Fut>(
         &'c mut self,
@@ -92,9 +104,12 @@ impl Coordinator {
         F: FnOnce(&'c mut Coordinator) -> Fut,
         Fut: Future<Output = ()>,
     {
-        let table_updates = self
+        let (table_updates, derived_side_effects) = self
             .catalog_transact_inner(session.map(|session| session.conn_id()), ops)
             .await?;
+
+        assert!(derived_side_effects.is_empty(), "cannot apply ops that produce side effects when using catalog_transact_with_side_effects");
+
         let side_effects_fut = side_effect(self);
 
         // Run our side effects concurrently with the table updates.
@@ -111,17 +126,60 @@ impl Coordinator {
         Ok(())
     }
 
+    /// Same as [`Self::catalog_transact_conn`] but takes a [`Session`] and runs
+    /// builtin table updates concurrently with any side effects that are
+    /// generated as part of applying the given `ops` (e.g. creating
+    /// collections).
+    #[instrument(name = "coord::catalog_transact_and_apply_side_effects")]
+    pub(crate) async fn catalog_transact_and_apply_side_effects(
+        &mut self,
+        session: Option<&Session>,
+        ops: Vec<catalog::Op>,
+    ) -> Result<(), AdapterError> {
+        let (table_updates, derived_side_effects) = self
+            .catalog_transact_inner(session.map(|session| session.conn_id()), ops)
+            .await?;
+
+        let side_effects_fut = self.controller_apply_side_effects(derived_side_effects);
+
+        // Run our side effects concurrently with the table updates.
+        let (side_effects_res, ()) = futures::future::join(
+            side_effects_fut.instrument(info_span!(
+                "coord::catalog_transact_with_side_effects::side_effects_fut"
+            )),
+            table_updates.instrument(info_span!(
+                "coord::catalog_transact_with_side_effects::table_updates"
+            )),
+        )
+        .await;
+
+        // We would get into an inconsistent state if we updated the catalog but
+        // then failed to apply the side effects to the controller. Easiest
+        // thing to do is panic and let restart/bootstrap handle it.
+        side_effects_res.expect("cannot fail to apply side effects");
+
+        Ok(())
+    }
+
     /// Same as [`Self::catalog_transact_inner`] but awaits the table updates.
+    ///
+    /// This asserts that there are no side effects being generated from
+    /// applying the given `ops`.
     #[instrument(name = "coord::catalog_transact_conn")]
     pub(crate) async fn catalog_transact_conn(
         &mut self,
         conn_id: Option<&ConnectionId>,
         ops: Vec<catalog::Op>,
     ) -> Result<(), AdapterError> {
-        let table_updates = self.catalog_transact_inner(conn_id, ops).await?;
+        let (table_updates, derived_side_effects) =
+            self.catalog_transact_inner(conn_id, ops).await?;
+
+        assert!(derived_side_effects.is_empty(), "cannot apply ops that produce side effects when using catalog_transact_with_side_effects");
+
         table_updates
             .instrument(info_span!("coord::catalog_transact_conn::table_updates"))
             .await;
+
         Ok(())
     }
 
@@ -185,7 +243,7 @@ impl Coordinator {
         &mut self,
         conn_id: Option<&ConnectionId>,
         ops: Vec<catalog::Op>,
-    ) -> Result<BuiltinTableAppendNotify, AdapterError> {
+    ) -> Result<(BuiltinTableAppendNotify, Vec<CatalogSideEffect>), AdapterError> {
         if self.controller.read_only() {
             return Err(AdapterError::ReadOnly);
         }
@@ -504,6 +562,7 @@ impl Coordinator {
 
         let TransactionResult {
             mut builtin_table_updates,
+            side_effects,
             audit_events,
         } = catalog
             .transact(Some(&mut *controller.storage), oracle_write_ts, conn, ops)
@@ -602,10 +661,9 @@ impl Coordinator {
                     assert_eq!(should_be_empty, became_empty, "emptiness did not match!");
                 }
             }
-            if !tables_to_drop.is_empty() {
-                let ts = self.get_local_write_ts().await;
-                self.drop_tables(tables_to_drop, ts.timestamp);
-            }
+            // TODO(aljoscha): When we wire up side-effects for sources, make
+            // sure we drop tables before sources.
+            //
             // Note that we drop tables before sources since there can be a weak dependency
             // on sources from tables in the storage controller that will result in error
             // logging that we'd prefer to avoid. This isn't an actual dependency issue but
@@ -803,7 +861,7 @@ impl Coordinator {
             "coordinator inconsistency detected"
         );
 
-        Ok(builtin_update_notify)
+        Ok((builtin_update_notify, side_effects))
     }
 
     fn drop_replica(&mut self, cluster_id: ClusterId, replica_id: ReplicaId) {
@@ -842,14 +900,6 @@ impl Coordinator {
             .storage
             .drop_sources(storage_metadata, sources)
             .unwrap_or_terminate("cannot fail to drop sources");
-    }
-
-    fn drop_tables(&mut self, tables: Vec<GlobalId>, ts: Timestamp) {
-        let storage_metadata = self.catalog.state().storage_metadata();
-        self.controller
-            .storage
-            .drop_tables(storage_metadata, tables, ts)
-            .unwrap_or_terminate("cannot fail to drop tables");
     }
 
     fn restart_webhook_sources(&mut self, sources: impl IntoIterator<Item = GlobalId>) {

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -309,7 +309,12 @@ impl Coordinator {
         }
 
         match self.catalog_transact_inner(None, ops).await {
-            Ok(table_updates) => {
+            Ok((table_updates, derived_side_effects)) => {
+                assert!(
+                    derived_side_effects.is_empty(),
+                    "applying builtin table updates does not produce side effects"
+                );
+
                 let internal_cmd_tx = self.internal_cmd_tx.clone();
                 let mut task_span =
                     info_span!(parent: None, "coord::storage_usage_update::table_updates");

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -230,7 +230,7 @@ impl Coordinator {
                     self.sequence_copy_to(ctx, plan, target_cluster).await;
                 }
                 Plan::DropObjects(plan) => {
-                    let result = self.sequence_drop_objects(ctx.session_mut(), plan).await;
+                    let result = self.sequence_drop_objects(&mut ctx, plan).await;
                     ctx.retire(result);
                 }
                 Plan::DropOwned(plan) => {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -19,7 +19,6 @@ use futures::future::BoxFuture;
 use futures::stream::FuturesOrdered;
 use futures::{future, Future, FutureExt};
 use itertools::Itertools;
-use maplit::btreeset;
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_cloud_resources::VpcEndpointConfig;
 use mz_controller_types::ReplicaId;
@@ -78,9 +77,7 @@ use mz_sql_parser::ast::{
     WithOptionValue,
 };
 use mz_ssh_util::keys::SshKeyPairSet;
-use mz_storage_client::controller::{
-    CollectionDescription, DataSource, DataSourceOther, ExportDescription,
-};
+use mz_storage_client::controller::{CollectionDescription, DataSource, ExportDescription};
 use mz_storage_types::connections::inline::IntoInlineConnection;
 use mz_storage_types::controller::StorageError;
 use mz_storage_types::stats::RelationPartStats;
@@ -927,113 +924,7 @@ impl Coordinator {
         }];
 
         let catalog_result = self
-            .catalog_transact_with_side_effects(Some(ctx.session()), ops, |coord| async {
-                // The table data_source determines whether this table will be written to
-                // by environmentd (e.g. with INSERT INTO statements) or by the storage layer
-                // (e.g. a source-fed table).
-                match table.data_source {
-                    TableDataSource::TableWrites { defaults: _ } => {
-                        // Determine the initial validity for the table.
-                        let register_ts = coord.get_local_write_ts().await.timestamp;
-
-                        // After acquiring `register_ts` but before using it, we need to
-                        // be sure we're still the leader. Otherwise a new generation
-                        // may also be trying to use `register_ts` for a different
-                        // purpose.
-                        //
-                        // See #28216.
-                        coord
-                            .catalog
-                            .confirm_leadership()
-                            .await
-                            .unwrap_or_terminate("unable to confirm leadership");
-
-                        if let Some(id) = ctx.extra().contents() {
-                            coord.set_statement_execution_timestamp(id, register_ts);
-                        }
-
-                        let collection_desc = CollectionDescription::from_desc(
-                            table.desc.clone(),
-                            DataSourceOther::TableWrites,
-                        );
-                        let storage_metadata = coord.catalog.state().storage_metadata();
-                        coord
-                            .controller
-                            .storage
-                            .create_collections(
-                                storage_metadata,
-                                Some(register_ts),
-                                vec![(table_id, collection_desc)],
-                            )
-                            .await
-                            .unwrap_or_terminate("cannot fail to create collections");
-                        coord.apply_local_write(register_ts).await;
-
-                        coord
-                            .initialize_storage_read_policies(
-                                btreeset![table_id],
-                                table
-                                    .custom_logical_compaction_window
-                                    .unwrap_or(CompactionWindow::Default),
-                            )
-                            .await;
-                    }
-                    TableDataSource::DataSource(data_source) => {
-                        match data_source {
-                            DataSourceDesc::IngestionExport {
-                                ingestion_id,
-                                external_reference: _,
-                                details,
-                                data_config,
-                            } => {
-                                // TODO: It's a little weird that a table will be present in this
-                                // source status collection, we might want to split out into a separate
-                                // status collection.
-                                let status_collection_id =
-                                    Some(coord.catalog().resolve_builtin_storage_collection(
-                                        &mz_catalog::builtin::MZ_SOURCE_STATUS_HISTORY,
-                                    ));
-                                let collection_desc = CollectionDescription::<Timestamp> {
-                                    desc: table.desc.clone(),
-                                    data_source: DataSource::IngestionExport {
-                                        ingestion_id,
-                                        details,
-                                        data_config: data_config
-                                            .into_inline_connection(coord.catalog.state()),
-                                    },
-                                    since: None,
-                                    status_collection_id,
-                                };
-                                let storage_metadata = coord.catalog.state().storage_metadata();
-                                coord
-                                    .controller
-                                    .storage
-                                    .create_collections(
-                                        storage_metadata,
-                                        None,
-                                        vec![(table_id, collection_desc)],
-                                    )
-                                    .await
-                                    .unwrap_or_terminate("cannot fail to create collections");
-
-                                let read_policies = coord
-                                    .catalog()
-                                    .state()
-                                    .source_compaction_windows(vec![table_id]);
-                                for (compaction_window, storage_policies) in read_policies {
-                                    coord
-                                        .initialize_storage_read_policies(
-                                            storage_policies,
-                                            compaction_window,
-                                        )
-                                        .await;
-                                }
-                            }
-                            _ => unreachable!("CREATE TABLE data source got {:?}", data_source),
-                        }
-                    }
-                }
-            })
+            .catalog_transact_and_apply_side_effects(Some(ctx.session()), ops)
             .await;
 
         match catalog_result {
@@ -1262,7 +1153,8 @@ impl Coordinator {
             dropped_in_use_indexes,
         } = self.sequence_drop_common(session, drop_ids).await?;
 
-        self.catalog_transact(Some(session), ops).await?;
+        self.catalog_transact_and_apply_side_effects(Some(session), ops)
+            .await?;
 
         fail::fail_point!("after_sequencer_drop_replica");
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -924,7 +924,7 @@ impl Coordinator {
         }];
 
         let catalog_result = self
-            .catalog_transact_and_apply_side_effects(Some(ctx.session()), ops)
+            .catalog_transact_and_apply_side_effects(Some(ctx), ops)
             .await;
 
         match catalog_result {
@@ -1122,7 +1122,7 @@ impl Coordinator {
     #[instrument]
     pub(super) async fn sequence_drop_objects(
         &mut self,
-        session: &Session,
+        ctx: &mut ExecuteContext,
         plan::DropObjectsPlan {
             drop_ids,
             object_type,
@@ -1135,7 +1135,7 @@ impl Coordinator {
             if !referenced_ids_hashset.contains(obj_id) {
                 let object_info = ErrorMessageObjectDescription::from_id(
                     obj_id,
-                    &self.catalog().for_session(session),
+                    &self.catalog().for_session(ctx.session()),
                 )
                 .to_string();
                 objects.push(object_info);
@@ -1143,7 +1143,8 @@ impl Coordinator {
         }
 
         if !objects.is_empty() {
-            session.add_notice(AdapterNotice::CascadeDroppedObject { objects });
+            ctx.session()
+                .add_notice(AdapterNotice::CascadeDroppedObject { objects });
         }
 
         let DropOps {
@@ -1151,25 +1152,28 @@ impl Coordinator {
             dropped_active_db,
             dropped_active_cluster,
             dropped_in_use_indexes,
-        } = self.sequence_drop_common(session, drop_ids).await?;
+        } = self.sequence_drop_common(ctx.session(), drop_ids).await?;
 
-        self.catalog_transact_and_apply_side_effects(Some(session), ops)
+        self.catalog_transact_and_apply_side_effects(Some(ctx), ops)
             .await?;
 
         fail::fail_point!("after_sequencer_drop_replica");
 
         if dropped_active_db {
-            session.add_notice(AdapterNotice::DroppedActiveDatabase {
-                name: session.vars().database().to_string(),
-            });
+            ctx.session()
+                .add_notice(AdapterNotice::DroppedActiveDatabase {
+                    name: ctx.session().vars().database().to_string(),
+                });
         }
         if dropped_active_cluster {
-            session.add_notice(AdapterNotice::DroppedActiveCluster {
-                name: session.vars().cluster().to_string(),
-            });
+            ctx.session()
+                .add_notice(AdapterNotice::DroppedActiveCluster {
+                    name: ctx.session().vars().cluster().to_string(),
+                });
         }
         for dropped_in_use_index in dropped_in_use_indexes {
-            session.add_notice(AdapterNotice::DroppedInUseIndex(dropped_in_use_index));
+            ctx.session()
+                .add_notice(AdapterNotice::DroppedInUseIndex(dropped_in_use_index));
             self.metrics
                 .optimization_notices
                 .with_label_values(&["DroppedInUseIndex"])

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -2504,7 +2504,7 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
 }
 
 /// A single update to the catalog state.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StateUpdate {
     pub kind: StateUpdateKind,
     pub ts: Timestamp,


### PR DESCRIPTION
First step towards https://github.com/MaterializeInc/materialize/issues/29279

With this we only wire up the new side-effects logic for
creating/dropping tables.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
