### PR TITLE
Enforce non-zero group size hints

### DIFF
--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -1091,14 +1091,16 @@ impl<T> CollectionPlan for Plan<T> {
 
 /// Returns bucket sizes, descending, suitable for hierarchical decomposition of an operator, based
 /// on the expected number of rows that will have the same group key.
-fn bucketing_of_expected_group_size(expected_group_size: Option<u64>) -> Vec<u64> {
+fn bucketing_of_expected_group_size(expected_group_size: Option<NonZeroU64>) -> Vec<u64> {
     // NOTE(vmarcos): The fan-in of 16 defined below is used in the tuning advice built-in view
     // mz_introspection.mz_expected_group_size_advice.
     let mut buckets = vec![];
     let mut current = 16;
 
     // Plan for 4B records in the expected case if the user didn't specify a group size.
-    let limit = expected_group_size.unwrap_or(4_000_000_000);
+    let limit = expected_group_size
+        .map(NonZeroU64::get)
+        .unwrap_or(4_000_000_000);
 
     // Distribute buckets in powers of 16, so that we can strike a balance between how many inputs
     // each layer gets from the preceding layer, while also limiting the number of layers.

--- a/src/compute-types/src/plan/top_k.rs
+++ b/src/compute-types/src/plan/top_k.rs
@@ -17,6 +17,8 @@
 //! * A [MonotonicTopKPlan] maintains up to K rows per key and is suitable for monotonic inputs.
 //! * A [BasicTopKPlan] maintains up to K rows per key and can handle retractions.
 
+use std::num::NonZeroU64;
+
 use mz_expr::ColumnOrder;
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use proptest_derive::Arbitrary;
@@ -55,7 +57,7 @@ impl TopKPlan {
         limit: Option<mz_expr::MirScalarExpr>,
         arity: usize,
         monotonic: bool,
-        expected_group_size: Option<u64>,
+        expected_group_size: Option<NonZeroU64>,
     ) -> Self {
         // Capture whether the limit is a literal integer first.
         let limit_as_int64 = limit.as_ref().and_then(|l| l.as_literal_int64());

--- a/src/expr-parser/src/parser.rs
+++ b/src/expr-parser/src/parser.rs
@@ -69,6 +69,7 @@ pub fn try_parse_def(catalog: &TestCatalog, s: &str) -> Result<Def, String> {
 /// Support for parsing [mz_expr::MirRelationExpr].
 mod relation {
     use std::collections::BTreeMap;
+    use std::num::NonZeroU64;
 
     use mz_expr::{AccessStrategy, Id, JoinImplementation, LocalId, MirRelationExpr};
     use mz_repr::{Diff, RelationType, Row, ScalarType};
@@ -410,7 +411,7 @@ mod relation {
 
         let expected_group_size = if input.eat(kw::exp_group_size) {
             input.parse::<syn::Token![=]>()?;
-            Some(input.parse::<syn::LitInt>()?.base10_parse::<u64>()?)
+            NonZeroU64::new(input.parse::<syn::LitInt>()?.base10_parse::<u64>()?)
         } else {
             None
         };
@@ -451,7 +452,7 @@ mod relation {
 
         let expected_group_size = if input.eat(kw::exp_group_size) {
             input.parse::<syn::Token![=]>()?;
-            Some(input.parse::<syn::LitInt>()?.base10_parse::<u64>()?)
+            NonZeroU64::new(input.parse::<syn::LitInt>()?.base10_parse::<u64>()?)
         } else {
             None
         };
@@ -507,7 +508,7 @@ mod relation {
 
         let expected_group_size = if input.eat(kw::exp_group_size) {
             input.parse::<syn::Token![=]>()?;
-            Some(input.parse::<syn::LitInt>()?.base10_parse::<u64>()?)
+            NonZeroU64::new(input.parse::<syn::LitInt>()?.base10_parse::<u64>()?)
         } else {
             None
         };

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -251,7 +251,7 @@ pub enum MirRelationExpr {
         monotonic: bool,
         /// User hint: expected number of values per group key. Used to optimize physical rendering.
         #[serde(default)]
-        expected_group_size: Option<u64>,
+        expected_group_size: Option<NonZeroU64>,
     },
     /// Groups and orders within each group, limiting output.
     ///
@@ -274,7 +274,7 @@ pub enum MirRelationExpr {
         monotonic: bool,
         /// User-supplied hint: how many rows will have the same group key.
         #[serde(default)]
-        expected_group_size: Option<u64>,
+        expected_group_size: Option<NonZeroU64>,
     },
     /// Return a dataflow where the row counts are negated
     ///
@@ -1324,7 +1324,7 @@ impl MirRelationExpr {
         self,
         group_key: Vec<usize>,
         aggregates: Vec<AggregateExpr>,
-        expected_group_size: Option<u64>,
+        expected_group_size: Option<NonZeroU64>,
     ) -> Self {
         MirRelationExpr::Reduce {
             input: Box::new(self),
@@ -1347,7 +1347,7 @@ impl MirRelationExpr {
         order_key: Vec<ColumnOrder>,
         limit: Option<MirScalarExpr>,
         offset: usize,
-        expected_group_size: Option<u64>,
+        expected_group_size: Option<NonZeroU64>,
     ) -> Self {
         MirRelationExpr::TopK {
             input: Box::new(self),

--- a/src/lowertest-derive/src/lib.rs
+++ b/src/lowertest-derive/src/lib.rs
@@ -16,7 +16,14 @@ use quote::{quote, ToTokens};
 use syn::{parse, Data, DeriveInput, Fields};
 
 /// Types defined outside of Materialize used to build test objects.
-const EXTERNAL_TYPES: &[&str] = &["String", "FixedOffset", "Tz", "NaiveDateTime", "Regex"];
+const EXTERNAL_TYPES: &[&str] = &[
+    "String",
+    "FixedOffset",
+    "Tz",
+    "NaiveDateTime",
+    "Regex",
+    "NonZeroU64",
+];
 const SUPPORTED_ANGLE_TYPES: &[&str] = &["Vec", "Box", "Option"];
 
 /// Macro generating an implementation for the trait MzReflect

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Display, Formatter};
+use std::num::NonZeroU64;
 use std::{fmt, mem};
 
 use itertools::Itertools;
@@ -151,7 +152,7 @@ pub enum HirRelationExpr {
         input: Box<HirRelationExpr>,
         group_key: Vec<usize>,
         aggregates: Vec<AggregateExpr>,
-        expected_group_size: Option<u64>,
+        expected_group_size: Option<NonZeroU64>,
     },
     Distinct {
         input: Box<HirRelationExpr>,
@@ -169,7 +170,7 @@ pub enum HirRelationExpr {
         /// Number of records to skip
         offset: usize,
         /// User-supplied hint: how many rows will have the same group key.
-        expected_group_size: Option<u64>,
+        expected_group_size: Option<NonZeroU64>,
     },
     Negate {
         input: Box<HirRelationExpr>,
@@ -1589,7 +1590,7 @@ impl HirRelationExpr {
         self,
         group_key: Vec<usize>,
         aggregates: Vec<AggregateExpr>,
-        expected_group_size: Option<u64>,
+        expected_group_size: Option<NonZeroU64>,
     ) -> Self {
         HirRelationExpr::Reduce {
             input: Box::new(self),
@@ -1605,7 +1606,7 @@ impl HirRelationExpr {
         order_key: Vec<ColumnOrder>,
         limit: Option<HirScalarExpr>,
         offset: usize,
-        expected_group_size: Option<u64>,
+        expected_group_size: Option<NonZeroU64>,
     ) -> Self {
         HirRelationExpr::TopK {
             input: Box::new(self),

--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -49,6 +49,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::iter::FromIterator;
+use std::num::NonZeroU64;
 
 use mz_expr::visit::Visit;
 use mz_expr::{AggregateExpr, JoinInputMapper, MirRelationExpr, MirScalarExpr};
@@ -163,7 +164,7 @@ fn try_push_reduce_through_join(
     group_key: &Vec<MirScalarExpr>,
     aggregates: &Vec<AggregateExpr>,
     monotonic: bool,
-    expected_group_size: Option<u64>,
+    expected_group_size: Option<NonZeroU64>,
 ) -> Option<MirRelationExpr> {
     // Variable name details:
     // The goal is to turn `old` (`Reduce { Join { <inputs> }}`) into
@@ -400,7 +401,7 @@ struct ReduceBuilder {
 impl ReduceBuilder {
     fn new(
         mut component: Component,
-        inputs: &Vec<MirRelationExpr>,
+        inputs: &[MirRelationExpr],
         old_join_mapper: &JoinInputMapper,
     ) -> Self {
         let localize_map = component
@@ -467,7 +468,7 @@ impl ReduceBuilder {
     fn construct_reduce(
         self,
         monotonic: bool,
-        expected_group_size: Option<u64>,
+        expected_group_size: Option<NonZeroU64>,
     ) -> MirRelationExpr {
         MirRelationExpr::Reduce {
             input: Box::new(self.input),


### PR DESCRIPTION
A group size hint of 0 isn't well-defined, so make it equivalent to disabling the hint. This is arguably an opinionated decision, but here it serves a single purpose: Make MirRelationExpr eight bytes smaller.

Before:

```
print-type-size type: `relation::MirRelationExpr`: 184 bytes, alignment: 8 bytes
print-type-size     variant `TopK`: 177 bytes
print-type-size         field `.expected_group_size`: 16 bytes
print-type-size         field `.limit`: 96 bytes
print-type-size         field `.group_key`: 24 bytes
print-type-size         field `.order_key`: 24 bytes
print-type-size         field `.input`: 8 bytes
print-type-size         field `.offset`: 8 bytes
print-type-size         field `.monotonic`: 1 bytes
print-type-size     variant `Join`: 176 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.implementation`: 120 bytes, alignment: 8 bytes
print-type-size         field `.inputs`: 24 bytes
print-type-size         field `.equivalences`: 24 bytes
print-type-size     variant `Constant`: 112 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.typ`: 48 bytes, alignment: 8 bytes
print-type-size         field `.rows`: 56 bytes
print-type-size     variant `FlatMap`: 112 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.exprs`: 24 bytes, alignment: 8 bytes
print-type-size         field `.func`: 72 bytes
print-type-size         field `.input`: 8 bytes
print-type-size     variant `Get`: 96 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.id`: 16 bytes, alignment: 8 bytes
print-type-size         field `.typ`: 48 bytes
print-type-size         field `.access_strategy`: 24 bytes
print-type-size     variant `LetRec`: 88 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.ids`: 24 bytes, alignment: 8 bytes
print-type-size         field `.values`: 24 bytes
print-type-size         field `.limits`: 24 bytes
print-type-size         field `.body`: 8 bytes
print-type-size     variant `Reduce`: 81 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.expected_group_size`: 16 bytes, alignment: 8 bytes
print-type-size         field `.group_key`: 24 bytes
print-type-size         field `.aggregates`: 24 bytes
print-type-size         field `.input`: 8 bytes
print-type-size         field `.monotonic`: 1 bytes
print-type-size     variant `Project`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.outputs`: 24 bytes, alignment: 8 bytes
print-type-size         field `.input`: 8 bytes
print-type-size     variant `Map`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.scalars`: 24 bytes, alignment: 8 bytes
print-type-size         field `.input`: 8 bytes
print-type-size     variant `Filter`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.predicates`: 24 bytes, alignment: 8 bytes
print-type-size         field `.input`: 8 bytes
print-type-size     variant `Union`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.inputs`: 24 bytes, alignment: 8 bytes
print-type-size         field `.base`: 8 bytes
print-type-size     variant `ArrangeBy`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.keys`: 24 bytes, alignment: 8 bytes
print-type-size         field `.input`: 8 bytes
print-type-size     variant `Let`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.value`: 8 bytes, alignment: 8 bytes
print-type-size         field `.body`: 8 bytes
print-type-size         field `.id`: 8 bytes
print-type-size     variant `Negate`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.input`: 8 bytes, alignment: 8 bytes
print-type-size     variant `Threshold`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.input`: 8 bytes, alignment: 8 bytes
print-type-size     end padding: 7 bytes
```

After:

```
print-type-size type: `relation::MirRelationExpr`: 176 bytes, alignment: 8 bytes
print-type-size     variant `Join`: 176 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.implementation`: 120 bytes, alignment: 8 bytes
print-type-size         field `.inputs`: 24 bytes
print-type-size         field `.equivalences`: 24 bytes
print-type-size     variant `TopK`: 169 bytes
print-type-size         field `.limit`: 96 bytes
print-type-size         field `.group_key`: 24 bytes
print-type-size         field `.order_key`: 24 bytes
print-type-size         field `.input`: 8 bytes
print-type-size         field `.offset`: 8 bytes
print-type-size         field `.expected_group_size`: 8 bytes
print-type-size         field `.monotonic`: 1 bytes
print-type-size     variant `Constant`: 112 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.typ`: 48 bytes, alignment: 8 bytes
print-type-size         field `.rows`: 56 bytes
print-type-size     variant `FlatMap`: 112 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.exprs`: 24 bytes, alignment: 8 bytes
print-type-size         field `.func`: 72 bytes
print-type-size         field `.input`: 8 bytes
print-type-size     variant `Get`: 96 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.id`: 16 bytes, alignment: 8 bytes
print-type-size         field `.typ`: 48 bytes
print-type-size         field `.access_strategy`: 24 bytes
print-type-size     variant `LetRec`: 88 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.ids`: 24 bytes, alignment: 8 bytes
print-type-size         field `.values`: 24 bytes
print-type-size         field `.limits`: 24 bytes
print-type-size         field `.body`: 8 bytes
print-type-size     variant `Reduce`: 73 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.group_key`: 24 bytes, alignment: 8 bytes
print-type-size         field `.aggregates`: 24 bytes
print-type-size         field `.input`: 8 bytes
print-type-size         field `.expected_group_size`: 8 bytes
print-type-size         field `.monotonic`: 1 bytes
print-type-size     variant `Project`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.outputs`: 24 bytes, alignment: 8 bytes
print-type-size         field `.input`: 8 bytes
print-type-size     variant `Map`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.scalars`: 24 bytes, alignment: 8 bytes
print-type-size         field `.input`: 8 bytes
print-type-size     variant `Filter`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.predicates`: 24 bytes, alignment: 8 bytes
print-type-size         field `.input`: 8 bytes
print-type-size     variant `Union`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.inputs`: 24 bytes, alignment: 8 bytes
print-type-size         field `.base`: 8 bytes
print-type-size     variant `ArrangeBy`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.keys`: 24 bytes, alignment: 8 bytes
print-type-size         field `.input`: 8 bytes
print-type-size     variant `Let`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.value`: 8 bytes, alignment: 8 bytes
print-type-size         field `.body`: 8 bytes
print-type-size         field `.id`: 8 bytes
print-type-size     variant `Negate`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.input`: 8 bytes, alignment: 8 bytes
print-type-size     variant `Threshold`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.input`: 8 bytes, alignment: 8 bytes
```


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
