### PR TITLE
storage,compute: remove small batch optimization in both persist_sinks

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -128,7 +128,6 @@ def get_default_system_parameters(
             "false" if version < MzVersion.parse_mz("v0.111.0-dev") else "true"
         ),
         "persist_schema_require": "true",
-        "persist_sink_minimum_batch_updates": "128",
         "persist_stats_audit_percent": "100",
         "persist_txn_tables": "lazy",  # removed, but keep value for older versions
         "persist_use_critical_since_catalog": "true",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -137,7 +137,6 @@ def get_default_system_parameters(
         "persist_part_decode_format": "row_with_validate",
         "statement_logging_default_sample_rate": "0.01",
         "statement_logging_max_sample_rate": "0.01",
-        "storage_persist_sink_minimum_batch_updates": "100",
         "storage_source_decode_fuel": "100000",
         "storage_use_reclock_v2": "true",
         "timestamp_oracle": "postgres",

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -32,7 +32,7 @@ use crate::internal::machine::{
     NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER,
 };
 use crate::internal::state::ROLLUP_THRESHOLD;
-use crate::operators::{PERSIST_SINK_MINIMUM_BATCH_UPDATES, STORAGE_SOURCE_DECODE_FUEL};
+use crate::operators::STORAGE_SOURCE_DECODE_FUEL;
 use crate::project::OPTIMIZE_IGNORED_DATA_DECODE;
 use crate::read::READER_LEASE_DURATION;
 
@@ -252,13 +252,6 @@ impl PersistConfig {
             .expect("we have a borrow on sender so it cannot drop");
     }
 
-    /// The minimum number of updates that justify writing out a batch in `persist_sink`'s
-    /// `write_batches` operator. (If there are fewer than this minimum number of updates,
-    /// they'll be forwarded on to `append_batch` to be combined and written there.)
-    pub fn sink_minimum_batch_updates(&self) -> usize {
-        PERSIST_SINK_MINIMUM_BATCH_UPDATES.get(self)
-    }
-
     /// The maximum amount of work to do in the persist_source mfp_and_decode
     /// operator before yielding.
     pub fn storage_source_decode_fuel(&self) -> usize {
@@ -350,7 +343,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::internal::state::ROLLUP_THRESHOLD)
         .add(&crate::internal::state::WRITE_DIFFS_SUM)
         .add(&crate::internal::apply::ROUNDTRIP_SPINE)
-        .add(&crate::operators::PERSIST_SINK_MINIMUM_BATCH_UPDATES)
         .add(&crate::operators::STORAGE_SOURCE_DECODE_FUEL)
         .add(&crate::project::OPTIMIZE_IGNORED_DATA_DECODE)
         .add(&crate::project::OPTIMIZE_IGNORED_DATA_FETCH)

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -32,10 +32,7 @@ use crate::internal::machine::{
     NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER,
 };
 use crate::internal::state::ROLLUP_THRESHOLD;
-use crate::operators::{
-    PERSIST_SINK_MINIMUM_BATCH_UPDATES, STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES,
-    STORAGE_SOURCE_DECODE_FUEL,
-};
+use crate::operators::{PERSIST_SINK_MINIMUM_BATCH_UPDATES, STORAGE_SOURCE_DECODE_FUEL};
 use crate::project::OPTIMIZE_IGNORED_DATA_DECODE;
 use crate::read::READER_LEASE_DURATION;
 
@@ -262,12 +259,6 @@ impl PersistConfig {
         PERSIST_SINK_MINIMUM_BATCH_UPDATES.get(self)
     }
 
-    /// The same as `Self::sink_minimum_batch_updates`, but
-    /// for storage `persist_sink`'s.
-    pub fn storage_sink_minimum_batch_updates(&self) -> usize {
-        STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES.get(self)
-    }
-
     /// The maximum amount of work to do in the persist_source mfp_and_decode
     /// operator before yielding.
     pub fn storage_source_decode_fuel(&self) -> usize {
@@ -360,7 +351,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::internal::state::WRITE_DIFFS_SUM)
         .add(&crate::internal::apply::ROUNDTRIP_SPINE)
         .add(&crate::operators::PERSIST_SINK_MINIMUM_BATCH_UPDATES)
-        .add(&crate::operators::STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES)
         .add(&crate::operators::STORAGE_SOURCE_DECODE_FUEL)
         .add(&crate::project::OPTIMIZE_IGNORED_DATA_DECODE)
         .add(&crate::project::OPTIMIZE_IGNORED_DATA_FETCH)

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -76,17 +76,6 @@ pub mod operators {
     pub mod shard_source;
 
     // TODO(cfg): Move this next to the use.
-    pub(crate) const PERSIST_SINK_MINIMUM_BATCH_UPDATES: Config<usize> = Config::new(
-        "persist_sink_minimum_batch_updates",
-        0,
-        "\
-    In the compute persist sink, workers with less than the minimum number of \
-    updates will flush their records to single downstream worker to be batched \
-    up there... in the hopes of grouping our updates into fewer, larger \
-    batches.",
-    );
-
-    // TODO(cfg): Move this next to the use.
     pub(crate) const STORAGE_SOURCE_DECODE_FUEL: Config<usize> = Config::new(
         "storage_source_decode_fuel",
         1_000_000,

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -87,18 +87,6 @@ pub mod operators {
     );
 
     // TODO(cfg): Move this next to the use.
-    pub(crate) const STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES: Config<usize> = Config::new(
-        "storage_persist_sink_minimum_batch_updates",
-        // Reasonable default based on our experience in production.
-        1024,
-        "\
-    In the storage persist sink, workers with less than the minimum number of \
-    updates will flush their records to single downstream worker to be batched \
-    up there... in the hopes of grouping our updates into fewer, larger \
-    batches.",
-    );
-
-    // TODO(cfg): Move this next to the use.
     pub(crate) const STORAGE_SOURCE_DECODE_FUEL: Config<usize> = Config::new(
         "storage_source_decode_fuel",
         1_000_000,


### PR DESCRIPTION
We're now relying on inline writes to make small batches cheap. This is
already turned off everywhere in staging/prod.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
