### PR TITLE
sinks/kafka: use ThreadedProducer to regularly poll librdkafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8288,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.29.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#4a217ecc7a05d6514c8d18c7e4c1d206605edb6b"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#727ae0719709276bf58a281a7fc4e50ac1c54dbc"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -8305,7 +8305,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "4.3.0+2.5.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#4a217ecc7a05d6514c8d18c7e4c1d206605edb6b"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#727ae0719709276bf58a281a7fc4e50ac1c54dbc"
 dependencies = [
  "cmake",
  "libc",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -966,7 +966,7 @@ version = "0.29.0@git:1e27332856a433235aeba7f82d46d06e3f646b69"
 [[audits.rdkafka]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
-version = "0.29.0@git:4a217ecc7a05d6514c8d18c7e4c1d206605edb6b"
+version = "0.29.0@git:727ae0719709276bf58a281a7fc4e50ac1c54dbc"
 importable = false
 
 [[audits.rdkafka]]
@@ -1007,7 +1007,7 @@ version = "4.3.0+2.4.0@git:f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
 [[audits.rdkafka-sys]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
-version = "4.3.0+2.5.0@git:4a217ecc7a05d6514c8d18c7e4c1d206605edb6b"
+version = "4.3.0+2.5.0@git:727ae0719709276bf58a281a7fc4e50ac1c54dbc"
 importable = false
 
 [[audits.redox_syscall]]


### PR DESCRIPTION
As part of an earlier refactor of mine I switched Kafka sinks to the `BaseProducer` flavor of client which does not automatically poll the `librdkafka` client, a crucial task to ensure that messages like statistics don't pile up. At the same time I didn't ensure poll was called so a slow memory leak was introduced.

The leak is too slow to notice but we finally did notice and so this PR fixes this by switching back to the `ThreadedProducer` that spins up a background thread to take care of regular polls.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
