### PR TITLE
[compute] refactor LirId treatment

### DIFF
--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -120,7 +120,7 @@ impl<T> DataflowDescription<Plan<T>, (), mz_repr::Timestamp> {
                     "duplicate `LirId` in `DataflowDescription`: {lir_id}"
                 ));
             }
-            plans.extend(plan.children());
+            plans.extend(plan.node.children());
         }
 
         Ok(())

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -114,7 +114,7 @@ impl<T> DataflowDescription<Plan<T>, (), mz_repr::Timestamp> {
         let mut lir_ids = BTreeSet::new();
 
         while let Some(plan) = plans.pop() {
-            let lir_id = plan.lir_id();
+            let lir_id = plan.lir_id;
             if !lir_ids.insert(lir_id) {
                 return Err(format!(
                     "duplicate `LirId` in `DataflowDescription`: {lir_id}"

--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -53,7 +53,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
         let annotations = PlanAnnotations::new(ctx.config.clone(), self);
 
         match &self.node {
-            Constant { rows, lir_id: _ } => match rows {
+            Constant { rows } => match rows {
                 Ok(rows) => {
                     if !rows.is_empty() {
                         writeln!(f, "{}Constant{}", ctx.indent, annotations)?;
@@ -83,12 +83,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                     }
                 }
             },
-            Get {
-                id,
-                keys,
-                plan,
-                lir_id: _,
-            } => {
+            Get { id, keys, plan } => {
                 ctx.indent.set(); // mark the current indent level
 
                 // Resolve the id as a string.
@@ -136,24 +131,13 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
 
                 ctx.indent.reset(); // reset the original indent level
             }
-            Let {
-                id,
-                value,
-                body,
-                lir_id: _,
-            } => {
+            Let { id, value, body } => {
                 let mut bindings = vec![(id, value.as_ref())];
                 let mut head = body.as_ref();
 
                 // Render Let-blocks nested in the body an outer Let-block in one step
                 // with a flattened list of bindings
-                while let Let {
-                    id,
-                    value,
-                    body,
-                    lir_id: _,
-                } = &head.node
-                {
+                while let Let { id, value, body } = &head.node {
                     bindings.push((id, value.as_ref()));
                     head = body.as_ref();
                 }
@@ -174,7 +158,6 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 values,
                 limits,
                 body,
-                lir_id: _,
             } => {
                 let bindings = izip!(ids.iter(), values, limits).collect_vec();
                 let head = body.as_ref();
@@ -198,7 +181,6 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 input,
                 mfp,
                 input_key_val,
-                lir_id: _,
             } => {
                 writeln!(f, "{}Mfp{}", ctx.indent, annotations)?;
                 ctx.indented(|ctx| {
@@ -223,7 +205,6 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 exprs,
                 mfp_after,
                 input_key,
-                lir_id: _,
             } => {
                 let exprs = mode.seq(exprs, None);
                 let exprs = CompactScalars(exprs);
@@ -245,11 +226,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                     input.fmt_text(f, ctx)
                 })?;
             }
-            Join {
-                inputs,
-                plan,
-                lir_id: _,
-            } => {
+            Join { inputs, plan } => {
                 use crate::plan::join::JoinPlan;
                 match plan {
                     JoinPlan::Linear(plan) => {
@@ -274,7 +251,6 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 plan,
                 input_key,
                 mfp_after,
-                lir_id: _,
             } => {
                 use crate::plan::reduce::ReducePlan;
                 match plan {
@@ -330,11 +306,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                     input.fmt_text(f, ctx)
                 })?;
             }
-            TopK {
-                input,
-                top_k_plan,
-                lir_id: _,
-            } => {
+            TopK { input, top_k_plan } => {
                 use crate::plan::top_k::TopKPlan;
                 match top_k_plan {
                     TopKPlan::MonotonicTop1(plan) => {
@@ -397,14 +369,13 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 writeln!(f, "{}", annotations)?;
                 ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
-            Negate { input, lir_id: _ } => {
+            Negate { input } => {
                 writeln!(f, "{}Negate{}", ctx.indent, annotations)?;
                 ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
             Threshold {
                 input,
                 threshold_plan,
-                lir_id: _,
             } => {
                 use crate::plan::threshold::ThresholdPlan;
                 match threshold_plan {
@@ -421,7 +392,6 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
             Union {
                 inputs,
                 consolidate_output,
-                lir_id: _,
             } => {
                 if *consolidate_output {
                     writeln!(
@@ -444,7 +414,6 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 forms,
                 input_key,
                 input_mfp,
-                lir_id: _,
             } => {
                 writeln!(f, "{}ArrangeBy{}", ctx.indent, annotations)?;
                 ctx.indented(|ctx| {
@@ -895,7 +864,7 @@ struct PlanAnnotations {
 // `AnnotatedPlan` here as well.
 impl PlanAnnotations {
     fn new(config: ExplainConfig, plan: &Plan) -> Self {
-        let node_id = plan.lir_id();
+        let node_id = plan.lir_id;
         Self { config, node_id }
     }
 }

--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -39,7 +39,7 @@ use crate::plan::join::{DeltaJoinPlan, JoinClosure, LinearJoinPlan};
 use crate::plan::reduce::{
     AccumulablePlan, BasicPlan, CollationPlan, HierarchicalPlan, SingleBasicPlan,
 };
-use crate::plan::{AvailableCollections, LirId, Plan};
+use crate::plan::{AvailableCollections, LirId, Plan, PlanNode};
 
 impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
     fn fmt_text(
@@ -47,12 +47,12 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
         f: &mut fmt::Formatter<'_>,
         ctx: &mut PlanRenderingContext<'_, Plan>,
     ) -> fmt::Result {
-        use Plan::*;
+        use PlanNode::*;
 
         let mode = HumanizedExplain::new(ctx.config.redacted);
         let annotations = PlanAnnotations::new(ctx.config.clone(), self);
 
-        match &self {
+        match &self.node {
             Constant { rows, lir_id: _ } => match rows {
                 Ok(rows) => {
                     if !rows.is_empty() {
@@ -152,7 +152,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                     value,
                     body,
                     lir_id: _,
-                } = head
+                } = &head.node
                 {
                     bindings.push((id, value.as_ref()));
                     head = body.as_ref();

--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -192,7 +192,16 @@ pub type LirId = u64;
 
 /// A rendering plan with as much conditional logic as possible removed.
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum Plan<T = mz_repr::Timestamp> {
+pub struct Plan<T = mz_repr::Timestamp> {
+    /// A dataflow-local identifier.
+    pub lir_id: LirId,
+    /// The underlying operator.
+    pub node: PlanNode<T>,
+}
+
+/// The actual AST node of the `Plan`.
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PlanNode<T = mz_repr::Timestamp> {
     /// A collection containing a pre-determined collection.
     Constant {
         /// Explicit update triples for the collection.
@@ -415,15 +424,15 @@ pub enum Plan<T = mz_repr::Timestamp> {
     },
 }
 
-impl<T> Plan<T> {
+impl<T> PlanNode<T> {
     /// Iterates through references to child expressions.
-    pub fn children(&self) -> impl Iterator<Item = &Self> {
+    pub fn children(&self) -> impl Iterator<Item = &Plan<T>> {
         let mut first = None;
         let mut second = None;
         let mut rest = None;
         let mut last = None;
 
-        use Plan::*;
+        use PlanNode::*;
         match self {
             Constant { .. } | Get { .. } => (),
             Let { value, body, .. } => {
@@ -456,13 +465,13 @@ impl<T> Plan<T> {
     }
 
     /// Iterates through mutable references to child expressions.
-    pub fn children_mut(&mut self) -> impl Iterator<Item = &mut Self> {
+    pub fn children_mut(&mut self) -> impl Iterator<Item = &mut Plan<T>> {
         let mut first = None;
         let mut second = None;
         let mut rest = None;
         let mut last = None;
 
-        use Plan::*;
+        use PlanNode::*;
         match self {
             Constant { .. } | Get { .. } => (),
             Let { value, body, .. } => {
@@ -498,22 +507,14 @@ impl<T> Plan<T> {
 impl<T> Plan<T> {
     /// Return this plan's `LirId`.
     pub fn lir_id(&self) -> LirId {
-        use Plan::*;
-        match self {
-            Constant { lir_id, .. }
-            | Get { lir_id, .. }
-            | Let { lir_id, .. }
-            | LetRec { lir_id, .. }
-            | Mfp { lir_id, .. }
-            | FlatMap { lir_id, .. }
-            | Join { lir_id, .. }
-            | Reduce { lir_id, .. }
-            | TopK { lir_id, .. }
-            | Negate { lir_id, .. }
-            | Threshold { lir_id, .. }
-            | Union { lir_id, .. }
-            | ArrangeBy { lir_id, .. } => *lir_id,
-        }
+        self.lir_id
+    }
+}
+
+impl<T> PlanNode<T> {
+    /// Attach an `lir_id` to a `PlanNode` to make a complete `Plan`.
+    pub fn as_plan(self, lir_id: LirId) -> Plan<T> {
+        Plan { lir_id, node: self }
     }
 }
 
@@ -550,8 +551,9 @@ impl Arbitrary for Plan {
             0..2,
         );
         let rows = prop::result::maybe_ok(row_diff, EvalError::arbitrary());
-        let constant =
-            (rows, any::<LirId>()).prop_map(|(rows, lir_id)| Plan::Constant { rows, lir_id });
+        let constant = (rows, any::<LirId>()).prop_map(|(rows, lir_id)| {
+            PlanNode::<mz_repr::Timestamp>::Constant { rows, lir_id }.as_plan(lir_id)
+        });
 
         let get = (
             any::<GlobalId>(),
@@ -559,11 +561,14 @@ impl Arbitrary for Plan {
             any::<GetPlan>(),
             any::<LirId>(),
         )
-            .prop_map(|(id, keys, plan, lir_id)| Plan::<mz_repr::Timestamp>::Get {
-                id: Id::Global(id),
-                keys,
-                plan,
-                lir_id,
+            .prop_map(|(id, keys, plan, lir_id)| {
+                PlanNode::<mz_repr::Timestamp>::Get {
+                    id: Id::Global(id),
+                    keys,
+                    plan,
+                    lir_id,
+                }
+                .as_plan(lir_id)
             });
 
         let leaf = prop::strategy::Union::new(vec![constant.boxed(), get.boxed()]).boxed();
@@ -577,11 +582,14 @@ impl Arbitrary for Plan {
                     inner.clone(),
                     any::<LirId>(),
                 )
-                    .prop_map(|(id, value, body, lir_id)| Plan::Let {
-                        id,
-                        value: value.into(),
-                        body: body.into(),
-                        lir_id,
+                    .prop_map(|(id, value, body, lir_id)| {
+                        PlanNode::<mz_repr::Timestamp>::Let {
+                            id,
+                            value: value.into(),
+                            body: body.into(),
+                            lir_id,
+                        }
+                        .as_plan(lir_id)
                     })
                     .boxed(),
                 //Plan::Mfp
@@ -591,11 +599,14 @@ impl Arbitrary for Plan {
                     any::<Option<(Vec<MirScalarExpr>, Option<Row>)>>(),
                     any::<LirId>(),
                 )
-                    .prop_map(|(input, mfp, input_key_val, lir_id)| Plan::Mfp {
-                        input: input.into(),
-                        mfp,
-                        input_key_val,
-                        lir_id,
+                    .prop_map(|(input, mfp, input_key_val, lir_id)| {
+                        PlanNode::Mfp {
+                            input: input.into(),
+                            mfp,
+                            input_key_val,
+                            lir_id,
+                        }
+                        .as_plan(lir_id)
                     })
                     .boxed(),
                 //Plan::FlatMap
@@ -607,16 +618,17 @@ impl Arbitrary for Plan {
                     any::<Option<Vec<MirScalarExpr>>>(),
                     any::<LirId>(),
                 )
-                    .prop_map(
-                        |(input, func, exprs, mfp, input_key, lir_id)| Plan::FlatMap {
+                    .prop_map(|(input, func, exprs, mfp, input_key, lir_id)| {
+                        PlanNode::FlatMap {
                             input: input.into(),
                             func,
                             exprs,
                             mfp_after: mfp,
                             input_key,
                             lir_id,
-                        },
-                    )
+                        }
+                        .as_plan(lir_id)
+                    })
                     .boxed(),
                 //Plan::Join
                 (
@@ -624,10 +636,13 @@ impl Arbitrary for Plan {
                     any::<JoinPlan>(),
                     any::<LirId>(),
                 )
-                    .prop_map(|(inputs, plan, lir_id)| Plan::Join {
-                        inputs,
-                        plan,
-                        lir_id,
+                    .prop_map(|(inputs, plan, lir_id)| {
+                        PlanNode::Join {
+                            inputs,
+                            plan,
+                            lir_id,
+                        }
+                        .as_plan(lir_id)
                     })
                     .boxed(),
                 //Plan::Reduce
@@ -640,37 +655,49 @@ impl Arbitrary for Plan {
                     any::<LirId>(),
                 )
                     .prop_map(
-                        |(input, key_val_plan, plan, input_key, mfp_after, lir_id)| Plan::Reduce {
-                            input: input.into(),
-                            key_val_plan,
-                            plan,
-                            input_key,
-                            mfp_after,
-                            lir_id,
+                        |(input, key_val_plan, plan, input_key, mfp_after, lir_id)| {
+                            PlanNode::Reduce {
+                                input: input.into(),
+                                key_val_plan,
+                                plan,
+                                input_key,
+                                mfp_after,
+                                lir_id,
+                            }
+                            .as_plan(lir_id)
                         },
                     )
                     .boxed(),
                 //Plan::TopK
                 (inner.clone(), any::<TopKPlan>(), any::<LirId>())
-                    .prop_map(|(input, top_k_plan, lir_id)| Plan::TopK {
-                        input: input.into(),
-                        top_k_plan,
-                        lir_id,
+                    .prop_map(|(input, top_k_plan, lir_id)| {
+                        PlanNode::TopK {
+                            input: input.into(),
+                            top_k_plan,
+                            lir_id,
+                        }
+                        .as_plan(lir_id)
                     })
                     .boxed(),
                 //Plan::Negate
                 (inner.clone(), any::<LirId>())
-                    .prop_map(|(x, lir_id)| Plan::Negate {
-                        input: x.into(),
-                        lir_id,
+                    .prop_map(|(x, lir_id)| {
+                        PlanNode::Negate {
+                            input: x.into(),
+                            lir_id,
+                        }
+                        .as_plan(lir_id)
                     })
                     .boxed(),
                 //Plan::Threshold
                 (inner.clone(), any::<ThresholdPlan>(), any::<LirId>())
-                    .prop_map(|(input, threshold_plan, lir_id)| Plan::Threshold {
-                        input: input.into(),
-                        threshold_plan,
-                        lir_id,
+                    .prop_map(|(input, threshold_plan, lir_id)| {
+                        PlanNode::Threshold {
+                            input: input.into(),
+                            threshold_plan,
+                            lir_id,
+                        }
+                        .as_plan(lir_id)
                     })
                     .boxed(),
                 // Plan::Union
@@ -679,10 +706,13 @@ impl Arbitrary for Plan {
                     any::<bool>(),
                     any::<LirId>(),
                 )
-                    .prop_map(|(x, b, lir_id)| Plan::Union {
-                        inputs: x,
-                        consolidate_output: b,
-                        lir_id,
+                    .prop_map(|(x, b, lir_id)| {
+                        PlanNode::Union {
+                            inputs: x,
+                            consolidate_output: b,
+                            lir_id,
+                        }
+                        .as_plan(lir_id)
                     })
                     .boxed(),
                 //Plan::ArrangeBy
@@ -693,15 +723,16 @@ impl Arbitrary for Plan {
                     any::<MapFilterProject>(),
                     any::<LirId>(),
                 )
-                    .prop_map(
-                        |(input, forms, input_key, input_mfp, lir_id)| Plan::ArrangeBy {
+                    .prop_map(|(input, forms, input_key, input_mfp, lir_id)| {
+                        PlanNode::ArrangeBy {
                             input: input.into(),
                             forms,
                             input_key,
                             input_mfp,
                             lir_id,
-                        },
-                    )
+                        }
+                        .as_plan(lir_id)
+                    })
                     .boxed(),
             ])
         })
@@ -874,7 +905,8 @@ impl<T: timely::progress::Timestamp> Plan<T> {
             for build_desc in dataflow.objects_to_build.iter_mut() {
                 let mut todo = vec![&mut build_desc.plan];
                 while let Some(expression) = todo.pop() {
-                    if let Plan::Get { id, plan, .. } = expression {
+                    let node = &mut expression.node;
+                    if let PlanNode::Get { id, plan, .. } = node {
                         if *id == mz_expr::Id::Global(*source_id) {
                             match plan {
                                 GetPlan::Collection(mfp) => mfps.push(mfp),
@@ -887,7 +919,7 @@ impl<T: timely::progress::Timestamp> Plan<T> {
                             }
                         }
                     } else {
-                        todo.extend(expression.children_mut());
+                        todo.extend(node.children_mut());
                     }
                 }
             }
@@ -925,22 +957,23 @@ impl<T: timely::progress::Timestamp> Plan<T> {
         for build_desc in dataflow.objects_to_build.iter_mut() {
             let mut todo = vec![&mut build_desc.plan];
             while let Some(expression) = todo.pop() {
-                match expression {
-                    Plan::Union {
+                let node = &mut expression.node;
+                match node {
+                    PlanNode::Union {
                         inputs,
                         consolidate_output,
                         ..
                     } => {
                         if inputs
                             .iter()
-                            .any(|input| matches!(input, Plan::Negate { .. }))
+                            .any(|input| matches!(input.node, PlanNode::Negate { .. }))
                         {
                             *consolidate_output = true;
                         }
                     }
                     _ => {}
                 }
-                todo.extend(expression.children_mut());
+                todo.extend(node.children_mut());
             }
         }
         mz_repr::explain::trace_plan(dataflow);
@@ -963,8 +996,9 @@ impl<T: timely::progress::Timestamp> Plan<T> {
         for build_desc in dataflow.objects_to_build.iter_mut() {
             let mut todo = vec![&mut build_desc.plan];
             while let Some(expression) = todo.pop() {
-                match expression {
-                    Plan::Reduce { plan, .. } => {
+                let node = &mut expression.node;
+                match node {
+                    PlanNode::Reduce { plan, .. } => {
                         // Upgrade non-monotonic hierarchical plans to monotonic with mandatory consolidation.
                         match plan {
                             ReducePlan::Collation(collation) => {
@@ -977,19 +1011,19 @@ impl<T: timely::progress::Timestamp> Plan<T> {
                                 // Nothing to do for other plans, and doing nothing is safe for future variants.
                             }
                         }
-                        todo.extend(expression.children_mut());
+                        todo.extend(node.children_mut());
                     }
-                    Plan::TopK { top_k_plan, .. } => {
+                    PlanNode::TopK { top_k_plan, .. } => {
                         top_k_plan.as_monotonic(true);
-                        todo.extend(expression.children_mut());
+                        todo.extend(node.children_mut());
                     }
-                    Plan::LetRec { body, .. } => {
+                    PlanNode::LetRec { body, .. } => {
                         // Only the non-recursive `body` is restricted to a single time.
                         todo.push(body);
                     }
                     _ => {
                         // Nothing to do for other expressions, and doing nothing is safe for future expressions.
-                        todo.extend(expression.children_mut());
+                        todo.extend(node.children_mut());
                     }
                 }
             }
@@ -1024,11 +1058,11 @@ impl<T: timely::progress::Timestamp> Plan<T> {
     }
 }
 
-impl<T> CollectionPlan for Plan<T> {
+impl<T> CollectionPlan for PlanNode<T> {
     fn depends_on_into(&self, out: &mut BTreeSet<GlobalId>) {
         match self {
-            Plan::Constant { rows: _, lir_id: _ } => (),
-            Plan::Get {
+            PlanNode::Constant { rows: _, lir_id: _ } => (),
+            PlanNode::Get {
                 id,
                 keys: _,
                 plan: _,
@@ -1039,7 +1073,7 @@ impl<T> CollectionPlan for Plan<T> {
                 }
                 Id::Local(_) => (),
             },
-            Plan::Let {
+            PlanNode::Let {
                 id: _,
                 value,
                 body,
@@ -1048,7 +1082,7 @@ impl<T> CollectionPlan for Plan<T> {
                 value.depends_on_into(out);
                 body.depends_on_into(out);
             }
-            Plan::LetRec {
+            PlanNode::LetRec {
                 ids: _,
                 values,
                 limits: _,
@@ -1060,12 +1094,12 @@ impl<T> CollectionPlan for Plan<T> {
                 }
                 body.depends_on_into(out);
             }
-            Plan::Join {
+            PlanNode::Join {
                 inputs,
                 plan: _,
                 lir_id: _,
             }
-            | Plan::Union {
+            | PlanNode::Union {
                 inputs,
                 consolidate_output: _,
                 lir_id: _,
@@ -1074,13 +1108,13 @@ impl<T> CollectionPlan for Plan<T> {
                     input.depends_on_into(out);
                 }
             }
-            Plan::Mfp {
+            PlanNode::Mfp {
                 input,
                 mfp: _,
                 input_key_val: _,
                 lir_id: _,
             }
-            | Plan::FlatMap {
+            | PlanNode::FlatMap {
                 input,
                 func: _,
                 exprs: _,
@@ -1088,14 +1122,14 @@ impl<T> CollectionPlan for Plan<T> {
                 input_key: _,
                 lir_id: _,
             }
-            | Plan::ArrangeBy {
+            | PlanNode::ArrangeBy {
                 input,
                 forms: _,
                 input_key: _,
                 input_mfp: _,
                 lir_id: _,
             }
-            | Plan::Reduce {
+            | PlanNode::Reduce {
                 input,
                 key_val_plan: _,
                 plan: _,
@@ -1103,13 +1137,13 @@ impl<T> CollectionPlan for Plan<T> {
                 mfp_after: _,
                 lir_id: _,
             }
-            | Plan::TopK {
+            | PlanNode::TopK {
                 input,
                 top_k_plan: _,
                 lir_id: _,
             }
-            | Plan::Negate { input, lir_id: _ }
-            | Plan::Threshold {
+            | PlanNode::Negate { input, lir_id: _ }
+            | PlanNode::Threshold {
                 input,
                 threshold_plan: _,
                 lir_id: _,
@@ -1117,6 +1151,12 @@ impl<T> CollectionPlan for Plan<T> {
                 input.depends_on_into(out);
             }
         }
+    }
+}
+
+impl<T> CollectionPlan for Plan<T> {
+    fn depends_on_into(&self, out: &mut BTreeSet<GlobalId>) {
+        self.node.depends_on_into(out);
     }
 }
 

--- a/src/compute-types/src/plan/flat_plan.rs
+++ b/src/compute-types/src/plan/flat_plan.rs
@@ -280,7 +280,7 @@ impl<T> From<Plan<T>> for FlatPlan<T> {
         // node (a) produce a corresponding `FlatPlanNode` and (b) push the contained subplans onto
         // the work stack. We do this until no further subplans remain.
 
-        let root = plan.lir_id();
+        let root = plan.lir_id;
 
         // Stack of nodes to flatten.
         let mut todo: Vec<Plan<T>> = vec![plan];
@@ -296,31 +296,21 @@ impl<T> From<Plan<T>> for FlatPlan<T> {
             flatten_order.push(id);
         };
 
-        while let Some(plan) = todo.pop() {
-            match plan.node {
-                PlanNode::Constant { rows, lir_id } => {
+        while let Some(Plan { node, lir_id }) = todo.pop() {
+            match node {
+                PlanNode::Constant { rows } => {
                     let node = Constant { rows };
                     insert_node(lir_id, node);
                 }
-                PlanNode::Get {
-                    id,
-                    keys,
-                    plan,
-                    lir_id,
-                } => {
+                PlanNode::Get { id, keys, plan } => {
                     let node = Get { id, keys, plan };
                     insert_node(lir_id, node);
                 }
-                PlanNode::Let {
-                    id,
-                    value,
-                    body,
-                    lir_id,
-                } => {
+                PlanNode::Let { id, value, body } => {
                     let node = Let {
                         id,
-                        value: value.lir_id(),
-                        body: body.lir_id(),
+                        value: value.lir_id,
+                        body: body.lir_id,
                     };
                     insert_node(lir_id, node);
 
@@ -331,13 +321,12 @@ impl<T> From<Plan<T>> for FlatPlan<T> {
                     values,
                     limits,
                     body,
-                    lir_id,
                 } => {
                     let node = LetRec {
                         ids,
-                        values: values.iter().map(|v| v.lir_id()).collect(),
+                        values: values.iter().map(|v| v.lir_id).collect(),
                         limits,
-                        body: body.lir_id(),
+                        body: body.lir_id,
                     };
                     insert_node(lir_id, node);
 
@@ -348,10 +337,9 @@ impl<T> From<Plan<T>> for FlatPlan<T> {
                     input,
                     mfp,
                     input_key_val,
-                    lir_id,
                 } => {
                     let node = Mfp {
-                        input: input.lir_id(),
+                        input: input.lir_id,
                         mfp,
                         input_key_val,
                     };
@@ -365,10 +353,9 @@ impl<T> From<Plan<T>> for FlatPlan<T> {
                     exprs,
                     mfp_after,
                     input_key,
-                    lir_id,
                 } => {
                     let node = FlatMap {
-                        input: input.lir_id(),
+                        input: input.lir_id,
                         func,
                         exprs,
                         mfp_after,
@@ -378,13 +365,9 @@ impl<T> From<Plan<T>> for FlatPlan<T> {
 
                     todo.push(*input);
                 }
-                PlanNode::Join {
-                    inputs,
-                    plan,
-                    lir_id,
-                } => {
+                PlanNode::Join { inputs, plan } => {
                     let node = Join {
-                        inputs: inputs.iter().map(|i| i.lir_id()).collect(),
+                        inputs: inputs.iter().map(|i| i.lir_id).collect(),
                         plan,
                     };
                     insert_node(lir_id, node);
@@ -397,10 +380,9 @@ impl<T> From<Plan<T>> for FlatPlan<T> {
                     plan,
                     input_key,
                     mfp_after,
-                    lir_id,
                 } => {
                     let node = Reduce {
-                        input: input.lir_id(),
+                        input: input.lir_id,
                         key_val_plan,
                         plan,
                         input_key,
@@ -410,22 +392,18 @@ impl<T> From<Plan<T>> for FlatPlan<T> {
 
                     todo.push(*input);
                 }
-                PlanNode::TopK {
-                    input,
-                    top_k_plan,
-                    lir_id,
-                } => {
+                PlanNode::TopK { input, top_k_plan } => {
                     let node = TopK {
-                        input: input.lir_id(),
+                        input: input.lir_id,
                         top_k_plan,
                     };
                     insert_node(lir_id, node);
 
                     todo.push(*input);
                 }
-                PlanNode::Negate { input, lir_id } => {
+                PlanNode::Negate { input } => {
                     let node = Negate {
-                        input: input.lir_id(),
+                        input: input.lir_id,
                     };
                     insert_node(lir_id, node);
 
@@ -434,10 +412,9 @@ impl<T> From<Plan<T>> for FlatPlan<T> {
                 PlanNode::Threshold {
                     input,
                     threshold_plan,
-                    lir_id,
                 } => {
                     let node = Threshold {
-                        input: input.lir_id(),
+                        input: input.lir_id,
                         threshold_plan,
                     };
                     insert_node(lir_id, node);
@@ -447,10 +424,9 @@ impl<T> From<Plan<T>> for FlatPlan<T> {
                 PlanNode::Union {
                     inputs,
                     consolidate_output,
-                    lir_id,
                 } => {
                     let node = Union {
-                        inputs: inputs.iter().map(|i| i.lir_id()).collect(),
+                        inputs: inputs.iter().map(|i| i.lir_id).collect(),
                         consolidate_output,
                     };
                     insert_node(lir_id, node);
@@ -462,10 +438,9 @@ impl<T> From<Plan<T>> for FlatPlan<T> {
                     forms,
                     input_key,
                     input_mfp,
-                    lir_id,
                 } => {
                     let node = ArrangeBy {
-                        input: input.lir_id(),
+                        input: input.lir_id,
                         forms,
                         input_key,
                         input_mfp,

--- a/src/compute-types/src/plan/interpret/api.rs
+++ b/src/compute-types/src/plan/interpret/api.rs
@@ -250,25 +250,15 @@ where
         use PlanNode::*;
         rg.checked_recur(|_| {
             match &expr.node {
-                Constant { rows, lir_id: _ } => {
+                Constant { rows } => {
                     // Interpret the current node.
                     Ok(self.interpret.constant(&self.ctx, rows))
                 }
-                Get {
-                    id,
-                    keys,
-                    plan,
-                    lir_id: _,
-                } => {
+                Get { id, keys, plan } => {
                     // Interpret the current node.
                     Ok(self.interpret.get(&self.ctx, id, keys, plan))
                 }
-                Let {
-                    id,
-                    value,
-                    body,
-                    lir_id: _,
-                } => {
+                Let { id, value, body } => {
                     // Extend context with the `value` result.
                     let res_value = self.apply_rec(value, rg)?;
                     let old_entry = self
@@ -291,7 +281,6 @@ where
                     values,
                     limits,
                     body,
-                    lir_id: _,
                 } => {
                     // Make context recursive and extend it with `bottom` for each recursive
                     // binding. This corresponds to starting with the most optimistic value.
@@ -369,7 +358,6 @@ where
                     input,
                     mfp,
                     input_key_val,
-                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -382,7 +370,6 @@ where
                     exprs,
                     mfp_after: mfp,
                     input_key,
-                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -391,11 +378,7 @@ where
                         .interpret
                         .flat_map(&self.ctx, input, func, exprs, mfp, input_key))
                 }
-                Join {
-                    inputs,
-                    plan,
-                    lir_id: _,
-                } => {
+                Join { inputs, plan } => {
                     // Descend recursively into all children.
                     let inputs = inputs
                         .iter()
@@ -410,7 +393,6 @@ where
                     plan,
                     input_key,
                     mfp_after,
-                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -424,17 +406,13 @@ where
                         mfp_after,
                     ))
                 }
-                TopK {
-                    input,
-                    top_k_plan,
-                    lir_id: _,
-                } => {
+                TopK { input, top_k_plan } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
                     // Interpret the current node.
                     Ok(self.interpret.top_k(&self.ctx, input, top_k_plan))
                 }
-                Negate { input, lir_id: _ } => {
+                Negate { input } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
                     // Interpret the current node.
@@ -443,7 +421,6 @@ where
                 Threshold {
                     input,
                     threshold_plan,
-                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -453,7 +430,6 @@ where
                 Union {
                     inputs,
                     consolidate_output,
-                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let inputs = inputs
@@ -468,7 +444,6 @@ where
                     forms,
                     input_key,
                     input_mfp,
-                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -530,7 +505,7 @@ where
         use PlanNode::*;
         rg.checked_recur(|_| {
             match &mut expr.node {
-                Constant { rows, lir_id: _ } => {
+                Constant { rows } => {
                     // Interpret the current node.
                     let result = self.interpret.constant(&self.ctx, rows);
                     // Mutate the current node using the given `action`.
@@ -538,12 +513,7 @@ where
                     // Pass the interpretation result up.
                     Ok(result)
                 }
-                Get {
-                    id,
-                    keys,
-                    plan,
-                    lir_id: _,
-                } => {
+                Get { id, keys, plan } => {
                     // Interpret the current node.
                     let result = self.interpret.get(&self.ctx, id, keys, plan);
                     // Mutate the current node using the given `action`.
@@ -551,12 +521,7 @@ where
                     // Pass the interpretation result up.
                     Ok(result)
                 }
-                Let {
-                    id,
-                    value,
-                    body,
-                    lir_id: _,
-                } => {
+                Let { id, value, body } => {
                     // Extend context with the `value` result.
                     let res_value = self.apply_rec(value, rg)?;
                     let old_entry = self
@@ -579,7 +544,6 @@ where
                     values,
                     limits,
                     body,
-                    lir_id: _,
                 } => {
                     // Make context recursive and extend it with `bottom` for each recursive
                     // binding. This corresponds to starting with the most optimistic value.
@@ -657,7 +621,6 @@ where
                     input,
                     mfp,
                     input_key_val,
-                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -676,7 +639,6 @@ where
                     exprs,
                     mfp_after: mfp,
                     input_key,
-                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -694,11 +656,7 @@ where
                     // Pass the interpretation result up.
                     Ok(result)
                 }
-                Join {
-                    inputs,
-                    plan,
-                    lir_id: _,
-                } => {
+                Join { inputs, plan } => {
                     // Descend recursively into all children.
                     let inputs: Vec<_> = inputs
                         .iter_mut()
@@ -717,7 +675,6 @@ where
                     plan,
                     input_key,
                     mfp_after,
-                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -735,11 +692,7 @@ where
                     // Pass the interpretation result up.
                     Ok(result)
                 }
-                TopK {
-                    input,
-                    top_k_plan,
-                    lir_id: _,
-                } => {
+                TopK { input, top_k_plan } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
                     // Interpret the current node.
@@ -749,7 +702,7 @@ where
                     // Pass the interpretation result up.
                     Ok(result)
                 }
-                Negate { input, lir_id: _ } => {
+                Negate { input } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
                     // Interpret the current node.
@@ -762,7 +715,6 @@ where
                 Threshold {
                     input,
                     threshold_plan,
-                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -778,7 +730,6 @@ where
                 Union {
                     inputs,
                     consolidate_output,
-                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let inputs: Vec<_> = inputs
@@ -799,7 +750,6 @@ where
                     forms,
                     input_key,
                     input_mfp,
-                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;

--- a/src/compute-types/src/plan/interpret/api.rs
+++ b/src/compute-types/src/plan/interpret/api.rs
@@ -31,7 +31,7 @@ use crate::plan::join::JoinPlan;
 use crate::plan::reduce::{KeyValPlan, ReducePlan};
 use crate::plan::threshold::ThresholdPlan;
 use crate::plan::top_k::TopKPlan;
-use crate::plan::{AvailableCollections, GetPlan, Plan};
+use crate::plan::{AvailableCollections, GetPlan, Plan, PlanNode};
 
 /// An [abstract interpreter] for [Plan] expressions.
 ///
@@ -247,9 +247,9 @@ where
         expr: &Plan<T>,
         rg: &RecursionGuard,
     ) -> Result<I::Domain, RecursionLimitError> {
-        use Plan::*;
+        use PlanNode::*;
         rg.checked_recur(|_| {
-            match expr {
+            match &expr.node {
                 Constant { rows, lir_id: _ } => {
                     // Interpret the current node.
                     Ok(self.interpret.constant(&self.ctx, rows))
@@ -527,9 +527,9 @@ where
         expr: &mut Plan<T>,
         rg: &RecursionGuard,
     ) -> Result<I::Domain, RecursionLimitError> {
-        use Plan::*;
+        use PlanNode::*;
         rg.checked_recur(|_| {
-            match expr {
+            match &mut expr.node {
                 Constant { rows, lir_id: _ } => {
                     // Interpret the current node.
                     let result = self.interpret.constant(&self.ctx, rows);

--- a/src/compute-types/src/plan/transform/relax_must_consolidate.rs
+++ b/src/compute-types/src/plan/transform/relax_must_consolidate.rs
@@ -16,7 +16,7 @@ use crate::plan::interpret::{PhysicallyMonotonic, SingleTimeMonotonic};
 use crate::plan::reduce::{HierarchicalPlan, MonotonicPlan};
 use crate::plan::top_k::{MonotonicTop1Plan, MonotonicTopKPlan, TopKPlan};
 use crate::plan::transform::{BottomUpTransform, TransformConfig};
-use crate::plan::{Plan, ReducePlan};
+use crate::plan::{Plan, PlanNode, ReducePlan};
 
 /// A transformation that takes the result of single-time physical monotonicity
 /// analysis and refines, as appropriate, the setting of the `must_consolidate`
@@ -51,9 +51,9 @@ impl<T> BottomUpTransform<T> for RelaxMustConsolidate<T> {
     fn action(plan: &mut Plan<T>, _plan_info: &Self::Info, input_infos: &[Self::Info]) {
         // Look at `input_infos` and type of `Plan` node and refine the `must_consolidate` flag.
         // Note that the LIR nodes we care about have a single input.
-        match (plan, input_infos) {
+        match (&mut plan.node, input_infos) {
             (
-                Plan::Reduce {
+                PlanNode::Reduce {
                     plan:
                         ReducePlan::Hierarchical(HierarchicalPlan::Monotonic(MonotonicPlan {
                             must_consolidate,
@@ -61,14 +61,14 @@ impl<T> BottomUpTransform<T> for RelaxMustConsolidate<T> {
                         })),
                     ..
                 }
-                | Plan::TopK {
+                | PlanNode::TopK {
                     top_k_plan:
                         TopKPlan::MonotonicTop1(MonotonicTop1Plan {
                             must_consolidate, ..
                         }),
                     ..
                 }
-                | Plan::TopK {
+                | PlanNode::TopK {
                     top_k_plan:
                         TopKPlan::MonotonicTopK(MonotonicTopKPlan {
                             must_consolidate, ..

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -109,11 +109,13 @@ SELECT 1 / 0
     {
       "id": "Explained Query",
       "plan": {
-        "Constant": {
-          "rows": {
-            "Err": "DivisionByZero"
-          },
-          "lir_id": 0
+        "lir_id": 0,
+        "node": {
+          "Constant": {
+            "rows": {
+              "Err": "DivisionByZero"
+            }
+          }
         }
       }
     }
@@ -132,36 +134,38 @@ EXPLAIN PHYSICAL PLAN WITH(no fast path) AS JSON FOR
     {
       "id": "Explained Query",
       "plan": {
-        "Constant": {
-          "rows": {
-            "Ok": [
-              [
-                {
-                  "data": [
-                    45,
-                    1,
-                    45,
-                    2
-                  ]
-                },
-                0,
-                2
-              ],
-              [
-                {
-                  "data": [
-                    45,
-                    3,
-                    45,
-                    4
-                  ]
-                },
-                0,
-                1
+        "lir_id": 0,
+        "node": {
+          "Constant": {
+            "rows": {
+              "Ok": [
+                [
+                  {
+                    "data": [
+                      45,
+                      1,
+                      45,
+                      2
+                    ]
+                  },
+                  0,
+                  2
+                ],
+                [
+                  {
+                    "data": [
+                      45,
+                      3,
+                      45,
+                      4
+                    ]
+                  },
+                  0,
+                  1
+                ]
               ]
-            ]
-          },
-          "lir_id": 0
+            }
+          }
         }
       }
     }
@@ -183,43 +187,45 @@ SELECT * FROM t
     {
       "id": "Explained Query",
       "plan": {
-        "Get": {
-          "id": {
-            "Global": {
-              "User": 1
-            }
-          },
-          "keys": {
-            "raw": false,
-            "arranged": [
-              [
-                [
-                  {
-                    "Column": 0
-                  }
-                ],
-                {
-                  "0": 0,
-                  "1": 1
-                },
-                [
-                  1
-                ]
-              ]
-            ],
-            "types": [
-              {
-                "scalar_type": "Int32",
-                "nullable": true
-              },
-              {
-                "scalar_type": "Int32",
-                "nullable": true
+        "lir_id": 0,
+        "node": {
+          "Get": {
+            "id": {
+              "Global": {
+                "User": 1
               }
-            ]
-          },
-          "plan": "PassArrangements",
-          "lir_id": 0
+            },
+            "keys": {
+              "raw": false,
+              "arranged": [
+                [
+                  [
+                    {
+                      "Column": 0
+                    }
+                  ],
+                  {
+                    "0": 0,
+                    "1": 1
+                  },
+                  [
+                    1
+                  ]
+                ]
+              ],
+              "types": [
+                {
+                  "scalar_type": "Int32",
+                  "nullable": true
+                },
+                {
+                  "scalar_type": "Int32",
+                  "nullable": true
+                }
+              ]
+            },
+            "plan": "PassArrangements"
+          }
         }
       }
     }
@@ -238,19 +244,21 @@ SELECT * FROM u
     {
       "id": "Explained Query",
       "plan": {
-        "Get": {
-          "id": {
-            "Global": {
-              "User": 2
-            }
-          },
-          "keys": {
-            "raw": true,
-            "arranged": [],
-            "types": null
-          },
-          "plan": "PassArrangements",
-          "lir_id": 0
+        "lir_id": 0,
+        "node": {
+          "Get": {
+            "id": {
+              "Global": {
+                "User": 2
+              }
+            },
+            "keys": {
+              "raw": true,
+              "arranged": [],
+              "types": null
+            },
+            "plan": "PassArrangements"
+          }
         }
       }
     }
@@ -276,89 +284,91 @@ SELECT a + b, 1 FROM t
     {
       "id": "Explained Query",
       "plan": {
-        "Get": {
-          "id": {
-            "Global": {
-              "User": 1
-            }
-          },
-          "keys": {
-            "raw": false,
-            "arranged": [
-              [
+        "lir_id": 0,
+        "node": {
+          "Get": {
+            "id": {
+              "Global": {
+                "User": 1
+              }
+            },
+            "keys": {
+              "raw": false,
+              "arranged": [
+                [
+                  [
+                    {
+                      "Column": 0
+                    }
+                  ],
+                  {
+                    "0": 0,
+                    "1": 1
+                  },
+                  [
+                    1
+                  ]
+                ]
+              ],
+              "types": [
+                {
+                  "scalar_type": "Int32",
+                  "nullable": true
+                },
+                {
+                  "scalar_type": "Int32",
+                  "nullable": true
+                }
+              ]
+            },
+            "plan": {
+              "Arrangement": [
                 [
                   {
                     "Column": 0
                   }
                 ],
+                null,
                 {
-                  "0": 0,
-                  "1": 1
-                },
-                [
-                  1
-                ]
-              ]
-            ],
-            "types": [
-              {
-                "scalar_type": "Int32",
-                "nullable": true
-              },
-              {
-                "scalar_type": "Int32",
-                "nullable": true
-              }
-            ]
-          },
-          "plan": {
-            "Arrangement": [
-              [
-                {
-                  "Column": 0
-                }
-              ],
-              null,
-              {
-                "expressions": [
-                  {
-                    "CallBinary": {
-                      "func": "AddInt32",
-                      "expr1": {
-                        "Column": 0
-                      },
-                      "expr2": {
-                        "Column": 1
-                      }
-                    }
-                  },
-                  {
-                    "Literal": [
-                      {
-                        "Ok": {
-                          "data": [
-                            45,
-                            1
-                          ]
+                  "expressions": [
+                    {
+                      "CallBinary": {
+                        "func": "AddInt32",
+                        "expr1": {
+                          "Column": 0
+                        },
+                        "expr2": {
+                          "Column": 1
                         }
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": false
                       }
-                    ]
-                  }
-                ],
-                "predicates": [],
-                "projection": [
-                  2,
-                  3
-                ],
-                "input_arity": 2
-              }
-            ]
-          },
-          "lir_id": 0
+                    },
+                    {
+                      "Literal": [
+                        {
+                          "Ok": {
+                            "data": [
+                              45,
+                              1
+                            ]
+                          }
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": false
+                        }
+                      ]
+                    }
+                  ],
+                  "predicates": [],
+                  "projection": [
+                    2,
+                    3
+                  ],
+                  "input_arity": 2
+                }
+              ]
+            }
+          }
         }
       }
     }
@@ -377,29 +387,31 @@ SELECT c + d, 1 FROM u
     {
       "id": "Explained Query",
       "plan": {
-        "Get": {
-          "id": {
-            "Global": {
-              "User": 2
+        "lir_id": 0,
+        "node": {
+          "Get": {
+            "id": {
+              "Global": {
+                "User": 2
+              }
+            },
+            "keys": {
+              "raw": true,
+              "arranged": [],
+              "types": null
+            },
+            "plan": {
+              "Collection": {
+                "expressions": [],
+                "predicates": [],
+                "projection": [
+                  0,
+                  1
+                ],
+                "input_arity": 2
+              }
             }
-          },
-          "keys": {
-            "raw": true,
-            "arranged": [],
-            "types": null
-          },
-          "plan": {
-            "Collection": {
-              "expressions": [],
-              "predicates": [],
-              "projection": [
-                0,
-                1
-              ],
-              "input_arity": 2
-            }
-          },
-          "lir_id": 0
+          }
         }
       }
     }
@@ -461,132 +473,16 @@ SELECT * FROM ov
     {
       "id": "Explained Query",
       "plan": {
-        "TopK": {
-          "input": {
-            "ArrangeBy": {
-              "input": {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "keys": {
-                    "raw": false,
-                    "arranged": [
-                      [
-                        [
-                          {
-                            "Column": 0
-                          }
-                        ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
-                        [
-                          1
-                        ]
-                      ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ]
-                  },
-                  "plan": "PassArrangements",
-                  "lir_id": 0
-                }
-              },
-              "forms": {
-                "raw": true,
-                "arranged": [],
-                "types": null
-              },
-              "input_key": [
-                {
-                  "Column": 0
-                }
-              ],
-              "input_mfp": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0,
-                  1
-                ],
-                "input_arity": 2
-              },
-              "lir_id": 1
-            }
-          },
-          "top_k_plan": {
-            "MonotonicTopK": {
-              "group_key": [],
-              "order_key": [
-                {
-                  "column": 1,
-                  "desc": false,
-                  "nulls_last": true
-                },
-                {
-                  "column": 0,
-                  "desc": true,
-                  "nulls_last": false
-                }
-              ],
-              "limit": {
-                "Literal": [
-                  {
-                    "Ok": {
-                      "data": [
-                        50,
-                        5
-                      ]
-                    }
-                  },
-                  {
-                    "scalar_type": "Int64",
-                    "nullable": false
-                  }
-                ]
-              },
-              "arity": 2,
-              "must_consolidate": true
-            }
-          },
-          "lir_id": 2
-        }
-      }
-    }
-  ],
-  "sources": []
-}
-EOF
-
-# Test Threshold, Union, Distinct, Negate.
-query T multiline
-EXPLAIN PHYSICAL PLAN AS JSON FOR
-SELECT a FROM t EXCEPT ALL SELECT b FROM mv
-----
-{
-  "plans": [
-    {
-      "id": "Explained Query",
-      "plan": {
-        "Threshold": {
-          "input": {
-            "ArrangeBy": {
-              "input": {
-                "Union": {
-                  "inputs": [
-                    {
+        "lir_id": 2,
+        "node": {
+          "TopK": {
+            "input": {
+              "lir_id": 1,
+              "node": {
+                "ArrangeBy": {
+                  "input": {
+                    "lir_id": 0,
+                    "node": {
                       "Get": {
                         "id": {
                           "Global": {
@@ -622,244 +518,68 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                             }
                           ]
                         },
-                        "plan": {
-                          "Arrangement": [
-                            [
-                              {
-                                "Column": 0
-                              }
-                            ],
-                            null,
-                            {
-                              "expressions": [],
-                              "predicates": [],
-                              "projection": [
-                                0
-                              ],
-                              "input_arity": 2
-                            }
-                          ]
-                        },
-                        "lir_id": 0
+                        "plan": "PassArrangements"
                       }
-                    },
+                    }
+                  },
+                  "forms": {
+                    "raw": true,
+                    "arranged": [],
+                    "types": null
+                  },
+                  "input_key": [
                     {
-                      "Negate": {
-                        "input": {
-                          "Get": {
-                            "id": {
-                              "Global": {
-                                "User": 7
-                              }
-                            },
-                            "keys": {
-                              "raw": true,
-                              "arranged": [],
-                              "types": null
-                            },
-                            "plan": {
-                              "Collection": {
-                                "expressions": [],
-                                "predicates": [],
-                                "projection": [
-                                  0
-                                ],
-                                "input_arity": 1
-                              }
-                            },
-                            "lir_id": 1
-                          }
-                        },
-                        "lir_id": 2
-                      }
+                      "Column": 0
                     }
                   ],
-                  "consolidate_output": true,
-                  "lir_id": 3
-                }
-              },
-              "forms": {
-                "raw": false,
-                "arranged": [
-                  [
-                    [
-                      {
-                        "Column": 0
-                      }
+                  "input_mfp": {
+                    "expressions": [],
+                    "predicates": [],
+                    "projection": [
+                      0,
+                      1
                     ],
+                    "input_arity": 2
+                  }
+                }
+              }
+            },
+            "top_k_plan": {
+              "MonotonicTopK": {
+                "group_key": [],
+                "order_key": [
+                  {
+                    "column": 1,
+                    "desc": false,
+                    "nulls_last": true
+                  },
+                  {
+                    "column": 0,
+                    "desc": true,
+                    "nulls_last": false
+                  }
+                ],
+                "limit": {
+                  "Literal": [
                     {
-                      "0": 0
-                    },
-                    []
-                  ]
-                ],
-                "types": [
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": true
-                  }
-                ]
-              },
-              "input_key": null,
-              "input_mfp": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0
-                ],
-                "input_arity": 1
-              },
-              "lir_id": 4
-            }
-          },
-          "threshold_plan": {
-            "Basic": {
-              "ensure_arrangement": [
-                [
-                  {
-                    "Column": 0
-                  }
-                ],
-                {
-                  "0": 0
-                },
-                []
-              ]
-            }
-          },
-          "lir_id": 5
-        }
-      }
-    }
-  ],
-  "sources": [
-    {
-      "id": {
-        "User": 7
-      },
-      "op": {
-        "expressions": [],
-        "predicates": [],
-        "projection": [
-          1
-        ],
-        "input_arity": 2
-      }
-    }
-  ]
-}
-EOF
-
-query T multiline
-EXPLAIN PHYSICAL PLAN WITH (TYPES) AS JSON FOR
-SELECT * FROM ov
-----
-{
-  "plans": [
-    {
-      "id": "Explained Query",
-      "plan": {
-        "TopK": {
-          "input": {
-            "ArrangeBy": {
-              "input": {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "keys": {
-                    "raw": false,
-                    "arranged": [
-                      [
-                        [
-                          {
-                            "Column": 0
-                          }
-                        ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
-                        [
-                          1
+                      "Ok": {
+                        "data": [
+                          50,
+                          5
                         ]
-                      ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
                       }
-                    ]
-                  },
-                  "plan": "PassArrangements",
-                  "lir_id": 0
-                }
-              },
-              "forms": {
-                "raw": true,
-                "arranged": [],
-                "types": null
-              },
-              "input_key": [
-                {
-                  "Column": 0
-                }
-              ],
-              "input_mfp": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0,
-                  1
-                ],
-                "input_arity": 2
-              },
-              "lir_id": 1
-            }
-          },
-          "top_k_plan": {
-            "MonotonicTopK": {
-              "group_key": [],
-              "order_key": [
-                {
-                  "column": 1,
-                  "desc": false,
-                  "nulls_last": true
-                },
-                {
-                  "column": 0,
-                  "desc": true,
-                  "nulls_last": false
-                }
-              ],
-              "limit": {
-                "Literal": [
-                  {
-                    "Ok": {
-                      "data": [
-                        50,
-                        5
-                      ]
+                    },
+                    {
+                      "scalar_type": "Int64",
+                      "nullable": false
                     }
-                  },
-                  {
-                    "scalar_type": "Int64",
-                    "nullable": false
-                  }
-                ]
-              },
-              "arity": 2,
-              "must_consolidate": true
+                  ]
+                },
+                "arity": 2,
+                "must_consolidate": true
+              }
             }
-          },
-          "lir_id": 2
+          }
         }
       }
     }
@@ -868,116 +588,124 @@ SELECT * FROM ov
 }
 EOF
 
-# Test CTEs.
+# Test Threshold, Union, Distinct, Negate.
 query T multiline
 EXPLAIN PHYSICAL PLAN AS JSON FOR
-WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
-(SELECT x + 1 FROM cte UNION ALL SELECT x - 1 FROM cte)
+SELECT a FROM t EXCEPT ALL SELECT b FROM mv
 ----
 {
   "plans": [
     {
       "id": "Explained Query",
       "plan": {
-        "Let": {
-          "id": 0,
-          "value": {
-            "Threshold": {
-              "input": {
+        "lir_id": 5,
+        "node": {
+          "Threshold": {
+            "input": {
+              "lir_id": 4,
+              "node": {
                 "ArrangeBy": {
                   "input": {
-                    "Union": {
-                      "inputs": [
-                        {
-                          "Get": {
-                            "id": {
-                              "Global": {
-                                "User": 1
-                              }
-                            },
-                            "keys": {
-                              "raw": false,
-                              "arranged": [
-                                [
-                                  [
-                                    {
-                                      "Column": 0
-                                    }
-                                  ],
-                                  {
-                                    "0": 0,
-                                    "1": 1
-                                  },
-                                  [
-                                    1
-                                  ]
-                                ]
-                              ],
-                              "types": [
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ]
-                            },
-                            "plan": {
-                              "Arrangement": [
-                                [
-                                  {
-                                    "Column": 0
-                                  }
-                                ],
-                                null,
-                                {
-                                  "expressions": [],
-                                  "predicates": [],
-                                  "projection": [
-                                    0
-                                  ],
-                                  "input_arity": 2
-                                }
-                              ]
-                            },
-                            "lir_id": 0
-                          }
-                        },
-                        {
-                          "Negate": {
-                            "input": {
+                    "lir_id": 3,
+                    "node": {
+                      "Union": {
+                        "inputs": [
+                          {
+                            "lir_id": 0,
+                            "node": {
                               "Get": {
                                 "id": {
                                   "Global": {
-                                    "User": 7
+                                    "User": 1
                                   }
                                 },
                                 "keys": {
-                                  "raw": true,
-                                  "arranged": [],
-                                  "types": null
+                                  "raw": false,
+                                  "arranged": [
+                                    [
+                                      [
+                                        {
+                                          "Column": 0
+                                        }
+                                      ],
+                                      {
+                                        "0": 0,
+                                        "1": 1
+                                      },
+                                      [
+                                        1
+                                      ]
+                                    ]
+                                  ],
+                                  "types": [
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    },
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    }
+                                  ]
                                 },
                                 "plan": {
-                                  "Collection": {
-                                    "expressions": [],
-                                    "predicates": [],
-                                    "projection": [
-                                      0
+                                  "Arrangement": [
+                                    [
+                                      {
+                                        "Column": 0
+                                      }
                                     ],
-                                    "input_arity": 1
-                                  }
-                                },
-                                "lir_id": 1
+                                    null,
+                                    {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0
+                                      ],
+                                      "input_arity": 2
+                                    }
+                                  ]
+                                }
                               }
-                            },
-                            "lir_id": 2
+                            }
+                          },
+                          {
+                            "lir_id": 2,
+                            "node": {
+                              "Negate": {
+                                "input": {
+                                  "lir_id": 1,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Global": {
+                                          "User": 7
+                                        }
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": [],
+                                        "types": null
+                                      },
+                                      "plan": {
+                                        "Collection": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0
+                                          ],
+                                          "input_arity": 1
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
                           }
-                        }
-                      ],
-                      "consolidate_output": true,
-                      "lir_id": 3
+                        ],
+                        "consolidate_output": true
+                      }
                     }
                   },
                   "forms": {
@@ -1010,183 +738,511 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                       0
                     ],
                     "input_arity": 1
-                  },
-                  "lir_id": 4
+                  }
                 }
-              },
-              "threshold_plan": {
-                "Basic": {
-                  "ensure_arrangement": [
-                    [
-                      {
-                        "Column": 0
-                      }
-                    ],
+              }
+            },
+            "threshold_plan": {
+              "Basic": {
+                "ensure_arrangement": [
+                  [
                     {
-                      "0": 0
+                      "Column": 0
+                    }
+                  ],
+                  {
+                    "0": 0
+                  },
+                  []
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "sources": [
+    {
+      "id": {
+        "User": 7
+      },
+      "op": {
+        "expressions": [],
+        "predicates": [],
+        "projection": [
+          1
+        ],
+        "input_arity": 2
+      }
+    }
+  ]
+}
+EOF
+
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH (TYPES) AS JSON FOR
+SELECT * FROM ov
+----
+{
+  "plans": [
+    {
+      "id": "Explained Query",
+      "plan": {
+        "lir_id": 2,
+        "node": {
+          "TopK": {
+            "input": {
+              "lir_id": 1,
+              "node": {
+                "ArrangeBy": {
+                  "input": {
+                    "lir_id": 0,
+                    "node": {
+                      "Get": {
+                        "id": {
+                          "Global": {
+                            "User": 1
+                          }
+                        },
+                        "keys": {
+                          "raw": false,
+                          "arranged": [
+                            [
+                              [
+                                {
+                                  "Column": 0
+                                }
+                              ],
+                              {
+                                "0": 0,
+                                "1": 1
+                              },
+                              [
+                                1
+                              ]
+                            ]
+                          ],
+                          "types": [
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            }
+                          ]
+                        },
+                        "plan": "PassArrangements"
+                      }
+                    }
+                  },
+                  "forms": {
+                    "raw": true,
+                    "arranged": [],
+                    "types": null
+                  },
+                  "input_key": [
+                    {
+                      "Column": 0
+                    }
+                  ],
+                  "input_mfp": {
+                    "expressions": [],
+                    "predicates": [],
+                    "projection": [
+                      0,
+                      1
+                    ],
+                    "input_arity": 2
+                  }
+                }
+              }
+            },
+            "top_k_plan": {
+              "MonotonicTopK": {
+                "group_key": [],
+                "order_key": [
+                  {
+                    "column": 1,
+                    "desc": false,
+                    "nulls_last": true
+                  },
+                  {
+                    "column": 0,
+                    "desc": true,
+                    "nulls_last": false
+                  }
+                ],
+                "limit": {
+                  "Literal": [
+                    {
+                      "Ok": {
+                        "data": [
+                          50,
+                          5
+                        ]
+                      }
                     },
-                    []
+                    {
+                      "scalar_type": "Int64",
+                      "nullable": false
+                    }
                   ]
-                }
-              },
-              "lir_id": 5
-            }
-          },
-          "body": {
-            "Union": {
-              "inputs": [
-                {
-                  "Get": {
-                    "id": {
-                      "Local": 0
-                    },
-                    "keys": {
-                      "raw": false,
-                      "arranged": [
-                        [
-                          [
-                            {
-                              "Column": 0
-                            }
-                          ],
-                          {
-                            "0": 0
-                          },
-                          []
-                        ]
-                      ],
-                      "types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        }
-                      ]
-                    },
-                    "plan": {
-                      "Arrangement": [
-                        [
-                          {
-                            "Column": 0
-                          }
-                        ],
-                        null,
-                        {
-                          "expressions": [
-                            {
-                              "CallBinary": {
-                                "func": "AddInt32",
-                                "expr1": {
-                                  "Column": 0
-                                },
-                                "expr2": {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          45,
-                                          1
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": false
-                                    }
-                                  ]
-                                }
-                              }
-                            }
-                          ],
-                          "predicates": [],
-                          "projection": [
-                            1
-                          ],
-                          "input_arity": 1
-                        }
-                      ]
-                    },
-                    "lir_id": 6
-                  }
                 },
-                {
-                  "Get": {
-                    "id": {
-                      "Local": 0
-                    },
-                    "keys": {
-                      "raw": false,
-                      "arranged": [
-                        [
-                          [
-                            {
-                              "Column": 0
+                "arity": 2,
+                "must_consolidate": true
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "sources": []
+}
+EOF
+
+# Test CTEs.
+query T multiline
+EXPLAIN PHYSICAL PLAN AS JSON FOR
+WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
+(SELECT x + 1 FROM cte UNION ALL SELECT x - 1 FROM cte)
+----
+{
+  "plans": [
+    {
+      "id": "Explained Query",
+      "plan": {
+        "lir_id": 9,
+        "node": {
+          "Let": {
+            "id": 0,
+            "value": {
+              "lir_id": 5,
+              "node": {
+                "Threshold": {
+                  "input": {
+                    "lir_id": 4,
+                    "node": {
+                      "ArrangeBy": {
+                        "input": {
+                          "lir_id": 3,
+                          "node": {
+                            "Union": {
+                              "inputs": [
+                                {
+                                  "lir_id": 0,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Global": {
+                                          "User": 1
+                                        }
+                                      },
+                                      "keys": {
+                                        "raw": false,
+                                        "arranged": [
+                                          [
+                                            [
+                                              {
+                                                "Column": 0
+                                              }
+                                            ],
+                                            {
+                                              "0": 0,
+                                              "1": 1
+                                            },
+                                            [
+                                              1
+                                            ]
+                                          ]
+                                        ],
+                                        "types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ]
+                                      },
+                                      "plan": {
+                                        "Arrangement": [
+                                          [
+                                            {
+                                              "Column": 0
+                                            }
+                                          ],
+                                          null,
+                                          {
+                                            "expressions": [],
+                                            "predicates": [],
+                                            "projection": [
+                                              0
+                                            ],
+                                            "input_arity": 2
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "lir_id": 2,
+                                  "node": {
+                                    "Negate": {
+                                      "input": {
+                                        "lir_id": 1,
+                                        "node": {
+                                          "Get": {
+                                            "id": {
+                                              "Global": {
+                                                "User": 7
+                                              }
+                                            },
+                                            "keys": {
+                                              "raw": true,
+                                              "arranged": [],
+                                              "types": null
+                                            },
+                                            "plan": {
+                                              "Collection": {
+                                                "expressions": [],
+                                                "predicates": [],
+                                                "projection": [
+                                                  0
+                                                ],
+                                                "input_arity": 1
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              ],
+                              "consolidate_output": true
                             }
+                          }
+                        },
+                        "forms": {
+                          "raw": false,
+                          "arranged": [
+                            [
+                              [
+                                {
+                                  "Column": 0
+                                }
+                              ],
+                              {
+                                "0": 0
+                              },
+                              []
+                            ]
                           ],
-                          {
-                            "0": 0
-                          },
-                          []
-                        ]
-                      ],
-                      "types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
+                          "types": [
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            }
+                          ]
+                        },
+                        "input_key": null,
+                        "input_mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 1
                         }
-                      ]
-                    },
-                    "plan": {
-                      "Arrangement": [
+                      }
+                    }
+                  },
+                  "threshold_plan": {
+                    "Basic": {
+                      "ensure_arrangement": [
                         [
                           {
                             "Column": 0
                           }
                         ],
-                        null,
                         {
-                          "expressions": [
-                            {
-                              "CallBinary": {
-                                "func": "SubInt32",
-                                "expr1": {
-                                  "Column": 0
-                                },
-                                "expr2": {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          45,
-                                          1
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": false
-                                    }
-                                  ]
-                                }
-                              }
-                            }
-                          ],
-                          "predicates": [],
-                          "projection": [
-                            1
-                          ],
-                          "input_arity": 1
-                        }
+                          "0": 0
+                        },
+                        []
                       ]
-                    },
-                    "lir_id": 7
+                    }
                   }
                 }
-              ],
-              "consolidate_output": false,
-              "lir_id": 8
+              }
+            },
+            "body": {
+              "lir_id": 8,
+              "node": {
+                "Union": {
+                  "inputs": [
+                    {
+                      "lir_id": 6,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Local": 0
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": 0
+                                  }
+                                ],
+                                {
+                                  "0": 0
+                                },
+                                []
+                              ]
+                            ],
+                            "types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ]
+                          },
+                          "plan": {
+                            "Arrangement": [
+                              [
+                                {
+                                  "Column": 0
+                                }
+                              ],
+                              null,
+                              {
+                                "expressions": [
+                                  {
+                                    "CallBinary": {
+                                      "func": "AddInt32",
+                                      "expr1": {
+                                        "Column": 0
+                                      },
+                                      "expr2": {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                45,
+                                                1
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ],
+                                "predicates": [],
+                                "projection": [
+                                  1
+                                ],
+                                "input_arity": 1
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "lir_id": 7,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Local": 0
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": 0
+                                  }
+                                ],
+                                {
+                                  "0": 0
+                                },
+                                []
+                              ]
+                            ],
+                            "types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ]
+                          },
+                          "plan": {
+                            "Arrangement": [
+                              [
+                                {
+                                  "Column": 0
+                                }
+                              ],
+                              null,
+                              {
+                                "expressions": [
+                                  {
+                                    "CallBinary": {
+                                      "func": "SubInt32",
+                                      "expr1": {
+                                        "Column": 0
+                                      },
+                                      "expr2": {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                45,
+                                                1
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ],
+                                "predicates": [],
+                                "projection": [
+                                  1
+                                ],
+                                "input_arity": 1
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "consolidate_output": false
+                }
+              }
             }
-          },
-          "lir_id": 9
+          }
         }
       }
     }
@@ -1220,196 +1276,249 @@ SELECT x * 5 FROM cte WHERE x = 5
     {
       "id": "Explained Query",
       "plan": {
-        "Mfp": {
-          "input": {
-            "Threshold": {
-              "input": {
-                "ArrangeBy": {
+        "lir_id": 9,
+        "node": {
+          "Mfp": {
+            "input": {
+              "lir_id": 8,
+              "node": {
+                "Threshold": {
                   "input": {
-                    "Union": {
-                      "inputs": [
-                        {
-                          "Join": {
-                            "inputs": [
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Global": {
-                                      "User": 1
-                                    }
-                                  },
-                                  "keys": {
-                                    "raw": false,
-                                    "arranged": [
-                                      [
-                                        [
-                                          {
-                                            "Column": 0
-                                          }
-                                        ],
+                    "lir_id": 7,
+                    "node": {
+                      "ArrangeBy": {
+                        "input": {
+                          "lir_id": 6,
+                          "node": {
+                            "Union": {
+                              "inputs": [
+                                {
+                                  "lir_id": 3,
+                                  "node": {
+                                    "Join": {
+                                      "inputs": [
                                         {
-                                          "0": 0,
-                                          "1": 1
+                                          "lir_id": 0,
+                                          "node": {
+                                            "Get": {
+                                              "id": {
+                                                "Global": {
+                                                  "User": 1
+                                                }
+                                              },
+                                              "keys": {
+                                                "raw": false,
+                                                "arranged": [
+                                                  [
+                                                    [
+                                                      {
+                                                        "Column": 0
+                                                      }
+                                                    ],
+                                                    {
+                                                      "0": 0,
+                                                      "1": 1
+                                                    },
+                                                    [
+                                                      1
+                                                    ]
+                                                  ]
+                                                ],
+                                                "types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  },
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  }
+                                                ]
+                                              },
+                                              "plan": "PassArrangements"
+                                            }
+                                          }
                                         },
-                                        [
-                                          1
-                                        ]
-                                      ]
-                                    ],
-                                    "types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ]
-                                  },
-                                  "plan": "PassArrangements",
-                                  "lir_id": 0
-                                }
-                              },
-                              {
-                                "ArrangeBy": {
-                                  "input": {
-                                    "Constant": {
-                                      "rows": {
-                                        "Ok": [
-                                          [
+                                        {
+                                          "lir_id": 2,
+                                          "node": {
+                                            "ArrangeBy": {
+                                              "input": {
+                                                "lir_id": 1,
+                                                "node": {
+                                                  "Constant": {
+                                                    "rows": {
+                                                      "Ok": [
+                                                        [
+                                                          {
+                                                            "data": [
+                                                              45,
+                                                              5
+                                                            ]
+                                                          },
+                                                          0,
+                                                          1
+                                                        ]
+                                                      ]
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              "forms": {
+                                                "raw": true,
+                                                "arranged": [
+                                                  [
+                                                    [
+                                                      {
+                                                        "Column": 0
+                                                      }
+                                                    ],
+                                                    {
+                                                      "0": 0
+                                                    },
+                                                    []
+                                                  ]
+                                                ],
+                                                "types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": false
+                                                  }
+                                                ]
+                                              },
+                                              "input_key": null,
+                                              "input_mfp": {
+                                                "expressions": [],
+                                                "predicates": [],
+                                                "projection": [
+                                                  0
+                                                ],
+                                                "input_arity": 1
+                                              }
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "plan": {
+                                        "Linear": {
+                                          "source_relation": 1,
+                                          "source_key": [
                                             {
-                                              "data": [
-                                                45,
-                                                5
-                                              ]
-                                            },
-                                            0,
-                                            1
-                                          ]
-                                        ]
-                                      },
-                                      "lir_id": 1
-                                    }
-                                  },
-                                  "forms": {
-                                    "raw": true,
-                                    "arranged": [
-                                      [
-                                        [
-                                          {
-                                            "Column": 0
-                                          }
-                                        ],
-                                        {
-                                          "0": 0
-                                        },
-                                        []
-                                      ]
-                                    ],
-                                    "types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  },
-                                  "input_key": null,
-                                  "input_mfp": {
-                                    "expressions": [],
-                                    "predicates": [],
-                                    "projection": [
-                                      0
-                                    ],
-                                    "input_arity": 1
-                                  },
-                                  "lir_id": 2
-                                }
-                              }
-                            ],
-                            "plan": {
-                              "Linear": {
-                                "source_relation": 1,
-                                "source_key": [
-                                  {
-                                    "Column": 0
-                                  }
-                                ],
-                                "initial_closure": null,
-                                "stage_plans": [
-                                  {
-                                    "lookup_relation": 0,
-                                    "stream_key": [
-                                      {
-                                        "Column": 0
-                                      }
-                                    ],
-                                    "stream_thinning": [],
-                                    "lookup_key": [
-                                      {
-                                        "Column": 0
-                                      }
-                                    ],
-                                    "closure": {
-                                      "ready_equivalences": [],
-                                      "before": {
-                                        "mfp": {
-                                          "expressions": [],
-                                          "predicates": [],
-                                          "projection": [
-                                            0
+                                              "Column": 0
+                                            }
                                           ],
-                                          "input_arity": 2
+                                          "initial_closure": null,
+                                          "stage_plans": [
+                                            {
+                                              "lookup_relation": 0,
+                                              "stream_key": [
+                                                {
+                                                  "Column": 0
+                                                }
+                                              ],
+                                              "stream_thinning": [],
+                                              "lookup_key": [
+                                                {
+                                                  "Column": 0
+                                                }
+                                              ],
+                                              "closure": {
+                                                "ready_equivalences": [],
+                                                "before": {
+                                                  "mfp": {
+                                                    "expressions": [],
+                                                    "predicates": [],
+                                                    "projection": [
+                                                      0
+                                                    ],
+                                                    "input_arity": 2
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ],
+                                          "final_closure": null
                                         }
                                       }
                                     }
                                   }
-                                ],
-                                "final_closure": null
-                              }
-                            },
-                            "lir_id": 3
+                                },
+                                {
+                                  "lir_id": 5,
+                                  "node": {
+                                    "Negate": {
+                                      "input": {
+                                        "lir_id": 4,
+                                        "node": {
+                                          "Get": {
+                                            "id": {
+                                              "Global": {
+                                                "User": 7
+                                              }
+                                            },
+                                            "keys": {
+                                              "raw": true,
+                                              "arranged": [],
+                                              "types": null
+                                            },
+                                            "plan": {
+                                              "Collection": {
+                                                "expressions": [],
+                                                "predicates": [],
+                                                "projection": [
+                                                  0
+                                                ],
+                                                "input_arity": 1
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              ],
+                              "consolidate_output": true
+                            }
                           }
                         },
-                        {
-                          "Negate": {
-                            "input": {
-                              "Get": {
-                                "id": {
-                                  "Global": {
-                                    "User": 7
-                                  }
-                                },
-                                "keys": {
-                                  "raw": true,
-                                  "arranged": [],
-                                  "types": null
-                                },
-                                "plan": {
-                                  "Collection": {
-                                    "expressions": [],
-                                    "predicates": [],
-                                    "projection": [
-                                      0
-                                    ],
-                                    "input_arity": 1
-                                  }
-                                },
-                                "lir_id": 4
-                              }
-                            },
-                            "lir_id": 5
-                          }
+                        "forms": {
+                          "raw": false,
+                          "arranged": [
+                            [
+                              [
+                                {
+                                  "Column": 0
+                                }
+                              ],
+                              {
+                                "0": 0
+                              },
+                              []
+                            ]
+                          ],
+                          "types": [
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": false
+                            }
+                          ]
+                        },
+                        "input_key": null,
+                        "input_mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 1
                         }
-                      ],
-                      "consolidate_output": true,
-                      "lir_id": 6
+                      }
                     }
                   },
-                  "forms": {
-                    "raw": false,
-                    "arranged": [
-                      [
+                  "threshold_plan": {
+                    "Basic": {
+                      "ensure_arrangement": [
                         [
                           {
                             "Column": 0
@@ -1420,78 +1529,45 @@ SELECT x * 5 FROM cte WHERE x = 5
                         },
                         []
                       ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": false
-                      }
-                    ]
-                  },
-                  "input_key": null,
-                  "input_mfp": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [
-                      0
-                    ],
-                    "input_arity": 1
-                  },
-                  "lir_id": 7
+                    }
+                  }
                 }
-              },
-              "threshold_plan": {
-                "Basic": {
-                  "ensure_arrangement": [
-                    [
-                      {
-                        "Column": 0
-                      }
-                    ],
+              }
+            },
+            "mfp": {
+              "expressions": [
+                {
+                  "Literal": [
                     {
-                      "0": 0
+                      "Ok": {
+                        "data": [
+                          45,
+                          25
+                        ]
+                      }
                     },
-                    []
+                    {
+                      "scalar_type": "Int32",
+                      "nullable": false
+                    }
                   ]
                 }
-              },
-              "lir_id": 8
-            }
-          },
-          "mfp": {
-            "expressions": [
-              {
-                "Literal": [
-                  {
-                    "Ok": {
-                      "data": [
-                        45,
-                        25
-                      ]
-                    }
-                  },
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": false
-                  }
-                ]
-              }
-            ],
-            "predicates": [],
-            "projection": [
-              1
-            ],
-            "input_arity": 1
-          },
-          "input_key_val": [
-            [
-              {
-                "Column": 0
-              }
-            ],
-            null
-          ],
-          "lir_id": 9
+              ],
+              "predicates": [],
+              "projection": [
+                1
+              ],
+              "input_arity": 1
+            },
+            "input_key_val": [
+              [
+                {
+                  "Column": 0
+                }
+              ],
+              null
+            ]
+          }
         }
       }
     }
@@ -1552,86 +1628,90 @@ SELECT generate_series(a, b) from t
     {
       "id": "Explained Query",
       "plan": {
-        "FlatMap": {
-          "input": {
-            "Get": {
-              "id": {
-                "Global": {
-                  "User": 1
-                }
-              },
-              "keys": {
-                "raw": false,
-                "arranged": [
-                  [
-                    [
-                      {
-                        "Column": 0
-                      }
+        "lir_id": 1,
+        "node": {
+          "FlatMap": {
+            "input": {
+              "lir_id": 0,
+              "node": {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
+                  },
+                  "keys": {
+                    "raw": false,
+                    "arranged": [
+                      [
+                        [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        {
+                          "0": 0,
+                          "1": 1
+                        },
+                        [
+                          1
+                        ]
+                      ]
                     ],
-                    {
-                      "0": 0,
-                      "1": 1
-                    },
-                    [
-                      1
+                    "types": [
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      },
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      }
                     ]
-                  ]
-                ],
-                "types": [
+                  },
+                  "plan": "PassArrangements"
+                }
+              }
+            },
+            "func": "GenerateSeriesInt32",
+            "exprs": [
+              {
+                "Column": 0
+              },
+              {
+                "Column": 1
+              },
+              {
+                "Literal": [
                   {
-                    "scalar_type": "Int32",
-                    "nullable": true
+                    "Ok": {
+                      "data": [
+                        45,
+                        1
+                      ]
+                    }
                   },
                   {
                     "scalar_type": "Int32",
-                    "nullable": true
+                    "nullable": false
                   }
                 ]
-              },
-              "plan": "PassArrangements",
-              "lir_id": 0
-            }
-          },
-          "func": "GenerateSeriesInt32",
-          "exprs": [
-            {
-              "Column": 0
-            },
-            {
-              "Column": 1
-            },
-            {
-              "Literal": [
-                {
-                  "Ok": {
-                    "data": [
-                      45,
-                      1
-                    ]
-                  }
-                },
-                {
-                  "scalar_type": "Int32",
-                  "nullable": false
-                }
-              ]
-            }
-          ],
-          "mfp_after": {
-            "expressions": [],
-            "predicates": [],
-            "projection": [
-              2
+              }
             ],
-            "input_arity": 3
-          },
-          "input_key": [
-            {
-              "Column": 0
-            }
-          ],
-          "lir_id": 1
+            "mfp_after": {
+              "expressions": [],
+              "predicates": [],
+              "projection": [
+                2
+              ],
+              "input_arity": 3
+            },
+            "input_key": [
+              {
+                "Column": 0
+              }
+            ]
+          }
         }
       }
     }
@@ -1650,84 +1730,88 @@ SELECT DISTINCT a, b FROM t
     {
       "id": "Explained Query",
       "plan": {
-        "Reduce": {
-          "input": {
-            "Get": {
-              "id": {
-                "Global": {
-                  "User": 1
-                }
-              },
-              "keys": {
-                "raw": false,
-                "arranged": [
-                  [
-                    [
-                      {
-                        "Column": 0
-                      }
-                    ],
-                    {
-                      "0": 0,
-                      "1": 1
-                    },
-                    [
-                      1
-                    ]
-                  ]
-                ],
-                "types": [
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": true
+        "lir_id": 1,
+        "node": {
+          "Reduce": {
+            "input": {
+              "lir_id": 0,
+              "node": {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
                   },
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": true
-                  }
-                ]
-              },
-              "plan": "PassArrangements",
-              "lir_id": 0
-            }
-          },
-          "key_val_plan": {
-            "key_plan": {
-              "mfp": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0,
-                  1
-                ],
-                "input_arity": 2
+                  "keys": {
+                    "raw": false,
+                    "arranged": [
+                      [
+                        [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        {
+                          "0": 0,
+                          "1": 1
+                        },
+                        [
+                          1
+                        ]
+                      ]
+                    ],
+                    "types": [
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      },
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      }
+                    ]
+                  },
+                  "plan": "PassArrangements"
+                }
               }
             },
-            "val_plan": {
-              "mfp": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [],
-                "input_arity": 2
+            "key_val_plan": {
+              "key_plan": {
+                "mfp": {
+                  "expressions": [],
+                  "predicates": [],
+                  "projection": [
+                    0,
+                    1
+                  ],
+                  "input_arity": 2
+                }
+              },
+              "val_plan": {
+                "mfp": {
+                  "expressions": [],
+                  "predicates": [],
+                  "projection": [],
+                  "input_arity": 2
+                }
               }
-            }
-          },
-          "plan": "Distinct",
-          "input_key": [
-            {
-              "Column": 0
-            }
-          ],
-          "mfp_after": {
-            "expressions": [],
-            "predicates": [],
-            "projection": [
-              0,
-              1
+            },
+            "plan": "Distinct",
+            "input_key": [
+              {
+                "Column": 0
+              }
             ],
-            "input_arity": 2
-          },
-          "lir_id": 1
+            "mfp_after": {
+              "expressions": [],
+              "predicates": [],
+              "projection": [
+                0,
+                1
+              ],
+              "input_arity": 2
+            }
+          }
         }
       }
     }
@@ -1751,105 +1835,84 @@ GROUP BY a
     {
       "id": "Explained Query",
       "plan": {
-        "Reduce": {
-          "input": {
-            "Get": {
-              "id": {
-                "Global": {
-                  "User": 1
-                }
-              },
-              "keys": {
-                "raw": false,
-                "arranged": [
-                  [
-                    [
-                      {
-                        "Column": 0
-                      }
-                    ],
-                    {
-                      "0": 0,
-                      "1": 1
-                    },
-                    [
-                      1
-                    ]
-                  ]
-                ],
-                "types": [
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": true
+        "lir_id": 1,
+        "node": {
+          "Reduce": {
+            "input": {
+              "lir_id": 0,
+              "node": {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
                   },
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": true
-                  }
-                ]
-              },
-              "plan": "PassArrangements",
-              "lir_id": 0
-            }
-          },
-          "key_val_plan": {
-            "key_plan": {
-              "mfp": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0
-                ],
-                "input_arity": 2
+                  "keys": {
+                    "raw": false,
+                    "arranged": [
+                      [
+                        [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        {
+                          "0": 0,
+                          "1": 1
+                        },
+                        [
+                          1
+                        ]
+                      ]
+                    ],
+                    "types": [
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      },
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      }
+                    ]
+                  },
+                  "plan": "PassArrangements"
+                }
               }
             },
-            "val_plan": {
-              "mfp": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  1,
-                  1
-                ],
-                "input_arity": 2
-              }
-            }
-          },
-          "plan": {
-            "Accumulable": {
-              "full_aggrs": [
-                {
-                  "func": "SumInt32",
-                  "expr": {
-                    "Column": 1
-                  },
-                  "distinct": false
-                },
-                {
-                  "func": "Count",
-                  "expr": {
-                    "Column": 1
-                  },
-                  "distinct": true
+            "key_val_plan": {
+              "key_plan": {
+                "mfp": {
+                  "expressions": [],
+                  "predicates": [],
+                  "projection": [
+                    0
+                  ],
+                  "input_arity": 2
                 }
-              ],
-              "simple_aggrs": [
-                [
-                  0,
-                  0,
+              },
+              "val_plan": {
+                "mfp": {
+                  "expressions": [],
+                  "predicates": [],
+                  "projection": [
+                    1,
+                    1
+                  ],
+                  "input_arity": 2
+                }
+              }
+            },
+            "plan": {
+              "Accumulable": {
+                "full_aggrs": [
                   {
                     "func": "SumInt32",
                     "expr": {
                       "Column": 1
                     },
                     "distinct": false
-                  }
-                ]
-              ],
-              "distinct_aggrs": [
-                [
-                  1,
-                  1,
+                  },
                   {
                     "func": "Count",
                     "expr": {
@@ -1857,26 +1920,51 @@ GROUP BY a
                     },
                     "distinct": true
                   }
+                ],
+                "simple_aggrs": [
+                  [
+                    0,
+                    0,
+                    {
+                      "func": "SumInt32",
+                      "expr": {
+                        "Column": 1
+                      },
+                      "distinct": false
+                    }
+                  ]
+                ],
+                "distinct_aggrs": [
+                  [
+                    1,
+                    1,
+                    {
+                      "func": "Count",
+                      "expr": {
+                        "Column": 1
+                      },
+                      "distinct": true
+                    }
+                  ]
                 ]
-              ]
-            }
-          },
-          "input_key": [
-            {
-              "Column": 0
-            }
-          ],
-          "mfp_after": {
-            "expressions": [],
-            "predicates": [],
-            "projection": [
-              0,
-              1,
-              2
+              }
+            },
+            "input_key": [
+              {
+                "Column": 0
+              }
             ],
-            "input_arity": 3
-          },
-          "lir_id": 1
+            "mfp_after": {
+              "expressions": [],
+              "predicates": [],
+              "projection": [
+                0,
+                1,
+                2
+              ],
+              "input_arity": 3
+            }
+          }
         }
       }
     }
@@ -1898,314 +1986,336 @@ FROM t
     {
       "id": "Explained Query",
       "plan": {
-        "Let": {
-          "id": 0,
-          "value": {
-            "Reduce": {
-              "input": {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "keys": {
-                    "raw": false,
-                    "arranged": [
-                      [
-                        [
-                          {
-                            "Column": 0
-                          }
-                        ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
-                        [
-                          1
-                        ]
-                      ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ]
-                  },
-                  "plan": {
-                    "Arrangement": [
-                      [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      null,
-                      {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          1
-                        ],
-                        "input_arity": 2
-                      }
-                    ]
-                  },
-                  "lir_id": 0
-                }
-              },
-              "key_val_plan": {
-                "key_plan": {
-                  "mfp": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [],
-                    "input_arity": 1
-                  }
-                },
-                "val_plan": {
-                  "mfp": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [
-                      0,
-                      0
-                    ],
-                    "input_arity": 1
-                  }
-                }
-              },
-              "plan": {
-                "Accumulable": {
-                  "full_aggrs": [
-                    {
-                      "func": "SumInt32",
-                      "expr": {
-                        "Column": 0
-                      },
-                      "distinct": false
-                    },
-                    {
-                      "func": "Count",
-                      "expr": {
-                        "Column": 0
-                      },
-                      "distinct": true
-                    }
-                  ],
-                  "simple_aggrs": [
-                    [
-                      0,
-                      0,
-                      {
-                        "func": "SumInt32",
-                        "expr": {
-                          "Column": 0
-                        },
-                        "distinct": false
-                      }
-                    ]
-                  ],
-                  "distinct_aggrs": [
-                    [
-                      1,
-                      1,
-                      {
-                        "func": "Count",
-                        "expr": {
-                          "Column": 0
-                        },
-                        "distinct": true
-                      }
-                    ]
-                  ]
-                }
-              },
-              "input_key": null,
-              "mfp_after": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0,
-                  1
-                ],
-                "input_arity": 2
-              },
-              "lir_id": 1
-            }
-          },
-          "body": {
-            "Union": {
-              "inputs": [
-                {
-                  "ArrangeBy": {
-                    "input": {
+        "lir_id": 10,
+        "node": {
+          "Let": {
+            "id": 0,
+            "value": {
+              "lir_id": 1,
+              "node": {
+                "Reduce": {
+                  "input": {
+                    "lir_id": 0,
+                    "node": {
                       "Get": {
                         "id": {
-                          "Local": 0
+                          "Global": {
+                            "User": 1
+                          }
                         },
                         "keys": {
                           "raw": false,
                           "arranged": [
                             [
-                              [],
+                              [
+                                {
+                                  "Column": 0
+                                }
+                              ],
                               {
                                 "0": 0,
                                 "1": 1
                               },
                               [
-                                0,
                                 1
                               ]
                             ]
                           ],
-                          "types": null
-                        },
-                        "plan": "PassArrangements",
-                        "lir_id": 2
-                      }
-                    },
-                    "forms": {
-                      "raw": true,
-                      "arranged": [],
-                      "types": null
-                    },
-                    "input_key": [],
-                    "input_mfp": {
-                      "expressions": [],
-                      "predicates": [],
-                      "projection": [
-                        0,
-                        1
-                      ],
-                      "input_arity": 2
-                    },
-                    "lir_id": 8
-                  }
-                },
-                {
-                  "Mfp": {
-                    "input": {
-                      "Union": {
-                        "inputs": [
-                          {
-                            "Negate": {
-                              "input": {
-                                "Get": {
-                                  "id": {
-                                    "Local": 0
-                                  },
-                                  "keys": {
-                                    "raw": false,
-                                    "arranged": [
-                                      [
-                                        [],
-                                        {
-                                          "0": 0,
-                                          "1": 1
-                                        },
-                                        [
-                                          0,
-                                          1
-                                        ]
-                                      ]
-                                    ],
-                                    "types": null
-                                  },
-                                  "plan": {
-                                    "Arrangement": [
-                                      [],
-                                      null,
-                                      {
-                                        "expressions": [],
-                                        "predicates": [],
-                                        "projection": [],
-                                        "input_arity": 2
-                                      }
-                                    ]
-                                  },
-                                  "lir_id": 3
-                                }
-                              },
-                              "lir_id": 4
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "rows": {
-                                "Ok": [
-                                  [
-                                    {
-                                      "data": []
-                                    },
-                                    0,
-                                    1
-                                  ]
-                                ]
-                              },
-                              "lir_id": 5
-                            }
-                          }
-                        ],
-                        "consolidate_output": true,
-                        "lir_id": 6
-                      }
-                    },
-                    "mfp": {
-                      "expressions": [
-                        {
-                          "Literal": [
+                          "types": [
                             {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
-                              }
+                              "scalar_type": "Int32",
+                              "nullable": true
                             },
                             {
-                              "scalar_type": "Int64",
+                              "scalar_type": "Int32",
                               "nullable": true
                             }
                           ]
                         },
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  49
-                                ]
+                        "plan": {
+                          "Arrangement": [
+                            [
+                              {
+                                "Column": 0
                               }
-                            },
+                            ],
+                            null,
                             {
-                              "scalar_type": "Int64",
-                              "nullable": false
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1
+                              ],
+                              "input_arity": 2
                             }
                           ]
                         }
-                      ],
-                      "predicates": [],
-                      "projection": [
-                        0,
-                        1
-                      ],
-                      "input_arity": 0
+                      }
+                    }
+                  },
+                  "key_val_plan": {
+                    "key_plan": {
+                      "mfp": {
+                        "expressions": [],
+                        "predicates": [],
+                        "projection": [],
+                        "input_arity": 1
+                      }
                     },
-                    "input_key_val": null,
-                    "lir_id": 7
+                    "val_plan": {
+                      "mfp": {
+                        "expressions": [],
+                        "predicates": [],
+                        "projection": [
+                          0,
+                          0
+                        ],
+                        "input_arity": 1
+                      }
+                    }
+                  },
+                  "plan": {
+                    "Accumulable": {
+                      "full_aggrs": [
+                        {
+                          "func": "SumInt32",
+                          "expr": {
+                            "Column": 0
+                          },
+                          "distinct": false
+                        },
+                        {
+                          "func": "Count",
+                          "expr": {
+                            "Column": 0
+                          },
+                          "distinct": true
+                        }
+                      ],
+                      "simple_aggrs": [
+                        [
+                          0,
+                          0,
+                          {
+                            "func": "SumInt32",
+                            "expr": {
+                              "Column": 0
+                            },
+                            "distinct": false
+                          }
+                        ]
+                      ],
+                      "distinct_aggrs": [
+                        [
+                          1,
+                          1,
+                          {
+                            "func": "Count",
+                            "expr": {
+                              "Column": 0
+                            },
+                            "distinct": true
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  "input_key": null,
+                  "mfp_after": {
+                    "expressions": [],
+                    "predicates": [],
+                    "projection": [
+                      0,
+                      1
+                    ],
+                    "input_arity": 2
                   }
                 }
-              ],
-              "consolidate_output": false,
-              "lir_id": 9
+              }
+            },
+            "body": {
+              "lir_id": 9,
+              "node": {
+                "Union": {
+                  "inputs": [
+                    {
+                      "lir_id": 8,
+                      "node": {
+                        "ArrangeBy": {
+                          "input": {
+                            "lir_id": 2,
+                            "node": {
+                              "Get": {
+                                "id": {
+                                  "Local": 0
+                                },
+                                "keys": {
+                                  "raw": false,
+                                  "arranged": [
+                                    [
+                                      [],
+                                      {
+                                        "0": 0,
+                                        "1": 1
+                                      },
+                                      [
+                                        0,
+                                        1
+                                      ]
+                                    ]
+                                  ],
+                                  "types": null
+                                },
+                                "plan": "PassArrangements"
+                              }
+                            }
+                          },
+                          "forms": {
+                            "raw": true,
+                            "arranged": [],
+                            "types": null
+                          },
+                          "input_key": [],
+                          "input_mfp": {
+                            "expressions": [],
+                            "predicates": [],
+                            "projection": [
+                              0,
+                              1
+                            ],
+                            "input_arity": 2
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "lir_id": 7,
+                      "node": {
+                        "Mfp": {
+                          "input": {
+                            "lir_id": 6,
+                            "node": {
+                              "Union": {
+                                "inputs": [
+                                  {
+                                    "lir_id": 4,
+                                    "node": {
+                                      "Negate": {
+                                        "input": {
+                                          "lir_id": 3,
+                                          "node": {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 0
+                                              },
+                                              "keys": {
+                                                "raw": false,
+                                                "arranged": [
+                                                  [
+                                                    [],
+                                                    {
+                                                      "0": 0,
+                                                      "1": 1
+                                                    },
+                                                    [
+                                                      0,
+                                                      1
+                                                    ]
+                                                  ]
+                                                ],
+                                                "types": null
+                                              },
+                                              "plan": {
+                                                "Arrangement": [
+                                                  [],
+                                                  null,
+                                                  {
+                                                    "expressions": [],
+                                                    "predicates": [],
+                                                    "projection": [],
+                                                    "input_arity": 2
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lir_id": 5,
+                                    "node": {
+                                      "Constant": {
+                                        "rows": {
+                                          "Ok": [
+                                            [
+                                              {
+                                                "data": []
+                                              },
+                                              0,
+                                              1
+                                            ]
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "consolidate_output": true
+                              }
+                            }
+                          },
+                          "mfp": {
+                            "expressions": [
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "Int64",
+                                    "nullable": true
+                                  }
+                                ]
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        49
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "Int64",
+                                    "nullable": false
+                                  }
+                                ]
+                              }
+                            ],
+                            "predicates": [],
+                            "projection": [
+                              0,
+                              1
+                            ],
+                            "input_arity": 0
+                          },
+                          "input_key_val": null
+                        }
+                      }
+                    }
+                  ],
+                  "consolidate_output": false
+                }
+              }
             }
-          },
-          "lir_id": 10
+          }
         }
       }
     }
@@ -2224,101 +2334,105 @@ SELECT * FROM hierarchical_group_by
     {
       "id": "Explained Query",
       "plan": {
-        "Reduce": {
-          "input": {
-            "Get": {
-              "id": {
-                "Global": {
-                  "User": 1
-                }
-              },
-              "keys": {
-                "raw": false,
-                "arranged": [
-                  [
-                    [
-                      {
-                        "Column": 0
-                      }
-                    ],
-                    {
-                      "0": 0,
-                      "1": 1
-                    },
-                    [
-                      1
-                    ]
-                  ]
-                ],
-                "types": [
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": true
+        "lir_id": 1,
+        "node": {
+          "Reduce": {
+            "input": {
+              "lir_id": 0,
+              "node": {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
                   },
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": true
-                  }
-                ]
-              },
-              "plan": "PassArrangements",
-              "lir_id": 0
-            }
-          },
-          "key_val_plan": {
-            "key_plan": {
-              "mfp": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0
-                ],
-                "input_arity": 2
+                  "keys": {
+                    "raw": false,
+                    "arranged": [
+                      [
+                        [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        {
+                          "0": 0,
+                          "1": 1
+                        },
+                        [
+                          1
+                        ]
+                      ]
+                    ],
+                    "types": [
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      },
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      }
+                    ]
+                  },
+                  "plan": "PassArrangements"
+                }
               }
             },
-            "val_plan": {
-              "mfp": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  1,
-                  1
-                ],
-                "input_arity": 2
+            "key_val_plan": {
+              "key_plan": {
+                "mfp": {
+                  "expressions": [],
+                  "predicates": [],
+                  "projection": [
+                    0
+                  ],
+                  "input_arity": 2
+                }
+              },
+              "val_plan": {
+                "mfp": {
+                  "expressions": [],
+                  "predicates": [],
+                  "projection": [
+                    1,
+                    1
+                  ],
+                  "input_arity": 2
+                }
               }
-            }
-          },
-          "plan": {
-            "Hierarchical": {
-              "Monotonic": {
-                "aggr_funcs": [
-                  "MinInt32",
-                  "MaxInt32"
-                ],
-                "skips": [
-                  0,
-                  0
-                ],
-                "must_consolidate": true
+            },
+            "plan": {
+              "Hierarchical": {
+                "Monotonic": {
+                  "aggr_funcs": [
+                    "MinInt32",
+                    "MaxInt32"
+                  ],
+                  "skips": [
+                    0,
+                    0
+                  ],
+                  "must_consolidate": true
+                }
               }
-            }
-          },
-          "input_key": [
-            {
-              "Column": 0
-            }
-          ],
-          "mfp_after": {
-            "expressions": [],
-            "predicates": [],
-            "projection": [
-              0,
-              1,
-              2
+            },
+            "input_key": [
+              {
+                "Column": 0
+              }
             ],
-            "input_arity": 3
-          },
-          "lir_id": 1
+            "mfp_after": {
+              "expressions": [],
+              "predicates": [],
+              "projection": [
+                0,
+                1,
+                2
+              ],
+              "input_arity": 3
+            }
+          }
         }
       }
     }
@@ -2337,251 +2451,45 @@ MATERIALIZED VIEW hierarchical_global_mv
     {
       "id": "materialize.public.hierarchical_global_mv",
       "plan": {
-        "Let": {
-          "id": 0,
-          "value": {
-            "Reduce": {
-              "input": {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "keys": {
-                    "raw": false,
-                    "arranged": [
-                      [
-                        [
-                          {
-                            "Column": 0
-                          }
-                        ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
-                        [
-                          1
-                        ]
-                      ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ]
-                  },
-                  "plan": {
-                    "Arrangement": [
-                      [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      null,
-                      {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          1
-                        ],
-                        "input_arity": 2
-                      }
-                    ]
-                  },
-                  "lir_id": 0
-                }
-              },
-              "key_val_plan": {
-                "key_plan": {
-                  "mfp": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [],
-                    "input_arity": 1
-                  }
-                },
-                "val_plan": {
-                  "mfp": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [
-                      0,
-                      0
-                    ],
-                    "input_arity": 1
-                  }
-                }
-              },
-              "plan": {
-                "Hierarchical": {
-                  "Bucketed": {
-                    "aggr_funcs": [
-                      "MinInt32",
-                      "MaxInt32"
-                    ],
-                    "skips": [
-                      0,
-                      0
-                    ],
-                    "buckets": [
-                      268435456,
-                      16777216,
-                      1048576,
-                      65536,
-                      4096,
-                      256,
-                      16
-                    ]
-                  }
-                }
-              },
-              "input_key": null,
-              "mfp_after": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0,
-                  1
-                ],
-                "input_arity": 2
-              },
-              "lir_id": 1
-            }
-          },
-          "body": {
-            "Union": {
-              "inputs": [
-                {
-                  "ArrangeBy": {
-                    "input": {
+        "lir_id": 10,
+        "node": {
+          "Let": {
+            "id": 0,
+            "value": {
+              "lir_id": 1,
+              "node": {
+                "Reduce": {
+                  "input": {
+                    "lir_id": 0,
+                    "node": {
                       "Get": {
                         "id": {
-                          "Local": 0
+                          "Global": {
+                            "User": 1
+                          }
                         },
                         "keys": {
                           "raw": false,
                           "arranged": [
                             [
-                              [],
+                              [
+                                {
+                                  "Column": 0
+                                }
+                              ],
                               {
                                 "0": 0,
                                 "1": 1
                               },
                               [
-                                0,
                                 1
                               ]
                             ]
                           ],
-                          "types": null
-                        },
-                        "plan": "PassArrangements",
-                        "lir_id": 2
-                      }
-                    },
-                    "forms": {
-                      "raw": true,
-                      "arranged": [],
-                      "types": null
-                    },
-                    "input_key": [],
-                    "input_mfp": {
-                      "expressions": [],
-                      "predicates": [],
-                      "projection": [
-                        0,
-                        1
-                      ],
-                      "input_arity": 2
-                    },
-                    "lir_id": 8
-                  }
-                },
-                {
-                  "Mfp": {
-                    "input": {
-                      "Union": {
-                        "inputs": [
-                          {
-                            "Negate": {
-                              "input": {
-                                "Get": {
-                                  "id": {
-                                    "Local": 0
-                                  },
-                                  "keys": {
-                                    "raw": false,
-                                    "arranged": [
-                                      [
-                                        [],
-                                        {
-                                          "0": 0,
-                                          "1": 1
-                                        },
-                                        [
-                                          0,
-                                          1
-                                        ]
-                                      ]
-                                    ],
-                                    "types": null
-                                  },
-                                  "plan": {
-                                    "Arrangement": [
-                                      [],
-                                      null,
-                                      {
-                                        "expressions": [],
-                                        "predicates": [],
-                                        "projection": [],
-                                        "input_arity": 2
-                                      }
-                                    ]
-                                  },
-                                  "lir_id": 3
-                                }
-                              },
-                              "lir_id": 4
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "rows": {
-                                "Ok": [
-                                  [
-                                    {
-                                      "data": []
-                                    },
-                                    0,
-                                    1
-                                  ]
-                                ]
-                              },
-                              "lir_id": 5
-                            }
-                          }
-                        ],
-                        "consolidate_output": true,
-                        "lir_id": 6
-                      }
-                    },
-                    "mfp": {
-                      "expressions": [
-                        {
-                          "Literal": [
+                          "types": [
                             {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
-                              }
+                              "scalar_type": "Int32",
+                              "nullable": true
                             },
                             {
                               "scalar_type": "Int32",
@@ -2589,39 +2497,267 @@ MATERIALIZED VIEW hierarchical_global_mv
                             }
                           ]
                         },
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
+                        "plan": {
+                          "Arrangement": [
+                            [
+                              {
+                                "Column": 0
                               }
-                            },
+                            ],
+                            null,
                             {
-                              "scalar_type": "Int32",
-                              "nullable": true
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1
+                              ],
+                              "input_arity": 2
                             }
                           ]
                         }
-                      ],
-                      "predicates": [],
-                      "projection": [
-                        0,
-                        1
-                      ],
-                      "input_arity": 0
+                      }
+                    }
+                  },
+                  "key_val_plan": {
+                    "key_plan": {
+                      "mfp": {
+                        "expressions": [],
+                        "predicates": [],
+                        "projection": [],
+                        "input_arity": 1
+                      }
                     },
-                    "input_key_val": null,
-                    "lir_id": 7
+                    "val_plan": {
+                      "mfp": {
+                        "expressions": [],
+                        "predicates": [],
+                        "projection": [
+                          0,
+                          0
+                        ],
+                        "input_arity": 1
+                      }
+                    }
+                  },
+                  "plan": {
+                    "Hierarchical": {
+                      "Bucketed": {
+                        "aggr_funcs": [
+                          "MinInt32",
+                          "MaxInt32"
+                        ],
+                        "skips": [
+                          0,
+                          0
+                        ],
+                        "buckets": [
+                          268435456,
+                          16777216,
+                          1048576,
+                          65536,
+                          4096,
+                          256,
+                          16
+                        ]
+                      }
+                    }
+                  },
+                  "input_key": null,
+                  "mfp_after": {
+                    "expressions": [],
+                    "predicates": [],
+                    "projection": [
+                      0,
+                      1
+                    ],
+                    "input_arity": 2
                   }
                 }
-              ],
-              "consolidate_output": false,
-              "lir_id": 9
+              }
+            },
+            "body": {
+              "lir_id": 9,
+              "node": {
+                "Union": {
+                  "inputs": [
+                    {
+                      "lir_id": 8,
+                      "node": {
+                        "ArrangeBy": {
+                          "input": {
+                            "lir_id": 2,
+                            "node": {
+                              "Get": {
+                                "id": {
+                                  "Local": 0
+                                },
+                                "keys": {
+                                  "raw": false,
+                                  "arranged": [
+                                    [
+                                      [],
+                                      {
+                                        "0": 0,
+                                        "1": 1
+                                      },
+                                      [
+                                        0,
+                                        1
+                                      ]
+                                    ]
+                                  ],
+                                  "types": null
+                                },
+                                "plan": "PassArrangements"
+                              }
+                            }
+                          },
+                          "forms": {
+                            "raw": true,
+                            "arranged": [],
+                            "types": null
+                          },
+                          "input_key": [],
+                          "input_mfp": {
+                            "expressions": [],
+                            "predicates": [],
+                            "projection": [
+                              0,
+                              1
+                            ],
+                            "input_arity": 2
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "lir_id": 7,
+                      "node": {
+                        "Mfp": {
+                          "input": {
+                            "lir_id": 6,
+                            "node": {
+                              "Union": {
+                                "inputs": [
+                                  {
+                                    "lir_id": 4,
+                                    "node": {
+                                      "Negate": {
+                                        "input": {
+                                          "lir_id": 3,
+                                          "node": {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 0
+                                              },
+                                              "keys": {
+                                                "raw": false,
+                                                "arranged": [
+                                                  [
+                                                    [],
+                                                    {
+                                                      "0": 0,
+                                                      "1": 1
+                                                    },
+                                                    [
+                                                      0,
+                                                      1
+                                                    ]
+                                                  ]
+                                                ],
+                                                "types": null
+                                              },
+                                              "plan": {
+                                                "Arrangement": [
+                                                  [],
+                                                  null,
+                                                  {
+                                                    "expressions": [],
+                                                    "predicates": [],
+                                                    "projection": [],
+                                                    "input_arity": 2
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lir_id": 5,
+                                    "node": {
+                                      "Constant": {
+                                        "rows": {
+                                          "Ok": [
+                                            [
+                                              {
+                                                "data": []
+                                              },
+                                              0,
+                                              1
+                                            ]
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "consolidate_output": true
+                              }
+                            }
+                          },
+                          "mfp": {
+                            "expressions": [
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  }
+                                ]
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  }
+                                ]
+                              }
+                            ],
+                            "predicates": [],
+                            "projection": [
+                              0,
+                              1
+                            ],
+                            "input_arity": 0
+                          },
+                          "input_key_val": null
+                        }
+                      }
+                    }
+                  ],
+                  "consolidate_output": false
+                }
+              }
             }
-          },
-          "lir_id": 10
+          }
         }
       }
     }
@@ -2640,243 +2776,45 @@ SELECT * FROM hierarchical_global
     {
       "id": "Explained Query",
       "plan": {
-        "Let": {
-          "id": 0,
-          "value": {
-            "Reduce": {
-              "input": {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "keys": {
-                    "raw": false,
-                    "arranged": [
-                      [
-                        [
-                          {
-                            "Column": 0
-                          }
-                        ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
-                        [
-                          1
-                        ]
-                      ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ]
-                  },
-                  "plan": {
-                    "Arrangement": [
-                      [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      null,
-                      {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          1
-                        ],
-                        "input_arity": 2
-                      }
-                    ]
-                  },
-                  "lir_id": 0
-                }
-              },
-              "key_val_plan": {
-                "key_plan": {
-                  "mfp": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [],
-                    "input_arity": 1
-                  }
-                },
-                "val_plan": {
-                  "mfp": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [
-                      0,
-                      0
-                    ],
-                    "input_arity": 1
-                  }
-                }
-              },
-              "plan": {
-                "Hierarchical": {
-                  "Monotonic": {
-                    "aggr_funcs": [
-                      "MinInt32",
-                      "MaxInt32"
-                    ],
-                    "skips": [
-                      0,
-                      0
-                    ],
-                    "must_consolidate": true
-                  }
-                }
-              },
-              "input_key": null,
-              "mfp_after": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0,
-                  1
-                ],
-                "input_arity": 2
-              },
-              "lir_id": 1
-            }
-          },
-          "body": {
-            "Union": {
-              "inputs": [
-                {
-                  "ArrangeBy": {
-                    "input": {
+        "lir_id": 10,
+        "node": {
+          "Let": {
+            "id": 0,
+            "value": {
+              "lir_id": 1,
+              "node": {
+                "Reduce": {
+                  "input": {
+                    "lir_id": 0,
+                    "node": {
                       "Get": {
                         "id": {
-                          "Local": 0
+                          "Global": {
+                            "User": 1
+                          }
                         },
                         "keys": {
                           "raw": false,
                           "arranged": [
                             [
-                              [],
+                              [
+                                {
+                                  "Column": 0
+                                }
+                              ],
                               {
                                 "0": 0,
                                 "1": 1
                               },
                               [
-                                0,
                                 1
                               ]
                             ]
                           ],
-                          "types": null
-                        },
-                        "plan": "PassArrangements",
-                        "lir_id": 2
-                      }
-                    },
-                    "forms": {
-                      "raw": true,
-                      "arranged": [],
-                      "types": null
-                    },
-                    "input_key": [],
-                    "input_mfp": {
-                      "expressions": [],
-                      "predicates": [],
-                      "projection": [
-                        0,
-                        1
-                      ],
-                      "input_arity": 2
-                    },
-                    "lir_id": 8
-                  }
-                },
-                {
-                  "Mfp": {
-                    "input": {
-                      "Union": {
-                        "inputs": [
-                          {
-                            "Negate": {
-                              "input": {
-                                "Get": {
-                                  "id": {
-                                    "Local": 0
-                                  },
-                                  "keys": {
-                                    "raw": false,
-                                    "arranged": [
-                                      [
-                                        [],
-                                        {
-                                          "0": 0,
-                                          "1": 1
-                                        },
-                                        [
-                                          0,
-                                          1
-                                        ]
-                                      ]
-                                    ],
-                                    "types": null
-                                  },
-                                  "plan": {
-                                    "Arrangement": [
-                                      [],
-                                      null,
-                                      {
-                                        "expressions": [],
-                                        "predicates": [],
-                                        "projection": [],
-                                        "input_arity": 2
-                                      }
-                                    ]
-                                  },
-                                  "lir_id": 3
-                                }
-                              },
-                              "lir_id": 4
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "rows": {
-                                "Ok": [
-                                  [
-                                    {
-                                      "data": []
-                                    },
-                                    0,
-                                    1
-                                  ]
-                                ]
-                              },
-                              "lir_id": 5
-                            }
-                          }
-                        ],
-                        "consolidate_output": true,
-                        "lir_id": 6
-                      }
-                    },
-                    "mfp": {
-                      "expressions": [
-                        {
-                          "Literal": [
+                          "types": [
                             {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
-                              }
+                              "scalar_type": "Int32",
+                              "nullable": true
                             },
                             {
                               "scalar_type": "Int32",
@@ -2884,39 +2822,259 @@ SELECT * FROM hierarchical_global
                             }
                           ]
                         },
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
+                        "plan": {
+                          "Arrangement": [
+                            [
+                              {
+                                "Column": 0
                               }
-                            },
+                            ],
+                            null,
                             {
-                              "scalar_type": "Int32",
-                              "nullable": true
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1
+                              ],
+                              "input_arity": 2
                             }
                           ]
                         }
-                      ],
-                      "predicates": [],
-                      "projection": [
-                        0,
-                        1
-                      ],
-                      "input_arity": 0
+                      }
+                    }
+                  },
+                  "key_val_plan": {
+                    "key_plan": {
+                      "mfp": {
+                        "expressions": [],
+                        "predicates": [],
+                        "projection": [],
+                        "input_arity": 1
+                      }
                     },
-                    "input_key_val": null,
-                    "lir_id": 7
+                    "val_plan": {
+                      "mfp": {
+                        "expressions": [],
+                        "predicates": [],
+                        "projection": [
+                          0,
+                          0
+                        ],
+                        "input_arity": 1
+                      }
+                    }
+                  },
+                  "plan": {
+                    "Hierarchical": {
+                      "Monotonic": {
+                        "aggr_funcs": [
+                          "MinInt32",
+                          "MaxInt32"
+                        ],
+                        "skips": [
+                          0,
+                          0
+                        ],
+                        "must_consolidate": true
+                      }
+                    }
+                  },
+                  "input_key": null,
+                  "mfp_after": {
+                    "expressions": [],
+                    "predicates": [],
+                    "projection": [
+                      0,
+                      1
+                    ],
+                    "input_arity": 2
                   }
                 }
-              ],
-              "consolidate_output": false,
-              "lir_id": 9
+              }
+            },
+            "body": {
+              "lir_id": 9,
+              "node": {
+                "Union": {
+                  "inputs": [
+                    {
+                      "lir_id": 8,
+                      "node": {
+                        "ArrangeBy": {
+                          "input": {
+                            "lir_id": 2,
+                            "node": {
+                              "Get": {
+                                "id": {
+                                  "Local": 0
+                                },
+                                "keys": {
+                                  "raw": false,
+                                  "arranged": [
+                                    [
+                                      [],
+                                      {
+                                        "0": 0,
+                                        "1": 1
+                                      },
+                                      [
+                                        0,
+                                        1
+                                      ]
+                                    ]
+                                  ],
+                                  "types": null
+                                },
+                                "plan": "PassArrangements"
+                              }
+                            }
+                          },
+                          "forms": {
+                            "raw": true,
+                            "arranged": [],
+                            "types": null
+                          },
+                          "input_key": [],
+                          "input_mfp": {
+                            "expressions": [],
+                            "predicates": [],
+                            "projection": [
+                              0,
+                              1
+                            ],
+                            "input_arity": 2
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "lir_id": 7,
+                      "node": {
+                        "Mfp": {
+                          "input": {
+                            "lir_id": 6,
+                            "node": {
+                              "Union": {
+                                "inputs": [
+                                  {
+                                    "lir_id": 4,
+                                    "node": {
+                                      "Negate": {
+                                        "input": {
+                                          "lir_id": 3,
+                                          "node": {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 0
+                                              },
+                                              "keys": {
+                                                "raw": false,
+                                                "arranged": [
+                                                  [
+                                                    [],
+                                                    {
+                                                      "0": 0,
+                                                      "1": 1
+                                                    },
+                                                    [
+                                                      0,
+                                                      1
+                                                    ]
+                                                  ]
+                                                ],
+                                                "types": null
+                                              },
+                                              "plan": {
+                                                "Arrangement": [
+                                                  [],
+                                                  null,
+                                                  {
+                                                    "expressions": [],
+                                                    "predicates": [],
+                                                    "projection": [],
+                                                    "input_arity": 2
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lir_id": 5,
+                                    "node": {
+                                      "Constant": {
+                                        "rows": {
+                                          "Ok": [
+                                            [
+                                              {
+                                                "data": []
+                                              },
+                                              0,
+                                              1
+                                            ]
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "consolidate_output": true
+                              }
+                            }
+                          },
+                          "mfp": {
+                            "expressions": [
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  }
+                                ]
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  }
+                                ]
+                              }
+                            ],
+                            "predicates": [],
+                            "projection": [
+                              0,
+                              1
+                            ],
+                            "input_arity": 0
+                          },
+                          "input_key_val": null
+                        }
+                      }
+                    }
+                  ],
+                  "consolidate_output": false
+                }
+              }
             }
-          },
-          "lir_id": 10
+          }
         }
       }
     }
@@ -2940,231 +3098,76 @@ GROUP BY a
     {
       "id": "Explained Query",
       "plan": {
-        "Reduce": {
-          "input": {
-            "Get": {
-              "id": {
-                "Global": {
-                  "User": 1
-                }
-              },
-              "keys": {
-                "raw": false,
-                "arranged": [
-                  [
-                    [
-                      {
-                        "Column": 0
-                      }
-                    ],
-                    {
-                      "0": 0,
-                      "1": 1
-                    },
-                    [
-                      1
-                    ]
-                  ]
-                ],
-                "types": [
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": true
+        "lir_id": 1,
+        "node": {
+          "Reduce": {
+            "input": {
+              "lir_id": 0,
+              "node": {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
                   },
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": true
-                  }
-                ]
-              },
-              "plan": "PassArrangements",
-              "lir_id": 0
-            }
-          },
-          "key_val_plan": {
-            "key_plan": {
-              "mfp": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0
-                ],
-                "input_arity": 2
+                  "keys": {
+                    "raw": false,
+                    "arranged": [
+                      [
+                        [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        {
+                          "0": 0,
+                          "1": 1
+                        },
+                        [
+                          1
+                        ]
+                      ]
+                    ],
+                    "types": [
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      },
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      }
+                    ]
+                  },
+                  "plan": "PassArrangements"
+                }
               }
             },
-            "val_plan": {
-              "mfp": {
-                "expressions": [
-                  {
-                    "CallUnary": {
-                      "func": {
-                        "CastInt32ToString": null
-                      },
-                      "expr": {
-                        "Column": 1
-                      }
-                    }
-                  },
-                  {
-                    "CallVariadic": {
-                      "func": {
-                        "RecordCreate": {
-                          "field_names": [
-                            ""
-                          ]
+            "key_val_plan": {
+              "key_plan": {
+                "mfp": {
+                  "expressions": [],
+                  "predicates": [],
+                  "projection": [
+                    0
+                  ],
+                  "input_arity": 2
+                }
+              },
+              "val_plan": {
+                "mfp": {
+                  "expressions": [
+                    {
+                      "CallUnary": {
+                        "func": {
+                          "CastInt32ToString": null
+                        },
+                        "expr": {
+                          "Column": 1
                         }
-                      },
-                      "exprs": [
-                        {
-                          "CallVariadic": {
-                            "func": {
-                              "RecordCreate": {
-                                "field_names": [
-                                  "value",
-                                  "sep"
-                                ]
-                              }
-                            },
-                            "exprs": [
-                              {
-                                "CallBinary": {
-                                  "func": "TextConcat",
-                                  "expr1": {
-                                    "Column": 2
-                                  },
-                                  "expr2": {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            49
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        19,
-                                        1,
-                                        44
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": false
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "CallVariadic": {
-                      "func": {
-                        "RecordCreate": {
-                          "field_names": [
-                            ""
-                          ]
-                        }
-                      },
-                      "exprs": [
-                        {
-                          "CallVariadic": {
-                            "func": {
-                              "RecordCreate": {
-                                "field_names": [
-                                  "value",
-                                  "sep"
-                                ]
-                              }
-                            },
-                            "exprs": [
-                              {
-                                "CallBinary": {
-                                  "func": "TextConcat",
-                                  "expr1": {
-                                    "Column": 2
-                                  },
-                                  "expr2": {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            50
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        19,
-                                        1,
-                                        44
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": false
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "predicates": [],
-                "projection": [
-                  3,
-                  4
-                ],
-                "input_arity": 2
-              }
-            }
-          },
-          "plan": {
-            "Basic": {
-              "Multiple": [
-                [
-                  0,
-                  {
-                    "func": {
-                      "StringAgg": {
-                        "order_by": []
                       }
                     },
-                    "expr": {
+                    {
                       "CallVariadic": {
                         "func": {
                           "RecordCreate": {
@@ -3189,14 +3192,7 @@ GROUP BY a
                                   "CallBinary": {
                                     "func": "TextConcat",
                                     "expr1": {
-                                      "CallUnary": {
-                                        "func": {
-                                          "CastInt32ToString": null
-                                        },
-                                        "expr": {
-                                          "Column": 1
-                                        }
-                                      }
+                                      "Column": 2
                                     },
                                     "expr2": {
                                       "Literal": [
@@ -3240,18 +3236,7 @@ GROUP BY a
                         ]
                       }
                     },
-                    "distinct": false
-                  }
-                ],
-                [
-                  1,
-                  {
-                    "func": {
-                      "StringAgg": {
-                        "order_by": []
-                      }
-                    },
-                    "expr": {
+                    {
                       "CallVariadic": {
                         "func": {
                           "RecordCreate": {
@@ -3276,14 +3261,7 @@ GROUP BY a
                                   "CallBinary": {
                                     "func": "TextConcat",
                                     "expr1": {
-                                      "CallUnary": {
-                                        "func": {
-                                          "CastInt32ToString": null
-                                        },
-                                        "expr": {
-                                          "Column": 1
-                                        }
-                                      }
+                                      "Column": 2
                                     },
                                     "expr2": {
                                       "Literal": [
@@ -3326,134 +3304,29 @@ GROUP BY a
                           }
                         ]
                       }
-                    },
-                    "distinct": false
-                  }
-                ]
-              ]
-            }
-          },
-          "input_key": [
-            {
-              "Column": 0
-            }
-          ],
-          "mfp_after": {
-            "expressions": [],
-            "predicates": [],
-            "projection": [
-              0,
-              1,
-              2
-            ],
-            "input_arity": 3
-          },
-          "lir_id": 1
-        }
-      }
-    }
-  ],
-  "sources": []
-}
-EOF
-
-# Test Reduce::Basic (global aggregate).
-query T multiline
-EXPLAIN PHYSICAL PLAN AS JSON FOR
-SELECT
-  STRING_AGG(b::text || '1',  ','),
-  STRING_AGG(b::text || '2',  ',')
-FROM t
-----
-{
-  "plans": [
-    {
-      "id": "Explained Query",
-      "plan": {
-        "Let": {
-          "id": 0,
-          "value": {
-            "Reduce": {
-              "input": {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
                     }
-                  },
-                  "keys": {
-                    "raw": false,
-                    "arranged": [
-                      [
-                        [
-                          {
-                            "Column": 0
-                          }
-                        ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
-                        [
-                          1
-                        ]
-                      ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ]
-                  },
-                  "plan": {
-                    "Arrangement": [
-                      [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      null,
-                      {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          1
-                        ],
-                        "input_arity": 2
-                      }
-                    ]
-                  },
-                  "lir_id": 0
+                  ],
+                  "predicates": [],
+                  "projection": [
+                    3,
+                    4
+                  ],
+                  "input_arity": 2
                 }
-              },
-              "key_val_plan": {
-                "key_plan": {
-                  "mfp": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [],
-                    "input_arity": 1
-                  }
-                },
-                "val_plan": {
-                  "mfp": {
-                    "expressions": [
-                      {
-                        "CallUnary": {
-                          "func": {
-                            "CastInt32ToString": null
-                          },
-                          "expr": {
-                            "Column": 0
-                          }
+              }
+            },
+            "plan": {
+              "Basic": {
+                "Multiple": [
+                  [
+                    0,
+                    {
+                      "func": {
+                        "StringAgg": {
+                          "order_by": []
                         }
                       },
-                      {
+                      "expr": {
                         "CallVariadic": {
                           "func": {
                             "RecordCreate": {
@@ -3478,7 +3351,14 @@ FROM t
                                     "CallBinary": {
                                       "func": "TextConcat",
                                       "expr1": {
-                                        "Column": 1
+                                        "CallUnary": {
+                                          "func": {
+                                            "CastInt32ToString": null
+                                          },
+                                          "expr": {
+                                            "Column": 1
+                                          }
+                                        }
                                       },
                                       "expr2": {
                                         "Literal": [
@@ -3522,7 +3402,18 @@ FROM t
                           ]
                         }
                       },
-                      {
+                      "distinct": false
+                    }
+                  ],
+                  [
+                    1,
+                    {
+                      "func": {
+                        "StringAgg": {
+                          "order_by": []
+                        }
+                      },
+                      "expr": {
                         "CallVariadic": {
                           "func": {
                             "RecordCreate": {
@@ -3547,7 +3438,14 @@ FROM t
                                     "CallBinary": {
                                       "func": "TextConcat",
                                       "expr1": {
-                                        "Column": 1
+                                        "CallUnary": {
+                                          "func": {
+                                            "CastInt32ToString": null
+                                          },
+                                          "expr": {
+                                            "Column": 1
+                                          }
+                                        }
                                       },
                                       "expr2": {
                                         "Literal": [
@@ -3590,22 +3488,973 @@ FROM t
                             }
                           ]
                         }
+                      },
+                      "distinct": false
+                    }
+                  ]
+                ]
+              }
+            },
+            "input_key": [
+              {
+                "Column": 0
+              }
+            ],
+            "mfp_after": {
+              "expressions": [],
+              "predicates": [],
+              "projection": [
+                0,
+                1,
+                2
+              ],
+              "input_arity": 3
+            }
+          }
+        }
+      }
+    }
+  ],
+  "sources": []
+}
+EOF
+
+# Test Reduce::Basic (global aggregate).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS JSON FOR
+SELECT
+  STRING_AGG(b::text || '1',  ','),
+  STRING_AGG(b::text || '2',  ',')
+FROM t
+----
+{
+  "plans": [
+    {
+      "id": "Explained Query",
+      "plan": {
+        "lir_id": 10,
+        "node": {
+          "Let": {
+            "id": 0,
+            "value": {
+              "lir_id": 1,
+              "node": {
+                "Reduce": {
+                  "input": {
+                    "lir_id": 0,
+                    "node": {
+                      "Get": {
+                        "id": {
+                          "Global": {
+                            "User": 1
+                          }
+                        },
+                        "keys": {
+                          "raw": false,
+                          "arranged": [
+                            [
+                              [
+                                {
+                                  "Column": 0
+                                }
+                              ],
+                              {
+                                "0": 0,
+                                "1": 1
+                              },
+                              [
+                                1
+                              ]
+                            ]
+                          ],
+                          "types": [
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            }
+                          ]
+                        },
+                        "plan": {
+                          "Arrangement": [
+                            [
+                              {
+                                "Column": 0
+                              }
+                            ],
+                            null,
+                            {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1
+                              ],
+                              "input_arity": 2
+                            }
+                          ]
+                        }
                       }
-                    ],
+                    }
+                  },
+                  "key_val_plan": {
+                    "key_plan": {
+                      "mfp": {
+                        "expressions": [],
+                        "predicates": [],
+                        "projection": [],
+                        "input_arity": 1
+                      }
+                    },
+                    "val_plan": {
+                      "mfp": {
+                        "expressions": [
+                          {
+                            "CallUnary": {
+                              "func": {
+                                "CastInt32ToString": null
+                              },
+                              "expr": {
+                                "Column": 0
+                              }
+                            }
+                          },
+                          {
+                            "CallVariadic": {
+                              "func": {
+                                "RecordCreate": {
+                                  "field_names": [
+                                    ""
+                                  ]
+                                }
+                              },
+                              "exprs": [
+                                {
+                                  "CallVariadic": {
+                                    "func": {
+                                      "RecordCreate": {
+                                        "field_names": [
+                                          "value",
+                                          "sep"
+                                        ]
+                                      }
+                                    },
+                                    "exprs": [
+                                      {
+                                        "CallBinary": {
+                                          "func": "TextConcat",
+                                          "expr1": {
+                                            "Column": 1
+                                          },
+                                          "expr2": {
+                                            "Literal": [
+                                              {
+                                                "Ok": {
+                                                  "data": [
+                                                    19,
+                                                    1,
+                                                    49
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "scalar_type": "String",
+                                                "nullable": false
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                19,
+                                                1,
+                                                44
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "String",
+                                            "nullable": false
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "CallVariadic": {
+                              "func": {
+                                "RecordCreate": {
+                                  "field_names": [
+                                    ""
+                                  ]
+                                }
+                              },
+                              "exprs": [
+                                {
+                                  "CallVariadic": {
+                                    "func": {
+                                      "RecordCreate": {
+                                        "field_names": [
+                                          "value",
+                                          "sep"
+                                        ]
+                                      }
+                                    },
+                                    "exprs": [
+                                      {
+                                        "CallBinary": {
+                                          "func": "TextConcat",
+                                          "expr1": {
+                                            "Column": 1
+                                          },
+                                          "expr2": {
+                                            "Literal": [
+                                              {
+                                                "Ok": {
+                                                  "data": [
+                                                    19,
+                                                    1,
+                                                    50
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "scalar_type": "String",
+                                                "nullable": false
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                19,
+                                                1,
+                                                44
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "String",
+                                            "nullable": false
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ],
+                        "predicates": [],
+                        "projection": [
+                          2,
+                          3
+                        ],
+                        "input_arity": 1
+                      }
+                    }
+                  },
+                  "plan": {
+                    "Basic": {
+                      "Multiple": [
+                        [
+                          0,
+                          {
+                            "func": {
+                              "StringAgg": {
+                                "order_by": []
+                              }
+                            },
+                            "expr": {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": 0
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      49
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "distinct": false
+                          }
+                        ],
+                        [
+                          1,
+                          {
+                            "func": {
+                              "StringAgg": {
+                                "order_by": []
+                              }
+                            },
+                            "expr": {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": 0
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      50
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "distinct": false
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  "input_key": null,
+                  "mfp_after": {
+                    "expressions": [],
                     "predicates": [],
                     "projection": [
-                      2,
-                      3
+                      0,
+                      1
                     ],
-                    "input_arity": 1
+                    "input_arity": 2
                   }
                 }
+              }
+            },
+            "body": {
+              "lir_id": 9,
+              "node": {
+                "Union": {
+                  "inputs": [
+                    {
+                      "lir_id": 8,
+                      "node": {
+                        "ArrangeBy": {
+                          "input": {
+                            "lir_id": 2,
+                            "node": {
+                              "Get": {
+                                "id": {
+                                  "Local": 0
+                                },
+                                "keys": {
+                                  "raw": false,
+                                  "arranged": [
+                                    [
+                                      [],
+                                      {
+                                        "0": 0,
+                                        "1": 1
+                                      },
+                                      [
+                                        0,
+                                        1
+                                      ]
+                                    ]
+                                  ],
+                                  "types": null
+                                },
+                                "plan": "PassArrangements"
+                              }
+                            }
+                          },
+                          "forms": {
+                            "raw": true,
+                            "arranged": [],
+                            "types": null
+                          },
+                          "input_key": [],
+                          "input_mfp": {
+                            "expressions": [],
+                            "predicates": [],
+                            "projection": [
+                              0,
+                              1
+                            ],
+                            "input_arity": 2
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "lir_id": 7,
+                      "node": {
+                        "Mfp": {
+                          "input": {
+                            "lir_id": 6,
+                            "node": {
+                              "Union": {
+                                "inputs": [
+                                  {
+                                    "lir_id": 4,
+                                    "node": {
+                                      "Negate": {
+                                        "input": {
+                                          "lir_id": 3,
+                                          "node": {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 0
+                                              },
+                                              "keys": {
+                                                "raw": false,
+                                                "arranged": [
+                                                  [
+                                                    [],
+                                                    {
+                                                      "0": 0,
+                                                      "1": 1
+                                                    },
+                                                    [
+                                                      0,
+                                                      1
+                                                    ]
+                                                  ]
+                                                ],
+                                                "types": null
+                                              },
+                                              "plan": {
+                                                "Arrangement": [
+                                                  [],
+                                                  null,
+                                                  {
+                                                    "expressions": [],
+                                                    "predicates": [],
+                                                    "projection": [],
+                                                    "input_arity": 2
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lir_id": 5,
+                                    "node": {
+                                      "Constant": {
+                                        "rows": {
+                                          "Ok": [
+                                            [
+                                              {
+                                                "data": []
+                                              },
+                                              0,
+                                              1
+                                            ]
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "consolidate_output": true
+                              }
+                            }
+                          },
+                          "mfp": {
+                            "expressions": [
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "String",
+                                    "nullable": true
+                                  }
+                                ]
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "String",
+                                    "nullable": true
+                                  }
+                                ]
+                              }
+                            ],
+                            "predicates": [],
+                            "projection": [
+                              0,
+                              1
+                            ],
+                            "input_arity": 0
+                          },
+                          "input_key_val": null
+                        }
+                      }
+                    }
+                  ],
+                  "consolidate_output": false
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "sources": []
+}
+EOF
+
+# Test Reduce::Collated (with GROUP BY).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS JSON FOR
+MATERIALIZED VIEW collated_group_by_mv
+----
+{
+  "plans": [
+    {
+      "id": "materialize.public.collated_group_by_mv",
+      "plan": {
+        "lir_id": 1,
+        "node": {
+          "Reduce": {
+            "input": {
+              "lir_id": 0,
+              "node": {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
+                  },
+                  "keys": {
+                    "raw": false,
+                    "arranged": [
+                      [
+                        [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        {
+                          "0": 0,
+                          "1": 1
+                        },
+                        [
+                          1
+                        ]
+                      ]
+                    ],
+                    "types": [
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      },
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      }
+                    ]
+                  },
+                  "plan": "PassArrangements"
+                }
+              }
+            },
+            "key_val_plan": {
+              "key_plan": {
+                "mfp": {
+                  "expressions": [],
+                  "predicates": [],
+                  "projection": [
+                    0
+                  ],
+                  "input_arity": 2
+                }
               },
-              "plan": {
-                "Basic": {
-                  "Multiple": [
+              "val_plan": {
+                "mfp": {
+                  "expressions": [
+                    {
+                      "CallUnary": {
+                        "func": {
+                          "CastInt32ToString": null
+                        },
+                        "expr": {
+                          "Column": 1
+                        }
+                      }
+                    },
+                    {
+                      "CallVariadic": {
+                        "func": {
+                          "RecordCreate": {
+                            "field_names": [
+                              ""
+                            ]
+                          }
+                        },
+                        "exprs": [
+                          {
+                            "CallVariadic": {
+                              "func": {
+                                "RecordCreate": {
+                                  "field_names": [
+                                    "value",
+                                    "sep"
+                                  ]
+                                }
+                              },
+                              "exprs": [
+                                {
+                                  "CallBinary": {
+                                    "func": "TextConcat",
+                                    "expr1": {
+                                      "Column": 2
+                                    },
+                                    "expr2": {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              19,
+                                              1,
+                                              49
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": false
+                                        }
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "Literal": [
+                                    {
+                                      "Ok": {
+                                        "data": [
+                                          19,
+                                          1,
+                                          44
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "scalar_type": "String",
+                                      "nullable": false
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "CallVariadic": {
+                        "func": {
+                          "RecordCreate": {
+                            "field_names": [
+                              ""
+                            ]
+                          }
+                        },
+                        "exprs": [
+                          {
+                            "CallVariadic": {
+                              "func": {
+                                "RecordCreate": {
+                                  "field_names": [
+                                    "value",
+                                    "sep"
+                                  ]
+                                }
+                              },
+                              "exprs": [
+                                {
+                                  "CallBinary": {
+                                    "func": "TextConcat",
+                                    "expr1": {
+                                      "Column": 2
+                                    },
+                                    "expr2": {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              19,
+                                              1,
+                                              50
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": false
+                                        }
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "Literal": [
+                                    {
+                                      "Ok": {
+                                        "data": [
+                                          19,
+                                          1,
+                                          44
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "scalar_type": "String",
+                                      "nullable": false
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "predicates": [],
+                  "projection": [
+                    1,
+                    3,
+                    1,
+                    1,
+                    1,
+                    4
+                  ],
+                  "input_arity": 2
+                }
+              }
+            },
+            "plan": {
+              "Collation": {
+                "accumulable": {
+                  "full_aggrs": [
+                    {
+                      "func": "Count",
+                      "expr": {
+                        "Column": 1
+                      },
+                      "distinct": true
+                    },
+                    {
+                      "func": "SumInt32",
+                      "expr": {
+                        "Column": 1
+                      },
+                      "distinct": false
+                    }
+                  ],
+                  "simple_aggrs": [
+                    [
+                      1,
+                      4,
+                      {
+                        "func": "SumInt32",
+                        "expr": {
+                          "Column": 1
+                        },
+                        "distinct": false
+                      }
+                    ]
+                  ],
+                  "distinct_aggrs": [
                     [
                       0,
+                      0,
+                      {
+                        "func": "Count",
+                        "expr": {
+                          "Column": 1
+                        },
+                        "distinct": true
+                      }
+                    ]
+                  ]
+                },
+                "hierarchical": {
+                  "Bucketed": {
+                    "aggr_funcs": [
+                      "MinInt32",
+                      "MaxInt32"
+                    ],
+                    "skips": [
+                      2,
+                      0
+                    ],
+                    "buckets": [
+                      268435456,
+                      16777216,
+                      1048576,
+                      65536,
+                      4096,
+                      256,
+                      16
+                    ]
+                  }
+                },
+                "basic": {
+                  "Multiple": [
+                    [
+                      1,
                       {
                         "func": {
                           "StringAgg": {
@@ -3642,7 +4491,7 @@ FROM t
                                               "CastInt32ToString": null
                                             },
                                             "expr": {
-                                              "Column": 0
+                                              "Column": 1
                                             }
                                           }
                                         },
@@ -3692,7 +4541,7 @@ FROM t
                       }
                     ],
                     [
-                      1,
+                      5,
                       {
                         "func": {
                           "StringAgg": {
@@ -3729,7 +4578,7 @@ FROM t
                                               "CastInt32ToString": null
                                             },
                                             "expr": {
-                                              "Column": 0
+                                              "Column": 1
                                             }
                                           }
                                         },
@@ -3779,698 +4628,37 @@ FROM t
                       }
                     ]
                   ]
-                }
-              },
-              "input_key": null,
-              "mfp_after": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0,
-                  1
-                ],
-                "input_arity": 2
-              },
-              "lir_id": 1
-            }
-          },
-          "body": {
-            "Union": {
-              "inputs": [
-                {
-                  "ArrangeBy": {
-                    "input": {
-                      "Get": {
-                        "id": {
-                          "Local": 0
-                        },
-                        "keys": {
-                          "raw": false,
-                          "arranged": [
-                            [
-                              [],
-                              {
-                                "0": 0,
-                                "1": 1
-                              },
-                              [
-                                0,
-                                1
-                              ]
-                            ]
-                          ],
-                          "types": null
-                        },
-                        "plan": "PassArrangements",
-                        "lir_id": 2
-                      }
-                    },
-                    "forms": {
-                      "raw": true,
-                      "arranged": [],
-                      "types": null
-                    },
-                    "input_key": [],
-                    "input_mfp": {
-                      "expressions": [],
-                      "predicates": [],
-                      "projection": [
-                        0,
-                        1
-                      ],
-                      "input_arity": 2
-                    },
-                    "lir_id": 8
-                  }
                 },
-                {
-                  "Mfp": {
-                    "input": {
-                      "Union": {
-                        "inputs": [
-                          {
-                            "Negate": {
-                              "input": {
-                                "Get": {
-                                  "id": {
-                                    "Local": 0
-                                  },
-                                  "keys": {
-                                    "raw": false,
-                                    "arranged": [
-                                      [
-                                        [],
-                                        {
-                                          "0": 0,
-                                          "1": 1
-                                        },
-                                        [
-                                          0,
-                                          1
-                                        ]
-                                      ]
-                                    ],
-                                    "types": null
-                                  },
-                                  "plan": {
-                                    "Arrangement": [
-                                      [],
-                                      null,
-                                      {
-                                        "expressions": [],
-                                        "predicates": [],
-                                        "projection": [],
-                                        "input_arity": 2
-                                      }
-                                    ]
-                                  },
-                                  "lir_id": 3
-                                }
-                              },
-                              "lir_id": 4
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "rows": {
-                                "Ok": [
-                                  [
-                                    {
-                                      "data": []
-                                    },
-                                    0,
-                                    1
-                                  ]
-                                ]
-                              },
-                              "lir_id": 5
-                            }
-                          }
-                        ],
-                        "consolidate_output": true,
-                        "lir_id": 6
-                      }
-                    },
-                    "mfp": {
-                      "expressions": [
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
-                              }
-                            },
-                            {
-                              "scalar_type": "String",
-                              "nullable": true
-                            }
-                          ]
-                        },
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
-                              }
-                            },
-                            {
-                              "scalar_type": "String",
-                              "nullable": true
-                            }
-                          ]
-                        }
-                      ],
-                      "predicates": [],
-                      "projection": [
-                        0,
-                        1
-                      ],
-                      "input_arity": 0
-                    },
-                    "input_key_val": null,
-                    "lir_id": 7
-                  }
-                }
-              ],
-              "consolidate_output": false,
-              "lir_id": 9
-            }
-          },
-          "lir_id": 10
-        }
-      }
-    }
-  ],
-  "sources": []
-}
-EOF
-
-# Test Reduce::Collated (with GROUP BY).
-query T multiline
-EXPLAIN PHYSICAL PLAN AS JSON FOR
-MATERIALIZED VIEW collated_group_by_mv
-----
-{
-  "plans": [
-    {
-      "id": "materialize.public.collated_group_by_mv",
-      "plan": {
-        "Reduce": {
-          "input": {
-            "Get": {
-              "id": {
-                "Global": {
-                  "User": 1
-                }
-              },
-              "keys": {
-                "raw": false,
-                "arranged": [
-                  [
-                    [
-                      {
-                        "Column": 0
-                      }
-                    ],
-                    {
-                      "0": 0,
-                      "1": 1
-                    },
-                    [
-                      1
-                    ]
-                  ]
-                ],
-                "types": [
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": true
-                  },
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": true
-                  }
+                "aggregate_types": [
+                  "Accumulable",
+                  "Basic",
+                  "Hierarchical",
+                  "Hierarchical",
+                  "Accumulable",
+                  "Basic"
                 ]
-              },
-              "plan": "PassArrangements",
-              "lir_id": 0
-            }
-          },
-          "key_val_plan": {
-            "key_plan": {
-              "mfp": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0
-                ],
-                "input_arity": 2
               }
             },
-            "val_plan": {
-              "mfp": {
-                "expressions": [
-                  {
-                    "CallUnary": {
-                      "func": {
-                        "CastInt32ToString": null
-                      },
-                      "expr": {
-                        "Column": 1
-                      }
-                    }
-                  },
-                  {
-                    "CallVariadic": {
-                      "func": {
-                        "RecordCreate": {
-                          "field_names": [
-                            ""
-                          ]
-                        }
-                      },
-                      "exprs": [
-                        {
-                          "CallVariadic": {
-                            "func": {
-                              "RecordCreate": {
-                                "field_names": [
-                                  "value",
-                                  "sep"
-                                ]
-                              }
-                            },
-                            "exprs": [
-                              {
-                                "CallBinary": {
-                                  "func": "TextConcat",
-                                  "expr1": {
-                                    "Column": 2
-                                  },
-                                  "expr2": {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            49
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        19,
-                                        1,
-                                        44
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": false
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "CallVariadic": {
-                      "func": {
-                        "RecordCreate": {
-                          "field_names": [
-                            ""
-                          ]
-                        }
-                      },
-                      "exprs": [
-                        {
-                          "CallVariadic": {
-                            "func": {
-                              "RecordCreate": {
-                                "field_names": [
-                                  "value",
-                                  "sep"
-                                ]
-                              }
-                            },
-                            "exprs": [
-                              {
-                                "CallBinary": {
-                                  "func": "TextConcat",
-                                  "expr1": {
-                                    "Column": 2
-                                  },
-                                  "expr2": {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            50
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        19,
-                                        1,
-                                        44
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": false
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "predicates": [],
-                "projection": [
-                  1,
-                  3,
-                  1,
-                  1,
-                  1,
-                  4
-                ],
-                "input_arity": 2
+            "input_key": [
+              {
+                "Column": 0
               }
-            }
-          },
-          "plan": {
-            "Collation": {
-              "accumulable": {
-                "full_aggrs": [
-                  {
-                    "func": "Count",
-                    "expr": {
-                      "Column": 1
-                    },
-                    "distinct": true
-                  },
-                  {
-                    "func": "SumInt32",
-                    "expr": {
-                      "Column": 1
-                    },
-                    "distinct": false
-                  }
-                ],
-                "simple_aggrs": [
-                  [
-                    1,
-                    4,
-                    {
-                      "func": "SumInt32",
-                      "expr": {
-                        "Column": 1
-                      },
-                      "distinct": false
-                    }
-                  ]
-                ],
-                "distinct_aggrs": [
-                  [
-                    0,
-                    0,
-                    {
-                      "func": "Count",
-                      "expr": {
-                        "Column": 1
-                      },
-                      "distinct": true
-                    }
-                  ]
-                ]
-              },
-              "hierarchical": {
-                "Bucketed": {
-                  "aggr_funcs": [
-                    "MinInt32",
-                    "MaxInt32"
-                  ],
-                  "skips": [
-                    2,
-                    0
-                  ],
-                  "buckets": [
-                    268435456,
-                    16777216,
-                    1048576,
-                    65536,
-                    4096,
-                    256,
-                    16
-                  ]
-                }
-              },
-              "basic": {
-                "Multiple": [
-                  [
-                    1,
-                    {
-                      "func": {
-                        "StringAgg": {
-                          "order_by": []
-                        }
-                      },
-                      "expr": {
-                        "CallVariadic": {
-                          "func": {
-                            "RecordCreate": {
-                              "field_names": [
-                                ""
-                              ]
-                            }
-                          },
-                          "exprs": [
-                            {
-                              "CallVariadic": {
-                                "func": {
-                                  "RecordCreate": {
-                                    "field_names": [
-                                      "value",
-                                      "sep"
-                                    ]
-                                  }
-                                },
-                                "exprs": [
-                                  {
-                                    "CallBinary": {
-                                      "func": "TextConcat",
-                                      "expr1": {
-                                        "CallUnary": {
-                                          "func": {
-                                            "CastInt32ToString": null
-                                          },
-                                          "expr": {
-                                            "Column": 1
-                                          }
-                                        }
-                                      },
-                                      "expr2": {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                49
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            44
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      "distinct": false
-                    }
-                  ],
-                  [
-                    5,
-                    {
-                      "func": {
-                        "StringAgg": {
-                          "order_by": []
-                        }
-                      },
-                      "expr": {
-                        "CallVariadic": {
-                          "func": {
-                            "RecordCreate": {
-                              "field_names": [
-                                ""
-                              ]
-                            }
-                          },
-                          "exprs": [
-                            {
-                              "CallVariadic": {
-                                "func": {
-                                  "RecordCreate": {
-                                    "field_names": [
-                                      "value",
-                                      "sep"
-                                    ]
-                                  }
-                                },
-                                "exprs": [
-                                  {
-                                    "CallBinary": {
-                                      "func": "TextConcat",
-                                      "expr1": {
-                                        "CallUnary": {
-                                          "func": {
-                                            "CastInt32ToString": null
-                                          },
-                                          "expr": {
-                                            "Column": 1
-                                          }
-                                        }
-                                      },
-                                      "expr2": {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                50
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            44
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      "distinct": false
-                    }
-                  ]
-                ]
-              },
-              "aggregate_types": [
-                "Accumulable",
-                "Basic",
-                "Hierarchical",
-                "Hierarchical",
-                "Accumulable",
-                "Basic"
-              ]
-            }
-          },
-          "input_key": [
-            {
-              "Column": 0
-            }
-          ],
-          "mfp_after": {
-            "expressions": [],
-            "predicates": [],
-            "projection": [
-              0,
-              1,
-              2,
-              3,
-              4,
-              5,
-              6
             ],
-            "input_arity": 7
-          },
-          "lir_id": 1
+            "mfp_after": {
+              "expressions": [],
+              "predicates": [],
+              "projection": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6
+              ],
+              "input_arity": 7
+            }
+          }
         }
       }
     }
@@ -4489,246 +4677,238 @@ SELECT * FROM collated_group_by
     {
       "id": "Explained Query",
       "plan": {
-        "Reduce": {
-          "input": {
-            "Get": {
-              "id": {
-                "Global": {
-                  "User": 1
-                }
-              },
-              "keys": {
-                "raw": false,
-                "arranged": [
-                  [
-                    [
-                      {
-                        "Column": 0
-                      }
-                    ],
-                    {
-                      "0": 0,
-                      "1": 1
-                    },
-                    [
-                      1
-                    ]
-                  ]
-                ],
-                "types": [
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": true
+        "lir_id": 1,
+        "node": {
+          "Reduce": {
+            "input": {
+              "lir_id": 0,
+              "node": {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
                   },
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": true
-                  }
-                ]
-              },
-              "plan": "PassArrangements",
-              "lir_id": 0
-            }
-          },
-          "key_val_plan": {
-            "key_plan": {
-              "mfp": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0
-                ],
-                "input_arity": 2
+                  "keys": {
+                    "raw": false,
+                    "arranged": [
+                      [
+                        [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        {
+                          "0": 0,
+                          "1": 1
+                        },
+                        [
+                          1
+                        ]
+                      ]
+                    ],
+                    "types": [
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      },
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      }
+                    ]
+                  },
+                  "plan": "PassArrangements"
+                }
               }
             },
-            "val_plan": {
-              "mfp": {
-                "expressions": [
-                  {
-                    "CallUnary": {
-                      "func": {
-                        "CastInt32ToString": null
-                      },
-                      "expr": {
-                        "Column": 1
+            "key_val_plan": {
+              "key_plan": {
+                "mfp": {
+                  "expressions": [],
+                  "predicates": [],
+                  "projection": [
+                    0
+                  ],
+                  "input_arity": 2
+                }
+              },
+              "val_plan": {
+                "mfp": {
+                  "expressions": [
+                    {
+                      "CallUnary": {
+                        "func": {
+                          "CastInt32ToString": null
+                        },
+                        "expr": {
+                          "Column": 1
+                        }
+                      }
+                    },
+                    {
+                      "CallVariadic": {
+                        "func": {
+                          "RecordCreate": {
+                            "field_names": [
+                              ""
+                            ]
+                          }
+                        },
+                        "exprs": [
+                          {
+                            "CallVariadic": {
+                              "func": {
+                                "RecordCreate": {
+                                  "field_names": [
+                                    "value",
+                                    "sep"
+                                  ]
+                                }
+                              },
+                              "exprs": [
+                                {
+                                  "CallBinary": {
+                                    "func": "TextConcat",
+                                    "expr1": {
+                                      "Column": 2
+                                    },
+                                    "expr2": {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              19,
+                                              1,
+                                              49
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": false
+                                        }
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "Literal": [
+                                    {
+                                      "Ok": {
+                                        "data": [
+                                          19,
+                                          1,
+                                          44
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "scalar_type": "String",
+                                      "nullable": false
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "CallVariadic": {
+                        "func": {
+                          "RecordCreate": {
+                            "field_names": [
+                              ""
+                            ]
+                          }
+                        },
+                        "exprs": [
+                          {
+                            "CallVariadic": {
+                              "func": {
+                                "RecordCreate": {
+                                  "field_names": [
+                                    "value",
+                                    "sep"
+                                  ]
+                                }
+                              },
+                              "exprs": [
+                                {
+                                  "CallBinary": {
+                                    "func": "TextConcat",
+                                    "expr1": {
+                                      "Column": 2
+                                    },
+                                    "expr2": {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              19,
+                                              1,
+                                              50
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": false
+                                        }
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "Literal": [
+                                    {
+                                      "Ok": {
+                                        "data": [
+                                          19,
+                                          1,
+                                          44
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "scalar_type": "String",
+                                      "nullable": false
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        ]
                       }
                     }
-                  },
-                  {
-                    "CallVariadic": {
-                      "func": {
-                        "RecordCreate": {
-                          "field_names": [
-                            ""
-                          ]
-                        }
-                      },
-                      "exprs": [
-                        {
-                          "CallVariadic": {
-                            "func": {
-                              "RecordCreate": {
-                                "field_names": [
-                                  "value",
-                                  "sep"
-                                ]
-                              }
-                            },
-                            "exprs": [
-                              {
-                                "CallBinary": {
-                                  "func": "TextConcat",
-                                  "expr1": {
-                                    "Column": 2
-                                  },
-                                  "expr2": {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            49
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        19,
-                                        1,
-                                        44
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": false
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "CallVariadic": {
-                      "func": {
-                        "RecordCreate": {
-                          "field_names": [
-                            ""
-                          ]
-                        }
-                      },
-                      "exprs": [
-                        {
-                          "CallVariadic": {
-                            "func": {
-                              "RecordCreate": {
-                                "field_names": [
-                                  "value",
-                                  "sep"
-                                ]
-                              }
-                            },
-                            "exprs": [
-                              {
-                                "CallBinary": {
-                                  "func": "TextConcat",
-                                  "expr1": {
-                                    "Column": 2
-                                  },
-                                  "expr2": {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            50
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        19,
-                                        1,
-                                        44
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": false
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "predicates": [],
-                "projection": [
-                  1,
-                  3,
-                  1,
-                  1,
-                  1,
-                  4
-                ],
-                "input_arity": 2
-              }
-            }
-          },
-          "plan": {
-            "Collation": {
-              "accumulable": {
-                "full_aggrs": [
-                  {
-                    "func": "Count",
-                    "expr": {
-                      "Column": 1
-                    },
-                    "distinct": true
-                  },
-                  {
-                    "func": "SumInt32",
-                    "expr": {
-                      "Column": 1
-                    },
-                    "distinct": false
-                  }
-                ],
-                "simple_aggrs": [
-                  [
+                  ],
+                  "predicates": [],
+                  "projection": [
                     1,
-                    4,
+                    3,
+                    1,
+                    1,
+                    1,
+                    4
+                  ],
+                  "input_arity": 2
+                }
+              }
+            },
+            "plan": {
+              "Collation": {
+                "accumulable": {
+                  "full_aggrs": [
+                    {
+                      "func": "Count",
+                      "expr": {
+                        "Column": 1
+                      },
+                      "distinct": true
+                    },
                     {
                       "func": "SumInt32",
                       "expr": {
@@ -4736,243 +4916,255 @@ SELECT * FROM collated_group_by
                       },
                       "distinct": false
                     }
-                  ]
-                ],
-                "distinct_aggrs": [
-                  [
-                    0,
-                    0,
-                    {
-                      "func": "Count",
-                      "expr": {
-                        "Column": 1
-                      },
-                      "distinct": true
-                    }
-                  ]
-                ]
-              },
-              "hierarchical": {
-                "Monotonic": {
-                  "aggr_funcs": [
-                    "MinInt32",
-                    "MaxInt32"
                   ],
-                  "skips": [
-                    2,
-                    0
+                  "simple_aggrs": [
+                    [
+                      1,
+                      4,
+                      {
+                        "func": "SumInt32",
+                        "expr": {
+                          "Column": 1
+                        },
+                        "distinct": false
+                      }
+                    ]
                   ],
-                  "must_consolidate": true
-                }
-              },
-              "basic": {
-                "Multiple": [
-                  [
-                    1,
-                    {
-                      "func": {
-                        "StringAgg": {
-                          "order_by": []
-                        }
-                      },
-                      "expr": {
-                        "CallVariadic": {
-                          "func": {
-                            "RecordCreate": {
-                              "field_names": [
-                                ""
-                              ]
-                            }
-                          },
-                          "exprs": [
-                            {
-                              "CallVariadic": {
-                                "func": {
-                                  "RecordCreate": {
-                                    "field_names": [
-                                      "value",
-                                      "sep"
-                                    ]
-                                  }
-                                },
-                                "exprs": [
-                                  {
-                                    "CallBinary": {
-                                      "func": "TextConcat",
-                                      "expr1": {
-                                        "CallUnary": {
-                                          "func": {
-                                            "CastInt32ToString": null
-                                          },
-                                          "expr": {
-                                            "Column": 1
-                                          }
-                                        }
-                                      },
-                                      "expr2": {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                49
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            44
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
+                  "distinct_aggrs": [
+                    [
+                      0,
+                      0,
+                      {
+                        "func": "Count",
+                        "expr": {
+                          "Column": 1
+                        },
+                        "distinct": true
+                      }
+                    ]
+                  ]
+                },
+                "hierarchical": {
+                  "Monotonic": {
+                    "aggr_funcs": [
+                      "MinInt32",
+                      "MaxInt32"
+                    ],
+                    "skips": [
+                      2,
+                      0
+                    ],
+                    "must_consolidate": true
+                  }
+                },
+                "basic": {
+                  "Multiple": [
+                    [
+                      1,
+                      {
+                        "func": {
+                          "StringAgg": {
+                            "order_by": []
+                          }
+                        },
+                        "expr": {
+                          "CallVariadic": {
+                            "func": {
+                              "RecordCreate": {
+                                "field_names": [
+                                  ""
                                 ]
                               }
-                            }
-                          ]
-                        }
-                      },
-                      "distinct": false
-                    }
-                  ],
-                  [
-                    5,
-                    {
-                      "func": {
-                        "StringAgg": {
-                          "order_by": []
-                        }
-                      },
-                      "expr": {
-                        "CallVariadic": {
-                          "func": {
-                            "RecordCreate": {
-                              "field_names": [
-                                ""
-                              ]
-                            }
-                          },
-                          "exprs": [
-                            {
-                              "CallVariadic": {
-                                "func": {
-                                  "RecordCreate": {
-                                    "field_names": [
-                                      "value",
-                                      "sep"
-                                    ]
-                                  }
-                                },
-                                "exprs": [
-                                  {
-                                    "CallBinary": {
-                                      "func": "TextConcat",
-                                      "expr1": {
-                                        "CallUnary": {
-                                          "func": {
-                                            "CastInt32ToString": null
-                                          },
-                                          "expr": {
-                                            "Column": 1
-                                          }
-                                        }
-                                      },
-                                      "expr2": {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                50
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
+                            },
+                            "exprs": [
+                              {
+                                "CallVariadic": {
+                                  "func": {
+                                    "RecordCreate": {
+                                      "field_names": [
+                                        "value",
+                                        "sep"
+                                      ]
                                     }
                                   },
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            44
+                                  "exprs": [
+                                    {
+                                      "CallBinary": {
+                                        "func": "TextConcat",
+                                        "expr1": {
+                                          "CallUnary": {
+                                            "func": {
+                                              "CastInt32ToString": null
+                                            },
+                                            "expr": {
+                                              "Column": 1
+                                            }
+                                          }
+                                        },
+                                        "expr2": {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  49
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
                                           ]
                                         }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
                                       }
-                                    ]
-                                  }
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              19,
+                                              1,
+                                              44
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": false
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "distinct": false
+                      }
+                    ],
+                    [
+                      5,
+                      {
+                        "func": {
+                          "StringAgg": {
+                            "order_by": []
+                          }
+                        },
+                        "expr": {
+                          "CallVariadic": {
+                            "func": {
+                              "RecordCreate": {
+                                "field_names": [
+                                  ""
                                 ]
                               }
-                            }
-                          ]
-                        }
-                      },
-                      "distinct": false
-                    }
+                            },
+                            "exprs": [
+                              {
+                                "CallVariadic": {
+                                  "func": {
+                                    "RecordCreate": {
+                                      "field_names": [
+                                        "value",
+                                        "sep"
+                                      ]
+                                    }
+                                  },
+                                  "exprs": [
+                                    {
+                                      "CallBinary": {
+                                        "func": "TextConcat",
+                                        "expr1": {
+                                          "CallUnary": {
+                                            "func": {
+                                              "CastInt32ToString": null
+                                            },
+                                            "expr": {
+                                              "Column": 1
+                                            }
+                                          }
+                                        },
+                                        "expr2": {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  50
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              19,
+                                              1,
+                                              44
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": false
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "distinct": false
+                      }
+                    ]
                   ]
+                },
+                "aggregate_types": [
+                  "Accumulable",
+                  "Basic",
+                  "Hierarchical",
+                  "Hierarchical",
+                  "Accumulable",
+                  "Basic"
                 ]
-              },
-              "aggregate_types": [
-                "Accumulable",
-                "Basic",
-                "Hierarchical",
-                "Hierarchical",
-                "Accumulable",
-                "Basic"
-              ]
-            }
-          },
-          "input_key": [
-            {
-              "Column": 0
-            }
-          ],
-          "mfp_after": {
-            "expressions": [],
-            "predicates": [],
-            "projection": [
-              0,
-              1,
-              2,
-              3,
-              4,
-              5,
-              6
+              }
+            },
+            "input_key": [
+              {
+                "Column": 0
+              }
             ],
-            "input_arity": 7
-          },
-          "lir_id": 1
+            "mfp_after": {
+              "expressions": [],
+              "predicates": [],
+              "projection": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6
+              ],
+              "input_arity": 7
+            }
+          }
         }
       }
     }
@@ -4991,319 +5183,96 @@ MATERIALIZED VIEW collated_global_mv
     {
       "id": "materialize.public.collated_global_mv",
       "plan": {
-        "Let": {
-          "id": 0,
-          "value": {
-            "Reduce": {
-              "input": {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
+        "lir_id": 10,
+        "node": {
+          "Let": {
+            "id": 0,
+            "value": {
+              "lir_id": 1,
+              "node": {
+                "Reduce": {
+                  "input": {
+                    "lir_id": 0,
+                    "node": {
+                      "Get": {
+                        "id": {
+                          "Global": {
+                            "User": 1
+                          }
+                        },
+                        "keys": {
+                          "raw": false,
+                          "arranged": [
+                            [
+                              [
+                                {
+                                  "Column": 0
+                                }
+                              ],
+                              {
+                                "0": 0,
+                                "1": 1
+                              },
+                              [
+                                1
+                              ]
+                            ]
+                          ],
+                          "types": [
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            }
+                          ]
+                        },
+                        "plan": {
+                          "Arrangement": [
+                            [
+                              {
+                                "Column": 0
+                              }
+                            ],
+                            null,
+                            {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1
+                              ],
+                              "input_arity": 2
+                            }
+                          ]
+                        }
+                      }
                     }
                   },
-                  "keys": {
-                    "raw": false,
-                    "arranged": [
-                      [
-                        [
-                          {
-                            "Column": 0
-                          }
-                        ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
-                        [
-                          1
-                        ]
-                      ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ]
-                  },
-                  "plan": {
-                    "Arrangement": [
-                      [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      null,
-                      {
+                  "key_val_plan": {
+                    "key_plan": {
+                      "mfp": {
                         "expressions": [],
                         "predicates": [],
-                        "projection": [
-                          1
-                        ],
-                        "input_arity": 2
+                        "projection": [],
+                        "input_arity": 1
                       }
-                    ]
-                  },
-                  "lir_id": 0
-                }
-              },
-              "key_val_plan": {
-                "key_plan": {
-                  "mfp": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [],
-                    "input_arity": 1
-                  }
-                },
-                "val_plan": {
-                  "mfp": {
-                    "expressions": [
-                      {
-                        "CallUnary": {
-                          "func": {
-                            "CastInt32ToString": null
-                          },
-                          "expr": {
-                            "Column": 0
-                          }
-                        }
-                      },
-                      {
-                        "CallVariadic": {
-                          "func": {
-                            "RecordCreate": {
-                              "field_names": [
-                                ""
-                              ]
-                            }
-                          },
-                          "exprs": [
-                            {
-                              "CallVariadic": {
-                                "func": {
-                                  "RecordCreate": {
-                                    "field_names": [
-                                      "value",
-                                      "sep"
-                                    ]
-                                  }
-                                },
-                                "exprs": [
-                                  {
-                                    "CallBinary": {
-                                      "func": "TextConcat",
-                                      "expr1": {
-                                        "Column": 1
-                                      },
-                                      "expr2": {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                49
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            44
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                ]
+                    },
+                    "val_plan": {
+                      "mfp": {
+                        "expressions": [
+                          {
+                            "CallUnary": {
+                              "func": {
+                                "CastInt32ToString": null
+                              },
+                              "expr": {
+                                "Column": 0
                               }
                             }
-                          ]
-                        }
-                      },
-                      {
-                        "CallVariadic": {
-                          "func": {
-                            "RecordCreate": {
-                              "field_names": [
-                                ""
-                              ]
-                            }
                           },
-                          "exprs": [
-                            {
-                              "CallVariadic": {
-                                "func": {
-                                  "RecordCreate": {
-                                    "field_names": [
-                                      "value",
-                                      "sep"
-                                    ]
-                                  }
-                                },
-                                "exprs": [
-                                  {
-                                    "CallBinary": {
-                                      "func": "TextConcat",
-                                      "expr1": {
-                                        "Column": 1
-                                      },
-                                      "expr2": {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                50
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            44
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    ],
-                    "predicates": [],
-                    "projection": [
-                      0,
-                      2,
-                      0,
-                      0,
-                      0,
-                      3
-                    ],
-                    "input_arity": 1
-                  }
-                }
-              },
-              "plan": {
-                "Collation": {
-                  "accumulable": {
-                    "full_aggrs": [
-                      {
-                        "func": "Count",
-                        "expr": {
-                          "Column": 0
-                        },
-                        "distinct": true
-                      },
-                      {
-                        "func": "SumInt32",
-                        "expr": {
-                          "Column": 0
-                        },
-                        "distinct": false
-                      }
-                    ],
-                    "simple_aggrs": [
-                      [
-                        1,
-                        4,
-                        {
-                          "func": "SumInt32",
-                          "expr": {
-                            "Column": 0
-                          },
-                          "distinct": false
-                        }
-                      ]
-                    ],
-                    "distinct_aggrs": [
-                      [
-                        0,
-                        0,
-                        {
-                          "func": "Count",
-                          "expr": {
-                            "Column": 0
-                          },
-                          "distinct": true
-                        }
-                      ]
-                    ]
-                  },
-                  "hierarchical": {
-                    "Bucketed": {
-                      "aggr_funcs": [
-                        "MinInt32",
-                        "MaxInt32"
-                      ],
-                      "skips": [
-                        2,
-                        0
-                      ],
-                      "buckets": [
-                        268435456,
-                        16777216,
-                        1048576,
-                        65536,
-                        4096,
-                        256,
-                        16
-                      ]
-                    }
-                  },
-                  "basic": {
-                    "Multiple": [
-                      [
-                        1,
-                        {
-                          "func": {
-                            "StringAgg": {
-                              "order_by": []
-                            }
-                          },
-                          "expr": {
+                          {
                             "CallVariadic": {
                               "func": {
                                 "RecordCreate": {
@@ -5328,14 +5297,7 @@ MATERIALIZED VIEW collated_global_mv
                                         "CallBinary": {
                                           "func": "TextConcat",
                                           "expr1": {
-                                            "CallUnary": {
-                                              "func": {
-                                                "CastInt32ToString": null
-                                              },
-                                              "expr": {
-                                                "Column": 0
-                                              }
-                                            }
+                                            "Column": 1
                                           },
                                           "expr2": {
                                             "Literal": [
@@ -5379,18 +5341,7 @@ MATERIALIZED VIEW collated_global_mv
                               ]
                             }
                           },
-                          "distinct": false
-                        }
-                      ],
-                      [
-                        5,
-                        {
-                          "func": {
-                            "StringAgg": {
-                              "order_by": []
-                            }
-                          },
-                          "expr": {
+                          {
                             "CallVariadic": {
                               "func": {
                                 "RecordCreate": {
@@ -5415,14 +5366,7 @@ MATERIALIZED VIEW collated_global_mv
                                         "CallBinary": {
                                           "func": "TextConcat",
                                           "expr1": {
-                                            "CallUnary": {
-                                              "func": {
-                                                "CastInt32ToString": null
-                                              },
-                                              "expr": {
-                                                "Column": 0
-                                              }
-                                            }
+                                            "Column": 1
                                           },
                                           "expr2": {
                                             "Literal": [
@@ -5465,290 +5409,560 @@ MATERIALIZED VIEW collated_global_mv
                                 }
                               ]
                             }
-                          },
-                          "distinct": false
-                        }
-                      ]
-                    ]
-                  },
-                  "aggregate_types": [
-                    "Accumulable",
-                    "Basic",
-                    "Hierarchical",
-                    "Hierarchical",
-                    "Accumulable",
-                    "Basic"
-                  ]
-                }
-              },
-              "input_key": null,
-              "mfp_after": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5
-                ],
-                "input_arity": 6
-              },
-              "lir_id": 1
-            }
-          },
-          "body": {
-            "Union": {
-              "inputs": [
-                {
-                  "ArrangeBy": {
-                    "input": {
-                      "Get": {
-                        "id": {
-                          "Local": 0
-                        },
-                        "keys": {
-                          "raw": false,
-                          "arranged": [
-                            [
-                              [],
-                              {
-                                "0": 0,
-                                "1": 1,
-                                "2": 2,
-                                "3": 3,
-                                "4": 4,
-                                "5": 5
-                              },
-                              [
-                                0,
-                                1,
-                                2,
-                                3,
-                                4,
-                                5
-                              ]
-                            ]
-                          ],
-                          "types": null
-                        },
-                        "plan": "PassArrangements",
-                        "lir_id": 2
-                      }
-                    },
-                    "forms": {
-                      "raw": true,
-                      "arranged": [],
-                      "types": null
-                    },
-                    "input_key": [],
-                    "input_mfp": {
-                      "expressions": [],
-                      "predicates": [],
-                      "projection": [
-                        0,
-                        1,
-                        2,
-                        3,
-                        4,
-                        5
-                      ],
-                      "input_arity": 6
-                    },
-                    "lir_id": 8
-                  }
-                },
-                {
-                  "Mfp": {
-                    "input": {
-                      "Union": {
-                        "inputs": [
-                          {
-                            "Negate": {
-                              "input": {
-                                "Get": {
-                                  "id": {
-                                    "Local": 0
-                                  },
-                                  "keys": {
-                                    "raw": false,
-                                    "arranged": [
-                                      [
-                                        [],
-                                        {
-                                          "0": 0,
-                                          "1": 1,
-                                          "2": 2,
-                                          "3": 3,
-                                          "4": 4,
-                                          "5": 5
-                                        },
-                                        [
-                                          0,
-                                          1,
-                                          2,
-                                          3,
-                                          4,
-                                          5
-                                        ]
-                                      ]
-                                    ],
-                                    "types": null
-                                  },
-                                  "plan": {
-                                    "Arrangement": [
-                                      [],
-                                      null,
-                                      {
-                                        "expressions": [],
-                                        "predicates": [],
-                                        "projection": [],
-                                        "input_arity": 6
-                                      }
-                                    ]
-                                  },
-                                  "lir_id": 3
-                                }
-                              },
-                              "lir_id": 4
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "rows": {
-                                "Ok": [
-                                  [
-                                    {
-                                      "data": []
-                                    },
-                                    0,
-                                    1
-                                  ]
-                                ]
-                              },
-                              "lir_id": 5
-                            }
                           }
                         ],
-                        "consolidate_output": true,
-                        "lir_id": 6
+                        "predicates": [],
+                        "projection": [
+                          0,
+                          2,
+                          0,
+                          0,
+                          0,
+                          3
+                        ],
+                        "input_arity": 1
                       }
-                    },
-                    "mfp": {
-                      "expressions": [
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  49
-                                ]
-                              }
+                    }
+                  },
+                  "plan": {
+                    "Collation": {
+                      "accumulable": {
+                        "full_aggrs": [
+                          {
+                            "func": "Count",
+                            "expr": {
+                              "Column": 0
                             },
+                            "distinct": true
+                          },
+                          {
+                            "func": "SumInt32",
+                            "expr": {
+                              "Column": 0
+                            },
+                            "distinct": false
+                          }
+                        ],
+                        "simple_aggrs": [
+                          [
+                            1,
+                            4,
                             {
-                              "scalar_type": "Int64",
-                              "nullable": false
+                              "func": "SumInt32",
+                              "expr": {
+                                "Column": 0
+                              },
+                              "distinct": false
                             }
                           ]
-                        },
-                        {
-                          "Literal": [
+                        ],
+                        "distinct_aggrs": [
+                          [
+                            0,
+                            0,
                             {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
-                              }
-                            },
-                            {
-                              "scalar_type": "String",
-                              "nullable": true
+                              "func": "Count",
+                              "expr": {
+                                "Column": 0
+                              },
+                              "distinct": true
                             }
                           ]
-                        },
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
-                              }
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
-                          ]
-                        },
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
-                              }
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
-                          ]
-                        },
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
-                              }
-                            },
-                            {
-                              "scalar_type": "Int64",
-                              "nullable": true
-                            }
-                          ]
-                        },
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
-                              }
-                            },
-                            {
-                              "scalar_type": "String",
-                              "nullable": true
-                            }
+                        ]
+                      },
+                      "hierarchical": {
+                        "Bucketed": {
+                          "aggr_funcs": [
+                            "MinInt32",
+                            "MaxInt32"
+                          ],
+                          "skips": [
+                            2,
+                            0
+                          ],
+                          "buckets": [
+                            268435456,
+                            16777216,
+                            1048576,
+                            65536,
+                            4096,
+                            256,
+                            16
                           ]
                         }
-                      ],
-                      "predicates": [],
-                      "projection": [
-                        0,
-                        1,
-                        2,
-                        3,
-                        4,
-                        5
-                      ],
-                      "input_arity": 0
-                    },
-                    "input_key_val": null,
-                    "lir_id": 7
+                      },
+                      "basic": {
+                        "Multiple": [
+                          [
+                            1,
+                            {
+                              "func": {
+                                "StringAgg": {
+                                  "order_by": []
+                                }
+                              },
+                              "expr": {
+                                "CallVariadic": {
+                                  "func": {
+                                    "RecordCreate": {
+                                      "field_names": [
+                                        ""
+                                      ]
+                                    }
+                                  },
+                                  "exprs": [
+                                    {
+                                      "CallVariadic": {
+                                        "func": {
+                                          "RecordCreate": {
+                                            "field_names": [
+                                              "value",
+                                              "sep"
+                                            ]
+                                          }
+                                        },
+                                        "exprs": [
+                                          {
+                                            "CallBinary": {
+                                              "func": "TextConcat",
+                                              "expr1": {
+                                                "CallUnary": {
+                                                  "func": {
+                                                    "CastInt32ToString": null
+                                                  },
+                                                  "expr": {
+                                                    "Column": 0
+                                                  }
+                                                }
+                                              },
+                                              "expr2": {
+                                                "Literal": [
+                                                  {
+                                                    "Ok": {
+                                                      "data": [
+                                                        19,
+                                                        1,
+                                                        49
+                                                      ]
+                                                    }
+                                                  },
+                                                  {
+                                                    "scalar_type": "String",
+                                                    "nullable": false
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "Literal": [
+                                              {
+                                                "Ok": {
+                                                  "data": [
+                                                    19,
+                                                    1,
+                                                    44
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "scalar_type": "String",
+                                                "nullable": false
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "distinct": false
+                            }
+                          ],
+                          [
+                            5,
+                            {
+                              "func": {
+                                "StringAgg": {
+                                  "order_by": []
+                                }
+                              },
+                              "expr": {
+                                "CallVariadic": {
+                                  "func": {
+                                    "RecordCreate": {
+                                      "field_names": [
+                                        ""
+                                      ]
+                                    }
+                                  },
+                                  "exprs": [
+                                    {
+                                      "CallVariadic": {
+                                        "func": {
+                                          "RecordCreate": {
+                                            "field_names": [
+                                              "value",
+                                              "sep"
+                                            ]
+                                          }
+                                        },
+                                        "exprs": [
+                                          {
+                                            "CallBinary": {
+                                              "func": "TextConcat",
+                                              "expr1": {
+                                                "CallUnary": {
+                                                  "func": {
+                                                    "CastInt32ToString": null
+                                                  },
+                                                  "expr": {
+                                                    "Column": 0
+                                                  }
+                                                }
+                                              },
+                                              "expr2": {
+                                                "Literal": [
+                                                  {
+                                                    "Ok": {
+                                                      "data": [
+                                                        19,
+                                                        1,
+                                                        50
+                                                      ]
+                                                    }
+                                                  },
+                                                  {
+                                                    "scalar_type": "String",
+                                                    "nullable": false
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "Literal": [
+                                              {
+                                                "Ok": {
+                                                  "data": [
+                                                    19,
+                                                    1,
+                                                    44
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "scalar_type": "String",
+                                                "nullable": false
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "distinct": false
+                            }
+                          ]
+                        ]
+                      },
+                      "aggregate_types": [
+                        "Accumulable",
+                        "Basic",
+                        "Hierarchical",
+                        "Hierarchical",
+                        "Accumulable",
+                        "Basic"
+                      ]
+                    }
+                  },
+                  "input_key": null,
+                  "mfp_after": {
+                    "expressions": [],
+                    "predicates": [],
+                    "projection": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4,
+                      5
+                    ],
+                    "input_arity": 6
                   }
                 }
-              ],
-              "consolidate_output": false,
-              "lir_id": 9
+              }
+            },
+            "body": {
+              "lir_id": 9,
+              "node": {
+                "Union": {
+                  "inputs": [
+                    {
+                      "lir_id": 8,
+                      "node": {
+                        "ArrangeBy": {
+                          "input": {
+                            "lir_id": 2,
+                            "node": {
+                              "Get": {
+                                "id": {
+                                  "Local": 0
+                                },
+                                "keys": {
+                                  "raw": false,
+                                  "arranged": [
+                                    [
+                                      [],
+                                      {
+                                        "0": 0,
+                                        "1": 1,
+                                        "2": 2,
+                                        "3": 3,
+                                        "4": 4,
+                                        "5": 5
+                                      },
+                                      [
+                                        0,
+                                        1,
+                                        2,
+                                        3,
+                                        4,
+                                        5
+                                      ]
+                                    ]
+                                  ],
+                                  "types": null
+                                },
+                                "plan": "PassArrangements"
+                              }
+                            }
+                          },
+                          "forms": {
+                            "raw": true,
+                            "arranged": [],
+                            "types": null
+                          },
+                          "input_key": [],
+                          "input_mfp": {
+                            "expressions": [],
+                            "predicates": [],
+                            "projection": [
+                              0,
+                              1,
+                              2,
+                              3,
+                              4,
+                              5
+                            ],
+                            "input_arity": 6
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "lir_id": 7,
+                      "node": {
+                        "Mfp": {
+                          "input": {
+                            "lir_id": 6,
+                            "node": {
+                              "Union": {
+                                "inputs": [
+                                  {
+                                    "lir_id": 4,
+                                    "node": {
+                                      "Negate": {
+                                        "input": {
+                                          "lir_id": 3,
+                                          "node": {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 0
+                                              },
+                                              "keys": {
+                                                "raw": false,
+                                                "arranged": [
+                                                  [
+                                                    [],
+                                                    {
+                                                      "0": 0,
+                                                      "1": 1,
+                                                      "2": 2,
+                                                      "3": 3,
+                                                      "4": 4,
+                                                      "5": 5
+                                                    },
+                                                    [
+                                                      0,
+                                                      1,
+                                                      2,
+                                                      3,
+                                                      4,
+                                                      5
+                                                    ]
+                                                  ]
+                                                ],
+                                                "types": null
+                                              },
+                                              "plan": {
+                                                "Arrangement": [
+                                                  [],
+                                                  null,
+                                                  {
+                                                    "expressions": [],
+                                                    "predicates": [],
+                                                    "projection": [],
+                                                    "input_arity": 6
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lir_id": 5,
+                                    "node": {
+                                      "Constant": {
+                                        "rows": {
+                                          "Ok": [
+                                            [
+                                              {
+                                                "data": []
+                                              },
+                                              0,
+                                              1
+                                            ]
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "consolidate_output": true
+                              }
+                            }
+                          },
+                          "mfp": {
+                            "expressions": [
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        49
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "Int64",
+                                    "nullable": false
+                                  }
+                                ]
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "String",
+                                    "nullable": true
+                                  }
+                                ]
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  }
+                                ]
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  }
+                                ]
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "Int64",
+                                    "nullable": true
+                                  }
+                                ]
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "String",
+                                    "nullable": true
+                                  }
+                                ]
+                              }
+                            ],
+                            "predicates": [],
+                            "projection": [
+                              0,
+                              1,
+                              2,
+                              3,
+                              4,
+                              5
+                            ],
+                            "input_arity": 0
+                          },
+                          "input_key_val": null
+                        }
+                      }
+                    }
+                  ],
+                  "consolidate_output": false
+                }
+              }
             }
-          },
-          "lir_id": 10
+          }
         }
       }
     }
@@ -5767,311 +5981,96 @@ SELECT * FROM collated_global
     {
       "id": "Explained Query",
       "plan": {
-        "Let": {
-          "id": 0,
-          "value": {
-            "Reduce": {
-              "input": {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
+        "lir_id": 10,
+        "node": {
+          "Let": {
+            "id": 0,
+            "value": {
+              "lir_id": 1,
+              "node": {
+                "Reduce": {
+                  "input": {
+                    "lir_id": 0,
+                    "node": {
+                      "Get": {
+                        "id": {
+                          "Global": {
+                            "User": 1
+                          }
+                        },
+                        "keys": {
+                          "raw": false,
+                          "arranged": [
+                            [
+                              [
+                                {
+                                  "Column": 0
+                                }
+                              ],
+                              {
+                                "0": 0,
+                                "1": 1
+                              },
+                              [
+                                1
+                              ]
+                            ]
+                          ],
+                          "types": [
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            }
+                          ]
+                        },
+                        "plan": {
+                          "Arrangement": [
+                            [
+                              {
+                                "Column": 0
+                              }
+                            ],
+                            null,
+                            {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1
+                              ],
+                              "input_arity": 2
+                            }
+                          ]
+                        }
+                      }
                     }
                   },
-                  "keys": {
-                    "raw": false,
-                    "arranged": [
-                      [
-                        [
-                          {
-                            "Column": 0
-                          }
-                        ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
-                        [
-                          1
-                        ]
-                      ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ]
-                  },
-                  "plan": {
-                    "Arrangement": [
-                      [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      null,
-                      {
+                  "key_val_plan": {
+                    "key_plan": {
+                      "mfp": {
                         "expressions": [],
                         "predicates": [],
-                        "projection": [
-                          1
-                        ],
-                        "input_arity": 2
+                        "projection": [],
+                        "input_arity": 1
                       }
-                    ]
-                  },
-                  "lir_id": 0
-                }
-              },
-              "key_val_plan": {
-                "key_plan": {
-                  "mfp": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [],
-                    "input_arity": 1
-                  }
-                },
-                "val_plan": {
-                  "mfp": {
-                    "expressions": [
-                      {
-                        "CallUnary": {
-                          "func": {
-                            "CastInt32ToString": null
-                          },
-                          "expr": {
-                            "Column": 0
-                          }
-                        }
-                      },
-                      {
-                        "CallVariadic": {
-                          "func": {
-                            "RecordCreate": {
-                              "field_names": [
-                                ""
-                              ]
-                            }
-                          },
-                          "exprs": [
-                            {
-                              "CallVariadic": {
-                                "func": {
-                                  "RecordCreate": {
-                                    "field_names": [
-                                      "value",
-                                      "sep"
-                                    ]
-                                  }
-                                },
-                                "exprs": [
-                                  {
-                                    "CallBinary": {
-                                      "func": "TextConcat",
-                                      "expr1": {
-                                        "Column": 1
-                                      },
-                                      "expr2": {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                49
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            44
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                ]
+                    },
+                    "val_plan": {
+                      "mfp": {
+                        "expressions": [
+                          {
+                            "CallUnary": {
+                              "func": {
+                                "CastInt32ToString": null
+                              },
+                              "expr": {
+                                "Column": 0
                               }
                             }
-                          ]
-                        }
-                      },
-                      {
-                        "CallVariadic": {
-                          "func": {
-                            "RecordCreate": {
-                              "field_names": [
-                                ""
-                              ]
-                            }
                           },
-                          "exprs": [
-                            {
-                              "CallVariadic": {
-                                "func": {
-                                  "RecordCreate": {
-                                    "field_names": [
-                                      "value",
-                                      "sep"
-                                    ]
-                                  }
-                                },
-                                "exprs": [
-                                  {
-                                    "CallBinary": {
-                                      "func": "TextConcat",
-                                      "expr1": {
-                                        "Column": 1
-                                      },
-                                      "expr2": {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                50
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            44
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    ],
-                    "predicates": [],
-                    "projection": [
-                      0,
-                      2,
-                      0,
-                      0,
-                      0,
-                      3
-                    ],
-                    "input_arity": 1
-                  }
-                }
-              },
-              "plan": {
-                "Collation": {
-                  "accumulable": {
-                    "full_aggrs": [
-                      {
-                        "func": "Count",
-                        "expr": {
-                          "Column": 0
-                        },
-                        "distinct": true
-                      },
-                      {
-                        "func": "SumInt32",
-                        "expr": {
-                          "Column": 0
-                        },
-                        "distinct": false
-                      }
-                    ],
-                    "simple_aggrs": [
-                      [
-                        1,
-                        4,
-                        {
-                          "func": "SumInt32",
-                          "expr": {
-                            "Column": 0
-                          },
-                          "distinct": false
-                        }
-                      ]
-                    ],
-                    "distinct_aggrs": [
-                      [
-                        0,
-                        0,
-                        {
-                          "func": "Count",
-                          "expr": {
-                            "Column": 0
-                          },
-                          "distinct": true
-                        }
-                      ]
-                    ]
-                  },
-                  "hierarchical": {
-                    "Monotonic": {
-                      "aggr_funcs": [
-                        "MinInt32",
-                        "MaxInt32"
-                      ],
-                      "skips": [
-                        2,
-                        0
-                      ],
-                      "must_consolidate": true
-                    }
-                  },
-                  "basic": {
-                    "Multiple": [
-                      [
-                        1,
-                        {
-                          "func": {
-                            "StringAgg": {
-                              "order_by": []
-                            }
-                          },
-                          "expr": {
+                          {
                             "CallVariadic": {
                               "func": {
                                 "RecordCreate": {
@@ -6096,14 +6095,7 @@ SELECT * FROM collated_global
                                         "CallBinary": {
                                           "func": "TextConcat",
                                           "expr1": {
-                                            "CallUnary": {
-                                              "func": {
-                                                "CastInt32ToString": null
-                                              },
-                                              "expr": {
-                                                "Column": 0
-                                              }
-                                            }
+                                            "Column": 1
                                           },
                                           "expr2": {
                                             "Literal": [
@@ -6147,18 +6139,7 @@ SELECT * FROM collated_global
                               ]
                             }
                           },
-                          "distinct": false
-                        }
-                      ],
-                      [
-                        5,
-                        {
-                          "func": {
-                            "StringAgg": {
-                              "order_by": []
-                            }
-                          },
-                          "expr": {
+                          {
                             "CallVariadic": {
                               "func": {
                                 "RecordCreate": {
@@ -6183,14 +6164,7 @@ SELECT * FROM collated_global
                                         "CallBinary": {
                                           "func": "TextConcat",
                                           "expr1": {
-                                            "CallUnary": {
-                                              "func": {
-                                                "CastInt32ToString": null
-                                              },
-                                              "expr": {
-                                                "Column": 0
-                                              }
-                                            }
+                                            "Column": 1
                                           },
                                           "expr2": {
                                             "Literal": [
@@ -6233,290 +6207,552 @@ SELECT * FROM collated_global
                                 }
                               ]
                             }
-                          },
-                          "distinct": false
-                        }
-                      ]
-                    ]
-                  },
-                  "aggregate_types": [
-                    "Accumulable",
-                    "Basic",
-                    "Hierarchical",
-                    "Hierarchical",
-                    "Accumulable",
-                    "Basic"
-                  ]
-                }
-              },
-              "input_key": null,
-              "mfp_after": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5
-                ],
-                "input_arity": 6
-              },
-              "lir_id": 1
-            }
-          },
-          "body": {
-            "Union": {
-              "inputs": [
-                {
-                  "ArrangeBy": {
-                    "input": {
-                      "Get": {
-                        "id": {
-                          "Local": 0
-                        },
-                        "keys": {
-                          "raw": false,
-                          "arranged": [
-                            [
-                              [],
-                              {
-                                "0": 0,
-                                "1": 1,
-                                "2": 2,
-                                "3": 3,
-                                "4": 4,
-                                "5": 5
-                              },
-                              [
-                                0,
-                                1,
-                                2,
-                                3,
-                                4,
-                                5
-                              ]
-                            ]
-                          ],
-                          "types": null
-                        },
-                        "plan": "PassArrangements",
-                        "lir_id": 2
-                      }
-                    },
-                    "forms": {
-                      "raw": true,
-                      "arranged": [],
-                      "types": null
-                    },
-                    "input_key": [],
-                    "input_mfp": {
-                      "expressions": [],
-                      "predicates": [],
-                      "projection": [
-                        0,
-                        1,
-                        2,
-                        3,
-                        4,
-                        5
-                      ],
-                      "input_arity": 6
-                    },
-                    "lir_id": 8
-                  }
-                },
-                {
-                  "Mfp": {
-                    "input": {
-                      "Union": {
-                        "inputs": [
-                          {
-                            "Negate": {
-                              "input": {
-                                "Get": {
-                                  "id": {
-                                    "Local": 0
-                                  },
-                                  "keys": {
-                                    "raw": false,
-                                    "arranged": [
-                                      [
-                                        [],
-                                        {
-                                          "0": 0,
-                                          "1": 1,
-                                          "2": 2,
-                                          "3": 3,
-                                          "4": 4,
-                                          "5": 5
-                                        },
-                                        [
-                                          0,
-                                          1,
-                                          2,
-                                          3,
-                                          4,
-                                          5
-                                        ]
-                                      ]
-                                    ],
-                                    "types": null
-                                  },
-                                  "plan": {
-                                    "Arrangement": [
-                                      [],
-                                      null,
-                                      {
-                                        "expressions": [],
-                                        "predicates": [],
-                                        "projection": [],
-                                        "input_arity": 6
-                                      }
-                                    ]
-                                  },
-                                  "lir_id": 3
-                                }
-                              },
-                              "lir_id": 4
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "rows": {
-                                "Ok": [
-                                  [
-                                    {
-                                      "data": []
-                                    },
-                                    0,
-                                    1
-                                  ]
-                                ]
-                              },
-                              "lir_id": 5
-                            }
                           }
                         ],
-                        "consolidate_output": true,
-                        "lir_id": 6
+                        "predicates": [],
+                        "projection": [
+                          0,
+                          2,
+                          0,
+                          0,
+                          0,
+                          3
+                        ],
+                        "input_arity": 1
                       }
-                    },
-                    "mfp": {
-                      "expressions": [
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  49
-                                ]
-                              }
+                    }
+                  },
+                  "plan": {
+                    "Collation": {
+                      "accumulable": {
+                        "full_aggrs": [
+                          {
+                            "func": "Count",
+                            "expr": {
+                              "Column": 0
                             },
+                            "distinct": true
+                          },
+                          {
+                            "func": "SumInt32",
+                            "expr": {
+                              "Column": 0
+                            },
+                            "distinct": false
+                          }
+                        ],
+                        "simple_aggrs": [
+                          [
+                            1,
+                            4,
                             {
-                              "scalar_type": "Int64",
-                              "nullable": false
+                              "func": "SumInt32",
+                              "expr": {
+                                "Column": 0
+                              },
+                              "distinct": false
                             }
                           ]
-                        },
-                        {
-                          "Literal": [
+                        ],
+                        "distinct_aggrs": [
+                          [
+                            0,
+                            0,
                             {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
-                              }
-                            },
-                            {
-                              "scalar_type": "String",
-                              "nullable": true
+                              "func": "Count",
+                              "expr": {
+                                "Column": 0
+                              },
+                              "distinct": true
                             }
                           ]
-                        },
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
-                              }
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
-                          ]
-                        },
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
-                              }
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
-                          ]
-                        },
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
-                              }
-                            },
-                            {
-                              "scalar_type": "Int64",
-                              "nullable": true
-                            }
-                          ]
-                        },
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  0
-                                ]
-                              }
-                            },
-                            {
-                              "scalar_type": "String",
-                              "nullable": true
-                            }
-                          ]
+                        ]
+                      },
+                      "hierarchical": {
+                        "Monotonic": {
+                          "aggr_funcs": [
+                            "MinInt32",
+                            "MaxInt32"
+                          ],
+                          "skips": [
+                            2,
+                            0
+                          ],
+                          "must_consolidate": true
                         }
-                      ],
-                      "predicates": [],
-                      "projection": [
-                        0,
-                        1,
-                        2,
-                        3,
-                        4,
-                        5
-                      ],
-                      "input_arity": 0
-                    },
-                    "input_key_val": null,
-                    "lir_id": 7
+                      },
+                      "basic": {
+                        "Multiple": [
+                          [
+                            1,
+                            {
+                              "func": {
+                                "StringAgg": {
+                                  "order_by": []
+                                }
+                              },
+                              "expr": {
+                                "CallVariadic": {
+                                  "func": {
+                                    "RecordCreate": {
+                                      "field_names": [
+                                        ""
+                                      ]
+                                    }
+                                  },
+                                  "exprs": [
+                                    {
+                                      "CallVariadic": {
+                                        "func": {
+                                          "RecordCreate": {
+                                            "field_names": [
+                                              "value",
+                                              "sep"
+                                            ]
+                                          }
+                                        },
+                                        "exprs": [
+                                          {
+                                            "CallBinary": {
+                                              "func": "TextConcat",
+                                              "expr1": {
+                                                "CallUnary": {
+                                                  "func": {
+                                                    "CastInt32ToString": null
+                                                  },
+                                                  "expr": {
+                                                    "Column": 0
+                                                  }
+                                                }
+                                              },
+                                              "expr2": {
+                                                "Literal": [
+                                                  {
+                                                    "Ok": {
+                                                      "data": [
+                                                        19,
+                                                        1,
+                                                        49
+                                                      ]
+                                                    }
+                                                  },
+                                                  {
+                                                    "scalar_type": "String",
+                                                    "nullable": false
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "Literal": [
+                                              {
+                                                "Ok": {
+                                                  "data": [
+                                                    19,
+                                                    1,
+                                                    44
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "scalar_type": "String",
+                                                "nullable": false
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "distinct": false
+                            }
+                          ],
+                          [
+                            5,
+                            {
+                              "func": {
+                                "StringAgg": {
+                                  "order_by": []
+                                }
+                              },
+                              "expr": {
+                                "CallVariadic": {
+                                  "func": {
+                                    "RecordCreate": {
+                                      "field_names": [
+                                        ""
+                                      ]
+                                    }
+                                  },
+                                  "exprs": [
+                                    {
+                                      "CallVariadic": {
+                                        "func": {
+                                          "RecordCreate": {
+                                            "field_names": [
+                                              "value",
+                                              "sep"
+                                            ]
+                                          }
+                                        },
+                                        "exprs": [
+                                          {
+                                            "CallBinary": {
+                                              "func": "TextConcat",
+                                              "expr1": {
+                                                "CallUnary": {
+                                                  "func": {
+                                                    "CastInt32ToString": null
+                                                  },
+                                                  "expr": {
+                                                    "Column": 0
+                                                  }
+                                                }
+                                              },
+                                              "expr2": {
+                                                "Literal": [
+                                                  {
+                                                    "Ok": {
+                                                      "data": [
+                                                        19,
+                                                        1,
+                                                        50
+                                                      ]
+                                                    }
+                                                  },
+                                                  {
+                                                    "scalar_type": "String",
+                                                    "nullable": false
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "Literal": [
+                                              {
+                                                "Ok": {
+                                                  "data": [
+                                                    19,
+                                                    1,
+                                                    44
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "scalar_type": "String",
+                                                "nullable": false
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "distinct": false
+                            }
+                          ]
+                        ]
+                      },
+                      "aggregate_types": [
+                        "Accumulable",
+                        "Basic",
+                        "Hierarchical",
+                        "Hierarchical",
+                        "Accumulable",
+                        "Basic"
+                      ]
+                    }
+                  },
+                  "input_key": null,
+                  "mfp_after": {
+                    "expressions": [],
+                    "predicates": [],
+                    "projection": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4,
+                      5
+                    ],
+                    "input_arity": 6
                   }
                 }
-              ],
-              "consolidate_output": false,
-              "lir_id": 9
+              }
+            },
+            "body": {
+              "lir_id": 9,
+              "node": {
+                "Union": {
+                  "inputs": [
+                    {
+                      "lir_id": 8,
+                      "node": {
+                        "ArrangeBy": {
+                          "input": {
+                            "lir_id": 2,
+                            "node": {
+                              "Get": {
+                                "id": {
+                                  "Local": 0
+                                },
+                                "keys": {
+                                  "raw": false,
+                                  "arranged": [
+                                    [
+                                      [],
+                                      {
+                                        "0": 0,
+                                        "1": 1,
+                                        "2": 2,
+                                        "3": 3,
+                                        "4": 4,
+                                        "5": 5
+                                      },
+                                      [
+                                        0,
+                                        1,
+                                        2,
+                                        3,
+                                        4,
+                                        5
+                                      ]
+                                    ]
+                                  ],
+                                  "types": null
+                                },
+                                "plan": "PassArrangements"
+                              }
+                            }
+                          },
+                          "forms": {
+                            "raw": true,
+                            "arranged": [],
+                            "types": null
+                          },
+                          "input_key": [],
+                          "input_mfp": {
+                            "expressions": [],
+                            "predicates": [],
+                            "projection": [
+                              0,
+                              1,
+                              2,
+                              3,
+                              4,
+                              5
+                            ],
+                            "input_arity": 6
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "lir_id": 7,
+                      "node": {
+                        "Mfp": {
+                          "input": {
+                            "lir_id": 6,
+                            "node": {
+                              "Union": {
+                                "inputs": [
+                                  {
+                                    "lir_id": 4,
+                                    "node": {
+                                      "Negate": {
+                                        "input": {
+                                          "lir_id": 3,
+                                          "node": {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 0
+                                              },
+                                              "keys": {
+                                                "raw": false,
+                                                "arranged": [
+                                                  [
+                                                    [],
+                                                    {
+                                                      "0": 0,
+                                                      "1": 1,
+                                                      "2": 2,
+                                                      "3": 3,
+                                                      "4": 4,
+                                                      "5": 5
+                                                    },
+                                                    [
+                                                      0,
+                                                      1,
+                                                      2,
+                                                      3,
+                                                      4,
+                                                      5
+                                                    ]
+                                                  ]
+                                                ],
+                                                "types": null
+                                              },
+                                              "plan": {
+                                                "Arrangement": [
+                                                  [],
+                                                  null,
+                                                  {
+                                                    "expressions": [],
+                                                    "predicates": [],
+                                                    "projection": [],
+                                                    "input_arity": 6
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lir_id": 5,
+                                    "node": {
+                                      "Constant": {
+                                        "rows": {
+                                          "Ok": [
+                                            [
+                                              {
+                                                "data": []
+                                              },
+                                              0,
+                                              1
+                                            ]
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "consolidate_output": true
+                              }
+                            }
+                          },
+                          "mfp": {
+                            "expressions": [
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        49
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "Int64",
+                                    "nullable": false
+                                  }
+                                ]
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "String",
+                                    "nullable": true
+                                  }
+                                ]
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  }
+                                ]
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  }
+                                ]
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "Int64",
+                                    "nullable": true
+                                  }
+                                ]
+                              },
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        0
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "String",
+                                    "nullable": true
+                                  }
+                                ]
+                              }
+                            ],
+                            "predicates": [],
+                            "projection": [
+                              0,
+                              1,
+                              2,
+                              3,
+                              4,
+                              5
+                            ],
+                            "input_arity": 0
+                          },
+                          "input_key_val": null
+                        }
+                      }
+                    }
+                  ],
+                  "consolidate_output": false
+                }
+              }
             }
-          },
-          "lir_id": 10
+          }
         }
       }
     }
@@ -6537,652 +6773,664 @@ WHERE a = c AND d = e AND b + d > 42
     {
       "id": "Explained Query",
       "plan": {
-        "Join": {
-          "inputs": [
-            {
-              "Get": {
-                "id": {
-                  "Global": {
-                    "User": 1
-                  }
-                },
-                "keys": {
-                  "raw": false,
-                  "arranged": [
-                    [
-                      [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      {
-                        "0": 0,
-                        "1": 1
-                      },
-                      [
-                        1
-                      ]
-                    ]
-                  ],
-                  "types": [
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": true
-                    },
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": true
-                    }
-                  ]
-                },
-                "plan": "PassArrangements",
-                "lir_id": 0
-              }
-            },
-            {
-              "ArrangeBy": {
-                "input": {
+        "lir_id": 5,
+        "node": {
+          "Join": {
+            "inputs": [
+              {
+                "lir_id": 0,
+                "node": {
                   "Get": {
                     "id": {
                       "Global": {
-                        "User": 2
+                        "User": 1
                       }
                     },
                     "keys": {
-                      "raw": true,
-                      "arranged": [],
-                      "types": null
-                    },
-                    "plan": {
-                      "Collection": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0,
-                          1
-                        ],
-                        "input_arity": 2
-                      }
-                    },
-                    "lir_id": 1
-                  }
-                },
-                "forms": {
-                  "raw": true,
-                  "arranged": [
-                    [
-                      [
-                        {
-                          "Column": 0
-                        }
+                      "raw": false,
+                      "arranged": [
+                        [
+                          [
+                            {
+                              "Column": 0
+                            }
+                          ],
+                          {
+                            "0": 0,
+                            "1": 1
+                          },
+                          [
+                            1
+                          ]
+                        ]
                       ],
-                      {
-                        "0": 0,
-                        "1": 1
-                      },
-                      [
-                        1
+                      "types": [
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        }
                       ]
-                    ],
-                    [
-                      [
-                        {
-                          "Column": 1
-                        }
-                      ],
-                      {
-                        "0": 1,
-                        "1": 0
-                      },
-                      [
-                        0
-                      ]
-                    ]
-                  ],
-                  "types": [
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": false
                     },
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": false
-                    }
-                  ]
-                },
-                "input_key": null,
-                "input_mfp": {
-                  "expressions": [],
-                  "predicates": [],
-                  "projection": [
-                    0,
-                    1
-                  ],
-                  "input_arity": 2
-                },
-                "lir_id": 2
-              }
-            },
-            {
-              "ArrangeBy": {
-                "input": {
-                  "Get": {
-                    "id": {
-                      "Global": {
-                        "User": 3
+                    "plan": "PassArrangements"
+                  }
+                }
+              },
+              {
+                "lir_id": 2,
+                "node": {
+                  "ArrangeBy": {
+                    "input": {
+                      "lir_id": 1,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 2
+                            }
+                          },
+                          "keys": {
+                            "raw": true,
+                            "arranged": [],
+                            "types": null
+                          },
+                          "plan": {
+                            "Collection": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                1
+                              ],
+                              "input_arity": 2
+                            }
+                          }
+                        }
                       }
                     },
-                    "keys": {
+                    "forms": {
                       "raw": true,
-                      "arranged": [],
-                      "types": null
-                    },
-                    "plan": {
-                      "Collection": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0
+                      "arranged": [
+                        [
+                          [
+                            {
+                              "Column": 0
+                            }
+                          ],
+                          {
+                            "0": 0,
+                            "1": 1
+                          },
+                          [
+                            1
+                          ]
                         ],
-                        "input_arity": 1
-                      }
+                        [
+                          [
+                            {
+                              "Column": 1
+                            }
+                          ],
+                          {
+                            "0": 1,
+                            "1": 0
+                          },
+                          [
+                            0
+                          ]
+                        ]
+                      ],
+                      "types": [
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": false
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": false
+                        }
+                      ]
                     },
-                    "lir_id": 3
-                  }
-                },
-                "forms": {
-                  "raw": true,
-                  "arranged": [
-                    [
-                      [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      {
-                        "0": 0
-                      },
-                      []
-                    ]
-                  ],
-                  "types": [
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": false
-                    }
-                  ]
-                },
-                "input_key": null,
-                "input_mfp": {
-                  "expressions": [],
-                  "predicates": [],
-                  "projection": [
-                    0
-                  ],
-                  "input_arity": 1
-                },
-                "lir_id": 4
-              }
-            }
-          ],
-          "plan": {
-            "Delta": {
-              "path_plans": [
-                {
-                  "source_relation": 0,
-                  "source_key": [
-                    {
-                      "Column": 0
-                    }
-                  ],
-                  "initial_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0,
-                          1
-                        ],
-                        "input_arity": 2
-                      }
-                    }
-                  },
-                  "stage_plans": [
-                    {
-                      "lookup_relation": 1,
-                      "stream_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "stream_thinning": [
+                    "input_key": null,
+                    "input_mfp": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
                         1
                       ],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [
-                              {
-                                "CallBinary": {
-                                  "func": "AddInt32",
-                                  "expr1": {
-                                    "Column": 1
-                                  },
-                                  "expr2": {
-                                    "Column": 2
-                                  }
-                                }
-                              },
-                              {
-                                "CallBinary": {
-                                  "func": "AddInt32",
-                                  "expr1": {
-                                    "Column": 0
-                                  },
-                                  "expr2": {
-                                    "Column": 2
-                                  }
-                                }
-                              }
-                            ],
-                            "predicates": [
-                              [
-                                4,
-                                {
-                                  "CallBinary": {
-                                    "func": "Gt",
-                                    "expr1": {
-                                      "Column": 3
-                                    },
-                                    "expr2": {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              45,
-                                              42
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  }
-                                }
-                              ]
-                            ],
-                            "projection": [
-                              2,
-                              3,
-                              4
-                            ],
-                            "input_arity": 3
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "lookup_relation": 2,
-                      "stream_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "stream_thinning": [
-                        1,
-                        2
-                      ],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              1,
-                              2
-                            ],
-                            "input_arity": 3
-                          }
-                        }
-                      }
-                    }
-                  ],
-                  "final_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0,
-                          1,
-                          1
-                        ],
-                        "input_arity": 2
-                      }
-                    }
-                  }
-                },
-                {
-                  "source_relation": 1,
-                  "source_key": [
-                    {
-                      "Column": 0
-                    }
-                  ],
-                  "initial_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0,
-                          1
-                        ],
-                        "input_arity": 2
-                      }
-                    }
-                  },
-                  "stage_plans": [
-                    {
-                      "lookup_relation": 0,
-                      "stream_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "stream_thinning": [
-                        1
-                      ],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [
-                              {
-                                "CallBinary": {
-                                  "func": "AddInt32",
-                                  "expr1": {
-                                    "Column": 2
-                                  },
-                                  "expr2": {
-                                    "Column": 1
-                                  }
-                                }
-                              },
-                              {
-                                "CallBinary": {
-                                  "func": "AddInt32",
-                                  "expr1": {
-                                    "Column": 0
-                                  },
-                                  "expr2": {
-                                    "Column": 1
-                                  }
-                                }
-                              }
-                            ],
-                            "predicates": [
-                              [
-                                4,
-                                {
-                                  "CallBinary": {
-                                    "func": "Gt",
-                                    "expr1": {
-                                      "Column": 3
-                                    },
-                                    "expr2": {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              45,
-                                              42
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  }
-                                }
-                              ]
-                            ],
-                            "projection": [
-                              1,
-                              3,
-                              4
-                            ],
-                            "input_arity": 3
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "lookup_relation": 2,
-                      "stream_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "stream_thinning": [
-                        1,
-                        2
-                      ],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              1,
-                              2
-                            ],
-                            "input_arity": 3
-                          }
-                        }
-                      }
-                    }
-                  ],
-                  "final_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0,
-                          1,
-                          1
-                        ],
-                        "input_arity": 2
-                      }
-                    }
-                  }
-                },
-                {
-                  "source_relation": 2,
-                  "source_key": [
-                    {
-                      "Column": 0
-                    }
-                  ],
-                  "initial_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0
-                        ],
-                        "input_arity": 1
-                      }
-                    }
-                  },
-                  "stage_plans": [
-                    {
-                      "lookup_relation": 1,
-                      "stream_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "stream_thinning": [],
-                      "lookup_key": [
-                        {
-                          "Column": 1
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              1,
-                              0
-                            ],
-                            "input_arity": 2
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "lookup_relation": 0,
-                      "stream_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "stream_thinning": [
-                        1
-                      ],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [
-                              {
-                                "CallBinary": {
-                                  "func": "AddInt32",
-                                  "expr1": {
-                                    "Column": 2
-                                  },
-                                  "expr2": {
-                                    "Column": 1
-                                  }
-                                }
-                              },
-                              {
-                                "CallBinary": {
-                                  "func": "AddInt32",
-                                  "expr1": {
-                                    "Column": 0
-                                  },
-                                  "expr2": {
-                                    "Column": 1
-                                  }
-                                }
-                              }
-                            ],
-                            "predicates": [
-                              [
-                                4,
-                                {
-                                  "CallBinary": {
-                                    "func": "Gt",
-                                    "expr1": {
-                                      "Column": 3
-                                    },
-                                    "expr2": {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              45,
-                                              42
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  }
-                                }
-                              ]
-                            ],
-                            "projection": [
-                              3,
-                              4
-                            ],
-                            "input_arity": 3
-                          }
-                        }
-                      }
-                    }
-                  ],
-                  "final_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0,
-                          1,
-                          1
-                        ],
-                        "input_arity": 2
-                      }
+                      "input_arity": 2
                     }
                   }
                 }
-              ]
+              },
+              {
+                "lir_id": 4,
+                "node": {
+                  "ArrangeBy": {
+                    "input": {
+                      "lir_id": 3,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 3
+                            }
+                          },
+                          "keys": {
+                            "raw": true,
+                            "arranged": [],
+                            "types": null
+                          },
+                          "plan": {
+                            "Collection": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0
+                              ],
+                              "input_arity": 1
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "forms": {
+                      "raw": true,
+                      "arranged": [
+                        [
+                          [
+                            {
+                              "Column": 0
+                            }
+                          ],
+                          {
+                            "0": 0
+                          },
+                          []
+                        ]
+                      ],
+                      "types": [
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": false
+                        }
+                      ]
+                    },
+                    "input_key": null,
+                    "input_mfp": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0
+                      ],
+                      "input_arity": 1
+                    }
+                  }
+                }
+              }
+            ],
+            "plan": {
+              "Delta": {
+                "path_plans": [
+                  {
+                    "source_relation": 0,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [
+                                {
+                                  "CallBinary": {
+                                    "func": "AddInt32",
+                                    "expr1": {
+                                      "Column": 1
+                                    },
+                                    "expr2": {
+                                      "Column": 2
+                                    }
+                                  }
+                                },
+                                {
+                                  "CallBinary": {
+                                    "func": "AddInt32",
+                                    "expr1": {
+                                      "Column": 0
+                                    },
+                                    "expr2": {
+                                      "Column": 2
+                                    }
+                                  }
+                                }
+                              ],
+                              "predicates": [
+                                [
+                                  4,
+                                  {
+                                    "CallBinary": {
+                                      "func": "Gt",
+                                      "expr1": {
+                                        "Column": 3
+                                      },
+                                      "expr2": {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                45,
+                                                42
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              ],
+                              "projection": [
+                                2,
+                                3,
+                                4
+                              ],
+                              "input_arity": 3
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2
+                              ],
+                              "input_arity": 3
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "source_relation": 1,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [
+                                {
+                                  "CallBinary": {
+                                    "func": "AddInt32",
+                                    "expr1": {
+                                      "Column": 2
+                                    },
+                                    "expr2": {
+                                      "Column": 1
+                                    }
+                                  }
+                                },
+                                {
+                                  "CallBinary": {
+                                    "func": "AddInt32",
+                                    "expr1": {
+                                      "Column": 0
+                                    },
+                                    "expr2": {
+                                      "Column": 1
+                                    }
+                                  }
+                                }
+                              ],
+                              "predicates": [
+                                [
+                                  4,
+                                  {
+                                    "CallBinary": {
+                                      "func": "Gt",
+                                      "expr1": {
+                                        "Column": 3
+                                      },
+                                      "expr2": {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                45,
+                                                42
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              ],
+                              "projection": [
+                                1,
+                                3,
+                                4
+                              ],
+                              "input_arity": 3
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2
+                              ],
+                              "input_arity": 3
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "source_relation": 2,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 1
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [],
+                        "lookup_key": [
+                          {
+                            "Column": 1
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                0
+                              ],
+                              "input_arity": 2
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [
+                                {
+                                  "CallBinary": {
+                                    "func": "AddInt32",
+                                    "expr1": {
+                                      "Column": 2
+                                    },
+                                    "expr2": {
+                                      "Column": 1
+                                    }
+                                  }
+                                },
+                                {
+                                  "CallBinary": {
+                                    "func": "AddInt32",
+                                    "expr1": {
+                                      "Column": 0
+                                    },
+                                    "expr2": {
+                                      "Column": 1
+                                    }
+                                  }
+                                }
+                              ],
+                              "predicates": [
+                                [
+                                  4,
+                                  {
+                                    "CallBinary": {
+                                      "func": "Gt",
+                                      "expr1": {
+                                        "Column": 3
+                                      },
+                                      "expr2": {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                45,
+                                                42
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              ],
+                              "projection": [
+                                3,
+                                4
+                              ],
+                              "input_arity": 3
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
             }
-          },
-          "lir_id": 5
+          }
         }
       }
     }
@@ -7304,51 +7552,766 @@ WHERE a = c AND d = e AND f = a
     {
       "id": "Explained Query",
       "plan": {
-        "Join": {
-          "inputs": [
-            {
-              "Get": {
-                "id": {
-                  "Global": {
-                    "User": 1
-                  }
-                },
-                "keys": {
-                  "raw": false,
-                  "arranged": [
-                    [
-                      [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      {
-                        "0": 0,
-                        "1": 1
-                      },
-                      [
-                        1
-                      ]
-                    ]
-                  ],
-                  "types": [
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": true
+        "lir_id": 5,
+        "node": {
+          "Join": {
+            "inputs": [
+              {
+                "lir_id": 0,
+                "node": {
+                  "Get": {
+                    "id": {
+                      "Global": {
+                        "User": 1
+                      }
                     },
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": true
+                    "keys": {
+                      "raw": false,
+                      "arranged": [
+                        [
+                          [
+                            {
+                              "Column": 0
+                            }
+                          ],
+                          {
+                            "0": 0,
+                            "1": 1
+                          },
+                          [
+                            1
+                          ]
+                        ]
+                      ],
+                      "types": [
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        }
+                      ]
+                    },
+                    "plan": "PassArrangements"
+                  }
+                }
+              },
+              {
+                "lir_id": 2,
+                "node": {
+                  "ArrangeBy": {
+                    "input": {
+                      "lir_id": 1,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 2
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": 0
+                                  }
+                                ],
+                                {
+                                  "0": 0,
+                                  "1": 1
+                                },
+                                [
+                                  1
+                                ]
+                              ]
+                            ],
+                            "types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ]
+                          },
+                          "plan": {
+                            "Arrangement": [
+                              [
+                                {
+                                  "Column": 0
+                                }
+                              ],
+                              null,
+                              {
+                                "expressions": [],
+                                "predicates": [
+                                  [
+                                    1,
+                                    {
+                                      "CallUnary": {
+                                        "func": {
+                                          "Not": null
+                                        },
+                                        "expr": {
+                                          "CallUnary": {
+                                            "func": {
+                                              "IsNull": null
+                                            },
+                                            "expr": {
+                                              "Column": 0
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  [
+                                    2,
+                                    {
+                                      "CallUnary": {
+                                        "func": {
+                                          "Not": null
+                                        },
+                                        "expr": {
+                                          "CallUnary": {
+                                            "func": {
+                                              "IsNull": null
+                                            },
+                                            "expr": {
+                                              "Column": 1
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                ],
+                                "projection": [
+                                  0,
+                                  1
+                                ],
+                                "input_arity": 2
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "forms": {
+                      "raw": true,
+                      "arranged": [
+                        [
+                          [
+                            {
+                              "Column": 0
+                            }
+                          ],
+                          {
+                            "0": 0,
+                            "1": 1
+                          },
+                          [
+                            1
+                          ]
+                        ],
+                        [
+                          [
+                            {
+                              "Column": 0
+                            },
+                            {
+                              "Column": 1
+                            }
+                          ],
+                          {
+                            "0": 0,
+                            "1": 1
+                          },
+                          []
+                        ]
+                      ],
+                      "types": [
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": false
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": false
+                        }
+                      ]
+                    },
+                    "input_key": null,
+                    "input_mfp": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 2
                     }
-                  ]
-                },
-                "plan": "PassArrangements",
-                "lir_id": 0
+                  }
+                }
+              },
+              {
+                "lir_id": 4,
+                "node": {
+                  "ArrangeBy": {
+                    "input": {
+                      "lir_id": 3,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 3
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": 0
+                                  }
+                                ],
+                                {
+                                  "0": 0,
+                                  "1": 1
+                                },
+                                [
+                                  1
+                                ]
+                              ]
+                            ],
+                            "types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ]
+                          },
+                          "plan": {
+                            "Arrangement": [
+                              [
+                                {
+                                  "Column": 0
+                                }
+                              ],
+                              null,
+                              {
+                                "expressions": [],
+                                "predicates": [
+                                  [
+                                    1,
+                                    {
+                                      "CallUnary": {
+                                        "func": {
+                                          "Not": null
+                                        },
+                                        "expr": {
+                                          "CallUnary": {
+                                            "func": {
+                                              "IsNull": null
+                                            },
+                                            "expr": {
+                                              "Column": 0
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  [
+                                    2,
+                                    {
+                                      "CallUnary": {
+                                        "func": {
+                                          "Not": null
+                                        },
+                                        "expr": {
+                                          "CallUnary": {
+                                            "func": {
+                                              "IsNull": null
+                                            },
+                                            "expr": {
+                                              "Column": 1
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                ],
+                                "projection": [
+                                  0,
+                                  1
+                                ],
+                                "input_arity": 2
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "forms": {
+                      "raw": true,
+                      "arranged": [
+                        [
+                          [
+                            {
+                              "Column": 0
+                            },
+                            {
+                              "Column": 1
+                            }
+                          ],
+                          {
+                            "0": 0,
+                            "1": 1
+                          },
+                          []
+                        ]
+                      ],
+                      "types": [
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": false
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": false
+                        }
+                      ]
+                    },
+                    "input_key": null,
+                    "input_mfp": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 2
+                    }
+                  }
+                }
               }
-            },
-            {
-              "ArrangeBy": {
-                "input": {
+            ],
+            "plan": {
+              "Delta": {
+                "path_plans": [
+                  {
+                    "source_relation": 0,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                1,
+                                2
+                              ],
+                              "input_arity": 3
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": 2
+                          },
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          },
+                          {
+                            "Column": 1
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2,
+                                0
+                              ],
+                              "input_arity": 3
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            0,
+                            2,
+                            2,
+                            0
+                          ],
+                          "input_arity": 3
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "source_relation": 1,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": 1
+                          },
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          },
+                          {
+                            "Column": 1
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                0
+                              ],
+                              "input_arity": 2
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                2,
+                                1
+                              ],
+                              "input_arity": 3
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            0,
+                            2,
+                            2,
+                            0
+                          ],
+                          "input_arity": 3
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "source_relation": 2,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      },
+                      {
+                        "Column": 1
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": 1
+                          },
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          },
+                          {
+                            "Column": 1
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                0
+                              ],
+                              "input_arity": 2
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": 1
+                          }
+                        ],
+                        "stream_thinning": [
+                          0
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                2,
+                                1
+                              ],
+                              "input_arity": 3
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            0,
+                            2,
+                            2,
+                            0
+                          ],
+                          "input_arity": 3
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "sources": []
+}
+EOF
+
+# Test Join::Delta (star).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(non negative) AS JSON FOR
+SELECT a, b, c, d, e, f
+FROM t, u, v
+WHERE a = c and a = e
+----
+{
+  "plans": [
+    {
+      "id": "Explained Query",
+      "plan": {
+        "lir_id": 3,
+        "node": {
+          "Join": {
+            "inputs": [
+              {
+                "lir_id": 0,
+                "node": {
+                  "Get": {
+                    "id": {
+                      "Global": {
+                        "User": 1
+                      }
+                    },
+                    "keys": {
+                      "raw": false,
+                      "arranged": [
+                        [
+                          [
+                            {
+                              "Column": 0
+                            }
+                          ],
+                          {
+                            "0": 0,
+                            "1": 1
+                          },
+                          [
+                            1
+                          ]
+                        ]
+                      ],
+                      "types": [
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        }
+                      ]
+                    },
+                    "plan": "PassArrangements"
+                  }
+                }
+              },
+              {
+                "lir_id": 1,
+                "node": {
                   "Get": {
                     "id": {
                       "Global": {
@@ -7384,129 +8347,13 @@ WHERE a = c AND d = e AND f = a
                         }
                       ]
                     },
-                    "plan": {
-                      "Arrangement": [
-                        [
-                          {
-                            "Column": 0
-                          }
-                        ],
-                        null,
-                        {
-                          "expressions": [],
-                          "predicates": [
-                            [
-                              1,
-                              {
-                                "CallUnary": {
-                                  "func": {
-                                    "Not": null
-                                  },
-                                  "expr": {
-                                    "CallUnary": {
-                                      "func": {
-                                        "IsNull": null
-                                      },
-                                      "expr": {
-                                        "Column": 0
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            ],
-                            [
-                              2,
-                              {
-                                "CallUnary": {
-                                  "func": {
-                                    "Not": null
-                                  },
-                                  "expr": {
-                                    "CallUnary": {
-                                      "func": {
-                                        "IsNull": null
-                                      },
-                                      "expr": {
-                                        "Column": 1
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            ]
-                          ],
-                          "projection": [
-                            0,
-                            1
-                          ],
-                          "input_arity": 2
-                        }
-                      ]
-                    },
-                    "lir_id": 1
+                    "plan": "PassArrangements"
                   }
-                },
-                "forms": {
-                  "raw": true,
-                  "arranged": [
-                    [
-                      [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      {
-                        "0": 0,
-                        "1": 1
-                      },
-                      [
-                        1
-                      ]
-                    ],
-                    [
-                      [
-                        {
-                          "Column": 0
-                        },
-                        {
-                          "Column": 1
-                        }
-                      ],
-                      {
-                        "0": 0,
-                        "1": 1
-                      },
-                      []
-                    ]
-                  ],
-                  "types": [
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": false
-                    },
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": false
-                    }
-                  ]
-                },
-                "input_key": null,
-                "input_mfp": {
-                  "expressions": [],
-                  "predicates": [],
-                  "projection": [
-                    0,
-                    1
-                  ],
-                  "input_arity": 2
-                },
-                "lir_id": 2
-              }
-            },
-            {
-              "ArrangeBy": {
-                "input": {
+                }
+              },
+              {
+                "lir_id": 2,
+                "node": {
                   "Get": {
                     "id": {
                       "Global": {
@@ -7542,15 +8389,25 @@ WHERE a = c AND d = e AND f = a
                         }
                       ]
                     },
-                    "plan": {
-                      "Arrangement": [
-                        [
-                          {
-                            "Column": 0
-                          }
-                        ],
-                        null,
-                        {
+                    "plan": "PassArrangements"
+                  }
+                }
+              }
+            ],
+            "plan": {
+              "Delta": {
+                "path_plans": [
+                  {
+                    "source_relation": 0,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
                           "expressions": [],
                           "predicates": [
                             [
@@ -7572,26 +8429,6 @@ WHERE a = c AND d = e AND f = a
                                   }
                                 }
                               }
-                            ],
-                            [
-                              2,
-                              {
-                                "CallUnary": {
-                                  "func": {
-                                    "Not": null
-                                  },
-                                  "expr": {
-                                    "CallUnary": {
-                                      "func": {
-                                        "IsNull": null
-                                      },
-                                      "expr": {
-                                        "Column": 1
-                                      }
-                                    }
-                                  }
-                                }
-                              }
                             ]
                           ],
                           "projection": [
@@ -7600,924 +8437,355 @@ WHERE a = c AND d = e AND f = a
                           ],
                           "input_arity": 2
                         }
-                      ]
+                      }
                     },
-                    "lir_id": 3
-                  }
-                },
-                "forms": {
-                  "raw": true,
-                  "arranged": [
-                    [
-                      [
-                        {
-                          "Column": 0
-                        },
-                        {
-                          "Column": 1
-                        }
-                      ],
+                    "stage_plans": [
                       {
-                        "0": 0,
-                        "1": 1
-                      },
-                      []
-                    ]
-                  ],
-                  "types": [
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": false
-                    },
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": false
-                    }
-                  ]
-                },
-                "input_key": null,
-                "input_mfp": {
-                  "expressions": [],
-                  "predicates": [],
-                  "projection": [
-                    0,
-                    1
-                  ],
-                  "input_arity": 2
-                },
-                "lir_id": 4
-              }
-            }
-          ],
-          "plan": {
-            "Delta": {
-              "path_plans": [
-                {
-                  "source_relation": 0,
-                  "source_key": [
-                    {
-                      "Column": 0
-                    }
-                  ],
-                  "initial_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0,
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
                           1
                         ],
-                        "input_arity": 2
-                      }
-                    }
-                  },
-                  "stage_plans": [
-                    {
-                      "lookup_relation": 1,
-                      "stream_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "stream_thinning": [
-                        1
-                      ],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              1,
-                              2
-                            ],
-                            "input_arity": 3
+                        "lookup_key": [
+                          {
+                            "Column": 0
                           }
-                        }
-                      }
-                    },
-                    {
-                      "lookup_relation": 2,
-                      "stream_key": [
-                        {
-                          "Column": 2
-                        },
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "stream_thinning": [
-                        1
-                      ],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        },
-                        {
-                          "Column": 1
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              1,
-                              2,
-                              0
-                            ],
-                            "input_arity": 3
-                          }
-                        }
-                      }
-                    }
-                  ],
-                  "final_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0,
-                          1,
-                          0,
-                          2,
-                          2,
-                          0
                         ],
-                        "input_arity": 3
-                      }
-                    }
-                  }
-                },
-                {
-                  "source_relation": 1,
-                  "source_key": [
-                    {
-                      "Column": 0
-                    }
-                  ],
-                  "initial_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0,
-                          1
-                        ],
-                        "input_arity": 2
-                      }
-                    }
-                  },
-                  "stage_plans": [
-                    {
-                      "lookup_relation": 2,
-                      "stream_key": [
-                        {
-                          "Column": 1
-                        },
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "stream_thinning": [],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        },
-                        {
-                          "Column": 1
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              1,
-                              0
-                            ],
-                            "input_arity": 2
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "lookup_relation": 0,
-                      "stream_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "stream_thinning": [
-                        1
-                      ],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              2,
-                              1
-                            ],
-                            "input_arity": 3
-                          }
-                        }
-                      }
-                    }
-                  ],
-                  "final_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0,
-                          1,
-                          0,
-                          2,
-                          2,
-                          0
-                        ],
-                        "input_arity": 3
-                      }
-                    }
-                  }
-                },
-                {
-                  "source_relation": 2,
-                  "source_key": [
-                    {
-                      "Column": 0
-                    },
-                    {
-                      "Column": 1
-                    }
-                  ],
-                  "initial_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0,
-                          1
-                        ],
-                        "input_arity": 2
-                      }
-                    }
-                  },
-                  "stage_plans": [
-                    {
-                      "lookup_relation": 1,
-                      "stream_key": [
-                        {
-                          "Column": 1
-                        },
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "stream_thinning": [],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        },
-                        {
-                          "Column": 1
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              1,
-                              0
-                            ],
-                            "input_arity": 2
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "lookup_relation": 0,
-                      "stream_key": [
-                        {
-                          "Column": 1
-                        }
-                      ],
-                      "stream_thinning": [
-                        0
-                      ],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              2,
-                              1
-                            ],
-                            "input_arity": 3
-                          }
-                        }
-                      }
-                    }
-                  ],
-                  "final_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0,
-                          1,
-                          0,
-                          2,
-                          2,
-                          0
-                        ],
-                        "input_arity": 3
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          },
-          "lir_id": 5
-        }
-      }
-    }
-  ],
-  "sources": []
-}
-EOF
-
-# Test Join::Delta (star).
-query T multiline
-EXPLAIN PHYSICAL PLAN WITH(non negative) AS JSON FOR
-SELECT a, b, c, d, e, f
-FROM t, u, v
-WHERE a = c and a = e
-----
-{
-  "plans": [
-    {
-      "id": "Explained Query",
-      "plan": {
-        "Join": {
-          "inputs": [
-            {
-              "Get": {
-                "id": {
-                  "Global": {
-                    "User": 1
-                  }
-                },
-                "keys": {
-                  "raw": false,
-                  "arranged": [
-                    [
-                      [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      {
-                        "0": 0,
-                        "1": 1
-                      },
-                      [
-                        1
-                      ]
-                    ]
-                  ],
-                  "types": [
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": true
-                    },
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": true
-                    }
-                  ]
-                },
-                "plan": "PassArrangements",
-                "lir_id": 0
-              }
-            },
-            {
-              "Get": {
-                "id": {
-                  "Global": {
-                    "User": 2
-                  }
-                },
-                "keys": {
-                  "raw": false,
-                  "arranged": [
-                    [
-                      [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      {
-                        "0": 0,
-                        "1": 1
-                      },
-                      [
-                        1
-                      ]
-                    ]
-                  ],
-                  "types": [
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": true
-                    },
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": true
-                    }
-                  ]
-                },
-                "plan": "PassArrangements",
-                "lir_id": 1
-              }
-            },
-            {
-              "Get": {
-                "id": {
-                  "Global": {
-                    "User": 3
-                  }
-                },
-                "keys": {
-                  "raw": false,
-                  "arranged": [
-                    [
-                      [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      {
-                        "0": 0,
-                        "1": 1
-                      },
-                      [
-                        1
-                      ]
-                    ]
-                  ],
-                  "types": [
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": true
-                    },
-                    {
-                      "scalar_type": "Int32",
-                      "nullable": true
-                    }
-                  ]
-                },
-                "plan": "PassArrangements",
-                "lir_id": 2
-              }
-            }
-          ],
-          "plan": {
-            "Delta": {
-              "path_plans": [
-                {
-                  "source_relation": 0,
-                  "source_key": [
-                    {
-                      "Column": 0
-                    }
-                  ],
-                  "initial_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [
-                          [
-                            1,
-                            {
-                              "CallUnary": {
-                                "func": {
-                                  "Not": null
-                                },
-                                "expr": {
-                                  "CallUnary": {
-                                    "func": {
-                                      "IsNull": null
-                                    },
-                                    "expr": {
-                                      "Column": 0
-                                    }
-                                  }
-                                }
-                              }
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                1,
+                                2
+                              ],
+                              "input_arity": 3
                             }
-                          ]
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
                         ],
-                        "projection": [
-                          0,
-                          1
+                        "stream_thinning": [
+                          1,
+                          2
                         ],
-                        "input_arity": 2
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                1,
+                                2,
+                                3
+                              ],
+                              "input_arity": 4
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            0,
+                            2,
+                            0,
+                            3
+                          ],
+                          "input_arity": 4
+                        }
                       }
                     }
                   },
-                  "stage_plans": [
-                    {
-                      "lookup_relation": 1,
-                      "stream_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "stream_thinning": [
-                        1
-                      ],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              1,
-                              2
-                            ],
-                            "input_arity": 3
-                          }
+                  {
+                    "source_relation": 1,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1
+                          ],
+                          "input_arity": 2
                         }
                       }
                     },
-                    {
-                      "lookup_relation": 2,
-                      "stream_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "stream_thinning": [
-                        1,
-                        2
-                      ],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              1,
-                              2,
-                              3
-                            ],
-                            "input_arity": 4
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": 0
                           }
-                        }
-                      }
-                    }
-                  ],
-                  "final_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0,
-                          1,
-                          0,
-                          2,
-                          0,
-                          3
                         ],
-                        "input_arity": 4
-                      }
-                    }
-                  }
-                },
-                {
-                  "source_relation": 1,
-                  "source_key": [
-                    {
-                      "Column": 0
-                    }
-                  ],
-                  "initial_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0,
+                        "stream_thinning": [
                           1
                         ],
-                        "input_arity": 2
-                      }
-                    }
-                  },
-                  "stage_plans": [
-                    {
-                      "lookup_relation": 0,
-                      "stream_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "stream_thinning": [
-                        1
-                      ],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [],
-                            "predicates": [
-                              [
-                                1,
-                                {
-                                  "CallUnary": {
-                                    "func": {
-                                      "Not": null
-                                    },
-                                    "expr": {
-                                      "CallUnary": {
-                                        "func": {
-                                          "IsNull": null
-                                        },
-                                        "expr": {
-                                          "Column": 0
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [
+                                [
+                                  1,
+                                  {
+                                    "CallUnary": {
+                                      "func": {
+                                        "Not": null
+                                      },
+                                      "expr": {
+                                        "CallUnary": {
+                                          "func": {
+                                            "IsNull": null
+                                          },
+                                          "expr": {
+                                            "Column": 0
+                                          }
                                         }
                                       }
                                     }
                                   }
-                                }
-                              ]
-                            ],
-                            "projection": [
-                              0,
-                              2,
-                              0,
-                              1
-                            ],
-                            "input_arity": 3
+                                ]
+                              ],
+                              "projection": [
+                                0,
+                                2,
+                                0,
+                                1
+                              ],
+                              "input_arity": 3
+                            }
                           }
                         }
-                      }
-                    },
-                    {
-                      "lookup_relation": 2,
-                      "stream_key": [
-                        {
-                          "Column": 2
-                        }
-                      ],
-                      "stream_thinning": [
-                        0,
-                        1,
-                        3
-                      ],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              1,
-                              2,
-                              3,
-                              4
-                            ],
-                            "input_arity": 5
+                      },
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": 2
                           }
-                        }
-                      }
-                    }
-                  ],
-                  "final_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
+                        ],
+                        "stream_thinning": [
                           0,
                           1,
-                          0,
-                          2,
-                          0,
                           3
                         ],
-                        "input_arity": 4
-                      }
-                    }
-                  }
-                },
-                {
-                  "source_relation": 2,
-                  "source_key": [
-                    {
-                      "Column": 0
-                    }
-                  ],
-                  "initial_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          0,
-                          1
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
                         ],
-                        "input_arity": 2
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2,
+                                3,
+                                4
+                              ],
+                              "input_arity": 5
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            0,
+                            2,
+                            0,
+                            3
+                          ],
+                          "input_arity": 4
+                        }
                       }
                     }
                   },
-                  "stage_plans": [
-                    {
-                      "lookup_relation": 0,
-                      "stream_key": [
-                        {
-                          "Column": 0
+                  {
+                    "source_relation": 2,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1
+                          ],
+                          "input_arity": 2
                         }
-                      ],
-                      "stream_thinning": [
-                        1
-                      ],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [],
-                            "predicates": [
-                              [
-                                1,
-                                {
-                                  "CallUnary": {
-                                    "func": {
-                                      "Not": null
-                                    },
-                                    "expr": {
-                                      "CallUnary": {
-                                        "func": {
-                                          "IsNull": null
-                                        },
-                                        "expr": {
-                                          "Column": 0
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [
+                                [
+                                  1,
+                                  {
+                                    "CallUnary": {
+                                      "func": {
+                                        "Not": null
+                                      },
+                                      "expr": {
+                                        "CallUnary": {
+                                          "func": {
+                                            "IsNull": null
+                                          },
+                                          "expr": {
+                                            "Column": 0
+                                          }
                                         }
                                       }
                                     }
                                   }
-                                }
-                              ]
-                            ],
-                            "projection": [
-                              0,
-                              2,
-                              0,
-                              1
-                            ],
-                            "input_arity": 3
+                                ]
+                              ],
+                              "projection": [
+                                0,
+                                2,
+                                0,
+                                1
+                              ],
+                              "input_arity": 3
+                            }
                           }
                         }
-                      }
-                    },
-                    {
-                      "lookup_relation": 1,
-                      "stream_key": [
-                        {
-                          "Column": 2
-                        }
-                      ],
-                      "stream_thinning": [
-                        0,
-                        1,
-                        3
-                      ],
-                      "lookup_key": [
-                        {
-                          "Column": 0
-                        }
-                      ],
-                      "closure": {
-                        "ready_equivalences": [],
-                        "before": {
-                          "mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              1,
-                              2,
-                              4,
-                              3
-                            ],
-                            "input_arity": 5
+                      },
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": 2
                           }
-                        }
-                      }
-                    }
-                  ],
-                  "final_closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
+                        ],
+                        "stream_thinning": [
                           0,
                           1,
-                          0,
-                          2,
-                          0,
                           3
                         ],
-                        "input_arity": 4
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2,
+                                4,
+                                3
+                              ],
+                              "input_arity": 5
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            0,
+                            2,
+                            0,
+                            3
+                          ],
+                          "input_arity": 4
+                        }
                       }
                     }
                   }
-                }
-              ]
+                ]
+              }
             }
-          },
-          "lir_id": 3
+          }
         }
       }
     }


### PR DESCRIPTION
In preparation for building the introspection views for attribution, I'm refactoring how we store `LirId`s to make things a bit more uniform.

### Motivation

   * This PR refactors existing code.

LIR `Plan`s used to just be an enum where every variant had an `lir_id` field; a `Plan::lir_id()` would pull it out from the appropriate structure. This PR refactors the code so that a `Plan` is a struct holding a `PlanNode` (the old enum) and an `LirId`.

### Tips for reviewer

I tried to break up the commits logically, so it may make sense go commit by commit. (The first two are small.)

The third commit---the SLT rewrite---is easier to vet if you ignore whitespace changes.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
