### PR TITLE
storage/sources: Fix source rendering persist source id argument bug

### DIFF
--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -301,7 +301,6 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                 GenericSourceConnection::Kafka(c) => crate::render::sources::render_source(
                     mz_scope,
                     &debug_name,
-                    primary_source_id,
                     c,
                     description.clone(),
                     &feedback,
@@ -311,7 +310,6 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                 GenericSourceConnection::Postgres(c) => crate::render::sources::render_source(
                     mz_scope,
                     &debug_name,
-                    primary_source_id,
                     c,
                     description.clone(),
                     &feedback,
@@ -321,7 +319,6 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                 GenericSourceConnection::MySql(c) => crate::render::sources::render_source(
                     mz_scope,
                     &debug_name,
-                    primary_source_id,
                     c,
                     description.clone(),
                     &feedback,
@@ -331,7 +328,6 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                 GenericSourceConnection::LoadGenerator(c) => crate::render::sources::render_source(
                     mz_scope,
                     &debug_name,
-                    primary_source_id,
                     c,
                     description.clone(),
                     &feedback,

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -61,7 +61,6 @@ pub(crate) type OutputIndex = usize;
 pub fn render_source<'g, G, C>(
     scope: &mut Child<'g, G, mz_repr::Timestamp>,
     dataflow_debug_name: &String,
-    id: GlobalId,
     connection: C,
     description: IngestionDescription<CollectionMetadata>,
     resume_stream: &Stream<Child<'g, G, mz_repr::Timestamp>, ()>,
@@ -112,7 +111,7 @@ where
     needed_tokens.extend(source_tokens);
 
     let mut outputs = vec![];
-    for (ok_source, err_source, data_config) in streams {
+    for (export_id, ok_source, err_source, data_config) in streams {
         // All sources should push their various error streams into this vector,
         // whose contents will be concatenated and inserted along the collection.
         // All subsources include the non-definite errors of the ingestion
@@ -121,7 +120,7 @@ where
         let (ok, err, extra_tokens, health_stream) = render_source_stream(
             scope,
             dataflow_debug_name,
-            id,
+            export_id,
             ok_source,
             data_config,
             description.clone(),
@@ -143,7 +142,7 @@ where
 fn render_source_stream<G, FromTime>(
     scope: &mut G,
     dataflow_debug_name: &String,
-    id: GlobalId,
+    export_id: GlobalId,
     ok_source: Collection<G, SourceOutput<FromTime>, Diff>,
     data_config: SourceExportDataConfig,
     description: IngestionDescription<CollectionMetadata>,
@@ -206,14 +205,14 @@ where
 
             let persist_clients = Arc::clone(&storage_state.persist_clients);
             // TODO: Get this to work with the as_of.
-            let resume_upper = base_source_config.resume_uppers[&id].clone();
+            let resume_upper = base_source_config.resume_uppers[&export_id].clone();
 
             let upper_ts = resume_upper
                 .as_option()
                 .expect("resuming an already finished ingestion")
                 .clone();
             let (upsert, health_update) = scope.scoped(
-                &format!("upsert_rehydration_backpressure({})", id),
+                &format!("upsert_rehydration_backpressure({})", export_id),
                 |scope| {
                     let (previous, previous_token, feedback_handle, backpressure_metrics) =
                         if mz_repr::Timestamp::minimum() < upper_ts {
@@ -236,7 +235,7 @@ where
                                         ?backpressure_max_inflight_bytes,
                                         "timely-{} using backpressure in upsert for source {}",
                                         base_source_config.worker_id,
-                                        id
+                                        export_id
                                     );
                                     if !storage_state
                                         .storage_configuration
@@ -255,7 +254,7 @@ where
                                         let backpressure_metrics = Some(
                                             base_source_config
                                                 .metrics
-                                                .get_backpressure_metrics(id, scope.index()),
+                                                .get_backpressure_metrics(export_id, scope.index()),
                                         );
 
                                         (
@@ -283,7 +282,7 @@ where
                                 .get(storage_state.storage_configuration.config_set());
                             let (stream, tok) = persist_source::persist_source_core(
                                 scope,
-                                id,
+                                export_id,
                                 persist_clients,
                                 description.ingestion_metadata,
                                 Some(as_of),
@@ -333,7 +332,7 @@ where
                     let upsert = upsert.inner.probe_notify_with(vec![handle.clone()]);
                     let probe = mz_timely_util::probe::source(
                         scope.clone(),
-                        format!("upsert_probe({id})"),
+                        format!("upsert_probe({export_id})"),
                         handle,
                     );
 

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -167,6 +167,7 @@ pub fn create_raw_source<'g, G: Scope<Timestamp = ()>, C>(
     start_signal: impl std::future::Future<Output = ()> + 'static,
 ) -> (
     Vec<(
+        GlobalId,
         Collection<Child<'g, G, mz_repr::Timestamp>, SourceOutput<C::Time>, Diff>,
         Collection<Child<'g, G, mz_repr::Timestamp>, DataflowError, Diff>,
         SourceExportDataConfig,
@@ -619,6 +620,7 @@ fn reclock_operator<G, FromTime, M>(
     remap_trace_updates: Collection<G, FromTime, Diff>,
     source_metrics: Arc<SourceMetrics>,
 ) -> Vec<(
+    GlobalId,
     Collection<G, SourceOutput<FromTime>, Diff>,
     Collection<G, DataflowError, Diff>,
     SourceExportDataConfig,
@@ -866,9 +868,9 @@ where
             },
         );
 
-    let data_config_per_index = source_exports
-        .values()
-        .map(|export| (export.ingestion_output, &export.export.data_config))
+    let exports_by_index = source_exports
+        .iter()
+        .map(|(id, export)| (export.ingestion_output, (*id, &export.export.data_config)))
         .collect::<BTreeMap<_, _>>();
 
     // We use the output index from the source export to route values to its ok
@@ -876,7 +878,7 @@ where
     // source export indices can be non-contiguous, so we need to ensure we have
     // at least as many partitions as we reference.
     let partition_count = u64::cast_from(
-        data_config_per_index
+        exports_by_index
             .keys()
             .max()
             .expect("source exports must have elements")
@@ -907,9 +909,9 @@ where
             // We only want to return streams for partitions with a data config, which
             // indicates that they actually have data. The filtered streams were just
             // empty partitions for any non-continuous values in the output indexes.
-            data_config_per_index
+            exports_by_index
                 .get(&idx)
-                .map(|data_config| (ok_stream, err_stream, (*data_config).clone()))
+                .map(|export| (export.0, ok_stream, err_stream, (*export.1).clone()))
         })
         .collect()
 }
@@ -919,6 +921,7 @@ fn demux_source_exports<G, FromTime>(
     config: RawSourceCreationConfig,
     input: Collection<G, (usize, Result<SourceOutput<FromTime>, DataflowError>), Diff>,
 ) -> Vec<(
+    GlobalId,
     Collection<G, SourceOutput<FromTime>, Diff>,
     Collection<G, DataflowError, Diff>,
     SourceExportDataConfig,
@@ -987,9 +990,9 @@ where
         },
     );
 
-    let data_config_per_index = source_exports
-        .values()
-        .map(|export| (export.ingestion_output, &export.export.data_config))
+    let exports_by_index = source_exports
+        .iter()
+        .map(|(id, export)| (export.ingestion_output, (*id, &export.export.data_config)))
         .collect::<BTreeMap<_, _>>();
 
     // We use the output index from the source export to route values to its ok
@@ -997,7 +1000,7 @@ where
     // source export indices can be non-contiguous, so we need to ensure we have
     // at least as many partitions as we reference.
     let partition_count = u64::cast_from(
-        data_config_per_index
+        exports_by_index
             .keys()
             .max()
             .expect("source exports must have elements")
@@ -1028,9 +1031,9 @@ where
             // We only want to return streams for partitions with a data config, which
             // indicates that they actually have data. The filtered streams were just
             // empty partitions for any non-continuous values in the output indexes.
-            data_config_per_index
+            exports_by_index
                 .get(&idx)
-                .map(|data_config| (ok_stream, err_stream, (*data_config).clone()))
+                .map(|export| (export.0, ok_stream, err_stream, (*export.1).clone()))
         })
         .collect()
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

Fixes a bug we discovered when working on https://github.com/MaterializeInc/materialize/pull/29600 but since that PR was reverted today for CI flakiness, this PR just re-introduces the fix for the bug.

The issue was that we always provided primary shard id to the persist source for every export of a source, which works when there is only ever one upsert source-export for a source but breaks as soon as more than one export is possible. The fix is to correctly provide the specific export's id to the persist source for each export dataflow.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]


    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
