### PR TITLE
docs: tools and integration overview page frontmatter fix

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -194,13 +194,6 @@ name = "Tools and integrations"
 weight= 25
 
 [[menu.main]]
-identifier = "tools-and-integrations"
-name = "Overview"
-parent = "integrations"
-url = "/integrations"
-weight = 5
-
-[[menu.main]]
 identifier = "cli-reference"
 name = "Command reference"
 parent = "cli"

--- a/doc/user/content/integrations/_index.md
+++ b/doc/user/content/integrations/_index.md
@@ -9,6 +9,13 @@ aliases:
     - /third-party/postgres-cloud/
     - /guides/postgres-cloud/
     - /guides/
+
+menu:
+  main:
+    parent: integrations
+    name: "Overview"
+    weight: 5
+
 ---
 
 [//]: # "TODO(morsapaes) Once database-issues#2562 lands, link the page here"


### PR DESCRIPTION
Currently, selecting the page collapses the nav because we use config.toml instead of just adding the frontmatter to the page.