### PR TITLE
storage: continual feedback upsert operator

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -235,6 +235,18 @@ steps:
               args: [--redpanda]
         skip: "Disabled due to taking too long for the value provided"
 
+      # TODO(def-) Remove this when old upsert implementation is removed
+      - id: testdrive-old-upsert
+        label: ":racing_car: testdrive with old Upsert"
+        depends_on: build-aarch64
+        timeout_in_minutes: 180
+        agents:
+          queue: hetzner-aarch64-8cpu-16gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: testdrive
+              args: [--system-param=storage_use_continual_feedback_upsert=false]
+
       - id: testdrive-partitions-5
         label: ":racing_car: testdrive with --kafka-default-partitions 5"
         depends_on: build-aarch64
@@ -440,6 +452,18 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: zippy
               args: [--scenario=KafkaSources, --actions=10000, --max-execution-time=30m]
+
+      # TODO(def-) Remove this when old upsert implementation is removed
+      - id: zippy-kafka-sources-old-upsert
+        label: "Zippy Kafka Sources with old Upsert"
+        depends_on: build-aarch64
+        timeout_in_minutes: 120
+        agents:
+          queue: hetzner-aarch64-8cpu-16gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: zippy
+              args: [--scenario=KafkaSources, --actions=10000, --max-execution-time=30m, --system-param=storage_use_continual_feedback_upsert=false]
 
       - id: zippy-kafka-parallel-insert
         label: "Zippy Kafka Parallel Insert"
@@ -662,6 +686,21 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=RestartEntireMz, "--seed=$BUILDKITE_JOB_ID"]
+
+      # TODO(def-) Remove this when old upsert implementation is removed
+      - id: checks-restart-entire-mz-old-upsert
+        label: "Checks + restart of the entire Mz with old Upsert %N"
+        depends_on: build-aarch64
+        timeout_in_minutes: 180
+        # Sometimes runs into query timeouts or entire test timeouts with parallelism 1, too much state, same in all other platform-checks
+        parallelism: 2
+        agents:
+          # A larger instance is needed due to frequent OOMs, same in all other platform-checks
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=RestartEntireMz, --system-param=storage_use_continual_feedback_upsert=false "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-backup-rollback
         label: "Checks + backup + rollback to previous %N"

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -700,7 +700,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=RestartEntireMz, --system-param=storage_use_continual_feedback_upsert=false "--seed=$BUILDKITE_JOB_ID"]
+              args: [--scenario=RestartEntireMz, --system-param=storage_use_continual_feedback_upsert=false, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-backup-rollback
         label: "Checks + backup + rollback to previous %N"

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -16,6 +16,7 @@ from kubernetes.client import V1Container, V1EnvVar, V1ObjectMeta, V1Pod, V1PodS
 
 from materialize.cloudtest import DEFAULT_K8S_NAMESPACE
 from materialize.cloudtest.k8s.api.k8s_pod import K8sPod
+from materialize.mzcompose import get_default_system_parameters
 from materialize.mzcompose.test_result import (
     extract_error_chunks_from_output,
 )
@@ -56,6 +57,13 @@ class TestdriveBase:
         log_filter: str = "off",
         suppress_command_error_output: bool = False,
     ) -> None:
