### PR TITLE
bazel: upgrade `rules_rust` to v0.51.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -307,9 +307,9 @@ c_repositories()
 # Rules for building Rust crates, and several convienence macros for building all transitive
 # dependencies.
 
-RULES_RUST_VERSION = "0.49.3"
+RULES_RUST_VERSION = "0.51.0"
 
-RULES_RUST_INTEGRITY = "sha256-3QBrdyIdWeTRQSB8DnrfEbH7YNFEC4/KA7+SVheTKmA="
+RULES_RUST_INTEGRITY = ""
 
 maybe(
     http_archive,

--- a/misc/bazel/rust_deps/cxxbridge-cmd/Cargo.cxxbridge-cmd.lock
+++ b/misc/bazel/rust_deps/cxxbridge-cmd/Cargo.cxxbridge-cmd.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "7905d1059c3fc9a17aea6dde4bd4d8986d354c80daa8018a50bd90bead380352",
+  "checksum": "39fbc481743551b458d7302144b516895738f12ed2b403519fb5b26a1a7a2d84",
   "crates": {
     "anstyle 1.0.4": {
       "name": "anstyle",
@@ -371,6 +371,9 @@
         "version": "1.0.69"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -752,6 +755,9 @@
         "version": "0.3.9"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -817,6 +823,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -932,6 +941,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/src/build-tools/src/lib.rs
+++ b/src/build-tools/src/lib.rs
@@ -49,7 +49,7 @@ pub fn protoc() -> PathBuf {
     cfg_if! {
         if #[cfg(bazel)] {
             let r = runfiles::Runfiles::create().unwrap();
-            r.rlocation("protobuf/protoc")
+            r.rlocation("protobuf/protoc").expect("set by Bazel")
         } else if #[cfg(feature = "protobuf-src")] {
             protobuf_src::protoc()
         } else {
@@ -70,7 +70,7 @@ pub fn protoc_include() -> PathBuf {
     cfg_if! {
         if #[cfg(bazel)] {
             let r = runfiles::Runfiles::create().unwrap();
-            r.rlocation("protobuf/src")
+            r.rlocation("protobuf/src").expect("set by Bazel")
         } else if #[cfg(feature = "protobuf-src")] {
             protobuf_src::include()
         } else {


### PR DESCRIPTION
Picks up the latest version of `rules_rust` for Bazel

### Motivation

Keep Bazel rules up-to-date

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
