### PR TITLE
persist: Reduce the number of lgalloc allocations in `S3Blob`

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -72,6 +72,7 @@ def get_default_system_parameters(
         # Persist internals changes: advance coverage
         "persist_enable_arrow_lgalloc_noncc_sizes": "true",
         "persist_enable_s3_lgalloc_noncc_sizes": "true",
+        "persist_enable_one_alloc_per_request": "true",
         # -----
         # Others (ordered by name)
         "allow_real_time_recency": "true",

--- a/src/ore/src/lgbytes.rs
+++ b/src/ore/src/lgbytes.rs
@@ -296,9 +296,10 @@ impl LgBytesOpMetrics {
                 Region::new_heap(capacity)
             }
         };
+        let region = self.metrics_region(region);
         self.alloc_seconds.inc_by(start.elapsed().as_secs_f64());
 
-        self.metrics_region(region)
+        region
     }
 
     /// Attempts to copy the given buf into an lgalloc managed file-based mapped

--- a/src/ore/src/lgbytes.rs
+++ b/src/ore/src/lgbytes.rs
@@ -58,6 +58,10 @@ impl<T: Copy> MetricsRegion<T> {
     }
 
     /// Copy all of the elements from `slice` into the [`Region`].
+    ///
+    /// # Panics
+    ///
+    /// * If the [`Region`] does not have enough capacity.
     pub fn extend_from_slice(&mut self, slice: &[T]) {
         self.buf.extend_from_slice(slice);
     }

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -35,6 +35,7 @@ pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::indexed::columnar::arrow::ENABLE_ARROW_LGALLOC_NONCC_SIZES)
         .add(&crate::s3::ENABLE_S3_LGALLOC_CC_SIZES)
         .add(&crate::s3::ENABLE_S3_LGALLOC_NONCC_SIZES)
+        .add(&crate::s3::ENABLE_ONE_ALLOC_PER_REQUEST)
 }
 
 /// Config for an implementation of [Blob].

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -493,6 +493,8 @@ impl Blob for S3Blob {
                 let mut buffer = match object.content_length() {
                     Some(len @ 1..) if enable_one_allocation => {
                         let len: u64 = len.try_into().expect("positive integer");
+                        // N.B. `lgalloc` cannot reallocate so we need to make sure the initial
+                        // allocation is large enough to fit then entire blob.
                         let buf: MetricsRegion<u8> = self
                             .metrics
                             .lgbytes


### PR DESCRIPTION
As we chatted about offline, this PR should use just a single `lgalloc` allocation for the entirety of a part in a multi-part GET request, instead of creating new allocations for each chunk of bytes that comes off the wire. This should result in using larger lgalloc size classes and fewer allocations in general.

There's a dyncfg `persist_enable_one_alloc_per_request` which we can disable if something goes wrong, but it defaults to `true`.

### Motivation

Improve memory usage in Persist

Fixes https://github.com/MaterializeInc/database-issues/issues/8516

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
