### PR TITLE
Update contribution guidelines to point to GH discussions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in Materialize! Contributions of many kinds are encouraged and most welcome.
 
-If you have questions, please [create a Github issue](https://github.com/MaterializeInc/materialize/issues/new/choose).
+If you have questions, please [create a Github discussion](https://github.com/MaterializeInc/materialize/discussions/new/choose).
 
 ## Getting started
 
@@ -16,19 +16,18 @@ our development process is available in the [doc/developer](doc/developer) folde
 Materialize is written entirely in Rust. Rust API documentation is hosted at
 <https://dev.materialize.com/api/rust/>.
 
-Prospective code contributors might find the [good for external contributors tag](https://github.com/MaterializeInc/materialize/issues?q=is%3Aopen+is%3Aissue+label%3A%22D-good+for+external+contributors%22+) useful.
+If you're interested in contributing to Materialize, please [create a Github
+discussion](https://github.com/MaterializeInc/materialize/discussions/new/choose)
+describing the work you're planning to pick up.
 
-It's a good idea to comment on any GitHub issue you're planning to pick up to
-let folks know. That way, you can get proactive advice and speedier reviews.
-
-If you start work on the issue before hearing back from a Materialize engineer,
-there is a risk that we may not be able to accept your changes. The team may not
-have bandwidth to review your changes, or the code in question may require
-specialized knowledge to modify without introducing bugs. When in doubt, wait
-for a Materialize engineer to respond before starting work!
+If you start working on a contribution before hearing back from a Materialize
+engineer, there is a risk that we may not be able to accept your changes. The
+team may not have bandwidth to review your changes, or the code in question may
+require specialized knowledge to modify without introducing bugs. When in
+doubt, wait for a Materialize engineer to respond before starting work!
 
 Bug reports are welcome, and the most effective way to report a bug is to [file
-an issue](https://github.com/MaterializeInc/materialize/issues/new/choose). As
+a discussion](https://github.com/MaterializeInc/materialize/discussions/new?category=bug-reports). As
 Materialize is under rapid development, it is helpful if you report the version
 of Materialize that you are using, and if it a crash report, the stack trace.
 


### PR DESCRIPTION
We missed updating our contribution guide after migrating the issues to a private repository. A user was misled by the contribution guide [here](https://github.com/MaterializeInc/materialize/discussions/29786), so updating it to point to GH discussions instead.

@chaas, not sure it makes much sense to encourage contributions (other than bug reports) now that we don't have "good first issues", but maybe you have some more context for future plans that I'm missing.