### PR TITLE
[persist] ProtoArrayData optimization - part two

### DIFF
--- a/src/persist-types/src/arrow.rs
+++ b/src/persist-types/src/arrow.rs
@@ -97,8 +97,7 @@ fn into_proto_with_type(data: &ArrayData, expected_type: Option<&DataType>) -> P
                 data.data_type(),
                 "actual type should match expected type"
             );
-            // TODO(bkirwi): return None here in a future release, assuming the types match
-            Some(expected.into_proto())
+            None
         }
         None => Some(data.data_type().into_proto()),
     };


### PR DESCRIPTION
### Motivation

Part 2 of #29457 - now that all released versions can handle proto with type info only at the top level, write it in the more compact form.

### Tips for reviewer

The upgrade tests are important here - I'll get nightlies going.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
