### PR TITLE
Box strings in EvalError

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -467,10 +467,9 @@ impl crate::coord::Coordinator {
             let mut results = Vec::new();
             for (row, count) in rows {
                 if count < 0 {
-                    Err(EvalError::InvalidParameterValue(format!(
-                        "Negative multiplicity in constant result: {}",
-                        count
-                    )))?
+                    Err(EvalError::InvalidParameterValue(
+                        format!("Negative multiplicity in constant result: {}", count).into(),
+                    ))?
                 };
                 if count > 0 {
                     let count = usize::cast_from(

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -237,7 +237,7 @@ impl AdapterError {
             severity,
             code: self.code(),
             message: self.to_string(),
-            detail: self.detail(),
+            detail: self.detail().into(),
             hint: self.hint(),
             position: self.position(),
         }

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -237,7 +237,7 @@ impl AdapterError {
             severity,
             code: self.code(),
             message: self.to_string(),
-            detail: self.detail().into(),
+            detail: self.detail(),
             hint: self.hint(),
             position: self.position(),
         }

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -721,7 +721,7 @@ where
                     if !limit.return_at_limit {
                         err = err.concat(&Collection::new(over_limit).map(move |_data| {
                             DataflowError::EvalError(Box::new(EvalError::LetRecLimitExceeded(
-                                format!("{}", limit.max_iters.get()),
+                                format!("{}", limit.max_iters.get()).into(),
                             )))
                         }));
                     }

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -442,7 +442,7 @@ where
                                 requested = input.len(),
                             ),
                         );
-                        output.push((EvalError::Internal(message.to_string()).into(), 1));
+                        output.push((EvalError::Internal(message.into()).into(), 1));
                         return;
                     }
 
@@ -477,7 +477,7 @@ where
                             // This situation is not expected, so we log an error if it occurs.
                             let message = "Missing value for key in ReduceCollation";
                             error_logger.log(message, &format!("typ={typ:?}, key={key:?}"));
-                            output.push((EvalError::Internal(message.to_string()).into(), 1));
+                            output.push((EvalError::Internal(message.into()).into(), 1));
                             return;
                         }
                     }
@@ -488,7 +488,7 @@ where
                     {
                         let message = "Rows too large for key in ReduceCollation";
                         error_logger.log(message, &format!("key={key:?}"));
-                        output.push((EvalError::Internal(message.to_string()).into(), 1));
+                        output.push((EvalError::Internal(message.into()).into(), 1));
                     }
 
                     // Finally, if `mfp_after` can produce errors, then we should also report
@@ -592,7 +592,7 @@ where
                         }
                         let message = "Non-positive multiplicity in DistinctBy";
                         error_logger.log(message, &format!("row={key:?}, count={count}"));
-                        output.push((EvalError::Internal(message.to_string()).into(), 1));
+                        output.push((EvalError::Internal(message.into()).into(), 1));
                         return;
                     }
                     // If `mfp_after` can error, then evaluate it here.
@@ -762,7 +762,7 @@ where
             if validating {
                 let (oks, errs) = self
                     .build_reduce_inaccumulable_distinct::<_, _, RowValSpine<Result<(), String>, _, _>>(keyed, None)
-                    .as_collection(|k, v| (k.into_owned(), v.into_owned()))
+                    .as_collection(|k, v| (k.into_owned(), v.as_ref().map(|&()| ()).map_err(|m| m.as_str().into())))
                     .map_fallible::<CapacityContainerBuilder<_>, CapacityContainerBuilder<_>, _, _, _>("Demux Errors", move |(key_val, result)| match result {
                         Ok(()) => Ok(pairer.split(&key_val)),
                         Err(m) => Err(EvalError::Internal(m).into()),
@@ -887,7 +887,7 @@ where
                                     let message = "Non-positive accumulation in ReduceInaccumulable";
                                     error_logger
                                         .log(message, &format!("value={value:?}, count={count}"));
-                                    target.push((EvalError::Internal(message.to_string()).into(), 1));
+                                    target.push((EvalError::Internal(message.into()).into(), 1));
                                     return;
                                 }
                             }
@@ -1140,8 +1140,7 @@ where
                                     let message = "Non-positive accumulation in ReduceMinsMaxes";
                                     error_logger
                                         .log(message, &format!("val={val:?}, count={count}"));
-                                    target
-                                        .push((EvalError::Internal(message.to_string()).into(), 1));
+                                    target.push((EvalError::Internal(message.into()).into(), 1));
                                     return;
                                 }
                             }
@@ -1252,7 +1251,7 @@ where
                             "Invalid data in source, saw non-positive accumulation \
                                          for key {key:?} in hierarchical mins-maxes aggregate"
                         );
-                        Err(EvalError::Internal(message).into())
+                        Err(EvalError::Internal(message.into()).into())
                     }
                     Ok(values) => Ok((hash_key, values)),
                 },
@@ -1394,7 +1393,7 @@ where
                 "Non-monotonic input to ReduceMonotonic",
                 &format!("data={data:?}, diff={diff}"),
             );
-            let m = "tried to build a monotonic reduction on non-monotonic input".to_string();
+            let m = "tried to build a monotonic reduction on non-monotonic input".into();
             (EvalError::Internal(m).into(), 1)
         });
         // We can place our rows directly into the diff field, and
@@ -1635,7 +1634,7 @@ where
                                 "Invalid data in source, saw net-zero records for key {key} \
                                  with non-zero accumulation in accumulable aggregate"
                             );
-                            output.push((EvalError::Internal(message).into(), 1));
+                            output.push((EvalError::Internal(message.into()).into(), 1));
                         }
                         match (&aggr.func, &accum) {
                             (AggregateFunc::SumUInt16, Accum::SimpleNumber { accum, .. })
@@ -1651,7 +1650,7 @@ where
                                         "Invalid data in source, saw negative accumulation with \
                                          unsigned type for key {key}"
                                     );
-                                    output.push((EvalError::Internal(message).into(), 1));
+                                    output.push((EvalError::Internal(message.into()).into(), 1));
                                 }
                             }
                             _ => (), // no more errors to check for at this point!

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -107,10 +107,10 @@ where
                         idx += skip + 1;
                         if datum.is_null() {
                             return Err(DataflowError::EvalError(Box::new(
-                                EvalError::MustNotBeNull(format!(
-                                    "column {}",
-                                    from_desc.get_name(i).as_str().quoted()
-                                )),
+                                EvalError::MustNotBeNull(
+                                    format!("column {}", from_desc.get_name(i).as_str().quoted())
+                                        .into(),
+                                ),
                             )));
                         }
                     }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -151,7 +151,7 @@ where
                             "Non-monotonic input to MonotonicTopK",
                             &format!("data={data:?}, diff={diff}"),
                         );
-                        let m = "tried to build monotonic top-k on non-monotonic input".to_string();
+                        let m = "tried to build monotonic top-k on non-monotonic input".into();
                         (DataflowError::from(EvalError::Internal(m)), 1)
                     });
                     err_collection = err_collection.concat(&errs);
@@ -418,7 +418,7 @@ where
                         let k = SharedRow::pack(hk_iter);
                         let message = "Negative multiplicities in TopK";
                         error_logger.log(message, &format!("k={k:?}, h={h}, v={v:?}"));
-                        Err(EvalError::Internal(message.to_string()).into())
+                        Err(EvalError::Internal(message.into()).into())
                     }
                     Ok(t) => Ok((hk, t)),
                 },
@@ -476,7 +476,7 @@ where
                 "Non-monotonic input to MonotonicTop1",
                 &format!("data={data:?}, diff={diff}"),
             );
-            let m = "tried to build monotonic top-1 on non-monotonic input".to_string();
+            let m = "tried to build monotonic top-1 on non-monotonic input".into();
             (EvalError::Internal(m).into(), 1)
         });
         let partial: KeyCollection<_, _, _> = partial

--- a/src/expr-parser/src/parser.rs
+++ b/src/expr-parser/src/parser.rs
@@ -987,7 +987,7 @@ mod scalar {
             content.parse::<syn::LitStr>()?.value()
         };
         let err = if msg.starts_with("internal error: ") {
-            Ok(mz_expr::EvalError::Internal(msg.split_off(16)))
+            Ok(mz_expr::EvalError::Internal(msg.split_off(16).into()))
         } else {
             Err(Error::new(msg.span(), "expected `internal error: $msg`"))
         }?;

--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -288,7 +288,7 @@ impl<'a> ResultSpec<'a> {
             // Since we only care about whether / not an error is possible, and not the specific
             // error, create an arbitrary error here.
             // NOTE! This assumes that functions do not discriminate on the type of the error.
-            let map_err = result_map(Err(EvalError::Internal(String::new())));
+            let map_err = result_map(Err(EvalError::Internal("".into())));
             let raise_err = ResultSpec::fails();
             // SQL has a very loose notion of evaluation order: https://www.postgresql.org/docs/current/sql-expressions.html#SYNTAX-EXPRESS-EVAL
             // Here, we account for the possibility that the expression is evaluated strictly,
@@ -819,7 +819,7 @@ impl<'a> ColumnSpecs<'a> {
     /// [Self::set_literal] is called on the resulting expression to give it a meaningful value
     /// before evaluating.
     fn placeholder(col_type: ColumnType) -> MirScalarExpr {
-        MirScalarExpr::Literal(Err(EvalError::Internal("".to_owned())), col_type)
+        MirScalarExpr::Literal(Err(EvalError::Internal("".into())), col_type)
     }
 }
 

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -2943,7 +2943,7 @@ where
 {
     if step == N::zero() {
         return Err(EvalError::InvalidParameterValue(
-            "step size cannot equal zero".to_owned(),
+            "step size cannot equal zero".into(),
         ));
     }
     Ok(num::range_step_inclusive(start, stop, step)
@@ -3000,7 +3000,7 @@ fn generate_series_ts<T: TimestampLike>(
     let normalized_step = step.as_microseconds();
     if normalized_step == 0 {
         return Err(EvalError::InvalidParameterValue(
-            "step size cannot equal zero".to_owned(),
+            "step size cannot equal zero".into(),
         ));
     }
     let rev = normalized_step < 0;
@@ -3027,17 +3027,16 @@ fn generate_subscripts_array(
     match a.unwrap_array().dims().into_iter().nth(
         (dim - 1)
             .try_into()
-            .map_err(|_| EvalError::Int32OutOfRange((dim - 1).to_string()))?,
+            .map_err(|_| EvalError::Int32OutOfRange((dim - 1).to_string().into()))?,
     ) {
         Some(requested_dim) => Ok(Box::new(generate_series::<i32>(
-            requested_dim
-                .lower_bound
-                .try_into()
-                .map_err(|_| EvalError::Int32OutOfRange(requested_dim.lower_bound.to_string()))?,
+            requested_dim.lower_bound.try_into().map_err(|_| {
+                EvalError::Int32OutOfRange(requested_dim.lower_bound.to_string().into())
+            })?,
             requested_dim
                 .length
                 .try_into()
-                .map_err(|_| EvalError::Int32OutOfRange(requested_dim.length.to_string()))?,
+                .map_err(|_| EvalError::Int32OutOfRange(requested_dim.length.to_string().into()))?,
             1,
         )?)),
         None => Ok(Box::new(iter::empty())),

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -861,7 +861,7 @@ impl MirScalarExpr {
                                     expr: Box::new(expr2.take()),
                                 },
                                 Err(_) => MirScalarExpr::literal(
-                                    Err(EvalError::UnknownUnits(units.to_owned())),
+                                    Err(EvalError::UnknownUnits(units.into())),
                                     e.typ(column_types).scalar_type,
                                 ),
                             }
@@ -873,7 +873,7 @@ impl MirScalarExpr {
                                     expr: Box::new(expr2.take()),
                                 },
                                 Err(_) => MirScalarExpr::literal(
-                                    Err(EvalError::UnknownUnits(units.to_owned())),
+                                    Err(EvalError::UnknownUnits(units.into())),
                                     e.typ(column_types).scalar_type,
                                 ),
                             }
@@ -887,7 +887,7 @@ impl MirScalarExpr {
                                     expr: Box::new(expr2.take()),
                                 },
                                 Err(_) => MirScalarExpr::literal(
-                                    Err(EvalError::UnknownUnits(units.to_owned())),
+                                    Err(EvalError::UnknownUnits(units.into())),
                                     e.typ(column_types).scalar_type,
                                 ),
                             }
@@ -901,7 +901,7 @@ impl MirScalarExpr {
                                     expr: Box::new(expr2.take()),
                                 },
                                 Err(_) => MirScalarExpr::literal(
-                                    Err(EvalError::UnknownUnits(units.to_owned())),
+                                    Err(EvalError::UnknownUnits(units.into())),
                                     e.typ(column_types).scalar_type,
                                 ),
                             }
@@ -913,7 +913,7 @@ impl MirScalarExpr {
                                     expr: Box::new(expr2.take()),
                                 },
                                 Err(_) => MirScalarExpr::literal(
-                                    Err(EvalError::UnknownUnits(units.to_owned())),
+                                    Err(EvalError::UnknownUnits(units.into())),
                                     e.typ(column_types).scalar_type,
                                 ),
                             }
@@ -927,7 +927,7 @@ impl MirScalarExpr {
                                     expr: Box::new(expr2.take()),
                                 },
                                 Err(_) => MirScalarExpr::literal(
-                                    Err(EvalError::UnknownUnits(units.to_owned())),
+                                    Err(EvalError::UnknownUnits(units.into())),
                                     e.typ(column_types).scalar_type,
                                 ),
                             }
@@ -939,7 +939,7 @@ impl MirScalarExpr {
                                     expr: Box::new(expr2.take()),
                                 },
                                 Err(_) => MirScalarExpr::literal(
-                                    Err(EvalError::UnknownUnits(units.to_owned())),
+                                    Err(EvalError::UnknownUnits(units.into())),
                                     e.typ(column_types).scalar_type,
                                 ),
                             }
@@ -953,7 +953,7 @@ impl MirScalarExpr {
                                     expr: Box::new(expr2.take()),
                                 },
                                 Err(_) => MirScalarExpr::literal(
-                                    Err(EvalError::UnknownUnits(units.to_owned())),
+                                    Err(EvalError::UnknownUnits(units.into())),
                                     e.typ(column_types).scalar_type,
                                 ),
                             }
@@ -967,7 +967,7 @@ impl MirScalarExpr {
                                     expr: Box::new(expr2.take()),
                                 },
                                 Err(_) => MirScalarExpr::literal(
-                                    Err(EvalError::UnknownUnits(units.to_owned())),
+                                    Err(EvalError::UnknownUnits(units.into())),
                                     e.typ(column_types).scalar_type,
                                 ),
                             }
@@ -981,7 +981,7 @@ impl MirScalarExpr {
                                     expr: Box::new(expr2.take()),
                                 },
                                 Err(_) => MirScalarExpr::literal(
-                                    Err(EvalError::UnknownUnits(units.to_owned())),
+                                    Err(EvalError::UnknownUnits(units.into())),
                                     e.typ(column_types).scalar_type,
                                 ),
                             }
@@ -995,7 +995,7 @@ impl MirScalarExpr {
                                     expr: Box::new(expr2.take()),
                                 },
                                 Err(_) => MirScalarExpr::literal(
-                                    Err(EvalError::UnknownUnits(units.to_owned())),
+                                    Err(EvalError::UnknownUnits(units.into())),
                                     e.typ(column_types).scalar_type,
                                 ),
                             }
