### PR TITLE
release: bump to version v0.118.1-dev.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4325,7 +4325,7 @@ dependencies = [
 
 [[package]]
 name = "mz-balancerd"
-version = "0.118.0-dev.0"
+version = "0.118.1-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4463,7 +4463,7 @@ dependencies = [
 
 [[package]]
 name = "mz-catalog-debug"
-version = "0.118.0-dev.0"
+version = "0.118.1-dev.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "mz-clusterd"
-version = "0.118.0-dev.0"
+version = "0.118.1-dev.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "mz-environmentd"
-version = "0.118.0-dev.0"
+version = "0.118.1-dev.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -5629,7 +5629,7 @@ dependencies = [
 
 [[package]]
 name = "mz-persist-client"
-version = "0.118.0-dev.0"
+version = "0.118.1-dev.0"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.4",
@@ -6714,7 +6714,7 @@ dependencies = [
 
 [[package]]
 name = "mz-testdrive"
-version = "0.118.0-dev.0"
+version = "0.118.1-dev.0"
 dependencies = [
  "anyhow",
  "arrow",

--- a/src/balancerd/BUILD.bazel
+++ b/src/balancerd/BUILD.bazel
@@ -30,7 +30,7 @@ rust_library(
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         "//src/alloc:mz_alloc",
         "//src/alloc-default:mz_alloc_default",
@@ -70,7 +70,7 @@ rust_test(
     ),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         "//src/alloc:mz_alloc",
         "//src/alloc-default:mz_alloc_default",
@@ -137,7 +137,7 @@ rust_test(
     ),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         ":mz_balancerd",
         "//src/alloc:mz_alloc",
@@ -175,7 +175,7 @@ rust_binary(
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         ":mz_balancerd",
         "//src/alloc:mz_alloc",

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-balancerd"
 description = "Balancer service."
-version = "0.118.0-dev.0"
+version = "0.118.1-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/catalog-debug/BUILD.bazel
+++ b/src/catalog-debug/BUILD.bazel
@@ -29,7 +29,7 @@ rust_binary(
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         "//src/adapter:mz_adapter",
         "//src/build-info:mz_build_info",

--- a/src/catalog-debug/Cargo.toml
+++ b/src/catalog-debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-catalog-debug"
 description = "Durable metadata storage debug tool."
-version = "0.118.0-dev.0"
+version = "0.118.1-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/clusterd/BUILD.bazel
+++ b/src/clusterd/BUILD.bazel
@@ -29,7 +29,7 @@ rust_binary(
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         "//src/alloc:mz_alloc",
         "//src/alloc-default:mz_alloc_default",

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-clusterd"
 description = "Materialize's cluster server."
-version = "0.118.0-dev.0"
+version = "0.118.1-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/environmentd/BUILD.bazel
+++ b/src/environmentd/BUILD.bazel
@@ -43,7 +43,7 @@ rust_library(
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         ":mz_environmentd_build_script",
         "//src/adapter:mz_adapter",
@@ -116,7 +116,7 @@ rust_test(
     ),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         "//src/adapter:mz_adapter",
         "//src/adapter-types:mz_adapter_types",
@@ -251,7 +251,7 @@ rust_test(
     ),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         "//src/adapter:mz_adapter",
         "//src/adapter-types:mz_adapter_types",
@@ -319,7 +319,7 @@ rust_test(
     ),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         "//src/adapter:mz_adapter",
         "//src/adapter-types:mz_adapter_types",
@@ -387,7 +387,7 @@ rust_test(
     ),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         "//src/adapter:mz_adapter",
         "//src/adapter-types:mz_adapter_types",
@@ -455,7 +455,7 @@ rust_test(
     ),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         "//src/adapter:mz_adapter",
         "//src/adapter-types:mz_adapter_types",
@@ -523,7 +523,7 @@ rust_test(
     ),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         "//src/adapter:mz_adapter",
         "//src/adapter-types:mz_adapter_types",
@@ -591,7 +591,7 @@ rust_test(
     ),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         "//src/adapter:mz_adapter",
         "//src/adapter-types:mz_adapter_types",
@@ -659,7 +659,7 @@ rust_test(
     ),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         "//src/adapter:mz_adapter",
         "//src/adapter-types:mz_adapter_types",
@@ -721,7 +721,7 @@ rust_binary(
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         ":mz_environmentd",
         "//src/adapter:mz_adapter",

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-environmentd"
 description = "Manages a single Materialize environment."
-version = "0.118.0-dev.0"
+version = "0.118.1-dev.0"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition.workspace = true

--- a/src/persist-client/BUILD.bazel
+++ b/src/persist-client/BUILD.bazel
@@ -28,7 +28,7 @@ rust_library(
     proc_macro_deps = ["//src/persist-proc:mz_persist_proc"] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         ":mz_persist_client_build_script",
         "//src/build-info:mz_build_info",
@@ -62,7 +62,7 @@ rust_test(
     ),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         "//src/build-info:mz_build_info",
         "//src/dyncfg:mz_dyncfg",

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-persist-client"
 description = "Client for Materialize pTVC durability system"
-version = "0.118.0-dev.0"
+version = "0.118.1-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/testdrive/BUILD.bazel
+++ b/src/testdrive/BUILD.bazel
@@ -28,7 +28,7 @@ rust_library(
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         ":mz_testdrive_build_script",
         "//src/adapter:mz_adapter",
@@ -73,7 +73,7 @@ rust_test(
     ),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         "//src/adapter:mz_adapter",
         "//src/avro:mz_avro",
@@ -162,7 +162,7 @@ rust_binary(
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.118.0-dev.0",
+    version = "0.118.1-dev.0",
     deps = [
         ":mz_testdrive",
         "//src/adapter:mz_adapter",

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-testdrive"
 description = "Integration test driver for Materialize."
-version = "0.118.0-dev.0"
+version = "0.118.1-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
Since we created the v0.118.0 for the in-between release tag, we need to bump this version to keep the Nightly upgrade tests working.

Bumping to v0.118.1-dev.0, rather than v0.119.0-dev.0 because we still want to release v0.118.1 next week. 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
