### PR TITLE
version consistency: improve version matching in ignore filter

### DIFF
--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -102,13 +102,13 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
         self, expression: Expression, row_selection: DataRowSelection
     ) -> IgnoreVerdict:
         if (
-            self.lower_version < MZ_VERSION_0_77_0 <= self.higher_version
+            self.lower_version <= MZ_VERSION_0_77_0 <= self.higher_version
             and is_any_date_time_expression(expression)
         ):
             return YesIgnore("Fixed issue regarding time zone handling")
 
         if (
-            self.lower_version < MZ_VERSION_0_78_0 <= self.higher_version
+            self.lower_version <= MZ_VERSION_0_78_0 <= self.higher_version
             and expression.matches(
                 partial(
                     matches_fun_by_any_name,
@@ -120,7 +120,7 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
             return YesIgnore("Accepted: no order explicitly specified")
 
         if (
-            self.lower_version < MZ_VERSION_0_81_0 <= self.higher_version
+            self.lower_version <= MZ_VERSION_0_81_0 <= self.higher_version
             and expression.matches(
                 partial(
                     matches_fun_by_any_name,
@@ -134,7 +134,7 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
             )
 
         if (
-            self.lower_version < MZ_VERSION_0_88_0 <= self.higher_version
+            self.lower_version <= MZ_VERSION_0_88_0 <= self.higher_version
             and expression.matches(
                 partial(
                     matches_fun_by_name,
@@ -146,7 +146,7 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
             return YesIgnore("date_trunc fixed in PR 25202")
 
         if (
-            self.lower_version < MZ_VERSION_0_93_0 <= self.higher_version
+            self.lower_version <= MZ_VERSION_0_93_0 <= self.higher_version
             and expression.matches(
                 partial(
                     matches_op_by_any_pattern,
@@ -161,7 +161,7 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
             return YesIgnore("ILIKE fixed in PR 26183")
 
         if (
-            self.lower_version < MZ_VERSION_0_93_0 <= self.higher_version
+            self.lower_version <= MZ_VERSION_0_93_0 <= self.higher_version
             and expression.matches(
                 partial(is_operation_tagged, tag=TAG_REGEX),
                 True,
@@ -170,7 +170,7 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
             return YesIgnore("Newline handling in regex fixed in PR 26191")
 
         if (
-            self.lower_version < MZ_VERSION_0_95_0 <= self.higher_version
+            self.lower_version <= MZ_VERSION_0_95_0 <= self.higher_version
             and expression.matches(
                 partial(
                     matches_fun_by_any_name,
@@ -183,7 +183,7 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
             return YesIgnore("Type of min(time) / max(time) fixed in PR 26335")
 
         if (
-            self.lower_version < MZ_VERSION_0_99_0 <= self.higher_version
+            self.lower_version <= MZ_VERSION_0_99_0 <= self.higher_version
             and is_any_date_time_expression(expression)
         ):
             return YesIgnore(
@@ -191,7 +191,7 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
             )
 
         if (
-            self.lower_version < MZ_VERSION_0_107_0 <= self.higher_version
+            self.lower_version <= MZ_VERSION_0_107_0 <= self.higher_version
             and expression.matches(
                 partial(
                     matches_op_by_pattern,
@@ -202,7 +202,7 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("Contains on list and array introduced in PR 27959")
 
-        if self.lower_version < MZ_VERSION_0_118_0 <= self.higher_version:
+        if self.lower_version <= MZ_VERSION_0_118_0 <= self.higher_version:
             if expression.matches(
                 partial(
                     involves_data_type_category,
@@ -241,7 +241,7 @@ class VersionPostExecutionInconsistencyIgnoreFilter(
         contains_aggregation: bool,
     ) -> IgnoreVerdict:
         if (
-            self.lower_version < MZ_VERSION_0_109_0 <= self.higher_version
+            self.lower_version <= MZ_VERSION_0_109_0 <= self.higher_version
             and self._aggregration_shortcut_changed(
                 query_template, contains_aggregation
             )
@@ -249,7 +249,7 @@ class VersionPostExecutionInconsistencyIgnoreFilter(
             return YesIgnore("Evaluation order changed with PR 28144")
 
         if (
-            self.lower_version < MZ_VERSION_0_117_0 <= self.higher_version
+            self.lower_version <= MZ_VERSION_0_117_0 <= self.higher_version
         ) and query_template.matches_any_expression(
             is_any_date_time_expression,
             True,
@@ -272,7 +272,7 @@ class VersionPostExecutionInconsistencyIgnoreFilter(
         all_involved_characteristics: set[ExpressionCharacteristics],
     ) -> IgnoreVerdict:
         if (
-            self.lower_version < MZ_VERSION_0_117_0 <= self.higher_version
+            self.lower_version <= MZ_VERSION_0_117_0 <= self.higher_version
             and query_template.matches_any_expression(
                 partial(
                     matches_fun_by_name,
@@ -301,7 +301,7 @@ class VersionPostExecutionInconsistencyIgnoreFilter(
         contains_aggregation: bool,
     ) -> IgnoreVerdict:
         if (
-            self.lower_version < MZ_VERSION_0_117_0 <= self.higher_version
+            self.lower_version <= MZ_VERSION_0_117_0 <= self.higher_version
         ) and query_template.matches_any_expression(
             is_any_date_time_expression,
             True,
@@ -323,7 +323,7 @@ class VersionPostExecutionInconsistencyIgnoreFilter(
         query_output_mode: QueryOutputMode,
     ) -> IgnoreVerdict:
         if (
-            self.lower_version < MZ_VERSION_0_109_0 <= self.higher_version
+            self.lower_version <= MZ_VERSION_0_109_0 <= self.higher_version
             and self._aggregration_shortcut_changed(
                 query_template, contains_aggregation
             )

--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -60,11 +60,23 @@ MZ_VERSION_0_118_0 = MzVersion.parse_mz("v0.118.0")
 
 
 class VersionConsistencyIgnoreFilter(GenericInconsistencyIgnoreFilter):
-    def __init__(self, mz1_version: MzVersion, mz2_version: MzVersion, uses_dfr: bool):
+    def __init__(
+        self,
+        mz1_version_without_dev_suffix: MzVersion,
+        mz2_version_without_dev_suffix: MzVersion,
+        uses_dfr: bool,
+    ):
+        assert (
+            not mz1_version_without_dev_suffix.is_dev_version()
+        ), "mz1_version is a dev version but that suffix should be dropped"
+        assert (
+            not mz2_version_without_dev_suffix.is_dev_version()
+        ), "mz1_version is a dev version but that suffix should be dropped"
+
         lower_version, higher_version = (
-            (mz1_version, mz2_version)
-            if mz1_version < mz2_version
-            else (mz2_version, mz1_version)
+            (mz1_version_without_dev_suffix, mz2_version_without_dev_suffix)
+            if mz1_version_without_dev_suffix < mz2_version_without_dev_suffix
+            else (mz2_version_without_dev_suffix, mz1_version_without_dev_suffix)
         )
         super().__init__(
             VersionPreExecutionInconsistencyIgnoreFilter(

--- a/misc/python/materialize/version_consistency/version_consistency_test.py
+++ b/misc/python/materialize/version_consistency/version_consistency_test.py
@@ -56,8 +56,8 @@ class VersionConsistencyTest(OutputConsistencyTest):
         self.evaluation_strategy_name: str | None = None
         self.allow_same_version_comparison = False
         # values will be available after create_sql_executors is called
-        self.mz1_version: MzVersion | None = None
-        self.mz2_version: MzVersion | None = None
+        self.mz1_version_without_dev_suffix: MzVersion | None = None
+        self.mz2_version_without_dev_suffix: MzVersion | None = None
 
     def shall_run(self, sql_executors: SqlExecutors) -> bool:
         assert isinstance(sql_executors, MultiVersionSqlExecutors)
@@ -100,10 +100,10 @@ class VersionConsistencyTest(OutputConsistencyTest):
             "mz2",
         )
 
-        self.mz1_version = MzVersion.parse_mz(
+        self.mz1_version_without_dev_suffix = MzVersion.parse_mz(
             mz1_sql_executor.query_version(), drop_dev_suffix=True
         )
-        self.mz2_version = MzVersion.parse_mz(
+        self.mz2_version_without_dev_suffix = MzVersion.parse_mz(
             mz2_sql_executor.query_version(), drop_dev_suffix=True
         )
 
@@ -113,8 +113,8 @@ class VersionConsistencyTest(OutputConsistencyTest):
         )
 
     def create_inconsistency_ignore_filter(self) -> GenericInconsistencyIgnoreFilter:
-        assert self.mz1_version is not None
-        assert self.mz2_version is not None
+        assert self.mz1_version_without_dev_suffix is not None
+        assert self.mz2_version_without_dev_suffix is not None
 
         assert (
             self.evaluation_strategy_name is not None
@@ -122,7 +122,9 @@ class VersionConsistencyTest(OutputConsistencyTest):
 
         uses_dfr = self.evaluation_strategy_name == EVALUATION_STRATEGY_NAME_DFR
         return VersionConsistencyIgnoreFilter(
-            self.mz1_version, self.mz2_version, uses_dfr
+            self.mz1_version_without_dev_suffix,
+            self.mz2_version_without_dev_suffix,
+            uses_dfr,
         )
 
     def create_evaluation_strategies(
@@ -166,12 +168,12 @@ class VersionConsistencyTest(OutputConsistencyTest):
         if operation.since_mz_version is None:
             return False
 
-        assert self.mz1_version is not None
-        assert self.mz2_version is not None
+        assert self.mz1_version_without_dev_suffix is not None
+        assert self.mz2_version_without_dev_suffix is not None
 
         return (
-            operation.since_mz_version > self.mz1_version
-            or operation.since_mz_version > self.mz2_version
+            operation.since_mz_version > self.mz1_version_without_dev_suffix
+            or operation.since_mz_version > self.mz2_version_without_dev_suffix
         )
 
 


### PR DESCRIPTION
This happened due to an entry in `ANCESTOR_OVERRIDES_FOR_CORRECTNESS_REGRESSIONS`.

This change is another, more reliable fix.