@@ -1893,10 +1893,9 @@ impl MirScalarExpr {
             // Unmaterializable functions must be transformed away before
             // evaluation. Their purpose is as a placeholder for data that is
             // not known at plan time but can be inlined before runtime.
-            MirScalarExpr::CallUnmaterializable(x) => Err(EvalError::Internal(format!(
-                "cannot evaluate unmaterializable function: {:?}",
-                x
-            ))),
+            MirScalarExpr::CallUnmaterializable(x) => Err(EvalError::Internal(
+                format!("cannot evaluate unmaterializable function: {:?}", x).into(),
+            )),
             MirScalarExpr::CallUnary { func, expr } => func.eval(datums, temp_storage, expr),
             MirScalarExpr::CallBinary { func, expr1, expr2 } => {
                 func.eval(datums, temp_storage, expr1, expr2)
@@ -1905,10 +1904,9 @@ impl MirScalarExpr {
             MirScalarExpr::If { cond, then, els } => match cond.eval(datums, temp_storage)? {
                 Datum::True => then.eval(datums, temp_storage),
                 Datum::False | Datum::Null => els.eval(datums, temp_storage),
-                d => Err(EvalError::Internal(format!(
-                    "if condition evaluated to non-boolean datum: {:?}",
-                    d
-                ))),
+                d => Err(EvalError::Internal(
+                    format!("if condition evaluated to non-boolean datum: {:?}", d).into(),
+                )),
             },
         }
     }
@@ -2420,27 +2418,27 @@ impl RustType<ProtoDomainLimit> for DomainLimit {
 pub enum EvalError {
     CharacterNotValidForEncoding(i32),
     CharacterTooLargeForEncoding(i32),
-    DateBinOutOfRange(String),
+    DateBinOutOfRange(Box<str>),
     DivisionByZero,
     Unsupported {
-        feature: String,
+        feature: Box<str>,
         discussion_no: Option<usize>,
     },
     FloatOverflow,
     FloatUnderflow,
     NumericFieldOverflow,
-    Float32OutOfRange(String),
-    Float64OutOfRange(String),
-    Int16OutOfRange(String),
-    Int32OutOfRange(String),
-    Int64OutOfRange(String),
-    UInt16OutOfRange(String),
-    UInt32OutOfRange(String),
-    UInt64OutOfRange(String),
-    MzTimestampOutOfRange(String),
+    Float32OutOfRange(Box<str>),
+    Float64OutOfRange(Box<str>),
+    Int16OutOfRange(Box<str>),
+    Int32OutOfRange(Box<str>),
+    Int64OutOfRange(Box<str>),
+    UInt16OutOfRange(Box<str>),
+    UInt32OutOfRange(Box<str>),
+    UInt64OutOfRange(Box<str>),
+    MzTimestampOutOfRange(Box<str>),
     MzTimestampStepOverflow,
-    OidOutOfRange(String),
-    IntervalOutOfRange(String),
+    OidOutOfRange(Box<str>),
+    IntervalOutOfRange(Box<str>),
     TimestampCannotBeNan,
     TimestampOutOfRange,
     DateOutOfRange,
@@ -2453,82 +2451,82 @@ pub enum EvalError {
     InvalidBase64Equals,
     InvalidBase64Symbol(char),
     InvalidBase64EndSequence,
-    InvalidTimezone(String),
+    InvalidTimezone(Box<str>),
     InvalidTimezoneInterval,
     InvalidTimezoneConversion,
-    InvalidIanaTimezoneId(String),
+    InvalidIanaTimezoneId(Box<str>),
     InvalidLayer {
         max_layer: usize,
         val: i64,
     },
     InvalidArray(InvalidArrayError),
-    InvalidEncodingName(String),
-    InvalidHashAlgorithm(String),
+    InvalidEncodingName(Box<str>),
+    InvalidHashAlgorithm(Box<str>),
     InvalidByteSequence {
-        byte_sequence: String,
-        encoding_name: String,
+        byte_sequence: Box<str>,
+        encoding_name: Box<str>,
     },
     InvalidJsonbCast {
-        from: String,
-        to: String,
+        from: Box<str>,
+        to: Box<str>,
     },
-    InvalidRegex(String),
+    InvalidRegex(Box<str>),
     InvalidRegexFlag(char),
-    InvalidParameterValue(String),
-    InvalidDatePart(String),
+    InvalidParameterValue(Box<str>),
+    InvalidDatePart(Box<str>),
     KeyCannotBeNull,
     NegSqrt,
     NegLimit,
     NullCharacterNotPermitted,
-    UnknownUnits(String),
-    UnsupportedUnits(String, String),
+    UnknownUnits(Box<str>),
+    UnsupportedUnits(Box<str>, Box<str>),
     UnterminatedLikeEscapeSequence,
     Parse(ParseError),
     ParseHex(ParseHexError),
-    Internal(String),
-    InfinityOutOfDomain(String),
-    NegativeOutOfDomain(String),
-    ZeroOutOfDomain(String),
-    OutOfDomain(DomainLimit, DomainLimit, String),
-    ComplexOutOfRange(String),
+    Internal(Box<str>),
+    InfinityOutOfDomain(Box<str>),
+    NegativeOutOfDomain(Box<str>),
+    ZeroOutOfDomain(Box<str>),
+    OutOfDomain(DomainLimit, DomainLimit, Box<str>),
+    ComplexOutOfRange(Box<str>),
     MultipleRowsFromSubquery,
-    Undefined(String),
+    Undefined(Box<str>),
     LikePatternTooLong,
     LikeEscapeTooLong,
     StringValueTooLong {
-        target_type: String,
+        target_type: Box<str>,
         length: usize,
     },
     MultidimensionalArrayRemovalNotSupported,
     IncompatibleArrayDimensions {
         dims: Option<(usize, usize)>,
     },
-    TypeFromOid(String),
+    TypeFromOid(Box<str>),
     InvalidRange(InvalidRangeError),
-    InvalidRoleId(String),
-    InvalidPrivileges(String),
-    LetRecLimitExceeded(String),
+    InvalidRoleId(Box<str>),
+    InvalidPrivileges(Box<str>),
+    LetRecLimitExceeded(Box<str>),
     MultiDimensionalArraySearch,
-    MustNotBeNull(String),
+    MustNotBeNull(Box<str>),
     InvalidIdentifier {
-        ident: String,
-        detail: Option<String>,
+        ident: Box<str>,
+        detail: Option<Box<str>>,
     },
     ArrayFillWrongArraySubscripts,
     // TODO: propagate this check more widely throughout the expr crate
     MaxArraySizeExceeded(usize),
     DateDiffOverflow {
-        unit: String,
-        a: String,
-        b: String,
+        unit: Box<str>,
+        a: Box<str>,
+        b: Box<str>,
     },
     // The error for ErrorIfNull; this should not be used in other contexts as a generic error
     // printer.
-    IfNullError(String),
+    IfNullError(Box<str>),
     LengthTooLarge,
     AclArrayNullElement,
     MzAclArrayNullElement,
-    PrettyError(String),
+    PrettyError(Box<str>),
 }
 
 impl fmt::Display for EvalError {
@@ -2738,8 +2736,7 @@ impl EvalError {
     pub fn detail(&self) -> Option<String> {
         match self {
             EvalError::IncompatibleArrayDimensions { dims: None } => Some(
-                "Arrays with differing dimensions are not compatible for concatenation."
-                    .to_string(),
+                "Arrays with differing dimensions are not compatible for concatenation.".into(),
             ),
             EvalError::IncompatibleArrayDimensions {
                 dims: Some((a_dims, b_dims)),
@@ -2747,9 +2744,9 @@ impl EvalError {
                 "Arrays of {} and {} dimensions are not compatible for concatenation.",
                 a_dims, b_dims
             )),
-            EvalError::InvalidIdentifier { detail, .. } => detail.clone(),
+            EvalError::InvalidIdentifier { detail, .. } => detail.as_deref().map(Into::into),
             EvalError::ArrayFillWrongArraySubscripts => {
-                Some("Low bound array has different size than dimensions array.".to_string())
+                Some("Low bound array has different size than dimensions array.".into())
             }
             _ => None,
         }
@@ -2796,13 +2793,13 @@ impl From<InvalidArrayError> for EvalError {
 
 impl From<regex::Error> for EvalError {
     fn from(e: regex::Error) -> EvalError {
-        EvalError::InvalidRegex(e.to_string())
+        EvalError::InvalidRegex(e.to_string().into())
     }
 }
 
 impl From<TypeFromOidError> for EvalError {
     fn from(e: TypeFromOidError) -> EvalError {
-        EvalError::TypeFromOid(e.to_string())
+        EvalError::TypeFromOid(e.to_string().into())
     }
 }
 
@@ -2835,13 +2832,13 @@ impl RustType<ProtoEvalError> for EvalError {
         let kind = match self {
             EvalError::CharacterNotValidForEncoding(v) => CharacterNotValidForEncoding(*v),
             EvalError::CharacterTooLargeForEncoding(v) => CharacterTooLargeForEncoding(*v),
-            EvalError::DateBinOutOfRange(v) => DateBinOutOfRange(v.clone()),
+            EvalError::DateBinOutOfRange(v) => DateBinOutOfRange(v.into_proto()),
             EvalError::DivisionByZero => DivisionByZero(()),
             EvalError::Unsupported {
                 feature,
                 discussion_no,
             } => Unsupported(ProtoUnsupported {
-                feature: feature.clone(),
+                feature: feature.into_proto(),
                 discussion_no: discussion_no.into_proto(),
             }),
             EvalError::FloatOverflow => FloatOverflow(()),
@@ -2895,7 +2892,7 @@ impl RustType<ProtoEvalError> for EvalError {
             EvalError::InvalidBase64Equals => InvalidBase64Equals(()),
             EvalError::InvalidBase64Symbol(sym) => InvalidBase64Symbol(sym.into_proto()),
             EvalError::InvalidBase64EndSequence => InvalidBase64EndSequence(()),
-            EvalError::InvalidTimezone(tz) => InvalidTimezone(tz.clone()),
+            EvalError::InvalidTimezone(tz) => InvalidTimezone(tz.into_proto()),
             EvalError::InvalidTimezoneInterval => InvalidTimezoneInterval(()),
             EvalError::InvalidTimezoneConversion => InvalidTimezoneConversion(()),
             EvalError::InvalidLayer { max_layer, val } => InvalidLayer(ProtoInvalidLayer {
@@ -2903,55 +2900,55 @@ impl RustType<ProtoEvalError> for EvalError {
                 val: *val,
             }),
             EvalError::InvalidArray(error) => InvalidArray(error.into_proto()),
-            EvalError::InvalidEncodingName(v) => InvalidEncodingName(v.clone()),
-            EvalError::InvalidHashAlgorithm(v) => InvalidHashAlgorithm(v.clone()),
+            EvalError::InvalidEncodingName(v) => InvalidEncodingName(v.into_proto()),
+            EvalError::InvalidHashAlgorithm(v) => InvalidHashAlgorithm(v.into_proto()),
             EvalError::InvalidByteSequence {
                 byte_sequence,
                 encoding_name,
             } => InvalidByteSequence(ProtoInvalidByteSequence {
-                byte_sequence: byte_sequence.clone(),
-                encoding_name: encoding_name.clone(),
+                byte_sequence: byte_sequence.into_proto(),
+                encoding_name: encoding_name.into_proto(),
             }),
             EvalError::InvalidJsonbCast { from, to } => InvalidJsonbCast(ProtoInvalidJsonbCast {
-                from: from.clone(),
-                to: to.clone(),
+                from: from.into_proto(),
+                to: to.into_proto(),
             }),
-            EvalError::InvalidRegex(v) => InvalidRegex(v.clone()),
+            EvalError::InvalidRegex(v) => InvalidRegex(v.into_proto()),
             EvalError::InvalidRegexFlag(v) => InvalidRegexFlag(v.into_proto()),
-            EvalError::InvalidParameterValue(v) => InvalidParameterValue(v.clone()),
-            EvalError::InvalidDatePart(part) => InvalidDatePart(part.to_string()),
+            EvalError::InvalidParameterValue(v) => InvalidParameterValue(v.into_proto()),
+            EvalError::InvalidDatePart(part) => InvalidDatePart(part.into_proto()),
             EvalError::KeyCannotBeNull => KeyCannotBeNull(()),
             EvalError::NegSqrt => NegSqrt(()),
             EvalError::NegLimit => NegLimit(()),
             EvalError::NullCharacterNotPermitted => NullCharacterNotPermitted(()),
-            EvalError::UnknownUnits(v) => UnknownUnits(v.clone()),
+            EvalError::UnknownUnits(v) => UnknownUnits(v.into_proto()),
             EvalError::UnsupportedUnits(units, typ) => UnsupportedUnits(ProtoUnsupportedUnits {
-                units: units.clone(),
-                typ: typ.clone(),
+                units: units.into_proto(),
+                typ: typ.into_proto(),
             }),
             EvalError::UnterminatedLikeEscapeSequence => UnterminatedLikeEscapeSequence(()),
             EvalError::Parse(error) => Parse(error.into_proto()),
             EvalError::PrettyError(error) => PrettyError(error.into_proto()),
             EvalError::ParseHex(error) => ParseHex(error.into_proto()),
-            EvalError::Internal(v) => Internal(v.clone()),
-            EvalError::InfinityOutOfDomain(v) => InfinityOutOfDomain(v.clone()),
-            EvalError::NegativeOutOfDomain(v) => NegativeOutOfDomain(v.clone()),
-            EvalError::ZeroOutOfDomain(v) => ZeroOutOfDomain(v.clone()),
+            EvalError::Internal(v) => Internal(v.into_proto()),
+            EvalError::InfinityOutOfDomain(v) => InfinityOutOfDomain(v.into_proto()),
+            EvalError::NegativeOutOfDomain(v) => NegativeOutOfDomain(v.into_proto()),
+            EvalError::ZeroOutOfDomain(v) => ZeroOutOfDomain(v.into_proto()),
             EvalError::OutOfDomain(lower, upper, id) => OutOfDomain(ProtoOutOfDomain {
                 lower: Some(lower.into_proto()),
                 upper: Some(upper.into_proto()),
-                id: id.clone(),
+                id: id.into_proto(),
             }),
-            EvalError::ComplexOutOfRange(v) => ComplexOutOfRange(v.clone()),
+            EvalError::ComplexOutOfRange(v) => ComplexOutOfRange(v.into_proto()),
             EvalError::MultipleRowsFromSubquery => MultipleRowsFromSubquery(()),
-            EvalError::Undefined(v) => Undefined(v.clone()),
+            EvalError::Undefined(v) => Undefined(v.into_proto()),
             EvalError::LikePatternTooLong => LikePatternTooLong(()),
             EvalError::LikeEscapeTooLong => LikeEscapeTooLong(()),
             EvalError::StringValueTooLong {
                 target_type,
                 length,
             } => StringValueTooLong(ProtoStringValueTooLong {
-                target_type: target_type.clone(),
+                target_type: target_type.into_proto(),
                 length: length.into_proto(),
             }),
             EvalError::MultidimensionalArrayRemovalNotSupported => {
@@ -2962,16 +2959,16 @@ impl RustType<ProtoEvalError> for EvalError {
                     dims: dims.into_proto(),
                 })
             }
-            EvalError::TypeFromOid(v) => TypeFromOid(v.clone()),
+            EvalError::TypeFromOid(v) => TypeFromOid(v.into_proto()),
             EvalError::InvalidRange(error) => InvalidRange(error.into_proto()),
-            EvalError::InvalidRoleId(v) => InvalidRoleId(v.clone()),
-            EvalError::InvalidPrivileges(v) => InvalidPrivileges(v.clone()),
-            EvalError::LetRecLimitExceeded(v) => WmrRecursionLimitExceeded(v.clone()),
+            EvalError::InvalidRoleId(v) => InvalidRoleId(v.into_proto()),
+            EvalError::InvalidPrivileges(v) => InvalidPrivileges(v.into_proto()),
+            EvalError::LetRecLimitExceeded(v) => WmrRecursionLimitExceeded(v.into_proto()),
             EvalError::MultiDimensionalArraySearch => MultiDimensionalArraySearch(()),
-            EvalError::MustNotBeNull(v) => MustNotBeNull(v.clone()),
+            EvalError::MustNotBeNull(v) => MustNotBeNull(v.into_proto()),
             EvalError::InvalidIdentifier { ident, detail } => {
                 InvalidIdentifier(ProtoInvalidIdentifier {
-                    ident: ident.clone(),
+                    ident: ident.into_proto(),
                     detail: detail.into_proto(),
                 })
             }
@@ -2980,15 +2977,15 @@ impl RustType<ProtoEvalError> for EvalError {
                 MaxArraySizeExceeded(u64::cast_from(*max_size))
             }
             EvalError::DateDiffOverflow { unit, a, b } => DateDiffOverflow(ProtoDateDiffOverflow {
-                unit: unit.to_owned(),
-                a: a.to_owned(),
-                b: b.to_owned(),
+                unit: unit.into_proto(),
+                a: a.into_proto(),
+                b: b.into_proto(),
             }),
-            EvalError::IfNullError(s) => IfNullError(s.clone()),
+            EvalError::IfNullError(s) => IfNullError(s.into_proto()),
             EvalError::LengthTooLarge => LengthTooLarge(()),
             EvalError::AclArrayNullElement => AclArrayNullElement(()),
             EvalError::MzAclArrayNullElement => MzAclArrayNullElement(()),
-            EvalError::InvalidIanaTimezoneId(s) => InvalidIanaTimezoneId(s.clone()),
+            EvalError::InvalidIanaTimezoneId(s) => InvalidIanaTimezoneId(s.into_proto()),
         };
         ProtoEvalError { kind: Some(kind) }
     }
@@ -2999,27 +2996,29 @@ impl RustType<ProtoEvalError> for EvalError {
             Some(kind) => match kind {
                 CharacterNotValidForEncoding(v) => Ok(EvalError::CharacterNotValidForEncoding(v)),
                 CharacterTooLargeForEncoding(v) => Ok(EvalError::CharacterTooLargeForEncoding(v)),
-                DateBinOutOfRange(v) => Ok(EvalError::DateBinOutOfRange(v)),
+                DateBinOutOfRange(v) => Ok(EvalError::DateBinOutOfRange(v.into())),
                 DivisionByZero(()) => Ok(EvalError::DivisionByZero),
                 Unsupported(v) => Ok(EvalError::Unsupported {
-                    feature: v.feature,
+                    feature: v.feature.into(),
                     discussion_no: v.discussion_no.into_rust()?,
                 }),
                 FloatOverflow(()) => Ok(EvalError::FloatOverflow),
                 FloatUnderflow(()) => Ok(EvalError::FloatUnderflow),
                 NumericFieldOverflow(()) => Ok(EvalError::NumericFieldOverflow),
-                Float32OutOfRange(val) => Ok(EvalError::Float32OutOfRange(val.value)),
-                Float64OutOfRange(val) => Ok(EvalError::Float64OutOfRange(val.value)),
-                Int16OutOfRange(val) => Ok(EvalError::Int16OutOfRange(val.value)),
-                Int32OutOfRange(val) => Ok(EvalError::Int32OutOfRange(val.value)),
-                Int64OutOfRange(val) => Ok(EvalError::Int64OutOfRange(val.value)),
-                Uint16OutOfRange(val) => Ok(EvalError::UInt16OutOfRange(val.value)),
-                Uint32OutOfRange(val) => Ok(EvalError::UInt32OutOfRange(val.value)),
-                Uint64OutOfRange(val) => Ok(EvalError::UInt64OutOfRange(val.value)),
-                MzTimestampOutOfRange(val) => Ok(EvalError::MzTimestampOutOfRange(val.value)),
+                Float32OutOfRange(val) => Ok(EvalError::Float32OutOfRange(val.value.into())),
+                Float64OutOfRange(val) => Ok(EvalError::Float64OutOfRange(val.value.into())),
+                Int16OutOfRange(val) => Ok(EvalError::Int16OutOfRange(val.value.into())),
+                Int32OutOfRange(val) => Ok(EvalError::Int32OutOfRange(val.value.into())),
+                Int64OutOfRange(val) => Ok(EvalError::Int64OutOfRange(val.value.into())),
+                Uint16OutOfRange(val) => Ok(EvalError::UInt16OutOfRange(val.value.into())),
+                Uint32OutOfRange(val) => Ok(EvalError::UInt32OutOfRange(val.value.into())),
+                Uint64OutOfRange(val) => Ok(EvalError::UInt64OutOfRange(val.value.into())),
+                MzTimestampOutOfRange(val) => {
+                    Ok(EvalError::MzTimestampOutOfRange(val.value.into()))
+                }
                 MzTimestampStepOverflow(()) => Ok(EvalError::MzTimestampStepOverflow),
-                OidOutOfRange(val) => Ok(EvalError::OidOutOfRange(val.value)),
-                IntervalOutOfRange(val) => Ok(EvalError::IntervalOutOfRange(val.value)),
+                OidOutOfRange(val) => Ok(EvalError::OidOutOfRange(val.value.into())),
+                IntervalOutOfRange(val) => Ok(EvalError::IntervalOutOfRange(val.value.into())),
                 TimestampCannotBeNan(()) => Ok(EvalError::TimestampCannotBeNan),
                 TimestampOutOfRange(()) => Ok(EvalError::TimestampOutOfRange),
                 DateOutOfRange(()) => Ok(EvalError::DateOutOfRange),
@@ -3031,7 +3030,7 @@ impl RustType<ProtoEvalError> for EvalError {
                 InvalidBase64Equals(()) => Ok(EvalError::InvalidBase64Equals),
                 InvalidBase64Symbol(v) => char::from_proto(v).map(EvalError::InvalidBase64Symbol),
                 InvalidBase64EndSequence(()) => Ok(EvalError::InvalidBase64EndSequence),
-                InvalidTimezone(v) => Ok(EvalError::InvalidTimezone(v)),
+                InvalidTimezone(v) => Ok(EvalError::InvalidTimezone(v.into())),
                 InvalidTimezoneInterval(()) => Ok(EvalError::InvalidTimezoneInterval),
                 InvalidTimezoneConversion(()) => Ok(EvalError::InvalidTimezoneConversion),
                 InvalidLayer(v) => Ok(EvalError::InvalidLayer {
@@ -3039,45 +3038,47 @@ impl RustType<ProtoEvalError> for EvalError {
                     val: v.val,
                 }),
                 InvalidArray(error) => Ok(EvalError::InvalidArray(error.into_rust()?)),
-                InvalidEncodingName(v) => Ok(EvalError::InvalidEncodingName(v)),
-                InvalidHashAlgorithm(v) => Ok(EvalError::InvalidHashAlgorithm(v)),
+                InvalidEncodingName(v) => Ok(EvalError::InvalidEncodingName(v.into())),
+                InvalidHashAlgorithm(v) => Ok(EvalError::InvalidHashAlgorithm(v.into())),
                 InvalidByteSequence(v) => Ok(EvalError::InvalidByteSequence {
-                    byte_sequence: v.byte_sequence,
-                    encoding_name: v.encoding_name,
+                    byte_sequence: v.byte_sequence.into(),
+                    encoding_name: v.encoding_name.into(),
                 }),
                 InvalidJsonbCast(v) => Ok(EvalError::InvalidJsonbCast {
-                    from: v.from,
-                    to: v.to,
+                    from: v.from.into(),
+                    to: v.to.into(),
                 }),
-                InvalidRegex(v) => Ok(EvalError::InvalidRegex(v)),
+                InvalidRegex(v) => Ok(EvalError::InvalidRegex(v.into())),
                 InvalidRegexFlag(v) => Ok(EvalError::InvalidRegexFlag(char::from_proto(v)?)),
-                InvalidParameterValue(v) => Ok(EvalError::InvalidParameterValue(v)),
-                InvalidDatePart(part) => Ok(EvalError::InvalidDatePart(part)),
+                InvalidParameterValue(v) => Ok(EvalError::InvalidParameterValue(v.into())),
+                InvalidDatePart(part) => Ok(EvalError::InvalidDatePart(part.into())),
                 KeyCannotBeNull(()) => Ok(EvalError::KeyCannotBeNull),
                 NegSqrt(()) => Ok(EvalError::NegSqrt),
                 NegLimit(()) => Ok(EvalError::NegLimit),
                 NullCharacterNotPermitted(()) => Ok(EvalError::NullCharacterNotPermitted),
-                UnknownUnits(v) => Ok(EvalError::UnknownUnits(v)),
-                UnsupportedUnits(v) => Ok(EvalError::UnsupportedUnits(v.units, v.typ)),
+                UnknownUnits(v) => Ok(EvalError::UnknownUnits(v.into())),
+                UnsupportedUnits(v) => {
+                    Ok(EvalError::UnsupportedUnits(v.units.into(), v.typ.into()))
+                }
                 UnterminatedLikeEscapeSequence(()) => Ok(EvalError::UnterminatedLikeEscapeSequence),
                 Parse(error) => Ok(EvalError::Parse(error.into_rust()?)),
                 ParseHex(error) => Ok(EvalError::ParseHex(error.into_rust()?)),
-                Internal(v) => Ok(EvalError::Internal(v)),
-                InfinityOutOfDomain(v) => Ok(EvalError::InfinityOutOfDomain(v)),
-                NegativeOutOfDomain(v) => Ok(EvalError::NegativeOutOfDomain(v)),
-                ZeroOutOfDomain(v) => Ok(EvalError::ZeroOutOfDomain(v)),
+                Internal(v) => Ok(EvalError::Internal(v.into())),
+                InfinityOutOfDomain(v) => Ok(EvalError::InfinityOutOfDomain(v.into())),
+                NegativeOutOfDomain(v) => Ok(EvalError::NegativeOutOfDomain(v.into())),
+                ZeroOutOfDomain(v) => Ok(EvalError::ZeroOutOfDomain(v.into())),
                 OutOfDomain(v) => Ok(EvalError::OutOfDomain(
                     v.lower.into_rust_if_some("ProtoDomainLimit::lower")?,
                     v.upper.into_rust_if_some("ProtoDomainLimit::upper")?,
-                    v.id,
+                    v.id.into(),
                 )),
-                ComplexOutOfRange(v) => Ok(EvalError::ComplexOutOfRange(v)),
+                ComplexOutOfRange(v) => Ok(EvalError::ComplexOutOfRange(v.into())),
                 MultipleRowsFromSubquery(()) => Ok(EvalError::MultipleRowsFromSubquery),
-                Undefined(v) => Ok(EvalError::Undefined(v)),
+                Undefined(v) => Ok(EvalError::Undefined(v.into())),
                 LikePatternTooLong(()) => Ok(EvalError::LikePatternTooLong),
                 LikeEscapeTooLong(()) => Ok(EvalError::LikeEscapeTooLong),
                 StringValueTooLong(v) => Ok(EvalError::StringValueTooLong {
-                    target_type: v.target_type,
+                    target_type: v.target_type.into(),
                     length: usize::from_proto(v.length)?,
                 }),
                 MultidimensionalArrayRemovalNotSupported(()) => {
@@ -3086,32 +3087,32 @@ impl RustType<ProtoEvalError> for EvalError {
                 IncompatibleArrayDimensions(v) => Ok(EvalError::IncompatibleArrayDimensions {
                     dims: v.dims.into_rust()?,
                 }),
-                TypeFromOid(v) => Ok(EvalError::TypeFromOid(v)),
+                TypeFromOid(v) => Ok(EvalError::TypeFromOid(v.into())),
                 InvalidRange(e) => Ok(EvalError::InvalidRange(e.into_rust()?)),
-                InvalidRoleId(v) => Ok(EvalError::InvalidRoleId(v)),
-                InvalidPrivileges(v) => Ok(EvalError::InvalidPrivileges(v)),
-                WmrRecursionLimitExceeded(v) => Ok(EvalError::LetRecLimitExceeded(v)),
+                InvalidRoleId(v) => Ok(EvalError::InvalidRoleId(v.into())),
+                InvalidPrivileges(v) => Ok(EvalError::InvalidPrivileges(v.into())),
+                WmrRecursionLimitExceeded(v) => Ok(EvalError::LetRecLimitExceeded(v.into())),
                 MultiDimensionalArraySearch(()) => Ok(EvalError::MultiDimensionalArraySearch),
-                MustNotBeNull(v) => Ok(EvalError::MustNotBeNull(v)),
+                MustNotBeNull(v) => Ok(EvalError::MustNotBeNull(v.into())),
                 InvalidIdentifier(v) => Ok(EvalError::InvalidIdentifier {
-                    ident: v.ident,
-                    detail: v.detail,
+                    ident: v.ident.into(),
+                    detail: v.detail.into_rust()?,
                 }),
                 ArrayFillWrongArraySubscripts(()) => Ok(EvalError::ArrayFillWrongArraySubscripts),
                 MaxArraySizeExceeded(max_size) => {
                     Ok(EvalError::MaxArraySizeExceeded(usize::cast_from(max_size)))
                 }
                 DateDiffOverflow(v) => Ok(EvalError::DateDiffOverflow {
-                    unit: v.unit,
-                    a: v.a,
-                    b: v.b,
+                    unit: v.unit.into(),
+                    a: v.a.into(),
+                    b: v.b.into(),
                 }),
-                IfNullError(v) => Ok(EvalError::IfNullError(v)),
+                IfNullError(v) => Ok(EvalError::IfNullError(v.into())),
                 LengthTooLarge(()) => Ok(EvalError::LengthTooLarge),
                 AclArrayNullElement(()) => Ok(EvalError::AclArrayNullElement),
                 MzAclArrayNullElement(()) => Ok(EvalError::MzAclArrayNullElement),
-                InvalidIanaTimezoneId(s) => Ok(EvalError::InvalidIanaTimezoneId(s)),
-                PrettyError(s) => Ok(EvalError::PrettyError(s)),
+                InvalidIanaTimezoneId(s) => Ok(EvalError::InvalidIanaTimezoneId(s.into())),
+                PrettyError(s) => Ok(EvalError::PrettyError(s.into())),
             },
             None => Err(TryFromProtoError::missing_field("ProtoEvalError::kind")),
         }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -333,21 +333,21 @@ fn add_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 fn add_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint16()
         .checked_add(b.unwrap_uint16())
-        .ok_or(EvalError::UInt16OutOfRange(format!("{a} + {b}")))
+        .ok_or(EvalError::UInt16OutOfRange(format!("{a} + {b}").into()))
         .map(Datum::from)
 }
 
 fn add_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint32()
         .checked_add(b.unwrap_uint32())
-        .ok_or(EvalError::UInt32OutOfRange(format!("{a} + {b}")))
+        .ok_or(EvalError::UInt32OutOfRange(format!("{a} + {b}").into()))
         .map(Datum::from)
 }
 
 fn add_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint64()
         .checked_add(b.unwrap_uint64())
-        .ok_or(EvalError::UInt64OutOfRange(format!("{a} + {b}")))
+        .ok_or(EvalError::UInt64OutOfRange(format!("{a} + {b}").into()))
         .map(Datum::from)
 }
 
@@ -481,7 +481,11 @@ fn convert_from<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
     // [1]: https://www.postgresql.org/docs/9.5/multibyte.html
     // [2]: https://encoding.spec.whatwg.org/
     // [3]: https://github.com/lifthrasiir/rust-encoding/blob/4e79c35ab6a351881a86dbff565c4db0085cc113/src/label.rs
-    let encoding_name = b.unwrap_str().to_lowercase().replace('_', "-");
+    let encoding_name = b
+        .unwrap_str()
+        .to_lowercase()
+        .replace('_', "-")
+        .into_boxed_str();
 
     // Supporting other encodings is tracked by database-issues#797.
     if encoding_from_whatwg_label(&encoding_name).map(|e| e.name()) != Some("utf-8") {
@@ -491,7 +495,7 @@ fn convert_from<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
     match str::from_utf8(a.unwrap_bytes()) {
         Ok(from) => Ok(Datum::String(from)),
         Err(e) => Err(EvalError::InvalidByteSequence {
-            byte_sequence: e.to_string(),
+            byte_sequence: e.to_string().into(),
             encoding_name,
         }),
     }
@@ -523,7 +527,11 @@ fn encoded_bytes_char_length<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>
     // [1]: https://www.postgresql.org/docs/9.5/multibyte.html
     // [2]: https://encoding.spec.whatwg.org/
     // [3]: https://github.com/lifthrasiir/rust-encoding/blob/4e79c35ab6a351881a86dbff565c4db0085cc113/src/label.rs
-    let encoding_name = b.unwrap_str().to_lowercase().replace('_', "-");
+    let encoding_name = b
+        .unwrap_str()
+        .to_lowercase()
+        .replace('_', "-")
+        .into_boxed_str();
 
     let enc = match encoding_from_whatwg_label(&encoding_name) {
         Some(enc) => enc,
@@ -534,7 +542,7 @@ fn encoded_bytes_char_length<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>
         Ok(s) => s,
         Err(e) => {
             return Err(EvalError::InvalidByteSequence {
-                byte_sequence: e.to_string(),
+                byte_sequence: e.into(),
                 encoding_name,
             })
         }
@@ -543,7 +551,7 @@ fn encoded_bytes_char_length<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>
     let count = decoded_string.chars().count();
     match i32::try_from(count) {
         Ok(l) => Ok(Datum::from(l)),
-        Err(_) => Err(EvalError::Int32OutOfRange(count.to_string())),
+        Err(_) => Err(EvalError::Int32OutOfRange(count.to_string().into())),
     }
 }
 
@@ -612,7 +620,7 @@ fn add_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 fn add_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_interval()
         .checked_add(&b.unwrap_interval())
-        .ok_or(EvalError::IntervalOutOfRange(format!("{a} + {b}")))
+        .ok_or(EvalError::IntervalOutOfRange(format!("{a} + {b}").into()))
         .map(Datum::from)
 }
 
@@ -812,21 +820,21 @@ fn sub_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 fn sub_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint16()
         .checked_sub(b.unwrap_uint16())
-        .ok_or(EvalError::UInt16OutOfRange(format!("{a} - {b}")))
+        .ok_or(EvalError::UInt16OutOfRange(format!("{a} - {b}").into()))
         .map(Datum::from)
 }
 
 fn sub_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint32()
         .checked_sub(b.unwrap_uint32())
-        .ok_or(EvalError::UInt32OutOfRange(format!("{a} - {b}")))
+        .ok_or(EvalError::UInt32OutOfRange(format!("{a} - {b}").into()))
         .map(Datum::from)
 }
 
 fn sub_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint64()
         .checked_sub(b.unwrap_uint64())
-        .ok_or(EvalError::UInt64OutOfRange(format!("{a} - {b}")))
+        .ok_or(EvalError::UInt64OutOfRange(format!("{a} - {b}").into()))
         .map(Datum::from)
 }
 
@@ -899,7 +907,7 @@ fn sub_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
     b.unwrap_interval()
         .checked_neg()
         .and_then(|b| b.checked_add(&a.unwrap_interval()))
-        .ok_or(EvalError::IntervalOutOfRange(format!("{a} - {b}")))
+        .ok_or(EvalError::IntervalOutOfRange(format!("{a} - {b}").into()))
         .map(Datum::from)
 }
 
@@ -911,7 +919,9 @@ fn sub_date_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalEr
     let dt = interval
         .months
         .checked_neg()
-        .ok_or(EvalError::IntervalOutOfRange(interval.months.to_string()))
+        .ok_or(EvalError::IntervalOutOfRange(
+            interval.months.to_string().into(),
+        ))
         .and_then(|months| add_timestamp_months(&dt, months))?;
     let dt = dt
         .checked_sub_signed(interval.duration_as_chrono())
@@ -950,21 +960,21 @@ fn mul_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 fn mul_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint16()
         .checked_mul(b.unwrap_uint16())
-        .ok_or(EvalError::UInt16OutOfRange(format!("{a} * {b}")))
+        .ok_or(EvalError::UInt16OutOfRange(format!("{a} * {b}").into()))
         .map(Datum::from)
 }
 
 fn mul_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint32()
         .checked_mul(b.unwrap_uint32())
-        .ok_or(EvalError::UInt32OutOfRange(format!("{a} * {b}")))
+        .ok_or(EvalError::UInt32OutOfRange(format!("{a} * {b}").into()))
         .map(Datum::from)
 }
 
 fn mul_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint64()
         .checked_mul(b.unwrap_uint64())
-        .ok_or(EvalError::UInt64OutOfRange(format!("{a} * {b}")))
+        .ok_or(EvalError::UInt64OutOfRange(format!("{a} * {b}").into()))
         .map(Datum::from)
 }
 
@@ -1012,7 +1022,7 @@ fn mul_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 fn mul_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_interval()
         .checked_mul(b.unwrap_float64())
-        .ok_or(EvalError::IntervalOutOfRange(format!("{a} * {b}")))
+        .ok_or(EvalError::IntervalOutOfRange(format!("{a} * {b}").into()))
         .map(Datum::from)
 }
 
@@ -1024,7 +1034,7 @@ fn div_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         a.unwrap_int16()
             .checked_div(b)
             .map(Datum::from)
-            .ok_or(EvalError::Int16OutOfRange(format!("{a} / {b}")))
+            .ok_or(EvalError::Int16OutOfRange(format!("{a} / {b}").into()))
     }
 }
 
