### PR TITLE
adapter,storage-controller: lay down 0dt scaffolding for sources

### DIFF
--- a/src/controller-types/src/dyncfgs.rs
+++ b/src/controller-types/src/dyncfgs.rs
@@ -20,6 +20,12 @@ pub const CONTROLLER_PAST_GENERATION_REPLICA_CLEANUP_RETRY_INTERVAL: Config<Dura
     "The interval at which to attempt to retry cleaning up replicas from past generations.",
 );
 
+pub const ENABLE_0DT_DEPLOYMENT_SOURCES: Config<bool> = Config::new(
+    "enable_0dt_deployment_sources",
+    false,
+    "Whether to enable zero-downtime deployments for sources that support it (experimental).",
+);
+
 /// The interval at which to refresh wallclock lag introspection.
 pub const WALLCLOCK_LAG_REFRESH_INTERVAL: Config<Duration> = Config::new(
     "wallclock_lag_refresh_interval",
@@ -31,5 +37,6 @@ pub const WALLCLOCK_LAG_REFRESH_INTERVAL: Config<Duration> = Config::new(
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
         .add(&CONTROLLER_PAST_GENERATION_REPLICA_CLEANUP_RETRY_INTERVAL)
+        .add(&ENABLE_0DT_DEPLOYMENT_SOURCES)
         .add(&WALLCLOCK_LAG_REFRESH_INTERVAL)
 }

--- a/src/storage-client/src/client.proto
+++ b/src/storage-client/src/client.proto
@@ -82,6 +82,7 @@ message ProtoStorageCommand {
         ProtoCreateSources create_sources = 1;
         ProtoAllowCompaction allow_compaction = 2;
         google.protobuf.Empty initialization_complete = 3;
+        google.protobuf.Empty allow_writes = 7;
         ProtoRunSinks run_sinks = 4;
         mz_storage_types.parameters.ProtoStorageParameters update_configuration = 5;
     }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -346,6 +346,9 @@ pub trait StorageController: Debug {
     /// capabilties.
     fn active_collection_metadatas(&self) -> Vec<(GlobalId, CollectionMetadata)>;
 
+    /// Returns the IDs of all active ingestions for the given storage instance.
+    fn active_ingestions(&self, instance_id: StorageInstanceId) -> &BTreeSet<GlobalId>;
+
     /// Checks whether a collection exists under the given `GlobalId`. Returns
     /// an error if the collection does not exist.
     fn check_exists(&self, id: GlobalId) -> Result<(), StorageError<Self::Timestamp>>;

--- a/src/storage-client/src/metrics.rs
+++ b/src/storage-client/src/metrics.rs
@@ -127,6 +127,7 @@ impl InstanceMetrics {
             run_sinks_count: command_gauge("run_sinks"),
             allow_compaction_count: command_gauge("allow_compaction"),
             initialization_complete_count: command_gauge("initialization_complete"),
+            allow_writes_count: command_gauge("allow_writes"),
             update_configuration_count: command_gauge("update_configuration"),
         }
     }
@@ -180,6 +181,8 @@ pub struct HistoryMetrics {
     pub allow_compaction_count: UIntGauge,
     /// Number of `InitializationComplete` commands.
     pub initialization_complete_count: UIntGauge,
+    /// Number of `AllowWrites` commands.
+    pub allow_writes_count: UIntGauge,
     /// Number of `UpdateConfiguration` commands.
     pub update_configuration_count: UIntGauge,
 }
@@ -191,6 +194,7 @@ impl HistoryMetrics {
         self.run_sinks_count.set(0);
         self.allow_compaction_count.set(0);
         self.initialization_complete_count.set(0);
+        self.allow_writes_count.set(0);
         self.update_configuration_count.set(0);
     }
 }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -29,7 +29,7 @@ use itertools::Itertools;
 use mz_build_info::BuildInfo;
 use mz_cluster_client::client::ClusterReplicaLocation;
 use mz_cluster_client::{ReplicaId, WallclockLagFn};
-use mz_controller_types::dyncfgs::WALLCLOCK_LAG_REFRESH_INTERVAL;
+use mz_controller_types::dyncfgs::{ENABLE_0DT_DEPLOYMENT_SOURCES, WALLCLOCK_LAG_REFRESH_INTERVAL};
 use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{EpochMillis, NowFn};
@@ -75,7 +75,8 @@ use mz_storage_types::read_holds::{ReadHold, ReadHoldError};
 use mz_storage_types::read_policy::ReadPolicy;
 use mz_storage_types::sinks::{StorageSinkConnection, StorageSinkDesc};
 use mz_storage_types::sources::{
-    GenericSourceConnection, IngestionDescription, SourceData, SourceDesc, SourceExport,
+    GenericSourceConnection, IngestionDescription, SourceConnection, SourceData, SourceDesc,
+    SourceExport,
 };
 use mz_storage_types::AlterCompatible;
 use mz_txn_wal::metrics::Metrics as TxnMetrics;
@@ -347,6 +348,10 @@ where
         self.storage_collections.active_collection_metadatas()
     }
 
