### PR TITLE
dbt-materialize: release v1.8.6

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,6 +1,6 @@
 # dbt-materialize Changelog
 
-## Unreleased
+## 1.8.6 - 2024-09-25
 
 * Enable the `cluster` configuration for seeds, which allows specifying a target
   cluster for `dbt seed` to run against (which is required for specific seed
@@ -21,6 +21,9 @@
       config:
         cluster: dbt_seed_cluster
   ```
+
+* Add a new `source_table` materialization type, in support of an upcoming
+  feature in Materialize (source versioning).
 
 ## 1.8.5 - 2024-08-21
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.8.5"
+version = "1.8.6"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -26,7 +26,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.8.5",
+    version="1.8.6",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Release `dbt-materialize` v1.8.6. See `CHANGELOG.md` for an overview of the release.