### PR TITLE
controller: Remove unnecessary `mut`s

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3336,7 +3336,7 @@ impl Coordinator {
     /// Group commit, which this method uses to write the retractions, has builtin fencing, and we
     /// never commit retractions to [`MZ_STORAGE_USAGE_BY_SHARD`] outside of this method, which is
     /// only called once during startup. So we don't have to worry about double/invalid retractions.
-    async fn prune_storage_usage_events_on_startup(&mut self, retention_period: Duration) {
+    async fn prune_storage_usage_events_on_startup(&self, retention_period: Duration) {
         let id = self
             .catalog()
             .resolve_builtin_table(&MZ_STORAGE_USAGE_BY_SHARD);

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -596,7 +596,7 @@ pub trait StorageController: Debug {
 
     /// Returns the snapshot of the contents of the local input named `id` at `as_of`.
     fn snapshot(
-        &mut self,
+        &self,
         id: GlobalId,
         as_of: Self::Timestamp,
     ) -> BoxFuture<Result<Vec<(Row, Diff)>, StorageError<Self::Timestamp>>>;
@@ -604,7 +604,7 @@ pub trait StorageController: Debug {
     /// Returns the snapshot of the contents of the local input named `id` at
     /// the largest readable `as_of`.
     async fn snapshot_latest(
-        &mut self,
+        &self,
         id: GlobalId,
     ) -> Result<Vec<Row>, StorageError<Self::Timestamp>>;
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1641,7 +1641,7 @@ where
     // actually existed. We should include the original time in the updates advanced by the as_of
     // frontier in the result and let the caller decide what to do with the information.
     fn snapshot(
-        &mut self,
+        &self,
         id: GlobalId,
         as_of: Self::Timestamp,
     ) -> BoxFuture<Result<Vec<(Row, Diff)>, StorageError<Self::Timestamp>>> {
@@ -1702,7 +1702,7 @@ where
     }
 
     async fn snapshot_latest(
-        &mut self,
+        &self,
         id: GlobalId,
     ) -> Result<Vec<Row>, StorageError<Self::Timestamp>> {
         let upper = self.recent_upper(id).await?;
@@ -3094,7 +3094,7 @@ where
     ///
     // TODO(guswynn): we need to be more careful about the update time we get here:
     // <https://github.com/MaterializeInc/materialize/issues/25349>
-    async fn snapshot_statistics(&mut self, id: GlobalId, upper: Antichain<T>) -> Vec<Row> {
+    async fn snapshot_statistics(&self, id: GlobalId, upper: Antichain<T>) -> Vec<Row> {
         match upper.as_option() {
             Some(f) if f > &T::minimum() => {
                 let as_of = f.step_back().unwrap();
@@ -3103,7 +3103,7 @@ where
                 snapshot
                     .into_iter()
                     .map(|(row, diff)| {
-                        assert!(diff == 1);
+                        assert_eq!(diff, 1);
                         row
                     })
                     .collect()
@@ -3140,7 +3140,7 @@ where
     ///
     /// Returns a map with latest unpacked row per key.
     async fn partially_truncate_status_history<K>(
-        &mut self,
+        &self,
         collection: IntrospectionType,
         write_handle: &mut WriteHandle<SourceData, (), T, Diff>,
         status_history_desc: StatusHistoryDesc<K>,


### PR DESCRIPTION
### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