@@ -1036,7 +1046,7 @@ fn div_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         a.unwrap_int32()
             .checked_div(b)
             .map(Datum::from)
-            .ok_or(EvalError::Int32OutOfRange(format!("{a} / {b}")))
+            .ok_or(EvalError::Int32OutOfRange(format!("{a} / {b}").into()))
     }
 }
 
@@ -1048,7 +1058,7 @@ fn div_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         a.unwrap_int64()
             .checked_div(b)
             .map(Datum::from)
-            .ok_or(EvalError::Int64OutOfRange(format!("{a} / {b}")))
+            .ok_or(EvalError::Int64OutOfRange(format!("{a} / {b}").into()))
     }
 }
 
@@ -1142,7 +1152,7 @@ fn div_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
     } else {
         a.unwrap_interval()
             .checked_div(b)
-            .ok_or(EvalError::IntervalOutOfRange(format!("{a} / {b}")))
+            .ok_or(EvalError::IntervalOutOfRange(format!("{a} / {b}").into()))
             .map(Datum::from)
     }
 }
@@ -1239,15 +1249,15 @@ pub fn neg_interval(a: Datum) -> Result<Datum, EvalError> {
 fn neg_interval_inner(a: Datum) -> Result<Interval, EvalError> {
     a.unwrap_interval()
         .checked_neg()
-        .ok_or(EvalError::IntervalOutOfRange(a.to_string()))
+        .ok_or(EvalError::IntervalOutOfRange(a.to_string().into()))
 }
 
 fn log_guard_numeric(val: &Numeric, function_name: &str) -> Result<(), EvalError> {
     if val.is_negative() {
-        return Err(EvalError::NegativeOutOfDomain(function_name.to_owned()));
+        return Err(EvalError::NegativeOutOfDomain(function_name.into()));
     }
     if val.is_zero() {
-        return Err(EvalError::ZeroOutOfDomain(function_name.to_owned()));
+        return Err(EvalError::ZeroOutOfDomain(function_name.into()));
     }
     Ok(())
 }
@@ -1295,13 +1305,13 @@ fn power<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_float64();
     if a == 0.0 && b.is_sign_negative() {
         return Err(EvalError::Undefined(
-            "zero raised to a negative power".to_owned(),
+            "zero raised to a negative power".into(),
         ));
     }
     if a.is_sign_negative() && b.fract() != 0.0 {
         // Equivalent to PG error:
         // > a negative number raised to a non-integer power yields a complex result
-        return Err(EvalError::ComplexOutOfRange("pow".to_owned()));
+        return Err(EvalError::ComplexOutOfRange("pow".into()));
     }
     let res = a.powf(b);
     if res.is_infinite() {
@@ -1329,14 +1339,14 @@ fn power_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError>
         }
         if b.is_negative() {
             return Err(EvalError::Undefined(
-                "zero raised to a negative power".to_owned(),
+                "zero raised to a negative power".into(),
             ));
         }
     }
     if a.is_negative() && b.exponent() < 0 {
         // Equivalent to PG error:
         // > a negative number raised to a non-integer power yields a complex result
-        return Err(EvalError::ComplexOutOfRange("pow".to_owned()));
+        return Err(EvalError::ComplexOutOfRange("pow".into()));
     }
     let mut cx = numeric::cx_datum();
     cx.pow(&mut a, &b);
@@ -1738,7 +1748,7 @@ where
     let units = a.unwrap_str();
     match units.parse() {
         Ok(units) => Ok(date_part_interval_inner::<D>(units, b.unwrap_interval())?.into()),
-        Err(_) => Err(EvalError::UnknownUnits(units.to_owned())),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
     }
 }
 
