### PR TITLE
[persist] Drop unnecessary null buffers while reallocating

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -1303,6 +1303,11 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
         batch_metrics.seconds.inc_by(start.elapsed().as_secs_f64());
         batch_metrics.bytes.inc_by(u64::cast_from(payload_len));
         batch_metrics.goodbytes.inc_by(u64::cast_from(goodbytes));
+        match cfg.expected_order {
+            RunOrder::Unordered => batch_metrics.unordered.inc(),
+            RunOrder::Codec => batch_metrics.codec_order.inc(),
+            RunOrder::Structured => batch_metrics.structured_order.inc(),
+        }
         let stats = stats.map(|(stats, stats_step_timing, trimmed_bytes)| {
             batch_metrics
                 .step_stats

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -316,6 +316,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::batch::ENCODING_COMPRESSION_FORMAT)
         .add(&crate::batch::RECORD_RUN_META)
         .add(&crate::batch::STRUCTURED_ORDER)
+        .add(&crate::batch::STRUCTURED_ORDER_UNTIL_SHARD)
         .add(&crate::batch::STRUCTURED_KEY_LOWER_LEN)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL_STAGGER)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL)

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -487,7 +487,7 @@ where
             };
 
             let res = Compactor::<K, V, T, D>::compact(
-                CompactConfig::new(&cfg, &writer_id),
+                CompactConfig::new(&cfg, shard_id),
                 Arc::clone(&blob),
                 Arc::clone(&metrics),
                 Arc::clone(&machine.applier.shard_metrics),
@@ -735,7 +735,6 @@ pub async fn dangerous_force_compaction_and_break_pushdown<K, V, T, D>(
             let res = Compactor::<K, V, T, D>::compact_and_apply(
                 &mut machine,
                 req,
-                write.writer_id.clone(),
                 write.write_schemas.clone(),
             )
             .await;

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -1284,8 +1284,8 @@ where
                 let diffs = realloc_array(do_filter(records.diffs()).as_primitive(), metrics);
                 let records = ColumnarRecords::new(keys, values, timestamps, diffs);
                 let ext = ext.map(|ext| ColumnarRecordsStructuredExt {
-                    key: realloc_any(&do_filter(&ext.key), metrics),
-                    val: realloc_any(&do_filter(&ext.val), metrics),
+                    key: realloc_any(do_filter(&ext.key), metrics),
+                    val: realloc_any(do_filter(&ext.val), metrics),
                 });
                 (records, ext)
             }

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -952,7 +952,7 @@ mod tests {
         let mut b1 = write.expect_batch(&data[..2], 0, 3).await;
         let mut b2 = write.expect_batch(&data[2..], 2, 5).await;
         if backpressure_would_flush {
-            let cfg = BatchBuilderConfig::new(&client.cfg, &write.writer_id, false);
+            let cfg = BatchBuilderConfig::new(&client.cfg, shard_id, false);
             b1.flush_to_blob(
                 &cfg,
                 &client.metrics.user,

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -145,7 +145,6 @@ where
             Compactor::new(
                 cfg.clone(),
                 Arc::clone(&metrics),
-                writer_id.clone(),
                 write_schemas.clone(),
                 gc.clone(),
             )
@@ -538,7 +537,7 @@ where
                     assert_eq!(received_inline_backpressure, false);
                     received_inline_backpressure = true;
 
-                    let cfg = BatchBuilderConfig::new(&self.cfg, &self.writer_id, false);
+                    let cfg = BatchBuilderConfig::new(&self.cfg, self.shard_id(), false);
                     // We could have a large number of inline parts (imagine the
                     // sharded persist_sink), do this flushing concurrently.
                     let flush_batches = batches
@@ -609,7 +608,7 @@ where
     /// O(MB) come talk to us.
     pub fn builder(&mut self, lower: Antichain<T>) -> BatchBuilder<K, V, T, D> {
         let builder = BatchBuilderInternal::new(
-            BatchBuilderConfig::new(&self.cfg, &self.writer_id, false),
+            BatchBuilderConfig::new(&self.cfg, self.shard_id(), false),
             Arc::clone(&self.metrics),
             self.write_schemas.clone(),
             Arc::clone(&self.machine.applier.shard_metrics),

--- a/src/persist-types/src/arrow.rs
+++ b/src/persist-types/src/arrow.rs
@@ -42,7 +42,7 @@ use crate::arrow::proto::data_type;
 pub use proto::ProtoArrayData;
 
 /// Extract the list of fields for our recursive datatypes.
-fn fields_for_type(data_type: &DataType) -> &[FieldRef] {
+pub fn fields_for_type(data_type: &DataType) -> &[FieldRef] {
     match data_type {
         DataType::Struct(fields) => fields,
         DataType::List(field) => std::slice::from_ref(field),

--- a/src/persist/src/indexed/columnar/parquet.rs
+++ b/src/persist/src/indexed/columnar/parquet.rs
@@ -32,7 +32,7 @@ use crate::gen::persist::proto_batch_part_inline::FormatMetadata as ProtoFormatM
 use crate::gen::persist::ProtoBatchFormat;
 use crate::indexed::columnar::arrow::{
     decode_arrow_batch_kvtd, decode_arrow_batch_kvtd_ks_vs, encode_arrow_batch_kvtd,
-    encode_arrow_batch_kvtd_ks_vs, SCHEMA_ARROW_RS_KVTD,
+    encode_arrow_batch_kvtd_ks_vs, realloc_any, SCHEMA_ARROW_RS_KVTD,
 };
 use crate::indexed::columnar::ColumnarRecords;
 use crate::indexed::encoding::{
@@ -224,12 +224,12 @@ pub fn decode_parquet_file_kvtd(
                 .fields()
                 .iter()
                 .position(|field| field.name() == "k_s")
-                .map(|idx| Arc::clone(&columns[idx]));
+                .map(|idx| realloc_any(Arc::clone(&columns[idx]), metrics));
             let v_s_column = schema
                 .fields()
                 .iter()
                 .position(|field| field.name() == "v_s")
-                .map(|idx| Arc::clone(&columns[idx]));
+                .map(|idx| realloc_any(Arc::clone(&columns[idx]), metrics));
 
             match (k_s_column, v_s_column) {
                 (Some(ks), Some(vs)) => {

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -203,6 +203,7 @@ pub struct ParquetMetrics {
     pub(crate) d_metrics: ParquetColumnMetrics,
     pub(crate) k_s_metrics: ParquetColumnMetrics,
     pub(crate) v_s_metrics: ParquetColumnMetrics,
+    pub(crate) elided_null_buffers: IntCounter,
 }
 
 impl ParquetMetrics {
@@ -233,6 +234,10 @@ impl ParquetMetrics {
             d_metrics: ParquetColumnMetrics::new("d", &column_size),
             k_s_metrics: ParquetColumnMetrics::new("k_s", &column_size),
             v_s_metrics: ParquetColumnMetrics::new("v_s", &column_size),
+            elided_null_buffers: registry.register(metric!(
+                name: "mz_persist_parquet_elided_null_buffer_count",
+                help: "times we dropped an unnecessary null buffer returned by parquet decoding",
+            )),
         }
     }
 }


### PR DESCRIPTION
### Motivation

Workaround for https://github.com/MaterializeInc/database-issues/issues/8615 - see that issue for more details on the upstream bug.

### Tips for reviewer

I've rolled this into `realloc`, since that is already doing a deep traversal / replacement of the incoming data. If we're uncomfortable with that I could do something more targeted. (eg. a separate method that we only called on parquet reads and only touched the null buffer.)

As part of investigating this issue I noticed that we weren't reallocating our structured data in all cases. (As part of reallocation, we run validations that would have caught this bug much earlier!) I've added a second commit that performs the reallocation up front.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
