### PR TITLE
add docs for new static ips cidrs

### DIFF
--- a/doc/user/content/ingest-data/network-security/static-ips.md
+++ b/doc/user/content/ingest-data/network-security/static-ips.md
@@ -1,6 +1,6 @@
 ---
 title: "Static IP addresses"
-description: "Materialize uses static IP addresses for outbound connections from sources and sinks"
+description: "Materialize provides static IP addresses that you can use to configure egress policies in your virtual networks that target outbound traffic to Materialize."
 menu:
   main:
     parent: network-security
@@ -10,14 +10,20 @@ aliases:
   - /connect-sources/static-ips/
 ---
 
-Each materialize region is associated with a unique set of static egress [Classless Inter-Domain Routing (CIDR)](https://aws.amazon.com/what-is/cidr/) blocks.
-All connections to the public internet initiated by your Materialize region will
-originate from an address in the provided blocks.
+Each materialize region is associated with a unique set of static egress
+[Classless Inter-Domain Routing (CIDR)](https://aws.amazon.com/what-is/cidr/)
+blocks. All connections to the public internet initiated by your Materialize
+region will originate from an IP address in the provided blocks.
 
-When connecting Materialize to services in your private networks (e.g., Kafka
-clusters or PostgreSQL databases), you must configure any firewalls to allow
-connections from all CIDR blocks associated with your region. **Connections may
-originate from any address in the region**.
+{{< note >}}
+On rare occasion, we may need to change the static egress CIDR blocks associated
+with a region. We make every effort to provide advance notice of such changes.
+{{< /note >}}
+
+When connecting Materialize to services in your private networks (e.g., Kafka,
+PostgreSQL, MySQL), you must configure any firewalls to allow connections from
+all CIDR blocks associated with your region. **Connections may originate from
+any address in the region**.
 
 Region          | CIDR
 ----------------|------------
@@ -28,22 +34,16 @@ Region          | CIDR
 `aws/eu-west-1` | 108.128.128.96/27
 `aws/eu-west-1` | 54.229.252.215/32
 
-{{< note >}}
-On rare occasion, we may need to change the static egress CIDR blocks associated with
-a region. We make every effort to provide advance notice of such changes.
-{{< /note >}}
 
+## Fetching static egress IPs addresses
 
-## Fetch static egress IPs
-You can fetch the static egress address blocks associated with your region by querying
-the [`mz_egress_ips`](/sql/system-catalog/mz_catalog/#mz_egress_ips) system catalog
-table.
+You can fetch the static egress CIDR blocks associated with your region by
+querying the [`mz_egress_ips`](/sql/system-catalog/mz_catalog/#mz_egress_ips)
+system catalog table.
 
 ```mzsql
 SELECT * FROM mz_egress_ips;
 ```
-
-<p></p>
 
 ```nofmt
   egress_ip    | prefix_length |      cidr
@@ -55,8 +55,7 @@ SELECT * FROM mz_egress_ips;
 As an alternative, you can also submit an HTTP request to Materialize's
 [SQL API](/integrations/http-api/) querying the [`mz_egress_ips`](/sql/system-catalog/mz_catalog/#mz_egress_ips)
 system catalog table. In the request, specify the username, app password, and
-host address of your Materialize region:
-
+host for your Materialize region:
 
 ```
 curl -s 'https://<host-address>/api/sql' \


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
We want to provide a list of our static egress IPs. This change adds the IPs directly to the docs, and also provides an example of fetching the IPS via an HTTP request.

Unfortunately we can't only return the results in this request, but it may still be useful. 
These IPs are static and therefore should be safe to put in documentation. 

I have used examples IPs for now rather than the real ranges as we discuss this change.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
