### PR TITLE
Reduce the size of CastRecord1ToRecord2 to 56 bytes

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -5182,7 +5182,7 @@ impl Arbitrary for UnaryFunc {
                 .prop_map(|(return_ty, cast_exprs)| {
                     UnaryFunc::CastRecord1ToRecord2(CastRecord1ToRecord2 {
                         return_ty,
-                        cast_exprs,
+                        cast_exprs: cast_exprs.into(),
                     })
                 })
                 .boxed(),

--- a/src/expr/src/scalar/func/impls/record.rs
+++ b/src/expr/src/scalar/func/impls/record.rs
@@ -78,7 +78,7 @@ impl fmt::Display for CastRecordToString {
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CastRecord1ToRecord2 {
     pub return_ty: ScalarType,
-    pub cast_exprs: Vec<MirScalarExpr>,
+    pub cast_exprs: Box<[MirScalarExpr]>,
 }
 
 impl LazyUnaryFunc for CastRecord1ToRecord2 {

--- a/src/proto/src/lib.rs
+++ b/src/proto/src/lib.rs
@@ -345,10 +345,21 @@ where
     }
 
     fn from_proto(proto: Vec<P>) -> Result<Self, TryFromProtoError> {
-        proto
-            .into_iter()
-            .map(R::from_proto)
-            .collect::<Result<Vec<_>, _>>()
+        proto.into_iter().map(R::from_proto).collect()
+    }
+}
+
+/// Blanket implementation for `Box<[R]>` where `R` is a [`RustType`].
+impl<R, P> RustType<Vec<P>> for Box<[R]>
+where
+    R: RustType<P>,
+{
+    fn into_proto(&self) -> Vec<P> {
+        self.iter().map(R::into_proto).collect()
+    }
+
+    fn from_proto(proto: Vec<P>) -> Result<Self, TryFromProtoError> {
+        proto.into_iter().map(R::from_proto).collect()
     }
 }
 

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -709,7 +709,7 @@ static VALID_CASTS: LazyLock<BTreeMap<(ScalarBaseType, ScalarBaseType), CastImpl
                     .iter()
                     .zip_eq(to_type.unwrap_record_element_type())
                     .map(|(f, t)| plan_hypothetical_cast(ecx, ccx, f, t))
-                    .collect::<Option<Vec<_>>>()?;
+                    .collect::<Option<Box<_>>>()?;
                 let to = to_type.clone();
                 Some(|e: HirScalarExpr| e.call_unary(CastRecord1ToRecord2(func::CastRecord1ToRecord2 { return_ty: to, cast_exprs })))
             }),


### PR DESCRIPTION
Reduce the size of the `CastRecord1ToRecord2` struct from 64 to 56 bytes
by converting the `cast_expres` field from `Vec<_>` to a boxed slice. This
benefits the size of `UnaryFunc` and in turn `MirScalarExpr`.

Before:

```
print-type-size type: `scalar::func::impls::record::CastRecord1ToRecord2`: 64 bytes, alignment: 8 bytes
print-type-size     field `.return_ty`: 40 bytes
print-type-size     field `.cast_exprs`: 24 bytes
```

After:

```
print-type-size type: `scalar::func::impls::record::CastRecord1ToRecord2`: 56 bytes, alignment: 8 bytes
print-type-size     field `.return_ty`: 40 bytes
print-type-size     field `.cast_exprs`: 16 bytes
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
