### PR TITLE
adapter: finish migration for mz_cluster_replica_frontiers

### DIFF
--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -10,12 +10,11 @@
 use std::collections::BTreeMap;
 
 use futures::future::BoxFuture;
-use mz_catalog::builtin::{BuiltinTable, MZ_CLUSTER_REPLICA_FRONTIERS};
-use mz_catalog::durable::{SystemObjectDescription, Transaction};
+use mz_catalog::builtin::BuiltinTable;
+use mz_catalog::durable::Transaction;
 use mz_catalog::memory::objects::StateUpdate;
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::NowFn;
-use mz_repr::namespaces::{MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA};
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{
@@ -236,31 +235,9 @@ async fn migrate_inject_ssh_public_keys_v0118(
 
 /// Migrations that run only on the durable catalog before any data is loaded into memory.
 pub(crate) fn durable_migrate(
-    tx: &mut Transaction,
+    _tx: &mut Transaction,
     _boot_ts: Timestamp,
 ) -> Result<(), anyhow::Error> {
-    // We're promoting mz_cluster_replica_frontiers from mz_internal to
-    // mz_catalog in this release. As a special case, if a mapping for
-    // mz_cluster_replica_frontiers exists in the mz_internal schema, rewrite it
-    // in place for the mz_catalog schema instead. This keeps the migration
-    // machinery from creating a new shard for the relation, which is important
-    // because the 0dt machinery relies on this shard to determine when to cut
-    // over to the new version.
-    //
-    // TODO(benesch): remove this for the next release (27 September 2024).
-    let mut mappings = tx.get_system_object_mappings().collect::<Vec<_>>();
-    if let Some(object) = mappings.iter_mut().find(|o| {
-        o.description
-            == SystemObjectDescription {
-                schema_name: MZ_INTERNAL_SCHEMA.into(),
-                object_name: MZ_CLUSTER_REPLICA_FRONTIERS.name.into(),
-                object_type: mz_sql::catalog::CatalogItemType::Source,
-            }
-    }) {
-        object.description.schema_name = MZ_CATALOG_SCHEMA.into();
-    }
-    tx.set_system_object_mappings(mappings)?;
-
     Ok(())
 }
 


### PR DESCRIPTION
The migration code made it into v0.118, so we no longer need to keep it around.

Fix #8479.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR finishes adding a known desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
