### PR TITLE
ci: Work around release qualification errors

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -91,7 +91,8 @@ steps:
         - ./ci/plugins/mzcompose:
             composition: zippy
             # Runs into upload size limits of Buildkite
-            args: [--scenario=PostgresCdcLarge, --actions=100000]
+            # Runs into slowness with new source syntax after a while
+            args: [--scenario=PostgresCdcLarge, --actions=50000]
 
     - id: zippy-mysql-cdc-large
       label: "Large Zippy MySqlCdc"
@@ -262,8 +263,9 @@ steps:
         agents:
           # no matching manifest of MySQL 5.7.x for linux/arm64/v8 in the manifest list entries
           # TODO(def-) Switch back to Hetzner when we have increased server limit
-          queue: linux-x86_64-small
-          # queue: hetzner-x86-64-4cpu-8gb
+          # Increased memory usage following new source syntax
+          queue: linux-x86_64
+          # queue: hetzner-x86-64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/release-qualification/builds/618
Triggered a run for verification: https://buildkite.com/materialize/release-qualification/builds/619
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
