### PR TITLE
Update CONTRIBUTING.md to reference the new Contribute to Materialize GH discussion category

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,9 @@ Materialize is written entirely in Rust. Rust API documentation is hosted at
 <https://dev.materialize.com/api/rust/>.
 
 If you're interested in contributing to Materialize, please [create a Github
-discussion](https://github.com/MaterializeInc/materialize/discussions/new/choose)
-describing the work you're planning to pick up.
+discussion](https://github.com/MaterializeInc/materialize/discussions/new?category=contribute-to-materialize)
+describing the work you're planning to pick up. Prospective code contributors might
+find the [good for external contributors tag](https://github.com/MaterializeInc/materialize/discussions/categories/contribute-to-materialize?discussions_q=is%3Aopen+category%3A%22Contribute+to+Materialize%22+label%3A%22D-good+for+external+contributors%22) useful.
 
 If you start working on a contribution before hearing back from a Materialize
 engineer, there is a risk that we may not be able to accept your changes. The

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Materialize is written entirely in Rust. Rust API documentation is hosted at
 If you're interested in contributing to Materialize, please [create a Github
 discussion](https://github.com/MaterializeInc/materialize/discussions/new?category=contribute-to-materialize)
 describing the work you're planning to pick up. Prospective code contributors might
-find the [good for external contributors tag](https://github.com/MaterializeInc/materialize/discussions/categories/contribute-to-materialize?discussions_q=is%3Aopen+category%3A%22Contribute+to+Materialize%22+label%3A%22D-good+for+external+contributors%22) useful.
+find the [`D-good for external contributors` tag](https://github.com/MaterializeInc/materialize/discussions/categories/contribute-to-materialize?discussions_q=is%3Aopen+category%3A%22Contribute+to+Materialize%22+label%3A%22D-good+for+external+contributors%22) useful.
 
 If you start working on a contribution before hearing back from a Materialize
 engineer, there is a risk that we may not be able to accept your changes. The


### PR DESCRIPTION
See the category here: https://github.com/MaterializeInc/materialize/discussions/categories/contribute-to-materialize

Part of the migration to github discussions for external tracking.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
