### PR TITLE
compute: remove compute_persist_sink_obey_read_only flag

### DIFF
--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -122,16 +122,6 @@ pub const COPY_TO_S3_MULTIPART_PART_SIZE_BYTES: Config<usize> = Config::new(
     "The size of each part in a multipart upload to S3.",
 );
 
-/// Whether the compute `persist_sink` obeys read-only mode. When false, it
-/// writes regardless of that mode.
-///
-/// As an escape hatch for de-risking rollout of read-only computation mode.
-pub const PERSIST_SINK_OBEY_READ_ONLY: Config<bool> = Config::new(
-    "compute_persist_sink_obey_read_only",
-    true,
-    "Whether the compute persist_sink obeys read-only mode.",
-);
-
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -149,5 +139,4 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&COPY_TO_S3_PARQUET_ROW_GROUP_FILE_RATIO)
         .add(&COPY_TO_S3_ARROW_BUILDER_BUFFER_RATIO)
         .add(&COPY_TO_S3_MULTIPART_PART_SIZE_BYTES)
-        .add(&PERSIST_SINK_OBEY_READ_ONLY)
 }

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{Collection, Hashable};
 use futures::StreamExt;
-use mz_compute_types::dyncfgs::PERSIST_SINK_OBEY_READ_ONLY;
 use mz_compute_types::sinks::{ComputeSinkDesc, PersistSinkConnection};
 use mz_ore::assert_none;
 use mz_ore::cast::CastFrom;
@@ -198,8 +197,6 @@ where
         );
     }
 
-    let obey_read_only_mode = PERSIST_SINK_OBEY_READ_ONLY.get(&compute_state.worker_config);
-
     let (batch_descriptions, desired_oks, desired_errs, mint_token) = mint_batch_descriptions(
         sink_id,
         operator_name.clone(),
@@ -222,7 +219,6 @@ where
         &persist_errs,
         Arc::clone(&persist_clients),
         compute_state.read_only_rx.clone(),
-        obey_read_only_mode,
     );
 
     let append_token = append_batches(
@@ -233,7 +229,6 @@ where
         &written_batches,
         persist_clients,
         compute_state.read_only_rx.clone(),
-        obey_read_only_mode,
     );
 
     let token = Rc::new((mint_token, write_token, append_token));
@@ -609,7 +604,6 @@ fn write_batches<G>(
     persist_errs: &Stream<G, (DataflowError, Timestamp, Diff)>,
     persist_clients: Arc<PersistClientCache>,
     mut read_only: watch::Receiver<bool>,
-    obey_read_only: bool,
 ) -> (Stream<G, BatchOrData>, Rc<dyn Any>)
 where
     G: Scope<Timestamp = Timestamp>,
@@ -868,7 +862,7 @@ where
             in_flight_batches
                 .retain(|(lower, _upper), _cap| PartialOrder::less_equal(&persist_upper, lower));
 
-            if obey_read_only && read_only.borrow().clone() {
+            if read_only.borrow().clone() {
                 // We are not allowed to do writes, so go back to the beginning
                 // of the loop.
                 //
@@ -977,7 +971,6 @@ fn append_batches<G>(
     batches: &Stream<G, BatchOrData>,
     persist_clients: Arc<PersistClientCache>,
     mut read_only: watch::Receiver<bool>,
-    obey_read_only: bool,
 ) -> Rc<dyn Any>
 where
     G: Scope<Timestamp = Timestamp>,
@@ -1189,7 +1182,7 @@ where
                 false
             });
 
-            if obey_read_only && read_only.borrow().clone() {
+            if read_only.borrow().clone() {
                 // We are not allowed to do writes, so go back to the beginning
                 // of the loop.
                 //


### PR DESCRIPTION
Read-only mode has been working stably in production for several months now.

Touches #27413.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