@@ -1749,7 +1759,7 @@ where
     let units = a.unwrap_str();
     match units.parse() {
         Ok(units) => Ok(date_part_time_inner::<D>(units, b.unwrap_time())?.into()),
-        Err(_) => Err(EvalError::UnknownUnits(units.to_owned())),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
     }
 }
 
@@ -1761,7 +1771,7 @@ where
     let units = a.unwrap_str();
     match units.parse() {
         Ok(units) => Ok(date_part_timestamp_inner::<_, D>(units, ts)?.into()),
-        Err(_) => Err(EvalError::UnknownUnits(units.to_owned())),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
     }
 }
 
@@ -1769,7 +1779,7 @@ fn extract_date<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
     let units = a.unwrap_str();
     match units.parse() {
         Ok(units) => Ok(extract_date_inner(units, b.unwrap_date().into())?.into()),
-        Err(_) => Err(EvalError::UnknownUnits(units.to_owned())),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
     }
 }
 
@@ -1783,20 +1793,18 @@ where
 {
     if stride.months != 0 {
         return Err(EvalError::DateBinOutOfRange(
-            "timestamps cannot be binned into intervals containing months or years".to_string(),
+            "timestamps cannot be binned into intervals containing months or years".into(),
         ));
     }
 
     let stride_ns = match stride.duration_as_chrono().num_nanoseconds() {
         Some(ns) if ns <= 0 => Err(EvalError::DateBinOutOfRange(
-            "stride must be greater than zero".to_string(),
+            "stride must be greater than zero".into(),
         )),
         Some(ns) => Ok(ns),
-        None => Err(EvalError::DateBinOutOfRange(format!(
-            "stride cannot exceed {}/{} nanoseconds",
-            i64::MAX,
-            i64::MIN,
-        ))),
+        None => Err(EvalError::DateBinOutOfRange(
+            format!("stride cannot exceed {}/{} nanoseconds", i64::MAX, i64::MIN,).into(),
+        )),
     }?;
 
     // Make sure the returned timestamp is at the start of the bin, even if the
@@ -1806,7 +1814,7 @@ where
 
     let tm_diff = (source - origin.clone()).num_nanoseconds().ok_or_else(|| {
         EvalError::DateBinOutOfRange(
-            "source and origin must not differ more than 2^63 nanoseconds".to_string(),
+            "source and origin must not differ more than 2^63 nanoseconds".into(),
         )
     })?;
 
@@ -1829,7 +1837,7 @@ where
     let units = a.unwrap_str();
     match units.parse() {
         Ok(units) => Ok(date_trunc_inner(units, ts)?.try_into()?),
-        Err(_) => Err(EvalError::UnknownUnits(units.to_owned())),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
     }
 }
 
@@ -1838,7 +1846,7 @@ fn date_trunc_interval<'a>(a: Datum, b: Datum) -> Result<Datum<'a>, EvalError> {
     let units = a.unwrap_str();
     let dtf = units
         .parse()
-        .map_err(|_| EvalError::UnknownUnits(units.to_owned()))?;
+        .map_err(|_| EvalError::UnknownUnits(units.into()))?;
 
     interval
         .truncate_low_fields(dtf, Some(0), RoundBehavior::Truncate)
@@ -1852,7 +1860,7 @@ fn date_diff_timestamp<'a>(unit: Datum, a: Datum, b: Datum) -> Result<Datum<'a>,
     let unit = unit.unwrap_str();
     let unit = unit
         .parse()
-        .map_err(|_| EvalError::InvalidDatePart(unit.to_string()))?;
+        .map_err(|_| EvalError::InvalidDatePart(unit.into()))?;
 
     let a = a.unwrap_timestamp();
     let b = b.unwrap_timestamp();
@@ -1865,7 +1873,7 @@ fn date_diff_timestamptz<'a>(unit: Datum, a: Datum, b: Datum) -> Result<Datum<'a
     let unit = unit.unwrap_str();
     let unit = unit
         .parse()
-        .map_err(|_| EvalError::InvalidDatePart(unit.to_string()))?;
+        .map_err(|_| EvalError::InvalidDatePart(unit.into()))?;
 
     let a = a.unwrap_timestamptz();
     let b = b.unwrap_timestamptz();
@@ -1878,7 +1886,7 @@ fn date_diff_date<'a>(unit: Datum, a: Datum, b: Datum) -> Result<Datum<'a>, Eval
     let unit = unit.unwrap_str();
     let unit = unit
         .parse()
-        .map_err(|_| EvalError::InvalidDatePart(unit.to_string()))?;
+        .map_err(|_| EvalError::InvalidDatePart(unit.into()))?;
 
     let a = a.unwrap_date();
     let b = b.unwrap_date();
@@ -1895,7 +1903,7 @@ fn date_diff_time<'a>(unit: Datum, a: Datum, b: Datum) -> Result<Datum<'a>, Eval
     let unit = unit.unwrap_str();
     let unit = unit
         .parse()
-        .map_err(|_| EvalError::InvalidDatePart(unit.to_string()))?;
+        .map_err(|_| EvalError::InvalidDatePart(unit.into()))?;
 
     let a = a.unwrap_time();
     let b = b.unwrap_time();
@@ -1915,7 +1923,7 @@ fn date_diff_time<'a>(unit: Datum, a: Datum, b: Datum) -> Result<Datum<'a>, Eval
 /// The interpretation of fixed offsets depend on whether the POSIX or ISO 8601 standard is being
 /// used.
 pub(crate) fn parse_timezone(tz: &str, spec: TimezoneSpec) -> Result<Timezone, EvalError> {
-    Timezone::parse(tz, spec).map_err(|_| EvalError::InvalidTimezone(tz.to_owned()))
+    Timezone::parse(tz, spec).map_err(|_| EvalError::InvalidTimezone(tz.into()))
 }
 
 /// Converts the time datum `b`, which is assumed to be in UTC, to the timezone that the interval datum `a` is assumed
@@ -1995,7 +2003,7 @@ fn mz_acl_item_contains_privilege(a: Datum<'_>, b: Datum<'_>) -> Result<Datum<'s
     let mz_acl_item = a.unwrap_mz_acl_item();
     let privileges = b.unwrap_str();
     let acl_mode = AclMode::parse_multiple_privileges(privileges)
-        .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(e.to_string()))?;
+        .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(e.to_string().into()))?;
     let contains = !mz_acl_item.acl_mode.intersection(acl_mode).is_empty();
     Ok(contains.into())
 }
@@ -2034,8 +2042,8 @@ fn parse_ident<'a>(
 
             if buf.next() != Some('"') {
                 return Err(EvalError::InvalidIdentifier {
-                    ident: ident.to_string(),
-                    detail: Some("String has unclosed double quotes.".to_string()),
+                    ident: ident.into(),
+                    detail: Some("String has unclosed double quotes.".into()),
                 });
             }
             elems.push(Datum::String(s));
@@ -2051,17 +2059,17 @@ fn parse_ident<'a>(
         if missing_ident {
             if c == Some('.') {
                 return Err(EvalError::InvalidIdentifier {
-                    ident: ident.to_string(),
-                    detail: Some("No valid identifier before \".\".".to_string()),
+                    ident: ident.into(),
+                    detail: Some("No valid identifier before \".\".".into()),
                 });
             } else if after_dot {
                 return Err(EvalError::InvalidIdentifier {
-                    ident: ident.to_string(),
-                    detail: Some("No valid identifier after \".\".".to_string()),
+                    ident: ident.into(),
+                    detail: Some("No valid identifier after \".\".".into()),
                 });
             } else {
                 return Err(EvalError::InvalidIdentifier {
-                    ident: ident.to_string(),
+                    ident: ident.into(),
                     detail: None,
                 });
             }
@@ -2077,7 +2085,7 @@ fn parse_ident<'a>(
             }
             Some(_) if strict => {
                 return Err(EvalError::InvalidIdentifier {
-                    ident: ident.to_string(),
+                    ident: ident.into(),
                     detail: None,
                 })
             }
@@ -2135,8 +2143,9 @@ fn pretty_sql<'a>(
     let sql = sql.unwrap_str();
     let width = width.unwrap_int32();
     let width =
-        usize::try_from(width).map_err(|_| EvalError::PrettyError("invalid width".to_string()))?;
-    let pretty = pretty_str(sql, width).map_err(|e| EvalError::PrettyError(e.to_string()))?;
+        usize::try_from(width).map_err(|_| EvalError::PrettyError("invalid width".into()))?;
+    let pretty =
+        pretty_str(sql, width).map_err(|e| EvalError::PrettyError(e.to_string().into()))?;
     let pretty = temp_storage.push_string(pretty);
     Ok(Datum::String(pretty))
 }
@@ -6279,12 +6288,12 @@ fn error_if_null<'a>(
             let err_msg = match datums[1] {
                 Datum::Null => {
                     return Err(EvalError::Internal(
-                        "unexpected NULL in error side of error_if_null".to_string(),
+                        "unexpected NULL in error side of error_if_null".into(),
                     ))
                 }
                 o => o.unwrap_str(),
             };
-            Err(EvalError::IfNullError(err_msg.to_string()))
+            Err(EvalError::IfNullError(err_msg.into()))
         }
         _ => Ok(datums[0]),
     }
@@ -6334,7 +6343,7 @@ fn pad_leading<'a>(
         Ok(len) => len,
         Err(_) => {
             return Err(EvalError::InvalidParameterValue(
-                "length must be nonnegative".to_owned(),
+                "length must be nonnegative".into(),
             ))
         }
     };
@@ -6371,10 +6380,13 @@ fn substr<'a>(datums: &[Datum<'a>]) -> Result<Datum<'a>, EvalError> {
     let start_idx = match usize::try_from(cmp::max(raw_start_idx, 0)) {
         Ok(i) => i,
         Err(_) => {
-            return Err(EvalError::InvalidParameterValue(format!(
-                "substring starting index ({}) exceeds min/max position",
-                raw_start_idx
-            )))
+            return Err(EvalError::InvalidParameterValue(
+                format!(
+                    "substring starting index ({}) exceeds min/max position",
+                    raw_start_idx
+                )
+                .into(),
+            ))
         }
     };
 
@@ -6388,7 +6400,7 @@ fn substr<'a>(datums: &[Datum<'a>]) -> Result<Datum<'a>, EvalError> {
         let end_idx = match i64::from(datums[2].unwrap_int32()) {
             e if e < 0 => {
                 return Err(EvalError::InvalidParameterValue(
-                    "negative substring length not allowed".to_owned(),
+                    "negative substring length not allowed".into(),
                 ))
             }
             e if e == 0 || e + raw_start_idx < 1 => return Ok(Datum::String("")),
@@ -6397,10 +6409,9 @@ fn substr<'a>(datums: &[Datum<'a>]) -> Result<Datum<'a>, EvalError> {
                 match usize::try_from(e) {
                     Ok(i) => i,
                     Err(_) => {
-                        return Err(EvalError::InvalidParameterValue(format!(
-                            "substring length ({}) exceeds max position",
-                            e
-                        )))
+                        return Err(EvalError::InvalidParameterValue(
+                            format!("substring length ({}) exceeds max position", e).into(),
+                        ))
                     }
                 }
             }
@@ -6423,7 +6434,7 @@ fn split_part<'a>(datums: &[Datum<'a>]) -> Result<Datum<'a>, EvalError> {
         Ok(index) => index,
         Err(_) => {
             return Err(EvalError::InvalidParameterValue(
-                "field position must be greater than zero".to_owned(),
+                "field position must be greater than zero".into(),
             ))
         }
     };
@@ -6652,7 +6663,7 @@ pub fn hmac_inner<'a>(
             mac.update(to_digest);
             mac.finalize().into_bytes().to_vec()
         }
-        other => return Err(EvalError::InvalidHashAlgorithm(other.to_owned())),
+        other => return Err(EvalError::InvalidHashAlgorithm(other.into())),
     };
     Ok(Datum::Bytes(temp_storage.push_bytes(bytes)))
 }
@@ -7103,7 +7114,7 @@ fn array_position<'a>(datums: &[Datum<'a>]) -> Result<Datum<'a>, EvalError> {
     }
 
     let skip: usize = match datums.get(2) {
-        Some(Datum::Null) => return Err(EvalError::MustNotBeNull("initial position".to_string())),
+        Some(Datum::Null) => return Err(EvalError::MustNotBeNull("initial position".into())),
         None => 0,
         Some(o) => usize::try_from(o.unwrap_int32())
             .unwrap_or(0)
@@ -7166,7 +7177,7 @@ fn position<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 
         let num_prefix_chars = string_prefix.chars().count();
         let num_prefix_chars = i32::try_from(num_prefix_chars)
-            .map_err(|_| EvalError::Int32OutOfRange(num_prefix_chars.to_string()))?;
+            .map_err(|_| EvalError::Int32OutOfRange(num_prefix_chars.to_string().into()))?;
 
         Ok(Datum::Int32(num_prefix_chars + 1))
     } else {
@@ -7184,14 +7195,14 @@ fn left<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         Ordering::Equal => 0,
         Ordering::Greater => {
             let n = usize::try_from(n).map_err(|_| {
-                EvalError::InvalidParameterValue(format!("invalid parameter n: {:?}", n))
+                EvalError::InvalidParameterValue(format!("invalid parameter n: {:?}", n).into())
             })?;
             // nth from the back
             byte_indices.nth(n).unwrap_or(string.len())
         }
         Ordering::Less => {
             let n = usize::try_from(n.abs() - 1).map_err(|_| {
-                EvalError::InvalidParameterValue(format!("invalid parameter n: {:?}", n))
+                EvalError::InvalidParameterValue(format!("invalid parameter n: {:?}", n).into())
             })?;
             byte_indices.rev().nth(n).unwrap_or(0)
         }
@@ -7210,7 +7221,7 @@ fn right<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         string.len()
     } else if n > 0 {
         let n = usize::try_from(n - 1).map_err(|_| {
-            EvalError::InvalidParameterValue(format!("invalid parameter n: {:?}", n))
+            EvalError::InvalidParameterValue(format!("invalid parameter n: {:?}", n).into())
         })?;
         // nth from the back
         byte_indices.rev().nth(n).unwrap_or(0)
@@ -7220,7 +7231,7 @@ fn right<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     } else {
         let n = n.abs();
         let n = usize::try_from(n).map_err(|_| {
-            EvalError::InvalidParameterValue(format!("invalid parameter n: {:?}", n))
+            EvalError::InvalidParameterValue(format!("invalid parameter n: {:?}", n).into())
         })?;
         byte_indices.nth(n).unwrap_or(string.len())
     };
@@ -7259,7 +7270,7 @@ fn array_length<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
         Some(dim) => Datum::Int32(
             dim.length
                 .try_into()
-                .map_err(|_| EvalError::Int32OutOfRange(dim.length.to_string()))?,
+                .map_err(|_| EvalError::Int32OutOfRange(dim.length.to_string().into()))?,
         ),
     })
 }
@@ -7321,7 +7332,7 @@ fn array_upper<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
             Some(dim) => Datum::Int32(
                 dim.length
                     .try_into()
-                    .map_err(|_| EvalError::Int32OutOfRange(dim.length.to_string()))?,
+                    .map_err(|_| EvalError::Int32OutOfRange(dim.length.to_string().into()))?,
             ),
             None => Datum::Null,
         },
@@ -7363,7 +7374,7 @@ fn list_length_max<'a>(
         match max_len_on_layer(a, b) {
             Some(l) => match l.try_into() {
                 Ok(c) => Ok(Datum::Int32(c)),
-                Err(_) => Err(EvalError::Int32OutOfRange(l.to_string())),
+                Err(_) => Err(EvalError::Int32OutOfRange(l.to_string().into())),
             },
             None => Ok(Datum::Null),
         }
@@ -7578,7 +7589,7 @@ fn digest_inner<'a>(
         "sha256" => Sha256::digest(bytes).to_vec(),
         "sha384" => Sha384::digest(bytes).to_vec(),
         "sha512" => Sha512::digest(bytes).to_vec(),
-        other => return Err(EvalError::InvalidHashAlgorithm(other.to_owned())),
+        other => return Err(EvalError::InvalidHashAlgorithm(other.into())),
     };
     Ok(Datum::Bytes(temp_storage.push_bytes(bytes)))
 }
@@ -7605,11 +7616,11 @@ fn make_acl_item<'a>(datums: &[Datum<'a>]) -> Result<Datum<'a>, EvalError> {
     let grantor = Oid(datums[1].unwrap_uint32());
     let privileges = datums[2].unwrap_str();
     let acl_mode = AclMode::parse_multiple_privileges(privileges)
-        .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(e.to_string()))?;
+        .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(e.to_string().into()))?;
     let is_grantable = datums[3].unwrap_bool();
     if is_grantable {
         return Err(EvalError::Unsupported {
-            feature: "GRANT OPTION".to_string(),
+            feature: "GRANT OPTION".into(),
             discussion_no: None,
         });
     }
@@ -7625,19 +7636,19 @@ fn make_mz_acl_item<'a>(datums: &[Datum<'a>]) -> Result<Datum<'a>, EvalError> {
     let grantee: RoleId = datums[0]
         .unwrap_str()
         .parse()
-        .map_err(|e: anyhow::Error| EvalError::InvalidRoleId(e.to_string()))?;
+        .map_err(|e: anyhow::Error| EvalError::InvalidRoleId(e.to_string().into()))?;
     let grantor: RoleId = datums[1]
         .unwrap_str()
         .parse()
-        .map_err(|e: anyhow::Error| EvalError::InvalidRoleId(e.to_string()))?;
+        .map_err(|e: anyhow::Error| EvalError::InvalidRoleId(e.to_string().into()))?;
     if grantor == RoleId::Public {
         return Err(EvalError::InvalidRoleId(
-            "mz_aclitem grantor cannot be PUBLIC role".to_string(),
+            "mz_aclitem grantor cannot be PUBLIC role".into(),
         ));
     }
     let privileges = datums[2].unwrap_str();
     let acl_mode = AclMode::parse_multiple_privileges(privileges)
