### PR TITLE
platform-checks: Upsert with unordered key

### DIFF
--- a/misc/python/materialize/checks/all_checks/upsert_unordered_key.py
+++ b/misc/python/materialize/checks/all_checks/upsert_unordered_key.py
@@ -1,0 +1,108 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+
+# A schema that allows null values
+SCHEMA = dedent(
+    """
+        # Must be a subset of the keys in the rows AND
+        # in a different order than the value.
+        $ set keyschema={
+            "type": "record",
+            "name": "Key",
+            "fields": [
+                {"name": "b", "type": "string"},
+                {"name": "a", "type": "long"}
+            ]
+          }
+
+        $ set schema={
+            "type" : "record",
+            "name" : "envelope",
+            "fields" : [
+              {
+                "name": "before",
+                "type": [
+                  {
+                    "name": "row",
+                    "type": "record",
+                    "fields": [
+                      {
+                          "name": "a",
+                          "type": "long"
+                      },
+                      {
+                        "name": "data",
+                        "type": "string"
+                      },
+                      {
+                          "name": "b",
+                          "type": "string"
+                      }]
+                   },
+                   "null"
+                 ]
+              },
+              {
+                "name": "after",
+                "type": ["row", "null"]
+              }
+            ]
+          }
+    """
+)
+
+
+class UpsertUnorderedKey(Check):
+    """Upsert with keys in a different order than values."""
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            SCHEMA
+            + dedent(
+                """
+                $ kafka-create-topic topic=upsert-unordered-key
+                $ kafka-ingest format=avro topic=upsert-unordered-key key-format=avro key-schema=${keyschema} schema=${schema}
+                {"b": "bdata", "a": 1} {"before": {"row": {"a": 1, "data": "fish", "b": "bdata"}}, "after": {"row": {"a": 1, "data": "fish2", "b": "bdata"}}}
+
+                > CREATE SOURCE upsert_unordered_key
+                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-unordered-key-${testdrive.seed}')
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE DEBEZIUM
+                """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(SCHEMA + dedent(s))
+            for s in [
+                """
+                $ kafka-ingest format=avro topic=upsert-unordered-key key-format=avro key-schema=${keyschema} schema=${schema}
+                {"b": "bdata", "a": 1} {"before": {"row": {"a": 1, "data": "fish2", "b": "bdata"}}, "after": {"row": {"a": 1, "data": "fish3", "b": "bdata"}}}
+                """,
+                """
+                $ kafka-ingest format=avro topic=upsert-unordered-key key-format=avro key-schema=${keyschema} schema=${schema}
+                {"b": "bdata", "a": 1} {"before": {"row": {"a": 1, "data": "fish3", "b": "bdata"}}, "after": {"row": {"a": 1, "data": "fish4", "b": "bdata"}}}
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SELECT * FROM upsert_unordered_key
+                1 fish4 bdata
+                """
+            )
+        )


### PR DESCRIPTION
Reproduces https://github.com/MaterializeInc/database-issues/issues/8622

See discussion in https://materializeinc.slack.com/archives/C0761MZ3QD9/p1728396197787329

```
$ bin/mzcompose --find platform-checks down && bin/mzcompose --find platform-checks run default --scenario=RestartEntireMz --check=UpsertUnorderedKey
```
currently fails:
```
> SELECT * FROM upsert_unordered_key
rows didn't match; sleeping to see if dataflow catches up 50ms 75ms 113ms 169ms 253ms 380ms 570ms 854ms 1s 2s 3s 4s 6s 10s 15s 22s 33s 49s 74s 78s
^^^ +++
2:1: error: non-matching rows: expected:
[["1", "fish4", "bdata"]]
got:
[["1", "fish2", "bdata"], ["1", "fish3", "bdata"], ["1", "fish4", "bdata"]]
Poor diff:
+ 1 fish2 bdata
+ 1 fish3 bdata
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