+        leaves_tombstones = (
+            "true"
+            if get_default_system_parameters()["storage_use_continual_feedback_upsert"]
+            == "false"
+            else "false"
+        )
+
         command: list[str] = [
             "testdrive",
             f"--materialize-url={self.materialize_url}",
@@ -65,6 +73,7 @@ class TestdriveBase:
             f"--default-timeout={default_timeout}",
             f"--log-filter={log_filter}",
             "--var=replicas=1",
+            f"--var=leaves-tombstones={leaves_tombstones}",
             "--var=single-replica-cluster=quickstart",
             "--var=default-storage-size=1",
             "--var=default-replica-size=1",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -150,6 +150,7 @@ def get_default_system_parameters(
         "statement_logging_default_sample_rate": "0.01",
         "statement_logging_max_sample_rate": "0.01",
         "storage_source_decode_fuel": "100000",
+        "storage_use_continual_feedback_upsert": "true",
         "storage_use_reclock_v2": "true",
         "timestamp_oracle": "postgres",
         "wait_catalog_consolidation_on_startup": "true",

--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -31,8 +31,8 @@ def get_ancestor_overrides_for_performance_regressions(
     if scenario_class_name == "KafkaUpsertUnique":
         # PR#29718 (storage: continual feedback upsert operator) increases CPU and memory
         min_ancestor_mz_version_per_commit[
-            "62f1ef27222be4ff1e9a3e55334c14e074c1be17"
-        ] = MzVersion.parse_mz("v0.122.0")
+            "b16b6a2c71f6e52adcbe37988cb262c15074a63f"
+        ] = MzVersion.parse_mz("v0.125.0")
 
     if scenario_class_name in (
         "SmallClusters",

--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -28,6 +28,12 @@ def get_ancestor_overrides_for_performance_regressions(
 
     min_ancestor_mz_version_per_commit = dict()
 
+    if scenario_class_name == "KafkaUpsertUnique":
+        # PR#29718 (storage: continual feedback upsert operator) increases CPU and memory
+        min_ancestor_mz_version_per_commit[
+            "62f1ef27222be4ff1e9a3e55334c14e074c1be17"
+        ] = MzVersion.parse_mz("v0.122.0")
+
     if scenario_class_name in (
         "SmallClusters",
         "AccumulateReductions",

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -179,7 +179,19 @@ class AncestorImageResolutionBase:
         context_when_image_of_commit_exists: str,
         context_when_falling_back_to_latest: str,
     ) -> tuple[str, str]:
+        # If the current PR has a known and accepted regression, don't compare
+        # against merge base of it
+        override_commit = self._get_override_commit_instead_of_version(
+            MzVersion.parse_cargo()
+        )
         common_ancestor_commit = buildkite.get_merge_base()
+
+        if override_commit is not None:
+            return (
+                commit_to_image_tag(override_commit),
+                f"commit override instead of merge base ({common_ancestor_commit})",
+            )
+
         if image_of_commit_exists(common_ancestor_commit):
             return (
                 commit_to_image_tag(common_ancestor_commit),

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -223,7 +223,7 @@ pub const STORAGE_RECLOCK_TO_LATEST: Config<bool> = Config::new(
 /// Whether to use the new continual feedback upsert operator.
 pub const STORAGE_USE_CONTINUAL_FEEDBACK_UPSERT: Config<bool> = Config::new(
     "storage_use_continual_feedback_upsert",
-    false,
+    true,
     "Whether to use the new continual feedback upsert operator.",
 );
 

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -220,6 +220,13 @@ pub const STORAGE_RECLOCK_TO_LATEST: Config<bool> = Config::new(
     "Whether to mint reclock bindings based on the latest probed offset or the latest ingested offset."
 );
 
+/// Whether to use the new continual feedback upsert operator.
+pub const STORAGE_USE_CONTINUAL_FEEDBACK_UPSERT: Config<bool> = Config::new(
+    "storage_use_continual_feedback_upsert",
+    false,
+    "Whether to use the new continual feedback upsert operator.",
+);
+
 /// Adds the full set of all storage `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -244,4 +251,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&STORAGE_SUSPEND_AND_RESTART_DELAY)
         .add(&STORAGE_USE_RECLOCK_V2)
         .add(&STORAGE_RECLOCK_TO_LATEST)
+        .add(&STORAGE_USE_CONTINUAL_FEEDBACK_UPSERT)
 }

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -223,7 +223,7 @@ pub const STORAGE_RECLOCK_TO_LATEST: Config<bool> = Config::new(
 /// Whether to use the new continual feedback upsert operator.
 pub const STORAGE_USE_CONTINUAL_FEEDBACK_UPSERT: Config<bool> = Config::new(
     "storage_use_continual_feedback_upsert",
-    true,
+    false,
     "Whether to use the new continual feedback upsert operator.",
 );
 

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -20,7 +20,8 @@ pub mod sink;
 pub mod source;
 pub mod statistics;
 pub mod storage_state;
-mod upsert;
+pub(crate) mod upsert;
+mod upsert_continual_feedback;
 
 pub(crate) mod healthcheck;
 

--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -47,6 +47,7 @@ use crate::healthcheck::HealthStatusUpdate;
 use crate::metrics::upsert::UpsertMetrics;
 use crate::render::sources::OutputIndex;
 use crate::storage_state::StorageInstanceContext;
+use crate::upsert_continual_feedback;
 use autospill::AutoSpillBackend;
 use memory::InMemoryHashMap;
 use types::{
@@ -57,7 +58,8 @@ use types::{
 mod autospill;
 mod memory;
 mod rocksdb;
-mod types;
+// TODO(aljoscha): Move next to upsert module, rename to upsert_types.
+pub(crate) mod types;
 
 pub type UpsertValue = Result<Row, UpsertError>;
 
@@ -408,8 +410,7 @@ where
     tracing::info!(id = %source_config.id, %use_continual_feedback_upsert, "upsert operator implementation");
 
     if use_continual_feedback_upsert {
-        // TODO: actually add the other implementation!
-        upsert_classic(
+        upsert_continual_feedback::upsert_inner(
             input,
             key_indices,
             resume_upper,

--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -191,7 +191,9 @@ pub fn rehydration_finished<G, T>(
             }
         }
         tracing::info!(
-            "timely-{worker_id} upsert source {id} has downgraded past the resume upper ({resume_upper:?}) across all workers",
+            %worker_id,
+            source_id = %id,
+            "upsert source has downgraded past the resume upper ({resume_upper:?}) across all workers",
         );
         drop(token);
     });
@@ -266,12 +268,12 @@ where
             .spill_to_disk_threshold_bytes;
 
         tracing::info!(
+            worker_id = %source_config.worker_id,
+            source_id = %source_config.id,
             ?tuning,
             ?storage_configuration.parameters.upsert_auto_spill_config,
             ?rocksdb_use_native_merge_operator,
-            "timely-{} rendering {} with rocksdb-backed upsert state",
-            source_config.worker_id,
-            source_config.id
+            "rendering upsert source with rocksdb-backed upsert state"
         );
         let rocksdb_shared_metrics = Arc::clone(&upsert_metrics.rocksdb_shared);
         let rocksdb_instance_metrics = Arc::clone(&upsert_metrics.rocksdb_instance_metrics);
@@ -355,9 +357,9 @@ where
         }
     } else {
         tracing::info!(
-            "timely-{} rendering {} with memory-backed upsert state",
-            source_config.worker_id,
-            source_config.id
+            worker_id = %source_config.worker_id,
+            source_id = %source_config.id,
+            "rendering upsert source with memory-backed upsert state",
         );
         upsert_operator(
             &thin_input,

--- a/src/storage/src/upsert_continual_feedback.rs
+++ b/src/storage/src/upsert_continual_feedback.rs
@@ -417,7 +417,7 @@ where
                                 // required to avoid buffering the entire source
                                 // snapshot in the `stash`.
                                 if prevent_snapshot_buffering && resume_upper.less_equal(&G::Timestamp::minimum()) && event_time == G::Timestamp::minimum() {
-                                    tracing::info!(?event_time, ?resume_upper, ?output_cap, "partial drain not implemented, yet");
+                                    tracing::debug!(?event_time, ?resume_upper, ?output_cap, "partial drain not implemented, yet");
                                 }
                             }
                             AsyncEvent::Progress(upper) => {

--- a/src/storage/src/upsert_continual_feedback.rs
+++ b/src/storage/src/upsert_continual_feedback.rs
@@ -1,0 +1,551 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::cmp::Reverse;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use differential_dataflow::consolidation;
+use differential_dataflow::hashable::Hashable;
+use differential_dataflow::{AsCollection, Collection};
+use futures::future::FutureExt;
+use futures::StreamExt;
+use indexmap::map::Entry;
+use itertools::Itertools;
+use mz_ore::cast::CastFrom;
+use mz_repr::{Diff, Row};
+use mz_storage_types::errors::{DataflowError, EnvelopeError, UpsertError};
+use mz_timely_util::builder_async::{
+    Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
+};
+use std::convert::Infallible;
+use timely::container::CapacityContainerBuilder;
+use timely::dataflow::channels::pact::Exchange;
+use timely::dataflow::{Scope, Stream};
+use timely::order::{PartialOrder, TotalOrder};
+use timely::progress::{Antichain, Timestamp};
+
+use crate::healthcheck::HealthStatusUpdate;
+use crate::metrics::upsert::UpsertMetrics;
+use crate::render::sources::OutputIndex;
+use crate::upsert::types as upsert_types;
+use crate::upsert::types::{StateValue, UpsertState, UpsertStateBackend, Value};
+use crate::upsert::UpsertConfig;
+use crate::upsert::UpsertErrorEmitter;
+use crate::upsert::UpsertKey;
+use crate::upsert::UpsertValue;
+
+use upsert_types::ValueMetadata;
+
+pub(crate) fn upsert_inner<G: Scope, FromTime, F, Fut, US>(
+    input: &Collection<G, (UpsertKey, Option<UpsertValue>, FromTime), Diff>,
+    key_indices: Vec<usize>,
+    resume_upper: Antichain<G::Timestamp>,
+    previous: Collection<G, Result<Row, DataflowError>, Diff>,
+    previous_token: Option<Vec<PressOnDropButton>>,
+    upsert_metrics: UpsertMetrics,
+    source_config: crate::source::RawSourceCreationConfig,
+    state: F,
+    upsert_config: UpsertConfig,
+    prevent_snapshot_buffering: bool,
+    snapshot_buffering_max: Option<usize>,
+) -> (
+    Collection<G, Result<Row, DataflowError>, Diff>,
+    Stream<G, (OutputIndex, HealthStatusUpdate)>,
+    Stream<G, Infallible>,
+    PressOnDropButton,
+)
+where
+    G::Timestamp: TotalOrder,
+    F: FnOnce() -> Fut + 'static,
+    Fut: std::future::Future<Output = US>,
+    US: UpsertStateBackend<Option<FromTime>>,
+    FromTime: timely::ExchangeData + Ord,
+{
+    let mut builder = AsyncOperatorBuilder::new("Upsert".to_string(), input.scope());
+
+    // We only care about UpsertValueError since this is the only error that we can retract
+    let previous = previous.flat_map(move |result| {
+        let value = match result {
+            Ok(ok) => Ok(ok),
+            Err(DataflowError::EnvelopeError(err)) => match *err {
+                EnvelopeError::Upsert(err) => Err(err),
+                _ => return None,
+            },
+            Err(_) => return None,
+        };
+        Some((UpsertKey::from_value(value.as_ref(), &key_indices), value))
+    });
+    let (output_handle, output) = builder.new_output();
+
+    // An output that just reports progress of the snapshot consolidation process upstream to the
+    // persist source to ensure that backpressure is applied
+    let (_snapshot_handle, snapshot_stream) =
+        builder.new_output::<CapacityContainerBuilder<Vec<Infallible>>>();
+
+    let (mut health_output, health_stream) = builder.new_output();
+    let mut input = builder.new_input_for(
+        &input.inner,
+        Exchange::new(move |((key, _, _), _, _)| UpsertKey::hashed(key)),
+        &output_handle,
+    );
+
+    let mut previous = builder.new_input_for(
+        &previous.inner,
+        Exchange::new(|((key, _), _, _)| UpsertKey::hashed(key)),
+        &output_handle,
+    );
+
+    let upsert_shared_metrics = Arc::clone(&upsert_metrics.shared);
+    let shutdown_button = builder.build(move |caps| async move {
+        let [mut output_cap, mut snapshot_cap, health_cap]: [_; 3] = caps.try_into().unwrap();
+
+        // The order key of the `UpsertState` is `Option<FromTime>`, which implements `Default`
+        // (as required for `consolidate_snapshot_chunk`), with slightly more efficient serialization
+        // than a default `Partitioned`.
+        let mut state = UpsertState::<_, Option<FromTime>>::new(
+            state().await,
+            upsert_shared_metrics,
+            &upsert_metrics,
+            source_config.source_statistics,
+            upsert_config.shrink_upsert_unused_buffers_by_ratio,
+        );
+        let mut events = vec![];
+        let mut snapshot_upper = Antichain::from_elem(Timestamp::minimum());
+
+        let mut stash = vec![];
+        let mut legacy_errors_to_correct = vec![];
+
+        let mut error_emitter = (&mut health_output, &health_cap);
+
+        tracing::info!(
+            ?resume_upper,
+            ?snapshot_upper,
+            "timely-{} upsert source {} starting rehydration",
+            source_config.worker_id,
+            source_config.id
+        );
+        // Read and consolidate the snapshot from the 'previous' input until it
+        // reaches the `resume_upper`.
+        while !PartialOrder::less_equal(&resume_upper, &snapshot_upper) {
+            previous.ready().await;
+            while let Some(event) = previous.next_sync() {
+                match event {
+                    AsyncEvent::Data(_cap, data) => {
+                        events.extend(data.into_iter().filter_map(|((key, value), ts, diff)| {
+                            if !resume_upper.less_equal(&ts) {
+                                Some((key, value, diff))
+                            } else {
+                                None
+                            }
+                        }))
+                    }
+                    AsyncEvent::Progress(upper) => {
+                        snapshot_upper = upper;
+                    }
+                };
+            }
+
+            for (_, value, diff) in events.iter_mut() {
+                if let Err(UpsertError::Value(ref mut err)) = value {
+                    // If we receive a legacy error in the snapshot we will keep a note of it but
+                    // insert a non-legacy error in our state. This is so that if this error is
+                    // ever retracted we will correctly retract the non-legacy version because by
+                    // that time we will have emitted the error correction, which happens before
+                    // processing any of the new source input.
+                    if err.is_legacy_dont_touch_it {
+                        legacy_errors_to_correct.push((err.clone(), diff.clone()));
+                        err.is_legacy_dont_touch_it = false;
+                    }
+                }
+            }
+
+            match state
+                .consolidate_snapshot_chunk(
+                    events.drain(..),
+                    PartialOrder::less_equal(&resume_upper, &snapshot_upper),
+                )
+                .await
+            {
+                Ok(_) => {
+                    if let Some(ts) = snapshot_upper.clone().into_option() {
+                        // As we shutdown, we could ostensibly get data from later than the
+                        // `resume_upper`, which we ignore above. We don't want our output capability to make
+                        // it further than the `resume_upper`.
+                        if !resume_upper.less_equal(&ts) {
+                            snapshot_cap.downgrade(&ts);
+                            output_cap.downgrade(&ts);
+                        }
+                    }
+                }
+                Err(e) => {
+                    UpsertErrorEmitter::<G>::emit(
+                        &mut error_emitter,
+                        "Failed to rehydrate state".to_string(),
+                        e,
+                    )
+                    .await;
+                }
+            }
+        }
+
+        drop(events);
+        drop(previous_token);
+        drop(snapshot_cap);
+
+        // Exchaust the previous input. It is expected to immediately reach the empty
+        // antichain since we have dropped its token.
+        //
+        // Note that we do not need to also process the `input` during this, as the dropped token
+        // will shutdown the `backpressure` operator
+        while let Some(_event) = previous.next().await {}
+
+        // After snapshotting, our output frontier is exactly the `resume_upper`
+        if let Some(ts) = resume_upper.as_option() {
+            output_cap.downgrade(ts);
+        }
+
+        // Now it's time to emit the error corrections. It doesn't matter at what timestamp we emit
+        // them at because all they do is change the representation. The error count at any
+        // timestamp remains constant.
+        upsert_metrics
+            .legacy_value_errors
+            .set(u64::cast_from(legacy_errors_to_correct.len()));
+        if !legacy_errors_to_correct.is_empty() {
+            tracing::error!(
+                "unexpected legacy error representation. Found {} occurences",
+                legacy_errors_to_correct.len()
+            );
+        }
+        consolidation::consolidate(&mut legacy_errors_to_correct);
+        for (mut error, diff) in legacy_errors_to_correct {
+            assert!(
+                error.is_legacy_dont_touch_it,
+                "attempted to correct non-legacy error"
+            );
+            tracing::info!("correcting legacy error {error:?} with diff {diff}");
+            let time = output_cap.time().clone();
+            let retraction = Err(UpsertError::Value(error.clone()));
+            error.is_legacy_dont_touch_it = false;
+            let insertion = Err(UpsertError::Value(error));
+            output_handle.give(&output_cap, (retraction, time.clone(), -diff));
+            output_handle.give(&output_cap, (insertion, time, diff));
+        }
+
+        tracing::info!(
+            "timely-{} upsert source {} finished rehydration",
+            source_config.worker_id,
+            source_config.id
+        );
+
+        // A re-usable buffer of changes, per key. This is an `IndexMap` because it has to be `drain`-able
+        // and have a consistent iteration order.
+        let mut commands_state: indexmap::IndexMap<
+            _,
+            upsert_types::UpsertValueAndSize<Option<FromTime>>,
+        > = indexmap::IndexMap::new();
+        let mut multi_get_scratch = Vec::new();
+
+        // Now can can resume consuming the collection
+        let mut output_updates = vec![];
+        let mut input_upper = Antichain::from_elem(Timestamp::minimum());
+
+        while let Some(event) = input.next().await {
+            // Buffer as many events as possible. This should be bounded, as new data can't be
+            // produced in this worker until we yield to timely.
+            let events = [event]
+                .into_iter()
+                .chain(std::iter::from_fn(|| input.next().now_or_never().flatten()))
+                .enumerate();
+
+            let mut partial_drain_time = None;
+            for (i, event) in events {
+                match event {
+                    AsyncEvent::Data(cap, mut data) => {
+                        tracing::trace!(
+                            time=?cap.time(),
+                            updates=%data.len(),
+                            "received data in upsert"
+                        );
+                        stage_input(
+                            &mut stash,
+                            &mut data,
+                            &input_upper,
+                            &resume_upper,
+                            upsert_config.shrink_upsert_unused_buffers_by_ratio,
+                        );
+
+                        let event_time = cap.time();
+                        // If the data is at _exactly_ the output frontier, we can preemptively drain it into the state.
+                        // Data within this set events strictly beyond this time are staged as
+                        // normal.
+                        //
+                        // This is a load-bearing optimization, as it is required to avoid buffering
+                        // the entire source snapshot in the `stash`.
+                        if prevent_snapshot_buffering && output_cap.time() == event_time {
+                            partial_drain_time = Some(event_time.clone());
+                        }
+                    }
+                    AsyncEvent::Progress(upper) => {
+                        tracing::trace!(?upper, "received progress in upsert");
+                        // Ignore progress updates before the `resume_upper`, which is our initial
+                        // capability post-snapshotting.
+                        if PartialOrder::less_than(&upper, &resume_upper) {
+                            continue;
+                        }
+
+                        // Disable the partial drain as this progress event covers
+                        // the `output_cap` time.
+                        partial_drain_time = None;
+                        drain_staged_input::<_, G, _, _, _>(
+                            &mut stash,
+                            &mut commands_state,
+                            &mut output_updates,
+                            &mut multi_get_scratch,
+                            DrainStyle::ToUpper(&upper),
+                            &mut error_emitter,
+                            &mut state,
+                        )
+                        .await;
+
+                        output_handle.give_container(&output_cap, &mut output_updates);
+
+                        if let Some(ts) = upper.as_option() {
+                            output_cap.downgrade(ts);
+                        }
+                        input_upper = upper;
+                    }
+                }
+                let events_processed = i + 1;
+                if let Some(max) = snapshot_buffering_max {
+                    if events_processed >= max {
+                        break;
+                    }
+                }
+            }
+
+            // If there were staged events that occurred at the capability time, drain
+            // them. This is safe because out-of-order updates to the same key that are
+            // drained in separate calls to `drain_staged_input` are correctly ordered by
+            // their `FromTime` in `drain_staged_input`.
+            //
+            // Note also that this may result in more updates in the output collection than
+            // the minimum. However, because the frontier only advances on `Progress` updates,
+            // the collection always accumulates correctly for all keys.
+            if let Some(partial_drain_time) = partial_drain_time {
+                drain_staged_input::<_, G, _, _, _>(
+                    &mut stash,
+                    &mut commands_state,
+                    &mut output_updates,
+                    &mut multi_get_scratch,
+                    DrainStyle::AtTime(partial_drain_time),
+                    &mut error_emitter,
+                    &mut state,
+                )
+                .await;
+
+                output_handle.give_container(&output_cap, &mut output_updates);
+            }
+        }
+    });
+
+    (
+        output.as_collection().map(|result| match result {
+            Ok(ok) => Ok(ok),
+            Err(err) => Err(DataflowError::from(EnvelopeError::Upsert(err))),
+        }),
+        health_stream,
+        snapshot_stream,
+        shutdown_button.press_on_drop(),
+    )
+}
+
+/// Helper method for `upsert_inner` used to stage `data` updates
+/// from the input timely edge.
+fn stage_input<T, FromTime>(
+    stash: &mut Vec<(T, UpsertKey, Reverse<FromTime>, Option<UpsertValue>)>,
+    data: &mut Vec<((UpsertKey, Option<UpsertValue>, FromTime), T, Diff)>,
+    input_upper: &Antichain<T>,
+    resume_upper: &Antichain<T>,
+    storage_shrink_upsert_unused_buffers_by_ratio: usize,
+) where
+    T: PartialOrder,
+    FromTime: Ord,
+{
+    if PartialOrder::less_equal(input_upper, resume_upper) {
+        data.retain(|(_, ts, _)| resume_upper.less_equal(ts));
+    }
+
+    stash.extend(data.drain(..).map(|((key, value, order), time, diff)| {
+        assert!(diff > 0, "invalid upsert input");
+        (time, key, Reverse(order), value)
+    }));
+
+    if storage_shrink_upsert_unused_buffers_by_ratio > 0 {
+        let reduced_capacity = stash.capacity() / storage_shrink_upsert_unused_buffers_by_ratio;
+        if reduced_capacity > stash.len() {
+            stash.shrink_to(reduced_capacity);
+        }
+    }
+}
+
+/// The style of drain we are performing on the stash. `AtTime`-drains cannot
+/// assume that all values have been seen, and must leave tombstones behind for deleted values.
+#[derive(Debug)]
+enum DrainStyle<'a, T> {
+    ToUpper(&'a Antichain<T>),
+    AtTime(T),
+}
+
+/// Helper method for `upsert_inner` used to stage `data` updates
+/// from the input timely edge.
+async fn drain_staged_input<S, G, T, FromTime, E>(
+    stash: &mut Vec<(T, UpsertKey, Reverse<FromTime>, Option<UpsertValue>)>,
+    commands_state: &mut indexmap::IndexMap<
+        UpsertKey,
+        upsert_types::UpsertValueAndSize<Option<FromTime>>,
+    >,
+    output_updates: &mut Vec<(Result<Row, UpsertError>, T, Diff)>,
+    multi_get_scratch: &mut Vec<UpsertKey>,
+    drain_style: DrainStyle<'_, T>,
+    error_emitter: &mut E,
+    state: &mut UpsertState<'_, S, Option<FromTime>>,
+) where
+    S: UpsertStateBackend<Option<FromTime>>,
+    G: Scope,
+    T: PartialOrder + Ord + Clone + Debug,
+    FromTime: timely::ExchangeData + Ord,
+    E: UpsertErrorEmitter<G>,
+{
+    stash.sort_unstable();
+
+    // Find the prefix that we can emit
+    let idx = stash.partition_point(|(ts, _, _, _)| match &drain_style {
+        DrainStyle::ToUpper(upper) => !upper.less_equal(ts),
+        DrainStyle::AtTime(time) => ts <= time,
+    });
+
+    tracing::trace!(?drain_style, updates = idx, "draining stash in upsert");
+
+    // Read the previous values _per key_ out of `state`, recording it
+    // along with the value with the _latest timestamp for that key_.
+    commands_state.clear();
+    for (_, key, _, _) in stash.iter().take(idx) {
+        commands_state.entry(*key).or_default();
+    }
+
+    // These iterators iterate in the same order because `commands_state`
+    // is an `IndexMap`.
+    multi_get_scratch.clear();
+    multi_get_scratch.extend(commands_state.iter().map(|(k, _)| *k));
+    match state
+        .multi_get(multi_get_scratch.drain(..), commands_state.values_mut())
+        .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            error_emitter
+                .emit("Failed to fetch records from state".to_string(), e)
+                .await;
+        }
+    }
+
+    // From the prefix that can be emitted we can deduplicate based on (ts, key) in
+    // order to only process the command with the maximum order within the (ts,
+    // key) group. This is achieved by wrapping order in `Reverse(FromTime)` above.;
+    let mut commands = stash.drain(..idx).dedup_by(|a, b| {
+        let ((a_ts, a_key, _, _), (b_ts, b_key, _, _)) = (a, b);
+        a_ts == b_ts && a_key == b_key
+    });
+
+    let bincode_opts = upsert_types::upsert_bincode_opts();
+    // Upsert the values into `commands_state`, by recording the latest
+    // value (or deletion). These will be synced at the end to the `state`.
+    //
+    // Note that we are effectively doing "mini-upsert" here, using
+    // `command_state`. This "mini-upsert" is seeded with data from `state`, using
+    // a single `multi_get` above, and the final state is written out into
+    // `state` using a single `multi_put`. This simplifies `UpsertStateBackend`
+    // implementations, and reduces the number of reads and write we need to do.
+    //
+    // This "mini-upsert" technique is actually useful in `UpsertState`'s
+    // `consolidate_snapshot_read_write_inner` implementation, minimizing gets and puts on
+    // the `UpsertStateBackend` implementations. In some sense, its "upsert all the way down".
+    while let Some((ts, key, from_time, value)) = commands.next() {
+        let mut command_state = if let Entry::Occupied(command_state) = commands_state.entry(key) {
+            command_state
+        } else {
+            panic!("key missing from commands_state");
+        };
+
+        let existing_value = &mut command_state.get_mut().value;
+
+        if let Some(cs) = existing_value.as_mut() {
+            cs.ensure_decoded(bincode_opts);
+        }
+
+        // Skip this command if its order key is below the one in the upsert state.
+        // Note that the existing order key may be `None` if the existing value
+        // is from snapshotting, which always sorts below new values/deletes.
+        let existing_order = existing_value.as_ref().and_then(|cs| cs.order().as_ref());
+        if existing_order >= Some(&from_time.0) {
+            // Skip this update. If no later updates adjust this key, then we just
+            // end up writing the same value back to state. If there
+            // is nothing in the state, `existing_order` is `None`, and this
+            // does not occur.
+            continue;
+        }
+
+        match value {
+            Some(value) => {
+                if let Some(old_value) = existing_value
+                    .replace(StateValue::value(value.clone(), Some(from_time.0.clone())))
+                {
+                    if let Value::Value(old_value, _) = old_value.into_decoded() {
+                        output_updates.push((old_value, ts.clone(), -1));
+                    }
+                }
+                output_updates.push((value, ts, 1));
+            }
+            None => {
+                if let Some(old_value) = existing_value.take() {
+                    if let Value::Value(old_value, _) = old_value.into_decoded() {
+                        output_updates.push((old_value, ts, -1));
+                    }
+                }
+
+                // Record a tombstone for deletes.
+                *existing_value = Some(StateValue::tombstone(Some(from_time.0.clone())));
+            }
+        }
+    }
+
+    match state
+        .multi_put(commands_state.drain(..).map(|(k, cv)| {
+            (
+                k,
+                upsert_types::PutValue {
+                    value: cv.value.map(|cv| cv.into_decoded()),
+                    previous_value_metadata: cv.metadata.map(|v| ValueMetadata {
+                        size: v.size.try_into().expect("less than i64 size"),
+                        is_tombstone: v.is_tombstone,
+                    }),
+                },
+            )
+        }))
+        .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            error_emitter
+                .emit("Failed to update records in state".to_string(), e)
+                .await;
+        }
+    }
+}

--- a/src/storage/src/upsert_continual_feedback.rs
+++ b/src/storage/src/upsert_continual_feedback.rs
@@ -7,6 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+//! Implementation of feedback UPSERT operator and associated helpers. See
+//! [`upsert_inner`] for a description of how the operator works and why.
+
 use std::cmp::Reverse;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -27,6 +30,7 @@ use mz_timely_util::builder_async::{
 use std::convert::Infallible;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Exchange;
+use timely::dataflow::operators::{Capability, CapabilitySet};
 use timely::dataflow::{Scope, Stream};
 use timely::order::{PartialOrder, TotalOrder};
 use timely::progress::{Antichain, Timestamp};
@@ -35,23 +39,90 @@ use crate::healthcheck::HealthStatusUpdate;
 use crate::metrics::upsert::UpsertMetrics;
 use crate::render::sources::OutputIndex;
 use crate::upsert::types as upsert_types;
+use crate::upsert::types::PutStats;
+use crate::upsert::types::UpsertValueAndSize;
 use crate::upsert::types::{StateValue, UpsertState, UpsertStateBackend, Value};
 use crate::upsert::UpsertConfig;
 use crate::upsert::UpsertErrorEmitter;
 use crate::upsert::UpsertKey;
 use crate::upsert::UpsertValue;
 
-use upsert_types::ValueMetadata;
-
-pub(crate) fn upsert_inner<G: Scope, FromTime, F, Fut, US>(
+/// An operator that transforms an input stream of upserts (updates to key-value
+/// pairs), which represents an imaginary key-value state, into a differential
+/// collection. It keeps an internal map-like state which keeps the latest value
+/// for each key, such that it can emit the retractions and additions implied by
+/// a new update for a given key.
+///
+/// This operator is intended to be used in an ingestion pipeline that reads
+/// from an external source, and the output of this operator is eventually
+/// written to persist.
+///
+/// The operator has two inputs: a) the source input, of upserts, and b) a
+/// persist input that feeds back the upsert state to the operator. Below, there
+/// is a section for each input that describes how and why we process updates
+/// from each input.
+///
+/// An important property of this operator is that it does _not_ update the
+/// map-like state that it keeps for translating the stream of upserts into a
+/// differential collection when it processes source input. It _only_ updates
+/// the map-like state based on updates from the persist (feedback) input. We do
+/// this because the operator is expected to be used in cases where there are
+/// multiple concurrent instances of the same ingestion pipeline, and the
+/// different instances might see different input because of concurrency and
+/// non-determinism. All instances of the upsert operator must produce output
+/// that is consistent with the current state of the output (that all instances
+/// produce "collaboratively"). This global state is what the operator
+/// continually learns about via updates from the persist input.
+///
+/// ## Processing the Source Input
+///
+/// Updates on the source input are stashed/staged until they can be processed.
+/// Whether or not an update can be processed depends both on the upper frontier
+/// of the source input and on the upper frontier of the persist input:
+///
+///  - Input updates are only processed once their timestamp is "done", that is
+///  the input upper is no longer `less_equal` their timestamp.
+///
+///  - Input updates are only processed once they are at the persist upper, that
+///  is we have emitted and written down updates for all previous times and we
+///  have updated our map-like state to the latest global state of the output of
+///  the ingestion pipeline. We know this is the case when the persist upper is
+///  no longer `less_than` their timestamp.
+///
+/// ## Processing the Persist Input
+///
+/// Processing of persist input happens differently based on whether we are
+/// still hydrating or not. The operator is hydrating when it is: a) ingesting
+/// the initial source snapshot, or b) ingesting a snapshot of previously
+/// written updates. We know we are ingesting the initial source snapshot when
+/// the `resume_upper` is `[MIN]`.
+///
+/// We need these different phases because while reading an initial snapshot,
+/// updates are not guaranteed to be physically consolidated, that is there
+/// might be multiple updates with varying diffs for a given key. The snapshot
+/// is still logically consolidated, that is when summing up all the diffs for a
+/// given key, the diff is either `1` (the key-value pair exists) or `0` the
+/// (key-value pair doesn't exist).
+///
+/// While hydrating, we therefore use a different method for ingesting updates
+/// into our map-like state, look for
+/// [`UpsertState::consolidate_snapshot_chunk`]. After hydration we can use
+/// [`UpsertState::multi_put_with_stats`], to ingest updates into our state as
+/// they come in.
+///
+/// Based on whether we are ingesting the initial source snapshot or not, the
+/// logic for determining when we are done hydrating is slightly different. It's
+/// explained inline in the code, look for `last_snapshot_chunk`, and the long
+/// comment above it.
+pub fn upsert_inner<G: Scope, FromTime, F, Fut, US>(
     input: &Collection<G, (UpsertKey, Option<UpsertValue>, FromTime), Diff>,
     key_indices: Vec<usize>,
     resume_upper: Antichain<G::Timestamp>,
-    previous: Collection<G, Result<Row, DataflowError>, Diff>,
-    previous_token: Option<Vec<PressOnDropButton>>,
+    persist_input: Collection<G, Result<Row, DataflowError>, Diff>,
+    mut persist_token: Option<Vec<PressOnDropButton>>,
     upsert_metrics: UpsertMetrics,
     source_config: crate::source::RawSourceCreationConfig,
-    state: F,
+    state_fn: F,
     upsert_config: UpsertConfig,
     prevent_snapshot_buffering: bool,
     snapshot_buffering_max: Option<usize>,
@@ -66,12 +137,12 @@ where
     F: FnOnce() -> Fut + 'static,
     Fut: std::future::Future<Output = US>,
     US: UpsertStateBackend<Option<FromTime>>,
-    FromTime: timely::ExchangeData + Ord,
+    FromTime: Debug + timely::ExchangeData + Ord,
 {
     let mut builder = AsyncOperatorBuilder::new("Upsert".to_string(), input.scope());
 
     // We only care about UpsertValueError since this is the only error that we can retract
-    let previous = previous.flat_map(move |result| {
+    let persist_input = persist_input.flat_map(move |result| {
         let value = match result {
             Ok(ok) => Ok(ok),
             Err(DataflowError::EnvelopeError(err)) => match *err {
@@ -96,261 +167,350 @@ where
         &output_handle,
     );
 
-    let mut previous = builder.new_input_for(
-        &previous.inner,
+    let mut persist_input = builder.new_disconnected_input(
+        &persist_input.inner,
         Exchange::new(|((key, _), _, _)| UpsertKey::hashed(key)),
-        &output_handle,
     );
 
     let upsert_shared_metrics = Arc::clone(&upsert_metrics.shared);
+
     let shutdown_button = builder.build(move |caps| async move {
-        let [mut output_cap, mut snapshot_cap, health_cap]: [_; 3] = caps.try_into().unwrap();
+        let [mut output_cap, snapshot_cap, health_cap]: [_; 3] = caps.try_into().unwrap();
+        let mut snapshot_cap = CapabilitySet::from_elem(snapshot_cap);
 
         // The order key of the `UpsertState` is `Option<FromTime>`, which implements `Default`
         // (as required for `consolidate_snapshot_chunk`), with slightly more efficient serialization
         // than a default `Partitioned`.
+
         let mut state = UpsertState::<_, Option<FromTime>>::new(
-            state().await,
+            state_fn().await,
             upsert_shared_metrics,
             &upsert_metrics,
             source_config.source_statistics,
             upsert_config.shrink_upsert_unused_buffers_by_ratio,
         );
-        let mut events = vec![];
-        let mut snapshot_upper = Antichain::from_elem(Timestamp::minimum());
 
-        let mut stash = vec![];
-        let mut legacy_errors_to_correct = vec![];
-
-        let mut error_emitter = (&mut health_output, &health_cap);
-
-        tracing::info!(
-            ?resume_upper,
-            ?snapshot_upper,
-            "timely-{} upsert source {} starting rehydration",
-            source_config.worker_id,
-            source_config.id
-        );
-        // Read and consolidate the snapshot from the 'previous' input until it
-        // reaches the `resume_upper`.
-        while !PartialOrder::less_equal(&resume_upper, &snapshot_upper) {
-            previous.ready().await;
-            while let Some(event) = previous.next_sync() {
-                match event {
-                    AsyncEvent::Data(_cap, data) => {
-                        events.extend(data.into_iter().filter_map(|((key, value), ts, diff)| {
-                            if !resume_upper.less_equal(&ts) {
-                                Some((key, value, diff))
-                            } else {
-                                None
-                            }
-                        }))
-                    }
-                    AsyncEvent::Progress(upper) => {
-                        snapshot_upper = upper;
-                    }
-                };
-            }
-
-            for (_, value, diff) in events.iter_mut() {
-                if let Err(UpsertError::Value(ref mut err)) = value {
-                    // If we receive a legacy error in the snapshot we will keep a note of it but
-                    // insert a non-legacy error in our state. This is so that if this error is
-                    // ever retracted we will correctly retract the non-legacy version because by
-                    // that time we will have emitted the error correction, which happens before
-                    // processing any of the new source input.
-                    if err.is_legacy_dont_touch_it {
-                        legacy_errors_to_correct.push((err.clone(), diff.clone()));
-                        err.is_legacy_dont_touch_it = false;
-                    }
-                }
-            }
-
-            match state
-                .consolidate_snapshot_chunk(
-                    events.drain(..),
-                    PartialOrder::less_equal(&resume_upper, &snapshot_upper),
-                )
-                .await
-            {
-                Ok(_) => {
-                    if let Some(ts) = snapshot_upper.clone().into_option() {
-                        // As we shutdown, we could ostensibly get data from later than the
-                        // `resume_upper`, which we ignore above. We don't want our output capability to make
-                        // it further than the `resume_upper`.
-                        if !resume_upper.less_equal(&ts) {
-                            snapshot_cap.downgrade(&ts);
-                            output_cap.downgrade(&ts);
-                        }
-                    }
-                }
-                Err(e) => {
-                    UpsertErrorEmitter::<G>::emit(
-                        &mut error_emitter,
-                        "Failed to rehydrate state".to_string(),
-                        e,
-                    )
-                    .await;
-                }
-            }
-        }
-
-        drop(events);
-        drop(previous_token);
-        drop(snapshot_cap);
-
-        // Exchaust the previous input. It is expected to immediately reach the empty
-        // antichain since we have dropped its token.
-        //
-        // Note that we do not need to also process the `input` during this, as the dropped token
-        // will shutdown the `backpressure` operator
-        while let Some(_event) = previous.next().await {}
-
-        // After snapshotting, our output frontier is exactly the `resume_upper`
-        if let Some(ts) = resume_upper.as_option() {
-            output_cap.downgrade(ts);
-        }
-
-        // Now it's time to emit the error corrections. It doesn't matter at what timestamp we emit
-        // them at because all they do is change the representation. The error count at any
-        // timestamp remains constant.
-        upsert_metrics
-            .legacy_value_errors
-            .set(u64::cast_from(legacy_errors_to_correct.len()));
-        if !legacy_errors_to_correct.is_empty() {
-            tracing::error!(
-                "unexpected legacy error representation. Found {} occurences",
-                legacy_errors_to_correct.len()
-            );
-        }
-        consolidation::consolidate(&mut legacy_errors_to_correct);
-        for (mut error, diff) in legacy_errors_to_correct {
-            assert!(
-                error.is_legacy_dont_touch_it,
-                "attempted to correct non-legacy error"
-            );
-            tracing::info!("correcting legacy error {error:?} with diff {diff}");
-            let time = output_cap.time().clone();
-            let retraction = Err(UpsertError::Value(error.clone()));
-            error.is_legacy_dont_touch_it = false;
-            let insertion = Err(UpsertError::Value(error));
-            output_handle.give(&output_cap, (retraction, time.clone(), -diff));
-            output_handle.give(&output_cap, (insertion, time, diff));
-        }
-
-        tracing::info!(
-            "timely-{} upsert source {} finished rehydration",
-            source_config.worker_id,
-            source_config.id
-        );
+        // True while we're still reading the initial "snapshot" (a whole bunch
+        // of updates, all at the same initial timestamp) from our persist
+        // input or while we're reading the initial snapshot from the upstream
+        // source.
+        let mut hydrating = true;
 
         // A re-usable buffer of changes, per key. This is an `IndexMap` because it has to be `drain`-able
         // and have a consistent iteration order.
-        let mut commands_state: indexmap::IndexMap<
-            _,
-            upsert_types::UpsertValueAndSize<Option<FromTime>>,
-        > = indexmap::IndexMap::new();
+        let mut commands_state: indexmap::IndexMap<_, upsert_types::UpsertValueAndSize<Option<FromTime>>> =
+            indexmap::IndexMap::new();
         let mut multi_get_scratch = Vec::new();
 
-        // Now can can resume consuming the collection
-        let mut output_updates = vec![];
+        // For our source input, both of these.
+        let mut stash = vec![];
         let mut input_upper = Antichain::from_elem(Timestamp::minimum());
 
-        while let Some(event) = input.next().await {
-            // Buffer as many events as possible. This should be bounded, as new data can't be
-            // produced in this worker until we yield to timely.
-            let events = [event]
-                .into_iter()
-                .chain(std::iter::from_fn(|| input.next().now_or_never().flatten()))
-                .enumerate();
 
-            let mut partial_drain_time = None;
-            for (i, event) in events {
-                match event {
-                    AsyncEvent::Data(cap, mut data) => {
-                        tracing::trace!(
-                            time=?cap.time(),
-                            updates=%data.len(),
-                            "received data in upsert"
-                        );
-                        stage_input(
-                            &mut stash,
-                            &mut data,
-                            &input_upper,
-                            &resume_upper,
-                            upsert_config.shrink_upsert_unused_buffers_by_ratio,
-                        );
+        // For our persist/feedback input, both of these.
+        let mut persist_stash = vec![];
+        let mut persist_upper = Antichain::from_elem(Timestamp::minimum());
 
-                        let event_time = cap.time();
-                        // If the data is at _exactly_ the output frontier, we can preemptively drain it into the state.
-                        // Data within this set events strictly beyond this time are staged as
-                        // normal.
-                        //
-                        // This is a load-bearing optimization, as it is required to avoid buffering
-                        // the entire source snapshot in the `stash`.
-                        if prevent_snapshot_buffering && output_cap.time() == event_time {
-                            partial_drain_time = Some(event_time.clone());
+        // A buffer for our output.
+        let mut output_updates = vec![];
+
+        let mut error_emitter = (&mut health_output, &health_cap);
+        let mut legacy_errors_to_correct = vec![];
+
+
+        loop {
+            tokio::select! {
+                Some(persist_event) = persist_input.next() => {
+
+                    // Buffer as many events as possible. This should be
+                    // bounded, as new data can't be produced in this worker
+                    // until we yield to timely.
+                    let persist_events = [persist_event]
+                        .into_iter()
+                        .chain(std::iter::from_fn(|| persist_input.next().now_or_never().flatten()));
+
+                    // Read away as much input as we can.
+                    for persist_event in persist_events {
+                        tracing::trace!(?persist_event, "persist input");
+
+                        match persist_event {
+                            AsyncEvent::Data(_cap, data) => {
+                                persist_stash.extend(data.into_iter().map(|((key, value), ts, diff)| {
+                                    (key, value, ts, diff)
+                                }))
+                            }
+                            AsyncEvent::Progress(upper) => persist_upper = upper,
                         }
                     }
-                    AsyncEvent::Progress(upper) => {
-                        tracing::trace!(?upper, "received progress in upsert");
-                        // Ignore progress updates before the `resume_upper`, which is our initial
-                        // capability post-snapshotting.
-                        if PartialOrder::less_than(&upper, &resume_upper) {
-                            continue;
+
+                    if hydrating {
+
+                        // Determine if this is the last time we call
+                        // consolidate_snapshot_chunk, and update our
+                        // `hydrating` state.
+                        //
+                        // There are two situations in which we're reading a
+                        // snapshot:
+                        //
+                        // 1. Reading the initial snapshot from the source: in
+                        //    this case there is no state in our output yet that
+                        //    we could read back in and our resume_upper is [0].
+                        //    We know we're done once the persist_upper is
+                        //    "past" that.
+                        // 2. Re-hydrating our state from persist: some instance
+                        //    of the source has already read/ingested/written
+                        //    down the initial snapshot from the source. We are
+                        //    reading a snapshot of our own upsert state back in
+                        //    from persist. In this case we read the snapshot at
+                        //    a timestamp that is "before" the resume upper, and
+                        //    we know that we're done when the persist_upper is
+                        //    "at or past" the resume_upper.
+                        //
+                        // It's unfortunate that we have to differentiate
+                        // between these cases, both here and in code below. The
+                        // root of the problem is that when reading the initial
+                        // source snapshot, the `resume_upper` is `[0]`, but
+                        // we're also reading in those updates at time `0`. When
+                        // starting the operator at any other `resume_upper`,
+                        // updates are read at a timestamp before that.
+                        let last_snapshot_chunk =  if resume_upper.less_equal(&G::Timestamp::minimum()) {
+                            PartialOrder::less_than(&resume_upper, &persist_upper)
+                        } else {
+                            PartialOrder::less_equal(&resume_upper, &persist_upper)
+                        };
+
+                        // Sort by ts and only present updates that are not
+                        // beyond the resume upper.
+                        persist_stash.sort_unstable_by(|a, b| {
+                            let (_, _, ts1, _) = a;
+                            let (_, _, ts2, _) = b;
+                            Ord::cmp(
+                                ts1,
+                                ts2,
+                            )
+                        });
+
+                        // Find the prefix that we can ingest.
+                        let idx = persist_stash.partition_point(|(_, _, ts, _)| {
+                            let first_source_snapshot = ts == &G::Timestamp::minimum();
+                            let rehydration_snapshot = !resume_upper.less_equal(ts);
+                            first_source_snapshot || rehydration_snapshot
+                        });
+
+                        tracing::debug!(persist_stash = %persist_stash.len(), %idx, %last_snapshot_chunk, ?resume_upper, ?persist_upper, "ingesting persist snapshot chunk");
+
+                        // Check for errors in the prefix that we will ingest.
+                        for (_, value, _ts, diff) in persist_stash.iter_mut().take(idx) {
+                            if let Err(UpsertError::Value(ref mut err)) = value {
+                                // If we receive a legacy error in the snapshot we will keep a note of it but
+                                // insert a non-legacy error in our state. This is so that if this error is
+                                // ever retracted we will correctly retract the non-legacy version because by
+                                // that time we will have emitted the error correction, which happens before
+                                // processing any of the new source input.
+                                if err.is_legacy_dont_touch_it {
+                                    legacy_errors_to_correct.push((err.clone(), diff.clone()));
+                                    err.is_legacy_dont_touch_it = false;
+                                }
+                            }
                         }
 
-                        // Disable the partial drain as this progress event covers
-                        // the `output_cap` time.
-                        partial_drain_time = None;
-                        drain_staged_input::<_, G, _, _, _>(
-                            &mut stash,
-                            &mut commands_state,
-                            &mut output_updates,
-                            &mut multi_get_scratch,
-                            DrainStyle::ToUpper(&upper),
+
+                        hydrating = !last_snapshot_chunk;
+
+                        match state
+                            .consolidate_snapshot_chunk(
+                                persist_stash
+                                    .drain(..idx)
+                                    .map(|(key, val, _ts, diff)| (key, val, diff)),
+                                last_snapshot_chunk,
+                            )
+                            .await
+                        {
+                            Ok(_) => {
+                                let _ = snapshot_cap.downgrade(persist_upper.iter());
+                            }
+                            Err(e) => {
+                                // Make sure our persist source can shut down.
+                                persist_token.take();
+                                UpsertErrorEmitter::<G>::emit(
+                                    &mut error_emitter,
+                                    "Failed to rehydrate state".to_string(),
+                                    e,
+                                )
+                                .await;
+                            }
+                        }
+
+
+                        if last_snapshot_chunk {
+                            // Now it's time to emit the error corrections. It doesn't matter at what timestamp we emit
+                            // them at because all they do is change the representation. The error count at any
+                            // timestamp remains constant.
+                            upsert_metrics
+                                .legacy_value_errors
+                                .set(u64::cast_from(legacy_errors_to_correct.len()));
+                            if !legacy_errors_to_correct.is_empty() {
+                                tracing::error!(
+                                    "unexpected legacy error representation. Found {} occurences",
+                                    legacy_errors_to_correct.len()
+                                );
+                            }
+                            consolidation::consolidate(&mut legacy_errors_to_correct);
+                            for (mut error, diff) in legacy_errors_to_correct.drain(..) {
+                                assert!(
+                                    error.is_legacy_dont_touch_it,
+                                    "attempted to correct non-legacy error"
+                                );
+                                tracing::info!("correcting legacy error {error:?} with diff {diff}");
+                                let time = output_cap.time().clone();
+                                let retraction = Err(UpsertError::Value(error.clone()));
+                                error.is_legacy_dont_touch_it = false;
+                                let insertion = Err(UpsertError::Value(error));
+                                output_handle.give(&output_cap, (retraction, time.clone(), -diff));
+                                output_handle.give(&output_cap, (insertion, time, diff));
+                            }
+
+                            tracing::info!(
+                                "timely-{} upsert source {} finished rehydration",
+                                source_config.worker_id,
+                                source_config.id
+                            );
+
+                            let _ = snapshot_cap.downgrade(&[]);
+                        }
+
+                    }
+
+                    // We don't have an else here, because we might notice we're
+                    // done snapshotting but already have some more persist
+                    // updates staged. We have to work them off eagerly here.
+                    if !hydrating {
+                        tracing::debug!(persist_stash = %persist_stash.len(), ?persist_upper, "ingesting state updates from persist");
+
+                        ingest_state_updates::<_, G, _, _, _>(
+                            &mut persist_stash,
+                            &persist_upper,
                             &mut error_emitter,
                             &mut state,
-                        )
-                        .await;
-
-                        output_handle.give_container(&output_cap, &mut output_updates);
-
-                        if let Some(ts) = upper.as_option() {
-                            output_cap.downgrade(ts);
-                        }
-                        input_upper = upper;
+                            ).await;
                     }
                 }
-                let events_processed = i + 1;
-                if let Some(max) = snapshot_buffering_max {
-                    if events_processed >= max {
+                input_event = input.next() => {
+                    let Some(input_event) = input_event else {
+                        tracing::debug!("input exhausted, shutting down");
                         break;
+                    };
+                    // Buffer as many events as possible. This should be bounded, as new data can't be
+                    // produced in this worker until we yield to timely.
+                    let events = [input_event]
+                        .into_iter()
+                        .chain(std::iter::from_fn(|| input.next().now_or_never().flatten()))
+                        .enumerate();
+
+                    for (i, event) in events {
+                        tracing::trace!(?event, "source input");
+
+                        match event {
+                            AsyncEvent::Data(cap, mut data) => {
+                                tracing::trace!(
+                                    time=?cap.time(),
+                                    updates=%data.len(),
+                                    "received data in upsert"
+                                );
+
+                                let event_time = cap.time().clone();
+
+                                stage_input(
+                                    &mut stash,
+                                    cap,
+                                    &mut data,
+                                    &input_upper,
+                                    &resume_upper,
+                                    upsert_config.shrink_upsert_unused_buffers_by_ratio,
+                                );
+
+                                // For the very first snapshot from the source,
+                                // we allow emitting partial updates without yet
+                                // seeing all updates for that timestamp. For
+                                // this, we use an ephemeral upsert state to run
+                                // our upserting logic that we throw away once
+                                // we receive the first updates on the persist
+                                // input.
+                                //
+                                // We can only do this for the very first
+                                // snapshot, because all subsequent emitted
+                                // updates need to have a consistent view of
+                                // upsert state as ingested from the persist
+                                // input.
+                                //
+                                // This is a load-bearing optimization, as it is
+                                // required to avoid buffering the entire source
+                                // snapshot in the `stash`.
+                                if prevent_snapshot_buffering && resume_upper.less_equal(&G::Timestamp::minimum()) && event_time == G::Timestamp::minimum() {
+                                    tracing::info!(?event_time, ?resume_upper, ?output_cap, "partial drain not implemented, yet");
+                                }
+                            }
+                            AsyncEvent::Progress(upper) => {
+                                tracing::trace!(?upper, "received progress in upsert");
+
+                                // Ignore progress updates before the `resume_upper`, which is our initial
+                                // capability post-snapshotting.
+                                if PartialOrder::less_than(&upper, &resume_upper) {
+                                    tracing::trace!(?upper, ?resume_upper, "ignoring progress updates before resume_upper");
+                                    continue;
+                                }
+
+                                if let Some(ts) = upper.as_option() {
+                                    tracing::trace!(?ts, "downgrading output capability");
+                                    let _ = output_cap.try_downgrade(ts);
+                                }
+                                input_upper = upper;
+                            }
+                        }
+                        let events_processed = i + 1;
+                        if let Some(max) = snapshot_buffering_max {
+                            if events_processed >= max {
+                                break;
+                            }
+                        }
                     }
                 }
-            }
+            };
 
-            // If there were staged events that occurred at the capability time, drain
-            // them. This is safe because out-of-order updates to the same key that are
-            // drained in separate calls to `drain_staged_input` are correctly ordered by
-            // their `FromTime` in `drain_staged_input`.
-            //
-            // Note also that this may result in more updates in the output collection than
-            // the minimum. However, because the frontier only advances on `Progress` updates,
-            // the collection always accumulates correctly for all keys.
-            if let Some(partial_drain_time) = partial_drain_time {
-                drain_staged_input::<_, G, _, _, _>(
-                    &mut stash,
-                    &mut commands_state,
-                    &mut output_updates,
-                    &mut multi_get_scratch,
-                    DrainStyle::AtTime(partial_drain_time),
-                    &mut error_emitter,
-                    &mut state,
-                )
-                .await;
+            // We try and drain from our stash every time we go through the
+            // loop. More of our stash can become eligible for draining both
+            // when the source-input frontier advances or when the persist
+            // frontier advances.
 
-                output_handle.give_container(&output_cap, &mut output_updates);
+            drain_staged_input::<_, G, _, _, _>(
+                &mut stash,
+                &mut commands_state,
+                &mut output_updates,
+                &mut multi_get_scratch,
+                DrainStyle::ToUpper{input_upper: &input_upper, persist_upper: &persist_upper},
+                &mut error_emitter,
+                &mut state,
+            )
+            .await;
+
+            tracing::trace!(?output_updates, "output updates for complete timestamp");
+
+            // TODO: Feels somewhat inefficient to be peeling
+            // of and creating new vecs per group of
+            // timestamp. Especially since at steady state
+            // we're expecting to only have one group...
+            while !output_updates.is_empty() {
+                let cap = output_updates[0].1.clone();
+                let ts = cap.time();
+
+                let partition_point = output_updates
+                    .partition_point(|update| update.1.time() == ts);
+
+                let mut ts_updates: Vec<_> = output_updates.drain(0..partition_point)
+                    .map(|(update, cap, diff)| (update, cap.time().clone(), diff))
+                    .collect();
+
+                output_handle.give_container(&cap,&mut ts_updates);
             }
         }
     });
@@ -369,13 +529,19 @@ where
 /// Helper method for `upsert_inner` used to stage `data` updates
 /// from the input timely edge.
 fn stage_input<T, FromTime>(
-    stash: &mut Vec<(T, UpsertKey, Reverse<FromTime>, Option<UpsertValue>)>,
+    stash: &mut Vec<(
+        Capability<T>,
+        UpsertKey,
+        Reverse<FromTime>,
+        Option<UpsertValue>,
+    )>,
+    cap: Capability<T>,
     data: &mut Vec<((UpsertKey, Option<UpsertValue>, FromTime), T, Diff)>,
     input_upper: &Antichain<T>,
     resume_upper: &Antichain<T>,
     storage_shrink_upsert_unused_buffers_by_ratio: usize,
 ) where
-    T: PartialOrder,
+    T: PartialOrder + timely::progress::Timestamp,
     FromTime: Ord,
 {
     if PartialOrder::less_equal(input_upper, resume_upper) {
@@ -384,7 +550,9 @@ fn stage_input<T, FromTime>(
 
     stash.extend(data.drain(..).map(|((key, value, order), time, diff)| {
         assert!(diff > 0, "invalid upsert input");
-        (time, key, Reverse(order), value)
+        // TODO: Don't retain a cap per update but instead bunch them up.
+        let cap = cap.delayed(&time);
+        (cap, key, Reverse(order), value)
     }));
 
     if storage_shrink_upsert_unused_buffers_by_ratio > 0 {
@@ -399,19 +567,26 @@ fn stage_input<T, FromTime>(
 /// assume that all values have been seen, and must leave tombstones behind for deleted values.
 #[derive(Debug)]
 enum DrainStyle<'a, T> {
-    ToUpper(&'a Antichain<T>),
+    ToUpper {
+        input_upper: &'a Antichain<T>,
+        persist_upper: &'a Antichain<T>,
+    },
+    // TODO: For partial draining when taking the source snapshot.
+    #[allow(unused)]
     AtTime(T),
 }
 
 /// Helper method for `upsert_inner` used to stage `data` updates
 /// from the input timely edge.
 async fn drain_staged_input<S, G, T, FromTime, E>(
-    stash: &mut Vec<(T, UpsertKey, Reverse<FromTime>, Option<UpsertValue>)>,
-    commands_state: &mut indexmap::IndexMap<
+    stash: &mut Vec<(
+        Capability<T>,
         UpsertKey,
-        upsert_types::UpsertValueAndSize<Option<FromTime>>,
-    >,
-    output_updates: &mut Vec<(Result<Row, UpsertError>, T, Diff)>,
+        Reverse<FromTime>,
+        Option<UpsertValue>,
+    )>,
+    commands_state: &mut indexmap::IndexMap<UpsertKey, UpsertValueAndSize<Option<FromTime>>>,
+    output_updates: &mut Vec<(Result<Row, UpsertError>, Capability<T>, Diff)>,
     multi_get_scratch: &mut Vec<UpsertKey>,
     drain_style: DrainStyle<'_, T>,
     error_emitter: &mut E,
@@ -419,19 +594,40 @@ async fn drain_staged_input<S, G, T, FromTime, E>(
 ) where
     S: UpsertStateBackend<Option<FromTime>>,
     G: Scope,
-    T: PartialOrder + Ord + Clone + Debug,
+    T: PartialOrder + Ord + Clone + Debug + timely::progress::Timestamp,
     FromTime: timely::ExchangeData + Ord,
     E: UpsertErrorEmitter<G>,
 {
-    stash.sort_unstable();
+    // Sort by (key, time, Reverse(from_time)) so that deduping by (key, time) gives
+    // the latest change for that key.
+    stash.sort_unstable_by(|a, b| {
+        let (ts1, key1, from_ts1, val1) = a;
+        let (ts2, key2, from_ts2, val2) = b;
+        Ord::cmp(
+            &(ts1.time(), key1, from_ts1, val1),
+            &(ts2.time(), key2, from_ts2, val2),
+        )
+    });
 
     // Find the prefix that we can emit
     let idx = stash.partition_point(|(ts, _, _, _)| match &drain_style {
-        DrainStyle::ToUpper(upper) => !upper.less_equal(ts),
-        DrainStyle::AtTime(time) => ts <= time,
+        DrainStyle::ToUpper {
+            input_upper,
+            persist_upper,
+        } => {
+            // We make sure that a) we only process updates when we know their
+            // timestamp is complete, that is there will be no more updates for
+            // that timestamp, and b) that "previous" times in the persist
+            // output are complete. The latter makes sure that we emit updates
+            // for the next timestamp that are consistent with the global state
+            // in the output persist shard, which also serves as a persistent
+            // copy of our in-memory/on-disk upsert state.
+            !input_upper.less_equal(ts.time()) && !persist_upper.less_than(ts.time())
+        }
+        DrainStyle::AtTime(time) => ts.time() <= time,
     });
 
-    tracing::trace!(?drain_style, updates = idx, "draining stash in upsert");
+    tracing::debug!(?drain_style, updates = idx, "draining stash");
 
     // Read the previous values _per key_ out of `state`, recording it
     // along with the value with the _latest timestamp for that key_.
@@ -525,20 +721,99 @@ async fn drain_staged_input<S, G, T, FromTime, E>(
             }
         }
     }
+}
+
+/// Helper method for `upsert_inner` used to ingest state updates from the
+/// persist input.
+async fn ingest_state_updates<S, G, T, FromTime, E>(
+    updates: &mut Vec<(UpsertKey, UpsertValue, T, Diff)>,
+    persist_upper: &Antichain<T>,
+    error_emitter: &mut E,
+    state: &mut UpsertState<'_, S, Option<FromTime>>,
+) where
+    S: UpsertStateBackend<Option<FromTime>>,
+    G: Scope,
+    T: PartialOrder + Ord + Clone + Debug + timely::progress::Timestamp,
+    FromTime: timely::ExchangeData + Ord,
+    E: UpsertErrorEmitter<G>,
+{
+    // Sort by (key, diff) and make sure additions sort before retractions,
+    // which allows us to de-duplicate below, and only keep the latest addition,
+    // if any.
+    updates.sort_unstable_by(|a, b| {
+        let (key1, _val1, ts1, diff1) = a;
+        let (key2, _val2, ts2, diff2) = b;
+        Ord::cmp(&(ts1, key1, Reverse(diff1)), &(ts2, key2, Reverse(diff2)))
+    });
+
+    // Find the prefix that we can ingest.
+    let idx = updates.partition_point(|(_, _, ts, _)| !persist_upper.less_equal(ts));
+
+    tracing::debug!(?persist_upper, updates = idx, "ingesting state updates");
+
+    let mut precomputed_putstats = PutStats::default();
+
+    // It's not ideal that we iterate once before ingesting, but we're doing it
+    // to precalculate our stats. We might want to rework how we keep stats in
+    // the future.
+    for (key, value, ts, diff) in &updates[0..idx] {
+        match diff {
+            1 => {
+                let value = StateValue::value(value.clone(), None::<FromTime>);
+                let size: i64 = value.memory_size().try_into().expect("less than i64 size");
+                precomputed_putstats.size_diff += size;
+                precomputed_putstats.values_diff += 1;
+            }
+            -1 => {
+                let value = StateValue::value(value.clone(), None::<FromTime>);
+                let size: i64 = value.memory_size().try_into().expect("less than i64 size");
+                precomputed_putstats.size_diff -= size;
+                precomputed_putstats.values_diff -= 1;
+            }
+            invalid_diff => {
+                panic!(
+                    "unexpected diff for update to upsert state: {:?}",
+                    (key, value, ts, invalid_diff)
+                );
+            }
+        }
+    }
+
+    let eligible_commands = updates.drain(..idx).dedup_by(|a, b| {
+        let ((a_key, _, a_ts, _), (b_key, _, b_ts, _)) = (a, b);
+        a_ts == b_ts && a_key == b_key
+    });
+
+    let commands = eligible_commands
+        .map(|(key, value, ts, diff)| match diff {
+            1 => {
+                let value = StateValue::value(value, None::<FromTime>);
+                (
+                    key,
+                    upsert_types::PutValue {
+                        value: Some(value),
+                        previous_value_metadata: None,
+                    },
+                )
+            }
+            -1 => (
+                key.clone(),
+                upsert_types::PutValue {
+                    value: None,
+                    previous_value_metadata: None,
+                },
+            ),
+            invalid_diff => {
+                panic!(
+                    "unexpected diff for update to upsert state: {:?}",
+                    (key, value, ts, invalid_diff)
+                );
+            }
+        })
+        .collect_vec();
 
     match state
-        .multi_put(commands_state.drain(..).map(|(k, cv)| {
-            (
-                k,
-                upsert_types::PutValue {
-                    value: cv.value.map(|cv| cv.into_decoded()),
-                    previous_value_metadata: cv.metadata.map(|v| ValueMetadata {
-                        size: v.size.try_into().expect("less than i64 size"),
-                        is_tombstone: v.is_tombstone,
-                    }),
-                },
-            )
-        }))
+        .multi_put_with_stats(commands, precomputed_putstats)
         .await
     {
         Ok(_) => {}

--- a/src/storage/src/upsert_continual_feedback.rs
+++ b/src/storage/src/upsert_continual_feedback.rs
@@ -309,7 +309,7 @@ where
                             .await
                         {
                             Ok(_) => {
-                                let _ = snapshot_cap.downgrade(persist_upper.iter());
+                                snapshot_cap.downgrade(persist_upper.iter());
                             }
                             Err(e) => {
                                 // Make sure our persist source can shut down.
@@ -358,7 +358,7 @@ where
                                 source_config.id
                             );
 
-                            let _ = snapshot_cap.downgrade(&[]);
+                            snapshot_cap.downgrade(&[]);
                         }
 
                     }

--- a/test/kafka-rtr/simple/verify-rtr.td
+++ b/test/kafka-rtr/simple/verify-rtr.td
@@ -81,7 +81,7 @@ A,B,0
 > SELECT sum FROM sum;
 5000207
 
-$ set-regex match=(s\d+|\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d\.\d\d\d\)|true|false) replacement=<>
+$ set-regex match=(s\d+|\d{13}|u\d+|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d\.\d\d\d\)|true|false) replacement=<>
 
 # RTR timestamp should be present.
 > EXPLAIN TIMESTAMP FOR SELECT sum FROM sum

--- a/test/testdrive-old-kafka-src-syntax/explain-timestamps.td
+++ b/test/testdrive-old-kafka-src-syntax/explain-timestamps.td
@@ -10,7 +10,7 @@
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET allow_real_time_recency = true
 
-$ set-regex match=(s\d+|\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d\.\d\d\d\)|true|false) replacement=<>
+$ set-regex match=(s\d+|\d{13}|u\d+|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d\.\d\d\d\)|true|false) replacement=<>
 
 > CREATE TABLE t1 (a INT);
 

--- a/test/testdrive-old-kafka-src-syntax/mzcompose.py
+++ b/test/testdrive-old-kafka-src-syntax/mzcompose.py
@@ -16,6 +16,7 @@ retried until it produces the desired result.
 from pathlib import Path
 
 from materialize import ci_util
+from materialize.mzcompose import get_default_system_parameters
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.fivetran_destination import FivetranDestination
 from materialize.mzcompose.services.kafka import Kafka
@@ -107,19 +108,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     else:
         dependencies += ["zookeeper", "kafka", "schema-registry"]
 
-    testdrive = Testdrive(
-        forward_buildkite_shard=True,
-        kafka_default_partitions=args.kafka_default_partitions,
-        aws_region=args.aws_region,
-        validate_catalog_store=True,
-        default_timeout=args.default_timeout,
-        volumes_extra=["mzdata:/mzdata"],
-        external_minio=True,
-        fivetran_destination=True,
-        fivetran_destination_files_path="/share/tmp",
-        entrypoint_extra=[f"--var=uses-redpanda={args.redpanda}"],
-    )
-
     sysparams = args.system_param
     if not args.system_param:
         sysparams = []
@@ -133,10 +121,36 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         additional_system_parameter_defaults[key] = val
 
+    leaves_tombstones = (
+        "true"
+        if additional_system_parameter_defaults.get(
+            "storage_use_continual_feedback_upsert",
+            get_default_system_parameters()["storage_use_continual_feedback_upsert"],
+        )
+        == "false"
+        else "false"
+    )
+
     materialized = Materialized(
         default_size=args.default_size,
         external_minio=True,
         additional_system_parameter_defaults=additional_system_parameter_defaults,
+    )
+
+    testdrive = Testdrive(
+        forward_buildkite_shard=True,
+        kafka_default_partitions=args.kafka_default_partitions,
+        aws_region=args.aws_region,
+        validate_catalog_store=True,
+        default_timeout=args.default_timeout,
+        volumes_extra=["mzdata:/mzdata"],
+        external_minio=True,
+        fivetran_destination=True,
+        fivetran_destination_files_path="/share/tmp",
+        entrypoint_extra=[
+            f"--var=uses-redpanda={args.redpanda}",
+            f"--var=leaves-tombstones={leaves_tombstones}",
+        ],
     )
 
     with c.override(testdrive, materialized):

--- a/test/testdrive-old-kafka-src-syntax/pr-24663-regression.td
+++ b/test/testdrive-old-kafka-src-syntax/pr-24663-regression.td
@@ -125,7 +125,7 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
   WHERE s.name IN ('dbz_no_before')
   GROUP BY s.name
   ORDER BY s.name
-true false 0
+true ${arg.leaves-tombstones} 0
 
 $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keyschema} schema=${schema} timestamp=1
 {"id": 1} {"after": {"row": {"id": 1, "creature": "mudskipper"}}, "op": "c", "source": {"file": "binlog1", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
@@ -163,4 +163,4 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
   WHERE s.name IN ('dbz_no_before')
   GROUP BY s.name
   ORDER BY s.name
-true false 0
+true ${arg.leaves-tombstones} 0

--- a/test/testdrive-old-kafka-src-syntax/pr-24663-regression.td
+++ b/test/testdrive-old-kafka-src-syntax/pr-24663-regression.td
@@ -114,6 +114,8 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
 > SELECT count(*) FROM dbz_no_before
 0
 
+# WIP: The feedback upsert implementation does not count tombstones in
+# bytes_indexed. For now.
 > SELECT
     bool_and(u.snapshot_committed),
     SUM(u.bytes_indexed) > 0,
@@ -123,7 +125,7 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
   WHERE s.name IN ('dbz_no_before')
   GROUP BY s.name
   ORDER BY s.name
-true true 0
+true false 0
 
 $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keyschema} schema=${schema} timestamp=1
 {"id": 1} {"after": {"row": {"id": 1, "creature": "mudskipper"}}, "op": "c", "source": {"file": "binlog1", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
@@ -150,7 +152,8 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
 > SELECT count(*) FROM dbz_no_before
 0
 
-# A tombstone is left behind
+# WIP: The feedback upsert implementation does not count tombstones in
+# bytes_indexed. For now.
 > SELECT
     bool_and(u.snapshot_committed),
     SUM(u.bytes_indexed) > 0,
@@ -160,4 +163,4 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
   WHERE s.name IN ('dbz_no_before')
   GROUP BY s.name
   ORDER BY s.name
-true true 0
+true false 0

--- a/test/testdrive/explain-timestamps.td
+++ b/test/testdrive/explain-timestamps.td
@@ -10,7 +10,7 @@
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET allow_real_time_recency = true
 
-$ set-regex match=(s\d+|\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d\.\d\d\d\)|true|false) replacement=<>
+$ set-regex match=(s\d+|\d{13}|u\d+|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d\.\d\d\d\)|true|false) replacement=<>
 
 > CREATE TABLE t1 (a INT);
 

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -120,18 +120,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         entrypoint_extra=[f"--var=uses-redpanda={args.redpanda}"],
     )
 
-    sysparams = args.system_param
-    if not args.system_param:
-        sysparams = []
-
     additional_system_parameter_defaults = {}
-    for val in sysparams:
+    for val in args.system_param or []:
         x = val[0].split("=", maxsplit=1)
         assert len(x) == 2, f"--system-param '{val}' should be the format <key>=<val>"
-        key = x[0]
-        val = x[1]
-
-        additional_system_parameter_defaults[key] = val
+        additional_system_parameter_defaults[x[0]] = x[1]
 
     materialized = Materialized(
         default_size=args.default_size,

--- a/test/testdrive/pr-24663-regression.td
+++ b/test/testdrive/pr-24663-regression.td
@@ -127,7 +127,8 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
   WHERE s.name IN ('dbz_no_before')
   GROUP BY s.name
   ORDER BY s.name
-true false 0
+true ${arg.leaves-tombstones} 0
+
 
 $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keyschema} schema=${schema} timestamp=1
 {"id": 1} {"after": {"row": {"id": 1, "creature": "mudskipper"}}, "op": "c", "source": {"file": "binlog1", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
@@ -165,4 +166,4 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
   WHERE s.name IN ('dbz_no_before')
   GROUP BY s.name
   ORDER BY s.name
-true false 0
+true ${arg.leaves-tombstones} 0

--- a/test/testdrive/pr-24663-regression.td
+++ b/test/testdrive/pr-24663-regression.td
@@ -116,6 +116,8 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
 > SELECT count(*) FROM dbz_no_before_tbl
 0
 
+# WIP: The feedback upsert implementation does not count tombstones in
+# bytes_indexed. For now.
 > SELECT
     bool_and(u.snapshot_committed),
     SUM(u.bytes_indexed) > 0,
@@ -125,7 +127,7 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
   WHERE s.name IN ('dbz_no_before')
   GROUP BY s.name
   ORDER BY s.name
-true true 0
+true false 0
 
 $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keyschema} schema=${schema} timestamp=1
 {"id": 1} {"after": {"row": {"id": 1, "creature": "mudskipper"}}, "op": "c", "source": {"file": "binlog1", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
@@ -152,7 +154,8 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
 > SELECT count(*) FROM dbz_no_before_tbl
 0
 
-# A tombstone is left behind
+# WIP: The feedback upsert implementation does not count tombstones in
+# bytes_indexed. For now.
 > SELECT
     bool_and(u.snapshot_committed),
     SUM(u.bytes_indexed) > 0,
@@ -162,4 +165,4 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
   WHERE s.name IN ('dbz_no_before')
   GROUP BY s.name
   ORDER BY s.name
-true true 0
+true false 0

--- a/test/upsert/rehydration/03-after-rehydration.td
+++ b/test/upsert/rehydration/03-after-rehydration.td
@@ -56,17 +56,17 @@ SELECT
 
 # Ensure we process updates correctly.
 $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
-{"key": "fish"} {"f1": "longerfish", "f2": 9000}
+{"key": "fish"} {"f1": "muchlongerfish", "f2": 9000}
 
 > SELECT * from upsert_tbl
 key           f1                  f2
 --------------------------------------
-fish          longerfish          9000
+fish          muchlongerfish      9000
 birdmore      geese               56
 mammalmore    moose               2
 
 # Wait for the value's new stats to propagate. We can't
-# just check that the `longerfish` value is larger here,
+# just check that the `muchlongerfish` value is larger here,
 # because the rehydrated value may be more costly. This
 # means we have to do this in 2 steps, like this.
 #


### PR DESCRIPTION
A new upsert operator that never updates its state based on the source
input but instead continually listens to updates from its own backing
persist shard to update its upsert map.
    
This allows multiple operator instances to run concurrently but still
emit changes that are consistent with the global state of the shard.


> [!IMPORTANT]  
> As is, this is presented as a diff on the regular upsert operator, to help reviewing. In addition to the new operator impl in it's own file. Once reviewed, I will revert the implementation in `upsert.rs` back to what it was before, so we can actually switch implementations using the dyncfg.

NOTE: This is missing the (load-bearing) optimization that we emit partial updates while we have not yet seen all updates of a timestamp, when ingesting the initial source snapshot. This makes the feature benchmark fail, and I believe also some of the platform checks that test Kafka sources with large number of updates. This also fails the select nightly tests that run things with large numbers of updates in Kafka.

@def- Because of the above this will not pass all existing tests. Once reviewed, I'm planning to merge this and leave the new dyncfg off. Once I add the mentioned optimization we should probably switch that on, but maybe also have tests for both implementations?

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
