### PR TITLE
bazel: fix cache invalidations

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,13 +33,13 @@ build:release-stamp --stamp --workspace_status_command "python3 misc/bazel/build
 # Output all test output by default, this makes it most like cargo.
 #
 # Note: We used to have 'stream' here, but that forces Bazel to serialize test execution.
-test --test_output=all
+build --test_output=all
 # Environment variables to pass through to the test runner. These can impact
 # remote cache hits, so add them sparingly.
 #
 # TODO(parkmycar): Switch over to using `env_inherit` on `rust_test` once that's stable.
 # <https://github.com/bazelbuild/rules_rust/pull/2809>
-test --test_env=COCKROACH_URL
+build --test_env=COCKROACH_URL
 
 # Allows spaces to in filenames, without this Rust Doc tests fail to build.
 build:macos --experimental_inprocess_symlink_creation


### PR DESCRIPTION
`--test_env` and `--test_output` only applies to the test runner, but by gating them behind the `test` action invalidated the cache when switching between `bazel build` and `bazel test`

### Motivation

Better Bazel builds

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
