### PR TITLE
ci: Move cloudtest from test to nightly pipeline

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1522,20 +1522,50 @@ steps:
     agents:
       queue: hetzner-aarch64-4cpu-8gb
 
-  - id: cloudtest-slow
-    label: "Slow Cloudtest"
-    depends_on: build-aarch64
-    timeout_in_minutes: 45
-    env:
-      CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
-    agents:
-      # TODO: Debezium DNS flakiness doesn't allow running on hetzner
-      # queue: hetzner-aarch64-8cpu-16gb
-      queue: linux-aarch64-medium
-    plugins:
-      - ./ci/plugins/cloudtest:
-          args: [-m=long, test/cloudtest/test_storage_shared_fate.py]
-    sanitizer: skip
+  - group: Cloud tests
+    key: cloudtests
+    steps:
+      - id: cloudtest
+        label: Cloudtest
+        depends_on: build-aarch64
+        timeout_in_minutes: 60
+        inputs:
+          - test/cloudtest
+          - misc/python/materialize/cloudtest
+          - misc/kind
+        env:
+          CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
+        plugins:
+          - ./ci/plugins/scratch-aws-access: ~
+          - ./ci/plugins/cloudtest:
+              args:
+                [
+                  --exitfirst,
+                  -m,
+                  "not long and not node_recovery",
+                  test/cloudtest/,
+                ]
+        agents:
+          # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
+          # queue: hetzner-aarch64-8cpu-16gb
+          queue: linux-aarch64
+        sanitizer: skip
+
+
+      - id: cloudtest-slow
+        label: "Slow Cloudtest"
+        depends_on: build-aarch64
+        timeout_in_minutes: 45
+        env:
+          CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
+        agents:
+          # TODO: Debezium DNS flakiness doesn't allow running on hetzner
+          # queue: hetzner-aarch64-8cpu-16gb
+          queue: linux-aarch64-medium
+        plugins:
+          - ./ci/plugins/cloudtest:
+              args: [-m=long, test/cloudtest/test_storage_shared_fate.py]
+        sanitizer: skip
 
   - id: txn-wal-fencing
     label: Txn-wal fencing %N

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -596,33 +596,6 @@ steps:
               composition: platform-checks
               args: [--scenario=NoRestartNoUpgrade, "--seed=$BUILDKITE_JOB_ID"]
 
-  - id: cloudtest
-    label: Cloudtest %N
-    depends_on: build-aarch64
-    parallelism: 8
-    timeout_in_minutes: 60
-    inputs:
-      - test/cloudtest
-      - misc/python/materialize/cloudtest
-      - misc/kind
-    env:
-      CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
-    plugins:
-      - ./ci/plugins/scratch-aws-access: ~
-      - ./ci/plugins/cloudtest:
-          args:
-            [
-              --exitfirst,
-              -m,
-              "not long and not node_recovery",
-              test/cloudtest/,
-            ]
-    agents:
-      # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-      # queue: hetzner-aarch64-8cpu-16gb
-      queue: linux-aarch64
-    sanitizer: skip
-
   - id: source-sink-errors
     label: "Source/Sink Error Reporting %N"
     depends_on: build-aarch64


### PR DESCRIPTION

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
