### PR TITLE
Box insights contexts to save stack space

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -516,7 +516,7 @@ pub struct PeekStageFinish {
     /// When present, an optimizer trace to be used for emitting a plan insights
     /// notice.
     plan_insights_optimizer_trace: Option<OptimizerTrace>,
-    insights_ctx: Option<PlanInsightsContext>,
+    insights_ctx: Option<Box<PlanInsightsContext>>,
     global_lir_plan: optimize::peek::GlobalLirPlan,
     optimization_finished_at: EpochMillis,
 }
@@ -536,7 +536,7 @@ pub struct PeekStageExplainPlan {
     optimizer: optimize::peek::Optimizer,
     df_meta: DataflowMetainfo,
     explain_ctx: ExplainPlanContext,
-    insights_ctx: Option<PlanInsightsContext>,
+    insights_ctx: Option<Box<PlanInsightsContext>>,
 }
 
 #[derive(Debug)]

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -613,7 +613,7 @@ impl Coordinator {
                             view_id: optimizer.select_id(),
                             index_id: optimizer.index_id(),
                             enable_re_optimize,
-                        });
+                        }).map(Box::new);
                             match explain_ctx {
                                 ExplainContext::Plan(explain_ctx) => {
                                     let (_, df_meta, _) = global_lir_plan.unapply();

--- a/src/adapter/src/explain/insights.rs
+++ b/src/adapter/src/explain/insights.rs
@@ -86,7 +86,7 @@ impl PlanInsights {
     pub async fn compute_fast_path_clusters(
         &mut self,
         humanizer: &dyn ExprHumanizer,
-        ctx: PlanInsightsContext,
+        ctx: Box<PlanInsightsContext>,
     ) {
         let session: Arc<dyn SessionMetadata + Send> = Arc::new(ctx.session);
         let tasks = ctx

--- a/src/adapter/src/explain/optimizer_trace.rs
+++ b/src/adapter/src/explain/optimizer_trace.rs
@@ -139,7 +139,7 @@ impl OptimizerTrace {
         dataflow_metainfo: DataflowMetainfo,
         stage: ExplainStage,
         stmt_kind: plan::ExplaineeStatementKind,
-        insights_ctx: Option<PlanInsightsContext>,
+        insights_ctx: Option<Box<PlanInsightsContext>>,
     ) -> Result<Vec<Row>, AdapterError> {
         let collect_all = |format| {
             self.collect_all(
@@ -306,7 +306,7 @@ impl OptimizerTrace {
         row_set_finishing: Option<RowSetFinishing>,
         target_cluster: Option<&Cluster>,
         dataflow_metainfo: DataflowMetainfo,
-        insights_ctx: Option<PlanInsightsContext>,
+        insights_ctx: Option<Box<PlanInsightsContext>>,
     ) -> Result<String, AdapterError> {
         let rows = self
             .into_rows(


### PR DESCRIPTION
The insights context is only used in some situations, but unconditionally requires 3-4KiB space for the struct. Move it to the heap to half the size of peek-related closures and structs.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
