### PR TITLE
lint: Print durations by default and sort them

### DIFF
--- a/ci/test/lint-main/checks/check-mzcompose-files.sh
+++ b/ci/test/lint-main/checks/check-mzcompose-files.sh
@@ -38,7 +38,10 @@ check_all_files_referenced_in_ci() {
 
 check_default_workflow_references_others() {
     RETURN=0
-    mapfile -t MZCOMPOSE_TEST_FILES < <(find ./test -name "mzcompose.py" \
+    MZCOMPOSE_TEST_FILES=()
+    while IFS= read -r file; do
+        MZCOMPOSE_TEST_FILES+=("$file")
+    done < <(find ./test -name "mzcompose.py" \
         -not -wholename "./test/canary-environment/mzcompose.py" `# Only run manually` \
         -not -wholename "./test/ssh-connection/mzcompose.py" `# Handled differently` \
         -not -wholename "./test/scalability/mzcompose.py" `# Other workflows are for manual usage` \

--- a/misc/python/materialize/lint/lint.py
+++ b/misc/python/materialize/lint/lint.py
@@ -37,7 +37,9 @@ def parse_args() -> argparse.Namespace:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="Lint the code",
     )
-    parser.add_argument("--print-duration", action="store_true")
+    parser.add_argument(
+        "--print-duration", action=argparse.BooleanOptionalAction, default=True
+    )
     parser.add_argument("--verbose", action="store_true")
     return parser.parse_args()
 
@@ -131,9 +133,9 @@ class LintManager:
 
         failed_checks = []
 
-        for thread in threads:
+        for thread in sorted(threads, key=lambda thread: thread.duration):
             formatted_duration = (
-                f" in {thread.duration.total_seconds():.2f}s"
+                f" [{thread.duration.total_seconds():5.2f}s]"
                 if self.print_duration
                 else ""
             )


### PR DESCRIPTION
By sorting them it's very easy to see which lint actually contributed to the huge runtime, both locally and in CI. `--no-print-duration` can be specified if you really don't want it. Example output:
```
1 check in ci/test/lint-main/before
✓ [ 0.01s] can-lint.sh
16 checks in ci/test/lint-main/checks
✓ [ 0.01s] check-rust-version.sh
✓ [ 0.10s] check-python-discouraged.sh
✓ [ 0.20s] check-test-history-versioning.sh
✓ [ 0.61s] check-mzcompose-files.sh
✓ [ 1.49s] check-generation.sh
✓ [ 3.81s] check-python-docs.sh
✓ [ 3.84s] check-python-formatting.sh
✓ [ 4.52s] check-shell-files.sh
✓ [ 5.24s] check-rust-test-attributes.sh
✓ [ 8.16s] check-bazel.sh
✓ [ 8.70s] check-cargo.sh
✓ [ 9.97s] check-new-line.sh
✓ [10.00s] check-copyright.sh
✓ [13.09s] check-protobuf.sh
✓ [14.96s] check-python-files.sh
✓ [150.44s] check-crate-license-listing.sh
1 check in ci/test/lint-main/after
✓ [ 0.02s] check-no-diff.sh
✓ All checks successful
```

check-crate-license-listing.sh is often slow for me, I'll try disabling it locally. Maybe related to `https://github.com/clearlydefined/service/issues/749`
```
2024-09-20 11:38:24.300092832 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:38:24.300124862 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:38:24.300165939 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:38:24.30018817 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:38:24.300221563 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:38:24.300778152 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:38:24.300290021 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:38:24.300297885 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:38:24.300379518 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:38:24.300388094 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:38:24.30126991 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:38:24.300235328 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:38:24.30088404 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:38:24.300459798 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:38:24.309217001 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:38:49.150011783 +00:00:00 [WARN] crate 'jsonpath-rust 0.5.1' doesn't have a license field
2024-09-20 11:38:54.301643775 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:39:14.12170684 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:39:14.941230381 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:39:44.121885999 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:39:46.383852837 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
2024-09-20 11:39:46.43471935 +00:00:00 [WARN] failed to request license information from clearly defined: error sending request for url (https://api.clearlydefined.io/definitions): operation timed out
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
