### PR TITLE
sql,storage: allow using PARTITION BY with ENVELOPE DEBEZIUM

### DIFF
--- a/doc/user/content/sql/create-sink/kafka.md
+++ b/doc/user/content/sql/create-sink/kafka.md
@@ -470,7 +470,10 @@ CREATE SINK ... INTO KAFKA CONNECTION <name> (
 
 The expression:
   * Must have a type that can be assignment cast to [`uint8`].
-  * Can refer to any column in the sink's underlying relation.
+  * Can refer to any column in the sink's underlying relation when using the
+    [upsert envelope](#upsert-envelope).
+  * Can refer to any column in the sink's key when using the
+    [Debezium envelope](#debezium-envelope).
 
 Materialize uses the computed hash value to assign a partition to each message
 as follows:
@@ -490,9 +493,6 @@ which are commonly used in Kafka partition assignment:
 
 For a full example of using the `PARTITION BY` option, see [Custom
 partioning](#custom-partitioning).
-
-**Known limitation:** Materialize only supports using the `PARTITION BY`
-option with the [upsert envelope](#upsert-envelope).
 
 ## Required permissions
 

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -95,6 +95,7 @@ def get_default_system_parameters(
         "enable_envelope_debezium_in_subscribe": "true",
         "enable_expressions_in_limit_syntax": "true",
         "enable_introspection_subscribes": "true",
+        "enable_kafka_sink_partition_by": "true",
         "enable_logical_compaction_window": "true",
         "enable_multi_worker_storage_persist_sink": "true",
         "enable_mysql_source": "true",

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -347,9 +347,9 @@ impl PlanError {
                 "subsources referencing table: {}",
                 itertools::join(target_names, ", ")
             )),
-            Self::InvalidPartitionByEnvelopeDebezium { .. } => Some(format!(
-                "When using ENVELOPE DEBEZIUM, only columns in the key can be referenced in the PARTITION BY expression.",
-            )),
+            Self::InvalidPartitionByEnvelopeDebezium { .. } => Some(
+                "When using ENVELOPE DEBEZIUM, only columns in the key can be referenced in the PARTITION BY expression.".to_string()
+            ),
             _ => None,
         }
     }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -211,6 +211,9 @@ pub enum PlanError {
     },
     InvalidKeysInSubscribeEnvelopeUpsert,
     InvalidKeysInSubscribeEnvelopeDebezium,
+    InvalidPartitionByEnvelopeDebezium {
+        column_name: String,
+    },
     InvalidOrderByInSubscribeWithinTimestampOrderBy,
     FromValueRequiresParen,
     VarError(VarError),
@@ -343,6 +346,9 @@ impl PlanError {
             } => Some(format!(
                 "subsources referencing table: {}",
                 itertools::join(target_names, ", ")
+            )),
+            Self::InvalidPartitionByEnvelopeDebezium { .. } => Some(format!(
+                "When using ENVELOPE DEBEZIUM, only columns in the key can be referenced in the PARTITION BY expression.",
             )),
             _ => None,
         }
@@ -656,6 +662,13 @@ impl fmt::Display for PlanError {
             }
             Self::InvalidKeysInSubscribeEnvelopeDebezium => {
                 write!(f, "invalid keys in SUBSCRIBE ENVELOPE DEBEZIUM (KEY (..))")
+            }
+            Self::InvalidPartitionByEnvelopeDebezium { column_name } => {
+                write!(
+                    f,
+                    "PARTITION BY expression cannot refer to non-key column {}",
+                    column_name.quoted(),
+                )
             }
             Self::InvalidOrderByInSubscribeWithinTimestampOrderBy => {
                 write!(f, "invalid ORDER BY in SUBSCRIBE WITHIN TIMESTAMP ORDER BY")

--- a/test/testdrive/kafka-sink-partition-by.td
+++ b/test/testdrive/kafka-sink-partition-by.td
@@ -18,19 +18,7 @@ ALTER SYSTEM SET enable_kafka_sink_partition_by = true
 > CREATE CONNECTION k
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)
 
-> CREATE TABLE input (a int);
-
-# Test that `PARTITION BY` does not work with `ENVELOPE DEBEZIUM`.
-
-! CREATE SINK bad
-  IN CLUSTER ${arg.single-replica-cluster}
-  FROM input
-  INTO KAFKA CONNECTION k (
-    TOPIC 'testdrive-bad-${testdrive.seed}',
-    PARTITION BY part
-  )
-  FORMAT JSON ENVELOPE DEBEZIUM
-contains:PARTITION BY option is not supported with ENVELOPE DEBEZIUM
+> CREATE TABLE input (a int, b int);
 
 # Test that `PARTITION BY` does not work with an invalid data type.
 
@@ -57,6 +45,17 @@ contains:PARTITION BY does not support casting from date to uint8
   KEY (a) NOT ENFORCED
   FORMAT JSON ENVELOPE UPSERT
 contains:column "noexist" does not exist
+
+! CREATE SINK bad
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM input
+  INTO KAFKA CONNECTION k (
+    TOPIC 'testdrive-bad-${testdrive.seed}',
+    PARTITION BY b
+  )
+  KEY (a) NOT ENFORCED
+  FORMAT JSON ENVELOPE DEBEZIUM
+contains:PARTITION BY expression cannot refer to non-key column "b"
 
 # Test that `PARTITION BY` works for direct partition assignment.
 
@@ -155,3 +154,38 @@ $ kafka-verify-data format=json sink=materialize.public.invalid_output sort-mess
 {"a": 1, "b": 0}  partition=0
 {"a": 1, "b": 1}  partition=1
 {"a": 2, "b": 1}  partition=2
+
+# Test that `PARTITION BY` works with `ENVELOPE DEBEZIUM`.
+
+> DROP MATERIALIZED VIEW input CASCADE
+> CREATE TABLE input (k int, v text);
+
+> CREATE SINK debezium_output
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM input
+  INTO KAFKA CONNECTION k (
+    TOPIC 'testdrive-debezium-${testdrive.seed}',
+    TOPIC PARTITION COUNT 2,
+    PARTITION BY k
+  )
+  KEY (k) NOT ENFORCED
+  FORMAT JSON
+  ENVELOPE DEBEZIUM
+
+> INSERT INTO input VALUES (0, 'apple'), (1, 'banana');
+
+$ kafka-verify-data format=json sink=materialize.public.debezium_output sort-messages=true
+{"before": null, "after": {"k": 0, "v": "apple"}} partition=0
+{"before": null, "after": {"k": 1, "v": "banana"}} partition=1
+
+> UPDATE input SET v = v || 's'
+
+$ kafka-verify-data format=json sink=materialize.public.debezium_output sort-messages=true
+{"before": {"k": 0, "v": "apple"}, "after": {"k": 0, "v": "apples"}} partition=0
+{"before": {"k": 1, "v": "banana"}, "after": {"k": 1, "v": "bananas"}} partition=1
+
+> DELETE FROM input
+
+$ kafka-verify-data format=json sink=materialize.public.debezium_output sort-messages=true
+{"before": {"k": 0, "v": "apples"}, "after": null} partition=0
+{"before": {"k": 1, "v": "bananas"}, "after": null} partition=1


### PR DESCRIPTION
We initially disallowed mixing PARTITION BY with ENVELOPE DEBEZIUM because, when a message representing an update is processed, if columns referenced in the PARTITION BY expression change, it's not clear which partition to send the message to: the PARTITION BY expression could plausibly be computed on either the `before` values or the `after` values for the update.

However, it *is* clear which partition to send the message to if the PARTITION BY expression only refers to columns in the sink's key.  The key columns are, by definition, the same in both the `before` and the `after`.

So, this commit allows this behavior. See the docs and tests enclosed in the patch for details.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
