### PR TITLE
mzcompose: Only bind to localhost

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -88,7 +88,7 @@ operations on macOS.)
 On Linux, we recommend using Docker:
 
 ```shell
-docker run --name=cockroach -d -p 26257:26257 -p 26258:8080 cockroachdb/cockroach:v23.1.11 start-single-node --insecure
+docker run --name=cockroach -d -p 127.0.0.1:26257:26257 -p 127.0.0.1:26258:8080 cockroachdb/cockroach:v23.1.11 start-single-node --insecure
 ```
 
 If you can successfully connect to CockroachDB with either

--- a/doc/user/content/get-started/install-materialize-emulator.md
+++ b/doc/user/content/get-started/install-materialize-emulator.md
@@ -62,7 +62,7 @@ not suitable for production deployments</redb>.
    been already downloaded.
 
    ```sh
-   docker run -d -p 6875:6875 -p 6876:6876 materialize/materialized:{{< version >}}
+   docker run -d -p 127.0.0.1:6875:6875 -p 127.0.0.1:6876:6876 materialize/materialized:{{< version >}}
    ```
 
    When running locally:

--- a/doc/user/content/get-started/install-materialize-emulator.md
+++ b/doc/user/content/get-started/install-materialize-emulator.md
@@ -14,8 +14,7 @@ for testing and evaluation purposes. The Materialize Emulator is not
 representative of Materialize's performance and full feature set. To evaluate
 Materialize for production scenarios, sign up for a [free trial
 account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation)
-or [schedule a
-demo](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+or [schedule a demo](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
 
 {{< warning >}}
 
@@ -49,11 +48,9 @@ not suitable for production deployments</redb>.
 
 {{< note >}}
 
-- Use of the Docker image is subject to Materialize's [BSL
-   License](https://github.com/MaterializeInc/materialize/blob/main/LICENSE).
+- Use of the Docker image is subject to Materialize's [BSL License](https://github.com/MaterializeInc/materialize/blob/main/LICENSE).
 
-- By downloading the Docker image, you are agreeing to Materialize's [privacy
-   policy](https://materialize.com/privacy-policy/).
+- By downloading the Docker image, you are agreeing to Materialize's [privacy policy](https://materialize.com/privacy-policy/).
 
 {{</ note >}}
 
@@ -67,6 +64,7 @@ not suitable for production deployments</redb>.
 
    When running locally:
 
+   - The Docker container binds exclusively to localhost, for security reasons.
    - The SQL interface is available on port `6875`.
    - Logs are available via `docker logs <container-id>`.
    - A default user `materialize` is created.
@@ -93,16 +91,14 @@ not suitable for production deployments</redb>.
 
 ### Next steps
 
-- To start ingesting your own data from an external system like Kafka MySQL or
+- To start ingesting your own data from an external system like Kafka, MySQL or
   PostgreSQL, check the documentation for [sources](/sql/create-source/).
 
-- Join the [Materialize Community on
-  Slack](https://materialize.com/s/chat).
+- Join the [Materialize Community on Slack](https://materialize.com/s/chat).
 
 - To more fully evaluate Materialize and its features, sign up for a [free trial
   account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation)
-  or [schedule a
-  demo](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+  or [schedule a demo](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
 
 ### Technical Support
 

--- a/misc/images/materialized/README.md
+++ b/misc/images/materialized/README.md
@@ -20,7 +20,7 @@ To launch the Docker container:
 
 ```
 docker pull materialize/materialized:latest
-docker run -d -p 6875:6875 -p 6876:6876 materialize/materialized:latest
+docker run -d -p 127.0.0.1:6875:6875 -p 127.0.0.1:6876:6876 materialize/materialized:latest
 ```
 
 After running this command...

--- a/misc/python/materialize/mzcompose/service.py
+++ b/misc/python/materialize/mzcompose/service.py
@@ -77,7 +77,7 @@ class ServiceConfig(TypedDict, total=False):
     host user.
 
     This is an mzcompose extension to Docker Compose. It is equivalent to
-    passing `--user $(id -u):$(id -g)` to `docker run`. The defualt is `False`.
+    passing `--user $(id -u):$(id -g)` to `docker run`. The default is `False`.
     """
 
     allow_host_ports: bool

--- a/test/cluster/README.md
+++ b/test/cluster/README.md
@@ -29,19 +29,19 @@ dataflow`).
 On `dataflow1`, run:
 
 ```
-docker run -p 2101:2101 -p 6876:6876 materialize/dataflowd:latest --workers 2 --process 0 0.0.0.0:2101 dataflow2:2101
+docker run -p 127.0.0.1:2101:2101 -p 127.0.0.1:6876:6876 materialize/dataflowd:latest --workers 2 --process 0 0.0.0.0:2101 dataflow2:2101
 ```
 
 On `dataflow2`, run:
 
 ```
-docker run -p 2101:2101 -p 6876:6876 materialize/dataflowd:latest --workers 2 --process 1 dataflow1:2101 0.0.0.0:2101
+docker run -p 127.0.0.1:2101:2101 -p 127.0.0.1:6876:6876 materialize/dataflowd:latest --workers 2 --process 1 dataflow1:2101 0.0.0.0:2101
 ```
 
 On `coord`, run:
 
 ```
-docker run -v /mzdata -p 6875:6875 materialize/coordd:latest dataflow1:6876 dataflow2:6876
+docker run -v /mzdata -p 127.0.0.1:6875:6875 materialize/coordd:latest dataflow1:6876 dataflow2:6876
 ```
 
 Then connect to the coordinator via psql:
@@ -57,7 +57,7 @@ cluster with *N* dataflow nodes and *W* worker threads per node. To launch
 the *I*th dataflow node, run:
 
 ```
-docker run -p 2101:2101 -p 6876:6876 materialize/dataflowd:latest \
+docker run -p 127.0.0.1:2101:2101 -p 127.0.0.1:6876:6876 materialize/dataflowd:latest \
     --workers <W> \
     --process <I> \
     --hosts dataflow1:2101 ... 0.0.0.0:2101 ... dataflow<N>:2101
@@ -66,7 +66,7 @@ docker run -p 2101:2101 -p 6876:6876 materialize/dataflowd:latest \
 To launch the coordinator:
 
 ```
-docker run -p 6875:6875 materialize/coordd:latest \
+docker run -p 127.0.0.1:6875:6875 materialize/coordd:latest \
     --dataflowd-addr dataflow1:2101 dataflow2:2101 ... dataflow<N>:2101
 ```
 


### PR DESCRIPTION
By default docker's port bindings will bind to all available network addresses (0.0.0.0). If you are running insecure services (as we are in testing) and there is no firewall in front of it, anyone can connect to those services. This does not affect our CI since we are blocking incoming connections there anyway, but can be relevant when you run tests locally.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
