### PR TITLE
test analytics: Print error message when running locally

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -224,7 +224,6 @@ case "$cmd" in
             --env POLAR_SIGNALS_API_TOKEN
             --env PRODUCTION_ANALYTICS_USERNAME
             --env PRODUCTION_ANALYTICS_APP_PASSWORD
-            --env PRODUCTION_ANALYTICS_MZ_CLI_APP_PASSWORD
             --env PYPI_TOKEN
             --env MZ_DEV_BUILD_SHA
             # For Miri with nightly Rust

--- a/misc/python/materialize/test_analytics/config/test_analytics_db_config.py
+++ b/misc/python/materialize/test_analytics/config/test_analytics_db_config.py
@@ -17,9 +17,7 @@ from materialize.test_analytics.config.mz_db_config import MzDbConfig
 
 def create_test_analytics_config(c: Composition) -> MzDbConfig:
     """This requires the "mz" service in the composition."""
-    app_password = os.getenv("PRODUCTION_ANALYTICS_MZ_CLI_APP_PASSWORD") or os.getenv(
-        "PRODUCTION_ANALYTICS_APP_PASSWORD"
-    )
+    app_password = os.getenv("PRODUCTION_ANALYTICS_APP_PASSWORD")
 
     if app_password is not None:
         hostname = get_cloud_hostname(c, app_password=app_password)

--- a/misc/python/materialize/test_analytics/test_analytics_db.py
+++ b/misc/python/materialize/test_analytics/test_analytics_db.py
@@ -77,6 +77,9 @@ class TestAnalyticsDb:
         self._communication_failed(f"Loading data failed! {e}")
 
     def _communication_failed(self, message: str) -> None:
+        if not buildkite.is_in_buildkite():
+            print(message)
+
         if not self.shall_notify_qa_team():
             return
 


### PR DESCRIPTION
And remove non-existant PRODUCTION_ANALYTICS_MZ_CLI_APP_PASSWORD

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
