### PR TITLE
storage: rely on batch truncation in persist_sink

### DIFF
--- a/src/persist-cli/src/open_loop.rs
+++ b/src/persist-cli/src/open_loop.rs
@@ -619,7 +619,7 @@ mod raw_persist_benchmark {
                         let lower = batch.lower().clone();
                         let upper = batch.upper().clone();
                         write
-                            .append_batch(batch, lower, upper)
+                            .append_batch(vec![batch], lower, upper)
                             .await
                             .expect("invalid usage")
                             .expect("unexpected upper");

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -1522,7 +1522,11 @@ mod tests {
             .expect("invalid usage");
         assert_eq!(batch.batch.part_count(), 3);
         write
-            .append_batch(batch, Antichain::from_elem(0), Antichain::from_elem(4))
+            .append_batch(
+                vec![batch],
+                Antichain::from_elem(0),
+                Antichain::from_elem(4),
+            )
             .await
             .expect("invalid usage")
             .expect("unexpected upper");

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -1206,7 +1206,11 @@ mod tests {
                 .expect("invalid usage");
             assert_eq!(
                 write0
-                    .append_batch(batch, Antichain::from_elem(4), Antichain::from_elem(5))
+                    .append_batch(
+                        vec![batch],
+                        Antichain::from_elem(4),
+                        Antichain::from_elem(5)
+                    )
                     .await
                     .unwrap_err(),
                 InvalidUsage::InvalidBatchBounds {
@@ -1222,7 +1226,11 @@ mod tests {
                 .expect("invalid usage");
             assert_eq!(
                 write0
-                    .append_batch(batch, Antichain::from_elem(2), Antichain::from_elem(3))
+                    .append_batch(
+                        vec![batch],
+                        Antichain::from_elem(2),
+                        Antichain::from_elem(3)
+                    )
                     .await
                     .unwrap_err(),
                 InvalidUsage::InvalidBatchBounds {
@@ -1240,7 +1248,11 @@ mod tests {
             // non-deterministic (the key)
             assert!(matches!(
                 write0
-                    .append_batch(batch, Antichain::from_elem(3), Antichain::from_elem(3))
+                    .append_batch(
+                        vec![batch],
+                        Antichain::from_elem(3),
+                        Antichain::from_elem(3)
+                    )
                     .await
                     .unwrap_err(),
                 InvalidUsage::InvalidEmptyTimeInterval { .. }
@@ -1749,7 +1761,7 @@ mod tests {
                     let lower = batch.lower().clone();
                     let upper = batch.upper().clone();
                     write
-                        .append_batch(batch, lower, upper)
+                        .append_batch(vec![batch], lower, upper)
                         .await
                         .expect("invalid usage")
                         .expect("unexpected upper");


### PR DESCRIPTION
Take a step towards 0dt/m2 and active replication for sources by using `append` instead of `compare_and_append` in the storage persist sink.

The idea is that, when appending batches in the storage persist sink, if we discover that the upper is ahead of what we expected, we can simply discard the updates that are behind the current upper, as we can trust that the other replica of the source correctly produced those updates.

Note that this needs to be paired with the self-correcting upsert state (MaterializeInc/database-issues#8585) to be correct.

Touches MaterializeInc/database-issues#8095.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
