### PR TITLE
32 byte ScalarType

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -2594,10 +2594,10 @@ impl AggregateFunc {
 
                 ScalarType::List {
                     element_type: Box::new(ScalarType::Record {
-                        fields: vec![
+                        fields: [
                             (column_name, output_type_inner),
                             (ColumnName::from("?orig_row?"), original_row_type),
-                        ],
+                        ].into(),
                         custom_id: None,
                     }),
                     custom_id: None,
@@ -2615,10 +2615,10 @@ impl AggregateFunc {
 
                 ScalarType::List {
                     element_type: Box::new(ScalarType::Record {
-                        fields: vec![
+                        fields: [
                             (ColumnName::from("?first_value?"), value_type),
                             (ColumnName::from("?orig_row?"), original_row_type),
-                        ],
+                        ].into(),
                         custom_id: None,
                     }),
                     custom_id: None,
@@ -2636,10 +2636,10 @@ impl AggregateFunc {
 
                 ScalarType::List {
                     element_type: Box::new(ScalarType::Record {
-                        fields: vec![
+                        fields: [
                             (ColumnName::from("?last_value?"), value_type),
                             (ColumnName::from("?orig_row?"), original_row_type),
-                        ],
+                        ].into(),
                         custom_id: None,
                     }),
                     custom_id: None,
@@ -2660,10 +2660,10 @@ impl AggregateFunc {
 
                 ScalarType::List {
                     element_type: Box::new(ScalarType::Record {
-                        fields: vec![
+                        fields: [
                             (ColumnName::from("?window_agg?"), wrapped_aggr_out_type),
                             (ColumnName::from("?orig_row?"), original_row_type),
-                        ],
+                        ].into(),
                         custom_id: None,
                     }),
                     custom_id: None,
@@ -2682,7 +2682,7 @@ impl AggregateFunc {
 
                 ScalarType::List {
                     element_type: Box::new(ScalarType::Record {
-                        fields: vec![
+                        fields: [
                             (ColumnName::from("?fused_value_window_func?"), ScalarType::Record {
                                 fields: encoded_args_type.into_iter().zip_eq(funcs).map(|(arg_type, func)| {
                                     match func {
@@ -2710,7 +2710,7 @@ impl AggregateFunc {
                                 custom_id: None,
                             }.nullable(false)),
                             (ColumnName::from("?orig_row?"), original_row_type),
-                        ],
+                        ].into(),
                         custom_id: None,
                     }),
                     custom_id: None,
@@ -2782,7 +2782,7 @@ impl AggregateFunc {
         match input_type.scalar_type {
             ScalarType::Record { ref fields, .. } => ScalarType::List {
                 element_type: Box::new(ScalarType::Record {
-                    fields: vec![
+                    fields: [
                         (
                             ColumnName::from(col_name),
                             ScalarType::Int64.nullable(false),
@@ -2794,7 +2794,8 @@ impl AggregateFunc {
                             };
                             inner.nullable(false)
                         }),
-                    ],
+                    ]
+                    .into(),
                     custom_id: None,
                 }),
                 custom_id: None,

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2739,11 +2739,11 @@ impl BinaryFunc {
             TimezoneIntervalTime => ScalarType::Time.nullable(in_nullable),
 
             TimezoneOffset => ScalarType::Record {
-                fields: vec![
+                fields: [
                     ("abbrev".into(), ScalarType::String.nullable(false)),
                     ("base_utc_offset".into(), ScalarType::Interval.nullable(false)),
                     ("dst_offset".into(), ScalarType::Interval.nullable(false)),
-                ],
+                ].into(),
                 custom_id: None,
             }.nullable(true),
 

--- a/src/expr/src/scalar/func/impls/record.rs
+++ b/src/expr/src/scalar/func/impls/record.rs
@@ -157,8 +157,9 @@ impl LazyUnaryFunc for RecordGet {
 
     fn output_type(&self, input_type: ColumnType) -> ColumnType {
         match input_type.scalar_type {
-            ScalarType::Record { mut fields, .. } => {
-                let (_name, mut ty) = fields.swap_remove(self.0);
+            ScalarType::Record { fields, .. } => {
+                let (_name, ty) = &fields[self.0];
+                let mut ty = ty.clone();
                 ty.nullable = ty.nullable || input_type.nullable;
                 ty
             }

--- a/src/interchange/src/avro/schema.rs
+++ b/src/interchange/src/avro/schema.rs
@@ -259,7 +259,7 @@ fn validate_schema_2(
                 }
             }
             ScalarType::Record {
-                fields: columns,
+                fields: columns.into(),
                 custom_id: None,
             }
         }

--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -152,7 +152,7 @@ pub(crate) fn dbz_envelope(
     let row = ColumnType {
         nullable: true,
         scalar_type: ScalarType::Record {
-            fields: names_and_types,
+            fields: names_and_types.into(),
             custom_id: Some(DBZ_ROW_TYPE_ID),
         },
     };

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -161,7 +161,7 @@ fn derive_inner_type(
             }
             seen_messages.remove(m.name());
             let ty = ScalarType::Record {
-                fields,
+                fields: fields.into(),
                 custom_id: None,
             };
             Ok(ty.nullable(true))

--- a/src/lowertest-derive/src/lib.rs
+++ b/src/lowertest-derive/src/lib.rs
@@ -186,7 +186,7 @@ fn get_type_as_string(t: &syn::Type) -> String {
 ///
 /// Supported types are:
 /// A plain path type A -> extracts A
-/// `Box<A>`, `Vec<A>`, `Option<A>` -> extracts A
+/// `Box<A>`, `Vec<A>`, `Option<A>`, `[A]` -> extracts A
 /// Tuple (A, (B, C)) -> extracts A, B, C.
 /// Remove A, B, C from expected results if they are primitive types or listed
 /// in [EXTERNAL_TYPES].
@@ -233,6 +233,9 @@ fn extract_reflected_type(t: &syn::Type) -> Vec<&syn::Type> {
                 .iter()
                 .flat_map(extract_reflected_type)
                 .collect::<Vec<_>>();
+        }
+        syn::Type::Slice(ts) => {
+            return extract_reflected_type(&ts.elem);
         }
         _ => {}
     }

--- a/src/lowertest/src/lib.rs
+++ b/src/lowertest/src/lib.rs
@@ -226,33 +226,30 @@ where
                     Delimiter::Bracket => {
                         if type_name.starts_with("Vec<") && type_name.ends_with('>') {
                             // This is a Vec<type_name>.
-                            Ok(Some(format!(
-                                "[{}]",
-                                separated(
-                                    ",",
-                                    parse_as_vec(
-                                        &mut inner_iter,
-                                        &type_name[4..(type_name.len() - 1)],
-                                        rti,
-                                        ctx
-                                    )?
-                                    .iter()
-                                )
-                            )))
+                            let vec = parse_as_vec(
+                                &mut inner_iter,
+                                &type_name[4..(type_name.len() - 1)],
+                                rti,
+                                ctx,
+                            )?;
+                            Ok(Some(format!("[{}]", separated(",", vec.iter()))))
+                        } else if type_name.starts_with("[") && type_name.ends_with(']') {
+                            // This is a [type_name].
+                            let vec = parse_as_vec(
+                                &mut inner_iter,
+                                &type_name[1..(type_name.len() - 1)],
+                                rti,
+                                ctx,
+                            )?;
+                            Ok(Some(format!("[{}]", separated(",", vec.iter()))))
                         } else if type_name.starts_with('(') && type_name.ends_with(')') {
-                            Ok(Some(format!(
-                                "[{}]",
-                                separated(
-                                    ",",
-                                    parse_as_tuple(
-                                        &mut inner_iter,
-                                        &type_name[1..(type_name.len() - 1)],
-                                        rti,
-                                        ctx
-                                    )?
-                                    .iter()
-                                )
-                            )))
+                            let vec = parse_as_tuple(
+                                &mut inner_iter,
+                                &type_name[1..(type_name.len() - 1)],
+                                rti,
+                                ctx,
+                            )?;
+                            Ok(Some(format!("[{}]", separated(",", vec.iter()))))
                         } else {
                             Err(format!(
                                 "Object specified with brackets {:?} has unsupported type `{}`",

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -1055,7 +1055,7 @@ impl TryFrom<&Type> for ScalarType {
             }
             Type::Oid => Ok(ScalarType::Oid),
             Type::Record(_) => Ok(ScalarType::Record {
-                fields: vec![],
+                fields: [].into(),
                 custom_id: None,
             }),
             Type::Text => Ok(ScalarType::String),

--- a/src/proto/src/lib.rs
+++ b/src/proto/src/lib.rs
@@ -352,6 +352,24 @@ where
     }
 }
 
+/// Blanket implementation for `Box<[R]>` where `R` is a [`RustType`].
+impl<R, P> RustType<Vec<P>> for Box<[R]>
+where
+    R: RustType<P>,
+{
+    fn into_proto(&self) -> Vec<P> {
+        self.iter().map(R::into_proto).collect()
+    }
+
+    fn from_proto(proto: Vec<P>) -> Result<Self, TryFromProtoError> {
+        proto
+            .into_iter()
+            .map(R::from_proto)
+            .collect::<Result<Vec<_>, _>>()
+            .map(Into::into)
+    }
+}
+
 /// Blanket implementation for `Option<R>` where `R` is a [`RustType`].
 impl<R, P> RustType<Option<P>> for Option<R>
 where

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -104,7 +104,7 @@ impl ColumnType {
 
                 Ok(ColumnType {
                     scalar_type: ScalarType::Record {
-                        fields: union_fields,
+                        fields: union_fields.into(),
                         custom_id,
                     },
                     nullable: self.nullable || other.nullable,

--- a/src/repr/src/row/encoding2.rs
+++ b/src/repr/src/row/encoding2.rs
@@ -1991,7 +1991,7 @@ mod tests {
             .with_column(
                 "a",
                 ScalarType::Record {
-                    fields: vec![
+                    fields: [
                         (ColumnName::from("foo"), ScalarType::Int64.nullable(false)),
                         (ColumnName::from("bar"), ScalarType::String.nullable(true)),
                         (
@@ -2002,7 +2002,8 @@ mod tests {
                             }
                             .nullable(false),
                         ),
-                    ],
+                    ]
+                    .into(),
                     custom_id: None,
                 }
                 .nullable(true),

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1500,7 +1500,9 @@ pub enum ScalarType {
     Record {
         /// The names and types of the fields of the record, in order from left
         /// to right.
-        fields: Vec<(ColumnName, ColumnType)>,
+        ///
+        /// Boxed slice to reduce the size of the enum variant.
+        fields: Box<[(ColumnName, ColumnType)]>,
         custom_id: Option<GlobalId>,
     },
     /// A PostgreSQL object identifier.
@@ -2713,7 +2715,7 @@ impl ScalarType {
                             },
                         )
                     })
-                    .collect_vec();
+                    .collect();
                 Record {
                     fields,
                     custom_id: None,
@@ -3683,7 +3685,10 @@ impl Arbitrary for ScalarType {
 
                     // Now we combine it with the default strategies to get Records.
                     (fields_strat, any::<Option<GlobalId>>())
-                        .prop_map(|(fields, custom_id)| ScalarType::Record { fields, custom_id })
+                        .prop_map(|(fields, custom_id)| ScalarType::Record {
+                            fields: fields.into(),
+                            custom_id,
+                        })
                         .boxed()
                 },
             ])

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -4337,27 +4337,29 @@ impl<'a> From<&'a PropDatum> for Datum<'a> {
 #[mz_ore::test]
 fn verify_base_eq_record_nullability() {
     let s1 = ScalarType::Record {
-        fields: vec![(
+        fields: [(
             "c".into(),
             ColumnType {
                 scalar_type: ScalarType::Bool,
                 nullable: true,
             },
-        )],
+        )]
+        .into(),
         custom_id: None,
     };
     let s2 = ScalarType::Record {
-        fields: vec![(
+        fields: [(
             "c".into(),
             ColumnType {
                 scalar_type: ScalarType::Bool,
                 nullable: false,
             },
-        )],
+        )]
+        .into(),
         custom_id: None,
     };
     let s3 = ScalarType::Record {
-        fields: vec![],
+        fields: [].into(),
         custom_id: None,
     };
     assert!(s1.base_eq(&s2));

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -924,7 +924,7 @@ impl CoercibleScalarType {
                 fields.push((name, ty))
             }
             ScalarType::Record {
-                fields,
+                fields: fields.into(),
                 custom_id: None,
             }
         }

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -1172,7 +1172,7 @@ impl HirScalarExpr {
                                     .map(|t| {
                                         (ColumnName::from("?column?"), t.clone().nullable(false))
                                     })
-                                    .collect_vec(),
+                                    .collect(),
                                 custom_id: None,
                             }
                             .nullable(false);
@@ -1209,13 +1209,13 @@ impl HirScalarExpr {
                             // 1. the original row in a record
                             // 2. the encoded args (which can be either a single value, or a record
                             //    if the window function has multiple arguments, such as `lag`)
-                            let fn_input_record_fields =
+                            let fn_input_record_fields: Box<[_]> =
                                 [original_row_record_type, mir_encoded_args_type]
                                     .iter()
                                     .map(|t| {
                                         (ColumnName::from("?column?"), t.clone().nullable(false))
                                     })
-                                    .collect_vec();
+                                    .collect();
                             let fn_input_record = MirScalarExpr::CallVariadic {
                                 func: mz_expr::VariadicFunc::RecordCreate {
                                     field_names: fn_input_record_fields
@@ -1245,10 +1245,11 @@ impl HirScalarExpr {
                             };
 
                             let agg_input_type = ScalarType::Record {
-                                fields: vec![(
+                                fields: [(
                                     ColumnName::from("?column?"),
                                     fn_input_record_type.nullable(false),
-                                )],
+                                )]
+                                .into(),
                                 custom_id: None,
                             }
                             .nullable(false);
@@ -1434,12 +1435,12 @@ impl HirScalarExpr {
                     let input_type = get_inner.typ();
 
                     // Original columns of the relation
-                    let fields = input_type
+                    let fields: Box<_> = input_type
                         .column_types
                         .iter()
                         .take(input_arity)
                         .map(|t| (ColumnName::from("?column?"), t.clone()))
-                        .collect_vec();
+                        .collect();
 
                     // Original row made into a record
                     let original_row_record = MirScalarExpr::CallVariadic {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -5806,7 +5806,7 @@ pub fn scalar_type_from_catalog(
                     element_type: Box::new(scalar_type_from_catalog(catalog, *element_id, &[])?),
                 }),
                 CatalogType::Record { fields } => {
-                    let scalars: Vec<(ColumnName, ColumnType)> = fields
+                    let scalars: Box<[(ColumnName, ColumnType)]> = fields
                         .iter()
                         .map(|f| {
                             let scalar_type = scalar_type_from_catalog(
@@ -5822,7 +5822,7 @@ pub fn scalar_type_from_catalog(
                                 },
                             ))
                         })
-                        .collect::<Result<Vec<_>, PlanError>>()?;
+                        .collect::<Result<Box<_>, PlanError>>()?;
                     Ok(ScalarType::Record {
                         fields: scalars,
                         custom_id: Some(id),

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -1028,7 +1028,7 @@ pub fn guess_best_common_type(
                 fields.push((name, guess.nullable(nullable)));
             }
             return Ok(ScalarType::Record {
-                fields,
+                fields: fields.into(),
                 custom_id: None,
             });
         }

--- a/src/storage-types/src/sources/envelope.rs
+++ b/src/storage-types/src/sources/envelope.rs
@@ -457,13 +457,14 @@ fn compute_envelope_value_desc(
             types.push(ColumnType {
                 nullable: true,
                 scalar_type: ScalarType::Record {
-                    fields: vec![(
+                    fields: [(
                         "description".into(),
                         ColumnType {
                             nullable: true,
                             scalar_type: ScalarType::String,
                         },
-                    )],
+                    )]
+                    .into(),
                     custom_id: None,
                 },
             });

--- a/src/storage-types/src/sources/kafka.rs
+++ b/src/storage-types/src/sources/kafka.rs
@@ -349,7 +349,7 @@ pub fn kafka_metadata_columns_desc(
                 } => ScalarType::String.nullable(true),
                 KafkaMetadataKind::Headers => ScalarType::List {
                     element_type: Box::new(ScalarType::Record {
-                        fields: vec![
+                        fields: [
                             (
                                 "key".into(),
                                 ColumnType {
@@ -364,7 +364,8 @@ pub fn kafka_metadata_columns_desc(
                                     scalar_type: ScalarType::Bytes,
                                 },
                             ),
-                        ],
+                        ]
+                        .into(),
                         custom_id: None,
                     }),
                     custom_id: None,


### PR DESCRIPTION
Reduce the size of the ScalarType struct from 40 bytes to 32 bytes by boxing a vector. This reduces the size of the largest variant, Record, by 8 bytes with minimal changes to the rest of the system.

Before:

```
print-type-size type: `mz_repr::ScalarType`: 40 bytes, alignment: 8 bytes
print-type-size     variant `Record`: 40 bytes
print-type-size         field `.custom_id`: 16 bytes
print-type-size         field `.fields`: 24 bytes
```

After:
```
print-type-size type: `mz_repr::ScalarType`: 32 bytes, alignment: 8 bytes
print-type-size     variant `List`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.custom_id`: 16 bytes, alignment: 8 bytes
print-type-size         field `.element_type`: 8 bytes
print-type-size     variant `Record`: 32 bytes
print-type-size         field `.custom_id`: 16 bytes
print-type-size         field `.fields`: 16 bytes
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