-        .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(e.to_string()))?;
+        .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(e.to_string().into()))?;
 
     Ok(Datum::MzAclItem(MzAclItem {
         grantee,
@@ -7657,13 +7668,13 @@ fn array_fill<'a>(
     let fill = datums[0];
     if matches!(fill, Datum::Array(_)) {
         return Err(EvalError::Unsupported {
-            feature: "array_fill with arrays".to_string(),
+            feature: "array_fill with arrays".into(),
             discussion_no: None,
         });
     }
 
     let arr = match datums[1] {
-        Datum::Null => return Err(EvalError::MustNotBeNull(NULL_ARR_ERR.to_string())),
+        Datum::Null => return Err(EvalError::MustNotBeNull(NULL_ARR_ERR.into())),
         o => o.unwrap_array(),
     };
 
@@ -7671,7 +7682,7 @@ fn array_fill<'a>(
         .elements()
         .iter()
         .map(|d| match d {
-            Datum::Null => Err(EvalError::MustNotBeNull(NULL_ELEM_ERR.to_string())),
+            Datum::Null => Err(EvalError::MustNotBeNull(NULL_ELEM_ERR.into())),
             d => Ok(usize::cast_from(u32::reinterpret_cast(d.unwrap_int32()))),
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -7679,14 +7690,14 @@ fn array_fill<'a>(
     let lower_bounds = match datums.get(2) {
         Some(d) => {
             let arr = match d {
-                Datum::Null => return Err(EvalError::MustNotBeNull(NULL_ARR_ERR.to_string())),
+                Datum::Null => return Err(EvalError::MustNotBeNull(NULL_ARR_ERR.into())),
                 o => o.unwrap_array(),
             };
 
             arr.elements()
                 .iter()
                 .map(|l| match l {
-                    Datum::Null => Err(EvalError::MustNotBeNull(NULL_ELEM_ERR.to_string())),
+                    Datum::Null => Err(EvalError::MustNotBeNull(NULL_ELEM_ERR.into())),
                     l => Ok(isize::cast_from(l.unwrap_int32())),
                 })
                 .collect::<Result<Vec<_>, _>>()?

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -42,7 +42,8 @@ impl LazyUnaryFunc for CastArrayToListOneDim {
                 feature: format!(
                     "casting multi-dimensional array to list; got array with {} dimensions",
                     ndims
-                ),
+                )
+                .into(),
                 discussion_no: None,
             });
         }

--- a/src/expr/src/scalar/func/impls/byte.rs
+++ b/src/expr/src/scalar/func/impls/byte.rs
@@ -68,7 +68,7 @@ sqlfunc!(
     #[sqlname = "bit_length"]
     fn bit_length_bytes<'a>(a: &'a [u8]) -> Result<i32, EvalError> {
         let val = a.len() * 8;
-        i32::try_from(val).or(Err(EvalError::Int32OutOfRange(val.to_string())))
+        i32::try_from(val).or(Err(EvalError::Int32OutOfRange(val.to_string().into())))
     }
 );
 
@@ -76,6 +76,6 @@ sqlfunc!(
     #[sqlname = "octet_length"]
     fn byte_length_bytes<'a>(a: &'a [u8]) -> Result<i32, EvalError> {
         let val = a.len();
-        i32::try_from(val).or(Err(EvalError::Int32OutOfRange(val.to_string())))
+        i32::try_from(val).or(Err(EvalError::Int32OutOfRange(val.to_string().into())))
     }
 );

--- a/src/expr/src/scalar/func/impls/date.rs
+++ b/src/expr/src/scalar/func/impls/date.rs
@@ -134,14 +134,14 @@ pub fn extract_date_inner(units: DateTimeUnits, date: NaiveDate) -> Result<Numer
         | DateTimeUnits::Second
         | DateTimeUnits::Milliseconds
         | DateTimeUnits::Microseconds => Err(EvalError::UnsupportedUnits(
-            format!("{}", units),
-            "date".to_string(),
+            format!("{}", units).into(),
+            "date".into(),
         )),
         DateTimeUnits::Timezone
         | DateTimeUnits::TimezoneHour
         | DateTimeUnits::TimezoneMinute
         | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported {
-            feature: format!("'{}' timestamp units", units),
+            feature: format!("'{}' timestamp units", units).into(),
             discussion_no: None,
         }),
     }

--- a/src/expr/src/scalar/func/impls/datum.rs
+++ b/src/expr/src/scalar/func/impls/datum.rs
@@ -41,7 +41,7 @@ sqlfunc!(
                 let sz = mz_repr::datum_size(&datum);
                 i32::try_from(sz)
                     .map(Some)
-                    .or(Err(EvalError::Int32OutOfRange(sz.to_string())))
+                    .or(Err(EvalError::Int32OutOfRange(sz.to_string().into())))
             }
         }
     }
@@ -52,6 +52,6 @@ sqlfunc!(
     // should we make this unmaterializable?
     fn mz_row_size<'a>(a: DatumList<'a>) -> Result<i32, EvalError> {
         let sz = mz_repr::row_size(a.iter());
-        i32::try_from(sz).or(Err(EvalError::Int32OutOfRange(sz.to_string())))
+        i32::try_from(sz).or(Err(EvalError::Int32OutOfRange(sz.to_string().into())))
     }
 );

--- a/src/expr/src/scalar/func/impls/float32.rs
+++ b/src/expr/src/scalar/func/impls/float32.rs
@@ -74,7 +74,7 @@ sqlfunc!(
         if (f >= (i16::MIN as f32)) && (f < -(i16::MIN as f32)) {
             Ok(f as i16)
         } else {
-            Err(EvalError::Int16OutOfRange(f.to_string()))
+            Err(EvalError::Int16OutOfRange(f.to_string().into()))
         }
     }
 );
@@ -95,7 +95,7 @@ sqlfunc!(
         if (f >= (i32::MIN as f32)) && (f < -(i32::MIN as f32)) {
             Ok(f as i32)
         } else {
-            Err(EvalError::Int32OutOfRange(f.to_string()))
+            Err(EvalError::Int32OutOfRange(f.to_string().into()))
         }
     }
 );
@@ -116,7 +116,7 @@ sqlfunc!(
         if (f >= (i64::MIN as f32)) && (f < -(i64::MIN as f32)) {
             Ok(f as i64)
         } else {
-            Err(EvalError::Int64OutOfRange(f.to_string()))
+            Err(EvalError::Int64OutOfRange(f.to_string().into()))
         }
     }
 );
@@ -154,7 +154,7 @@ sqlfunc!(
         if (f >= 0.0) && (f <= (u16::MAX as f32)) {
             Ok(f as u16)
         } else {
-            Err(EvalError::UInt16OutOfRange(f.to_string()))
+            Err(EvalError::UInt16OutOfRange(f.to_string().into()))
         }
     }
 );
@@ -171,7 +171,7 @@ sqlfunc!(
         if (f >= 0.0) && (f <= (u32::MAX as f32)) {
             Ok(f as u32)
         } else {
-            Err(EvalError::UInt32OutOfRange(f.to_string()))
+            Err(EvalError::UInt32OutOfRange(f.to_string().into()))
         }
     }
 );
@@ -188,7 +188,7 @@ sqlfunc!(
         if (f >= 0.0) && (f <= (u64::MAX as f32)) {
             Ok(f as u64)
         } else {
-            Err(EvalError::UInt64OutOfRange(f.to_string()))
+            Err(EvalError::UInt64OutOfRange(f.to_string().into()))
         }
     }
 );
@@ -203,7 +203,7 @@ impl<'a> EagerUnaryFunc<'a> for CastFloat32ToNumeric {
     fn call(&self, a: f32) -> Result<Numeric, EvalError> {
         if a.is_infinite() {
             return Err(EvalError::InfinityOutOfDomain(
-                "casting real to numeric".to_owned(),
+                "casting real to numeric".into(),
             ));
         }
         let mut a = Numeric::from(a);

--- a/src/expr/src/scalar/func/impls/float64.rs
+++ b/src/expr/src/scalar/func/impls/float64.rs
@@ -78,7 +78,7 @@ sqlfunc!(
         if (f >= (i16::MIN as f64)) && (f < -(i16::MIN as f64)) {
             Ok(f as i16)
         } else {
-            Err(EvalError::Int16OutOfRange(f.to_string()))
+            Err(EvalError::Int16OutOfRange(f.to_string().into()))
         }
     }
 );
@@ -99,7 +99,7 @@ sqlfunc!(
         if (f >= (i32::MIN as f64)) && (f < -(i32::MIN as f64)) {
             Ok(f as i32)
         } else {
-            Err(EvalError::Int32OutOfRange(f.to_string()))
+            Err(EvalError::Int32OutOfRange(f.to_string().into()))
         }
     }
 );
@@ -120,7 +120,7 @@ sqlfunc!(
         if (f >= (i64::MIN as f64)) && (f < -(i64::MIN as f64)) {
             Ok(f as i64)
         } else {
-            Err(EvalError::Int64OutOfRange(f.to_string()))
+            Err(EvalError::Int64OutOfRange(f.to_string().into()))
         }
     }
 );
@@ -167,7 +167,7 @@ sqlfunc!(
         if (f >= 0.0) && (f <= (u16::MAX as f64)) {
             Ok(f as u16)
         } else {
-            Err(EvalError::UInt16OutOfRange(f.to_string()))
+            Err(EvalError::UInt16OutOfRange(f.to_string().into()))
         }
     }
 );
@@ -184,7 +184,7 @@ sqlfunc!(
         if (f >= 0.0) && (f <= (u32::MAX as f64)) {
             Ok(f as u32)
         } else {
-            Err(EvalError::UInt32OutOfRange(f.to_string()))
+            Err(EvalError::UInt32OutOfRange(f.to_string().into()))
         }
     }
 );
@@ -201,7 +201,7 @@ sqlfunc!(
         if (f >= 0.0) && (f <= (u64::MAX as f64)) {
             Ok(f as u64)
         } else {
-            Err(EvalError::UInt64OutOfRange(f.to_string()))
+            Err(EvalError::UInt64OutOfRange(f.to_string().into()))
         }
     }
 );
@@ -216,7 +216,7 @@ impl<'a> EagerUnaryFunc<'a> for CastFloat64ToNumeric {
     fn call(&self, a: f64) -> Result<Numeric, EvalError> {
         if a.is_infinite() {
             return Err(EvalError::InfinityOutOfDomain(
-                "casting double precision to numeric".to_owned(),
+                "casting double precision to numeric".into(),
             ));
         }
         let mut a = Numeric::from(a);
@@ -270,7 +270,7 @@ sqlfunc!(
 sqlfunc!(
     fn cos(a: f64) -> Result<f64, EvalError> {
         if a.is_infinite() {
-            return Err(EvalError::InfinityOutOfDomain("cos".to_owned()));
+            return Err(EvalError::InfinityOutOfDomain("cos".into()));
         }
         Ok(a.cos())
     }
@@ -282,7 +282,7 @@ sqlfunc!(
             return Err(EvalError::OutOfDomain(
                 DomainLimit::Inclusive(-1),
                 DomainLimit::Inclusive(1),
-                "acos".to_owned(),
+                "acos".into(),
             ));
         }
         Ok(a.acos())
@@ -301,7 +301,7 @@ sqlfunc!(
             return Err(EvalError::OutOfDomain(
                 DomainLimit::Inclusive(1),
                 DomainLimit::None,
-                "acosh".to_owned(),
+                "acosh".into(),
             ));
         }
         Ok(a.acosh())
@@ -311,7 +311,7 @@ sqlfunc!(
 sqlfunc!(
     fn sin(a: f64) -> Result<f64, EvalError> {
         if a.is_infinite() {
-            return Err(EvalError::InfinityOutOfDomain("sin".to_owned()));
+            return Err(EvalError::InfinityOutOfDomain("sin".into()));
         }
         Ok(a.sin())
     }
@@ -323,7 +323,7 @@ sqlfunc!(
             return Err(EvalError::OutOfDomain(
                 DomainLimit::Inclusive(-1),
                 DomainLimit::Inclusive(1),
-                "asin".to_owned(),
+                "asin".into(),
             ));
         }
         Ok(a.asin())
@@ -345,7 +345,7 @@ sqlfunc!(
 sqlfunc!(
     fn tan(a: f64) -> Result<f64, EvalError> {
         if a.is_infinite() {
-            return Err(EvalError::InfinityOutOfDomain("tan".to_owned()));
+            return Err(EvalError::InfinityOutOfDomain("tan".into()));
         }
         Ok(a.tan())
     }
@@ -369,7 +369,7 @@ sqlfunc!(
             return Err(EvalError::OutOfDomain(
                 DomainLimit::Inclusive(-1),
                 DomainLimit::Inclusive(1),
-                "atanh".to_owned(),
+                "atanh".into(),
             ));
         }
         Ok(a.atanh())
@@ -379,7 +379,7 @@ sqlfunc!(
 sqlfunc!(
     fn cot(a: f64) -> Result<f64, EvalError> {
         if a.is_infinite() {
-            return Err(EvalError::InfinityOutOfDomain("cot".to_owned()));
+            return Err(EvalError::InfinityOutOfDomain("cot".into()));
         }
         Ok(1.0 / a.tan())
     }
@@ -401,10 +401,10 @@ sqlfunc!(
     #[sqlname = "log10f64"]
     fn log10(a: f64) -> Result<f64, EvalError> {
         if a.is_sign_negative() {
-            return Err(EvalError::NegativeOutOfDomain("log10".to_owned()));
+            return Err(EvalError::NegativeOutOfDomain("log10".into()));
         }
         if a == 0.0 {
-            return Err(EvalError::ZeroOutOfDomain("log10".to_owned()));
+            return Err(EvalError::ZeroOutOfDomain("log10".into()));
         }
         Ok(a.log10())
     }
@@ -414,10 +414,10 @@ sqlfunc!(
     #[sqlname = "lnf64"]
     fn ln(a: f64) -> Result<f64, EvalError> {
         if a.is_sign_negative() {
-            return Err(EvalError::NegativeOutOfDomain("ln".to_owned()));
+            return Err(EvalError::NegativeOutOfDomain("ln".into()));
         }
         if a == 0.0 {
-            return Err(EvalError::ZeroOutOfDomain("ln".to_owned()));
+            return Err(EvalError::ZeroOutOfDomain("ln".into()));
         }
         Ok(a.ln())
     }

--- a/src/expr/src/scalar/func/impls/int16.rs
+++ b/src/expr/src/scalar/func/impls/int16.rs
@@ -24,7 +24,7 @@ sqlfunc!(
     #[is_monotone = true]
     fn neg_int16(a: i16) -> Result<i16, EvalError> {
         a.checked_neg()
-            .ok_or(EvalError::Int16OutOfRange(a.to_string()))
+            .ok_or(EvalError::Int16OutOfRange(a.to_string().into()))
     }
 );
 
@@ -41,7 +41,7 @@ sqlfunc!(
     #[sqlname = "abs"]
     fn abs_int16(a: i16) -> Result<i16, EvalError> {
         a.checked_abs()
-            .ok_or(EvalError::Int16OutOfRange(a.to_string()))
+            .ok_or(EvalError::Int16OutOfRange(a.to_string().into()))
     }
 );
 
@@ -102,7 +102,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastUint16ToInt16)]
     #[is_monotone = true]
     fn cast_int16_to_uint16(a: i16) -> Result<u16, EvalError> {
-        u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string())))
+        u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string().into())))
     }
 );
 
@@ -112,7 +112,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastUint32ToInt16)]
     #[is_monotone = true]
     fn cast_int16_to_uint32(a: i16) -> Result<u32, EvalError> {
-        u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string())))
+        u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string().into())))
     }
 );
 
@@ -122,7 +122,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastUint64ToInt16)]
     #[is_monotone = true]
     fn cast_int16_to_uint64(a: i16) -> Result<u64, EvalError> {
-        u64::try_from(a).or(Err(EvalError::UInt64OutOfRange(a.to_string())))
+        u64::try_from(a).or(Err(EvalError::UInt64OutOfRange(a.to_string().into())))
     }
 );
 

--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -26,7 +26,7 @@ sqlfunc!(
     #[is_monotone = true]
     fn neg_int32(a: i32) -> Result<i32, EvalError> {
         a.checked_neg()
-            .ok_or(EvalError::Int32OutOfRange(a.to_string()))
+            .ok_or(EvalError::Int32OutOfRange(a.to_string().into()))
     }
 );
 
@@ -43,7 +43,7 @@ sqlfunc!(
     #[sqlname = "abs"]
     fn abs_int32(a: i32) -> Result<i32, EvalError> {
         a.checked_abs()
-            .ok_or(EvalError::Int32OutOfRange(a.to_string()))
+            .ok_or(EvalError::Int32OutOfRange(a.to_string().into()))
     }
 );
 
@@ -86,7 +86,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastInt16ToInt32)]
     #[is_monotone = true]
     fn cast_int32_to_int16(a: i32) -> Result<i16, EvalError> {
-        i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string())))
+        i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string().into())))
     }
 );
 
@@ -117,7 +117,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastUint16ToInt32)]
     #[is_monotone = true]
     fn cast_int32_to_uint16(a: i32) -> Result<u16, EvalError> {
-        u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string())))
+        u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string().into())))
     }
 );
 
@@ -127,7 +127,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastUint32ToInt32)]
     #[is_monotone = true]
     fn cast_int32_to_uint32(a: i32) -> Result<u32, EvalError> {
-        u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string())))
+        u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string().into())))
     }
 );
 
@@ -137,7 +137,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastUint64ToInt32)]
     #[is_monotone = true]
     fn cast_int32_to_uint64(a: i32) -> Result<u64, EvalError> {
-        u64::try_from(a).or(Err(EvalError::UInt64OutOfRange(a.to_string())))
+        u64::try_from(a).or(Err(EvalError::UInt64OutOfRange(a.to_string().into())))
     }
 );
 

--- a/src/expr/src/scalar/func/impls/int64.rs
+++ b/src/expr/src/scalar/func/impls/int64.rs
@@ -25,7 +25,7 @@ sqlfunc!(
     #[is_monotone = true]
     fn neg_int64(a: i64) -> Result<i64, EvalError> {
         a.checked_neg()
-            .ok_or(EvalError::Int64OutOfRange(a.to_string()))
+            .ok_or(EvalError::Int64OutOfRange(a.to_string().into()))
     }
 );
 
@@ -42,7 +42,7 @@ sqlfunc!(
     #[sqlname = "abs"]
     fn abs_int64(a: i64) -> Result<i64, EvalError> {
         a.checked_abs()
-            .ok_or(EvalError::Int64OutOfRange(a.to_string()))
+            .ok_or(EvalError::Int64OutOfRange(a.to_string().into()))
     }
 );
 
@@ -61,7 +61,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastInt16ToInt64)]
     #[is_monotone = true]
     fn cast_int64_to_int16(a: i64) -> Result<i16, EvalError> {
-        i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string())))
+        i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string().into())))
     }
 );
 
@@ -71,7 +71,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastInt32ToInt64)]
     #[is_monotone = true]
     fn cast_int64_to_int32(a: i64) -> Result<i32, EvalError> {
-        i32::try_from(a).or(Err(EvalError::Int32OutOfRange(a.to_string())))
+        i32::try_from(a).or(Err(EvalError::Int32OutOfRange(a.to_string().into())))
     }
 );
 
@@ -84,7 +84,7 @@ sqlfunc!(
         // integers to an OID rejects negative values.
         u32::try_from(a)
             .map(Oid)
-            .or(Err(EvalError::OidOutOfRange(a.to_string())))
+            .or(Err(EvalError::OidOutOfRange(a.to_string().into())))
     }
 );
 
@@ -94,7 +94,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastUint16ToInt64)]
     #[is_monotone = true]
     fn cast_int64_to_uint16(a: i64) -> Result<u16, EvalError> {
-        u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string())))
+        u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string().into())))
     }
 );
 
