### PR TITLE
testdrive: Disable source-tables.td, get-started.td and end of materialization-lag.td

### DIFF
--- a/test/testdrive/get-started.td
+++ b/test/testdrive/get-started.td
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# TODO(def-) Reenable when database-issues#8581 is fixed
+$ skip-if
+SELECT true
+
 $ set-arg-default default-replica-size=1
 $ set-arg-default single-replica-cluster=quickstart
 

--- a/test/testdrive/materialization-lag.td
+++ b/test/testdrive/materialization-lag.td
@@ -173,6 +173,10 @@ snk
 # Test that when there are multiple inputs to a materialization the right one
 # is reported as the "slowest".
 
+# TODO(def-) Reenable when database-issues#8626 is fixed
+$ skip-if
+SELECT true
+
 > ALTER CLUSTER source SET (REPLICATION FACTOR 0)
 
 > SELECT o.name, d.name

--- a/test/testdrive/source-tables.td
+++ b/test/testdrive/source-tables.td
@@ -10,7 +10,7 @@
 $ set-arg-default default-replica-size=1
 $ set-arg-default single-replica-cluster=quickstart
 
-# TODO(def-) Remove when materialize#29397 and database-issues#8526 are fixed
+# TODO(def-) Remove when database-issues#8515 and database-issues#8526 are fixed
 $ skip-if
 SELECT true
 
@@ -281,8 +281,12 @@ var1 4444 12
 ! SELECT * FROM mysql_table_3;
 contains:unknown catalog item 'mysql_table_3'
 
-# TODO(def-) Remove when materialize#29397 and database-issues#8526 are fixed
+# TODO(def-) Remove when database-issues#8515 and database-issues#8526 are fixed
 $ skip-end
+
+# TODO(def-) Remove when database-issues#8625 is fixed
+$ skip-if
+SELECT true
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_create_table_from_source = true


### PR DESCRIPTION
See https://github.com/MaterializeInc/database-issues/issues/8625

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
