### PR TITLE
storage/adapter: Truncate mz_cluster_replica_status_history via retention window instead of last n entries

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -53,7 +53,7 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
         keep_n_sink_status_history_entries: config.keep_n_sink_status_history_entries(),
         keep_n_privatelink_status_history_entries: config
             .keep_n_privatelink_status_history_entries(),
-        keep_n_replica_status_history_entries: config.keep_n_replica_status_history_entries(),
+        replica_status_history_retention_window: config.replica_status_history_retention_window(),
         upsert_rocksdb_tuning_config: {
             match mz_rocksdb_types::RocksDBTuningParameters::from_parameters(
                 config.upsert_rocksdb_compaction_style(),

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1243,7 +1243,7 @@ impl SystemVars {
             &KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES,
             &KEEP_N_SINK_STATUS_HISTORY_ENTRIES,
             &KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES,
-            &KEEP_N_REPLICA_STATUS_HISTORY_ENTRIES,
+            &REPLICA_STATUS_HISTORY_RETENTION_WINDOW,
             &ARRANGEMENT_EXERT_PROPORTIONALITY,
             &ENABLE_STORAGE_SHARD_FINALIZATION,
             &ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE,
@@ -2038,8 +2038,8 @@ impl SystemVars {
         *self.expect_value(&KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES)
     }
 
-    pub fn keep_n_replica_status_history_entries(&self) -> usize {
-        *self.expect_value(&KEEP_N_REPLICA_STATUS_HISTORY_ENTRIES)
+    pub fn replica_status_history_retention_window(&self) -> Duration {
+        *self.expect_value(&REPLICA_STATUS_HISTORY_RETENTION_WINDOW)
     }
 
     /// Returns the `arrangement_exert_proportionality` configuration parameter.

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -26,6 +26,7 @@ use mz_repr::bytes::ByteSize;
 use mz_repr::optimize::OptimizerFeatures;
 use mz_sql_parser::ast::Ident;
 use mz_sql_parser::ident;
+use mz_storage_types::parameters::REPLICA_STATUS_HISTORY_RETENTION_WINDOW_DEFAULT;
 use mz_storage_types::parameters::{
     DEFAULT_PG_SOURCE_CONNECT_TIMEOUT, DEFAULT_PG_SOURCE_TCP_CONFIGURE_SERVER,
     DEFAULT_PG_SOURCE_TCP_KEEPALIVES_IDLE, DEFAULT_PG_SOURCE_TCP_KEEPALIVES_INTERVAL,
@@ -1436,11 +1437,11 @@ pub static KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES: VarDefinition = VarDefinit
     false,
 );
 
-/// Controls [`mz_storage_types::parameters::StorageParameters::keep_n_replica_status_history_entries`].
-pub static KEEP_N_REPLICA_STATUS_HISTORY_ENTRIES: VarDefinition = VarDefinition::new(
-    "keep_n_replica_status_history_entries",
-    value!(usize; 5),
-    "On reboot, truncate all but the last n entries per ID in the mz_cluster_replica_status_history \
+/// Controls [`mz_storage_types::parameters::StorageParameters::replica_status_history_retention_window`].
+pub static REPLICA_STATUS_HISTORY_RETENTION_WINDOW: VarDefinition = VarDefinition::new(
+    "replica_status_history_retention_window",
+    value!(Duration; REPLICA_STATUS_HISTORY_RETENTION_WINDOW_DEFAULT),
+    "On reboot, truncate up all entries past the retention window in the mz_cluster_replica_status_history \
         collection (Materialize).",
     false,
 );

--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -107,7 +107,7 @@ use tracing::{debug, error, info};
 use crate::{
     collection_mgmt, collection_status, privatelink_status_history_desc,
     replica_status_history_desc, snapshot, snapshot_statistics, statistics, StatusHistoryDesc,
-    StorageError,
+    StatusHistoryRetentionPolicy, StorageError,
 };
 
 // Default rate at which we advance the uppers of managed collections.
@@ -1246,6 +1246,7 @@ async fn prepare_append_only_introspection_collection<T>(
                 IntrospectionType::PrivatelinkConnectionStatusHistory,
                 write_handle,
                 privatelink_status_history_desc(&parameters),
+                now.clone(),
                 &storage_collections,
                 &txns_read,
                 &persist,
@@ -1258,6 +1259,7 @@ async fn prepare_append_only_introspection_collection<T>(
                 IntrospectionType::ReplicaStatusHistory,
                 write_handle,
                 replica_status_history_desc(&parameters),
+                now.clone(),
                 &storage_collections,
                 &txns_read,
                 &persist,
@@ -1386,8 +1388,7 @@ where
         .map_err(|e| anyhow!("appending retractions: {e:?}"))
 }
 
-/// Effectively truncates the status history shard except for the most
-/// recent updates from each key.
+/// Effectively truncates the status history shard based on its retention policy.
 ///
 /// NOTE: The history collections are really append-only collections, but
 /// every-now-and-then we want to retract old updates so that the collection
@@ -1401,6 +1402,7 @@ pub(crate) async fn partially_truncate_status_history<T, K>(
     introspection_type: IntrospectionType,
     write_handle: &mut WriteHandle<SourceData, (), T, Diff>,
     status_history_desc: StatusHistoryDesc<K>,
+    now: NowFn,
     storage_collections: &Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
     txns_read: &TxnsRead<T>,
     persist: &Arc<PersistClientCache>,
@@ -1424,12 +1426,6 @@ where
         _ => return BTreeMap::new(),
     };
 
-    // BTreeMap to track the earliest events for each key.
-    let mut last_n_entries_per_key: BTreeMap<
-        K,
-        BinaryHeap<Reverse<(CheckedTimestamp<DateTime<Utc>>, Row)>>,
-    > = BTreeMap::new();
-
     // BTreeMap to keep track of the row with the latest timestamp for each key.
     let mut latest_row_per_key: BTreeMap<K, (CheckedTimestamp<DateTime<Utc>>, Row)> =
         BTreeMap::new();
@@ -1439,46 +1435,77 @@ where
 
     let mut deletions = vec![];
 
-    for (row, diff) in rows {
-        let datums = row.unpack();
-        let key = (status_history_desc.extract_key)(&datums);
-        let timestamp = (status_history_desc.extract_time)(&datums);
+    let mut handle_row = {
+        let latest_row_per_key = &mut latest_row_per_key;
+        move |row: &Row, diff| {
+            let datums = row.unpack();
+            let key = (status_history_desc.extract_key)(&datums);
+            let timestamp = (status_history_desc.extract_time)(&datums);
 
-        // Duplicate rows ARE possible if many status changes happen in VERY quick succession,
-        // so we go ahead and handle them.
-        assert!(
-            diff > 0,
-            "only know how to operate over consolidated data with diffs > 0, \
-                found diff {diff} for object {key:?} in {introspection_type:?}",
-        );
+            assert!(
+                diff > 0,
+                "only know how to operate over consolidated data with diffs > 0, \
+                    found diff {diff} for object {key:?} in {introspection_type:?}",
+            );
 
-        // Keep track of the timestamp of the latest row per key.
-        match latest_row_per_key.get(&key) {
-            Some(existing) if &existing.0 > &timestamp => {}
-            _ => {
-                latest_row_per_key.insert(key.clone(), (timestamp, row.clone()));
+            // Keep track of the timestamp of the latest row per key.
+            match latest_row_per_key.get(&key) {
+                Some(existing) if &existing.0 > &timestamp => {}
+                _ => {
+                    latest_row_per_key.insert(key.clone(), (timestamp, row.clone()));
+                }
+            };
+            (key, timestamp)
+        }
+    };
+
+    match status_history_desc.retention_policy {
+        StatusHistoryRetentionPolicy::LastN(n) => {
+            // BTreeMap to track the earliest events for each key.
+            let mut last_n_entries_per_key: BTreeMap<
+                K,
+                BinaryHeap<Reverse<(CheckedTimestamp<DateTime<Utc>>, Row)>>,
+            > = BTreeMap::new();
+
+            for (row, diff) in rows {
+                let (key, timestamp) = handle_row(&row, diff);
+
+                // Duplicate rows ARE possible if many status changes happen in VERY quick succession,
+                // so we handle duplicated rows separately.
+                let entries = last_n_entries_per_key.entry(key).or_default();
+                for _ in 0..diff {
+                    // We CAN have multiple statuses (most likely Starting and Running) at the exact same
+                    // millisecond, depending on how the `health_operator` is scheduled.
+                    //
+                    // Note that these will be arbitrarily ordered, so a Starting event might
+                    // survive and a Running one won't. The next restart will remove the other,
+                    // so we don't bother being careful about it.
+                    //
+                    // TODO(guswynn): unpack these into health-status objects and use
+                    // their `Ord` impl.
+                    entries.push(Reverse((timestamp, row.clone())));
+
+                    // Retain some number of entries, using pop to mark the oldest entries for
+                    // deletion.
+                    while entries.len() > n {
+                        if let Some(Reverse((_, r))) = entries.pop() {
+                            deletions.push(r);
+                        }
+                    }
+                }
             }
         }
+        StatusHistoryRetentionPolicy::TimeWindow(time_window) => {
+            // Get the lower bound of our retention window
+            let now = mz_ore::now::to_datetime(now());
+            let keep_since = now - time_window;
 
-        // Consider duplicated rows separately.
-        let entries = last_n_entries_per_key.entry(key).or_default();
-        for _ in 0..diff {
-            // We CAN have multiple statuses (most likely Starting and Running) at the exact same
-            // millisecond, depending on how the `health_operator` is scheduled.
-            //
-            // Note that these will be arbitrarily ordered, so a Starting event might
-            // survive and a Running one won't. The next restart will remove the other,
-            // so we don't bother being careful about it.
-            //
-            // TODO(guswynn): unpack these into health-status objects and use
-            // their `Ord` impl.
-            entries.push(Reverse((timestamp, row.clone())));
+            // Mark any row outside the retention window for deletion
+            for (row, diff) in rows {
+                let (_, timestamp) = handle_row(&row, diff);
 
-            // Retain some number of entries, using pop to mark the oldest entries for
-            // deletion.
-            while entries.len() > status_history_desc.keep_n {
-                if let Some(Reverse((_, r))) = entries.pop() {
-                    deletions.push(r);
+                if *timestamp < keep_since {
+                    deletions.push(row);
                 }
             }
         }
@@ -1512,7 +1539,7 @@ where
         }
         Err(err) => {
             // This is fine, it just means the upper moved because
-            // of continual upper advancement or because seomeone
+            // of continual upper advancement or because someone
             // already appended some more retractions/updates.
             //
             // NOTE: We might want to attempt these partial

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -18,7 +18,7 @@ import "service/src/params.proto";
 package mz_storage_types.parameters;
 
 message ProtoStorageParameters {
-    reserved 1, 2, 3, 25, 12, 16, 26, 31;
+    reserved 1, 2, 3, 25, 12, 16, 26, 31, 39;
     uint64 keep_n_source_status_history_entries = 4;
     mz_rocksdb_types.config.ProtoRocksDbTuningParameters upsert_rocksdb_tuning_config = 5;
     bool finalize_shards = 6;
@@ -46,7 +46,7 @@ message ProtoStorageParameters {
     optional mz_proto.ProtoDuration pg_source_tcp_keepalives_interval = 36;
     optional mz_proto.ProtoDuration pg_source_tcp_user_timeout = 37;
     bool pg_source_tcp_configure_server = 38;
-    uint64 keep_n_replica_status_history_entries = 39;
+    mz_proto.ProtoDuration replica_status_history_retention_window = 40;
 
     mz_dyncfg.ConfigUpdates dyncfg_updates = 30;
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->
- Extends `partially_truncate_status_history` to truncate via a retention window config variable instead of a `..._last_n` config variable. 


### Motivation
  * This PR fixes a recognized bug.
Fixes [#8596](https://github.com/MaterializeInc/database-issues/issues/8596)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))

Wasn't too sure how to create a test for this since it requires a restart of envd _I think_. I was considering something similar to [the test we use for cluster_replica_metrics](https://github.com/MaterializeInc/materialize/blob/main/src/environmentd/tests/sql.rs#L1383) but I saw it's flakey. Is there a way to create one via `testdrive`?

Here's how I manually tested it:

1. Boot up envd locally as `mz_system` and make sure `mz_cluster_replica_status_history` as entries older than a minute via `select * from mz_internal.mz_cluster_replica_status_history WHERE replica_id='u1'ORDER BY occurred_at;`. `u1` is the quickstart replica

2. change the retention window to 20 seconds via `ALTER SYSTEM SET replica_status_history_retention_window = '20s';` 

3. Kill the local instance then boot it up without restarting. Run the command from 1. to see if the truncation worked.

- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.