### PR TITLE
give mz_analytics select access to a few more builtin views

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -1746,6 +1746,12 @@ const SUPPORT_SELECT: MzAclItem = MzAclItem {
     acl_mode: AclMode::SELECT,
 };
 
+const ANALYTICS_SELECT: MzAclItem = MzAclItem {
+    grantee: MZ_ANALYTICS_ROLE_ID,
+    grantor: MZ_SYSTEM_ROLE_ID,
+    acl_mode: AclMode::SELECT,
+};
+
 const MONITOR_SELECT: MzAclItem = MzAclItem {
     grantee: MZ_MONITOR_ROLE_ID,
     grantor: MZ_SYSTEM_ROLE_ID,
@@ -2912,7 +2918,7 @@ cluster_name, database_name, search_path, transaction_isolation, execution_times
 transient_index_id, mz_version, began_at, finished_at, finished_status,
 rows_returned, execution_strategy
 FROM mz_internal.mz_statement_execution_history",
-    access: vec![SUPPORT_SELECT, MONITOR_REDACTED_SELECT, MONITOR_SELECT],
+    access: vec![SUPPORT_SELECT, ANALYTICS_SELECT, MONITOR_REDACTED_SELECT, MONITOR_SELECT],
 }
 });
 
@@ -2943,7 +2949,12 @@ pub static MZ_SQL_TEXT_REDACTED: LazyLock<BuiltinView> = LazyLock::new(|| Builti
     oid: oid::VIEW_MZ_SQL_TEXT_REDACTED_OID,
     column_defs: None,
     sql: "SELECT sql_hash, redacted_sql FROM mz_internal.mz_sql_text",
-    access: vec![MONITOR_SELECT, MONITOR_REDACTED_SELECT, SUPPORT_SELECT],
+    access: vec![
+        MONITOR_SELECT,
+        MONITOR_REDACTED_SELECT,
+        SUPPORT_SELECT,
+        ANALYTICS_SELECT,
+    ],
 });
 
 pub static MZ_RECENT_SQL_TEXT: LazyLock<BuiltinView> = LazyLock::new(|| {
@@ -2967,7 +2978,12 @@ pub static MZ_RECENT_SQL_TEXT_REDACTED: LazyLock<BuiltinView> = LazyLock::new(||
     oid: oid::VIEW_MZ_RECENT_SQL_TEXT_REDACTED_OID,
     column_defs: None,
     sql: "SELECT sql_hash, redacted_sql FROM mz_internal.mz_recent_sql_text",
-    access: vec![MONITOR_SELECT, MONITOR_REDACTED_SELECT, SUPPORT_SELECT],
+    access: vec![
+        MONITOR_SELECT,
+        MONITOR_REDACTED_SELECT,
+        SUPPORT_SELECT,
+        ANALYTICS_SELECT,
+    ],
 });
 
 pub static MZ_RECENT_SQL_TEXT_IND: LazyLock<BuiltinIndex> = LazyLock::new(|| BuiltinIndex {
@@ -3053,7 +3069,7 @@ pub static MZ_RECENT_ACTIVITY_LOG_REDACTED: LazyLock<BuiltinView> = LazyLock::ne
 FROM mz_internal.mz_recent_activity_log_thinned mralt,
      mz_internal.mz_recent_sql_text mrst
 WHERE mralt.sql_hash = mrst.sql_hash",
-    access: vec![MONITOR_SELECT, MONITOR_REDACTED_SELECT, SUPPORT_SELECT],
+    access: vec![MONITOR_SELECT, MONITOR_REDACTED_SELECT, SUPPORT_SELECT, ANALYTICS_SELECT],
 }
 });
 
@@ -3075,7 +3091,12 @@ pub static MZ_STATEMENT_LIFECYCLE_HISTORY: LazyLock<BuiltinSource> =
         // TODO[btv]: Maybe this should be public instead of
         // `MONITOR_REDACTED`, but since that would be a backwards-compatible
         // chagne, we probably don't need to worry about it now.
