### PR TITLE
Compute controller: avoid ready/process pattern

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -63,7 +63,6 @@ use mz_storage_client::controller::StorageController;
 use timely::Container;
 use tracing::{error, info, warn, Instrument};
 use uuid::Uuid;
-
 // DO NOT add any more imports from `crate` outside of `crate::catalog`.
 use crate::catalog::open::builtin_item_migration::{
     migrate_builtin_items, BuiltinItemMigrationResult,
@@ -558,12 +557,17 @@ impl Catalog {
         envd_epoch: core::num::NonZeroI64,
         read_only: bool,
         storage_collections_to_drop: BTreeSet<GlobalId>,
-    ) -> Result<mz_controller::Controller<mz_repr::Timestamp>, mz_catalog::durable::CatalogError>
-    {
+    ) -> Result<
+        (
+            mz_controller::Controller<mz_repr::Timestamp>,
+            mz_controller::ControllerReceivers<mz_repr::Timestamp>,
+        ),
+        mz_catalog::durable::CatalogError,
+    > {
         let controller_start = Instant::now();
         info!("startup: controller init: beginning");
 
-        let mut controller = {
+        let (mut controller, rxs) = {
             let mut storage = self.storage().await;
             let mut tx = storage.transaction().await?;
             mz_controller::prepare_initialization(&mut tx)
@@ -591,7 +595,7 @@ impl Catalog {
             controller_start.elapsed()
         );
 
-        Ok(controller)
+        Ok((controller, rxs))
     }
 
     /// The objects in the catalog form one or more DAGs (directed acyclic graph) via object

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -76,8 +76,20 @@ impl Coordinator {
                     .process(storage_metadata)
                     .expect("`process` never returns an error")
                 {
-                    self.message_controller(m).boxed_local().await
+                    self.message_controller(m).boxed_local().await;
                 }
+            }
+            Message::Controller(response) => {
+                self.message_controller(response).boxed_local().await;
+            }
+            Message::Compute(response) => {
+                if let Some(m) = self.controller.process_compute_response(response) {
+                    self.message_controller(m).boxed_local().await;
+                }
+            }
+            Message::Maintenance => {
+                // Periodic maintenance tasks.
+                self.controller.maintenance();
             }
             Message::PurifiedStatementReady(ready) => {
                 self.message_purified_statement_ready(ready)
@@ -468,27 +480,25 @@ impl Coordinator {
                     self.builtin_table_update().background(updates);
                 }
             }
-            ControllerResponse::WatchSetFinished(ws_ids) => {
+            ControllerResponse::WatchSetFinished(ws_id) => {
                 let now = self.now();
-                for ws_id in ws_ids {
-                    let Some((conn_id, rsp)) = self.installed_watch_sets.remove(&ws_id) else {
-                        continue;
-                    };
-                    self.connection_watch_sets
-                        .get_mut(&conn_id)
-                        .expect("corrupted coordinator state: unknown connection id")
-                        .remove(&ws_id);
-                    if self.connection_watch_sets[&conn_id].is_empty() {
-                        self.connection_watch_sets.remove(&conn_id);
-                    }
+                let Some((conn_id, rsp)) = self.installed_watch_sets.remove(&ws_id) else {
+                    return;
+                };
+                self.connection_watch_sets
+                    .get_mut(&conn_id)
+                    .expect("corrupted coordinator state: unknown connection id")
+                    .remove(&ws_id);
+                if self.connection_watch_sets[&conn_id].is_empty() {
+                    self.connection_watch_sets.remove(&conn_id);
+                }
 
-                    match rsp {
-                        WatchSetResponse::StatementDependenciesReady(id, ev) => {
-                            self.record_statement_lifecycle_event(&id, &ev, now);
-                        }
-                        WatchSetResponse::AlterSinkReady(ctx) => {
-                            self.sequence_alter_sink_finish(ctx).await;
-                        }
+                match rsp {
+                    WatchSetResponse::StatementDependenciesReady(id, ev) => {
+                        self.record_statement_lifecycle_event(&id, &ev, now);
+                    }
+                    WatchSetResponse::AlterSinkReady(ctx) => {
+                        self.sequence_alter_sink_finish(ctx).await;
                     }
                 }
             }


### PR DESCRIPTION
Change the compute controller to avoid the read/process pattern that limits it to message-at-a-time. Instead, use a channel and loop that through the main coordinator thread, which can handle batches of messages at once.

The main effect of this change should be a drop in controller-ready messages and a lower increase in compute/controller messages.

Before merging, I will do some performance analysis to see what the impact of this change might be.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
