### PR TITLE
storage-controller: flatten DataSourceOther

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -142,7 +142,7 @@ use mz_sql::session::vars::{ConnectionCounter, SystemVars};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::ExplainStage;
 use mz_storage_client::client::TimestamplessUpdate;
-use mz_storage_client::controller::{CollectionDescription, DataSource, DataSourceOther};
+use mz_storage_client::controller::{CollectionDescription, DataSource};
 use mz_storage_types::connections::inline::{IntoInlineConnection, ReferencedConnection};
 use mz_storage_types::connections::Connection as StorageConnection;
 use mz_storage_types::connections::ConnectionContext;
@@ -2471,10 +2471,7 @@ impl Coordinator {
                     CatalogItem::Table(table) => {
                         let collection_desc = match &table.data_source {
                             TableDataSource::TableWrites { defaults: _ } => {
-                                CollectionDescription::from_desc(
-                                    table.desc.clone(),
-                                    DataSourceOther::TableWrites,
-                                )
+                                CollectionDescription::for_table(table.desc.clone())
                             }
                             TableDataSource::DataSource(data_source_desc) => {
                                 source_desc(data_source_desc, &table.desc)
@@ -2485,7 +2482,7 @@ impl Coordinator {
                     CatalogItem::MaterializedView(mv) => {
                         let collection_desc = CollectionDescription {
                             desc: mv.desc.clone(),
-                            data_source: DataSource::Other(DataSourceOther::Compute),
+                            data_source: DataSource::Other,
                             since: mv.initial_as_of.clone(),
                             status_collection_id: None,
                         };
@@ -2494,7 +2491,7 @@ impl Coordinator {
                     CatalogItem::ContinualTask(ct) => {
                         let collection_desc = CollectionDescription {
                             desc: ct.desc.clone(),
-                            data_source: DataSource::Other(DataSourceOther::Compute),
+                            data_source: DataSource::Other,
                             since: ct.initial_as_of.clone(),
                             status_collection_id: None,
                         };

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -81,9 +81,7 @@ use mz_sql_parser::ast::{
     WithOptionValue,
 };
 use mz_ssh_util::keys::SshKeyPairSet;
-use mz_storage_client::controller::{
-    CollectionDescription, DataSource, DataSourceOther, ExportDescription,
-};
+use mz_storage_client::controller::{CollectionDescription, DataSource, ExportDescription};
 use mz_storage_types::connections::inline::IntoInlineConnection;
 use mz_storage_types::controller::StorageError;
 use mz_storage_types::stats::RelationPartStats;
@@ -969,10 +967,7 @@ impl Coordinator {
                             coord.set_statement_execution_timestamp(id, register_ts);
                         }
 
-                        let collection_desc = CollectionDescription::from_desc(
-                            table.desc.clone(),
-                            DataSourceOther::TableWrites,
-                        );
+                        let collection_desc = CollectionDescription::for_table(table.desc.clone());
                         let storage_metadata = coord.catalog.state().storage_metadata();
                         coord
                             .controller

--- a/src/adapter/src/coord/sequencer/inner/create_continual_task.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_continual_task.rs
@@ -29,7 +29,7 @@ use mz_sql::plan;
 use mz_sql::session::metadata::SessionMetadata;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::Statement;
-use mz_storage_client::controller::{CollectionDescription, DataSource, DataSourceOther};
+use mz_storage_client::controller::{CollectionDescription, DataSource};
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::notice::OptimizerNotice;
 
@@ -137,7 +137,7 @@ impl Coordinator {
                             sink_id,
                             CollectionDescription {
                                 desc,
-                                data_source: DataSource::Other(DataSourceOther::Compute),
+                                data_source: DataSource::Other,
                                 since: Some(as_of),
                                 status_collection_id: None,
                             },

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -29,7 +29,7 @@ use mz_sql::plan;
 use mz_sql::session::metadata::SessionMetadata;
 use mz_sql_parser::ast;
 use mz_sql_parser::ast::display::AstDisplay;
-use mz_storage_client::controller::{CollectionDescription, DataSource, DataSourceOther};
+use mz_storage_client::controller::{CollectionDescription, DataSource};
 use std::collections::BTreeMap;
 use timely::progress::Antichain;
 use tracing::Span;
@@ -676,7 +676,7 @@ impl Coordinator {
                             sink_id,
                             CollectionDescription {
                                 desc: output_desc,
-                                data_source: DataSource::Other(DataSourceOther::Compute),
+                                data_source: DataSource::Other,
                                 since: Some(storage_as_of),
                                 status_collection_id: None,
                             },


### PR DESCRIPTION
The `DataSource::Other(DataSourceOther)` variant was meant to house all data sources that were not "managed" by the storage controller. However:

  * Collections with a data source of `DataSourceOther::TableWrites` are *very much* managed by the storage controller. They have a special background worker that handles registering them with the txns system and incoming write requests.

  * Collections with a data source of `DataSourceOther::Compute` are indeed unmanaged by the storage controller, but the name is overly restrictive. Collections registered as `DataSourceOther::Compute` could just as well be managed by adapter or any other component of the system.

So this commit does away with the `DataSourceOther` type. Instead, we add a top-level `DataSource::Table` variant, for the collections that need to be managed as tables, and `DataSource::Other`, for the collections that the storage controller truly should leave alone, and do not require special handling of any sort.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