-        access: vec![SUPPORT_SELECT, MONITOR_REDACTED_SELECT, MONITOR_SELECT],
+        access: vec![
+            SUPPORT_SELECT,
+            ANALYTICS_SELECT,
+            MONITOR_REDACTED_SELECT,
+            MONITOR_SELECT,
+        ],
     });
 
 pub static MZ_SOURCE_STATUSES: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinView {

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -109,6 +109,7 @@ SELECT DISTINCT(privilege) FROM item_privileges WHERE type = 'view' OR type = 'm
 mz_system=r/mz_system
 mz_monitor=r/mz_system
 mz_support=r/mz_system
+mz_analytics=r/mz_system
 materialize=r/materialize
 mz_monitor_redacted=r/mz_system
 
@@ -4738,11 +4739,13 @@ mz_system,mz_monitor,materialize,mz_internal,mz_optimizer_notices,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_recent_activity_log,SELECT,NO,YES
+mz_system,mz_analytics,materialize,mz_internal,mz_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_activity_log_thinned,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_recent_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_recent_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_notices_redacted,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_prepared_statement_history,SELECT,NO,YES
+mz_system,mz_analytics,materialize,mz_internal,mz_recent_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_recent_activity_log_thinned,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_statement_execution_history,SELECT,NO,YES
@@ -4750,13 +4753,16 @@ mz_system,mz_monitor,materialize,mz_internal,mz_statement_lifecycle_history,SELE
 mz_system,mz_support,materialize,mz_internal,mz_statement_lifecycle_history,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_recent_activity_log_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_recent_activity_log_redacted,SELECT,NO,YES
+mz_system,mz_analytics,materialize,mz_internal,mz_statement_lifecycle_history,SELECT,NO,YES
+mz_system,mz_analytics,materialize,mz_internal,mz_recent_activity_log_redacted,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_recent_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_statement_lifecycle_history,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_recent_activity_log_redacted,SELECT,NO,YES
+mz_system,mz_analytics,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
-COMPLETE 41
+COMPLETE 46
 
 simple conn=mz_system,user=mz_system
 SELECT COUNT(*) >= 166 FROM information_schema.table_privileges WHERE grantee = 'PUBLIC'
@@ -4808,11 +4814,13 @@ mz_system,mz_monitor,materialize,mz_internal,mz_optimizer_notices,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_recent_activity_log,SELECT,NO,YES
+mz_system,mz_analytics,materialize,mz_internal,mz_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_activity_log_thinned,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_recent_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_recent_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_notices_redacted,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_prepared_statement_history,SELECT,NO,YES
+mz_system,mz_analytics,materialize,mz_internal,mz_recent_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_recent_activity_log_thinned,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_statement_execution_history,SELECT,NO,YES
@@ -4820,13 +4828,16 @@ mz_system,mz_monitor,materialize,mz_internal,mz_statement_lifecycle_history,SELE
 mz_system,mz_support,materialize,mz_internal,mz_statement_lifecycle_history,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_recent_activity_log_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_recent_activity_log_redacted,SELECT,NO,YES
+mz_system,mz_analytics,materialize,mz_internal,mz_statement_lifecycle_history,SELECT,NO,YES
+mz_system,mz_analytics,materialize,mz_internal,mz_recent_activity_log_redacted,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_recent_sql_text_redacted,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_statement_lifecycle_history,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_recent_activity_log_redacted,SELECT,NO,YES
+mz_system,mz_analytics,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
-COMPLETE 41
+COMPLETE 46
 
 simple conn=mz_system,user=mz_system
 SELECT COUNT(*) >= 166 FROM information_schema.role_table_grants WHERE grantee = 'PUBLIC'


### PR DESCRIPTION
### Motivation

we want to be able to run internal analytics queries on mz_recent_activity_log_redacted

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
