### PR TITLE
bazel: Improve `cargo-gazelle` aka `bin/bazel gen`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,12 +1228,14 @@ dependencies = [
  "clap",
  "convert_case",
  "guppy",
+ "md-5",
  "proc-macro2",
  "protobuf-parse",
  "quote",
  "serde",
  "serde_json",
  "syn 1.0.107",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
  "workspace-hack",
@@ -1293,12 +1295,13 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -3327,9 +3330,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.21"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]

--- a/misc/bazel/cargo-gazelle/Cargo.toml
+++ b/misc/bazel/cargo-gazelle/Cargo.toml
@@ -19,12 +19,14 @@ cargo_toml = "0.19.1"
 clap = { version = "3.2.24", features = ["derive"] }
 convert_case = "0.6"
 guppy = "0.17.5"
+md-5 = "0.10.5"
 proc-macro2 = "1.0.60"
 protobuf-parse = "3.4.0"
 quote = "1.0.23"
 syn = { version = "1.0.107", features = ["extra-traits", "full"] }
 serde = "1.0.152"
 serde_json = "1.0.125"
+tempfile = "3.8.1"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "std"] }
 workspace-hack = { version = "0.0.0", path = "../../../src/workspace-hack", optional = true }

--- a/misc/bazel/cargo-gazelle/examples/gen.rs
+++ b/misc/bazel/cargo-gazelle/examples/gen.rs
@@ -38,7 +38,10 @@ pub fn main() -> Result<(), anyhow::Error> {
     let library = RustLibrary::generate(&config, &package, &crate_config, Some(&build_script))?;
 
     #[allow(clippy::as_conversions)]
-    let targets = vec![&library as &dyn RustTarget, &build_script];
+    let targets = vec![
+        Box::new(library) as Box<dyn RustTarget>,
+        Box::new(build_script),
+    ];
     let bazel_file = BazelBuildFile {
         header: BazelHeader::generate(&targets[..]),
         targets,

--- a/misc/bazel/cargo-gazelle/src/args.rs
+++ b/misc/bazel/cargo-gazelle/src/args.rs
@@ -18,7 +18,7 @@ pub struct Args {
     #[clap(long, value_name = "FORMATTER")]
     pub formatter: Option<PathBuf>,
     /// Path to a `Cargo.toml` file to generate a `BUILD.bazel` file for.
-    /// 
+    ///
     /// Can be a path to a single crate or a workspace.
     #[clap(value_name = "CARGO_TOML")]
     pub path: PathBuf,

--- a/misc/bazel/cargo-gazelle/src/args.rs
+++ b/misc/bazel/cargo-gazelle/src/args.rs
@@ -14,6 +14,12 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 pub struct Args {
-    #[clap(long, value_name = "FILE")]
+    /// Path to an executable that can be used to format `BUILD.bazel` files.
+    #[clap(long, value_name = "FORMATTER")]
+    pub formatter: Option<PathBuf>,
+    /// Path to a `Cargo.toml` file to generate a `BUILD.bazel` file for.
+    /// 
+    /// Can be a path to a single crate or a workspace.
+    #[clap(value_name = "CARGO_TOML")]
     pub path: PathBuf,
 }

--- a/misc/bazel/cargo-gazelle/src/args.rs
+++ b/misc/bazel/cargo-gazelle/src/args.rs
@@ -17,6 +17,9 @@ pub struct Args {
     /// Path to an executable that can be used to format `BUILD.bazel` files.
     #[clap(long, value_name = "FORMATTER")]
     pub formatter: Option<PathBuf>,
+    /// Doesn't actually update any files, just checks if they would have changed.
+    #[clap(long)]
+    pub check: bool,
     /// Path to a `Cargo.toml` file to generate a `BUILD.bazel` file for.
     ///
     /// Can be a path to a single crate or a workspace.

--- a/misc/bazel/cargo-gazelle/src/bin/main.rs
+++ b/misc/bazel/cargo-gazelle/src/bin/main.rs
@@ -7,19 +7,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::io::Write;
+use std::io::{Read, Write};
+use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::Context;
-use cargo_toml::Manifest;
-use clap::Parser;
-
 use cargo_gazelle::args::Args;
 use cargo_gazelle::config::{CrateConfig, GlobalConfig};
 use cargo_gazelle::context::CrateContext;
 use cargo_gazelle::header::BazelHeader;
 use cargo_gazelle::targets::{CargoBuildScript, RustBinary, RustLibrary, RustTarget, RustTest};
 use cargo_gazelle::BazelBuildFile;
+use cargo_toml::Manifest;
+use clap::Parser;
 use guppy::graph::{BuildTargetId, PackageMetadata};
+use md5::{Digest, Md5};
 use tracing_subscriber::EnvFilter;
 
 fn main() -> Result<(), anyhow::Error> {
@@ -45,75 +47,167 @@ fn main() -> Result<(), anyhow::Error> {
         None => Box::new(graph.workspace().iter()),
     };
 
-    let config = GlobalConfig::default();
+    let config = Arc::new(GlobalConfig::default());
 
-    for package in packages {
-        let crate_config = CrateConfig::new(&package);
-        tracing::debug!(?crate_config, "found config");
-        if crate_config.skip_generating() {
-            tracing::info!(path = ?package.manifest_path(), "skipping, because crate config");
-            continue;
+    std::thread::scope(|s| {
+        let mut handles = Vec::new();
+
+        // Process all of the build files in parallel.
+        for package in packages {
+            let config = Arc::clone(&config);
+            let formatter = args.formatter.clone();
+
+            let handle = s.spawn(move || {
+                let Some(bazel_build) = generage_build_bazel(&config, &package)? else {
+                    return Ok::<_, anyhow::Error>(None);
+                };
+                let bazel_build_str = bazel_build.to_string();
+
+                // Useful when iterating.
+                // println!("{bazel_build}");
+
+                // Place the BUILD.bazel file next to the Cargo.toml file.
+                let crate_path = package.manifest_path().parent().ok_or_else(|| {
+                    anyhow::anyhow!("Should have at least a Cargo.toml component")
+                })?;
+                let build_path = crate_path.join("BUILD.bazel").into_std_path_buf();
+
+                // Write to a temp file that we'll swap into place.
+                let mut temp_file = tempfile::NamedTempFile::new().context("creating tempfile")?;
+                tracing::debug!(?temp_file, "Writing BUILD.bazel file");
+                temp_file
+                    .write_all(bazel_build_str.as_bytes())
+                    .context("writing temp file")?;
+                temp_file.flush().context("flushing temp file")?;
+
+                // Format the generated build file, if a formatter is provided.
+                if let Some(formatter_exec) = &formatter {
+                    let result = std::process::Command::new(formatter_exec)
+                        .args(["-type", "build"])
+                        .arg(temp_file.path())
+                        .output()
+                        .context("executing formatter")?;
+                    if !result.status.success() {
+                        let msg = String::from_utf8_lossy(&result.stderr[..]);
+                        anyhow::bail!("failed to format {build_path:?}, err: {msg}");
+                    }
+                } else {
+                    tracing::debug!(?crate_path, "skipping formatting");
+                }
+
+                let temp_file_hash = hash_file(temp_file.path()).context("hash temp file")?;
+                let existing_hash = hash_file(&build_path).context("hashing existing file")?;
+
+                // If the file didn't change then there's no reason to swap it in.
+                if temp_file_hash == existing_hash {
+                    tracing::debug!(?build_path, "didn't change, skipping");
+                    let _ = temp_file.close();
+                    Ok(None)
+                } else {
+                    Ok(Some((temp_file, build_path)))
+                }
+            });
+            handles.push(handle);
         }
 
-        let additive_content = crate_config.additive_content();
-
-        tracing::info!(path = ?package.manifest_path(), "generating");
-
-        let error_context = format!("generating {}", package.name());
-        let crate_context =
-            CrateContext::generate(&config, &crate_config, &package).context(error_context)?;
-
-        let build_script =
-            CargoBuildScript::generate(&config, &crate_context, &crate_config, &package)?;
-        let library =
-            RustLibrary::generate(&config, &package, &crate_config, build_script.as_ref())?;
-
-        let integration_tests: Vec<_> = package
-            .build_targets()
-            .filter(|target| matches!(target.id(), BuildTargetId::Test(_)))
-            .map(|target| RustTest::integration(&config, &package, &crate_config, &target))
-            .collect::<Result<_, _>>()?;
-
-        let binaries: Vec<_> = package
-            .build_targets()
-            .filter(|target| matches!(target.id(), BuildTargetId::Binary(_)))
-            .map(|target| RustBinary::generate(&config, &package, &crate_config, &target))
-            .collect::<Result<_, _>>()?;
-
-        #[allow(clippy::as_conversions)]
-        let targets: Vec<&dyn RustTarget> = [&library as &dyn RustTarget]
+        // Collect all of the results, bailing if any fail.
+        let results: Vec<_> = handles
             .into_iter()
-            .chain(build_script.iter().map(|x| x as &dyn RustTarget))
-            .chain(integration_tests.iter().map(|x| x as &dyn RustTarget))
-            .chain(binaries.iter().map(|x| x as &dyn RustTarget))
-            .chain(additive_content.as_ref().map(|x| x as &dyn RustTarget))
-            .collect();
+            .map(|handle| handle.join().expect("failed to join!"))
+            .collect::<Result<_, anyhow::Error>>()
+            .context("genrating a BUILD.bazel file")?;
 
-        let bazel_file = BazelBuildFile {
-            header: BazelHeader::generate(&targets[..]),
-            targets,
-        };
+        // If everything succeeded then swap all of our files into their final path.
+        for maybe_temp_file in results {
+            let Some((temp_file, dst_path)) = maybe_temp_file else {
+                continue;
+            };
+            temp_file.persist(dst_path).context("swapping in file")?;
+        }
 
-        // Useful when iterating.
-        // println!("{bazel_file}");
-
-        let crate_path = package
-            .manifest_path()
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("Should have at least a Cargo.toml component"))?;
-        let build_path = crate_path.join("BUILD.bazel");
-        tracing::debug!(?crate_path, "Writing BUILD.bazel file");
-
-        let mut build_file = std::fs::File::options()
-            .create(true)
-            .truncate(true)
-            .write(true)
-            .open(&build_path)?;
-
-        let contents = bazel_file.to_string();
-        build_file.write_all(contents.as_bytes())?;
-        build_file.flush()?;
-    }
+        Ok::<_, anyhow::Error>(())
+    })?;
 
     Ok(())
+}
+
+/// Given the [`PackageMetadata`] for a single crate, generates a `BUILD.bazel` file.
+fn generage_build_bazel<'a>(
+    config: &'a GlobalConfig,
+    package: &'a PackageMetadata<'a>,
+) -> Result<Option<BazelBuildFile>, anyhow::Error> {
+    let crate_config = CrateConfig::new(&package);
+    tracing::debug!(?crate_config, "found config");
+    if crate_config.skip_generating() {
+        tracing::info!(path = ?package.manifest_path(), "skipping, because crate config");
+        return Ok(None);
+    }
+
+    let additive_content = crate_config.additive_content();
+
+    tracing::info!(path = ?package.manifest_path(), "generating");
+
+    let error_context = format!("generating {}", package.name());
+    let crate_context =
+        CrateContext::generate(&config, &crate_config, &package).context(error_context)?;
+
+    let build_script =
+        CargoBuildScript::generate(&config, &crate_context, &crate_config, &package)?;
+    let library = RustLibrary::generate(&config, &package, &crate_config, build_script.as_ref())?;
+
+    let integration_tests: Vec<_> = package
+        .build_targets()
+        .filter(|target| matches!(target.id(), BuildTargetId::Test(_)))
+        .map(|target| RustTest::integration(&config, &package, &crate_config, &target))
+        .collect::<Result<_, _>>()?;
+
+    let binaries: Vec<_> = package
+        .build_targets()
+        .filter(|target| matches!(target.id(), BuildTargetId::Binary(_)))
+        .map(|target| RustBinary::generate(&config, &package, &crate_config, &target))
+        .collect::<Result<_, _>>()?;
+
+    #[allow(clippy::as_conversions)]
+    let targets: Vec<Box<dyn RustTarget>> = [Box::new(library) as Box<dyn RustTarget>]
+        .into_iter()
+        .chain(
+            build_script
+                .into_iter()
+                .map(|t| Box::new(t) as Box<dyn RustTarget>),
+        )
+        .chain(
+            integration_tests
+                .into_iter()
+                .map(|t| Box::new(t) as Box<dyn RustTarget>),
+        )
+        .chain(
+            binaries
+                .into_iter()
+                .map(|t| Box::new(t) as Box<dyn RustTarget>),
+        )
+        .chain(additive_content.map(|t| Box::new(t) as Box<dyn RustTarget>))
+        .collect();
+
+    Ok(Some(BazelBuildFile {
+        header: BazelHeader::generate(&targets[..]),
+        targets,
+    }))
+}
+
+/// Returns a [`blake3`] hash of a file, returning `None` if the specified `path` doesn't exist.
+fn hash_file(file: &Path) -> Result<Option<Vec<u8>>, anyhow::Error> {
+    if !file.exists() {
+        return Ok(None);
+    }
+
+    let file = std::fs::File::open(file).context("openning file")?;
+    let mut reader = std::io::BufReader::new(file);
+    let mut contents = Vec::new();
+    reader.read_to_end(&mut contents).context("reading file")?;
+
+    let mut file_hasher = Md5::new();
+    file_hasher.update(&contents[..]);
+    let file_hash = file_hasher.finalize();
+
+    Ok(Some(file_hash.to_vec()))
 }

--- a/misc/bazel/cargo-gazelle/src/config.rs
+++ b/misc/bazel/cargo-gazelle/src/config.rs
@@ -94,7 +94,7 @@ impl CrateConfig {
         self.skip_generating
     }
 
-    pub fn additive_content(&self) -> Option<AdditiveContent<'_>> {
+    pub fn additive_content(&self) -> Option<AdditiveContent> {
         self.additive_content
             .as_ref()
             .map(|s| AdditiveContent::new(s.as_str()))

--- a/misc/bazel/cargo-gazelle/src/header.rs
+++ b/misc/bazel/cargo-gazelle/src/header.rs
@@ -40,7 +40,7 @@ pub struct BazelHeader {
 }
 
 impl BazelHeader {
-    pub fn generate(targets: &[&dyn RustTarget]) -> Self {
+    pub fn generate(targets: &[Box<dyn RustTarget>]) -> Self {
         let x = targets
             .iter()
             .flat_map(|t| t.rules().into_iter())

--- a/misc/bazel/cargo-gazelle/src/lib.rs
+++ b/misc/bazel/cargo-gazelle/src/lib.rs
@@ -26,12 +26,12 @@ pub mod targets;
 ///
 /// This includes an auto-generated header, `load(...)` statements, and all
 /// Bazel targets.
-pub struct BazelBuildFile<'a> {
+pub struct BazelBuildFile {
     pub header: header::BazelHeader,
-    pub targets: Vec<&'a dyn RustTarget>,
+    pub targets: Vec<Box<dyn RustTarget>>,
 }
 
-impl<'a> fmt::Display for BazelBuildFile<'a> {
+impl fmt::Display for BazelBuildFile {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.header.format(f)?;
         for target in &self.targets {

--- a/misc/bazel/cargo-gazelle/src/targets.rs
+++ b/misc/bazel/cargo-gazelle/src/targets.rs
@@ -17,7 +17,6 @@ use guppy::graph::{
 use guppy::platform::EnabledTernary;
 use guppy::DependencyKind;
 
-use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Write};
 use std::str::FromStr;
@@ -941,22 +940,22 @@ impl ToBazelDefinition for CargoBuildScript {
 
 /// An opaque blob of text that we treat as a target.
 #[derive(Debug)]
-pub struct AdditiveContent<'a>(Cow<'a, str>);
+pub struct AdditiveContent(String);
 
-impl<'a> AdditiveContent<'a> {
-    pub fn new(s: &'a str) -> Self {
-        AdditiveContent(s.into())
+impl AdditiveContent {
+    pub fn new(s: &str) -> Self {
+        AdditiveContent(s.to_string())
     }
 }
 
-impl<'a> ToBazelDefinition for AdditiveContent<'a> {
+impl ToBazelDefinition for AdditiveContent {
     fn format(&self, writer: &mut dyn fmt::Write) -> Result<(), fmt::Error> {
         writeln!(writer, "{}", self.0)?;
         Ok(())
     }
 }
 
-impl<'a> RustTarget for AdditiveContent<'a> {
+impl RustTarget for AdditiveContent {
     fn rules(&self) -> Vec<Rule> {
         vec![]
     }

--- a/misc/python/materialize/cli/bazel.py
+++ b/misc/python/materialize/cli/bazel.py
@@ -47,6 +47,7 @@ def gen_cmd(args: list[str]):
     parser = argparse.ArgumentParser(
         prog="gen", description="Generate BUILD.bazel files."
     )
+    parser.add_argument("--check", action="store_true")
     parser.add_argument(
         "path",
         type=pathlib.Path,
@@ -60,7 +61,7 @@ def gen_cmd(args: list[str]):
     else:
         path = None
 
-    gen(path)
+    gen(path, gen_args.check)
 
 
 def fmt_cmd(args: list[str]):
@@ -84,7 +85,7 @@ def bazel_cmd(args: list[str]):
     subprocess.run(["bazel"] + args, check=True)
 
 
-def gen(path):
+def gen(path, check):
     """
     Generates BUILD.bazel files from Cargo.toml.
 
@@ -106,6 +107,10 @@ def gen(path):
         formatter_path = MZ_ROOT / paths[-1]
         formatter += ["--formatter", str(formatter_path)]
 
+    check_arg = []
+    if check:
+        check_arg += ["--check"]
+
     # TODO(parkmycar): Use Bazel to run this lint.
     cmd_args = [
         "cargo",
@@ -114,6 +119,7 @@ def gen(path):
         "--no-default-features",
         "--manifest-path=misc/bazel/cargo-gazelle/Cargo.toml",
         "--",
+        *check_arg,
         *formatter,
         f"{str(path)}",
     ]

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -159,7 +159,7 @@ bstr-6f8ce4dd05d13bba = { package = "bstr", version = "0.2.14" }
 bstr-dff4ba8e3ae991db = { package = "bstr", version = "1.10.0" }
 byteorder = { version = "1.5.0" }
 bytes = { version = "1.4.0", features = ["serde"] }
-cc = { version = "1.0.83", default-features = false, features = ["parallel"] }
+cc = { version = "1.1.28", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4.35", default-features = false, features = ["clock", "serde"] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
 console = { version = "0.15.5", default-features = false, features = ["ansi-parsing", "unicode-width"] }


### PR DESCRIPTION
This PR improves cargo-gazelle, the tool we use to generate `BUILD.bazel` files from `Cargo.toml`s, in a couple of ways:

1. It generates the `BUILD.bazel` files in a temporary directory and formats these temporary files instead of generating them in-place. Only if the formatted file has changed does it replace the existing one. This fixes a common issue folks have with `BUILD.bazel` files getting partially updated and/or artifacts getting left behind when linting is killed part way through.
2. Generates and formats `BUILD.bazel` files in parallel which leads to a decent speed up.
3. Adds a `--check` arg to `cargo-gazelle` that just reports what files would have changed.

### Motivation

* This PR fixes a recognized bug.
  A number of folks have run into the same issue with the existing `bin/bazel gen` command.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