@@ -104,7 +104,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastUint32ToInt64)]
     #[is_monotone = true]
     fn cast_int64_to_uint32(a: i64) -> Result<u32, EvalError> {
-        u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string())))
+        u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string().into())))
     }
 );
 
@@ -114,7 +114,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastUint64ToInt64)]
     #[is_monotone = true]
     fn cast_int64_to_uint64(a: i64) -> Result<u64, EvalError> {
-        u64::try_from(a).or(Err(EvalError::UInt64OutOfRange(a.to_string())))
+        u64::try_from(a).or(Err(EvalError::UInt64OutOfRange(a.to_string().into())))
     }
 );
 

--- a/src/expr/src/scalar/func/impls/interval.rs
+++ b/src/expr/src/scalar/func/impls/interval.rs
@@ -66,7 +66,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::NegInterval)]
     fn neg_interval(i: Interval) -> Result<Interval, EvalError> {
         i.checked_neg()
-            .ok_or(EvalError::IntervalOutOfRange(i.to_string()))
+            .ok_or(EvalError::IntervalOutOfRange(i.to_string().into()))
     }
 );
 
@@ -74,7 +74,7 @@ sqlfunc!(
     #[sqlname = "justify_days"]
     fn justify_days(i: Interval) -> Result<Interval, EvalError> {
         i.justify_days()
-            .map_err(|_| EvalError::IntervalOutOfRange(i.to_string()))
+            .map_err(|_| EvalError::IntervalOutOfRange(i.to_string().into()))
     }
 );
 
@@ -82,7 +82,7 @@ sqlfunc!(
     #[sqlname = "justify_hours"]
     fn justify_hours(i: Interval) -> Result<Interval, EvalError> {
         i.justify_hours()
-            .map_err(|_| EvalError::IntervalOutOfRange(i.to_string()))
+            .map_err(|_| EvalError::IntervalOutOfRange(i.to_string().into()))
     }
 );
 
@@ -90,6 +90,6 @@ sqlfunc!(
     #[sqlname = "justify_interval"]
     fn justify_interval(i: Interval) -> Result<Interval, EvalError> {
         i.justify_interval()
-            .map_err(|_| EvalError::IntervalOutOfRange(i.to_string()))
+            .map_err(|_| EvalError::IntervalOutOfRange(i.to_string().into()))
     }
 );

--- a/src/expr/src/scalar/func/impls/jsonb.rs
+++ b/src/expr/src/scalar/func/impls/jsonb.rs
@@ -187,7 +187,7 @@ sqlfunc!(
                 let count = list.iter().count();
                 match i32::try_from(count) {
                     Ok(len) => Ok(Some(len)),
-                    Err(_) => Err(EvalError::Int32OutOfRange(count.to_string())),
+                    Err(_) => Err(EvalError::Int32OutOfRange(count.to_string().into())),
                 }
             }
             _ => Ok(None),

--- a/src/expr/src/scalar/func/impls/list.rs
+++ b/src/expr/src/scalar/func/impls/list.rs
@@ -222,7 +222,7 @@ impl LazyUnaryFunc for ListLength {
         let count = a.unwrap_list().iter().count();
         match count.try_into() {
             Ok(c) => Ok(Datum::Int32(c)),
-            Err(_) => Err(EvalError::Int32OutOfRange(count.to_string())),
+            Err(_) => Err(EvalError::Int32OutOfRange(count.to_string().into())),
         }
     }
 

--- a/src/expr/src/scalar/func/impls/map.rs
+++ b/src/expr/src/scalar/func/impls/map.rs
@@ -92,7 +92,7 @@ impl LazyUnaryFunc for MapLength {
         let count = a.unwrap_map().iter().count();
         match count.try_into() {
             Ok(c) => Ok(Datum::Int32(c)),
-            Err(_) => Err(EvalError::Int32OutOfRange(count.to_string())),
+            Err(_) => Err(EvalError::Int32OutOfRange(count.to_string().into())),
         }
     }
 

--- a/src/expr/src/scalar/func/impls/mz_acl_item.rs
+++ b/src/expr/src/scalar/func/impls/mz_acl_item.rs
@@ -70,7 +70,7 @@ sqlfunc!(
                         .collect(),
                 )
             })
-            .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(e.to_string()))
+            .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(e.to_string().into()))
     }
 );
 
@@ -79,7 +79,7 @@ sqlfunc!(
     fn mz_validate_privileges(privileges: String) -> Result<bool, EvalError> {
         AclMode::parse_multiple_privileges(&privileges)
             .map(|_| true)
-            .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(e.to_string()))
+            .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(e.to_string().into()))
     }
 );
 
@@ -88,10 +88,9 @@ sqlfunc!(
     fn mz_validate_role_privilege(privilege: String) -> Result<bool, EvalError> {
         let privilege_upper = privilege.to_uppercase();
         if privilege_upper != "MEMBER" && privilege_upper != "USAGE" {
-            Err(EvalError::InvalidPrivileges(format!(
-                "{}",
-                privilege.quoted()
-            )))
+            Err(EvalError::InvalidPrivileges(
+                format!("{}", privilege.quoted()).into(),
+            ))
         } else {
             Ok(true)
         }

--- a/src/expr/src/scalar/func/impls/mz_timestamp.rs
+++ b/src/expr/src/scalar/func/impls/mz_timestamp.rs
@@ -48,7 +48,7 @@ sqlfunc!(
     fn cast_numeric_to_mz_timestamp(a: Numeric) -> Result<Timestamp, EvalError> {
         // The try_into will error if the conversion is lossy (out of range or fractional).
         a.try_into()
-            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string()))
+            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into()))
     }
 );
 
@@ -76,7 +76,7 @@ sqlfunc!(
     #[is_monotone = true]
     fn cast_int64_to_mz_timestamp(a: i64) -> Result<Timestamp, EvalError> {
         a.try_into()
-            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string()))
+            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into()))
     }
 );
 
@@ -87,7 +87,7 @@ sqlfunc!(
     fn cast_int32_to_mz_timestamp(a: i32) -> Result<Timestamp, EvalError> {
         i64::from(a)
             .try_into()
-            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string()))
+            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into()))
     }
 );
 
@@ -99,7 +99,7 @@ sqlfunc!(
     ) -> Result<Timestamp, EvalError> {
         a.timestamp_millis()
             .try_into()
-            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string()))
+            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into()))
     }
 );
 
@@ -112,7 +112,7 @@ sqlfunc!(
         a.and_utc()
             .timestamp_millis()
             .try_into()
-            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string()))
+            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into()))
     }
 );
 
@@ -125,7 +125,7 @@ sqlfunc!(
         ts.and_utc()
             .timestamp_millis()
             .try_into()
-            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string()))
+            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into()))
     }
 );
 

--- a/src/expr/src/scalar/func/impls/numeric.rs
+++ b/src/expr/src/scalar/func/impls/numeric.rs
@@ -90,10 +90,10 @@ sqlfunc!(
 
 fn log_guard_numeric(val: &Numeric, function_name: &str) -> Result<(), EvalError> {
     if val.is_negative() {
-        return Err(EvalError::NegativeOutOfDomain(function_name.to_owned()));
+        return Err(EvalError::NegativeOutOfDomain(function_name.into()));
     }
     if val.is_zero() {
-        return Err(EvalError::ZeroOutOfDomain(function_name.to_owned()));
+        return Err(EvalError::ZeroOutOfDomain(function_name.into()));
     }
     Ok(())
 }
@@ -181,8 +181,8 @@ sqlfunc!(
         cx.clear_status();
         let i = cx
             .try_into_i32(a)
-            .or(Err(EvalError::Int16OutOfRange(a.to_string())))?;
-        i16::try_from(i).or(Err(EvalError::Int16OutOfRange(i.to_string())))
+            .or(Err(EvalError::Int16OutOfRange(a.to_string().into())))?;
+        i16::try_from(i).or(Err(EvalError::Int16OutOfRange(i.to_string().into())))
     }
 );
 
@@ -196,7 +196,7 @@ sqlfunc!(
         cx.round(&mut a);
         cx.clear_status();
         cx.try_into_i32(a)
-            .or(Err(EvalError::Int32OutOfRange(a.to_string())))
+            .or(Err(EvalError::Int32OutOfRange(a.to_string().into())))
     }
 );
 
@@ -210,7 +210,7 @@ sqlfunc!(
         cx.round(&mut a);
         cx.clear_status();
         cx.try_into_i64(a)
-            .or(Err(EvalError::Int64OutOfRange(a.to_string())))
+            .or(Err(EvalError::Int64OutOfRange(a.to_string().into())))
     }
 );
 
@@ -222,7 +222,7 @@ sqlfunc!(
     fn cast_numeric_to_float32(a: Numeric) -> Result<f32, EvalError> {
         let i = a.to_string().parse::<f32>().unwrap();
         if i.is_infinite() {
-            Err(EvalError::Float32OutOfRange(i.to_string()))
+            Err(EvalError::Float32OutOfRange(i.to_string().into()))
         } else {
             Ok(i)
         }
@@ -237,7 +237,7 @@ sqlfunc!(
     fn cast_numeric_to_float64(a: Numeric) -> Result<f64, EvalError> {
         let i = a.to_string().parse::<f64>().unwrap();
         if i.is_infinite() {
-            Err(EvalError::Float64OutOfRange(i.to_string()))
+            Err(EvalError::Float64OutOfRange(i.to_string().into()))
         } else {
             Ok(i)
         }
@@ -266,8 +266,8 @@ sqlfunc!(
         cx.clear_status();
         let u = cx
             .try_into_u32(a)
-            .or(Err(EvalError::UInt16OutOfRange(a.to_string())))?;
-        u16::try_from(u).or(Err(EvalError::UInt16OutOfRange(u.to_string())))
+            .or(Err(EvalError::UInt16OutOfRange(a.to_string().into())))?;
+        u16::try_from(u).or(Err(EvalError::UInt16OutOfRange(u.to_string().into())))
     }
 );
 
@@ -281,7 +281,7 @@ sqlfunc!(
         cx.round(&mut a);
         cx.clear_status();
         cx.try_into_u32(a)
-            .or(Err(EvalError::UInt32OutOfRange(a.to_string())))
+            .or(Err(EvalError::UInt32OutOfRange(a.to_string().into())))
     }
 );
 
@@ -295,7 +295,7 @@ sqlfunc!(
         cx.round(&mut a);
         cx.clear_status();
         cx.try_into_u64(a)
-            .or(Err(EvalError::UInt64OutOfRange(a.to_string())))
+            .or(Err(EvalError::UInt64OutOfRange(a.to_string().into())))
     }
 );
 

--- a/src/expr/src/scalar/func/impls/pg_legacy_char.rs
+++ b/src/expr/src/scalar/func/impls/pg_legacy_char.rs
@@ -28,7 +28,7 @@ where
             Ok(())
         }
         Err(_) => Err(EvalError::InvalidByteSequence {
-            byte_sequence: format!("{:#02x}", c),
+            byte_sequence: format!("{:#02x}", c).into(),
             encoding_name: "UTF8".into(),
         }),
     }

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -553,7 +553,7 @@ impl<'a> EagerUnaryFunc<'a> for CastStringToChar {
         let s = format_str_trim(a, self.length, self.fail_on_len).map_err(|_| {
             assert!(self.fail_on_len);
             EvalError::StringValueTooLong {
-                target_type: "character".to_string(),
+                target_type: "character".into(),
                 length: usize::cast_from(self.length.unwrap().into_u32()),
             }
         })?;
@@ -677,7 +677,7 @@ impl<'a> EagerUnaryFunc<'a> for CastStringToVarChar {
             mz_repr::adt::varchar::format_str(a, self.length, self.fail_on_len).map_err(|_| {
                 assert!(self.fail_on_len);
                 EvalError::StringValueTooLong {
-                    target_type: "character varying".to_string(),
+                    target_type: "character varying".into(),
                     length: usize::cast_from(self.length.unwrap().into_u32()),
                 }
             })?;
@@ -842,7 +842,7 @@ sqlfunc!(
     #[sqlname = "char_length"]
     fn char_length<'a>(a: &'a str) -> Result<i32, EvalError> {
         let length = a.chars().count();
-        i32::try_from(length).or(Err(EvalError::Int32OutOfRange(length.to_string())))
+        i32::try_from(length).or(Err(EvalError::Int32OutOfRange(length.to_string().into())))
     }
 );
 
@@ -850,7 +850,7 @@ sqlfunc!(
     #[sqlname = "bit_length"]
     fn bit_length_string<'a>(a: &'a str) -> Result<i32, EvalError> {
         let length = a.as_bytes().len() * 8;
-        i32::try_from(length).or(Err(EvalError::Int32OutOfRange(length.to_string())))
+        i32::try_from(length).or(Err(EvalError::Int32OutOfRange(length.to_string().into())))
     }
 );
 
@@ -858,7 +858,7 @@ sqlfunc!(
     #[sqlname = "octet_length"]
     fn byte_length_string<'a>(a: &'a str) -> Result<i32, EvalError> {
         let length = a.as_bytes().len();
-        i32::try_from(length).or(Err(EvalError::Int32OutOfRange(length.to_string())))
+        i32::try_from(length).or(Err(EvalError::Int32OutOfRange(length.to_string().into())))
     }
 );
 
@@ -1069,8 +1069,8 @@ impl LazyUnaryFunc for QuoteIdent {
         }
         let v = d.unwrap_str();
         let i = mz_sql_parser::ast::Ident::new(v).map_err(|err| EvalError::InvalidIdentifier {
-            ident: v.to_string(),
-            detail: Some(err.to_string()),
+            ident: v.into(),
+            detail: Some(err.to_string().into()),
         })?;
         let r = temp_storage.push_string(i.to_string());
 

--- a/src/expr/src/scalar/func/impls/time.rs
+++ b/src/expr/src/scalar/func/impls/time.rs
@@ -75,12 +75,12 @@ where
         | DateTimeUnits::DayOfWeek
         | DateTimeUnits::IsoDayOfYear
         | DateTimeUnits::IsoDayOfWeek => Err(EvalError::UnsupportedUnits(
-            format!("{}", units),
-            "time".to_string(),
+            format!("{}", units).into(),
+            "time".into(),
         )),
         DateTimeUnits::Timezone | DateTimeUnits::TimezoneHour | DateTimeUnits::TimezoneMinute => {
             Err(EvalError::Unsupported {
-                feature: format!("'{}' timestamp units", units),
+                feature: format!("'{}' timestamp units", units).into(),
                 discussion_no: None,
             })
         }

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -313,7 +313,7 @@ where
         | DateTimeUnits::DayOfYear
         | DateTimeUnits::IsoDayOfWeek
         | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported {
-            feature: format!("'{}' timestamp units", units),
+            feature: format!("'{}' timestamp units", units).into(),
             discussion_no: None,
         }),
     }
@@ -394,7 +394,7 @@ where
         | DateTimeUnits::TimezoneHour
         | DateTimeUnits::TimezoneMinute
         | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported {
-            feature: format!("'{}' timestamp units", units),
+            feature: format!("'{}' timestamp units", units).into(),
             discussion_no: None,
         }),
     }
@@ -543,7 +543,7 @@ pub fn date_trunc_inner<T: TimestampLike>(units: DateTimeUnits, ts: &T) -> Resul
         | DateTimeUnits::DayOfYear
         | DateTimeUnits::IsoDayOfWeek
         | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported {
-            feature: format!("'{}' timestamp units", units),
+            feature: format!("'{}' timestamp units", units).into(),
             discussion_no: None,
         }),
     }

--- a/src/expr/src/scalar/func/impls/uint16.rs
+++ b/src/expr/src/scalar/func/impls/uint16.rs
@@ -72,7 +72,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastInt16ToUint16)]
     #[is_monotone = true]
     fn cast_uint16_to_int16(a: u16) -> Result<i16, EvalError> {
-        i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string())))
+        i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string().into())))
     }
 );
 

--- a/src/expr/src/scalar/func/impls/uint32.rs
+++ b/src/expr/src/scalar/func/impls/uint32.rs
@@ -56,7 +56,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastUint16ToUint32)]
     #[is_monotone = true]
     fn cast_uint32_to_uint16(a: u32) -> Result<u16, EvalError> {
-        u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string())))
+        u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string().into())))
     }
 );
 
@@ -76,7 +76,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastInt16ToUint32)]
     #[is_monotone = true]
     fn cast_uint32_to_int16(a: u32) -> Result<i16, EvalError> {
-        i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string())))
+        i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string().into())))
     }
 );
 
@@ -86,7 +86,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastInt32ToUint32)]
     #[is_monotone = true]
     fn cast_uint32_to_int32(a: u32) -> Result<i32, EvalError> {
-        i32::try_from(a).or(Err(EvalError::Int32OutOfRange(a.to_string())))
+        i32::try_from(a).or(Err(EvalError::Int32OutOfRange(a.to_string().into())))
     }
 );
 

--- a/src/expr/src/scalar/func/impls/uint64.rs
+++ b/src/expr/src/scalar/func/impls/uint64.rs
@@ -60,7 +60,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastUint16ToUint64)]
     #[is_monotone = true]
     fn cast_uint64_to_uint16(a: u64) -> Result<u16, EvalError> {
-        u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string())))
+        u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string().into())))
     }
 );
 
@@ -70,7 +70,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastUint32ToUint64)]
     #[is_monotone = true]
     fn cast_uint64_to_uint32(a: u64) -> Result<u32, EvalError> {
-        u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string())))
+        u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string().into())))
     }
 );
 
@@ -80,7 +80,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastInt16ToUint64)]
     #[is_monotone = true]
     fn cast_uint64_to_int16(a: u64) -> Result<i16, EvalError> {
-        i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string())))
+        i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string().into())))
     }
 );
 
@@ -90,7 +90,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastInt32ToUint64)]
     #[is_monotone = true]
     fn cast_uint64_to_int32(a: u64) -> Result<i32, EvalError> {
-        i32::try_from(a).or(Err(EvalError::Int32OutOfRange(a.to_string())))
+        i32::try_from(a).or(Err(EvalError::Int32OutOfRange(a.to_string().into())))
     }
 );
 
@@ -100,7 +100,7 @@ sqlfunc!(
     #[inverse = to_unary!(super::CastInt64ToUint64)]
     #[is_monotone = true]
     fn cast_uint64_to_int64(a: u64) -> Result<i64, EvalError> {
-        i64::try_from(a).or(Err(EvalError::Int64OutOfRange(a.to_string())))
+        i64::try_from(a).or(Err(EvalError::Int64OutOfRange(a.to_string().into())))
     }
 );
 

