### PR TITLE
controller: Truncate status history in background

### DIFF
--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -57,13 +57,16 @@
 //! [`MonotonicAppender`] returned from
 //! [`CollectionManager::monotonic_appender`].
 
-use std::collections::BTreeMap;
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BinaryHeap};
+use std::fmt::Debug;
 use std::ops::ControlFlow;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, bail};
+use chrono::{DateTime, Utc};
 use differential_dataflow::consolidation;
 use differential_dataflow::lattice::Lattice;
 use futures::future::BoxFuture;
@@ -79,6 +82,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::read::ReadHandle;
 use mz_persist_client::write::WriteHandle;
 use mz_persist_types::Codec64;
+use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::{ColumnName, Diff, GlobalId, Row, TimestampManipulation};
 use mz_storage_client::client::TimestamplessUpdate;
 use mz_storage_client::controller::{IntrospectionType, MonotonicAppender, StorageWriteOp};
@@ -95,7 +99,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::time::{Duration, Instant};
 use tracing::{debug, error, info};
 
-use crate::{collection_status, snapshot, StorageError};
+use crate::{collection_status, snapshot, StatusHistoryDesc, StorageError};
 
 // Default rate at which we advance the uppers of managed collections.
 const DEFAULT_TICK_MS: u64 = 1_000;
@@ -1208,6 +1212,151 @@ where
         .await
         .expect("valid usage")
         .map_err(|e| anyhow!("appending retractions: {e:?}"))
+}
+
+/// Effectively truncates the status history shard except for the most
+/// recent updates from each key.
+///
+/// NOTE: The history collections are really append-only collections, but
+/// every-now-and-then we want to retract old updates so that the collection
+/// does not grow unboundedly. Crucially, these are _not_ incremental
+/// collections, they are not derived from a state at some time `t` and we
+/// cannot maintain a desired state for them.
+///
+/// Returns a map with latest unpacked row per key.
+pub(crate) async fn partially_truncate_status_history<T, K>(
+    id: GlobalId,
+    collection: IntrospectionType,
+    write_handle: &mut WriteHandle<SourceData, (), T, Diff>,
+    status_history_desc: StatusHistoryDesc<K>,
+    storage_collections: &Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
+    txns_read: &TxnsRead<T>,
+    persist: &Arc<PersistClientCache>,
+) -> BTreeMap<K, Row>
+where
+    T: Codec64 + From<EpochMillis> + TimestampManipulation,
+    K: Clone + Debug + Ord,
+{
+    let upper = write_handle.fetch_recent_upper().await.clone();
+
+    let mut rows = match upper.as_option() {
+        Some(f) if f > &T::minimum() => {
+            let as_of = f.step_back().unwrap();
+
+            snapshot(id, as_of, storage_collections, txns_read, persist)
+                .await
+                .expect("snapshot succeeds")
+        }
+        // If collection is closed or the frontier is the minimum, we cannot
+        // or don't need to truncate (respectively).
+        _ => return BTreeMap::new(),
+    };
+
+    // BTreeMap to track the earliest events for each key.
+    let mut last_n_entries_per_key: BTreeMap<
+        K,
+        BinaryHeap<Reverse<(CheckedTimestamp<DateTime<Utc>>, Row)>>,
+    > = BTreeMap::new();
+
+    // BTreeMap to keep track of the row with the latest timestamp for each key.
+    let mut latest_row_per_key: BTreeMap<K, (CheckedTimestamp<DateTime<Utc>>, Row)> =
+        BTreeMap::new();
+
+    // Consolidate the snapshot, so we can process it correctly below.
+    differential_dataflow::consolidation::consolidate(&mut rows);
+
+    let mut deletions = vec![];
+
+    for (row, diff) in rows {
+        let datums = row.unpack();
+        let key = (status_history_desc.extract_key)(&datums);
+        let timestamp = (status_history_desc.extract_time)(&datums);
+
+        // Duplicate rows ARE possible if many status changes happen in VERY quick succession,
+        // so we go ahead and handle them.
+        assert!(
+            diff > 0,
+            "only know how to operate over consolidated data with diffs > 0, \
+                found diff {diff} for object {key:?} in {collection:?}",
+        );
+
+        // Keep track of the timestamp of the latest row per key.
+        match latest_row_per_key.get(&key) {
+            Some(existing) if &existing.0 > &timestamp => {}
+            _ => {
+                latest_row_per_key.insert(key.clone(), (timestamp, row.clone()));
+            }
+        }
+
+        // Consider duplicated rows separately.
+        let entries = last_n_entries_per_key.entry(key).or_default();
+        for _ in 0..diff {
+            // We CAN have multiple statuses (most likely Starting and Running) at the exact same
+            // millisecond, depending on how the `health_operator` is scheduled.
+            //
+            // Note that these will be arbitrarily ordered, so a Starting event might
+            // survive and a Running one won't. The next restart will remove the other,
+            // so we don't bother being careful about it.
+            //
+            // TODO(guswynn): unpack these into health-status objects and use
+            // their `Ord` impl.
+            entries.push(Reverse((timestamp, row.clone())));
+
+            // Retain some number of entries, using pop to mark the oldest entries for
+            // deletion.
+            while entries.len() > status_history_desc.keep_n {
+                if let Some(Reverse((_, r))) = entries.pop() {
+                    deletions.push(r);
+                }
+            }
+        }
+    }
+
+    // It is very important that we append our retractions at the timestamp
+    // right after the timestamp at which we got our snapshot. Otherwise,
+    // it's possible for someone else to sneak in retractions or other
+    // unexpected changes.
+    let expected_upper = upper.into_option().expect("checked above");
+    let new_upper = TimestampManipulation::step_forward(&expected_upper);
+
+    // Updates are only deletes because everything else is already in the shard.
+    let updates = deletions
+        .into_iter()
+        .map(|row| ((SourceData(Ok(row)), ()), expected_upper.clone(), -1))
+        .collect::<Vec<_>>();
+
+    let res = write_handle
+        .compare_and_append(
+            updates,
+            Antichain::from_elem(expected_upper.clone()),
+            Antichain::from_elem(new_upper),
+        )
+        .await
+        .expect("usage was valid");
+
+    match res {
+        Ok(_) => {
+            // All good, yay!
+        }
+        Err(err) => {
+            // This is fine, it just means the upper moved because
+            // of continual upper advancement or because seomeone
+            // already appended some more retractions/updates.
+            //
+            // NOTE: We might want to attempt these partial
+            // retractions on an interval, instead of only when
+            // starting up!
+            info!(
+                %id, ?expected_upper, current_upper = ?err.current,
+                "failed to append partial truncation",
+            );
+        }
+    }
+
+    latest_row_per_key
+        .into_iter()
+        .map(|(key, (_, row))| (key, row))
+        .collect()
 }
 
 async fn monotonic_append<T: Timestamp + Lattice + Codec64 + TimestampManipulation>(


### PR DESCRIPTION
Previously, during startup the controller would sequentially truncate
the append-only status history introspection collections. This process
would block startup and take a non-trivial amount of time.

This commit moves the process of truncating some of the status
metrics history introspection sources into the append only background
write task. This truncation no longer blocks startup and happens
completely in the background. This commit also lays the foundation to
move status history truncation into the background.

The remaining two status history introspection sources rely on shared
state with the controller and can't as easily be moved into the
background.

Works towards resolving MaterializeInc/database-issues#8384

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
