### PR TITLE
persist: Remove 'persist_batch_record_part_format' dyncfg

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -111,7 +111,6 @@ def get_default_system_parameters(
         ),
         "persist_batch_columnar_format_percent": "10",
         "persist_batch_delete_enabled": "true",
-        "persist_batch_record_part_format": "true",
         "persist_batch_record_run_meta": (
             "true" if version >= MzVersion.parse_mz("v0.115.0-dev") else "false"
         ),

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1020,7 +1020,6 @@ class FlipFlagsAction(Action):
             "75",
             "100",
         ]
-        self.flags_with_values["persist_batch_record_part_format"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_record_run_meta"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_order"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -325,7 +325,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::batch::BATCH_DELETE_ENABLED)
         .add(&crate::batch::BATCH_COLUMNAR_FORMAT)
         .add(&crate::batch::BATCH_COLUMNAR_FORMAT_PERCENT)
-        .add(&crate::batch::BATCH_RECORD_PART_FORMAT)
         .add(&crate::batch::BLOB_TARGET_SIZE)
         .add(&crate::batch::INLINE_WRITES_TOTAL_MAX_BYTES)
         .add(&crate::batch::INLINE_WRITES_SINGLE_MAX_BYTES)

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -373,9 +373,7 @@ pub struct HollowBatchPart<T> {
     /// Columnar format that this batch was written in.
     ///
     /// This is `None` if this part was written before we started writing structured
-    /// columnar data, or if the [`BATCH_RECORD_PART_FORMAT`] dyncfg is off.
-    ///
-    /// [`BATCH_RECORD_PART_FORMAT`]: crate::batch::BATCH_RECORD_PART_FORMAT
+    /// columnar data.
     pub format: Option<BatchColumnarFormat>,
     /// The schemas used to encode the data in this batch part.
     ///

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -98,12 +98,6 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                 {
                     // Write the format of a Part in State.
                     let mut x = ::mz_dyncfg::ConfigUpdates::default();
-                    x.add_dynamic("persist_batch_record_part_format", ::mz_dyncfg::ConfigVal::Bool(true));
-                    x
-                },
-                {
-                    // Write the format of a Part in State.
-                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
                     x.add_dynamic("persist_batch_record_run_meta", ::mz_dyncfg::ConfigVal::Bool(true));
                     x
                 },


### PR DESCRIPTION
This flag has been rolled out to 100% in Staging and Prod for a while now and we no longer need it.

Note: This flag will remain in LaunchDarkly until this PR gets released to all environments.

### Motivation

* This PR refactors existing code.

Clean up feature flags.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
