### PR TITLE
storage-controller: demonstrate limiting R/O mode to upsert sources

### DIFF
--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -815,7 +815,7 @@ where
                 DataSource::Ingestion(ingestion) => {
                     if !self.read_only || (
                         ENABLE_0DT_DEPLOYMENT_SOURCES.get(self.config.config_set())
-                        && ingestion.desc.connection.supports_read_only()
+                        && ingestion.wants_read_only()
                     ) {
                         self.run_ingestion(id)?;
                     }


### PR DESCRIPTION
Per @aljoscha's post-merge feedback in #29699.

@aljoscha: I had actually tried this, but abandoned it because I couldn't figure out how to handle source exports in a nice way. We're fast approaching (or perhaps have already approached, not sure!) a world where a single Kafka source might have upsert and non-upsert subsources. So it seemed the simple thing to do was to ensure that all Kafka sources, upsert or no, could handle R/O mode, and then just enable R/O mode for all Kafka sources, regardless of whether they supported upsert or not.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
