### PR TITLE
bazel: use minimum sysroot for macOS

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -171,14 +171,14 @@ filegroup(
 
 DARWIN_SYSROOT_VERSION = "14.5"
 
-DARWIN_SYSROOT_INTEGRITY = "sha256-k8OxF+DSVq0L1dy1S9TPqhFxDHF/bT32Ust3a1ldat8="
+DARWIN_SYSROOT_INTEGRITY = "sha256-JCleYWOca1Z/B4Li1iwDKGEP/IkWWgKqXoygtJXyNTU="
 
 http_archive(
     name = "sysroot_darwin_universal",
     build_file_content = _SYSROOT_DARWIN_BUILD_FILE,
     integrity = DARWIN_SYSROOT_INTEGRITY,
-    strip_prefix = "MacOSX{0}.sdk".format(DARWIN_SYSROOT_VERSION),
-    urls = ["https://github.com/MaterializeInc/toolchains/releases/download/macos-sysroot-sdk-{0}/MacOSX{0}.sdk.tar.zst".format(DARWIN_SYSROOT_VERSION)],
+    strip_prefix = "MacOSX{0}.sdk-min".format(DARWIN_SYSROOT_VERSION),
+    urls = ["https://github.com/MaterializeInc/toolchains/releases/download/macos-sysroot-sdk-{0}-1/MacOSX{0}.sdk-min.tar.zst".format(DARWIN_SYSROOT_VERSION)],
 )
 
 _LINUX_SYSROOT_BUILD_FILE = """


### PR DESCRIPTION
Adds a new sysroot for macOS Bazel builds. The new sysroot is the minimum required set of files necessary to build Materialize and greatly improves sandbox performance by reducing the number of files in the sysroot from ~40,000 to ~4,000, and thus the number of symlinks Bazel needs to create.

Note: the new `-min` sysroot is still created by our toolchains repo, it was added in https://github.com/MaterializeInc/toolchains/commit/4e085a332a4b2efc8042257fbffe1e8d208ddb7f.

### Motivation

Improve the performance of Bazel builds on macOS

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
