### PR TITLE
mz: add support for hard region deletion

### DIFF
--- a/src/cloud-api/src/client.rs
+++ b/src/cloud-api/src/client.rs
@@ -53,12 +53,13 @@ impl Client {
         &self,
         method: Method,
         path: P,
+        query: Option<&[(&str, &str)]>,
     ) -> Result<RequestBuilder, Error>
     where
         P: IntoIterator,
         P::Item: AsRef<str>,
     {
-        self.build_request(method, path, self.endpoint.clone(), None)
+        self.build_request(method, path, query, self.endpoint.clone(), None)
             .await
     }
 
@@ -73,6 +74,7 @@ impl Client {
         &self,
         method: Method,
         path: P,
+        query: Option<&[(&str, &str)]>,
         cloud_provider: &CloudProvider,
         api_version: Option<u16>,
     ) -> Result<RequestBuilder, Error>
@@ -83,6 +85,7 @@ impl Client {
         self.build_request(
             method,
             path,
+            query,
             cloud_provider.url.clone(),
             api_version.and_then(|api_ver| {
                 let mut headers = HeaderMap::with_capacity(1);
@@ -98,6 +101,7 @@ impl Client {
         &self,
         method: Method,
         path: P,
+        query: Option<&[(&str, &str)]>,
         mut domain: Url,
         headers: Option<HeaderMap>,
     ) -> Result<RequestBuilder, Error>
@@ -114,6 +118,9 @@ impl Client {
         let mut req = self.inner.request(method, domain);
         if let Some(header_map) = headers {
             req = req.headers(header_map);
+        }
+        if let Some(query_params) = query {
+            req = req.query(&query_params);
         }
         let token = self.auth_client.auth().await?;
 

--- a/src/cloud-api/src/client/cloud_provider.rs
+++ b/src/cloud-api/src/client/cloud_provider.rs
@@ -141,7 +141,7 @@ impl Client {
 
         loop {
             let req = self
-                .build_global_request(Method::GET, ["api", "cloud-regions"])
+                .build_global_request(Method::GET, ["api", "cloud-regions"], None)
                 .await?;
 
             let req = req.query(&[("limit", "50"), ("cursor", &cursor)]);

--- a/src/mz/src/bin/mz/command/region.rs
+++ b/src/mz/src/bin/mz/command/region.rs
@@ -35,7 +35,10 @@ pub enum RegionSubcommand {
     },
     /// Disable a region.
     #[clap(hide = true)]
-    Disable,
+    Disable {
+        #[clap(long)]
+        hard: bool,
+    },
     /// List all regions.
     #[clap(alias = "ls")]
     List,
@@ -50,7 +53,7 @@ pub async fn run(cx: Context, cmd: RegionCommand) -> Result<(), Error> {
             version,
             environmentd_extra_arg,
         } => mz::command::region::enable(cx, version, environmentd_extra_arg).await,
-        RegionSubcommand::Disable => mz::command::region::disable(cx).await,
+        RegionSubcommand::Disable { hard } => mz::command::region::disable(cx, hard).await,
         RegionSubcommand::List => mz::command::region::list(cx).await,
         RegionSubcommand::Show => mz::command::region::show(cx).await,
     }

--- a/src/mz/src/command/region.rs
+++ b/src/mz/src/command/region.rs
@@ -114,7 +114,7 @@ pub async fn enable(
 /// Disable a region in the profile organization.
 ///
 /// This command can take several minutes to complete.
-pub async fn disable(cx: RegionContext) -> Result<(), Error> {
+pub async fn disable(cx: RegionContext, hard: bool) -> Result<(), Error> {
     let loading_spinner = cx
         .output_formatter()
         .loading_spinner("Retrieving information...");
@@ -131,7 +131,7 @@ pub async fn disable(cx: RegionContext) -> Result<(), Error> {
         .retry_async(|_| async {
             loading_spinner.set_message("Disabling region...");
             cx.cloud_client()
-                .delete_region(cloud_provider.clone())
+                .delete_region(cloud_provider.clone(), hard)
                 .await?;
 
             loading_spinner.finish_with_message("Region disabled.");

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -299,7 +299,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 def disable_region(c: Composition) -> None:
     print(f"Shutting down region {REGION} ...")
 
-    c.run("mz", "region", "disable")
+    c.run("mz", "region", "disable", "--hard")
 
 
 def wait_for_cloud(c: Composition) -> None:

--- a/test/mz-e2e/mzcompose.py
+++ b/test/mz-e2e/mzcompose.py
@@ -244,7 +244,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 def disable_region(c: Composition) -> None:
     print(f"Shutting down region {REGION} ...")
 
-    c.run("mz", "region", "disable")
+    c.run("mz", "region", "disable", "--hard")
 
 
 def wait_for_cloud(c: Composition) -> None:


### PR DESCRIPTION


<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


  * This PR adds a known-desirable feature.

The Cloud Region API will soon default to soft-deletion (deprovisioning). Provide support for existing use-cases by adding a `--hard` flag to the region `disable` subcommand.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

[The cloud change](https://github.com/MaterializeInc/cloud/pull/10292) hasn't gone out yet, but since it's additive this won't impact anyone until the cloud change is deployed.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
