### PR TITLE
catalog: Remove deploy gen req from savepoint

### DIFF
--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -1240,7 +1240,7 @@ impl UnopenedPersistCatalogState {
                 .into());
             }
             (
-                Mode::Writable | Mode::Savepoint,
+                Mode::Writable,
                 FenceableToken::Initializing {
                     current_deploy_generation: None,
                     ..


### PR DESCRIPTION
Previously, the catalog required a deploy generation when opening in savepoint mode. However, the upgrade checker has no access to a deploy generation and was failing to open a savepoint catalog. Ideally, the upgrade checker would have a deploy generation so that it can test the exact code path that an upgrade would take. For now, we're removing the requirement to unblock the upgrade checker.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
