### PR TITLE
ct: fix restart bugs by sharing code

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2349,7 +2349,7 @@ mod tests {
                     .expect("unable to open debug catalog");
             let item = catalog
                 .state()
-                .deserialize_item(&create_sql)
+                .deserialize_item(id, &create_sql)
                 .expect("unable to parse view");
             catalog
                 .transact(
@@ -3234,16 +3234,16 @@ mod tests {
             let schema_spec = schema.id().clone();
             let schema_name = &schema.name().schema;
             let database_spec = ResolvedDatabaseSpecifier::Id(database_id);
-            let mv = catalog
-                .state()
-                .deserialize_item(&format!(
-                    "CREATE MATERIALIZED VIEW {database_name}.{schema_name}.{mv_name} AS SELECT name FROM mz_tables"
-                ))
-                .expect("unable to deserialize item");
             let mv_id = catalog
                 .allocate_user_id()
                 .await
                 .expect("unable to allocate id");
+            let mv = catalog
+                .state()
+                .deserialize_item(mv_id, &format!(
+                    "CREATE MATERIALIZED VIEW {database_name}.{schema_name}.{mv_name} AS SELECT name FROM mz_tables"
+                ))
+                .expect("unable to deserialize item");
             catalog
                 .transact(
                     None,

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -142,7 +142,7 @@ impl CatalogItemRebuilder {
         }
     }
 
-    fn build(self, state: &CatalogState) -> CatalogItem {
+    fn build(self, id: GlobalId, state: &CatalogState) -> CatalogItem {
         match self {
             Self::SystemSource(item) => item,
             Self::Object {
@@ -151,6 +151,7 @@ impl CatalogItemRebuilder {
                 custom_logical_compaction_window,
             } => state
                 .parse_item(
+                    id,
                     &sql,
                     None,
                     is_retained_metrics_object,
@@ -808,7 +809,7 @@ impl Catalog {
             item_rebuilder,
         } in migration_metadata.user_item_create_ops.drain(..)
         {
-            let item = item_rebuilder.build(state);
+            let item = item_rebuilder.build(id, state);
             let serialized_item = item.to_serialized();
             txn.insert_item(
                 id,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -28,9 +28,9 @@ use mz_catalog::builtin::{
 use mz_catalog::config::{AwsPrincipalContext, ClusterReplicaSizeMap};
 use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
-    CatalogEntry, CatalogItem, Cluster, ClusterReplica, CommentsMap, Connection, ContinualTask,
-    DataSourceDesc, Database, DefaultPrivileges, Index, MaterializedView, Role, Schema, Secret,
-    Sink, Source, Table, TableDataSource, Type, View,
+    CatalogEntry, CatalogItem, Cluster, ClusterReplica, CommentsMap, Connection, DataSourceDesc,
+    Database, DefaultPrivileges, Index, MaterializedView, Role, Schema, Secret, Sink, Source,
+    Table, TableDataSource, Type, View,
 };
 use mz_catalog::SYSTEM_CONN_ID;
 use mz_controller::clusters::{
@@ -65,9 +65,9 @@ use mz_sql::names::{
     ResolvedIds, SchemaId, SchemaSpecifier, SystemObjectId,
 };
 use mz_sql::plan::{
-    CreateConnectionPlan, CreateContinualTaskPlan, CreateIndexPlan, CreateMaterializedViewPlan,
-    CreateSecretPlan, CreateSinkPlan, CreateSourcePlan, CreateTablePlan, CreateTypePlan,
-    CreateViewPlan, Params, Plan, PlanContext,
+    CreateConnectionPlan, CreateIndexPlan, CreateMaterializedViewPlan, CreateSecretPlan,
+    CreateSinkPlan, CreateSourcePlan, CreateTablePlan, CreateTypePlan, CreateViewPlan, Params,
+    Plan, PlanContext,
 };
 use mz_sql::rbac;
 use mz_sql::session::metadata::SessionMetadata;
@@ -955,18 +955,9 @@ impl CatalogState {
                     initial_as_of,
                 })
             }
-            Plan::CreateContinualTask(CreateContinualTaskPlan {
-                desc,
-                continual_task,
-                ..
-            }) => CatalogItem::ContinualTask(ContinualTask {
-                create_sql: continual_task.create_sql,
-                raw_expr: Arc::new(continual_task.expr.clone()),
-                desc,
-                resolved_ids,
-                cluster_id: continual_task.cluster_id,
-                initial_as_of: continual_task.as_of.map(Antichain::from_elem),
-            }),
+            Plan::CreateContinualTask(plan) => CatalogItem::ContinualTask(
+                crate::continual_task::ct_item_from_plan(plan, id, resolved_ids)?,
+            ),
             Plan::CreateIndex(CreateIndexPlan { index, .. }) => CatalogItem::Index(Index {
                 create_sql: index.create_sql,
                 on: index.on,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -791,14 +791,19 @@ impl CatalogState {
     }
 
     /// Parses the given SQL string into a pair of [`CatalogItem`].
-    pub(crate) fn deserialize_item(&self, create_sql: &str) -> Result<CatalogItem, AdapterError> {
-        self.parse_item(create_sql, None, false, None)
+    pub(crate) fn deserialize_item(
+        &self,
+        id: GlobalId,
+        create_sql: &str,
+    ) -> Result<CatalogItem, AdapterError> {
+        self.parse_item(id, create_sql, None, false, None)
     }
 
     /// Parses the given SQL string into a `CatalogItem`.
     #[mz_ore::instrument]
     pub(crate) fn parse_item(
         &self,
+        id: GlobalId,
         create_sql: &str,
         pcx: Option<&PlanContext>,
         is_retained_metrics_object: bool,

--- a/src/adapter/src/continual_task.rs
+++ b/src/adapter/src/continual_task.rs
@@ -1,0 +1,66 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Common methods for `CONTINUAL TASK`s.
+
+use std::sync::Arc;
+
+use mz_catalog::memory::objects::ContinualTask;
+use mz_expr::visit::Visit;
+use mz_expr::Id;
+use mz_repr::GlobalId;
+use mz_sql::names::ResolvedIds;
+use mz_sql::plan::{self, HirRelationExpr};
+use timely::progress::Antichain;
+
+use crate::AdapterError;
+
+pub fn ct_item_from_plan(
+    plan: plan::CreateContinualTaskPlan,
+    output_id: GlobalId,
+    resolved_ids: ResolvedIds,
+) -> Result<ContinualTask, AdapterError> {
+    let plan::CreateContinualTaskPlan {
+        name: _,
+        placeholder_id,
+        desc,
+        input_id,
+        continual_task:
+            plan::MaterializedView {
+                create_sql,
+                cluster_id,
+                expr: mut raw_expr,
+                column_names: _,
+                non_null_assertions: _,
+                compaction_window: _,
+                refresh_schedule: _,
+                as_of,
+            },
+    } = plan;
+
+    // Replace any placeholder LocalIds.
+    if let Some(placeholder_id) = placeholder_id {
+        raw_expr.visit_mut_post(&mut |expr| match expr {
+            HirRelationExpr::Get { id, .. } if *id == Id::Local(placeholder_id) => {
+                *id = Id::Global(output_id);
+            }
+            _ => {}
+        })?;
+    }
+
+    Ok(ContinualTask {
+        create_sql,
+        input_id,
+        raw_expr: Arc::new(raw_expr),
+        desc,
+        resolved_ids,
+        cluster_id,
+        initial_as_of: as_of.map(Antichain::from_elem),
+    })
+}

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2670,54 +2670,18 @@ impl Coordinator {
                     compute_instance.insert_collection(id);
                 }
                 CatalogItem::ContinualTask(ct) => {
-                    // Collect optimizer parameters.
                     let compute_instance =
                         instance_snapshots.entry(ct.cluster_id).or_insert_with(|| {
                             self.instance_snapshot(ct.cluster_id)
                                 .expect("compute instance exists")
                         });
-                    let internal_view_id = self.allocate_transient_id();
+
                     let debug_name = self
                         .catalog()
                         .resolve_full_name(entry.name(), None)
                         .to_string();
-
-                    let (optimized_plan, global_lir_plan) = {
-                        let mut optimizer = optimize::materialized_view::Optimizer::new(
-                            self.owned_catalog().as_optimizer_catalog(),
-                            compute_instance.clone(),
-                            entry.id(),
-                            internal_view_id,
-                            ct.desc.iter_names().cloned().collect(),
-                            Vec::new(),
-                            None,
-                            debug_name,
-                            optimizer_config.clone(),
-                            self.optimizer_metrics(),
-                        );
-
-                        // MIR ⇒ MIR optimization (global)
-                        let local_mir_plan =
-                            optimizer.catch_unwind_optimize(ct.raw_expr.as_ref().clone())?;
-                        let global_mir_plan = optimizer.optimize(local_mir_plan)?;
-                        let optimized_plan = global_mir_plan.df_desc().clone();
-
-                        // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                        let global_lir_plan = optimizer.optimize(global_mir_plan)?;
-
-                        (optimized_plan, global_lir_plan)
-                    };
-
-                    let (physical_plan, metainfo) = global_lir_plan.unapply();
-                    let metainfo = {
-                        // Pre-allocate a vector of transient GlobalIds for each notice.
-                        let notice_ids = std::iter::repeat_with(|| self.allocate_transient_id())
-                            .take(metainfo.optimizer_notices.len())
-                            .collect::<Vec<_>>();
-                        // Return a metainfo with rendered notices.
-                        self.catalog()
-                            .render_notices(metainfo, notice_ids, Some(entry.id()))
-                    };
+                    let (optimized_plan, physical_plan, metainfo) = self
+                        .optimize_create_continual_task(ct, id, self.owned_catalog(), debug_name)?;
 
                     let catalog = self.catalog_mut();
                     catalog.set_optimized_plan(id, optimized_plan);

--- a/src/adapter/src/coord/sequencer/inner/create_continual_task.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_continual_task.rs
@@ -12,11 +12,12 @@ use std::sync::Arc;
 use mz_catalog::memory::objects::{
     CatalogEntry, CatalogItem, ContinualTask, Table, TableDataSource,
 };
+use mz_compute_types::dataflows::DataflowDescription;
+use mz_compute_types::plan::Plan;
 use mz_compute_types::sinks::{
     ComputeSinkConnection, ContinualTaskConnection, PersistSinkConnection,
 };
-use mz_expr::visit::Visit;
-use mz_expr::Id;
+use mz_expr::OptimizedMirRelationExpr;
 use mz_ore::collections::CollectionExt;
 use mz_ore::instrument;
 use mz_repr::adt::mz_acl_item::PrivilegeMap;
@@ -24,11 +25,13 @@ use mz_repr::optimize::OverrideFrom;
 use mz_repr::GlobalId;
 use mz_sql::ast::{ContinualTaskStmt, RawItemName};
 use mz_sql::names::{FullItemName, PartialItemName, ResolvedIds};
-use mz_sql::plan::{self, HirRelationExpr};
+use mz_sql::plan;
 use mz_sql::session::metadata::SessionMetadata;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::Statement;
 use mz_storage_client::controller::{CollectionDescription, DataSource, DataSourceOther};
+use mz_transform::dataflow::DataflowMetainfo;
+use mz_transform::notice::OptimizerNotice;
 
 use crate::catalog;
 use crate::command::ExecuteResponse;
@@ -45,26 +48,13 @@ impl Coordinator {
     pub(crate) async fn sequence_create_continual_task(
         &mut self,
         session: &Session,
-        plan: plan::CreateContinualTaskPlan,
+        mut plan: plan::CreateContinualTaskPlan,
         resolved_ids: ResolvedIds,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let plan::CreateContinualTaskPlan {
-            name,
-            placeholder_id,
-            desc,
-            input_id,
-            continual_task:
-                plan::MaterializedView {
-                    create_sql,
-                    cluster_id,
-                    mut expr,
-                    column_names,
-                    non_null_assertions,
-                    compaction_window: _,
-                    refresh_schedule,
-                    as_of: _,
-                },
-        } = plan;
+        let desc = plan.desc.clone();
+        let name = plan.name.clone();
+        let cluster_id = plan.continual_task.cluster_id;
+
         // Put a placeholder in the catalog so the optimizer can find something
         // for the sink_id.
         let sink_id = self.catalog_mut().allocate_user_id().await?;
@@ -93,52 +83,24 @@ impl Coordinator {
             },
         };
 
-        // First thing, assign the id and then rewrite `create_sql` and `expr`
-        // to use it.
+        // Rewrite `create_sql` to reference self with the fully qualified name.
+        // This is normally done when `create_sql` is created at plan time, but
+        // we didn't have the necessary info in name resolution.
         let full_name = bootstrap_catalog.resolve_full_name(&name, Some(session.conn_id()));
-        let create_sql = replace_full_name(&create_sql, &full_name);
-        let placeholder_id = placeholder_id.expect("set during initial creation");
-        expr.visit_mut_post(&mut |expr| match expr {
-            HirRelationExpr::Get { id, .. } if *id == Id::Local(placeholder_id) => {
-                *id = Id::Global(sink_id);
-            }
-            _ => {}
-        })?;
+        plan.continual_task.create_sql =
+            replace_full_name(&plan.continual_task.create_sql, &full_name);
 
-        // Collect optimizer parameters.
-        let compute_instance = self
-            .instance_snapshot(cluster_id)
-            .expect("compute instance does not exist");
-
-        let debug_name = self.catalog().resolve_full_name(&name, None).to_string();
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
-            .override_from(&self.catalog.get_cluster(cluster_id).config.features());
-
-        // Build an optimizer for this CONTINUAL TASK.
-        let view_id = self.allocate_transient_id();
-        let mut optimizer = optimize::materialized_view::Optimizer::new(
-            Arc::new(bootstrap_catalog),
-            compute_instance,
+        // Construct the CatalogItem for this CT and optimize it.
+        let item = crate::continual_task::ct_item_from_plan(plan, sink_id, resolved_ids)?;
+        let (optimized_plan, mut physical_plan, metainfo) = self.optimize_create_continual_task(
+            &item,
             sink_id,
-            view_id,
-            column_names,
-            non_null_assertions,
-            refresh_schedule.clone(),
-            debug_name,
-            optimizer_config,
-            self.optimizer_metrics(),
-        );
-
-        // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local and global)
-        let raw_expr = expr.clone();
-        let local_mir_plan = optimizer.catch_unwind_optimize(expr)?;
-        let global_mir_plan = optimizer.catch_unwind_optimize(local_mir_plan.clone())?;
-        // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-        let global_lir_plan = optimizer.catch_unwind_optimize(global_mir_plan.clone())?;
-        let (mut df_desc, _df_meta) = global_lir_plan.unapply();
+            Arc::new(bootstrap_catalog),
+            full_name.to_string(),
+        )?;
 
         // Timestamp selection
-        let mut id_bundle = dataflow_import_id_bundle(&df_desc, cluster_id.clone());
+        let mut id_bundle = dataflow_import_id_bundle(&physical_plan, cluster_id.clone());
         // Can't acquire a read hold on ourselves because we don't exist yet.
         //
         // It is not necessary to take a read hold on the CT output in the
@@ -149,47 +111,22 @@ impl Coordinator {
         id_bundle.storage_ids.remove(&sink_id);
         let read_holds = self.acquire_read_holds(&id_bundle);
         let as_of = read_holds.least_valid_read();
-        df_desc.set_as_of(as_of.clone());
-
-        // The MV optimizer is hardcoded to output a PersistSinkConnection.
-        // Sniff it and swap for the ContinualTaskSink. If/when we split out a
-        // Continual Task optimizer, this won't be necessary, and in the
-        // meantime, it seems undesirable to burden the MV optimizer with a
-        // configuration for this.
-        for sink in df_desc.sink_exports.values_mut() {
-            match &mut sink.connection {
-                ComputeSinkConnection::Persist(PersistSinkConnection {
-                    storage_metadata, ..
-                }) => {
-                    sink.connection =
-                        ComputeSinkConnection::ContinualTask(ContinualTaskConnection {
-                            input_id,
-                            storage_metadata: *storage_metadata,
-                        })
-                }
-                _ => unreachable!("MV should produce persist sink connection"),
-            }
-        }
+        physical_plan.set_as_of(as_of.clone());
 
         let ops = vec![catalog::Op::CreateItem {
             id: sink_id,
             name: name.clone(),
-            item: CatalogItem::ContinualTask(ContinualTask {
-                // TODO(ct): This doesn't give the `DELETE FROM` / `INSERT INTO`
-                // names the `[u1 AS "materialize"."public"."append_only"]`
-                // style expansion. Bug?
-                create_sql,
-                raw_expr: Arc::new(raw_expr),
-                desc: desc.clone(),
-                resolved_ids,
-                cluster_id,
-                initial_as_of: Some(as_of.clone()),
-            }),
+            item: CatalogItem::ContinualTask(item),
             owner_id: *session.current_role_id(),
         }];
 
         let () = self
             .catalog_transact_with_side_effects(Some(session), ops, |coord| async {
+                let catalog = coord.catalog_mut();
+                catalog.set_optimized_plan(sink_id, optimized_plan);
+                catalog.set_physical_plan(sink_id, physical_plan.clone());
+                catalog.set_dataflow_metainfo(sink_id, metainfo);
+
                 coord
                     .controller
                     .storage
@@ -209,10 +146,85 @@ impl Coordinator {
                     .await
                     .unwrap_or_terminate("cannot fail to append");
 
-                coord.ship_dataflow(df_desc, cluster_id.clone(), None).await;
+                coord.ship_dataflow(physical_plan, cluster_id, None).await;
             })
             .await?;
         Ok(ExecuteResponse::CreatedContinualTask)
+    }
+
+    pub fn optimize_create_continual_task(
+        &mut self,
+        ct: &ContinualTask,
+        output_id: GlobalId,
+        catalog: Arc<dyn OptimizerCatalog>,
+        debug_name: String,
+    ) -> Result<
+        (
+            DataflowDescription<OptimizedMirRelationExpr>,
+            DataflowDescription<Plan>,
+            DataflowMetainfo<Arc<OptimizerNotice>>,
+        ),
+        AdapterError,
+    > {
+        let view_id = self.allocate_transient_id();
+        let compute_instance = self
+            .instance_snapshot(ct.cluster_id)
+            .expect("compute instance does not exist");
+        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
+            .override_from(&self.catalog.get_cluster(ct.cluster_id).config.features());
+        let non_null_assertions = Vec::new();
+        let refresh_schedule = None;
+        let mut optimizer = optimize::materialized_view::Optimizer::new(
+            catalog,
+            compute_instance,
+            output_id,
+            view_id,
+            ct.desc.iter_names().cloned().collect(),
+            non_null_assertions,
+            refresh_schedule,
+            debug_name,
+            optimizer_config,
+            self.optimizer_metrics(),
+        );
+
+        // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local and global)
+        let local_mir_plan = optimizer.catch_unwind_optimize((*ct.raw_expr).clone())?;
+        let global_mir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
+        let optimized_plan = global_mir_plan.df_desc().clone();
+        // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
+        let global_lir_plan = optimizer.catch_unwind_optimize(global_mir_plan)?;
+        let (mut physical_plan, metainfo) = global_lir_plan.unapply();
+
+        // The MV optimizer is hardcoded to output a PersistSinkConnection.
+        // Sniff it and swap for the ContinualTaskSink. If/when we split out a
+        // Continual Task optimizer, this won't be necessary, and in the
+        // meantime, it seems undesirable to burden the MV optimizer with a
+        // configuration for this.
+        for sink in physical_plan.sink_exports.values_mut() {
+            match &mut sink.connection {
+                ComputeSinkConnection::Persist(PersistSinkConnection {
+                    storage_metadata, ..
+                }) => {
+                    sink.connection =
+                        ComputeSinkConnection::ContinualTask(ContinualTaskConnection {
+                            input_id: ct.input_id,
+                            storage_metadata: *storage_metadata,
+                        })
+                }
+                _ => unreachable!("MV should produce persist sink connection"),
+            }
+        }
+
+        // Create a metainfo with rendered notices, preallocating a transient
+        // GlobalId for each.
+        let notice_ids = std::iter::repeat_with(|| self.allocate_transient_id())
+            .take(metainfo.optimizer_notices.len())
+            .collect();
+        let metainfo = self
+            .catalog()
+            .render_notices(metainfo, notice_ids, Some(output_id));
+
+        Ok((optimized_plan, physical_plan, metainfo))
     }
 }
 

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -50,6 +50,7 @@ mod util;
 pub mod catalog;
 pub mod client;
 pub mod config;
+pub mod continual_task;
 pub mod flags;
 pub mod metrics;
 pub mod session;

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -958,6 +958,7 @@ pub struct Connection {
 #[derive(Debug, Clone, Serialize)]
 pub struct ContinualTask {
     pub create_sql: String,
+    pub input_id: GlobalId,
     /// ContinualTasks are self-referential. We make this work by using a
     /// placeholder `LocalId` for the CT itself through name resolution and
     /// planning. Then we fill in the real `GlobalId` before constructing this
@@ -1825,7 +1826,11 @@ impl CatalogEntry {
     /// referenced. For example this will include any catalog objects used to implement functions
     /// and casts in the item.
     pub fn uses(&self) -> BTreeSet<GlobalId> {
-        self.item.uses()
+        let mut uses = self.item.uses();
+        // Remove self for self-referential tasks (e.g. Continual Tasks), if
+        // present.
+        let _ = uses.remove(&self.id);
+        uses
     }
 
     /// Returns the `CatalogItem` associated with this catalog entry.

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -958,6 +958,10 @@ pub struct Connection {
 #[derive(Debug, Clone, Serialize)]
 pub struct ContinualTask {
     pub create_sql: String,
+    /// ContinualTasks are self-referential. We make this work by using a
+    /// placeholder `LocalId` for the CT itself through name resolution and
+    /// planning. Then we fill in the real `GlobalId` before constructing this
+    /// catalog item.
     pub raw_expr: Arc<HirRelationExpr>,
     pub desc: RelationDesc,
     pub resolved_ids: ResolvedIds,


### PR DESCRIPTION
This should be enough to get Dennis's initial tests passing.

On restart, we weren't replacing the MV sink with a CT one. We also
weren't swapping out the LocalId placeholders at the right time in an
upcoming PR to add a builtin CT.

Closes database-issues#8591
Touches database-issues#8427

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
