### PR TITLE
adapter/persist: Make columns of Materialized Views nullable

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -40,8 +40,8 @@ use mz_controller::clusters::{
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::NOW_ZERO;
-use mz_ore::str::StrExt;
 use mz_ore::soft_assert_no_log;
+use mz_ore::str::StrExt;
 use mz_pgrepr::oid::INVALID_OID;
 use mz_repr::adt::mz_acl_item::PrivilegeMap;
 use mz_repr::namespaces::{

--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -75,6 +75,8 @@ impl Transactor {
             mz_txn_wal::all_dyncfgs(client.dyncfgs().clone()),
             Arc::new(TxnMetrics::new(&MetricsRegistry::new())),
             txns_id,
+            Arc::new(StringSchema),
+            Arc::new(UnitSchema),
         )
         .await;
         oracle.apply_write(init_ts.into()).await;

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -367,6 +367,8 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::read::READER_LEASE_DURATION)
         .add(&crate::rpc::PUBSUB_CLIENT_ENABLED)
         .add(&crate::rpc::PUBSUB_PUSH_DIFF_ENABLED)
+        .add(&crate::schema::SCHEMA_REGISTER)
+        .add(&crate::schema::SCHEMA_REQUIRE)
         .add(&crate::stats::STATS_AUDIT_PERCENT)
         .add(&crate::stats::STATS_BUDGET_BYTES)
         .add(&crate::stats::STATS_COLLECTION_ENABLED)

--- a/src/persist-client/src/internal/diff.proto
+++ b/src/persist-client/src/internal/diff.proto
@@ -24,7 +24,8 @@ enum ProtoStateField {
     LEASED_READERS = 2;
     CRITICAL_READERS = 6;
     WRITERS = 3;
-    SCHEMAS = 12;
+    DEPRECATED_SCHEMAS = 12;
+    SCHEMAS = 13;
     SINCE = 4;
     LEGACY_BATCHES = 5;
     HOLLOW_BATCHES = 9;

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -202,11 +202,15 @@ message ProtoRollup {
     map<string, ProtoLeasedReaderState> leased_readers = 8;
     map<string, ProtoCriticalReaderState> critical_readers = 13;
     map<string, ProtoWriterState> writers = 9;
-    map<uint64, ProtoEncodedSchemas> schemas = 18;
+    map<uint64, ProtoEncodedSchemas> schemas = 19;
 
     ProtoInlinedDiffs diffs = 17;
 
     // MIGRATION: We previously stored rollups as a `SeqNo -> string Key` map,
     // but now the value is a `struct HollowRollup`.
     map<uint64, string> deprecated_rollups = 12;
+    // MIGRATION: We previously registered schemas that have since changed
+    // nullability. We've made changes to stabilize the schemas and are just
+    // forgetting all of the old values.
+    map<uint64, ProtoEncodedSchemas> deprecated_schemas = 18;
 }

--- a/src/persist-client/src/schema.rs
+++ b/src/persist-client/src/schema.rs
@@ -16,6 +16,7 @@ use std::time::Instant;
 
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
+use mz_dyncfg::Config;
 use mz_ore::cast::CastFrom;
 use mz_persist_types::columnar::data_type;
 use mz_persist_types::schema::{backward_compatible, Migration, SchemaId};
@@ -401,6 +402,18 @@ impl<K: Codec, V: Codec> PartMigration<K, V> {
         }
     }
 }
