### PR TITLE
[persist] Minor structured-data fixes and improvements

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -115,6 +115,12 @@ def get_default_system_parameters(
         "persist_batch_record_run_meta": (
             "true" if version >= MzVersion.parse_mz("v0.115.0-dev") else "false"
         ),
+        "persist_batch_structured_order": (
+            "true" if version >= MzVersion.parse_mz("v0.119.0-dev") else "false"
+        ),
+        "persist_batch_structured_key_lower_len": (
+            "256" if version >= MzVersion.parse_mz("v0.117.0-dev") else "0"
+        ),
         "persist_catalog_force_compaction_fuel": "1024",
         "persist_catalog_force_compaction_wait": "1s",
         "persist_fast_path_limit": "1000",

--- a/test/testdrive/coordinator-multiplicities.td
+++ b/test/testdrive/coordinator-multiplicities.td
@@ -23,40 +23,6 @@
 
 > INSERT INTO t1 VALUES (NULL), (NULL);
 
-
-#
-# LIMIT only
-#
-
-> SELECT * FROM t1 LIMIT 0;
-
-> SELECT * FROM t1 LIMIT 1;
-<null>
-
-> SELECT * FROM t1 LIMIT 2;
-<null>
-<null>
-
-> SELECT * FROM t1 LIMIT 3;
-<null>
-<null>
-1
-
-> SELECT * FROM t1 LIMIT 4;
-<null>
-<null>
-1
-1
-
-> SELECT * FROM t1 LIMIT 999999;
-<null>
-<null>
-1
-1
-1
-2
-2
-
 #
 # ORDER BY + LIMIT
 #
@@ -104,37 +70,6 @@
 2
 <null>
 <null>
-
-#
-# LIMIT + OFFSET
-#
-
-> SELECT * FROM t1 LIMIT 0 OFFSET 0;
-
-> SELECT * FROM t1 LIMIT 0 OFFSET 1;
-
-> SELECT * FROM t1 LIMIT 1 OFFSET 1;
-<null>
-
-> SELECT * FROM t1 LIMIT 1 OFFSET 2;
-1
-
-> SELECT * FROM t1 LIMIT 2 OFFSET 1;
-<null>
-1
-
-> SELECT * FROM t1 LIMIT 3 OFFSET 1;
-<null>
-1
-1
-
-> SELECT * FROM t1 LIMIT 5 OFFSET 1;
-<null>
-1
-1
-1
-2
-
 
 #
 # ORDER BY + LIMIT + OFFSET


### PR DESCRIPTION
Bundling together some small fixups - see the individual commits & code comments for motivation.

### Motivation

A few minor things as part of the rollout of: https://github.com/MaterializeInc/database-issues/issues/7411

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
