### PR TITLE
storage/sources: Refactor purification reference resolution and populate available source references table

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -505,6 +505,7 @@ impl Coordinator {
                 create_progress_subsource_stmt,
                 create_source_stmt,
                 subsources,
+                available_source_references,
             } => {
                 self.plan_purified_create_source(
                     &ctx,
@@ -512,6 +513,7 @@ impl Coordinator {
                     create_progress_subsource_stmt,
                     create_source_stmt,
                     subsources,
+                    available_source_references,
                 )
                 .await
             }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -440,6 +440,7 @@ impl Coordinator {
         progress_stmt: CreateSubsourceStatement<Aug>,
         mut source_stmt: mz_sql::ast::CreateSourceStatement<Aug>,
         subsources: BTreeMap<UnresolvedItemName, PurifiedSourceExport>,
+        available_source_references: SourceReferences,
     ) -> Result<(Plan, ResolvedIds), AdapterError> {
         let mut create_source_plans = Vec::with_capacity(subsources.len() + 2);
 
@@ -502,8 +503,7 @@ impl Coordinator {
             source_id,
             plan: source_plan,
             resolved_ids: resolved_ids.clone(),
-            // TODO(roshan): Populate this based on the results of purification
-            available_source_references: None,
+            available_source_references: Some(available_source_references),
         });
 
         // 3. Finally, plan all the subsources

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -440,7 +440,7 @@ impl Coordinator {
         progress_stmt: CreateSubsourceStatement<Aug>,
         mut source_stmt: mz_sql::ast::CreateSourceStatement<Aug>,
         subsources: BTreeMap<UnresolvedItemName, PurifiedSourceExport>,
-        available_source_references: SourceReferences,
+        available_source_references: plan::SourceReferences,
     ) -> Result<(Plan, ResolvedIds), AdapterError> {
         let mut create_source_plans = Vec::with_capacity(subsources.len() + 2);
 

--- a/src/mysql-util/src/schemas.rs
+++ b/src/mysql-util/src/schemas.rs
@@ -72,6 +72,12 @@ impl FromRow for InfoSchema {
     }
 }
 
+impl InfoSchema {
+    pub fn name(self) -> String {
+        self.column_name
+    }
+}
+
 /// A representation of the raw schema info for a table from MySQL
 #[derive(Debug, Clone)]
 pub struct MySqlTableSchema {

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -635,7 +635,7 @@ pub struct CreateSourcePlan {
     pub in_cluster: Option<ClusterId>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SourceReferences {
     pub updated_at: u64,
     pub references: Vec<SourceReference>,
@@ -643,7 +643,7 @@ pub struct SourceReferences {
 
 /// An available external reference for a source and if possible to retrieve,
 /// any column names it contains.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SourceReference {
     pub name: String,
     pub namespace: Option<String>,

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -353,7 +353,7 @@ impl PlanError {
             ),
             Self::NoTablesFoundForSchemas(schemas) => Some(format!(
                 "missing schemas: {}",
-                itertools::join(schemas.iter(), ", ")
+                separated(", ", schemas.iter().map(|c| c.quoted()))
             )),
             _ => None,
         }
@@ -612,7 +612,9 @@ impl fmt::Display for PlanError {
                 write!(f, "multiple subsources refer to table {}", name)
             },
             Self::NoTablesFoundForSchemas(schemas) => {
-                write!(f, "no tables found in referenced schemas: {}", schemas.join(", "))
+                write!(f, "no tables found in referenced schemas: {}",
+                    separated(", ", schemas.iter().map(|c| c.quoted()))
+                )
             },
             Self::InvalidProtobufSchema { .. } => {
                 write!(f, "invalid protobuf schema")

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -164,6 +164,7 @@ pub enum PlanError {
         name: UnresolvedItemName,
         target_names: Vec<UnresolvedItemName>,
     },
+    NoTablesFoundForSchemas(Vec<String>),
     InvalidProtobufSchema {
         cause: protobuf_native::OperationFailedError,
     },
@@ -350,6 +351,10 @@ impl PlanError {
             Self::InvalidPartitionByEnvelopeDebezium { .. } => Some(
                 "When using ENVELOPE DEBEZIUM, only columns in the key can be referenced in the PARTITION BY expression.".to_string()
             ),
+            Self::NoTablesFoundForSchemas(schemas) => Some(format!(
+                "missing schemas: {}",
+                itertools::join(schemas.iter(), ", ")
+            )),
             _ => None,
         }
     }
@@ -605,6 +610,9 @@ impl fmt::Display for PlanError {
                 target_names: _,
             } => {
                 write!(f, "multiple subsources refer to table {}", name)
+            },
+            Self::NoTablesFoundForSchemas(schemas) => {
+                write!(f, "no tables found in referenced schemas: {}", schemas.join(", "))
             },
             Self::InvalidProtobufSchema { .. } => {
                 write!(f, "invalid protobuf schema")

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -96,7 +96,7 @@ use mz_storage_types::sources::kafka::{
     kafka_metadata_columns_desc, KafkaMetadataKind, KafkaSourceConnection, KafkaSourceExportDetails,
 };
 use mz_storage_types::sources::load_generator::{
-    KeyValueLoadGenerator, LoadGenerator, LoadGeneratorOutput, LoadGeneratorSourceConnection,
+    KeyValueLoadGenerator, LoadGenerator, LoadGeneratorSourceConnection,
     LoadGeneratorSourceExportDetails, LOAD_GENERATOR_KEY_VALUE_OFFSET_DEFAULT,
 };
 use mz_storage_types::sources::mysql::{
@@ -121,8 +121,8 @@ use crate::catalog::{
 use crate::kafka_util::{KafkaSinkConfigOptionExtracted, KafkaSourceConfigOptionExtracted};
 use crate::names::{
     Aug, CommentObjectId, DatabaseId, ObjectId, PartialItemName, QualifiedItemName,
-    RawDatabaseSpecifier, ResolvedClusterName, ResolvedColumnReference, ResolvedDataType,
-    ResolvedDatabaseSpecifier, ResolvedItemName, SchemaSpecifier, SystemObjectId,
+    ResolvedClusterName, ResolvedColumnReference, ResolvedDataType, ResolvedDatabaseSpecifier,
+    ResolvedItemName, SchemaSpecifier, SystemObjectId,
 };
 use crate::normalize::{self, ident};
 use crate::plan::error::PlanError;
@@ -147,10 +147,9 @@ use crate::plan::{
     CreateContinualTaskPlan, CreateDatabasePlan, CreateIndexPlan, CreateMaterializedViewPlan,
     CreateRolePlan, CreateSchemaPlan, CreateSecretPlan, CreateSinkPlan, CreateSourcePlan,
     CreateTablePlan, CreateTypePlan, CreateViewPlan, DataSourceDesc, DropObjectsPlan,
-    DropOwnedPlan, FullItemName, Index, Ingestion, MaterializedView, Params, Plan,
-    PlanClusterOption, PlanNotice, QueryContext, ReplicaConfig, Secret, Sink, Source, Table,
-    TableDataSource, Type, VariableValue, View, WebhookBodyFormat, WebhookHeaderFilters,
-    WebhookHeaders, WebhookValidation,
+    DropOwnedPlan, Index, Ingestion, MaterializedView, Params, Plan, PlanClusterOption, PlanNotice,
+    QueryContext, ReplicaConfig, Secret, Sink, Source, Table, TableDataSource, Type, VariableValue,
+    View, WebhookBodyFormat, WebhookHeaderFilters, WebhookHeaders, WebhookValidation,
 };
 use crate::session::vars::{
     self, ENABLE_CLUSTER_SCHEDULE_REFRESH, ENABLE_CREATE_CONTINUAL_TASK, ENABLE_KAFKA_SINK_HEADERS,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -897,7 +897,7 @@ pub fn plan_create_source(
             connection
         }
         CreateSourceConnection::LoadGenerator { generator, options } => {
-            let (load_generator, _available_subsources) =
+            let load_generator =
                 load_generator_ast_to_generator(scx, generator, options, include_metadata)?;
 
             let LoadGeneratorOptionExtracted {
@@ -1824,13 +1824,7 @@ pub(crate) fn load_generator_ast_to_generator(
     loadgen: &ast::LoadGenerator,
     options: &[LoadGeneratorOption<Aug>],
     include_metadata: &[SourceIncludeMetadata],
-) -> Result<
-    (
-        LoadGenerator,
-        Option<BTreeMap<FullItemName, (RelationDesc, LoadGeneratorOutput)>>,
-    ),
-    PlanError,
-> {
+) -> Result<LoadGenerator, PlanError> {
     let extracted: LoadGeneratorOptionExtracted = options.to_vec().try_into()?;
     extracted.ensure_only_valid_options(loadgen)?;
 
@@ -1965,24 +1959,7 @@ pub(crate) fn load_generator_ast_to_generator(
         }
     };
 
-    let mut available_subsources = BTreeMap::new();
-    for (name, desc, output) in load_generator.views() {
-        let name = FullItemName {
-            database: RawDatabaseSpecifier::Name(
-                mz_storage_types::sources::load_generator::LOAD_GENERATOR_DATABASE_NAME.to_owned(),
-            ),
-            schema: load_generator.schema_name().into(),
-            item: name.to_string(),
-        };
-        available_subsources.insert(name, (desc, output));
-    }
-    let available_subsources = if available_subsources.is_empty() {
-        None
-    } else {
-        Some(available_subsources)
-    };
-
-    Ok((load_generator, available_subsources))
+    Ok(load_generator)
 }
 
 fn typecheck_debezium(value_desc: &RelationDesc) -> Result<(Option<usize>, usize), PlanError> {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1059,13 +1059,11 @@ async fn purify_create_source(
                             PurifiedSourceExport {
                                 external_reference: export.external_reference,
                                 details: PurifiedExportDetails::LoadGenerator {
-                                    table: Some(
-                                        export
-                                            .meta
-                                            .load_generator_desc()
-                                            .expect("is loadgen")
-                                            .clone(),
-                                    ),
+                                    table: export
+                                        .meta
+                                        .load_generator_desc()
+                                        .expect("is loadgen")
+                                        .clone(),
                                     output: export
                                         .meta
                                         .load_generator_output()
@@ -1622,13 +1620,11 @@ async fn purify_create_table_from_source(
             PurifiedSourceExport {
                 external_reference: export.external_reference,
                 details: PurifiedExportDetails::LoadGenerator {
-                    table: Some(
-                        export
-                            .meta
-                            .load_generator_desc()
-                            .expect("is loadgen")
-                            .clone(),
-                    ),
+                    table: export
+                        .meta
+                        .load_generator_desc()
+                        .expect("is loadgen")
+                        .clone(),
                     output: export
                         .meta
                         .load_generator_output()

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -66,7 +66,7 @@ use prost::Message;
 use protobuf_native::compiler::{SourceTreeDescriptorDatabase, VirtualSourceTree};
 use protobuf_native::MessageLite;
 use rdkafka::admin::AdminClient;
-use references::SourceReferenceClient;
+use references::{RetrievedSourceReferences, SourceReferenceClient};
 use uuid::Uuid;
 
 use crate::ast::{
@@ -96,58 +96,20 @@ pub mod mysql;
 pub mod postgres;
 mod references;
 
-pub(crate) struct RequestedSourceExport<'a, T> {
+pub(crate) struct RequestedSourceExport<T> {
     external_reference: UnresolvedItemName,
     name: UnresolvedItemName,
-    table: &'a T,
+    meta: T,
 }
 
-/// Generates appropriate source exports for a set of external references to export from a source.
-fn source_export_gen<'a, T: ExternalCatalogReference>(
-    selected_references: &'a [ExternalReferenceExport],
-    resolver: &SourceReferenceResolver,
-    references: &'a [T],
-    canonical_width: usize,
-    source_name: &UnresolvedItemName,
-) -> Result<Vec<RequestedSourceExport<'a, T>>, PlanError> {
-    let mut validated_exports = vec![];
-
-    for reference in selected_references {
-        let name = match &reference.alias {
-            Some(name) => {
-                let partial = normalize::unresolved_item_name(name.clone())?;
-                match partial.schema {
-                    Some(_) => name.clone(),
-                    // In cases when a prefix is not provided for the deferred name
-                    // fallback to using the schema of the source with the given name
-                    None => source_export_name_gen(source_name, &partial.item)?,
-                }
-            }
-            None => {
-                // Use the entered name as the upstream reference, and then use
-                // the item as the subsource name to ensure it's created in the
-                // current schema or the source's schema if provided, not mirroring
-                // the schema of the reference.
-                source_export_name_gen(
-                    source_name,
-                    &normalize::unresolved_item_name(reference.reference.clone())?.item,
-                )?
-            }
-        };
-
-        let (external_reference, idx) =
-            resolver.resolve(&reference.reference.0, canonical_width)?;
-
-        let table = &references[idx];
-
-        validated_exports.push(RequestedSourceExport {
-            external_reference,
-            name,
-            table,
-        });
+impl<'a, T> RequestedSourceExport<T> {
+    fn change_meta<F>(self, new_meta: F) -> RequestedSourceExport<F> {
+        RequestedSourceExport {
+            external_reference: self.external_reference,
+            name: self.name,
+            meta: new_meta,
+        }
     }
-
-    Ok(validated_exports)
 }
 
 /// Generates a subsource name by prepending source schema name if present
@@ -674,7 +636,7 @@ async fn purify_create_source(
 
     let mut format_options = SourceFormatOptions::Default;
 
-    let available_source_references: SourceReferences;
+    let retrieved_source_references: RetrievedSourceReferences;
 
     match source_connection {
         CreateSourceConnection::Kafka {
@@ -787,8 +749,8 @@ async fn purify_create_source(
                 }
             }
 
-            let mut reference_client = SourceReferenceClient::Kafka { topic: &topic };
-            available_source_references = reference_client.get_source_references().await?;
+            let reference_client = SourceReferenceClient::Kafka { topic: &topic };
+            retrieved_source_references = reference_client.get_source_references().await?;
 
             format_options = SourceFormatOptions::Kafka { topic };
         }
@@ -888,11 +850,12 @@ async fn purify_create_source(
                 Err(PgSourcePurificationError::InsufficientReplicationSlotsAvailable { count: 2 })?;
             }
 
-            let mut reference_client = SourceReferenceClient::Postgres {
+            let reference_client = SourceReferenceClient::Postgres {
                 client: &client,
                 publication: &publication,
+                database: &connection.database,
             };
-            available_source_references = reference_client.get_source_references().await?;
+            retrieved_source_references = reference_client.get_source_references().await?;
 
             let postgres::PurifiedSourceExports {
                 source_exports: subsources,
@@ -900,8 +863,7 @@ async fn purify_create_source(
             } = postgres::purify_source_exports(
                 &client,
                 &config,
-                &publication,
-                &connection,
+                &retrieved_source_references,
                 external_references,
                 text_columns,
                 source_name,
@@ -1018,8 +980,8 @@ async fn purify_create_source(
             let initial_gtid_set =
                 mz_mysql_util::query_sys_var(&mut conn, "global.gtid_executed").await?;
 
-            let mut reference_client = SourceReferenceClient::MySql { conn: &mut conn };
-            available_source_references = reference_client.get_source_references().await?;
+            let reference_client = SourceReferenceClient::MySql { conn: &mut conn };
+            retrieved_source_references = reference_client.get_source_references().await?;
 
             let mysql::PurifiedSourceExports {
                 source_exports: subsources,
@@ -1027,6 +989,7 @@ async fn purify_create_source(
                 normalized_exclude_columns,
             } = mysql::purify_source_exports(
                 &mut conn,
+                &retrieved_source_references,
                 external_references,
                 text_columns,
                 exclude_columns,
@@ -1068,58 +1031,55 @@ async fn purify_create_source(
             let load_generator =
                 load_generator_ast_to_generator(&scx, generator, options, include_metadata)?;
 
-            let mut reference_client = SourceReferenceClient::LoadGenerator {
+            let reference_client = SourceReferenceClient::LoadGenerator {
                 generator: &load_generator,
             };
-            available_source_references = reference_client.get_source_references().await?;
+            retrieved_source_references = reference_client.get_source_references().await?;
+            // Filter to the references that need to be created as 'subsources' which
+            // don't include the output for single-output sources.
+            let subsource_references = retrieved_source_references
+                .all_references()
+                .iter()
+                .filter(|r| {
+                    r.load_generator_output().expect("is loadgen") != &LoadGeneratorOutput::Default
+                })
+                .collect::<Vec<_>>();
 
-            // TODO: Refactor this to use the available references
-            let mut available_subsources = BTreeMap::new();
-            for (name, desc, output) in load_generator.views() {
-                let name = FullItemName {
-                    database: RawDatabaseSpecifier::Name(
-                        mz_storage_types::sources::load_generator::LOAD_GENERATOR_DATABASE_NAME
-                            .to_owned(),
-                    ),
-                    schema: load_generator.schema_name().into(),
-                    item: name.to_string(),
-                };
-                available_subsources.insert(name, (desc, output));
-            }
             match external_references {
-                Some(ExternalReferences::All) => {
-                    if available_subsources.is_empty() {
-                        Err(LoadGeneratorSourcePurificationError::ForAllTables)?;
-                    }
-                    for (name, (desc, output)) in available_subsources {
-                        let subsource_name = source_export_name_gen(source_name, &name.item)?;
-                        let external_reference = UnresolvedItemName::from(name);
+                Some(requested) => {
+                    let requested_exports = retrieved_source_references
+                        .requested_source_exports(requested, source_name)?;
+                    for export in requested_exports {
                         requested_subsource_map.insert(
-                            subsource_name,
+                            export.name,
                             PurifiedSourceExport {
-                                external_reference,
+                                external_reference: export.external_reference,
                                 details: PurifiedExportDetails::LoadGenerator {
-                                    table: Some(desc),
-                                    output,
+                                    table: Some(
+                                        export
+                                            .meta
+                                            .load_generator_desc()
+                                            .expect("is loadgen")
+                                            .clone(),
+                                    ),
+                                    output: export
+                                        .meta
+                                        .load_generator_output()
+                                        .expect("is loadgen")
+                                        .clone(),
                                 },
                             },
                         );
                     }
                 }
-                Some(ExternalReferences::SubsetSchemas(..)) => {
-                    Err(LoadGeneratorSourcePurificationError::ForSchemas)?
-                }
-                Some(ExternalReferences::SubsetTables(_)) => {
-                    Err(LoadGeneratorSourcePurificationError::ForTables)?
-                }
                 None => {
                     if matches!(reference_policy, SourceReferencePolicy::Required)
-                        && !available_subsources.is_empty()
+                        && !subsource_references.is_empty()
                     {
                         Err(LoadGeneratorSourcePurificationError::MultiOutputRequiresForAllTables)?
                     }
                 }
-            };
+            }
 
             if let LoadGenerator::Clock = generator {
                 if !options
@@ -1206,7 +1166,7 @@ async fn purify_create_source(
         create_progress_subsource_stmt,
         create_source_stmt,
         subsources: requested_subsource_map,
-        available_source_references,
+        available_source_references: retrieved_source_references.available_source_references(),
     })
 }
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -66,6 +66,7 @@ use prost::Message;
 use protobuf_native::compiler::{SourceTreeDescriptorDatabase, VirtualSourceTree};
 use protobuf_native::MessageLite;
 use rdkafka::admin::AdminClient;
+use references::SourceReferenceClient;
 use uuid::Uuid;
 
 use crate::ast::{
@@ -76,12 +77,12 @@ use crate::ast::{
 use crate::catalog::{CatalogItemType, SessionCatalog};
 use crate::kafka_util::{KafkaSinkConfigOptionExtracted, KafkaSourceConfigOptionExtracted};
 use crate::names::{
-    Aug, FullItemName, PartialItemName, ResolvedColumnReference, ResolvedDataType, ResolvedIds,
-    ResolvedItemName,
+    Aug, FullItemName, PartialItemName, RawDatabaseSpecifier, ResolvedColumnReference,
+    ResolvedDataType, ResolvedIds, ResolvedItemName,
 };
 use crate::plan::error::PlanError;
 use crate::plan::statement::ddl::load_generator_ast_to_generator;
-use crate::plan::StatementContext;
+use crate::plan::{SourceReferences, StatementContext};
 use crate::session::vars;
 use crate::{kafka_util, normalize};
 
@@ -93,6 +94,7 @@ use self::error::{
 pub(crate) mod error;
 pub mod mysql;
 pub mod postgres;
+mod references;
 
 pub(crate) struct RequestedSourceExport<'a, T> {
     external_reference: UnresolvedItemName,
@@ -154,7 +156,7 @@ fn source_export_gen<'a, T: ExternalCatalogReference>(
 /// so that it's generated in the same schema as source
 fn source_export_name_gen(
     source_name: &UnresolvedItemName,
-    subsource_name: &String,
+    subsource_name: &str,
 ) -> Result<UnresolvedItemName, PlanError> {
     let mut partial = normalize::unresolved_item_name(source_name.clone())?;
     partial.item = subsource_name.to_string();
@@ -233,6 +235,9 @@ pub enum PurifiedStatement {
         create_source_stmt: CreateSourceStatement<Aug>,
         // Map of subsource names to external details
         subsources: BTreeMap<UnresolvedItemName, PurifiedSourceExport>,
+        /// All the available upstream references that can be added as tables
+        /// to this primary source.
+        available_source_references: SourceReferences,
     },
     PurifiedAlterSource {
         alter_source_stmt: AlterSourceStatement<Aug>,
@@ -669,6 +674,8 @@ async fn purify_create_source(
 
     let mut format_options = SourceFormatOptions::Default;
 
+    let available_source_references: SourceReferences;
+
     match source_connection {
         CreateSourceConnection::Kafka {
             connection,
@@ -780,6 +787,9 @@ async fn purify_create_source(
                 }
             }
 
+            let mut reference_client = SourceReferenceClient::Kafka { topic: &topic };
+            available_source_references = reference_client.get_source_references().await?;
+
             format_options = SourceFormatOptions::Kafka { topic };
         }
         source_connection @ CreateSourceConnection::Postgres { .. }
@@ -877,6 +887,12 @@ async fn purify_create_source(
             if available_replication_slots < 2 {
                 Err(PgSourcePurificationError::InsufficientReplicationSlotsAvailable { count: 2 })?;
             }
+
+            let mut reference_client = SourceReferenceClient::Postgres {
+                client: &client,
+                publication: &publication,
+            };
+            available_source_references = reference_client.get_source_references().await?;
 
             let postgres::PurifiedSourceExports {
                 source_exports: subsources,
@@ -1002,6 +1018,9 @@ async fn purify_create_source(
             let initial_gtid_set =
                 mz_mysql_util::query_sys_var(&mut conn, "global.gtid_executed").await?;
 
+            let mut reference_client = SourceReferenceClient::MySql { conn: &mut conn };
+            available_source_references = reference_client.get_source_references().await?;
+
             let mysql::PurifiedSourceExports {
                 source_exports: subsources,
                 normalized_text_columns,
@@ -1046,15 +1065,32 @@ async fn purify_create_source(
             }
         }
         CreateSourceConnection::LoadGenerator { generator, options } => {
-            let (_load_generator, available_subsources) =
+            let load_generator =
                 load_generator_ast_to_generator(&scx, generator, options, include_metadata)?;
 
+            let mut reference_client = SourceReferenceClient::LoadGenerator {
+                generator: &load_generator,
+            };
+            available_source_references = reference_client.get_source_references().await?;
+
+            // TODO: Refactor this to use the available references
+            let mut available_subsources = BTreeMap::new();
+            for (name, desc, output) in load_generator.views() {
+                let name = FullItemName {
+                    database: RawDatabaseSpecifier::Name(
+                        mz_storage_types::sources::load_generator::LOAD_GENERATOR_DATABASE_NAME
+                            .to_owned(),
+                    ),
+                    schema: load_generator.schema_name().into(),
+                    item: name.to_string(),
+                };
+                available_subsources.insert(name, (desc, output));
+            }
             match external_references {
                 Some(ExternalReferences::All) => {
-                    let available_subsources = match available_subsources {
-                        Some(available_subsources) => available_subsources,
-                        None => Err(LoadGeneratorSourcePurificationError::ForAllTables)?,
-                    };
+                    if available_subsources.is_empty() {
+                        Err(LoadGeneratorSourcePurificationError::ForAllTables)?;
+                    }
                     for (name, (desc, output)) in available_subsources {
                         let subsource_name = source_export_name_gen(source_name, &name.item)?;
                         let external_reference = UnresolvedItemName::from(name);
@@ -1078,7 +1114,7 @@ async fn purify_create_source(
                 }
                 None => {
                     if matches!(reference_policy, SourceReferencePolicy::Required)
-                        && available_subsources.is_some()
+                        && !available_subsources.is_empty()
                     {
                         Err(LoadGeneratorSourcePurificationError::MultiOutputRequiresForAllTables)?
                     }
@@ -1170,6 +1206,7 @@ async fn purify_create_source(
         create_progress_subsource_stmt,
         create_source_stmt,
         subsources: requested_subsource_map,
+        available_source_references,
     })
 }
 

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -344,9 +344,8 @@ pub(super) async fn purify_source_exports(
     reference_policy: &SourceReferencePolicy,
 ) -> Result<PurifiedSourceExports, PlanError> {
     let requested_exports = match requested_references.as_ref() {
-        Some(requested) => {
-            retrieved_references.requested_source_exports(requested, unresolved_source_name)?
-        }
+        Some(requested) => retrieved_references
+            .requested_source_exports(Some(requested), unresolved_source_name)?,
         None => {
             if matches!(reference_policy, SourceReferencePolicy::Required) {
                 Err(PgSourcePurificationError::RequiresExternalReferences)?

--- a/src/sql/src/pure/references.rs
+++ b/src/sql/src/pure/references.rs
@@ -1,0 +1,392 @@
+use std::collections::BTreeSet;
+use std::ops::DerefMut;
+
+use mz_ore::now::SYSTEM_TIME;
+use mz_repr::RelationDesc;
+use mz_sql_parser::ast::{ExternalReferences, Ident, IdentError, UnresolvedItemName};
+use mz_storage_types::sources::load_generator::{LoadGenerator, LoadGeneratorOutput};
+use mz_storage_types::sources::SourceReferenceResolver;
+
+use crate::names::{FullItemName, RawDatabaseSpecifier};
+use crate::plan::{PlanError, SourceReference, SourceReferences};
+
+use super::{
+    error::{MySqlSourcePurificationError, PgSourcePurificationError},
+    RequestedSourceExport,
+};
+
+/// A client that allows determining all available source references and resolving
+/// them to a user-specified source reference during purification.
+pub(super) enum SourceReferenceClient<'a> {
+    Postgres {
+        client: &'a mz_postgres_util::Client,
+        publication: &'a str,
+        database: &'a str,
+    },
+    MySql {
+        conn: &'a mut mz_mysql_util::MySqlConn,
+    },
+    Kafka {
+        topic: &'a str,
+    },
+    LoadGenerator {
+        generator: &'a LoadGenerator,
+    },
+}
+
+/// Metadata about an available source reference retrieved from the upstream system.
+#[derive(Clone)]
+enum ReferenceMetadata {
+    Postgres {
+        table: mz_postgres_util::desc::PostgresTableDesc,
+        database: String,
+    },
+    MySql(mz_mysql_util::MySqlTableSchema),
+    Kafka(String),
+    LoadGenerator {
+        name: String,
+        desc: RelationDesc,
+        namespace: String,
+        output: LoadGeneratorOutput,
+    },
+}
+
+impl ReferenceMetadata {
+    fn namespace(&self) -> Option<&str> {
+        match self {
+            ReferenceMetadata::Postgres { table, .. } => Some(&table.namespace),
+            ReferenceMetadata::MySql(table) => Some(&table.schema_name),
+            ReferenceMetadata::Kafka(_) => None,
+            ReferenceMetadata::LoadGenerator { namespace, .. } => Some(namespace),
+        }
+    }
+
+    fn name(&self) -> &str {
+        match self {
+            ReferenceMetadata::Postgres { table, .. } => &table.name,
+            ReferenceMetadata::MySql(table) => &table.name,
+            ReferenceMetadata::Kafka(topic) => topic,
+            ReferenceMetadata::LoadGenerator { name, .. } => name,
+        }
+    }
+
+    pub(super) fn postgres_desc(&self) -> Option<&mz_postgres_util::desc::PostgresTableDesc> {
+        match self {
+            ReferenceMetadata::Postgres { table, .. } => Some(table),
+            _ => None,
+        }
+    }
+
+    pub(super) fn mysql_table(&self) -> Option<&mz_mysql_util::MySqlTableSchema> {
+        match self {
+            ReferenceMetadata::MySql(table) => Some(table),
+            _ => None,
+        }
+    }
+
+    pub(super) fn load_generator_desc(&self) -> Option<&RelationDesc> {
+        match self {
+            ReferenceMetadata::LoadGenerator { desc, .. } => Some(desc),
+            _ => None,
+        }
+    }
+
+    pub(super) fn load_generator_output(&self) -> Option<&LoadGeneratorOutput> {
+        match self {
+            ReferenceMetadata::LoadGenerator { output, .. } => Some(output),
+            _ => None,
+        }
+    }
+
+    /// Convert the reference metadata into an `UnresolvedItemName` representing the
+    /// external reference, normalized for each source type to be stored as part of
+    /// the relevant statement in the catalog.
+    pub(super) fn external_reference(&self) -> Result<UnresolvedItemName, IdentError> {
+        match self {
+            ReferenceMetadata::Postgres { table, database } => {
+                Ok(UnresolvedItemName::qualified(&[
+                    Ident::new(database)?,
+                    Ident::new(&table.namespace)?,
+                    Ident::new(&table.name)?,
+                ]))
+            }
+            ReferenceMetadata::MySql(table) => Ok(UnresolvedItemName::qualified(&[
+                Ident::new(&table.schema_name)?,
+                Ident::new(&table.name)?,
+            ])),
+            ReferenceMetadata::Kafka(topic) => {
+                Ok(UnresolvedItemName::qualified(&[Ident::new(topic)?]))
+            }
+            ReferenceMetadata::LoadGenerator {
+                name, namespace, ..
+            } => {
+                let name = FullItemName {
+                    database: RawDatabaseSpecifier::Name(
+                        mz_storage_types::sources::load_generator::LOAD_GENERATOR_DATABASE_NAME
+                            .to_owned(),
+                    ),
+                    schema: namespace.to_string(),
+                    item: name.to_string(),
+                };
+                Ok(UnresolvedItemName::from(name))
+            }
+        }
+    }
+}
+
+/// A set of resolved source references.
+#[derive(Clone)]
+pub(super) struct RetrievedSourceReferences {
+    updated_at: u64,
+    references: Vec<ReferenceMetadata>,
+    resolver: SourceReferenceResolver,
+}
+
+/// The name of the fake database that we use for non-Postgres sources
+/// to fit the model of a 3-layer catalog used to resolve references
+/// in the `SourceReferenceResolver`. This isn't actually stored in
+/// the catalog since the `ReferenceMetadata::external_reference`
+/// method only includes the database name for Postgres sources.
+pub(crate) static DATABASE_FAKE_NAME: &str = "database";
+
+impl<'a> SourceReferenceClient<'a> {
+    /// Get all available source references from the upstream system
+    /// and return a `RetrievedSourceReferences` object that can be used
+    /// to resolve user-specified source references and create `SourceReferences`
+    /// for storage in the catalog.
+    pub(super) async fn get_source_references(
+        mut self,
+    ) -> Result<RetrievedSourceReferences, PlanError> {
+        let references = match self {
+            SourceReferenceClient::Postgres {
+                client,
+                publication,
+                database,
+            } => {
+                let tables = mz_postgres_util::publication_info(client, publication).await?;
+
+                if tables.is_empty() {
+                    Err(PgSourcePurificationError::EmptyPublication(
+                        publication.to_string(),
+                    ))?;
+                }
+
+                tables
+                    .into_iter()
+                    .map(|desc| ReferenceMetadata::Postgres {
+                        table: desc,
+                        database: database.to_string(),
+                    })
+                    .collect()
+            }
+            SourceReferenceClient::MySql { ref mut conn } => {
+                // NOTE: mysql will only expose the schemas of tables we have at least one privilege on
+                // and we can't tell if a table exists without a privilege, so in some cases we may
+                // return an EmptyDatabase error in the case of privilege issues.
+                let tables = mz_mysql_util::schema_info(
+                    (*conn).deref_mut(),
+                    &mz_mysql_util::SchemaRequest::All,
+                )
+                .await?;
+
+                if tables.is_empty() {
+                    Err(MySqlSourcePurificationError::EmptyDatabase)?;
+                }
+
+                tables.into_iter().map(ReferenceMetadata::MySql).collect()
+            }
+            SourceReferenceClient::Kafka { topic } => {
+                vec![ReferenceMetadata::Kafka(topic.to_string())]
+            }
+            SourceReferenceClient::LoadGenerator { generator } => {
+                let mut references = generator
+                    .views()
+                    .into_iter()
+                    .map(
+                        |(view, relation, output)| ReferenceMetadata::LoadGenerator {
+                            name: view.to_string(),
+                            desc: relation,
+                            namespace: generator.schema_name().to_string(),
+                            output,
+                        },
+                    )
+                    .collect::<Vec<_>>();
+
+                if references.is_empty() {
+                    // If there are no views then this load-generator just has a single output
+                    // that uses the load-generator's schema name.
+                    references.push(ReferenceMetadata::LoadGenerator {
+                        name: generator.schema_name().to_string(),
+                        desc: RelationDesc::empty(),
+                        namespace: generator.schema_name().to_string(),
+                        output: LoadGeneratorOutput::Default,
+                    });
+                }
+                references
+            }
+        };
+
+        let reference_names: Vec<(&str, &str)> = references
+            .iter()
+            .map(|reference| {
+                (
+                    reference.namespace().unwrap_or(reference.name()),
+                    reference.name(),
+                )
+            })
+            .collect();
+        let resolver = match self {
+            SourceReferenceClient::Postgres { database, .. } => {
+                SourceReferenceResolver::new(database, &reference_names)
+            }
+            _ => SourceReferenceResolver::new(DATABASE_FAKE_NAME, &reference_names),
+        }?;
+
+        Ok(RetrievedSourceReferences {
+            updated_at: SYSTEM_TIME(),
+            references,
+            resolver,
+        })
+    }
+}
+
+impl RetrievedSourceReferences {
+    /// Convert the resolved source references into a `SourceReferences` object
+    /// for storage in the catalog.
+    pub(super) fn available_source_references(self) -> SourceReferences {
+        SourceReferences {
+            updated_at: self.updated_at,
+            references: self
+                .references
+                .into_iter()
+                .map(|reference| match reference {
+                    ReferenceMetadata::Postgres { table, .. } => SourceReference {
+                        name: table.name,
+                        namespace: Some(table.namespace),
+                        columns: table.columns.into_iter().map(|c| c.name).collect(),
+                    },
+                    ReferenceMetadata::MySql(table) => SourceReference {
+                        name: table.name,
+                        namespace: Some(table.schema_name),
+                        columns: table
+                            .columns
+                            .into_iter()
+                            .map(|column| column.name())
+                            .collect(),
+                    },
+                    ReferenceMetadata::Kafka(topic) => SourceReference {
+                        name: topic,
+                        namespace: None,
+                        columns: vec![],
+                    },
+                    ReferenceMetadata::LoadGenerator {
+                        name,
+                        desc,
+                        namespace,
+                        ..
+                    } => SourceReference {
+                        name,
+                        namespace: Some(namespace),
+                        columns: desc.iter_names().map(|n| n.to_string()).collect(),
+                    },
+                })
+                .collect(),
+        }
+    }
+
+    /// Resolve the requested external references to their appropriate source exports.
+    pub(super) fn requested_source_exports<'a>(
+        &'a self,
+        requested: &ExternalReferences,
+        source_name: &UnresolvedItemName,
+    ) -> Result<Vec<RequestedSourceExport<&ReferenceMetadata>>, PlanError> {
+        // Filter all available references to those requested by the `ExternalReferences`
+        // specification and include any alias that the user has specified.
+        // TODO(#8260): The alias handling can be removed once subsources are removed.
+        let filtered: Vec<(&ReferenceMetadata, Option<&UnresolvedItemName>)> = match requested {
+            ExternalReferences::All => self.references.iter().map(|r| (r, None)).collect(),
+            ExternalReferences::SubsetSchemas(schemas) => {
+                let available_schemas: BTreeSet<&str> = self
+                    .references
+                    .iter()
+                    .filter_map(|r| r.namespace())
+                    .collect();
+                let requested_schemas: BTreeSet<&str> =
+                    schemas.iter().map(|s| s.as_str()).collect();
+
+                let missing_schemas: Vec<_> = requested_schemas
+                    .difference(&available_schemas)
+                    .map(|s| s.to_string())
+                    .collect();
+
+                if !missing_schemas.is_empty() {
+                    Err(PlanError::NoTablesFoundForSchemas(missing_schemas))?
+                }
+
+                self.references
+                    .iter()
+                    .filter_map(|reference| {
+                        reference
+                            .namespace()
+                            .map(|namespace| {
+                                requested_schemas
+                                    .contains(namespace)
+                                    .then(|| (reference, None))
+                            })
+                            .flatten()
+                    })
+                    .collect()
+            }
+            ExternalReferences::SubsetTables(requested_tables) => {
+                // Use the `SourceReferenceResolver` to resolve the requested tables to their
+                // appropriate index in the available references.
+                requested_tables
+                    .into_iter()
+                    .map(|requested_table| {
+                        let idx = self.resolver.resolve_idx(&requested_table.reference.0)?;
+                        Ok((&self.references[idx], requested_table.alias.as_ref()))
+                    })
+                    .collect::<Result<Vec<_>, PlanError>>()?
+            }
+        };
+
+        // Convert the filtered references to their appropriate `RequestedSourceExport` form.
+        Ok(filtered
+            .into_iter()
+            .map(|(reference, alias)| {
+                let name = match alias {
+                    Some(alias_name) => {
+                        let partial = crate::normalize::unresolved_item_name(alias_name.clone())?;
+                        match partial.schema {
+                            Some(_) => alias_name.clone(),
+                            // In cases when a prefix is not provided for the aliased name
+                            // fallback to using the schema of the source with the given name
+                            None => super::source_export_name_gen(source_name, &partial.item)?,
+                        }
+                    }
+                    None => {
+                        // Just use the item name for this reference and ensure it's created in
+                        // the current schema or the source's schema if provided, not mirroring
+                        // the schema of the reference.
+                        super::source_export_name_gen(source_name, reference.name())?
+                    }
+                };
+
+                Ok(RequestedSourceExport {
+                    external_reference: reference.external_reference()?,
+                    name,
+                    meta: reference,
+                })
+            })
+            .collect::<Result<Vec<_>, PlanError>>()?)
+    }
+
+    pub(super) fn resolve_name(&self, name: &[Ident]) -> Result<&ReferenceMetadata, PlanError> {
+        let idx = self.resolver.resolve_idx(name)?;
+        Ok(&self.references[idx])
+    }
+
+    pub(super) fn all_references(&self) -> &Vec<ReferenceMetadata> {
+        &self.references
+    }
+}

--- a/src/sql/src/pure/references.rs
+++ b/src/sql/src/pure/references.rs
@@ -1,3 +1,12 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
 use std::collections::BTreeSet;
 use std::ops::DerefMut;
 
@@ -302,7 +311,7 @@ impl RetrievedSourceReferences {
     ) -> Result<Vec<RequestedSourceExport<&ReferenceMetadata>>, PlanError> {
         // Filter all available references to those requested by the `ExternalReferences`
         // specification and include any alias that the user has specified.
-        // TODO(#8260): The alias handling can be removed once subsources are removed.
+        // TODO(database-issues#8620): The alias handling can be removed once subsources are removed.
         let filtered: Vec<(&ReferenceMetadata, Option<&UnresolvedItemName>)> = match requested {
             Some(ExternalReferences::All) => self.references.iter().map(|r| (r, None)).collect(),
             Some(ExternalReferences::SubsetSchemas(schemas)) => {

--- a/src/sql/src/pure/references.rs
+++ b/src/sql/src/pure/references.rs
@@ -54,7 +54,7 @@ pub(super) enum ReferenceMetadata {
     Kafka(String),
     LoadGenerator {
         name: String,
-        desc: RelationDesc,
+        desc: Option<RelationDesc>,
         namespace: String,
         output: LoadGeneratorOutput,
     },
@@ -93,7 +93,7 @@ impl ReferenceMetadata {
         }
     }
 
-    pub(super) fn load_generator_desc(&self) -> Option<&RelationDesc> {
+    pub(super) fn load_generator_desc(&self) -> Option<&Option<RelationDesc>> {
         match self {
             ReferenceMetadata::LoadGenerator { desc, .. } => Some(desc),
             _ => None,
@@ -214,7 +214,7 @@ impl<'a> SourceReferenceClient<'a> {
                     .map(
                         |(view, relation, output)| ReferenceMetadata::LoadGenerator {
                             name: view.to_string(),
-                            desc: relation,
+                            desc: Some(relation),
                             namespace: generator.schema_name().to_string(),
                             output,
                         },
@@ -226,7 +226,7 @@ impl<'a> SourceReferenceClient<'a> {
                     // that uses the load-generator's schema name.
                     references.push(ReferenceMetadata::LoadGenerator {
                         name: generator.schema_name().to_string(),
-                        desc: RelationDesc::empty(),
+                        desc: None,
                         namespace: generator.schema_name().to_string(),
                         output: LoadGeneratorOutput::Default,
                     });
@@ -296,7 +296,9 @@ impl RetrievedSourceReferences {
                     } => SourceReference {
                         name,
                         namespace: Some(namespace),
-                        columns: desc.iter_names().map(|n| n.to_string()).collect(),
+                        columns: desc
+                            .map(|desc| desc.iter_names().map(|n| n.to_string()).collect())
+                            .unwrap_or_default(),
                     },
                 })
                 .collect(),

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1469,7 +1469,7 @@ pub enum ExternalReferenceResolutionError {
     #[error("reference to {name} not found in source")]
     DoesNotExist { name: String },
     #[error(
-        "reference to {name} is ambiguous, consider specifying an additional \
+        "reference {name} is ambiguous, consider specifying an additional \
     layer of qualification"
     )]
     Ambiguous { name: String },

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1420,7 +1420,7 @@ pub trait ExternalCatalogReference {
     fn item_name(&self) -> &str;
 }
 
-impl ExternalCatalogReference for mz_mysql_util::MySqlTableDesc {
+impl ExternalCatalogReference for &mz_mysql_util::MySqlTableDesc {
     fn schema_name(&self) -> &str {
         &self.schema_name
     }

--- a/test/mysql-cdc/table-in-mysql-schema.td
+++ b/test/mysql-cdc/table-in-mysql-schema.td
@@ -35,23 +35,26 @@ INSERT INTO t_in_mysql VALUES (1), (2);
 
 > DROP SOURCE IF EXISTS mz_source;
 
-> CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn;
+# TODO(database-issues#8624): Uncomment when addressed
 
-! CREATE TABLE timezone FROM SOURCE mz_source (REFERENCE public.timezone);
+! CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn;
 contains:No tables found
 
-> CREATE TABLE t_in_mysql FROM SOURCE mz_source (REFERENCE mysql.t_in_mysql);
+# ! CREATE TABLE timezone FROM SOURCE mz_source (REFERENCE public.timezone);
+# contains:No tables found
 
-> SELECT * FROM t_in_mysql;
-1
-2
+# > CREATE TABLE t_in_mysql FROM SOURCE mz_source (REFERENCE mysql.t_in_mysql);
 
-> DROP SOURCE mz_source CASCADE;
+# > SELECT * FROM t_in_mysql;
+# 1
+# 2
 
-> CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn;
+# > DROP SOURCE mz_source CASCADE;
 
-! CREATE TABLE t_in_mysql FROM SOURCE mz_source (REFERENCE mysql.time_zone);
-contains:referenced tables use unsupported types
+# > CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn;
+
+# ! CREATE TABLE t_in_mysql FROM SOURCE mz_source (REFERENCE mysql.time_zone);
+# contains:referenced tables use unsupported types
 
 $ mysql-execute name=mysql
 DROP TABLE t_in_mysql;

--- a/test/mysql-cdc/temporary-tables.td
+++ b/test/mysql-cdc/temporary-tables.td
@@ -41,4 +41,4 @@ CREATE TEMPORARY TABLE t_temp (f1 BOOLEAN);
 0
 
 ! CREATE TABLE t_temp FROM SOURCE mz_source (REFERENCE public.t_temp);
-contains:No tables found
+contains:reference to public.t_temp not found in source

--- a/test/mysql-cdc/views.td
+++ b/test/mysql-cdc/views.td
@@ -38,7 +38,7 @@ CREATE VIEW v1 (f1) AS SELECT f1 FROM t1;
 > CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn;
 
 ! CREATE TABLE v1 FROM SOURCE mz_source (REFERENCE public.v1);
-contains:No tables found
+contains:reference to public.v1 not found in source
 
 ! CREATE VIEW v1 FROM SOURCE mz_source (REFERENCE public.v1);
 contains:Expected AS, found FROM

--- a/test/pg-cdc-old-syntax/pg-cdc.td
+++ b/test/pg-cdc-old-syntax/pg-cdc.td
@@ -718,7 +718,7 @@ contains: invalid TEXT COLUMNS option value: reference to table_dne not found in
     conflict_schema.another_enum_table AS conflict_enum,
     public.another_enum_table AS public_enum
   );
-contains: invalid TEXT COLUMNS option value: reference to another_enum_table is ambiguous, consider specifying an additional layer of qualification
+contains: invalid TEXT COLUMNS option value: reference another_enum_table is ambiguous, consider specifying an additional layer of qualification
 
 ! CREATE SOURCE enum_source
   IN CLUSTER cdc_cluster

--- a/test/pg-cdc-old-syntax/two-source-schemas.td
+++ b/test/pg-cdc-old-syntax/two-source-schemas.td
@@ -52,7 +52,7 @@ contains:multiple subsources would be named t1
 ! CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR TABLES (t1);
-contains:reference to t1 is ambiguous, consider specifying an additional layer of qualification
+contains:reference t1 is ambiguous, consider specifying an additional layer of qualification
 
 > CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')

--- a/test/pg-cdc/subsource-resolution-duplicates.td
+++ b/test/pg-cdc/subsource-resolution-duplicates.td
@@ -40,7 +40,7 @@ ALTER TABLE other.t REPLICA IDENTITY FULL;
 > CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source');
 
 ! CREATE TABLE t FROM SOURCE mz_source (REFERENCE t);
-contains: reference to t is ambiguous
+contains: reference t is ambiguous
 
 > CREATE TABLE t FROM SOURCE mz_source (REFERENCE public.t);
 

--- a/test/pg-cdc/two-source-schemas.td
+++ b/test/pg-cdc/two-source-schemas.td
@@ -54,7 +54,7 @@ contains:catalog item 't1' already exists
 > DROP TABLE t1;
 
 ! CREATE TABLE t1 FROM SOURCE mz_source (REFERENCE t1);
-contains:reference to t1 is ambiguous, consider specifying an additional layer of qualification
+contains:reference t1 is ambiguous, consider specifying an additional layer of qualification
 
 > CREATE TABLE t1 FROM SOURCE mz_source (REFERENCE schema1.t1);
 

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -60,7 +60,7 @@ exact:COUNTER load generators do not support SCALE FACTOR values
 "materialize.public.auction_house" "CREATE SOURCE \"materialize\".\"public\".\"auction_house\" IN CLUSTER \"${arg.single-replica-cluster}\" FROM LOAD GENERATOR AUCTION (AS OF = 300, UP TO = 301) EXPOSE PROGRESS AS \"materialize\".\"public\".\"auction_house_progress\""
 
 > SHOW CREATE TABLE accounts
-materialize.public.accounts "CREATE TABLE \"materialize\".\"public\".\"accounts\" (\"id\" \"pg_catalog\".\"int8\" NOT NULL, \"org_id\" \"pg_catalog\".\"int8\" NOT NULL, \"balance\" \"pg_catalog\".\"int8\" NOT NULL, UNIQUE (\"id\")) FROM SOURCE \"materialize\".\"public\".\"auction_house\" (REFERENCE = \"auction\".\"accounts\") WITH (DETAILS = '1a040a021002')"
+materialize.public.accounts "CREATE TABLE \"materialize\".\"public\".\"accounts\" (\"id\" \"pg_catalog\".\"int8\" NOT NULL, \"org_id\" \"pg_catalog\".\"int8\" NOT NULL, \"balance\" \"pg_catalog\".\"int8\" NOT NULL, UNIQUE (\"id\")) FROM SOURCE \"materialize\".\"public\".\"auction_house\" (REFERENCE = \"mz_load_generators\".\"auction\".\"accounts\") WITH (DETAILS = '1a040a021002')"
 
 > SHOW SOURCES
 auction_house           load-generator ${arg.single-replica-cluster}    ""
@@ -76,16 +76,11 @@ users                   ""
 > SELECT count(*) FROM bids
 255
 
-# FOR TABLES doesn't always work.
-# A previous test here checked bids, which worked.
-# It did not check users, which causes a panic.
-# If this is fixed in the future, tests should probably exhaustively check each subsource.
 ! CREATE SOURCE auction_house
   IN CLUSTER ${arg.single-replica-cluster}
   FROM LOAD GENERATOR AUCTION FOR TABLES (user);
-contains:LOAD GENERATOR source validation: FOR TABLES (..) unsupported
+contains:reference to user not found in source
 
-# For Tables with mentioned schema should work
 > CREATE SCHEMA another;
 > CREATE SOURCE another.auction_house
   IN CLUSTER ${arg.single-replica-cluster}
@@ -122,7 +117,7 @@ users                   ""
 $ set-regex match="DETAILS = '[a-f0-9]+'" replacement=<DETAILS>
 
 > SHOW CREATE TABLE accounts
-materialize.public.accounts "CREATE TABLE \"materialize\".\"public\".\"accounts\" (\"id\" \"pg_catalog\".\"int8\" NOT NULL, \"org_id\" \"pg_catalog\".\"int8\" NOT NULL, \"balance\" \"pg_catalog\".\"int8\" NOT NULL, UNIQUE (\"id\")) FROM SOURCE \"materialize\".\"public\".\"auction_house\" (REFERENCE = \"auction\".\"accounts\") WITH (<DETAILS>)"
+materialize.public.accounts "CREATE TABLE \"materialize\".\"public\".\"accounts\" (\"id\" \"pg_catalog\".\"int8\" NOT NULL, \"org_id\" \"pg_catalog\".\"int8\" NOT NULL, \"balance\" \"pg_catalog\".\"int8\" NOT NULL, UNIQUE (\"id\")) FROM SOURCE \"materialize\".\"public\".\"auction_house\" (REFERENCE = \"mz_load_generators\".\"auction\".\"accounts\") WITH (<DETAILS>)"
 
 # CLOCK load generator source
 
@@ -192,13 +187,6 @@ $ set-regex match=\d+ replacement=<NUMBER>
 $ set-regex match=(\s{12}0|\d{13,20}|u\d{1,5}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d\.\d\d\d\)|true|false) replacement=<>
 > EXPLAIN TIMESTAMP FOR SELECT * FROM another.auction_house_progress
 "                query timestamp: <> <>\n          oracle read timestamp: <> <>\nlargest not in advance of upper: <> <>\n                          upper:[<> <>]\n                          since:[<> <>]\n        can respond immediately: <>\n                       timeline: Some(EpochMilliseconds)\n              session wall time: <> <>\n\nsource materialize.another.auction_house_progress (<>, storage):\n                  read frontier:[<> <>]\n                 write frontier:[<> <>]\n"
-
-# Check that for all tables clause is rejected with no subsources
-! CREATE SOURCE counter6
-  IN CLUSTER ${arg.single-replica-cluster}
-  FROM LOAD GENERATOR COUNTER (MAX CARDINALITY 8, TICK INTERVAL '0.001s')
-  FOR ALL TABLES;
-contains: FOR ALL TABLES is only valid for multi-output sources
 
 > DROP SOURCE auction_house CASCADE
 > DROP SOURCE another.auction_house CASCADE

--- a/test/testdrive/source-tables.td
+++ b/test/testdrive/source-tables.td
@@ -10,6 +10,9 @@
 $ set-arg-default default-replica-size=1
 $ set-arg-default single-replica-cluster=quickstart
 
+# TODO(def-) Remove when database-issues#8515 and database-issues#8526 are fixed
+$ skip-if
+SELECT true
 
 #
 # Validate feature flag
@@ -294,6 +297,9 @@ var1 4444 12
 # ensure that CASCADE propagates to the tables
 ! SELECT * FROM mysql_table_3;
 contains:unknown catalog item 'mysql_table_3'
+
+# TODO(def-) Remove when database-issues#8515 and database-issues#8526 are fixed
+$ skip-end
 
 #
 # Kafka source using source-fed tables

--- a/test/testdrive/source-tables.td
+++ b/test/testdrive/source-tables.td
@@ -10,9 +10,6 @@
 $ set-arg-default default-replica-size=1
 $ set-arg-default single-replica-cluster=quickstart
 
-# TODO(def-) Remove when database-issues#8515 and database-issues#8526 are fixed
-$ skip-if
-SELECT true
 
 #
 # Validate feature flag
@@ -55,7 +52,24 @@ ALTER SYSTEM SET enable_load_generator_key_value = true
 > SELECT count(*) FROM bids2
 255
 
+
+# Validate that the available source references table was correctly populated
+> SELECT u.name, u.namespace, u.columns
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_references u ON s.id = u.source_id
+  WHERE
+  s.name = 'auction_house'
+  ORDER BY u.name;
+accounts auction {id,org_id,balance}
+auctions auction {id,seller,item,end_time}
+bids auction {id,buyer,auction_id,amount,bid_time}
+organizations auction {id,name}
+users auction {id,org_id,name}
+
 > DROP SOURCE auction_house CASCADE;
+
+> SELECT count(*) FROM mz_internal.mz_source_references;
+0
 
 #
 # Single-output load generator source using source-fed tables
@@ -280,10 +294,6 @@ var1 4444 12
 # ensure that CASCADE propagates to the tables
 ! SELECT * FROM mysql_table_3;
 contains:unknown catalog item 'mysql_table_3'
-
-# TODO(def-) Remove when database-issues#8515 and database-issues#8526 are fixed
-$ skip-end
-
 
 #
 # Kafka source using source-fed tables

--- a/test/yugabyte-cdc/yugabyte-cdc.td
+++ b/test/yugabyte-cdc/yugabyte-cdc.td
@@ -576,7 +576,7 @@ hint: The similarly named column "pk_table.f2" does exist.
   FOR TABLES (
     "enum_table"
   );
-contains: invalid TEXT COLUMNS option value: reference to table_dne not found in source
+contains: reference to table_dne not found in source
 
 # Reference exists in two schemas, so is not unambiguous
 ! CREATE SOURCE enum_source
@@ -589,7 +589,7 @@ contains: invalid TEXT COLUMNS option value: reference to table_dne not found in
     conflict_schema.another_enum_table AS conflict_enum,
     public.another_enum_table AS public_enum
   );
-contains: invalid TEXT COLUMNS option value: reference to another_enum_table is ambiguous, consider specifying an additional layer of qualification
+contains: reference another_enum_table is ambiguous, consider specifying an additional layer of qualification
 
 ! CREATE SOURCE enum_source
   IN CLUSTER cdc_cluster
@@ -598,7 +598,7 @@ contains: invalid TEXT COLUMNS option value: reference to another_enum_table is 
     TEXT COLUMNS [foo]
   )
   FOR TABLES (pk_table);
-contains: invalid TEXT COLUMNS option value: column name 'foo' must have at least a table qualification
+contains: column name 'foo' must have at least a table qualification
 
 ! CREATE SOURCE enum_source
   IN CLUSTER cdc_cluster
@@ -607,7 +607,7 @@ contains: invalid TEXT COLUMNS option value: column name 'foo' must have at leas
     TEXT COLUMNS [foo.bar.qux.qax.foo]
   )
   FOR TABLES (pk_table);
-contains: invalid TEXT COLUMNS option value: reference to foo.bar.qux.qax not found in source
+contains: reference to foo.bar.qux.qax not found in source
 
 ! CREATE SOURCE enum_source
   IN CLUSTER cdc_cluster
@@ -616,7 +616,7 @@ contains: invalid TEXT COLUMNS option value: reference to foo.bar.qux.qax not fo
     TEXT COLUMNS [enum_table.a, enum_table.a]
   )
   FOR TABLES (enum_table);
-contains: invalid TEXT COLUMNS option value: unexpected multiple references to yugabyte.public.enum_table.a
+contains: unexpected multiple references to yugabyte.public.enum_table.a
 
 # utf8_table is not part of mz_source_narrow publication
 ! CREATE SOURCE enum_source
@@ -626,7 +626,7 @@ contains: invalid TEXT COLUMNS option value: unexpected multiple references to y
     TEXT COLUMNS [enum_table.a, utf8_table.f1]
   )
   FOR TABLES (enum_table);
-contains: invalid TEXT COLUMNS option value: reference to utf8_table not found in source
+contains: reference to utf8_table not found in source
 
 # n.b includes a reference to pk_table, which is not a table that's part of the
 # source, but is part of the publication.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/8376 (populate `mz_internal.mz_source_references`)
and Fixes https://github.com/MaterializeInc/database-issues/issues/8550 (refactor purification to simplify reference external resolution logic)

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

This PR was originally intended just to retrieve all available source references during purification of `CREATE SOURCE` statements, but expanded to refactor purification handling of external reference resolution, which is why it's a little long.

It aims to simplify things overall by centralizing the logic for resolving external references against the set of 'all available source references'.

The downside to this approach (as previously discussed) is that we will always retrieve _all_ upstream references first and then resolve the the user-specified reference(s) locally, rather than querying the upstream system with the specific reference(s) directly. 

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
