### PR TITLE
parallel-benchmark: Fix disabling

### DIFF
--- a/misc/python/materialize/parallel_benchmark/framework.py
+++ b/misc/python/materialize/parallel_benchmark/framework.py
@@ -334,10 +334,6 @@ class Scenario:
     def __init__(self, c: Composition, conn_infos: dict[str, PgConnInfo]):
         raise NotImplementedError
 
-    @staticmethod
-    def enabled_by_default() -> bool:
-        return True
-
     @classmethod
     def name(cls) -> str:
         return cls.__name__

--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -1089,14 +1089,11 @@ class ReadReplicaBenchmark(Scenario):
         )
 
 
+@disabled("Only run separately in QA Canary pipeline")
 class StagingBench(Scenario):
     # TODO: Reenable queries other than SELECT 1
     # TODO: Kafka source + sink
     # TODO: Webhook source
-    @staticmethod
-    def enabled_by_default() -> bool:
-        return False
-
     def __init__(self, c: Composition, conn_infos: dict[str, PgConnInfo]):
         conn_infos = deepcopy(conn_infos)
         conn_infos["materialized"].cluster = "quickstart"


### PR DESCRIPTION
Noticed in https://buildkite.com/materialize/nightly/builds/9738#0192386b-5997-4785-9597-078f07fba6f9
Green run: https://buildkite.com/materialize/nightly/builds/9741

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
