### PR TITLE
ct: small bug fixes

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1885,7 +1885,7 @@ impl Coordinator {
                     || entry
                         .uses()
                         .iter()
-                        .all(|dependency_id| *dependency_id < entry.id),
+                        .all(|dependency_id| *dependency_id <= entry.id),
                 "entries should only use to items with lesser `GlobalId`s, but \
                 {:?} uses {:?}",
                 entry.id,

--- a/src/dyncfg/src/lib.rs
+++ b/src/dyncfg/src/lib.rs
@@ -488,6 +488,11 @@ mod impls {
         }
 
         fn parse(s: &str) -> Result<Self, String> {
+            match s {
+                "on" => return Ok(true),
+                "off" => return Ok(false),
+                _ => {}
+            }
             s.parse().map_err(|e: ParseBoolError| e.to_string())
         }
     }
@@ -834,7 +839,9 @@ mod tests {
     #[mz_ore::test]
     fn config_parse() {
         assert_eq!(BOOL.parse_val("true"), Ok(ConfigVal::Bool(true)));
+        assert_eq!(BOOL.parse_val("on"), Ok(ConfigVal::Bool(true)));
         assert_eq!(BOOL.parse_val("false"), Ok(ConfigVal::Bool(false)));
+        assert_eq!(BOOL.parse_val("off"), Ok(ConfigVal::Bool(false)));
         assert_err!(BOOL.parse_val("42"));
         assert_err!(BOOL.parse_val("66.6"));
         assert_err!(BOOL.parse_val("farragut"));


### PR DESCRIPTION
- Allow self to show up in `uses` for CTs, which can be self-referential (found in #29745).
- Support "on" and "off" as bool values in dyncfg. This seems to be what we're getting from LD on the initial parameter sync? This parse method is used in balancerd, but AFIAK not previously in environmentd/clusterd, so could just be an oversight

Touches MaterializeInc/database-issues#8427

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
