### PR TITLE
doc/user: promote MySQL to Public Preview

### DIFF
--- a/doc/user/content/ingest-data/network-security/privatelink.md
+++ b/doc/user/content/ingest-data/network-security/privatelink.md
@@ -10,8 +10,11 @@ menu:
     name: "AWS PrivateLink connections"
 ---
 
-Materialize can connect to a Kafka broker, a Confluent Schema Registry server or
-a PostgreSQL database through an [AWS PrivateLink](https://aws.amazon.com/privatelink/) service.
+[//]: # "TODO(morsapaes) Add shortcode with instructions for AWS RDS MySQL"
+
+Materialize can connect to a Kafka broker, a Confluent Schema Registry server, a
+PostgreSQL database, or a MySQL database through an [AWS PrivateLink](https://aws.amazon.com/privatelink/)
+service.
 
 In this guide, we'll cover how to create `AWS PRIVATELINK` connections
 and retrieve the AWS principal needed to configure the AWS PrivateLink service.

--- a/doc/user/content/integrations/_index.md
+++ b/doc/user/content/integrations/_index.md
@@ -94,7 +94,7 @@ database as a source requires enabling [**GTID-based binlog replication**](/sql/
 
 | Service                | Support level                    | Notes                                                                                                |             |
 | ---------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------- |
-| MySQL _(direct)_       | {{< supportLevel beta >}} | See the [source documentation](/sql/create-source/mysql/) for more details, and the relevant integration guide for step-by-step instructions:<p></p><ul><li>[Amazon RDS for MySQL](/ingest-data/mysql/amazon-rds)</li><li>[Amazon Aurora for MySQL](/ingest-data/mysql/amazon-aurora)</li><li>[Azure DB for MySQL](/ingest-data/mysql/azure-db)</li><li>[Google Cloud SQL for MySQL](/ingest-data/mysql/google-cloud-sql)</li><li>[Self-hosted MySQL](/ingest-data/mysql/self-hosted)</li></ul> |
+| MySQL _(direct)_       | {{< supportLevel alpha >}} | See the [source documentation](/sql/create-source/mysql/) for more details, and the relevant integration guide for step-by-step instructions:<p></p><ul><li>[Amazon RDS for MySQL](/ingest-data/mysql/amazon-rds)</li><li>[Amazon Aurora for MySQL](/ingest-data/mysql/amazon-aurora)</li><li>[Azure DB for MySQL](/ingest-data/mysql/azure-db)</li><li>[Google Cloud SQL for MySQL](/ingest-data/mysql/google-cloud-sql)</li><li>[Self-hosted MySQL](/ingest-data/mysql/self-hosted)</li></ul> |
 | MySQL _(via Debezium)_ | {{< supportLevel production >}}  | See the [MySQL CDC guide](/integrations/cdc-mysql/) for a step-by-step breakdown of the integration. |             |
 
 ### Other databases

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -625,7 +625,7 @@ CREATE CONNECTION csr_ssh TO CONFLUENT SCHEMA REGISTRY (
 
 ### MySQL
 
-{{< private-preview />}}
+{{< public-preview />}}
 
 A MySQL connection establishes a link to a [MySQL] server. You can use
 MySQL connections to create [sources](/sql/create-source/mysql).
@@ -669,9 +669,39 @@ CREATE CONNECTION mysql_connection TO MYSQL (
 #### Network security {#mysql-network-security}
 
 If your MySQL server is not exposed to the public internet, you can tunnel
-the connection through an SSH bastion host.
+the connection through an AWS PrivateLink service or an SSH bastion host.
 
 {{< tabs >}}
+{{< tab "AWS PrivateLink">}}
+
+##### Connection options {#mysql-privatelink-options}
+
+Field                       | Value            | Required | Description
+----------------------------|------------------|:--------:|-----------------------------
+`AWS PRIVATELINK`           | object name      | ✓        | The name of an [AWS PrivateLink connection](#aws-privatelink) through which network traffic should be routed.
+
+##### Example {#mysql-privatelink-example}
+
+```mzsql
+CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
+   SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc',
+   AVAILABILITY ZONES ('use1-az1', 'use1-az4')
+);
+
+CREATE CONNECTION mysql_connection TO MYSQL (
+    HOST 'instance.foo000.us-west-1.rds.amazonaws.com',
+    PORT 3306,
+    USER 'root',
+    PASSWORD SECRET mysqlpass,
+    AWS PRIVATELINK privatelink_svc
+);
+```
+
+For step-by-step instructions on creating AWS PrivateLink connections and
+configuring an AWS PrivateLink service to accept connections from Materialize,
+check [this guide](/ops/network-security/privatelink/).
+
+{{< /tab >}}
 {{< tab "SSH tunnel">}}
 
 ##### Connection options {#mysql-ssh-options}

--- a/doc/user/content/sql/create-source/mysql.md
+++ b/doc/user/content/sql/create-source/mysql.md
@@ -10,7 +10,7 @@ menu:
     weight: 20
 ---
 
-{{< private-preview />}}
+{{< public-preview />}}
 
 {{% create-source/intro %}}
 Materialize supports MySQL (5.7+) as a real-time data source. To connect to a
@@ -305,9 +305,31 @@ CREATE CONNECTION mysql_connection TO MYSQL (
 
 If your MySQL server is not exposed to the public internet, you can
 [tunnel the connection](/sql/create-connection/#network-security-connections)
-through an SSH bastion host.
+through an AWS PrivateLink service or an SSH bastion host SSH bastion host.
 
 {{< tabs tabID="1" >}}
+{{< tab "AWS PrivateLink">}}
+
+```mzsql
+CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
+   SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc',
+   AVAILABILITY ZONES ('use1-az1', 'use1-az4')
+);
+
+CREATE CONNECTION mysql_connection TO MYSQL (
+    HOST 'instance.foo000.us-west-1.rds.amazonaws.com',
+    PORT 3306,
+    USER 'root',
+    PASSWORD SECRET mysqlpass,
+    AWS PRIVATELINK privatelink_svc
+);
+```
+
+For step-by-step instructions on creating AWS PrivateLink connections and
+configuring an AWS PrivateLink service to accept connections from Materialize,
+check [this guide](/ops/network-security/privatelink/).
+
+{{< /tab >}}
 {{< tab "SSH tunnel">}}
 ```mzsql
 CREATE CONNECTION ssh_connection TO SSH TUNNEL (


### PR DESCRIPTION
The MySQL source is ready for Public Preview, so promoting it in the documentation as a first step. Also documenting support for AWS PrivateLink connections in the source, which was blocked on adding automated cloud tests (now ✅).

@bobbyiliev: could you add the shortcode with the instructions for AWS RDS MySQL (similar to [this one](https://github.com/MaterializeInc/materialize/blob/main/doc/user/layouts/shortcodes/network-security/privatelink-postgres.md))?