--- a/src/expr/src/scalar/like_pattern.rs
+++ b/src/expr/src/scalar/like_pattern.rs
@@ -406,10 +406,9 @@ fn build_regex(subpatterns: &[Subpattern], case_insensitive: bool) -> Result<Reg
     match Regex::new(r, case_insensitive) {
         Ok(regex) => Ok(regex),
         Err(regex::Error::CompiledTooBig(_)) => Err(EvalError::LikePatternTooLong),
-        Err(e) => Err(EvalError::Internal(format!(
-            "build_regex produced invalid regex: {}",
-            e
-        ))),
+        Err(e) => Err(EvalError::Internal(
+            format!("build_regex produced invalid regex: {}", e).into(),
+        )),
     }
 }
 

--- a/src/proto/src/lib.rs
+++ b/src/proto/src/lib.rs
@@ -549,7 +549,7 @@ impl<'a> RustType<String> for Cow<'a, str> {
     }
 }
 
-impl<'a> RustType<String> for Box<str> {
+impl RustType<String> for Box<str> {
     fn into_proto(&self) -> String {
         self.to_string()
     }

--- a/src/proto/src/lib.rs
+++ b/src/proto/src/lib.rs
@@ -549,6 +549,15 @@ impl<'a> RustType<String> for Cow<'a, str> {
     }
 }
 
+impl<'a> RustType<String> for Box<str> {
+    fn into_proto(&self) -> String {
+        self.to_string()
+    }
+    fn from_proto(proto: String) -> Result<Self, TryFromProtoError> {
+        Ok(proto.into())
+    }
+}
+
 /// The symmetric counterpart of [`RustType`], similar to
 /// what [`Into`] is to [`From`].
 ///

