### PR TITLE
grpc: validate hostname

### DIFF
--- a/misc/python/materialize/mzcompose/services/clusterd.py
+++ b/misc/python/materialize/mzcompose/services/clusterd.py
@@ -27,6 +27,7 @@ class Clusterd(Service):
     ) -> None:
         environment = [
             "CLUSTERD_LOG_FILTER",
+            f"CLUSTERD_GRPC_HOST={name}",
             "MZ_SOFT_ASSERTIONS=1",
             *environment_extra,
         ]

--- a/src/clusterd/ci/entrypoint.sh
+++ b/src/clusterd/ci/entrypoint.sh
@@ -21,4 +21,11 @@ export CLUSTERD_INTERNAL_HTTP_LISTEN_ADDR=${CLUSTERD_INTERNAL_HTTP_LISTEN_ADDR:-
 export CLUSTERD_SECRETS_READER=${CLUSTERD_SECRETS_READER:-local-file}
 export CLUSTERD_SECRETS_READER_LOCAL_FILE_DIR=${CLUSTERD_SECRETS_READER_LOCAL_DIR:-/mzdata/secrets}
 
+# Pass the host's FQDN as the host to be used for GRPC request validation only
+# when running in Kubernetes. In other contexts (like when running locally, or
+# in Docker), this is likely not desirable.
+if [[ "${KUBERNETES_SERVICE_HOST:-}" ]]; then
+    export CLUSTERD_GRPC_HOST=${CLUSTERD_GRPC_HOST:-$(hostname --fqdn)}
+fi
+
 exec clusterd "$@"

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -369,15 +369,14 @@ disruptions = [
             ArrangedIntro("cluster1.replica2", "clusterd_2_1"),
         ],
     ),
-    # TODO: Reenable when materialize#28997 is fixed
-    # Disruption(
-    #     name="restart-replica",
-    #     disruption=lambda c: restart_replica(c),
-    #     compaction_checks=AllowCompactionCheck.all_checks(
-    #         "cluster1.replica1", "clusterd_1_1"
-    #     )
-    #     + AllowCompactionCheck.all_checks("cluster1.replica2", "clusterd_2_1"),
-    # ),
+    Disruption(
+        name="restart-replica",
+        disruption=lambda c: restart_replica(c),
+        compaction_checks=AllowCompactionCheck.all_checks(
+            "cluster1.replica1", "clusterd_1_1"
+        )
+        + AllowCompactionCheck.all_checks("cluster1.replica2", "clusterd_2_1"),
+    ),
     Disruption(
         name="pause-one-clusterd",
         disruption=lambda c: c.pause("clusterd_1_1"),


### PR DESCRIPTION
In the clusterd GRPC server, validate the process' hostname against the hostname in the request URI. This detects cases where the controller connects to a wrong process due to a stale hostname-IP mapping.


### Motivation

  * This PR fixes a recognized bug.

Fixes [#28997](https://github.com/MaterializeInc/database-issues/issues/8448)

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
