### PR TITLE
adapter: Add scratch directory argument

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -463,6 +463,9 @@ pub struct Args {
         parse(try_from_str = humantime::parse_duration),
     )]
     config_sync_loop_interval: Option<Duration>,
+    /// A scratch directory that can be used for ephemeral storage.
+    #[clap(long, env = "SCRATCH_DIRECTORY", value_name = "PATH")]
+    scratch_directory: Option<PathBuf>,
 
     // === Bootstrap options. ===
     #[clap(

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -464,6 +464,10 @@ pub struct Args {
     )]
     config_sync_loop_interval: Option<Duration>,
     /// A scratch directory that can be used for ephemeral storage.
+    //
+    // NOTE(jkosh44): this argument is intentionally unused at present. It is
+    // future proofing for a world where `environmentd` needs to spill
+    // ephemeral state to disk.
     #[clap(long, env = "SCRATCH_DIRECTORY", value_name = "PATH")]
     scratch_directory: Option<PathBuf>,
 


### PR DESCRIPTION
This commit adds a `--scratch-directory` argument to environmentd. This argument is currently unused but will eventually be used in the adapter for ephemeral storage. We're adding the unused argument to unblock cloud from wiring up storage on their side.

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
