### PR TITLE
storage: Correctly handle dependencies on CSR connections from source tables when a connection is altered

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3526,7 +3526,7 @@ impl Coordinator {
 
         let mut source_connections = BTreeMap::new();
         let mut sink_connections = BTreeMap::new();
-        let mut source_export_data_configs = Vec::new();
+        let mut source_export_data_configs = BTreeMap::new();
 
         while let Some(id) = connections.pop_front() {
             for id in self.catalog.get_entry(&id).used_by() {
@@ -3557,15 +3557,12 @@ impl Coordinator {
                     CatalogItemType::Table => {
                         // This is a source-fed table that reference a schema registry
                         // connection as a part of its encoding / data config
-                        if let Some((ingestion_id, _, _, export_data_config)) =
-                            entry.source_export_details()
-                        {
+                        if let Some((_, _, _, export_data_config)) = entry.source_export_details() {
                             let data_config = export_data_config.clone();
-                            source_export_data_configs.push((
-                                ingestion_id,
+                            source_export_data_configs.insert(
                                 *id,
                                 data_config.into_inline_connection(self.catalog().state()),
-                            ));
+                            );
                         }
                     }
                     t => unreachable!("connection dependency not expected on {}", t),

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3526,7 +3526,7 @@ impl Coordinator {
 
         let mut source_connections = BTreeMap::new();
         let mut sink_connections = BTreeMap::new();
-        let mut source_export_data_configs = BTreeMap::new();
+        let mut source_export_data_configs = Vec::new();
 
         while let Some(id) = connections.pop_front() {
             for id in self.catalog.get_entry(&id).used_by() {
@@ -3561,13 +3561,11 @@ impl Coordinator {
                             entry.source_export_details()
                         {
                             let data_config = export_data_config.clone();
-                            source_export_data_configs.insert(
+                            source_export_data_configs.push((
                                 ingestion_id,
-                                (
-                                    *id,
-                                    data_config.into_inline_connection(self.catalog().state()),
-                                ),
-                            );
+                                *id,
+                                data_config.into_inline_connection(self.catalog().state()),
+                            ));
                         }
                     }
                     t => unreachable!("connection dependency not expected on {}", t),

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3526,6 +3526,7 @@ impl Coordinator {
 
         let mut source_connections = BTreeMap::new();
         let mut sink_connections = BTreeMap::new();
+        let mut source_export_data_configs = BTreeMap::new();
 
         while let Some(id) = connections.pop_front() {
             for id in self.catalog.get_entry(&id).used_by() {
@@ -3553,6 +3554,22 @@ impl Coordinator {
                                 .into_inline_connection(self.catalog().state()),
                         );
                     }
+                    CatalogItemType::Table => {
+                        // This is a source-fed table that reference a schema registry
+                        // connection as a part of its encoding / data config
+                        if let Some((ingestion_id, _, _, export_data_config)) =
+                            entry.source_export_details()
+                        {
+                            let data_config = export_data_config.clone();
+                            source_export_data_configs.insert(
+                                ingestion_id,
+                                (
+                                    *id,
+                                    data_config.into_inline_connection(self.catalog().state()),
+                                ),
+                            );
+                        }
+                    }
                     t => unreachable!("connection dependency not expected on {}", t),
                 }
             }
@@ -3572,6 +3589,14 @@ impl Coordinator {
                 .alter_export_connections(sink_connections)
                 .await
                 .unwrap_or_terminate("altering exports after txn must succeed");
+        }
+
+        if !source_export_data_configs.is_empty() {
+            self.controller
+                .storage
+                .alter_ingestion_export_data_configs(source_export_data_configs)
+                .await
+                .unwrap_or_terminate("altering source export data configs after txn must succeed");
         }
 
         Ok(ExecuteResponse::AlteredObject(ObjectType::Connection))

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -1821,15 +1821,20 @@ impl CatalogEntry {
     /// ingestion it is an export of, as well as the item it exports.
     pub fn source_export_details(
         &self,
-    ) -> Option<(GlobalId, &UnresolvedItemName, &SourceExportDetails)> {
+    ) -> Option<(
+        GlobalId,
+        &UnresolvedItemName,
+        &SourceExportDetails,
+        &SourceExportDataConfig<ReferencedConnection>,
+    )> {
         match &self.item() {
             CatalogItem::Source(source) => match &source.data_source {
                 DataSourceDesc::IngestionExport {
                     ingestion_id,
                     external_reference,
                     details,
-                    data_config: _,
-                } => Some((*ingestion_id, external_reference, details)),
+                    data_config,
+                } => Some((*ingestion_id, external_reference, details, data_config)),
                 _ => None,
             },
             CatalogItem::Table(table) => match &table.data_source {
@@ -1837,8 +1842,8 @@ impl CatalogEntry {
                     ingestion_id,
                     external_reference,
                     details,
-                    data_config: _,
-                }) => Some((*ingestion_id, external_reference, details)),
+                    data_config,
+                }) => Some((*ingestion_id, external_reference, details, data_config)),
                 _ => None,
             },
             _ => None,
@@ -2629,7 +2634,12 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
 
     fn source_export_details(
         &self,
-    ) -> Option<(GlobalId, &UnresolvedItemName, &SourceExportDetails)> {
+    ) -> Option<(
+        GlobalId,
+        &UnresolvedItemName,
+        &SourceExportDetails,
+        &SourceExportDataConfig<ReferencedConnection>,
+    )> {
         self.source_export_details()
     }
 

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -760,6 +760,7 @@ mod tests {
     use mz_storage_types::controller::{CollectionMetadata, StorageError};
     use mz_storage_types::parameters::StorageParameters;
     use mz_storage_types::read_holds::ReadHoldError;
+    use mz_storage_types::sources::SourceExportDataConfig;
     use mz_storage_types::sources::{GenericSourceConnection, SourceDesc};
 
     use super::*;
@@ -870,6 +871,13 @@ mod tests {
             &self,
             _ingestion_id: GlobalId,
             _source_desc: SourceDesc,
+        ) -> Result<(), StorageError<Self::Timestamp>> {
+            unimplemented!()
+        }
+
+        async fn alter_ingestion_export_data_configs(
+            &self,
+            _source_exports: BTreeMap<GlobalId, (GlobalId, SourceExportDataConfig)>,
         ) -> Result<(), StorageError<Self::Timestamp>> {
             unimplemented!()
         }

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -877,7 +877,7 @@ mod tests {
 
         async fn alter_ingestion_export_data_configs(
             &self,
-            _source_exports: BTreeMap<GlobalId, (GlobalId, SourceExportDataConfig)>,
+            _source_exports: Vec<(GlobalId, GlobalId, SourceExportDataConfig)>,
         ) -> Result<(), StorageError<Self::Timestamp>> {
             unimplemented!()
         }

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -877,7 +877,7 @@ mod tests {
 
         async fn alter_ingestion_export_data_configs(
             &self,
-            _source_exports: Vec<(GlobalId, GlobalId, SourceExportDataConfig)>,
+            _source_exports: BTreeMap<GlobalId, SourceExportDataConfig>,
         ) -> Result<(), StorageError<Self::Timestamp>> {
             unimplemented!()
         }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -33,7 +33,7 @@ use mz_repr::{ColumnName, GlobalId, RelationDesc};
 use mz_sql_parser::ast::{Expr, QualifiedReplica, UnresolvedItemName};
 use mz_storage_types::connections::inline::{ConnectionResolver, ReferencedConnection};
 use mz_storage_types::connections::{Connection, ConnectionContext};
-use mz_storage_types::sources::{SourceDesc, SourceExportDetails};
+use mz_storage_types::sources::{SourceDesc, SourceExportDataConfig, SourceExportDetails};
 use proptest_derive::Arbitrary;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -623,7 +623,12 @@ pub trait CatalogItem {
     /// ingestion it is an export of, as well as the item it exports.
     fn source_export_details(
         &self,
-    ) -> Option<(GlobalId, &UnresolvedItemName, &SourceExportDetails)>;
+    ) -> Option<(
+        GlobalId,
+        &UnresolvedItemName,
+        &SourceExportDetails,
+        &SourceExportDataConfig<ReferencedConnection>,
+    )>;
 
     /// Reports whether this catalog item is a progress source.
     fn is_progress_source(&self) -> bool;

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -452,8 +452,8 @@ pub trait StorageController: Debug {
     /// Alters the data config for the specified source exports of the specified ingestions.
     async fn alter_ingestion_export_data_configs(
         &mut self,
-        // Map from primary ingestion id to source-export id and new data config
-        source_exports: BTreeMap<GlobalId, (GlobalId, SourceExportDataConfig)>,
+        // Primary ingestion id, source-export id, and new data config
+        source_exports: Vec<(GlobalId, GlobalId, SourceExportDataConfig)>,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
     async fn alter_table_desc(

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -449,6 +449,13 @@ pub trait StorageController: Debug {
         source_connections: BTreeMap<GlobalId, GenericSourceConnection<InlinedConnection>>,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
+    /// Alters the data config for the specified source exports of the specified ingestions.
+    async fn alter_ingestion_export_data_configs(
+        &mut self,
+        // Map from primary ingestion id to source-export id and new data config
+        source_exports: BTreeMap<GlobalId, (GlobalId, SourceExportDataConfig)>,
+    ) -> Result<(), StorageError<Self::Timestamp>>;
+
     async fn alter_table_desc(
         &mut self,
         table_id: GlobalId,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -452,8 +452,7 @@ pub trait StorageController: Debug {
     /// Alters the data config for the specified source exports of the specified ingestions.
     async fn alter_ingestion_export_data_configs(
         &mut self,
-        // Primary ingestion id, source-export id, and new data config
-        source_exports: Vec<(GlobalId, GlobalId, SourceExportDataConfig)>,
+        source_exports: BTreeMap<GlobalId, SourceExportDataConfig>,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
     async fn alter_table_desc(

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -245,8 +245,8 @@ pub trait StorageCollections: Debug {
     /// Alters the data config for the specified source exports of the specified ingestions.
     async fn alter_ingestion_export_data_configs(
         &self,
-        // Map from primary ingestion id to source-export id and new data config
-        source_exports: BTreeMap<GlobalId, (GlobalId, SourceExportDataConfig)>,
+        // Primary ingestion id, source-export id, and new data config
+        source_exports: Vec<(GlobalId, GlobalId, SourceExportDataConfig)>,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
     /// Alters each identified collection to use the correlated
@@ -1707,12 +1707,12 @@ where
 
     async fn alter_ingestion_export_data_configs(
         &self,
-        // Map from primary ingestion id to source-export id and new data config
-        source_exports: BTreeMap<GlobalId, (GlobalId, SourceExportDataConfig)>,
+        // Primary ingestion id, source-export id, and new data config
+        source_exports: Vec<(GlobalId, GlobalId, SourceExportDataConfig)>,
     ) -> Result<(), StorageError<Self::Timestamp>> {
         let mut self_collections = self.collections.lock().expect("lock poisoned");
 
-        for (ingestion_id, (source_export_id, data_config)) in source_exports {
+        for (ingestion_id, source_export_id, data_config) in source_exports {
             let ingestion_collection = self_collections
                 .get_mut(&ingestion_id)
                 .ok_or_else(|| StorageError::IdentifierMissing(ingestion_id))?;

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -48,6 +48,7 @@ use mz_storage_types::read_holds::{ReadHold, ReadHoldError};
 use mz_storage_types::read_policy::ReadPolicy;
 use mz_storage_types::sources::{
     GenericSourceConnection, IngestionDescription, SourceData, SourceDesc, SourceExport,
+    SourceExportDataConfig,
 };
 use mz_txn_wal::metrics::Metrics as TxnMetrics;
 use mz_txn_wal::txn_read::{DataSnapshot, TxnsRead};
@@ -239,6 +240,13 @@ pub trait StorageCollections: Debug {
         &self,
         ingestion_id: GlobalId,
         source_desc: SourceDesc,
+    ) -> Result<(), StorageError<Self::Timestamp>>;
+
+    /// Alters the data config for the specified source exports of the specified ingestions.
+    async fn alter_ingestion_export_data_configs(
+        &self,
+        // Map from primary ingestion id to source-export id and new data config
+        source_exports: BTreeMap<GlobalId, (GlobalId, SourceExportDataConfig)>,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
     /// Alters each identified collection to use the correlated
@@ -1693,6 +1701,69 @@ where
 
         curr_ingestion.desc = source_desc;
         debug!("altered {ingestion_id}'s SourceDesc");
+
+        Ok(())
+    }
+
+    async fn alter_ingestion_export_data_configs(
+        &self,
+        // Map from primary ingestion id to source-export id and new data config
+        source_exports: BTreeMap<GlobalId, (GlobalId, SourceExportDataConfig)>,
+    ) -> Result<(), StorageError<Self::Timestamp>> {
+        let mut self_collections = self.collections.lock().expect("lock poisoned");
+
+        for (ingestion_id, (source_export_id, data_config)) in source_exports {
+            let ingestion_collection = self_collections
+                .get_mut(&ingestion_id)
+                .ok_or_else(|| StorageError::IdentifierMissing(ingestion_id))?;
+
+            match &mut ingestion_collection.description.data_source {
+                DataSource::Ingestion(ingestion_desc) => {
+                    let source_export = ingestion_desc
+                        .source_exports
+                        .get_mut(&source_export_id)
+                        .ok_or_else(|| StorageError::IdentifierMissing(source_export_id))?;
+
+                    // If the data config hasn't changed, there's no sense in
+                    // re-rendering the dataflow.
+                    if source_export.data_config != data_config {
+                        tracing::info!(?source_export_id, from = ?source_export.data_config, to = ?data_config, "alter_ingestion_export_data_configs, updating");
+                        source_export.data_config = data_config;
+
+                        // We also need to adjust the data config on the CollectionState for
+                        // the source export collection directly
+                        let source_export_collection = self_collections
+                            .get_mut(&source_export_id)
+                            .ok_or_else(|| StorageError::IdentifierMissing(source_export_id))?;
+                        match &mut source_export_collection.description.data_source {
+                            DataSource::IngestionExport {
+                                ingestion_id: _,
+                                details: _,
+                                data_config,
+                            } => {
+                                *data_config = data_config.clone();
+                            }
+                            o => {
+                                tracing::warn!(
+                                    "alter_ingestion_export_data_configs called on {:?}",
+                                    o
+                                );
+                                Err(StorageError::IdentifierInvalid(source_export_id))?;
+                            }
+                        }
+                    } else {
+                        tracing::warn!(
+                            "alter_ingestion_export_data_configs called on export {source_export_id} \
+                            of {ingestion_id} but the data config was the same"
+                        );
+                    }
+                }
+                o => {
+                    tracing::warn!("alter_ingestion_export_data_configs called on {:?}", o);
+                    Err(StorageError::IdentifierInvalid(ingestion_id))?;
+                }
+            }
+        }
 
         Ok(())
     }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -979,8 +979,8 @@ where
 
     async fn alter_ingestion_export_data_configs(
         &mut self,
-        // Map from primary ingestion id to source-export id and new data config
-        source_exports: BTreeMap<GlobalId, (GlobalId, SourceExportDataConfig)>,
+        // Primary ingestion id, source-export id, and new data config
+        source_exports: Vec<(GlobalId, GlobalId, SourceExportDataConfig)>,
     ) -> Result<(), StorageError<Self::Timestamp>> {
         // Also have to let StorageCollections know!
         self.storage_collections
@@ -989,7 +989,7 @@ where
 
         let mut ingestions_to_run = BTreeSet::new();
 
-        for (ingestion_id, (source_export_id, data_config)) in source_exports {
+        for (ingestion_id, source_export_id, data_config) in source_exports {
             let ingestion_collection = self
                 .collections
                 .get_mut(&ingestion_id)

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -979,8 +979,7 @@ where
 
     async fn alter_ingestion_export_data_configs(
         &mut self,
-        // Primary ingestion id, source-export id, and new data config
-        source_exports: Vec<(GlobalId, GlobalId, SourceExportDataConfig)>,
+        source_exports: BTreeMap<GlobalId, SourceExportDataConfig>,
     ) -> Result<(), StorageError<Self::Timestamp>> {
         // Also have to let StorageCollections know!
         self.storage_collections
@@ -989,7 +988,29 @@ where
 
         let mut ingestions_to_run = BTreeSet::new();
 
-        for (ingestion_id, source_export_id, data_config) in source_exports {
+        for (source_export_id, new_data_config) in source_exports {
+            // We need to adjust the data config on the CollectionState for
+            // the source export collection directly
+            let source_export_collection = self
+                .collections
+                .get_mut(&source_export_id)
+                .ok_or_else(|| StorageError::IdentifierMissing(source_export_id))?;
+            let ingestion_id = match &mut source_export_collection.data_source {
+                DataSource::IngestionExport {
+                    ingestion_id,
+                    details: _,
+                    data_config,
+                } => {
+                    *data_config = new_data_config.clone();
+                    *ingestion_id
+                }
+                o => {
+                    tracing::warn!("alter_ingestion_export_data_configs called on {:?}", o);
+                    Err(StorageError::IdentifierInvalid(source_export_id))?
+                }
+            };
+            // We also need to adjust the data config on the CollectionState of the
+            // Ingestion that the export is associated with.
             let ingestion_collection = self
                 .collections
                 .get_mut(&ingestion_id)
@@ -1004,38 +1025,16 @@ where
 
                     // If the data config hasn't changed, there's no sense in
                     // re-rendering the dataflow.
-                    if source_export.data_config != data_config {
-                        tracing::info!(?source_export_id, from = ?source_export.data_config, to = ?data_config, "alter_ingestion_export_data_configs, updating");
-                        source_export.data_config = data_config;
-
-                        // We also need to adjust the data config on the CollectionState for
-                        // the source export collection directly
-                        let source_export_collection = self
-                            .collections
-                            .get_mut(&source_export_id)
-                            .ok_or_else(|| StorageError::IdentifierMissing(source_export_id))?;
-                        match &mut source_export_collection.data_source {
-                            DataSource::IngestionExport {
-                                ingestion_id: _,
-                                details: _,
-                                data_config,
-                            } => {
-                                *data_config = data_config.clone();
-                            }
-                            o => {
-                                tracing::warn!(
-                                    "alter_ingestion_export_data_configs called on {:?}",
-                                    o
-                                );
-                                Err(StorageError::IdentifierInvalid(source_export_id))?;
-                            }
-                        }
+                    if source_export.data_config != new_data_config {
+                        tracing::info!(?source_export_id, from = ?source_export.data_config, to = ?new_data_config, "alter_ingestion_export_data_configs, updating");
+                        source_export.data_config = new_data_config;
 
                         ingestions_to_run.insert(ingestion_id);
                     } else {
                         tracing::warn!(
-                            "alter_ingestion_export_data_configs called on export {source_export_id} \
-                            of {ingestion_id} but the data config was the same"
+                            "alter_ingestion_export_data_configs called on \
+                                    export {source_export_id} of {ingestion_id} but \
+                                    the data config was the same"
                         );
                     }
                 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.
Fixes https://github.com/MaterializeInc/database-issues/issues/8600

Fixes the above issue which occurs when a CSR / Schema Registry connection is altered and a reference to that connection is stored inside the `data_config` / `encoding` settings for a `CREATE TABLE .. FROM SOURCE .. FORMAT AVRO .. ` statement.

This connection change should trigger updates to the underlying ingestions in the Storage Controller to re-render any sources as necessary.

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