+
+pub(crate) const SCHEMA_REGISTER: Config<bool> = Config::new(
+    "persist_schema_register",
+    true,
+    "register schemas with the shard when opening a read or write handle",
+);
+
+pub(crate) const SCHEMA_REQUIRE: Config<bool> = Config::new(
+    "persist_schema_require",
+    true,
+    "error if schema registration is unsuccessful when opening a read or write handle",
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/persist-client/tests/machine/regression_listen_compaction
+++ b/src/persist-client/tests/machine/regression_listen_compaction
@@ -11,6 +11,12 @@
 # Listen would emit a batch, then the batch would get compacted, then the Listen
 # would emit the entire merged batch, which double emitted the first batch.
 
+# Enable schema registry so the seqnos are stable
+dyncfg
+persist_schema_register true
+----
+ok
+
 # Write a batch and emit it from a Listen
 write-batch output=b0 lower=0 upper=2
 one 1 1

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -103,6 +103,12 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                 },
                 {
                     let mut x = ::mz_dyncfg::ConfigUpdates::default();
+                    x.add_dynamic("persist_schema_register", ::mz_dyncfg::ConfigVal::Bool(true));
+                    x.add_dynamic("persist_schema_require", ::mz_dyncfg::ConfigVal::Bool(true));
+                    x
+                },
+                {
+                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
                     x.add_dynamic("persist_batch_columnar_format", ::mz_dyncfg::ConfigVal::String("both_v2".into()));
                     x.add_dynamic("persist_batch_columnar_format_percent", ::mz_dyncfg::ConfigVal::Usize(100));
                     x.add_dynamic("persist_part_decode_format", ::mz_dyncfg::ConfigVal::String("arrow".into()));

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -189,7 +189,7 @@ pub enum Response<T> {
 }
 
 /// Metadata that the storage controller must know to properly handle the life
-/// cycle of creating and dropping collections.j
+/// cycle of creating and dropping collections.
 ///
 /// This data should be kept consistent with the state modified using
 /// [`StorageTxn`].

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -440,6 +440,8 @@ where
                 txns_client.dyncfgs().clone(),
                 Arc::clone(&txns_metrics),
                 txns_id,
+                Arc::new(RelationDesc::empty()),
+                Arc::new(UnitSchema),
             )
             .await;
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2198,6 +2198,8 @@ where
                 txns_client.dyncfgs().clone(),
                 Arc::clone(&txns_metrics),
                 txns_id,
+                Arc::new(RelationDesc::empty()),
+                Arc::new(UnitSchema),
             )
             .await;
             persist_handles::PersistTableWriteWorker::new_txns(txns)

--- a/src/txn-wal/src/lib.rs
+++ b/src/txn-wal/src/lib.rs
@@ -127,7 +127,7 @@
 //! // Open a txn shard, initializing it if necessary.
 //! let txns_id = ShardId::new();
 //! let mut txns = TxnsHandle::<String, (), u64, i64>::open(
-//!     0u64, client.clone(), dyncfgs, metrics, txns_id
+//!     0u64, client.clone(), dyncfgs, metrics, txns_id, StringSchema.into(), UnitSchema.into()
 //! ).await;
 //!
 //! // Register data shards to the txn set.

--- a/src/txn-wal/src/txns.rs
+++ b/src/txn-wal/src/txns.rs
@@ -136,6 +136,11 @@ where
         dyncfgs: ConfigSet,
         metrics: Arc<Metrics>,
         txns_id: ShardId,
+        // TODO(txn): Get rid of these once the persist schema stuff finishes
+        // rolling out. Once every shard in prod has a schema, we can look up
+        // the latest one instead of falling back to these.
+        key_schema: Arc<K::Schema>,
+        val_schema: Arc<V::Schema>,
     ) -> Self {
         let (txns_key_schema, txns_val_schema) = C::schemas();
         let (mut txns_write, txns_read) = client
@@ -175,6 +180,8 @@ where
                 client: Arc::new(client),
                 data_write_for_apply: BTreeMap::new(),
                 data_write_for_commit: BTreeMap::new(),
+                key_schema,
+                val_schema,
             },
         }
     }
@@ -700,6 +707,8 @@ pub(crate) struct DataHandles<K: Codec, V: Codec, T, D> {
     /// of shards, but this is not required. A shard can be in either and not
     /// the other.
     data_write_for_commit: BTreeMap<ShardId, DataWriteCommit<K, V, T, D>>,
+    key_schema: Arc<K::Schema>,
+    val_schema: Arc<V::Schema>,
 }
 
 impl<K, V, T, D> DataHandles<K, V, T, D>
