### PR TITLE
testdrive: Increase allowed lag for wallclock-lag test

### DIFF
--- a/test/testdrive/wallclock-lag.td
+++ b/test/testdrive/wallclock-lag.td
@@ -46,7 +46,7 @@ ALTER SYSTEM SET wallclock_lag_refresh_interval = '1s'
   ENVELOPE DEBEZIUM
 
 > SELECT DISTINCT ON(o.name, r.name)
-    o.name, r.name, l.lag >= '0s', l.lag < '5s'
+    o.name, r.name, l.lag >= '0s', l.lag < '10s'
   FROM mz_internal.mz_wallclock_lag_history l
   JOIN mz_objects o ON o.id = l.object_id
   LEFT JOIN mz_cluster_replicas r ON r.id = l.replica_id
@@ -68,7 +68,7 @@ src_progress <null> true  true
 tbl          <null> true  true
 
 > SELECT DISTINCT ON(o.name)
-    o.name, l.lag >= '0s', l.lag < '5s'
+    o.name, l.lag >= '0s', l.lag < '10s'
   FROM mz_internal.mz_wallclock_global_lag_history l
   JOIN mz_objects o ON o.id = l.object_id
   WHERE l.object_id LIKE 'u%'
@@ -83,7 +83,7 @@ src_progress true  true
 tbl          true  true
 
 > SELECT DISTINCT ON(o.name)
-    o.name, l.lag >= '0s', l.lag < '5s'
+    o.name, l.lag >= '0s', l.lag < '10s'
   FROM mz_internal.mz_wallclock_global_lag_recent_history l
   JOIN mz_objects o ON o.id = l.object_id
   WHERE l.object_id LIKE 'u%'


### PR DESCRIPTION
Seen flaking in https://buildkite.com/materialize/test/builds/91457#0192497a-4937-434f-abe1-91178212bc72

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
