### PR TITLE
bazel: Small cleanup of protobuf-native `BUILD` file

### DIFF
--- a/misc/bazel/c_deps/rust-sys/BUILD.protobuf-native.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.protobuf-native.bazel
@@ -59,16 +59,6 @@ rust_cxx_bridge(
     ],
 )
 
-cc_library(
-    name = "io-include",
-    hdrs = ["src/io.h"],
-    include_prefix = "protobuf-native",
-    deps = [
-        ":internal-include",
-        "@protobuf//src/google/protobuf/compiler:importer",
-    ],
-)
-
 rust_cxx_bridge(
     name = "lib-bridge",
     src = "src/lib.rs",
@@ -77,13 +67,6 @@ rust_cxx_bridge(
         ":internal-include",
         ":lib-include",
     ],
-)
-
-cc_library(
-    name = "lib-include",
-    hdrs = ["src/lib.h"],
-    include_prefix = "protobuf-native",
-    deps = ["@protobuf//src/google/protobuf/compiler:code_generator"],
 )
 
 rust_cxx_bridge(


### PR DESCRIPTION
We have an additive `BUILD.bazel` file for protobuf-native that runs `cxx`. There were some extra unused targets there from previous iteration that are now unused.

### Motivation

Cleanup dead code

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
