### PR TITLE
output consistency: abort run after reaching a certain number of failures

### DIFF
--- a/misc/python/materialize/output_consistency/common/configuration.py
+++ b/misc/python/materialize/output_consistency/common/configuration.py
@@ -30,6 +30,7 @@ class ConsistencyTestConfiguration:
         print_reproduction_code: bool,
         max_runtime_in_sec: int,
         max_iterations: int,
+        max_failures_until_abort: int,
         avoid_expressions_expecting_db_error: bool,
         disable_predefined_queries: bool,
         query_output_mode: QueryOutputMode,
@@ -48,6 +49,7 @@ class ConsistencyTestConfiguration:
         self.print_reproduction_code = print_reproduction_code
         self.max_runtime_in_sec = max_runtime_in_sec
         self.max_iterations = max_iterations
+        self.max_failures_until_abort = max_failures_until_abort
         self.avoid_expressions_expecting_db_error = avoid_expressions_expecting_db_error
         self.disable_predefined_queries = disable_predefined_queries
         self.query_output_mode = query_output_mode

--- a/misc/python/materialize/output_consistency/common/configuration.py
+++ b/misc/python/materialize/output_consistency/common/configuration.py
@@ -25,7 +25,6 @@ class ConsistencyTestConfiguration:
         random_seed: str,
         split_and_retry_on_db_error: bool,
         dry_run: bool,
-        fail_fast: bool,
         verbose_output: bool,
         print_reproduction_code: bool,
         max_runtime_in_sec: int,
@@ -44,7 +43,6 @@ class ConsistencyTestConfiguration:
         self.random_seed = random_seed
         self.split_and_retry_on_db_error = split_and_retry_on_db_error
         self.dry_run = dry_run
-        self.fail_fast = fail_fast
         self.verbose_output = verbose_output
         self.print_reproduction_code = print_reproduction_code
         self.max_runtime_in_sec = max_runtime_in_sec

--- a/misc/python/materialize/output_consistency/output_consistency_test.py
+++ b/misc/python/materialize/output_consistency/output_consistency_test.py
@@ -147,11 +147,13 @@ class OutputConsistencyTest:
 
         scenario = self.get_scenario()
 
+        if fail_fast:
+            max_failures_until_abort = 1
+
         config = ConsistencyTestConfiguration(
             random_seed=random_seed,
             scenario=scenario,
             dry_run=dry_run,
-            fail_fast=fail_fast,
             verbose_output=verbose_output,
             max_cols_per_query=max_cols_per_query,
             max_runtime_in_sec=max_runtime_in_sec,

--- a/misc/python/materialize/output_consistency/output_consistency_test.py
+++ b/misc/python/materialize/output_consistency/output_consistency_test.py
@@ -82,6 +82,7 @@ class OutputConsistencyTest:
             args.max_cols_per_query,
             override_max_runtime_in_sec or args.max_runtime_in_sec,
             args.max_iterations,
+            args.max_failures_until_abort,
             args.avoid_expressions_expecting_db_error,
             args.disable_predefined_queries,
             query_output_mode=query_output_mode,
@@ -110,6 +111,7 @@ class OutputConsistencyTest:
         parser.add_argument("--max-cols-per-query", default=20, type=int)
         parser.add_argument("--max-runtime-in-sec", default=600, type=int)
         parser.add_argument("--max-iterations", default=100000, type=int)
+        parser.add_argument("--max-failures-until-abort", default=15, type=int)
         parser.add_argument(
             "--avoid-expressions-expecting-db-error",
             default=False,
@@ -136,6 +138,7 @@ class OutputConsistencyTest:
         max_cols_per_query: int,
         max_runtime_in_sec: int,
         max_iterations: int,
+        max_failures_until_abort: int,
         avoid_expressions_expecting_db_error: bool,
         disable_predefined_queries: bool,
         query_output_mode: QueryOutputMode,
@@ -153,6 +156,7 @@ class OutputConsistencyTest:
             max_cols_per_query=max_cols_per_query,
             max_runtime_in_sec=max_runtime_in_sec,
             max_iterations=max_iterations,
+            max_failures_until_abort=max_failures_until_abort,
             avoid_expressions_expecting_db_error=avoid_expressions_expecting_db_error,
             queries_per_tx=20,
             max_pending_expressions=100,

--- a/misc/python/materialize/output_consistency/runner/test_runner.py
+++ b/misc/python/materialize/output_consistency/runner/test_runner.py
@@ -98,21 +98,13 @@ class ConsistencyTestRunner:
             self.output_printer.start_section("Running predefined queries")
             success = self._run_predefined_queries(test_summary)
 
-            if not success:
-                if self.config.fail_fast:
-                    self.output_printer.print_info(
-                        "Ending test run because the of a comparison mismatch in predefined queries (fail_fast mode)"
-                    )
-                    return test_summary
-                elif (
-                    test_summary.count_failures()
-                    >= self.config.max_failures_until_abort
-                ):
-                    self.output_printer.print_info(
-                        f"Ending test run because {test_summary.count_failures()} failures occurred"
-                    )
-                    return test_summary
-
+            if not success and (
+                test_summary.count_failures() >= self.config.max_failures_until_abort
+            ):
+                self.output_printer.print_info(
+                    f"Ending test run because {test_summary.count_failures()} failures occurred"
+                )
+                return test_summary
         else:
             self.output_printer.print_info(
                 "Not running predefined queries because they are disabled"
@@ -188,20 +180,13 @@ class ConsistencyTestRunner:
                 self.query_generator.add_random_where_condition_to_query(query)
             success = self.execution_manager.execute_query(query, test_summary)
 
-            if not success:
-                if self.config.fail_fast:
-                    self.output_printer.print_info(
-                        "Ending test run because the first comparison mismatch has occurred (fail_fast mode)"
-                    )
-                    return True
-                elif (
-                    test_summary.count_failures()
-                    >= self.config.max_failures_until_abort
-                ):
-                    self.output_printer.print_info(
-                        f"Ending test run because {test_summary.count_failures()} failures occurred"
-                    )
-                    return True
+            if not success and (
+                test_summary.count_failures() >= self.config.max_failures_until_abort
+            ):
+                self.output_printer.print_info(
+                    f"Ending test run because {test_summary.count_failures()} failures occurred"
+                )
+                return True
             if time_guard.shall_abort():
                 self.output_printer.print_info(
                     "Ending test run because the time elapsed"
@@ -241,7 +226,11 @@ class ConsistencyTestRunner:
             )
             all_passed = all_passed and query_succeeded
 
-            if not query_succeeded and self.config.fail_fast:
+            if (
+                not query_succeeded
+                and test_summary.count_failures()
+                >= self.config.max_failures_until_abort
+            ):
                 return False
 
         self.output_printer.print_status(

--- a/misc/python/materialize/output_consistency/status/test_summary.py
+++ b/misc/python/materialize/output_consistency/status/test_summary.py
@@ -119,6 +119,9 @@ class ConsistencyTestSummary(ConsistencyTestLogger):
     def __post_init__(self):
         self.mode = "LIVE_DATABASE" if not self.dry_run else "DRY_RUN"
 
+    def count_failures(self) -> int:
+        return len(self.failures)
+
     def merge(self, other: ConsistencyTestSummary) -> None:
         assert self.dry_run == other.dry_run
         assert self.mode == other.mode


### PR DESCRIPTION
This should reduce the noise when things break.

Nightly: https://buildkite.com/materialize/nightly/builds/9691