### PR TITLE
docs: suppress default creation of Categories and Tags docs pages

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -3,6 +3,7 @@ title = "Materialize Documentation"
 pygmentsCodeFences = true
 pygmentsUseClasses = true
 
+disableKinds = ['taxonomy']
 
 [params]
 repo = "//github.com/MaterializeInc/materialize"


### PR DESCRIPTION
Hugo defaults to creating Categories and Tags pages as part of its default taxonomies -- https://gohugo.io/content-management/taxonomies/#default-taxonomies -- which is what builds the following pages:
https://materialize.com/docs/tags/
https://materialize.com/docs/categories/