+    fn active_ingestions(&self, instance_id: StorageInstanceId) -> &BTreeSet<GlobalId> {
+        self.instances[&instance_id].active_ingestions()
+    }
+
     fn check_exists(&self, id: GlobalId) -> Result<(), StorageError<Self::Timestamp>> {
         self.storage_collections.check_exists(id)
     }
@@ -361,6 +366,9 @@ where
         );
         if self.initialized {
             instance.send(StorageCommand::InitializationComplete);
+        }
+        if !self.read_only {
+            instance.send(StorageCommand::AllowWrites);
         }
         instance.send(StorageCommand::UpdateConfiguration(
             self.config.parameters.clone(),
@@ -806,8 +814,11 @@ where
         // TODO(guswynn): perform the io in this final section concurrently.
         for id in to_execute {
             match &self.collection(id)?.data_source {
-                DataSource::Ingestion(_) => {
-                    if !self.read_only {
+                DataSource::Ingestion(ingestion) => {
+                    if !self.read_only || (
+                        ENABLE_0DT_DEPLOYMENT_SOURCES.get(self.config.config_set())
+                        && ingestion.desc.connection.supports_read_only()
+                    ) {
                         self.run_ingestion(id)?;
                     }
                 }

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -687,6 +687,9 @@ pub trait SourceConnection: Debug + Clone + PartialEq + AlterCompatible {
     /// details of that export, else is set to `SourceExportDetails::None` to indicate that
     /// this source should not export to the primary collection.
     fn primary_export_details(&self) -> SourceExportDetails;
+
+    /// Whether the source type supports read only mode.
+    fn supports_read_only(&self) -> bool;
 }
 
 #[derive(Arbitrary, Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -1042,6 +1045,15 @@ impl<C: ConnectionAccess> SourceConnection for GenericSourceConnection<C> {
             Self::Postgres(conn) => conn.primary_export_details(),
             Self::MySql(conn) => conn.primary_export_details(),
             Self::LoadGenerator(conn) => conn.primary_export_details(),
+        }
+    }
+
+    fn supports_read_only(&self) -> bool {
+        match self {
+            GenericSourceConnection::Kafka(conn) => conn.supports_read_only(),
+            GenericSourceConnection::Postgres(conn) => conn.supports_read_only(),
+            GenericSourceConnection::MySql(conn) => conn.supports_read_only(),
+            GenericSourceConnection::LoadGenerator(conn) => conn.supports_read_only(),
         }
     }
 }

--- a/src/storage-types/src/sources/kafka.rs
+++ b/src/storage-types/src/sources/kafka.rs
@@ -224,6 +224,10 @@ impl<C: ConnectionAccess> SourceConnection for KafkaSourceConnection<C> {
             metadata_columns: self.metadata_columns.clone(),
         })
     }
+
+    fn supports_read_only(&self) -> bool {
+        true
+    }
 }
 
 impl<C: ConnectionAccess> crate::AlterCompatible for KafkaSourceConnection<C> {

--- a/src/storage-types/src/sources/load_generator.rs
+++ b/src/storage-types/src/sources/load_generator.rs
@@ -163,6 +163,10 @@ impl SourceConnection for LoadGeneratorSourceConnection {
             }
         }
     }
+
+    fn supports_read_only(&self) -> bool {
+        false
+    }
 }
 
 impl crate::AlterCompatible for LoadGeneratorSourceConnection {}

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -135,6 +135,10 @@ impl<C: ConnectionAccess> SourceConnection for MySqlSourceConnection<C> {
     fn primary_export_details(&self) -> SourceExportDetails {
         SourceExportDetails::None
     }
+
+    fn supports_read_only(&self) -> bool {
+        false
+    }
 }
 
 impl<C: ConnectionAccess> AlterCompatible for MySqlSourceConnection<C> {

--- a/src/storage-types/src/sources/postgres.rs
+++ b/src/storage-types/src/sources/postgres.rs
@@ -126,6 +126,10 @@ impl<C: ConnectionAccess> SourceConnection for PostgresSourceConnection<C> {
     fn primary_export_details(&self) -> SourceExportDetails {
         SourceExportDetails::None
     }
+
+    fn supports_read_only(&self) -> bool {
+        false
+    }
 }
 
 impl<C: ConnectionAccess> AlterCompatible for PostgresSourceConnection<C> {


### PR DESCRIPTION
Add a new feature flag called `enable_0dt_deployment_sources` which
controls whether 0dt deployment is attempted for source types that
support it.

To start, only Kafka sources will support 0dt deployments. The rationale
is twofold:

  * Kafka does not have a notion of replication slots, so it's easy to
    have multiple processes reading from the same Kafka topic.

  * Only Kafka sources support the upsert envelope, which is the only
    source operator that has a meaningful rehydration time. Other source
    types (e.g., PostgreSQL) effectively already support 0dt upgrades
    because they can do a cold restart from where they left off nearly
    instantaneously.

This commit does not begin to tackle the hard parts of 0dt deployments
for Kafka upsert sources (read-only mode for the persist sink,
self-correcting upsert state, etc.). Enabling the
`enable_0dt_deployment_sources` is not yet expected to work. The idea is
just to lay down the scaffolding so that we can start to fill in the
missing pieces in parallel.

Touches https://github.com/MaterializeInc/database-issues/issues/8095.

### Motivation

  * This PR works towards a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
