### PR TITLE
version consistency: add ignore regarding timestamp casting

### DIFF
--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -221,6 +221,11 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
             ):
                 return YesIgnore("Changes to byte array presentation in PR 29591")
 
+            if is_any_date_time_expression(expression):
+                return YesIgnore(
+                    "Implicit cast from interval to mz_timestamp removed in PR 29579"
+                )
+
         return super().shall_ignore_expression(expression, row_selection)
 
 


### PR DESCRIPTION
This addresses https://buildkite.com/materialize/nightly/builds/9682#0192213e-a8da-439f-b4d9-060069a4097a.