### PR TITLE
ci: Try cloudtest on hetzner again

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -311,9 +311,7 @@ steps:
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
-          # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
-          queue: linux-aarch64-medium
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/cloudtest:
               # Uses .td-file based parallelism instead
@@ -840,9 +838,7 @@ steps:
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
-          # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
-          queue: linux-aarch64-medium
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/cloudtest:
               args: [-m=long, test/cloudtest/test_upgrade.py]
@@ -863,9 +859,7 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
-          queue: linux-aarch64
+          queue: hetzner-aarch64-8cpu-16gb
         inputs:
           - test/cloudtest
           - misc/python/materialize/cloudtest
@@ -889,9 +883,7 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
-          queue: linux-aarch64
+          queue: hetzner-aarch64-8cpu-16gb
         inputs:
           - test/cloudtest
           - misc/python/materialize/cloudtest
@@ -915,9 +907,7 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
-          queue: linux-aarch64
+          queue: hetzner-aarch64-8cpu-16gb
         inputs:
           - test/cloudtest
           - misc/python/materialize/cloudtest
@@ -941,9 +931,7 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
-          queue: linux-aarch64
+          queue: hetzner-aarch64-8cpu-16gb
         inputs:
           - test/cloudtest
           - misc/python/materialize/cloudtest
@@ -1525,9 +1513,7 @@ steps:
                   test/cloudtest/,
                 ]
         agents:
-          # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
-          queue: linux-aarch64
+          queue: hetzner-aarch64-8cpu-16gb
         sanitizer: skip
 
 
@@ -1538,9 +1524,7 @@ steps:
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
-          # TODO: Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
-          queue: linux-aarch64-medium
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/cloudtest:
               args: [-m=long, test/cloudtest/test_storage_shared_fate.py]

--- a/misc/kind/configmaps/coredns.yaml
+++ b/misc/kind/configmaps/coredns.yaml
@@ -14,22 +14,26 @@ metadata:
     namespace: kube-system
 data:
     Corefile: |
-        # This is the stock EKS configuration for CoreDNS, with modifications
-        # noted inline.
         .:53 {
             errors
-            health
+            health {
+              lameduck 5s
+            }
             ready
             kubernetes cluster.local in-addr.arpa ip6.arpa {
                 pods insecure
                 fallthrough in-addr.arpa ip6.arpa
-                # Set the TTL to 1
-                ttl 1
             }
             prometheus :9153
-            forward . /etc/resolv.conf
+            forward . /etc/resolv.conf {
+              max_concurrent 1000
+            }
             # Set the TTL to 1 in general
-            cache 1
+            cache {
+              success 0
+              denial 0
+            }
             loop
             reload
+            loadbalance
         }


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
