### PR TITLE
python: update cryptography, paramiko

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -8,7 +8,7 @@ black==24.4.2
 boto3-stubs[ec2,iam,kinesis,s3,sqs,ssm,sts]==1.26.89
 boto3==1.34.63
 click==8.1.3
-cryptography==42.0.8 # TODO(def-) Upgrade when https://github.com/paramiko/paramiko/issues/2419 is fixed
+cryptography==43.0.1
 colored==1.4.4
 docker==7.1.0
 ec2instanceconnectcli==1.0.2
@@ -31,7 +31,7 @@ numpy==1.26.1
 pandas==2.1.2
 pandas-stubs==2.1.1.230928
 parameterized==0.8.1
-paramiko==3.4.0
+paramiko==3.4.1
 pdoc==14.6.0
 # We can revert back to standard pg800 versions once https://github.com/tlocke/pg8000/pull/161 merges
 pg8000 @ git+https://github.com/benesch/pg8000@0e7d1fbe02bd47958f9cf0cf132d6d08fbcca18e


### PR DESCRIPTION
https://github.com/paramiko/paramiko/issues/2419 was fixed and released in Paramiko 3.3.2 and 3.4.1.