### PR TITLE
cut-release: allow leading 'v' in version strings

### DIFF
--- a/misc/python/materialize/release/cut_release.py
+++ b/misc/python/materialize/release/cut_release.py
@@ -10,12 +10,17 @@
 """Cut a new release and push the tag to the upstream Materialize repository."""
 
 import argparse
+import re
 import sys
 
 from semver.version import Version
 
 from materialize import MZ_ROOT, spawn
 from materialize.git import checkout, get_branch_name, tag_annotated
+
+
+def parse_version(version: str) -> Version:
+    return Version.parse(re.sub(r"^v", "", version))
 
 
 def main():
@@ -32,7 +37,7 @@ def main():
     parser.add_argument(
         "--version",
         help="Version of release",
-        type=Version.parse,
+        type=parse_version,
         required=True,
     )
     parser.add_argument(


### PR DESCRIPTION
Without this fix:

```bash
bin/cut-release --sha HEAD --version v0.117.2 --remote origin
usage: cut_release [-h] --sha SHA --version VERSION --remote REMOTE
cut_release: error: argument --version: invalid parse value: 'v0.117.2'
```

