### PR TITLE
mzbuild: Don't try to build on non-builder CI machines

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -45,6 +45,7 @@ class StartMz(MzcomposeAction):
         deploy_generation: int | None = None,
         restart: str | None = None,
         force_migrations: str | None = None,
+        publish: bool | None = None,
     ) -> None:
         if healthcheck is None:
             healthcheck = ["CMD", "curl", "-f", "localhost:6878/api/readyz"]
@@ -59,6 +60,7 @@ class StartMz(MzcomposeAction):
         self.deploy_generation = deploy_generation
         self.restart = restart
         self.force_migrations = force_migrations
+        self.publish = publish
 
     def execute(self, e: Executor) -> None:
         c = e.mzcompose_composition()
@@ -81,6 +83,7 @@ class StartMz(MzcomposeAction):
             deploy_generation=self.deploy_generation,
             restart=self.restart,
             force_migrations=self.force_migrations,
+            publish=self.publish,
         )
 
         # Don't fail since we are careful to explicitly kill and collect logs

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -68,6 +68,7 @@ def start_mz_read_only(
     system_parameter_defaults: dict[str, str] | None = None,
     system_parameter_version: MzVersion | None = None,
     force_migrations: str | None = None,
+    publish: bool | None = None,
 ) -> StartMz:
     return StartMz(
         scenario,
@@ -79,6 +80,7 @@ def start_mz_read_only(
         system_parameter_defaults=system_parameter_defaults,
         system_parameter_version=system_parameter_version,
         force_migrations=force_migrations,
+        publish=publish,
     )
 
 

--- a/misc/python/materialize/checks/scenarios_zero_downtime.py
+++ b/misc/python/materialize/checks/scenarios_zero_downtime.py
@@ -189,6 +189,7 @@ class ZeroDowntimeBumpedVersion(Scenario):
                 deploy_generation=2,
                 mz_service="mz_3",
                 system_parameter_defaults=system_parameter_defaults,
+                publish=False,  # Allows us to build the image during the test in CI
             ),
             Validate(self, mz_service="mz_2"),
             *wait_ready_and_promote("mz_3"),

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -219,6 +219,11 @@ class Composition:
                         image.rd.arch = Arch.AARCH64
                     else:
                         raise ValueError(f"Unknown platform {config['platform']}")
+                if config.get("publish") is not None:
+                    # Override whether an image is expected to be published, so
+                    # that we will build it in CI instead of failing.
+                    image.publish = config["publish"]
+                    del config["publish"]
                 images.append(image)
 
             if "propagate_uid_gid" in config:

--- a/misc/python/materialize/mzcompose/service.py
+++ b/misc/python/materialize/mzcompose/service.py
@@ -165,6 +165,9 @@ class ServiceConfig(TypedDict, total=False):
     platform: str
     """Target platform for service to run on. Syntax: os[/arch[/variant]]"""
 
+    publish: bool | None
+    """Override whether an image is publishable. Unpublishable images can be built during normal test runs in CI."""
+
 
 class Service:
     """A Docker Compose service in a `Composition`.

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -58,6 +58,7 @@ class Materialized(Service):
         healthcheck: list[str] | None = None,
         deploy_generation: int | None = None,
         force_migrations: str | None = None,
+        publish: bool | None = None,
     ) -> None:
         if name is None:
             name = "materialized"
@@ -199,6 +200,9 @@ class Materialized(Service):
             # change when the container is recreated.
             "hostname": name,
         }
+
+        if publish is not None:
+            config["publish"] = publish
 
         if image:
             config["image"] = image


### PR DESCRIPTION
They won't succeed anyway, better to fail the test than time out while uselessly building. Seen in https://buildkite.com/materialize/test/builds/90870

Also retry longer (~1 minute) and not just with a 1s sleep inbetween

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
