### PR TITLE
fix balancer ld context

### DIFF
--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -201,20 +201,30 @@ impl BalancerService {
                     .unwrap_or_else(|| String::from("unknown"));
                 if let Some(provider) = cfg.cloud_provider.clone() {
                     builder.add_context(
-                        ld::ContextBuilder::new(provider)
-                            .kind("cloud_provider")
-                            .set_string("cloud_provider_region", region)
-                            .build()
-                            .map_err(|e| anyhow::anyhow!(e))?,
+                        ld::ContextBuilder::new(format!(
+                            "{}/{}/{}",
+                            provider, region, cfg.build_version
+                        ))
+                        .kind("balancer")
+                        .set_string("provider", provider)
+                        .set_string("region", region)
+                        .set_string("version", cfg.build_version.to_string())
+                        .build()
+                        .map_err(|e| anyhow::anyhow!(e))?,
                     );
                 } else {
                     builder.add_context(
-                        ld::ContextBuilder::new("unknown")
-                            .anonymous(true) // exclude this user from the dashboard
-                            .kind("cloud_provider")
-                            .set_string("cloud_provider_region", region)
-                            .build()
-                            .map_err(|e| anyhow::anyhow!(e))?,
+                        ld::ContextBuilder::new(format!(
+                            "{}/{}/{}",
+                            "unknown", region, cfg.build_version
+                        ))
+                        .anonymous(true) // exclude this user from the dashboard
+                        .kind("balancer")
+                        .set_string("provider", "unknown")
+                        .set_string("region", region)
+                        .set_string("version", cfg.build_version.to_string())
+                        .build()
+                        .map_err(|e| anyhow::anyhow!(e))?,
                     );
                 }
                 Ok(())


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Currently balancer uses a `cloud_provider` context with a key of the cloud provider which means all balancers use the same key `aws`. This seems to break LD contexts for the balancers and goes against the docs. dyncfg works with the current setup, but LD just won't recommend all keys/regions when create or updating a rule. 


https://docs.launchdarkly.com/sdk/features/context-config
> Keys must be a string type. Keys must be unique, deterministic, and should not contain personally identifiable
> information (PII). Keys must be consistent, which means the same person must correspond to the same key across > different services to contribute to consistent flag evaluations. You can use a primary key or a hash, as long as the
> same person always has the same key. We recommend using a hash if possible.`


The fix is to use a more specific contex and a key that reduces the scope of balancers to a set we can treat as the same. I'm also taking the opportunity to add build version into the context.


It's entirely possible we just don't want to do this and are more or less ok with the contexts overwriting each other. 
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
