### PR TITLE
ci: Parallelize test pipeline more, move one test to nightly

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1601,6 +1601,16 @@ steps:
       agents:
         queue: hetzner-aarch64-16cpu-32gb
 
+  - id: backup-restore
+    label: "CRDB / Persist backup and restore"
+    depends_on: build-aarch64
+    timeout_in_minutes: 30
+    agents:
+      queue: hetzner-aarch64-4cpu-8gb
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: backup-restore
+
   - group: "Language tests"
     key: language-tests
     steps:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -326,6 +326,7 @@ steps:
 
   - id: legacy-upgrade
     label: "Legacy upgrade tests (last version from docs)"
+    parallelism: 2
     depends_on: build-aarch64
     timeout_in_minutes: 60
     plugins:
@@ -395,7 +396,7 @@ steps:
 
       - id: mysql-cdc-resumption
         label: "MySQL CDC resumption tests %N"
-        parallelism: 3
+        parallelism: 4
         depends_on: build-aarch64
         timeout_in_minutes: 30
         inputs: [test/mysql-cdc-resumption]
@@ -403,8 +404,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc-resumption
         agents:
-          # Larger argent so it runs faster
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
 
       - id: mysql-rtr
         label: "MySQL RTR tests"
@@ -421,7 +421,8 @@ steps:
     key: postgres-tests
     steps:
       - id: pg-cdc
-        label: "Postgres CDC tests"
+        label: "Postgres CDC tests %N"
+        parallelism: 2
         depends_on: build-aarch64
         timeout_in_minutes: 30
         inputs: [test/pg-cdc]
@@ -550,7 +551,8 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: kafka-rtr
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          # Larger agent to run test faster
+          queue: hetzner-aarch64-8cpu-16gb
 
   - id: zippy-kafka-sources-short
     label: "Short Zippy"
@@ -607,16 +609,6 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: source-sink-errors
-
-  - id: backup-restore
-    label: "CRDB / Persist backup and restore"
-    depends_on: build-aarch64
-    timeout_in_minutes: 30
-    agents:
-      queue: hetzner-aarch64-4cpu-8gb
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: backup-restore
 
   - id: feature-benchmark-kafka-only
     label: "Feature benchmark (Kafka only)"

--- a/test/pg-cdc-old-syntax/mzcompose.py
+++ b/test/pg-cdc-old-syntax/mzcompose.py
@@ -326,14 +326,16 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     if remaining_args:
         workflow_cdc(c, parser)
     else:
+        workflows_with_internal_sharding = ["cdc"]
         # Otherwise we are running all workflows
-        for name in c.workflows:
-            # clear postgres and materialized to avoid issues with special arguments conflicting with existing state
-            c.kill("postgres")
-            c.rm("postgres")
-            c.kill("materialized")
-            c.rm("materialized")
-
+        sharded_workflows = workflows_with_internal_sharding + buildkite.shard_list(
+            [w for w in c.workflows if w not in workflows_with_internal_sharding],
+            lambda w: w,
+        )
+        print(
+            f"Workflows in shard with index {buildkite.get_parallelism_index()}: {sharded_workflows}"
+        )
+        for name in sharded_workflows:
             if name == "default":
                 continue
 
@@ -344,6 +346,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             # TODO: Flaky, reenable when database-issues#8447 is fixed
             if name == "silent-connection-drop":
                 continue
+
+            c.kill("postgres")
+            c.rm("postgres")
+            c.kill("materialized")
+            c.rm("materialized")
 
             with c.test_case(name):
                 c.workflow(name)


### PR DESCRIPTION
Since it was slow and hasn't been failing recently.

I checked all tests that ran >= 19 minutes, the goal is now for every test to be done in 18 min max. (when having to pull dependencies from dockerhub)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
