### PR TITLE
test: Add startup feature benchmark

### DIFF
--- a/doc/developer/feature-benchmark.md
+++ b/doc/developer/feature-benchmark.md
@@ -174,7 +174,7 @@ The feature benchmark will retry any regressed scenarios up to `--max-cycles=3` 
 
 ## Benchmark definition format
 
-Benchmark scenarios live in `test/feature-benchmark/scenarios.py` and follow the following format:
+Benchmark scenarios live in `test/feature-benchmark/scenarios/` and follow the following format:
 
 ```
 class NewBenchmark(Scenario):

--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -30,4 +30,5 @@ SHA256_BY_SCENARIO_FILE: dict[str, str] = {
     "scale.py": "c4c8749d166e4df34e0b0e92220434fdb508c5c2ac56eb80c07043be0048dded",
     "skew.py": "bf60802205fc51ebf94fb008bbdb6b2ccce3c9ed88a6188fa7f090f2c84b120f",
     "subscribe.py": "510cf9037308936f1bb02a1c2e6345a90bcbda89f701653518d46d1fb56a2328",
+    "startup.py": "adbfecb8e79224d92f047ea0820f74de521f035d8b7b0da35f7f5acb04fec75a",
 }

--- a/misc/python/materialize/feature_benchmark/executor.py
+++ b/misc/python/materialize/feature_benchmark/executor.py
@@ -72,6 +72,14 @@ class Docker(Executor):
             self._composition.up("clusterd")
         return None
 
+    def RestartMzMaterialized(self) -> None:
+        self._composition.kill("materialized")
+        # Make sure we are restarting Materialized() with the
+        # same parameters (docker tag, SIZE) it was initially started with
+        with self._composition.override(self._materialized):
+            self._composition.up("materialized")
+        return None
+
     def Td(self, input: str) -> Any:
         return self._composition.exec(
             "testdrive",
@@ -167,6 +175,9 @@ class MzCloud(Executor):
         ]
 
     def RestartMzClusterd(self) -> None:
+        assert False, "We can't restart the cloud"
+
+    def RestartMzMaterialized(self) -> None:
         assert False, "We can't restart the cloud"
 
     def Reset(self) -> None:

--- a/misc/python/materialize/feature_benchmark/scenarios/startup.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/startup.py
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from pathlib import Path
+
+import materialize.optbench
+import materialize.optbench.sql
+from materialize.feature_benchmark.action import Action
+from materialize.feature_benchmark.executor import Executor
+from materialize.feature_benchmark.measurement_source import (
+    Lambda,
+    MeasurementSource,
+)
+from materialize.feature_benchmark.scenario import Scenario
+from materialize.feature_benchmark.scenarios.optbench import OptbenchInit
+
+
+class StartupInit(Action):
+    def __init__(self, n: int) -> None:
+        self._executor: Executor | None = None
+        self._n = n
+
+    def run(self, executor: Executor | None = None) -> None:
+        e = executor or self._executor
+        queries = materialize.optbench.sql.parse_from_file(
+            Path("misc/python/materialize/optbench/workload/tpch.sql")
+        )
+        statements = []
+        for i in range(self._n):
+            for q, query in enumerate(queries):
+                statements.extend(
+                    [
+                        f"CREATE VIEW vq_{q}_{i} AS {query}",
+                        f"CREATE DEFAULT INDEX ON vq_{q}_{i}",
+                        f"CREATE MATERIALIZED VIEW mvq_{q}_{i} AS {query}",
+                    ]
+                )
+        e._composition.sql("\n".join(statements))  # type: ignore
+
+
+class Startup(Scenario):
+    """Startup benchmark"""
+
+    def before(self) -> list[Action]:
+        return [OptbenchInit("tpch", no_indexes=True), StartupInit(self.n())]
+
+    def benchmark(self) -> MeasurementSource:
+        return Lambda(lambda e: e.RestartMzMaterialized())


### PR DESCRIPTION
### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