--- a/src/repr/src/adt/range.rs
+++ b/src/repr/src/adt/range.rs
@@ -727,7 +727,7 @@ impl<'a, const UPPER: bool> RangeBound<Datum<'a>, UPPER> {
             self.bound = Some(
                 cur.step()
                     .ok_or_else(|| {
-                        InvalidRangeError::CanonicalizationOverflow(T::err_type_name().to_string())
+                        InvalidRangeError::CanonicalizationOverflow(T::err_type_name().into())
                     })?
                     .into(),
             );
@@ -743,7 +743,7 @@ impl<'a, const UPPER: bool> RangeBound<Datum<'a>, UPPER> {
 )]
 pub enum InvalidRangeError {
     MisorderedRangeBounds,
-    CanonicalizationOverflow(String),
+    CanonicalizationOverflow(Box<str>),
     InvalidRangeBoundFlags,
     DiscontiguousUnion,
     DiscontiguousDifference,
@@ -792,7 +792,9 @@ impl RustType<ProtoInvalidRangeError> for InvalidRangeError {
         use Kind::*;
         let kind = match self {
             InvalidRangeError::MisorderedRangeBounds => MisorderedRangeBounds(()),
-            InvalidRangeError::CanonicalizationOverflow(s) => CanonicalizationOverflow(s.clone()),
+            InvalidRangeError::CanonicalizationOverflow(s) => {
+                CanonicalizationOverflow(s.into_proto())
+            }
             InvalidRangeError::InvalidRangeBoundFlags => InvalidRangeBoundFlags(()),
             InvalidRangeError::DiscontiguousUnion => DiscontiguousUnion(()),
             InvalidRangeError::DiscontiguousDifference => DiscontiguousDifference(()),
@@ -806,7 +808,9 @@ impl RustType<ProtoInvalidRangeError> for InvalidRangeError {
         match proto.kind {
             Some(kind) => Ok(match kind {
                 MisorderedRangeBounds(()) => InvalidRangeError::MisorderedRangeBounds,
-                CanonicalizationOverflow(s) => InvalidRangeError::CanonicalizationOverflow(s),
+                CanonicalizationOverflow(s) => {
+                    InvalidRangeError::CanonicalizationOverflow(s.into())
+                }
                 InvalidRangeBoundFlags(()) => InvalidRangeError::InvalidRangeBoundFlags,
                 DiscontiguousUnion(()) => InvalidRangeError::DiscontiguousUnion,
                 DiscontiguousDifference(()) => InvalidRangeError::DiscontiguousDifference,

--- a/src/storage-types/src/errors.rs
+++ b/src/storage-types/src/errors.rs
@@ -1159,7 +1159,7 @@ mod tests {
     #[mz_ore::test]
     fn test_decode_error_codec_roundtrip() -> Result<(), String> {
         let original = DecodeError {
-            kind: DecodeErrorKind::Text("ciao".to_string()),
+            kind: DecodeErrorKind::Text("ciao".into()),
             raw: b"oaic".to_vec(),
         };
         let mut encoded = Vec::new();

--- a/src/storage-types/src/errors.rs
+++ b/src/storage-types/src/errors.rs
@@ -485,8 +485,7 @@ mod boxed_str {
             Self: 'a,
             I: Iterator<Item = &'a Self> + Clone,
         {
-            self.region
-                .reserve(regions.clone().map(|r| r.region.len()).sum());
+            self.region.reserve(regions.map(|r| r.region.len()).sum());
         }
         #[inline]
         fn heap_size(&self, callback: impl FnMut(usize, usize)) {

--- a/src/storage-types/src/errors.rs
+++ b/src/storage-types/src/errors.rs
@@ -90,8 +90,8 @@ impl Display for DecodeError {
 
 #[derive(Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum DecodeErrorKind {
-    Text(String),
-    Bytes(String),
+    Text(Box<str>),
+    Bytes(Box<str>),
 }
 
 impl RustType<ProtoDecodeErrorKind> for DecodeErrorKind {
@@ -99,8 +99,8 @@ impl RustType<ProtoDecodeErrorKind> for DecodeErrorKind {
         use proto_decode_error_kind::Kind::*;
         ProtoDecodeErrorKind {
             kind: Some(match self {
-                DecodeErrorKind::Text(v) => Text(v.clone()),
-                DecodeErrorKind::Bytes(v) => Bytes(v.clone()),
+                DecodeErrorKind::Text(v) => Text(v.into_proto()),
+                DecodeErrorKind::Bytes(v) => Bytes(v.into_proto()),
             }),
         }
     }
@@ -108,8 +108,8 @@ impl RustType<ProtoDecodeErrorKind> for DecodeErrorKind {
     fn from_proto(proto: ProtoDecodeErrorKind) -> Result<Self, TryFromProtoError> {
         use proto_decode_error_kind::Kind::*;
         match proto.kind {
-            Some(Text(v)) => Ok(DecodeErrorKind::Text(v)),
-            Some(Bytes(v)) => Ok(DecodeErrorKind::Bytes(v)),
+            Some(Text(v)) => Ok(DecodeErrorKind::Text(v.into())),
+            Some(Bytes(v)) => Ok(DecodeErrorKind::Bytes(v.into())),
             None => Err(TryFromProtoError::missing_field("ProtoDecodeError::kind")),
         }
     }
@@ -131,7 +131,7 @@ pub enum EnvelopeError {
     Upsert(UpsertError),
     /// Errors corresponding to `ENVELOPE NONE`. Naming this
     /// `None`, though, would have been too confusing.
-    Flat(String),
+    Flat(Box<str>),
 }
 
 impl RustType<ProtoEnvelopeErrorV1> for EnvelopeError {
@@ -140,7 +140,7 @@ impl RustType<ProtoEnvelopeErrorV1> for EnvelopeError {
         ProtoEnvelopeErrorV1 {
             kind: Some(match self {
                 EnvelopeError::Upsert(rust) => Kind::Upsert(rust.into_proto()),
-                EnvelopeError::Flat(text) => Kind::Flat(text.clone()),
+                EnvelopeError::Flat(text) => Kind::Flat(text.into_proto()),
             }),
         }
     }
@@ -152,7 +152,7 @@ impl RustType<ProtoEnvelopeErrorV1> for EnvelopeError {
                 let rust = RustType::from_proto(proto)?;
                 Ok(Self::Upsert(rust))
             }
-            Some(Kind::Flat(text)) => Ok(Self::Flat(text)),
+            Some(Kind::Flat(text)) => Ok(Self::Flat(text.into())),
             None => Err(TryFromProtoError::missing_field(
                 "ProtoEnvelopeErrorV1::kind",
             )),
@@ -374,8 +374,8 @@ impl Display for SourceError {
 
 #[derive(Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum SourceErrorDetails {
-    Initialization(String),
-    Other(String),
+    Initialization(Box<str>),
+    Other(Box<str>),
 }
 
 impl RustType<ProtoSourceErrorDetails> for SourceErrorDetails {
@@ -383,8 +383,8 @@ impl RustType<ProtoSourceErrorDetails> for SourceErrorDetails {
         use proto_source_error_details::Kind;
         ProtoSourceErrorDetails {
             kind: Some(match self {
-                SourceErrorDetails::Initialization(s) => Kind::Initialization(s.clone()),
-                SourceErrorDetails::Other(s) => Kind::Other(s.clone()),
+                SourceErrorDetails::Initialization(s) => Kind::Initialization(s.into_proto()),
+                SourceErrorDetails::Other(s) => Kind::Other(s.into_proto()),
             }),
         }
     }
@@ -393,12 +393,12 @@ impl RustType<ProtoSourceErrorDetails> for SourceErrorDetails {
         use proto_source_error_details::Kind;
         match proto.kind {
             Some(kind) => match kind {
-                Kind::Initialization(s) => Ok(SourceErrorDetails::Initialization(s)),
+                Kind::Initialization(s) => Ok(SourceErrorDetails::Initialization(s.into())),
                 Kind::DeprecatedFileIo(s) | Kind::DeprecatedPersistence(s) => {
                     warn!("Deprecated source error kind: {s}");
-                    Ok(SourceErrorDetails::Other(s))
+                    Ok(SourceErrorDetails::Other(s.into()))
                 }
-                Kind::Other(s) => Ok(SourceErrorDetails::Other(s)),
+                Kind::Other(s) => Ok(SourceErrorDetails::Other(s.into())),
             },
             None => Err(TryFromProtoError::missing_field(
                 "ProtoSourceErrorDetails::kind",
@@ -444,6 +444,57 @@ pub enum DataflowError {
 
 impl Error for DataflowError {}
 
+mod boxed_str {
+
+    use timely::container::columnation::Region;
+    use timely::container::columnation::StableRegion;
+
+    /// Region allocation for `String` data.
+    ///
+    /// Content bytes are stored in stable contiguous memory locations,
+    /// and then a `String` referencing them is falsified.
+    #[derive(Default)]
+    pub struct BoxStrStack {
+        region: StableRegion<u8>,
+    }
+
+    impl Region for BoxStrStack {
+        type Item = Box<str>;
+        #[inline]
+        fn clear(&mut self) {
+            self.region.clear();
+        }
+        // Removing `(always)` is a 20% performance regression in
+        // the `string10_copy` benchmark.
+        #[inline(always)]
+        unsafe fn copy(&mut self, item: &Box<str>) -> Box<str> {
+            let bytes = self.region.copy_slice(item.as_bytes());
+            Box::from(std::str::from_utf8_unchecked(bytes))
+        }
+        #[inline(always)]
+        fn reserve_items<'a, I>(&mut self, items: I)
+        where
+            Self: 'a,
+            I: Iterator<Item = &'a Self::Item> + Clone,
+        {
+            self.region.reserve(items.map(|x| x.len()).sum());
+        }
+
+        fn reserve_regions<'a, I>(&mut self, regions: I)
+        where
+            Self: 'a,
+            I: Iterator<Item = &'a Self> + Clone,
+        {
+            self.region
+                .reserve(regions.clone().map(|r| r.region.len()).sum());
+        }
+        #[inline]
+        fn heap_size(&self, callback: impl FnMut(usize, usize)) {
+            self.region.heap_size(callback)
+        }
+    }
+}
+
 mod columnation {
     use std::iter::once;
 
@@ -453,6 +504,7 @@ mod columnation {
     use mz_repr::Row;
     use timely::container::columnation::{Columnation, Region, StableRegion};
 
+    use crate::errors::boxed_str::BoxStrStack;
     use crate::errors::{
         DataflowError, DecodeError, DecodeErrorKind, EnvelopeError, SourceError,
         SourceErrorDetails, UpsertError, UpsertValueError,
@@ -476,7 +528,7 @@ mod columnation {
         /// Stable location for [`SourceError`] for inserting into a box.
         source_error_region: StableRegion<SourceError>,
         /// Region for storing strings.
-        string_region: <String as Columnation>::InnerRegion,
+        string_region: BoxStrStack,
         /// Region for storing u8 vectors.
         u8_region: <Vec<u8> as Columnation>::InnerRegion,
     }

--- a/src/storage/src/decode.rs
+++ b/src/storage/src/decode.rs
@@ -221,21 +221,20 @@ impl PreDelimitedFormat {
             PreDelimitedFormat::Bytes => Ok(Some(Row::pack(Some(Datum::Bytes(bytes))))),
             PreDelimitedFormat::Json => {
                 let j = mz_repr::adt::jsonb::Jsonb::from_slice(bytes).map_err(|e| {
-                    DecodeErrorKind::Bytes(format!(
-                        "Failed to decode JSON: {}",
-                        e.display_with_causes(),
-                    ))
+                    DecodeErrorKind::Bytes(
+                        format!("Failed to decode JSON: {}", e.display_with_causes(),).into(),
+                    )
                 })?;
                 Ok(Some(j.into_row()))
             }
             PreDelimitedFormat::Text => {
                 let s = std::str::from_utf8(bytes)
-                    .map_err(|_| DecodeErrorKind::Text("Failed to decode UTF-8".to_string()))?;
+                    .map_err(|_| DecodeErrorKind::Text("Failed to decode UTF-8".into()))?;
                 Ok(Some(Row::pack(Some(Datum::String(s)))))
             }
             PreDelimitedFormat::Regex(regex, row_buf) => {
                 let s = std::str::from_utf8(bytes)
-                    .map_err(|_| DecodeErrorKind::Text("Failed to decode UTF-8".to_string()))?;
+                    .map_err(|_| DecodeErrorKind::Text("Failed to decode UTF-8".into()))?;
                 let captures = match regex.captures(s) {
                     Some(captures) => captures,
                     None => return Ok(None),
@@ -429,9 +428,10 @@ async fn decode_delimited(
                     None => decoder.eof(&mut remaining_buf)?,
                 }
             } else {
-                Err(DecodeErrorKind::Text(format!(
-                    "Unexpected bytes remaining for decoded value: {remaining_buf:?}"
-                )))
+                Err(DecodeErrorKind::Text(
+                    format!("Unexpected bytes remaining for decoded value: {remaining_buf:?}")
+                        .into(),
+                ))
             }
         }
         Err(err) => Err(err),

--- a/src/storage/src/decode/avro.rs
+++ b/src/storage/src/decode/avro.rs
@@ -40,10 +40,9 @@ impl AvroDecoderState {
                 self.events_success += 1;
                 Ok(Some(row))
             }
-            Err(err) => Err(DecodeErrorKind::Text(format!(
-                "avro deserialization error: {}",
-                err.display_with_causes()
-            ))),
+            Err(err) => Err(DecodeErrorKind::Text(
+                format!("avro deserialization error: {}", err.display_with_causes()).into(),
+            )),
         };
         Ok(result)
     }

--- a/src/storage/src/decode/csv.rs
+++ b/src/storage/src/decode/csv.rs
@@ -87,12 +87,15 @@ impl CsvDecoderState {
                         }
                         if ends_valid != self.n_cols {
                             self.events_error += 1;
-                            Err(DecodeErrorKind::Text(format!(
-                                "CSV error at record number {}: expected {} columns, got {}.",
-                                self.total_events(),
-                                self.n_cols,
-                                ends_valid
-                            )))
+                            Err(DecodeErrorKind::Text(
+                                format!(
+                                    "CSV error at record number {}: expected {} columns, got {}.",
+                                    self.total_events(),
+                                    self.n_cols,
+                                    ends_valid
+                                )
+                                .into(),
+                            ))
                         } else {
                             match std::str::from_utf8(&self.output[0..self.output_cursor]) {
                                 Ok(output) => {
@@ -107,11 +110,14 @@ impl CsvDecoderState {
                                 }
                                 Err(e) => {
                                     self.events_error += 1;
-                                    Err(DecodeErrorKind::Text(format!(
-                                        "CSV error at record number {}: invalid UTF-8 ({})",
-                                        self.total_events(),
-                                        e
-                                    )))
+                                    Err(DecodeErrorKind::Text(
+                                        format!(
+                                            "CSV error at record number {}: invalid UTF-8 ({})",
+                                            self.total_events(),
+                                            e
+                                        )
+                                        .into(),
+                                    ))
                                 }
                             }
                         }
@@ -128,14 +134,17 @@ impl CsvDecoderState {
                                 .enumerate()
                                 .find(|(_, (actual, expected))| actual.unwrap_str() != &**expected);
                             if let Some((i, (actual, expected))) = mismatched {
-                                break Err(DecodeErrorKind::Text(format!(
-                                    "source file contains incorrect columns '{:?}', \
+                                break Err(DecodeErrorKind::Text(
+                                    format!(
+                                        "source file contains incorrect columns '{:?}', \
                                      first mismatched column at index {} expected={} actual={}",
-                                    row,
-                                    i + 1,
-                                    expected,
-                                    actual
-                                )));
+                                        row,
+                                        i + 1,
+                                        expected,
+                                        actual
+                                    )
+                                    .into(),
+                                ));
                             }
                         }
                         if chunk.is_empty() {

--- a/src/storage/src/decode/protobuf.rs
+++ b/src/storage/src/decode/protobuf.rs
@@ -45,16 +45,19 @@ impl ProtobufDecoderState {
                 } else {
                     self.events_error += 1;
                     Some(Err(DecodeErrorKind::Text(
-                        "protobuf deserialization returned None".to_string(),
+                        "protobuf deserialization returned None".into(),
                     )))
                 }
             }
             Err(err) => {
                 self.events_error += 1;
-                Some(Err(DecodeErrorKind::Text(format!(
-                    "protobuf deserialization error: {}",
-                    err.display_with_causes()
-                ))))
+                Some(Err(DecodeErrorKind::Text(
+                    format!(
+                        "protobuf deserialization error: {}",
+                        err.display_with_causes()
+                    )
+                    .into(),
+                )))
             }
         }
     }

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -628,7 +628,7 @@ fn raise_key_value_errors(
         (None, None) => None,
         // TODO(petrosagg): these errors would be better grouped under an EnvelopeError enum
         _ => Some(Err(DataflowError::from(EnvelopeError::Flat(
-            "Value not present for message".to_string(),
+            "Value not present for message".into(),
         )))),
     }
 }

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -606,10 +606,13 @@ impl SourceRender for KafkaSourceConnection {
                             let prev_pid_count = prev_pid_info.map(|info| info.len()).unwrap_or(0);
                             let pid_count = partitions.len();
                             let err = DataflowError::SourceError(Box::new(SourceError {
-                                error: SourceErrorDetails::Other(format!(
-                                    "topic was recreated: partition \
+                                error: SourceErrorDetails::Other(
+                                    format!(
+                                        "topic was recreated: partition \
                                      count regressed from {prev_pid_count} to {pid_count}"
-                                )),
+                                    )
+                                    .into(),
+                                ),
                             }));
                             let time = data_cap.time().clone();
                             data_output
@@ -624,11 +627,14 @@ impl SourceRender for KafkaSourceConnection {
                                 let watermarks = &partitions[&pid];
                                 if !(prev_watermarks.high <= watermarks.high) {
                                     let err = DataflowError::SourceError(Box::new(SourceError {
-                                        error: SourceErrorDetails::Other(format!(
-                                            "topic was recreated: high watermark of \
+                                        error: SourceErrorDetails::Other(
+                                            format!(
+                                                "topic was recreated: high watermark of \
                                         partition {pid} regressed from {} to {}",
-                                            prev_watermarks.high, watermarks.high
-                                        )),
+                                                prev_watermarks.high, watermarks.high
+                                            )
+                                            .into(),
+                                        ),
                                     }));
                                     let time = data_cap.time().clone();
                                     data_output
@@ -751,7 +757,9 @@ impl SourceRender for KafkaSourceConnection {
                                         let part_cap = &reader.partition_capabilities[pid].data;
                                         let msg = msg.map_err(|e| {
                                             DataflowError::SourceError(Box::new(SourceError {
-                                                error: SourceErrorDetails::Other(format!("{}", e)),
+                                                error: SourceErrorDetails::Other(
+                                                    e.to_string().into(),
+                                                ),
                                             }))
                                         });
                                         data_output
@@ -801,7 +809,9 @@ impl SourceRender for KafkaSourceConnection {
                                         let part_cap = &reader.partition_capabilities[pid].data;
                                         let msg = msg.map_err(|e| {
                                             DataflowError::SourceError(Box::new(SourceError {
-                                                error: SourceErrorDetails::Other(format!("{}", e)),
+                                                error: SourceErrorDetails::Other(
+                                                    e.to_string().into(),
+                                                ),
                                             }))
                                         });
                                         data_output

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -286,27 +286,22 @@ pub enum DefiniteError {
 
 impl From<DefiniteError> for DataflowError {
     fn from(err: DefiniteError) -> Self {
+        let m = err.to_string().into();
         DataflowError::SourceError(Box::new(SourceError {
             error: match &err {
-                DefiniteError::ValueDecodeError(_) => SourceErrorDetails::Other(err.to_string()),
-                DefiniteError::TableTruncated(_) => SourceErrorDetails::Other(err.to_string()),
-                DefiniteError::TableDropped(_) => SourceErrorDetails::Other(err.to_string()),
-                DefiniteError::IncompatibleSchema(_) => SourceErrorDetails::Other(err.to_string()),
-                DefiniteError::UnsupportedGtidState(_) => {
-                    SourceErrorDetails::Other(err.to_string())
-                }
+                DefiniteError::ValueDecodeError(_) => SourceErrorDetails::Other(m),
+                DefiniteError::TableTruncated(_) => SourceErrorDetails::Other(m),
+                DefiniteError::TableDropped(_) => SourceErrorDetails::Other(m),
+                DefiniteError::IncompatibleSchema(_) => SourceErrorDetails::Other(m),
+                DefiniteError::UnsupportedGtidState(_) => SourceErrorDetails::Other(m),
                 DefiniteError::BinlogGtidMonotonicityViolation(_, _) => {
-                    SourceErrorDetails::Other(err.to_string())
+                    SourceErrorDetails::Other(m)
                 }
-                DefiniteError::BinlogNotAvailable => {
-                    SourceErrorDetails::Initialization(err.to_string())
-                }
+                DefiniteError::BinlogNotAvailable => SourceErrorDetails::Initialization(m),
                 DefiniteError::BinlogMissingResumePoint(_, _) => {
-                    SourceErrorDetails::Initialization(err.to_string())
+                    SourceErrorDetails::Initialization(m)
                 }
-                DefiniteError::ServerConfigurationError(_) => {
-                    SourceErrorDetails::Initialization(err.to_string())
-                }
+                DefiniteError::ServerConfigurationError(_) => SourceErrorDetails::Initialization(m),
             },
         }))
     }

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -333,29 +333,22 @@ pub enum DefiniteError {
 
 impl From<DefiniteError> for DataflowError {
     fn from(err: DefiniteError) -> Self {
+        let m = err.to_string().into();
         DataflowError::SourceError(Box::new(SourceError {
             error: match &err {
-                DefiniteError::SlotCompactedPastResumePoint(_, _) => {
-                    SourceErrorDetails::Other(err.to_string())
-                }
-                DefiniteError::TableTruncated => SourceErrorDetails::Other(err.to_string()),
-                DefiniteError::TableDropped => SourceErrorDetails::Other(err.to_string()),
-                DefiniteError::PublicationDropped(_) => {
-                    SourceErrorDetails::Initialization(err.to_string())
-                }
-                DefiniteError::InvalidReplicationSlot => {
-                    SourceErrorDetails::Initialization(err.to_string())
-                }
-                DefiniteError::MissingColumn => SourceErrorDetails::Other(err.to_string()),
-                DefiniteError::InvalidCopyInput => SourceErrorDetails::Other(err.to_string()),
-                DefiniteError::InvalidTimelineId { .. } => {
-                    SourceErrorDetails::Initialization(err.to_string())
-                }
-                DefiniteError::MissingToast => SourceErrorDetails::Other(err.to_string()),
-                DefiniteError::DefaultReplicaIdentity => SourceErrorDetails::Other(err.to_string()),
-                DefiniteError::IncompatibleSchema(_) => SourceErrorDetails::Other(err.to_string()),
-                DefiniteError::InvalidUTF8(_) => SourceErrorDetails::Other(err.to_string()),
-                DefiniteError::CastError(_) => SourceErrorDetails::Other(err.to_string()),
+                DefiniteError::SlotCompactedPastResumePoint(_, _) => SourceErrorDetails::Other(m),
+                DefiniteError::TableTruncated => SourceErrorDetails::Other(m),
+                DefiniteError::TableDropped => SourceErrorDetails::Other(m),
+                DefiniteError::PublicationDropped(_) => SourceErrorDetails::Initialization(m),
+                DefiniteError::InvalidReplicationSlot => SourceErrorDetails::Initialization(m),
+                DefiniteError::MissingColumn => SourceErrorDetails::Other(m),
+                DefiniteError::InvalidCopyInput => SourceErrorDetails::Other(m),
+                DefiniteError::InvalidTimelineId { .. } => SourceErrorDetails::Initialization(m),
+                DefiniteError::MissingToast => SourceErrorDetails::Other(m),
+                DefiniteError::DefaultReplicaIdentity => SourceErrorDetails::Other(m),
+                DefiniteError::IncompatibleSchema(_) => SourceErrorDetails::Other(m),
+                DefiniteError::InvalidUTF8(_) => SourceErrorDetails::Other(m),
+                DefiniteError::CastError(_) => SourceErrorDetails::Other(m),
             },
         }))
     }

--- a/src/transform/src/fold_constants.rs
+++ b/src/transform/src/fold_constants.rs
@@ -438,10 +438,9 @@ impl FoldConstants {
             // arrive at a reduce.
 
             if *diff <= 0 {
-                return Some(Err(EvalError::InvalidParameterValue(String::from(
-                    "constant folding encountered reduce on collection \
-                                               with non-positive multiplicities",
-                ))));
+                return Some(Err(EvalError::InvalidParameterValue(
+                    "constant folding encountered reduce on collection with non-positive multiplicities".into()
+                )));
             }
 
             if limit_remaining < *diff as usize {


### PR DESCRIPTION
Convert all instances of `String` in `EvalError` and its dependencies to `Box<str>`, which saves eight bytes per string, and reduces the size of `EvalError` from 80 to 56 bytes.

Before:

```
type: `scalar::EvalError`: 80 bytes, alignment: 8 bytes
print-type-size     variant `Parse`: 80 bytes
print-type-size         field `.0`: 80 bytes
print-type-size     variant `DateDiffOverflow`: 80 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.unit`: 24 bytes, alignment: 8 bytes
print-type-size         field `.a`: 24 bytes
print-type-size         field `.b`: 24 bytes
print-type-size     variant `OutOfDomain`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 8 bytes
print-type-size         field `.1`: 16 bytes
print-type-size         field `.2`: 24 bytes
print-type-size     variant `InvalidByteSequence`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.byte_sequence`: 24 bytes, alignment: 8 bytes
print-type-size         field `.encoding_name`: 24 bytes
print-type-size     variant `InvalidJsonbCast`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.from`: 24 bytes, alignment: 8 bytes
print-type-size         field `.to`: 24 bytes
print-type-size     variant `UnsupportedUnits`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size         field `.1`: 24 bytes
print-type-size     variant `InvalidIdentifier`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.ident`: 24 bytes, alignment: 8 bytes
print-type-size         field `.detail`: 24 bytes
print-type-size     variant `Unsupported`: 48 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.discussion_no`: 16 bytes, alignment: 8 bytes
print-type-size         field `.feature`: 24 bytes
print-type-size     variant `StringValueTooLong`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.target_type`: 24 bytes, alignment: 8 bytes
print-type-size         field `.length`: 8 bytes
print-type-size     variant `DateBinOutOfRange`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `Float32OutOfRange`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `Float64OutOfRange`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `Int16OutOfRange`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `Int32OutOfRange`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `Int64OutOfRange`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `UInt16OutOfRange`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `UInt32OutOfRange`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `UInt64OutOfRange`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `MzTimestampOutOfRange`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `OidOutOfRange`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `IntervalOutOfRange`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidTimezone`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidIanaTimezoneId`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidArray`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidEncodingName`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidHashAlgorithm`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidRegex`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidParameterValue`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidDatePart`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `UnknownUnits`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `Internal`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InfinityOutOfDomain`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `NegativeOutOfDomain`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `ZeroOutOfDomain`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `ComplexOutOfRange`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `Undefined`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `IncompatibleArrayDimensions`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.dims`: 24 bytes, alignment: 8 bytes
print-type-size     variant `TypeFromOid`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidRange`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidRoleId`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidPrivileges`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `LetRecLimitExceeded`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `MustNotBeNull`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `IfNullError`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `PrettyError`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidLayer`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.max_layer`: 8 bytes, alignment: 8 bytes
print-type-size         field `.val`: 8 bytes
print-type-size     variant `IndexOutOfRange`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.provided`: 4 bytes, alignment: 4 bytes
print-type-size         field `.valid_end`: 4 bytes
print-type-size     variant `MaxArraySizeExceeded`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `CharacterNotValidForEncoding`: 12 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 4 bytes, alignment: 4 bytes
print-type-size     variant `CharacterTooLargeForEncoding`: 12 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 4 bytes, alignment: 4 bytes
print-type-size     variant `InvalidBase64Symbol`: 12 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 4 bytes, alignment: 4 bytes
print-type-size     variant `InvalidRegexFlag`: 12 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 4 bytes, alignment: 4 bytes
print-type-size     variant `ParseHex`: 12 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 4 bytes, alignment: 4 bytes
print-type-size     variant `DivisionByZero`: 0 bytes
print-type-size     variant `FloatOverflow`: 0 bytes
print-type-size     variant `FloatUnderflow`: 0 bytes
print-type-size     variant `NumericFieldOverflow`: 0 bytes
print-type-size     variant `MzTimestampStepOverflow`: 0 bytes
print-type-size     variant `TimestampCannotBeNan`: 0 bytes
print-type-size     variant `TimestampOutOfRange`: 0 bytes
print-type-size     variant `DateOutOfRange`: 0 bytes
print-type-size     variant `CharOutOfRange`: 0 bytes
print-type-size     variant `InvalidBase64Equals`: 0 bytes
print-type-size     variant `InvalidBase64EndSequence`: 0 bytes
print-type-size     variant `InvalidTimezoneInterval`: 0 bytes
print-type-size     variant `InvalidTimezoneConversion`: 0 bytes
print-type-size     variant `KeyCannotBeNull`: 0 bytes
print-type-size     variant `NegSqrt`: 0 bytes
print-type-size     variant `NegLimit`: 0 bytes
print-type-size     variant `NullCharacterNotPermitted`: 0 bytes
print-type-size     variant `UnterminatedLikeEscapeSequence`: 0 bytes
print-type-size     variant `MultipleRowsFromSubquery`: 0 bytes
print-type-size     variant `LikePatternTooLong`: 0 bytes
print-type-size     variant `LikeEscapeTooLong`: 0 bytes
print-type-size     variant `MultidimensionalArrayRemovalNotSupported`: 0 bytes
print-type-size     variant `MultiDimensionalArraySearch`: 0 bytes
print-type-size     variant `ArrayFillWrongArraySubscripts`: 0 bytes
print-type-size     variant `LengthTooLarge`: 0 bytes
print-type-size     variant `AclArrayNullElement`: 0 bytes
print-type-size     variant `MzAclArrayNullElement`: 0 bytes
```

After:

```
print-type-size type: `scalar::EvalError`: 56 bytes, alignment: 8 bytes
print-type-size     variant `Parse`: 56 bytes
print-type-size         field `.0`: 56 bytes
print-type-size     variant `OutOfDomain`: 48 bytes
print-type-size         field `.0`: 16 bytes
print-type-size         field `.1`: 16 bytes
print-type-size         field `.2`: 16 bytes
print-type-size     variant `DateDiffOverflow`: 48 bytes
print-type-size         field `.unit`: 16 bytes
print-type-size         field `.a`: 16 bytes
print-type-size         field `.b`: 16 bytes
print-type-size     variant `Unsupported`: 32 bytes
print-type-size         field `.discussion_no`: 16 bytes
print-type-size         field `.feature`: 16 bytes
print-type-size     variant `InvalidByteSequence`: 32 bytes
print-type-size         field `.byte_sequence`: 16 bytes
print-type-size         field `.encoding_name`: 16 bytes
print-type-size     variant `InvalidJsonbCast`: 32 bytes
print-type-size         field `.from`: 16 bytes
print-type-size         field `.to`: 16 bytes
print-type-size     variant `UnsupportedUnits`: 32 bytes
print-type-size         field `.0`: 16 bytes
print-type-size         field `.1`: 16 bytes
print-type-size     variant `InvalidIdentifier`: 32 bytes
print-type-size         field `.ident`: 16 bytes
print-type-size         field `.detail`: 16 bytes
print-type-size     variant `InvalidArray`: 24 bytes
print-type-size         field `.0`: 24 bytes
print-type-size     variant `StringValueTooLong`: 24 bytes
print-type-size         field `.target_type`: 16 bytes
print-type-size         field `.length`: 8 bytes
print-type-size     variant `IncompatibleArrayDimensions`: 24 bytes
print-type-size         field `.dims`: 24 bytes
print-type-size     variant `InvalidRange`: 24 bytes
print-type-size         field `.0`: 24 bytes
print-type-size     variant `DateBinOutOfRange`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `Float32OutOfRange`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `Float64OutOfRange`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `Int16OutOfRange`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `Int32OutOfRange`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `Int64OutOfRange`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `UInt16OutOfRange`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `UInt32OutOfRange`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `UInt64OutOfRange`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `MzTimestampOutOfRange`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `OidOutOfRange`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `IntervalOutOfRange`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `InvalidTimezone`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `InvalidIanaTimezoneId`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `InvalidLayer`: 16 bytes
print-type-size         field `.max_layer`: 8 bytes
print-type-size         field `.val`: 8 bytes
print-type-size     variant `InvalidEncodingName`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `InvalidHashAlgorithm`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `InvalidRegex`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `InvalidParameterValue`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `InvalidDatePart`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `UnknownUnits`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `Internal`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `InfinityOutOfDomain`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `NegativeOutOfDomain`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `ZeroOutOfDomain`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `ComplexOutOfRange`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `Undefined`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `TypeFromOid`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `InvalidRoleId`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `InvalidPrivileges`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `LetRecLimitExceeded`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `MustNotBeNull`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `IfNullError`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `PrettyError`: 16 bytes
print-type-size         field `.0`: 16 bytes
print-type-size     variant `IndexOutOfRange`: 8 bytes
print-type-size         field `.provided`: 4 bytes
print-type-size         field `.valid_end`: 4 bytes
print-type-size     variant `MaxArraySizeExceeded`: 8 bytes
print-type-size         field `.0`: 8 bytes
print-type-size     variant `CharacterNotValidForEncoding`: 4 bytes
print-type-size         field `.0`: 4 bytes
print-type-size     variant `CharacterTooLargeForEncoding`: 4 bytes
print-type-size         field `.0`: 4 bytes
print-type-size     variant `InvalidBase64Symbol`: 4 bytes
print-type-size         field `.0`: 4 bytes
print-type-size     variant `InvalidRegexFlag`: 4 bytes
print-type-size         field `.0`: 4 bytes
print-type-size     variant `ParseHex`: 4 bytes
print-type-size         field `.0`: 4 bytes
print-type-size     variant `DivisionByZero`: 0 bytes
print-type-size     variant `FloatOverflow`: 0 bytes
print-type-size     variant `FloatUnderflow`: 0 bytes
print-type-size     variant `NumericFieldOverflow`: 0 bytes
print-type-size     variant `MzTimestampStepOverflow`: 0 bytes
print-type-size     variant `TimestampCannotBeNan`: 0 bytes
print-type-size     variant `TimestampOutOfRange`: 0 bytes
print-type-size     variant `DateOutOfRange`: 0 bytes
print-type-size     variant `CharOutOfRange`: 0 bytes
print-type-size     variant `InvalidBase64Equals`: 0 bytes
print-type-size     variant `InvalidBase64EndSequence`: 0 bytes
print-type-size     variant `InvalidTimezoneInterval`: 0 bytes
print-type-size     variant `InvalidTimezoneConversion`: 0 bytes
print-type-size     variant `KeyCannotBeNull`: 0 bytes
print-type-size     variant `NegSqrt`: 0 bytes
print-type-size     variant `NegLimit`: 0 bytes
print-type-size     variant `NullCharacterNotPermitted`: 0 bytes
print-type-size     variant `UnterminatedLikeEscapeSequence`: 0 bytes
print-type-size     variant `MultipleRowsFromSubquery`: 0 bytes
print-type-size     variant `LikePatternTooLong`: 0 bytes
print-type-size     variant `LikeEscapeTooLong`: 0 bytes
print-type-size     variant `MultidimensionalArrayRemovalNotSupported`: 0 bytes
print-type-size     variant `MultiDimensionalArraySearch`: 0 bytes
print-type-size     variant `ArrayFillWrongArraySubscripts`: 0 bytes
print-type-size     variant `LengthTooLarge`: 0 bytes
print-type-size     variant `AclArrayNullElement`: 0 bytes
print-type-size     variant `MzAclArrayNullElement`: 0 bytes
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
