### PR TITLE
testdrive: Parallelize more runs

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -248,6 +248,7 @@ steps:
         label: ":racing_car: testdrive with --kafka-default-partitions 5"
         depends_on: build-aarch64
         timeout_in_minutes: 180
+        parallelism: 2 # to prevent high CPU load
         agents:
           queue: hetzner-aarch64-8cpu-16gb
         plugins:
@@ -281,6 +282,7 @@ steps:
         label: ":racing_car: testdrive with SIZE 8"
         depends_on: build-aarch64
         timeout_in_minutes: 180
+        parallelism: 2 # to prevent high CPU load
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -292,6 +294,7 @@ steps:
         label: ":racing_car: testdrive with Structured Persist (Only Structured)"
         depends_on: build-aarch64
         timeout_in_minutes: 180
+        parallelism: 2 # to prevent high CPU load
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:


### PR DESCRIPTION
Seen timing out in
https://buildkite.com/materialize/nightly/builds/9786 https://buildkite.com/materialize/nightly/builds/9803 https://buildkite.com/materialize/nightly/builds/9810

Will check if this actually works, maybe it's a more serious regression

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
