### PR TITLE
postgres consistency: add ignore for IS NULL on record with NULL value

### DIFF
--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -483,6 +483,19 @@ class PgPreExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("database-issues#8068: casting bpchar or char")
 
+        if (
+            db_operation.pattern == "$ IS NULL"
+            and ExpressionCharacteristics.NULL in all_involved_characteristics
+            and expression.matches(
+                partial(
+                    involves_data_type_category,
+                    data_type_category=DataTypeCategory.RECORD,
+                ),
+                True,
+            )
+        ):
+            return YesIgnore("database-issues#8632: IS NULL on record with NULL value")
+
         return NoIgnore()
 
 


### PR DESCRIPTION
This addresses https://buildkite.com/materialize/nightly/builds/9849#0192680a-0d37-4eea-8052-fa195d413a58.

```
CONTENT_MISMATCH: Value differs at row index 0, column index 2.
Expression: (row(bpchar_8_null) IS NULL)
  Value 1 (Materialize evaluation): 'False' (type: <class 'bool'>)
  Value 2 (Postgres evaluation): 'True' (type: <class 'bool'>)
  Query 1: SELECT (bpchar_8_null IS NULL), mod(decimal_39_0_tiny, decimal_39_8_null), (row(bpchar_8_null) IS NULL), (uuid_val_3 <> uuid_val_3) FROM t_dfr_horiz;
  Query 2: SELECT (bpchar_8_null IS NULL), mod(decimal_39_0_tiny, decimal_39_8_null), (row(bpchar_8_null) IS NULL), (uuid_val_3 <> uuid_val_3) FROM t_pg_horiz;
  Expression hash: 14805525798944107227
```

Filed issues
* https://github.com/MaterializeInc/database-issues/issues/8632