### PR TITLE
Box SelectPlan::select

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -600,7 +600,7 @@ impl Coordinator {
                             !(matches!(explain_ctx, ExplainContext::PlanInsightsNotice(_))
                                 && optimizer.duration() > opt_limit);
                         let insights_ctx = needs_plan_insights.then(|| PlanInsightsContext {
-                            stmt: plan.select.clone().map(Statement::Select),
+                            stmt: plan.select.as_deref().map(Clone::clone).map(Statement::Select),
                             raw_expr: plan.source.clone(),
                             catalog,
                             compute_instances,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -813,7 +813,7 @@ pub struct SetTransactionPlan {
 
 #[derive(Clone, Debug)]
 pub struct SelectPlan {
-    pub select: Option<SelectStatement<Aug>>,
+    pub select: Option<Box<SelectStatement<Aug>>>,
     pub source: HirRelationExpr,
     pub when: QueryWhen,
     pub finishing: RowSetFinishing,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -811,12 +811,19 @@ pub struct SetTransactionPlan {
     pub modes: Vec<TransactionMode>,
 }
 
+/// A plan for select statements.
 #[derive(Clone, Debug)]
 pub struct SelectPlan {
+    /// The `SELECT` statement itself. Used for explain/notices, but not otherwise
+    /// load-bearing. Boxed to save stack space.
     pub select: Option<Box<SelectStatement<Aug>>>,
+    /// The plan as a HIR.
     pub source: HirRelationExpr,
+    /// At what time should this select happen?
     pub when: QueryWhen,
+    /// Instructions how to form the result set.
     pub finishing: RowSetFinishing,
+    /// For `COPY TO`, the format to use.
     pub copy_to: Option<CopyFormat>,
 }
 

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -247,7 +247,7 @@ fn plan_select_inner(
             order_by: finishing.order_by,
         },
         copy_to,
-        select: Some(select),
+        select: Some(Box::new(select)),
     };
 
     Ok((plan, desc))


### PR DESCRIPTION
The SelectPlan struct optionally stores a copy of the select plan. The
SelectStatement struct is rather large (>2KiB), and because we're using
the SelectPlan struct in async state machines, we multiply the space
required to store the statement. This change boxes the select statement
so it doesn't need space on the stack.

A better implementation would be to conditionally store the statement if
it'll be needed based on the explains enabled. This is not as easy as
we're creating the plan before determining what explain modes are enabled.
w to determine the size of async closures

```
RUSTFLAGS=-Zprint-type-sizes cargo +nightly build -p mz-adapter > print-type-sizes.txt
grep awaitee print-type-sizes.txt | cut -c 45- | sort -n | less
```

Largest async closures before the change:

```
29856 bytes, alignment: 8 bytes, type: {async fn body of create_view::<impl Coordinator>::explain_replan_view()}
31128 bytes, alignment: 8 bytes, type: {async fn body of StorageCollectionsImpl<mz_repr::Timestamp>::new()}
31584 bytes, alignment: 8 bytes, type: {async block@Controller::new::{closure#0}::{closure#0}}
31616 bytes, alignment: 8 bytes, type: Instrumented<{async block@Controller::new::{closure#0}::{closure#0}}>
31680 bytes, alignment: 8 bytes, type: {async fn body of create_index::<impl Coordinator>::explain_replan_index()}
31712 bytes, alignment: 8 bytes, type: {async fn body of inner::<impl Coordinator>::sequence_staged<PeekStage>()}
31712 bytes, type: {async fn body of inner::<impl Coordinator>::sequence_staged<PeekStage>()}
31712 bytes, type: {async fn body of inner::<impl Coordinator>::sequence_staged<PeekStage>()}
31712 bytes, type: {async fn body of inner::<impl Coordinator>::sequence_staged<PeekStage>()}
32072 bytes, alignment: 8 bytes, type: {async fn body of Controller::new()}
32840 bytes, alignment: 8 bytes, type: {async block@src/adapter/src/coord/sequencer/inner/create_materialized_view.rs:166:5: 166:18}
32872 bytes, alignment: 8 bytes, type: Instrumented<{async block@src/adapter/src/coord/sequencer/inner/create_materialized_view.rs:166:5: 166:18}>
33128 bytes, alignment: 8 bytes, type: {async fn body of create_materialized_view::<impl Coordinator>::explain_create_materialized_view()}
35224 bytes, alignment: 8 bytes, type: {async block@src/adapter/src/coord/sequencer/inner/peek.rs:121:5: 121:18}
35256 bytes, alignment: 8 bytes, type: Instrumented<{async block@src/adapter/src/coord/sequencer/inner/peek.rs:121:5: 121:18}>
35880 bytes, alignment: 8 bytes, type: {async block@src/adapter/src/coord/sequencer/inner/peek.rs:150:5: 150:18}
35912 bytes, alignment: 8 bytes, type: Instrumented<{async block@src/adapter/src/coord/sequencer/inner/peek.rs:150:5: 150:18}>
36528 bytes, alignment: 8 bytes, type: {async fn body of create_materialized_view::<impl Coordinator>::explain_replan_materialized_view()}
37552 bytes, alignment: 8 bytes, type: {async block@src/adapter/src/coord/sequencer/inner/peek.rs:215:5: 215:18}
37584 bytes, alignment: 8 bytes, type: Instrumented<{async block@src/adapter/src/coord/sequencer/inner/peek.rs:215:5: 215:18}>
38800 bytes, alignment: 8 bytes, type: {async fn body of inner::peek::<impl Coordinator>::sequence_peek()}
38800 bytes, type: {async fn body of inner::peek::<impl Coordinator>::sequence_peek()}
38800 bytes, type: {async fn body of inner::peek::<impl Coordinator>::sequence_peek()}
38832 bytes, alignment: 8 bytes, type: {async fn body of inner::<impl Coordinator>::sequence_explain_pushdown()}
40096 bytes, alignment: 8 bytes, type: {async fn body of inner::peek::<impl Coordinator>::sequence_copy_to()}
41088 bytes, alignment: 8 bytes, type: {async block@src/adapter/src/coord/sequencer/inner.rs:2532:5: 2532:18}
41120 bytes, alignment: 8 bytes, type: Instrumented<{async block@src/adapter/src/coord/sequencer/inner.rs:2532:5: 2532:18}>
41256 bytes, alignment: 8 bytes, type: {async fn body of inner::peek::<impl Coordinator>::explain_peek()}
42928 bytes, alignment: 8 bytes, type: {async fn body of inner::<impl Coordinator>::sequence_read_then_write()}
42928 bytes, type: {async fn body of inner::<impl Coordinator>::sequence_read_then_write()}
44816 bytes, alignment: 8 bytes, type: {async block@src/adapter/src/coord/sequencer/inner.rs:2434:5: 2434:18}
44848 bytes, alignment: 8 bytes, type: Instrumented<{async block@src/adapter/src/coord/sequencer/inner.rs:2434:5: 2434:18}>
44896 bytes, alignment: 8 bytes, type: {async block@src/adapter/src/coord/sequencer/inner.rs:2240:5: 2240:18}
44928 bytes, alignment: 8 bytes, type: Instrumented<{async block@src/adapter/src/coord/sequencer/inner.rs:2240:5: 2240:18}>
46552 bytes, alignment: 8 bytes, type: {async fn body of inner::<impl Coordinator>::sequence_insert()}
48600 bytes, alignment: 8 bytes, type: {async fn body of inner::<impl Coordinator>::sequence_explain_plan()}
```

After the change:
```
24184 bytes, type: {async fn body of inner::peek::<impl Coordinator>::sequence_peek()}
24184 bytes, type: {async fn body of inner::peek::<impl Coordinator>::sequence_peek()}
~~~
29488 bytes, alignment: 8 bytes, type: Instrumented<{async block@src/adapter/src/coord/sequencer/inner/create_materialized_view.rs:166:5: 166:18}>
30200 bytes, alignment: 8 bytes, type: {async block@src/adapter/src/coord/sequencer/inner.rs:2434:5: 2434:18}
30232 bytes, alignment: 8 bytes, type: Instrumented<{async block@src/adapter/src/coord/sequencer/inner.rs:2434:5: 2434:18}>
31128 bytes, alignment: 8 bytes, type: {async fn body of StorageCollectionsImpl<mz_repr::Timestamp>::new()}
31520 bytes, alignment: 8 bytes, type: {async fn body of create_materialized_view::<impl Coordinator>::explain_replan_materialized_view()}
31584 bytes, alignment: 8 bytes, type: {async block@Controller::new::{closure#0}::{closure#0}}
31616 bytes, alignment: 8 bytes, type: Instrumented<{async block@Controller::new::{closure#0}::{closure#0}}>
31936 bytes, alignment: 8 bytes, type: {async fn body of inner::<impl Coordinator>::sequence_insert()}
32072 bytes, alignment: 8 bytes, type: {async fn body of Controller::new()}
33536 bytes, alignment: 8 bytes, type: {async block@src/adapter/src/coord/sequencer/inner.rs:2240:5: 2240:18}
33568 bytes, alignment: 8 bytes, type: Instrumented<{async block@src/adapter/src/coord/sequencer/inner.rs:2240:5: 2240:18}>
35616 bytes, alignment: 8 bytes, type: {async fn body of inner::<impl Coordinator>::sequence_explain_plan()}
```


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
