### PR TITLE
docs: Fix Kafka page having menu on left side open

### DIFF
--- a/doc/user/content/sql/create-sink/kafka.md
+++ b/doc/user/content/sql/create-sink/kafka.md
@@ -2,6 +2,12 @@
 title: "CREATE SINK: Kafka"
 description: "Connecting Materialize to a Kafka or Redpanda broker sink"
 pagerank: 40
+menu:
+  main:
+    parent: 'create-sink'
+    identifier: csink_kafka
+    name: Kafka
+    weight: 20
 aliases:
     - /sql/create-sink/
 

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -2,6 +2,12 @@
 title: "CREATE SOURCE: Kafka"
 description: "Connecting Materialize to a Kafka or Redpanda broker"
 pagerank: 40
+menu:
+  main:
+    parent: 'create-source'
+    identifier: cs_kafka
+    name: Kafka
+    weight: 20
 aliases:
     - /sql/create-source/avro-kafka
     - /sql/create-source/json-kafka


### PR DESCRIPTION
Works: https://preview.materialize.com/materialize/29800/sql/create-source/kafka/
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
