### PR TITLE
Fix merge skew in proto/src/lib.rs

### DIFF
--- a/src/proto/src/lib.rs
+++ b/src/proto/src/lib.rs
@@ -363,24 +363,6 @@ where
     }
 }
 
-/// Blanket implementation for `Box<[R]>` where `R` is a [`RustType`].
-impl<R, P> RustType<Vec<P>> for Box<[R]>
-where
-    R: RustType<P>,
-{
-    fn into_proto(&self) -> Vec<P> {
-        self.iter().map(R::into_proto).collect()
-    }
-
-    fn from_proto(proto: Vec<P>) -> Result<Self, TryFromProtoError> {
-        proto
-            .into_iter()
-            .map(R::from_proto)
-            .collect::<Result<Vec<_>, _>>()
-            .map(Into::into)
-    }
-}
-
 /// Blanket implementation for `Option<R>` where `R` is a [`RustType`].
 impl<R, P> RustType<Option<P>> for Option<R>
 where


### PR DESCRIPTION
Between https://github.com/MaterializeInc/materialize/pull/29838 and https://github.com/MaterializeInc/materialize/pull/29854

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
