### PR TITLE
deps: upgrade to protobuf-native v0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,7 @@ dependencies = [
  "bitflags 2.4.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -8005,7 +8005,7 @@ checksum = "f8650aabb6c35b860610e9cff5dc1af886c9e25073b7b1712a68972af4281302"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -8025,7 +8025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.63",
@@ -8067,9 +8067,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-native"
-version = "0.3.1+26.1"
+version = "0.3.2+26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d044214db6b29e30fa2d8f9dfb5234e13383a2577330eb06e3763495e4a466"
+checksum = "ab382248bd8151301b96bd4630671199d65401c7d39a96a1423aa581669f0049"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -8095,9 +8095,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-src"
-version = "2.0.1+26.1"
+version = "2.1.0+27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ba1cfa4b9dc098926b8cce388bf434b93516db3ecf6e8b1a37eb643d733ee7"
+checksum = "a7edafa3bcc668fa93efafcbdf58d7821bbda0f4b458ac7fae3d57ec0fec8167"
 dependencies = [
  "cmake",
 ]

--- a/misc/bazel/c_deps/rust-sys/BUILD.protobuf-native.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.protobuf-native.bazel
@@ -65,7 +65,6 @@ cc_library(
     include_prefix = "protobuf-native",
     deps = [
         ":internal-include",
-        "@cxxbridge//:cxx_cc",
         "@protobuf//src/google/protobuf/compiler:importer",
     ],
 )
@@ -98,5 +97,8 @@ cc_library(
     name = "internal-include",
     hdrs = ["src/internal.h"],
     include_prefix = "protobuf-native",
-    deps = ["@com_google_absl//absl/strings"],
+    deps = [
+        "@com_google_absl//absl/strings",
+        "@crates_io__cxx-1.0.122//:cxx_cc",
+    ],
 )

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -913,6 +913,11 @@ who = "Parker Timmerman <parker.timmerman@materialize.com>"
 criteria = "safe-to-deploy"
 version = "3.4.0"
 
+[[audits.protobuf-native]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2+26.1"
+
 [[audits.protobuf-parse]]
 who = "Parker Timmerman <parker.timmerman@materialize.com>"
 criteria = "safe-to-deploy"
@@ -927,6 +932,11 @@ version = "2.0.0+26.1"
 who = "Petros Angelatos <petrosagg@gmail.com>"
 criteria = "safe-to-deploy"
 version = "2.0.1+26.1"
+
+[[audits.protobuf-src]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "2.1.0+27.1"
 
 [[audits.protobuf-support]]
 who = "Parker Timmerman <parker.timmerman@materialize.com>"

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -870,10 +870,6 @@ criteria = "safe-to-deploy"
 version = "0.3.0@git:4d8c406c32260484747c828050016de599b9f3a4"
 criteria = "safe-to-deploy"
 
-[[exemptions.protobuf-native]]
-version = "0.3.1+26.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.psm]]
 version = "0.1.16"
 criteria = "safe-to-deploy"

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -65,7 +65,7 @@ mz-txn-wal = { path = "../txn-wal" }
 num_enum = "0.5.7"
 paste = "1.0"
 prometheus = { version = "0.13.3", default-features = false }
-protobuf-native = "0.3.1"
+protobuf-native = "0.3.2"
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }


### PR DESCRIPTION
This version of protobuf-native fixes a memory error that presents when compiling with libstdc++. We presently compile with libc++ rather than libstdc++, but better safe than sorry.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug noticed by @ParkMyCar during the bazel migration.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
