### PR TITLE
ci: Correct version in license file updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -13,7 +13,7 @@ Business Source License 1.1
 
 Licensor:                  Materialize, Inc.
 
-Licensed Work:             Materialize Version 20240925
+Licensed Work:             Materialize Version v0.118.0-dev.0
                            The Licensed Work is © 2024 Materialize, Inc.
 
 Additional Use Grant:      Within a single installation of Materialize, you

--- a/ci/license/bump-change-date.sh
+++ b/ci/license/bump-change-date.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 
 git_date=$(date "+%B %d, %Y 00:00:00 UTC")
 change_date=$(date -d "+4 years" "+%B %d, %Y")
-version_date=$(date "+%Y%m%d")
+version=$(cargo metadata --no-deps --format-version=1 | jq -r ".packages[] | select(.name == \"mz-environmentd\") .version")
 year=$(date "+%Y")
 
 export GIT_AUTHOR_DATE=$git_date
@@ -28,7 +28,7 @@ export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
 git checkout main
 git pull
 sed -Ei \
-    -e "s/Licensed Work:.*/Licensed Work:             Materialize Version $version_date/g" \
+    -e "s/Licensed Work:.*/Licensed Work:             Materialize Version v$version/g" \
     -e "s/Change Date:.*/Change Date:               $change_date/g" \
     -e "s/The Licensed Work is © [0-9]{4}/The Licensed Work is © $year/g" \
     LICENSE


### PR DESCRIPTION
Noticed in https://github.com/MaterializeInc/materialize/pull/29740
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
