### PR TITLE
parallel-benchmark: Allow running against Postgres

### DIFF
--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -325,7 +325,11 @@ def run_once(
                 conn_infos = {"materialized": target}
                 conn = target.connect()
                 with conn.cursor() as cur:
-                    cur.execute("SELECT mz_version()")
+                    cur.execute(
+                        "SELECT version()"
+                        if args.pure_postgres
+                        else "SELECT mz_version()"
+                    )
                     mz_version = cur.fetchall()[0][0]
                 conn.close()
                 mz_string = f"{mz_version} ({target.host})"
@@ -613,6 +617,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
 
     parser.add_argument("--mz-url", type=str, help="Remote Mz instance to run against")
+
+    parser.add_argument(
+        "--pure-postgres",
+        action="store_true",
+        help="Don't run any Materialize-specific preparation commands",
+    )
 
     parser.add_argument(
         "--canary-env",


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
