### PR TITLE
output consistency: add ignore regarding evaluation order

### DIFF
--- a/misc/python/materialize/output_consistency/ignore_filter/internal_output_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/internal_output_inconsistency_ignore_filter.py
@@ -52,6 +52,7 @@ from materialize.output_consistency.validation.validation_message import (
 )
 
 AGGREGATION_SHORTCUT_FUNCTION_NAMES = {"count", "string_agg"}
+DIFFERENT_EVALUATION_ORDER_FUNCTION_NAMES = {"map_agg"}
 
 
 class InternalOutputInconsistencyIgnoreFilter(GenericInconsistencyIgnoreFilter):
@@ -239,6 +240,15 @@ class PostExecutionInternalOutputInconsistencyIgnoreFilter(
             return YesIgnore(
                 "Table function rows executed in different order, resulting in different error messages"
             )
+
+        if query_template.matches_any_expression(
+            partial(
+                matches_fun_by_any_name,
+                function_names_in_lower_case=DIFFERENT_EVALUATION_ORDER_FUNCTION_NAMES,
+            ),
+            True,
+        ):
+            return YesIgnore("database-issues#4972: evaluation order")
 
         return NoIgnore()
 


### PR DESCRIPTION
This addresses https://buildkite.com/materialize/nightly/builds/9850#0192685c-ce86-4c08-a4a0-4917cf830ac7.

```
ERROR_MISMATCH: Error message differs.
Expression: map_agg(chr(uint2_zero), justify_days(interval_min_val) ORDER BY row_index, justify_days(interval_min_val))
  Value 1 (Dataflow rendering): '"-178956970 years -8 months -2147483648 days -2562047788:00:54.775808" interval out of range' (type: <class 'str'>)
  Value 2 (Constant folding): 'null character not permitted' (type: <class 'str'>)
  Query 1: SELECT map_agg(chr(uint2_zero), justify_days(interval_min_val) ORDER BY row_index, justify_days(interval_min_val)) FROM t_dfr_horiz;
  Query 2: SELECT map_agg(chr(uint2_zero), justify_days(interval_min_val) ORDER BY row_index, justify_days(interval_min_val)) FROM v_ctf_horiz;
  Expression hash: 9706815160047513486
```