### PR TITLE
Reduce size of IsLikeMatch by 16 bytes

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -3282,7 +3282,7 @@ impl RustType<ProtoAnalyzedRegex> for AnalyzedRegex {
 }
 
 impl AnalyzedRegex {
-    pub fn new(s: String) -> Result<Self, regex::Error> {
+    pub fn new(s: &str) -> Result<Self, regex::Error> {
         let r = ReprRegex::new(s, false)?;
         // TODO(benesch): remove potentially dangerous usage of `as`.
         #[allow(clippy::as_conversions)]

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -841,7 +841,7 @@ impl MirScalarExpr {
                         } else if let BinaryFunc::IsRegexpMatch { case_insensitive } = func {
                             if let MirScalarExpr::Literal(Ok(row), _) = &**expr2 {
                                 *e = match Regex::new(
-                                    row.unpack_first().unwrap_str().to_string(),
+                                    row.unpack_first().unwrap_str(),
                                     *case_insensitive,
                                 ) {
                                     Ok(regex) => expr1.take().call_unary(UnaryFunc::IsRegexpMatch(

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3733,7 +3733,7 @@ impl fmt::Display for BinaryFunc {
                 Ok((regex, limit)) => write!(
                     f,
                     "regexp_replace[{}, case_insensitive={}, limit={}]",
-                    regex.pattern.escaped(),
+                    regex.pattern().escaped(),
                     regex.case_insensitive,
                     limit
                 ),
@@ -6592,7 +6592,7 @@ pub fn build_regex(needle: &str, flags: &str) -> Result<Regex, EvalError> {
             _ => return Err(EvalError::InvalidRegexFlag(f)),
         }
     }
-    Ok(Regex::new(needle.to_string(), case_insensitive)?)
+    Ok(Regex::new(needle, case_insensitive)?)
 }
 
 pub fn hmac_string<'a>(

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -922,7 +922,7 @@ impl fmt::Display for IsRegexpMatch {
         write!(
             f,
             "is_regexp_match[{}, case_insensitive={}]",
-            self.0.pattern.escaped(),
+            self.0.pattern().escaped(),
             self.0.case_insensitive
         )
     }
@@ -980,7 +980,7 @@ impl fmt::Display for RegexpMatch {
         write!(
             f,
             "regexp_match[{}, case_insensitive={}]",
-            self.0.pattern.escaped(),
+            self.0.pattern().escaped(),
             self.0.case_insensitive
         )
     }
@@ -1037,7 +1037,7 @@ impl fmt::Display for RegexpSplitToArray {
         write!(
             f,
             "regexp_split_to_array[{}, case_insensitive={}]",
-            self.0.pattern.escaped(),
+            self.0.pattern().escaped(),
             self.0.case_insensitive
         )
     }

--- a/src/expr/src/scalar/like_pattern.rs
+++ b/src/expr/src/scalar/like_pattern.rs
@@ -403,7 +403,7 @@ fn build_regex(subpatterns: &[Subpattern], case_insensitive: bool) -> Result<Reg
         sp.write_regex_to(&mut r);
     }
     r.push('$');
-    match Regex::new(r, case_insensitive) {
+    match Regex::new(&r, case_insensitive) {
         Ok(regex) => Ok(regex),
         Err(regex::Error::CompiledTooBig(_)) => Err(EvalError::LikePatternTooLong),
         Err(e) => Err(EvalError::Internal(format!(

--- a/src/regexp/src/lib.rs
+++ b/src/regexp/src/lib.rs
@@ -46,7 +46,7 @@ mod tests {
 
     use crate::regexp_split_to_array;
 
-    fn build_regex(needle: String, flags: &str) -> Result<Regex, anyhow::Error> {
+    fn build_regex(needle: &str, flags: &str) -> Result<Regex, anyhow::Error> {
         let mut case_insensitive = false;
         // Note: Postgres accepts it when both flags are present, taking the last one. We do the same.
         for f in flags.chars() {
@@ -76,7 +76,7 @@ mod tests {
         let regexps = vec!["", "\\s", "\\s+", "\\s*"];
         for input in inputs {
             for re in &regexps {
-                let regex = build_regex(re.to_string(), "").unwrap();
+                let regex = build_regex(re, "").unwrap();
                 let pg: Vec<String> = client
                     .query_one("select regexp_split_to_array($1, $2)", &[&input, re])
                     .unwrap()
@@ -227,7 +227,7 @@ mod tests {
             },
         ];
         for tc in tests {
-            let regex = build_regex(tc.regexp.to_string(), "").unwrap();
+            let regex = build_regex(tc.regexp, "").unwrap();
             let result = regexp_split_to_array(tc.text, &regex);
             if tc.expect != result {
                 println!(

--- a/src/repr/src/adt/regex.rs
+++ b/src/repr/src/adt/regex.rs
@@ -53,7 +53,6 @@ include!(concat!(env!("OUT_DIR"), "/mz_repr.adt.regex.rs"));
 /// and also making the same mistake in our own protobuf serialization code.)
 #[derive(Debug, Clone, MzReflect)]
 pub struct Regex {
-    pub pattern: String,
     pub case_insensitive: bool,
     pub dot_matches_new_line: bool,
     pub regex: regex::Regex,
@@ -63,31 +62,35 @@ impl Regex {
     /// A simple constructor for the default setting of `dot_matches_new_line: true`.
     /// See <https://www.postgresql.org/docs/current/functions-matching.html#POSIX-MATCHING-RULES>
     /// "newline-sensitive matching"
-    pub fn new(pattern: String, case_insensitive: bool) -> Result<Regex, Error> {
+    pub fn new(pattern: &str, case_insensitive: bool) -> Result<Regex, Error> {
         Self::new_dot_matches_new_line(pattern, case_insensitive, true)
     }
 
     /// Allows explicitly setting `dot_matches_new_line`.
     pub fn new_dot_matches_new_line(
-        pattern: String,
+        pattern: &str,
         case_insensitive: bool,
         dot_matches_new_line: bool,
     ) -> Result<Regex, Error> {
-        let mut regex_builder = RegexBuilder::new(pattern.as_str());
+        let mut regex_builder = RegexBuilder::new(pattern);
         regex_builder.case_insensitive(case_insensitive);
         regex_builder.dot_matches_new_line(dot_matches_new_line);
         Ok(Regex {
-            pattern,
             case_insensitive,
             dot_matches_new_line,
             regex: regex_builder.build()?,
         })
     }
+
+    /// Returns the pattern string of the regex.
+    pub fn pattern(&self) -> &str {
+        self.regex.as_str()
+    }
 }
 
 impl PartialEq<Regex> for Regex {
     fn eq(&self, other: &Regex) -> bool {
-        self.pattern == other.pattern
+        self.pattern() == other.pattern()
             && self.case_insensitive == other.case_insensitive
             && self.dot_matches_new_line == other.dot_matches_new_line
     }
@@ -104,12 +107,12 @@ impl PartialOrd for Regex {
 impl Ord for Regex {
     fn cmp(&self, other: &Regex) -> Ordering {
         (
-            &self.pattern,
+            self.pattern(),
             self.case_insensitive,
             self.dot_matches_new_line,
         )
             .cmp(&(
-                &other.pattern,
+                other.pattern(),
                 other.case_insensitive,
                 other.dot_matches_new_line,
             ))
@@ -118,7 +121,7 @@ impl Ord for Regex {
 
 impl Hash for Regex {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
-        self.pattern.hash(hasher);
+        self.pattern().hash(hasher);
         self.case_insensitive.hash(hasher);
         self.dot_matches_new_line.hash(hasher);
     }
@@ -135,7 +138,7 @@ impl Deref for Regex {
 impl RustType<ProtoRegex> for Regex {
     fn into_proto(&self) -> ProtoRegex {
         ProtoRegex {
-            pattern: self.pattern.clone(),
+            pattern: self.pattern().to_owned(),
             case_insensitive: self.case_insensitive,
             dot_matches_new_line: self.dot_matches_new_line,
         }
@@ -143,7 +146,7 @@ impl RustType<ProtoRegex> for Regex {
 
     fn from_proto(proto: ProtoRegex) -> Result<Self, TryFromProtoError> {
         Ok(Regex::new_dot_matches_new_line(
-            proto.pattern,
+            &proto.pattern,
             proto.case_insensitive,
             proto.dot_matches_new_line,
         )?)
@@ -156,7 +159,7 @@ impl Serialize for Regex {
         S: Serializer,
     {
         let mut state = serializer.serialize_struct("Regex", 3)?;
-        state.serialize_field("pattern", &self.pattern)?;
+        state.serialize_field("pattern", &self.pattern())?;
         state.serialize_field("case_insensitive", &self.case_insensitive)?;
         state.serialize_field("dot_matches_new_line", &self.dot_matches_new_line)?;
         state.end()
@@ -242,7 +245,7 @@ impl<'de> Deserialize<'de> for Regex {
             where
                 V: de::MapAccess<'de>,
             {
-                let mut pattern: Option<String> = None;
+                let mut pattern: Option<&str> = None;
                 let mut case_insensitive: Option<bool> = None;
                 let mut dot_matches_new_line: Option<bool> = None;
                 while let Some(key) = map.next_key()? {
@@ -302,7 +305,7 @@ prop_compose! {
                  r in REPETITIONS, e in END_SYMBOLS, case_insensitive in any::<bool>(), dot_matches_new_line in any::<bool>())
                 -> Regex {
         let string = format!("{}{}{}{}", b, c, r, e);
-        Regex::new_dot_matches_new_line(string, case_insensitive, dot_matches_new_line).unwrap()
+        Regex::new_dot_matches_new_line(&string, case_insensitive, dot_matches_new_line).unwrap()
     }
 }
 
@@ -329,7 +332,7 @@ mod tests {
     /// Nowadays, we use our own handwritten Serialize/Deserialize impls for our Regex wrapper struct.
     #[mz_ore::test]
     fn regex_serde_case_insensitive() {
-        let orig_regex = Regex::new("AAA".to_string(), true).unwrap();
+        let orig_regex = Regex::new("AAA", true).unwrap();
         let serialized: String = serde_json::to_string(&orig_regex).unwrap();
         let roundtrip_result: Regex = serde_json::from_str(&serialized).unwrap();
         // Equality test between orig and roundtrip_result wouldn't work, because Eq doesn't test
@@ -345,8 +348,7 @@ mod tests {
     fn regex_serde_dot_matches_new_line() {
         {
             // dot_matches_new_line: true
-            let orig_regex =
-                Regex::new_dot_matches_new_line("A.*B".to_string(), true, true).unwrap();
+            let orig_regex = Regex::new_dot_matches_new_line("A.*B", true, true).unwrap();
             let serialized: String = serde_json::to_string(&orig_regex).unwrap();
             let roundtrip_result: Regex = serde_json::from_str(&serialized).unwrap();
             assert_eq!(orig_regex.regex.is_match("axxx\nxxxb"), true);
@@ -354,8 +356,7 @@ mod tests {
         }
         {
             // dot_matches_new_line: false
-            let orig_regex =
-                Regex::new_dot_matches_new_line("A.*B".to_string(), true, false).unwrap();
+            let orig_regex = Regex::new_dot_matches_new_line("A.*B", true, false).unwrap();
             let serialized: String = serde_json::to_string(&orig_regex).unwrap();
             let roundtrip_result: Regex = serde_json::from_str(&serialized).unwrap();
             assert_eq!(orig_regex.regex.is_match("axxx\nxxxb"), false);
@@ -363,7 +364,7 @@ mod tests {
         }
         {
             // dot_matches_new_line: default
-            let orig_regex = Regex::new("A.*B".to_string(), true).unwrap();
+            let orig_regex = Regex::new("A.*B", true).unwrap();
             let serialized: String = serde_json::to_string(&orig_regex).unwrap();
             let roundtrip_result: Regex = serde_json::from_str(&serialized).unwrap();
             assert_eq!(orig_regex.regex.is_match("axxx\nxxxb"), true);

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3811,7 +3811,7 @@ pub static MZ_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
             params!(String, String) => Operation::binary(move |_ecx, regex, haystack| {
                 let regex = match regex.into_literal_string() {
                     None => sql_bail!("regexp_extract requires a string literal as its first argument"),
-                    Some(regex) => mz_expr::AnalyzedRegex::new(regex).map_err(|e| sql_err!("analyzing regex: {}", e))?,
+                    Some(regex) => mz_expr::AnalyzedRegex::new(&regex).map_err(|e| sql_err!("analyzing regex: {}", e))?,
                 };
                 let column_names = regex
                     .capture_groups_iter()

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2216,7 +2216,7 @@ fn get_encoding_inner(
             }
         },
         Format::Regex(regex) => DataEncoding::Regex(RegexEncoding {
-            regex: mz_repr::adt::regex::Regex::new(regex.clone(), false)
+            regex: mz_repr::adt::regex::Regex::new(regex, false)
                 .map_err(|e| sql_err!("parsing regex: {e}"))?,
         }),
         Format::Csv { columns, delimiter } => {


### PR DESCRIPTION
IsLikeMatch stores the pattern next to the regex, but the regex also stores the pattern. Avoid duplication.

This is work towards reducing the size of scalar expressions, reachable here through unary functions.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
