### PR TITLE
Avoid FuturesUnordered in compute controller

### DIFF
--- a/src/cluster-client/build.rs
+++ b/src/cluster-client/build.rs
@@ -11,7 +11,8 @@ fn main() {
     let mut config = prost_build::Config::new();
     config
         .protoc_executable(mz_build_tools::protoc())
-        .btree_map(["."]);
+        .btree_map(["."])
+        .type_attribute(".", "#[allow(missing_docs)]");
 
     tonic_build::configure()
         // Enabling `emit_rerun_if_changed` will rerun the build script when

--- a/src/cluster-client/src/client.rs
+++ b/src/cluster-client/src/client.rs
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![allow(missing_docs)]
-
 //! Types for commands to clusters.
 
 use std::num::NonZeroI64;
@@ -32,7 +30,9 @@ include!(concat!(env!("OUT_DIR"), "/mz_cluster_client.client.rs"));
 /// another in-memory and local to the current incarnation of environmentd)
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct ClusterStartupEpoch {
+    /// The environment incarnation.
     envd: NonZeroI64,
+    /// The replica incarnation.
     replica: u64,
 }
 
@@ -76,6 +76,7 @@ impl Arbitrary for ClusterStartupEpoch {
 }
 
 impl ClusterStartupEpoch {
+    /// Construct a new cluster startup epoch, from the environment epoch and replica incarnation.
     pub fn new(envd: NonZeroI64, replica: u64) -> Self {
         Self { envd, replica }
     }
@@ -100,10 +101,12 @@ impl ClusterStartupEpoch {
         }
     }
 
+    /// The environment epoch.
     pub fn envd(&self) -> NonZeroI64 {
         self.envd
     }
 
+    /// The replica incarnation.
     pub fn replica(&self) -> u64 {
         self.replica
     }
@@ -174,6 +177,7 @@ impl RustType<ProtoTimelyConfig> for TimelyConfig {
 }
 
 impl TimelyConfig {
+    /// Split the timely configuration into `parts` pieces, each with a different `process` number.
     pub fn split_command(&self, parts: usize) -> Vec<Self> {
         (0..parts)
             .map(|part| TimelyConfig {

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -46,7 +46,6 @@ use timely::progress::frontier::MutableAntichain;
 use timely::progress::{Antichain, ChangeBatch, Timestamp};
 use timely::PartialOrder;
 use tokio::sync::mpsc;
-use tracing::warn;
 use uuid::Uuid;
 
 use crate::controller::error::{

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -45,6 +45,7 @@ use timely::progress::frontier::MutableAntichain;
 use timely::progress::{Antichain, ChangeBatch, Timestamp};
 use timely::PartialOrder;
 use tokio::sync::mpsc;
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::controller::error::{
@@ -1698,21 +1699,21 @@ where
         replica_id: ReplicaId,
     ) {
         if !self.collections.contains_key(&id) {
-            soft_panic_or_log!(
+            warn!(
                 "frontiers update for an unknown collection \
                  (id={id}, replica_id={replica_id}, frontiers={frontiers:?})"
             );
             return;
         }
         let Some(replica) = self.replicas.get_mut(&replica_id) else {
-            soft_panic_or_log!(
+            warn!(
                 "frontiers update for an unknown replica \
                  (replica_id={replica_id}, frontiers={frontiers:?})"
             );
             return;
         };
         let Some(replica_collection) = replica.collections.get_mut(&id) else {
-            soft_panic_or_log!(
+            warn!(
                 "frontiers update for an unknown replica collection \
                  (id={id}, replica_id={replica_id}, frontiers={frontiers:?})"
             );

--- a/src/ore/src/channel.rs
+++ b/src/ore/src/channel.rs
@@ -72,7 +72,7 @@ where
 /// A wrapper around tokio's `UnboundedSender` that increments a metric when a send occurs.
 ///
 /// The metric is not dropped until this sender is dropped.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct InstrumentedUnboundedSender<T, M> {
     tx: UnboundedSender<T>,
     metric: M,

--- a/src/ore/src/metrics/delete_on_drop.rs
+++ b/src/ore/src/metrics/delete_on_drop.rs
@@ -182,7 +182,7 @@ impl<'a> PromLabelsExt<'a> for BTreeMap<&'a str, &'a str> {
 /// NOTE: This type implements [`Borrow`], which imposes some constraints on implementers. To
 /// ensure these constraints, do *not* implement any of the `Eq`, `Ord`, or `Hash` traits on this.
 /// type.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DeleteOnDropMetric<'a, V, L>
 where
     V: MetricVec_,

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2765,8 +2765,11 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     assert count > 0, f"got {count}"
     count = metrics.get_value("mz_compute_controller_command_queue_size")
     assert count < 10, f"got {count}"
-    count = metrics.get_value("mz_compute_controller_response_queue_size")
-    assert count < 10, f"got {count}"
+    send_count = metrics.get_value("mz_compute_controller_response_send_count")
+    assert send_count > 10, f"got {send_count}"
+    recv_count = metrics.get_value("mz_compute_controller_response_recv_count")
+    assert recv_count > 10, f"got {recv_count}"
+    assert send_count - recv_count < 10, f"got {send_count}, {recv_count}"
     count = metrics.get_value("mz_compute_controller_hydration_queue_size")
     assert count == 0, f"got {count}"
 


### PR DESCRIPTION
Avoid the use of FuturesUnordered in the compute controller for gathering
responses from replicas. Instead, share a channel with each replica task.

Fixes MaterializeInc/database-issues#8587

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