@@ -718,13 +727,10 @@ where
             .expect("codecs have not changed");
         let (key_schema, val_schema) = match schemas {
             Some((_, key_schema, val_schema)) => (Arc::new(key_schema), Arc::new(val_schema)),
-            // - For new shards we will always have at least one schema
-            //   registered by the time we reach this point, because that
-            //   happens at txn-registration time.
-            // - For pre-existing shards, every txns shard will have had
-            //   open_writer called on it at least once in the previous release,
-            //   so the schema should exist.
-            None => unreachable!("data shard {} should have a schema", data_id),
+            None => {
+                tracing::warn!("falling back to default schemas for {}", data_id);
+                (Arc::clone(&self.key_schema), Arc::clone(&self.val_schema))
+            }
         };
         let wrapped = self
             .client
@@ -912,6 +918,7 @@ mod tests {
     use mz_persist_client::cache::PersistClientCache;
     use mz_persist_client::cfg::RetryParameters;
     use mz_persist_client::PersistLocation;
+    use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
     use rand::rngs::SmallRng;
     use rand::{RngCore, SeedableRng};
     use timely::progress::Antichain;
@@ -936,6 +943,8 @@ mod tests {
                 dyncfgs,
                 Arc::new(Metrics::new(&MetricsRegistry::new())),
                 txns_id,
+                Arc::new(StringSchema),
+                Arc::new(UnitSchema),
             )
             .await
         }


### PR DESCRIPTION
This PR should allow us to use Persist's `compare_and_evolve_schema`, it does a few things:

1. Makes all columns of a Materialized View nullable, except those annotated with an `ASSERT NOT NULL`. This fixes a bug we saw previously where across an upgrade of Materialize columns could change their nullability.
2. Renamed the existing `schemas` field in Persist State to `deprecated_schemas` and added a new `schemas` field. This should cause us to ignore all of the existing schemas which have incorrect nullability and register new ones.
3. Updated the Catalog upgrade-check to now also check that the newly parsed items have the same schemas that we have in Persist. This should allow us to catch issues like https://github.com/MaterializeInc/incidents-and-escalations/issues/117 before the new version rolls out.
4. Added a `proptest` to make sure these new nullable schemas can still read any structured non-nullable data that has already been written.
5. Re-added the 'persist_schema_register' and 'persist_schema_require' dyncfgs since we're essentially re-starting the process.

Notably what this PR doesn't do but we talked about previously is also making all of the columns in a Table nullable, because AFAICT that is already the [existing behavior](https://github.com/MaterializeInc/materialize/blob/e47f5d2f5a1328ad6577e83c6a387550bca377ab/src/sql/src/plan/statement/ddl.rs#L268-L290). In planning we mark all of the columns nullable, unless they're annotated with `NOT NULL` or `PRIMARY KEY`, which seems like exactly our desired end state.

**Rollout**: Because we're essentially adding a new field I believe we'll need to turn ~~both~~ `persist_schema_register` ~~and `persist_schema_require`~~ off. When 0.119.0 finishes rolling out we can turn `persist_schema_register` on, and then in 0.120.0 we're guaranteed to have all schemas registered for all shards again, ~~at which point we can turn `persist_schema_require` back on~~. I might be misunderstanding the flow of how schemas get registered though, so @danhhz I would appreciate your thoughts here.
Update: Chatted with Dan an we shouldn't need to touch `persist_schema_require`.

### Motivation

Fixes https://github.com/MaterializeInc/incidents-and-escalations/issues/117

### Tips for reviewers

Everything is separated by commit, so you should be able to review the changes independently. 

For commit 2 where I added the 'deprecated_schemas' field, I would appreciate the most thorough review here. I essentially just added the new field where `rustc` told me to, and I think it's all correct but I'm not totally positive.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
