### PR TITLE
storage/sources: Refactor key-value load generator to support multiple source exports and upsert persist source feedback

### DIFF
--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1583,18 +1583,6 @@ async fn purify_create_table_from_source(
             purified_export
         }
         GenericSourceConnection::LoadGenerator(load_gen_connection) => {
-            // TODO(roshan): Refactor KeyValue load generator rendering to support multiple outputs
-            if matches!(
-                load_gen_connection.load_generator,
-                mz_storage_types::sources::load_generator::LoadGenerator::KeyValue(_)
-            ) {
-                sql_bail!(
-                    "{} is a {} source, which does not support CREATE TABLE .. FROM SOURCE.",
-                    scx.catalog.minimal_qualification(qualified_source_name),
-                    connection_name
-                )
-            };
-
             let mut views = load_gen_connection.load_generator.views();
             if views.is_empty() {
                 // If there are no views then this load-generator just has a single output

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -308,33 +308,25 @@ where
                         } else {
                             (Collection::new(empty(scope)), None, None, None)
                         };
-                    let (upsert, health_update, upsert_token) = crate::upsert::upsert(
-                        &upsert_input.enter(scope),
-                        upsert_envelope.clone(),
-                        refine_antichain(&resume_upper),
-                        previous,
-                        previous_token,
-                        base_source_config.clone(),
-                        &storage_state.instance_context,
-                        &storage_state.storage_configuration,
-                        &storage_state.dataflow_parameters,
-                        backpressure_metrics,
-                    );
+                    let (upsert, health_update, snapshot_progress, upsert_token) =
+                        crate::upsert::upsert(
+                            &upsert_input.enter(scope),
+                            upsert_envelope.clone(),
+                            refine_antichain(&resume_upper),
+                            previous,
+                            previous_token,
+                            base_source_config.clone(),
+                            &storage_state.instance_context,
+                            &storage_state.storage_configuration,
+                            &storage_state.dataflow_parameters,
+                            backpressure_metrics,
+                        );
 
                     // Even though we register the `persist_sink` token at a top-level,
                     // which will stop any data from being committed, we also register
                     // a token for the `upsert` operator which may be in the middle of
                     // rehydration processing the `persist_source` input above.
                     needed_tokens.push(upsert_token);
-
-                    use mz_timely_util::probe::ProbeNotify;
-                    let handle = mz_timely_util::probe::Handle::default();
-                    let upsert = upsert.inner.probe_notify_with(vec![handle.clone()]);
-                    let probe = mz_timely_util::probe::source(
-                        scope.clone(),
-                        format!("upsert_probe({export_id})"),
-                        handle,
-                    );
 
                     // If configured, delay raw sources until we rehydrate the upsert
                     // source. Otherwise, drop the token, unblocking the sources at the
@@ -347,20 +339,20 @@ where
                             &base_source_config,
                             rehydrated_token,
                             refine_antichain(&resume_upper),
-                            &probe,
+                            &snapshot_progress,
                         );
                     } else {
                         drop(rehydrated_token)
                     };
 
-                    // If backpressure is enabled, we probe the upsert operator's
-                    // output, which is the easiest way to extract frontier information.
+                    // If backpressure from persist is enabled, we connect the upsert operator's
+                    // snapshot progress to the persist source feedback handle.
                     let upsert = match feedback_handle {
                         Some(feedback_handle) => {
-                            probe.connect_loop(feedback_handle);
-                            upsert.as_collection()
+                            snapshot_progress.connect_loop(feedback_handle);
+                            upsert
                         }
-                        None => upsert.as_collection(),
+                        None => upsert,
                     };
 
                     (

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -15,10 +15,12 @@ use std::time::Duration;
 
 use differential_dataflow::AsCollection;
 use futures::StreamExt;
+use mz_ore::iter::IteratorExt;
 use mz_repr::Row;
 use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::load_generator::{
-    Event, Generator, KeyValueLoadGenerator, LoadGenerator, LoadGeneratorSourceConnection,
+    Event, Generator, KeyValueLoadGenerator, LoadGenerator, LoadGeneratorOutput,
+    LoadGeneratorSourceConnection,
 };
 use mz_storage_types::sources::{MzOffset, SourceExportDetails, SourceTimestamp};
 use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
@@ -142,6 +144,24 @@ impl GeneratorKind {
         Stream<G, Probe<MzOffset>>,
         Vec<PressOnDropButton>,
     ) {
+        // figure out which output types from the generator belong to which output indexes
+        let mut output_map = BTreeMap::new();
+        for (_, export) in config.source_exports.iter() {
+            let output_type = match &export.export.details {
+                SourceExportDetails::LoadGenerator(details) => details.output,
+                // This is an export that doesn't need any data output to it.
+                SourceExportDetails::None => continue,
+                _ => panic!(
+                    "unexpected source export details: {:?}",
+                    export.export.details
+                ),
+            };
+            output_map
+                .entry(output_type)
+                .or_insert_with(Vec::new)
+                .push(export.ingestion_output);
+        }
+
         match self {
             GeneratorKind::Simple {
                 tick_micros,
@@ -156,10 +176,16 @@ impl GeneratorKind {
                 scope,
                 config,
                 committed_uppers,
+                output_map,
             ),
-            GeneratorKind::KeyValue(kv) => {
-                key_value::render(kv, scope, config, committed_uppers, start_signal)
-            }
+            GeneratorKind::KeyValue(kv) => key_value::render(
+                kv,
+                scope,
+                config,
+                committed_uppers,
+                start_signal,
+                output_map,
+            ),
         }
     }
 }
@@ -201,6 +227,7 @@ fn render_simple_generator<G: Scope<Timestamp = MzOffset>>(
     scope: &mut G,
     config: RawSourceCreationConfig,
     committed_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
+    output_map: BTreeMap<LoadGeneratorOutput, Vec<usize>>,
 ) -> (
     StackedCollection<G, (usize, Result<SourceMessage, DataflowError>)>,
     Option<Stream<G, Infallible>>,
@@ -209,24 +236,6 @@ fn render_simple_generator<G: Scope<Timestamp = MzOffset>>(
     Stream<G, Probe<MzOffset>>,
     Vec<PressOnDropButton>,
 ) {
-    // figure out which output types from the generator belong to which output indexes
-    let mut output_map = BTreeMap::new();
-    for (_, export) in config.source_exports.iter() {
-        let output_type = match &export.export.details {
-            SourceExportDetails::LoadGenerator(details) => details.output,
-            // This is an export that doesn't need any data output to it.
-            SourceExportDetails::None => continue,
-            _ => panic!(
-                "unexpected source export details: {:?}",
-                export.export.details
-            ),
-        };
-        output_map
-            .entry(output_type)
-            .or_insert_with(Vec::new)
-            .push(export.ingestion_output);
-    }
-
     let mut builder = AsyncOperatorBuilder::new(config.name.clone(), scope.clone());
 
     let (mut data_output, stream) = builder.new_output::<AccountedStackBuilder<_>>();
@@ -326,9 +335,9 @@ fn render_simple_generator<G: Scope<Timestamp = MzOffset>>(
                         // generate a significant amount of data that will overwhelm the dataflow.
                         // Since those are not required downstream we eagerly ignore them here.
                         if resume_offset <= offset {
-                            for &output in outputs {
+                            for (&output, message) in outputs.iter().repeat_clone(message) {
                                 data_output
-                                    .give_fueled(&cap, ((output, message.clone()), offset, diff))
+                                    .give_fueled(&cap, ((output, message), offset, diff))
                                     .await;
                             }
                         }

--- a/src/storage/src/source/generator/key_value.rs
+++ b/src/storage/src/source/generator/key_value.rs
@@ -7,15 +7,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::sync::Arc;
 
 use differential_dataflow::AsCollection;
 use futures::stream::StreamExt;
 use mz_ore::cast::CastFrom;
+use mz_ore::iter::IteratorExt;
 use mz_repr::{Datum, Diff, Row};
 use mz_storage_types::errors::DataflowError;
-use mz_storage_types::sources::load_generator::KeyValueLoadGenerator;
+use mz_storage_types::sources::load_generator::{KeyValueLoadGenerator, LoadGeneratorOutput};
 use mz_storage_types::sources::{MzOffset, SourceTimestamp};
 use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
 use mz_timely_util::containers::stack::AccountedStackBuilder;
@@ -25,6 +27,7 @@ use timely::container::CapacityContainerBuilder;
 use timely::dataflow::operators::{Concat, ToStream};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
+use tracing::info;
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
 use crate::source::types::{Probe, ProgressStatisticsUpdate, SignaledFuture, StackedCollection};
@@ -36,6 +39,7 @@ pub fn render<G: Scope<Timestamp = MzOffset>>(
     config: RawSourceCreationConfig,
     committed_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
     start_signal: impl std::future::Future<Output = ()> + 'static,
+    output_map: BTreeMap<LoadGeneratorOutput, Vec<usize>>,
 ) -> (
     StackedCollection<G, (usize, Result<SourceMessage, DataflowError>)>,
     Option<Stream<G, Infallible>>,
@@ -61,18 +65,31 @@ pub fn render<G: Scope<Timestamp = MzOffset>>(
                 caps.try_into().unwrap();
 
             let resume_upper = Antichain::from_iter(
-                config.source_resume_uppers[&config.id]
-                    .iter()
-                    .map(MzOffset::decode_row),
+                config
+                    .source_resume_uppers
+                    .values()
+                    .flat_map(|f| f.iter().map(MzOffset::decode_row)),
             );
 
             let Some(resume_offset) = resume_upper.into_option() else {
                 return;
             };
 
+            // The key-value load generator only has one 'output' stream, which is the default output
+            // that needs to be emitted to all output indexes.
+            let output_indexes = output_map
+                .get(&LoadGeneratorOutput::Default)
+                .expect("default output");
+
+            info!(
+                ?config.worker_id,
+                "starting key-value load generator at {}",
+                resume_offset.offset,
+            );
             cap.downgrade(&resume_offset);
             progress_cap.downgrade(&resume_offset);
             start_signal.await;
+            info!(?config.worker_id, "received key-value load generator start signal");
 
             let snapshotting = resume_offset.offset == 0;
 
@@ -132,7 +149,7 @@ pub fn render<G: Scope<Timestamp = MzOffset>>(
                 );
                 while local_partitions.iter().any(|si| !si.finished()) {
                     for sp in local_partitions.iter_mut() {
-                        for u in sp.produce_batch(&mut value_buffer) {
+                        for u in sp.produce_batch(&mut value_buffer, output_indexes) {
                             data_output.give_fueled(&cap, u).await;
                             emitted += 1;
                         }
@@ -184,7 +201,7 @@ pub fn render<G: Scope<Timestamp = MzOffset>>(
                     }
 
                     for up in local_partitions.iter_mut() {
-                        let (new_upper, iter) = up.produce_batch(&mut value_buffer);
+                        let (new_upper, iter) = up.produce_batch(&mut value_buffer, output_indexes);
                         upper_offset = new_upper;
                         for u in iter {
                             data_output.give_fueled(&cap, u).await;
@@ -333,6 +350,7 @@ impl TransactionalSnapshotProducer {
     fn produce_batch<'a>(
         &'a mut self,
         value_buffer: &'a mut Vec<u8>,
+        output_indexes: &'a [usize],
     ) -> impl Iterator<
         Item = (
             (usize, Result<SourceMessage, DataflowError>),
@@ -356,24 +374,21 @@ impl TransactionalSnapshotProducer {
             } else {
                 usize::cast_from(self.batch_size)
             })
-            .map(move |key| {
+            .flat_map(move |key| {
                 rng.fill_bytes(value_buffer.as_mut_slice());
-                let msg = (
-                    0,
-                    Ok(SourceMessage {
-                        key: Row::pack_slice(&[Datum::UInt64(key)]),
-                        value: Row::pack_slice(&[
-                            Datum::UInt64(partition),
-                            Datum::Bytes(value_buffer),
-                        ]),
-                        metadata: if include_offset {
-                            Row::pack(&[Datum::UInt64(iter_round)])
-                        } else {
-                            Row::default()
-                        },
-                    }),
-                );
-                (msg, MzOffset::from(iter_round), 1)
+                let msg = Ok(SourceMessage {
+                    key: Row::pack_slice(&[Datum::UInt64(key)]),
+                    value: Row::pack_slice(&[Datum::UInt64(partition), Datum::Bytes(value_buffer)]),
+                    metadata: if include_offset {
+                        Row::pack(&[Datum::UInt64(iter_round)])
+                    } else {
+                        Row::default()
+                    },
+                });
+                output_indexes
+                    .iter()
+                    .repeat_clone(msg)
+                    .map(move |(idx, msg)| ((*idx, msg), MzOffset::from(iter_round), 1))
             });
 
         if !finished {
@@ -455,6 +470,7 @@ impl UpdateProducer {
     fn produce_batch<'a>(
         &'a mut self,
         value_buffer: &'a mut Vec<u8>,
+        output_indexes: &'a [usize],
     ) -> (
         u64,
         impl Iterator<
@@ -473,24 +489,21 @@ impl UpdateProducer {
         let iter = self
             .pi
             .take(usize::cast_from(self.batch_size))
-            .map(move |key| {
+            .flat_map(move |key| {
                 rng.fill_bytes(value_buffer.as_mut_slice());
-                let msg = (
-                    0,
-                    Ok(SourceMessage {
-                        key: Row::pack_slice(&[Datum::UInt64(key)]),
-                        value: Row::pack_slice(&[
-                            Datum::UInt64(partition),
-                            Datum::Bytes(value_buffer),
-                        ]),
-                        metadata: if include_offset {
-                            Row::pack(&[Datum::UInt64(iter_offset)])
-                        } else {
-                            Row::default()
-                        },
-                    }),
-                );
-                (msg, MzOffset::from(iter_offset), 1)
+                let msg = Ok(SourceMessage {
+                    key: Row::pack_slice(&[Datum::UInt64(key)]),
+                    value: Row::pack_slice(&[Datum::UInt64(partition), Datum::Bytes(value_buffer)]),
+                    metadata: if include_offset {
+                        Row::pack(&[Datum::UInt64(iter_offset)])
+                    } else {
+                        Row::default()
+                    },
+                });
+                output_indexes
+                    .iter()
+                    .repeat_clone(msg)
+                    .map(move |(idx, msg)| ((*idx, msg), MzOffset::from(iter_offset), 1))
             });
 
         // Advance to the next offset.

--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -213,6 +213,7 @@ pub(crate) fn upsert<G: Scope, FromTime>(
 ) -> (
     Collection<G, Result<Row, DataflowError>, Diff>,
     Stream<G, (OutputIndex, HealthStatusUpdate)>,
+    Stream<G, Infallible>,
     PressOnDropButton,
 )
 where
@@ -225,10 +226,6 @@ where
         backpressure_metrics,
     );
 
-    // If we are configured to delay raw sources till we rehydrate, we do so. Otherwise, skip
-    // this, to prevent unnecessary work.
-    let wait_for_input_resumption =
-        dyncfgs::DELAY_SOURCES_PAST_REHYDRATION.get(storage_configuration.config_set());
     let rocksdb_cleanup_tries =
         dyncfgs::STORAGE_ROCKSDB_CLEANUP_TRIES.get(storage_configuration.config_set());
 
@@ -246,7 +243,6 @@ where
         dyncfgs::STORAGE_ROCKSDB_USE_MERGE_OPERATOR.get(storage_configuration.config_set());
 
     let upsert_config = UpsertConfig {
-        wait_for_input_resumption,
         shrink_upsert_unused_buffers_by_ratio: storage_configuration
             .parameters
             .shrink_upsert_unused_buffers_by_ratio,
@@ -617,9 +613,6 @@ async fn drain_staged_input<S, G, T, FromTime, E>(
 // Created a struct to hold the configs for upserts.
 // So that new configs don't require a new method parameter.
 struct UpsertConfig {
-    // Whether or not to wait for the `input` to reach the `resumption_frontier`
-    // before we finalize `rehydration`.
-    wait_for_input_resumption: bool,
     shrink_upsert_unused_buffers_by_ratio: usize,
 }
 
@@ -638,6 +631,7 @@ fn upsert_inner<G: Scope, FromTime, F, Fut, US>(
 ) -> (
     Collection<G, Result<Row, DataflowError>, Diff>,
     Stream<G, (OutputIndex, HealthStatusUpdate)>,
+    Stream<G, Infallible>,
     PressOnDropButton,
 )
 where
@@ -665,6 +659,12 @@ where
         Some((UpsertKey::from_value(value.as_ref(), &key_indices), value))
     });
     let (mut output_handle, output) = builder.new_output();
+
+    // An output that just reports progress of the snapshot consolidation process upstream to the
+    // persist source to ensure that backpressure is applied
+    let (_snapshot_handle, snapshot_stream) =
+        builder.new_output::<CapacityContainerBuilder<Vec<Infallible>>>();
+
     let (mut health_output, health_stream) = builder.new_output();
     let mut input = builder.new_input_for(
         &input.inner,
@@ -680,7 +680,7 @@ where
 
     let upsert_shared_metrics = Arc::clone(&upsert_metrics.shared);
     let shutdown_button = builder.build(move |caps| async move {
-        let [mut output_cap, health_cap]: [_; 2] = caps.try_into().unwrap();
+        let [mut output_cap, mut snapshot_cap, health_cap]: [_; 3] = caps.try_into().unwrap();
 
         // The order key of the `UpsertState` is `Option<FromTime>`, which implements `Default`
         // (as required for `consolidate_snapshot_chunk`), with slightly more efficient serialization
@@ -696,58 +696,24 @@ where
         let mut snapshot_upper = Antichain::from_elem(Timestamp::minimum());
 
         let mut stash = vec![];
-        let mut input_upper = Antichain::from_elem(Timestamp::minimum());
         let mut legacy_errors_to_correct = vec![];
 
         let mut error_emitter = (&mut health_output, &health_cap);
 
-        while !PartialOrder::less_equal(&resume_upper, &snapshot_upper)
-            || (upsert_config.wait_for_input_resumption
-                && !PartialOrder::less_equal(&resume_upper, &input_upper))
-        {
-            let previous_event = tokio::select! {
-                // Note that these are both cancel-safe. The reason we drain the `input` is to
-                // ensure the `output_frontier` (and therefore flow control on `previous`) make
-                // progress.
-                Some(previous_event) = previous.next(), if !PartialOrder::less_equal(
-                    &resume_upper,
-                    &snapshot_upper,
-                ) => {
-                    previous_event
-                }
-                Some(input_event) = input.next() => {
-                    match input_event {
-                        AsyncEvent::Data(_cap, mut data) => {
-                            stage_input(
-                                &mut stash,
-                                &mut data,
-                                &input_upper,
-                                &resume_upper,
-                                upsert_config.shrink_upsert_unused_buffers_by_ratio
-                            );
-                        }
-                        AsyncEvent::Progress(upper) => {
-                            input_upper = upper;
-                        }
-                    }
-                    continue;
-                }
-            };
-            match previous_event {
-                AsyncEvent::Data(_cap, data) => {
-                    events.extend(data.into_iter().filter_map(|((key, value), ts, diff)| {
-                        if !resume_upper.less_equal(&ts) {
-                            Some((key, value, diff))
-                        } else {
-                            None
-                        }
-                    }))
-                }
-                AsyncEvent::Progress(upper) => snapshot_upper = upper,
-            };
-            while let Some(event) = previous.next().now_or_never() {
+        tracing::info!(
+            ?resume_upper,
+            ?snapshot_upper,
+            "timely-{} upsert source {} starting rehydration",
+            source_config.worker_id,
+            source_config.id
+        );
+        // Read and consolidate the snapshot from the 'previous' input until it
+        // reaches the `resume_upper`.
+        while !PartialOrder::less_equal(&resume_upper, &snapshot_upper) {
+            previous.ready().await;
+            while let Some(event) = previous.next_sync() {
                 match event {
-                    Some(AsyncEvent::Data(_cap, data)) => {
+                    AsyncEvent::Data(_cap, data) => {
                         events.extend(data.into_iter().filter_map(|((key, value), ts, diff)| {
                             if !resume_upper.less_equal(&ts) {
                                 Some((key, value, diff))
@@ -756,12 +722,10 @@ where
                             }
                         }))
                     }
-                    Some(AsyncEvent::Progress(upper)) => snapshot_upper = upper,
-                    None => {
-                        snapshot_upper = Antichain::new();
-                        break;
+                    AsyncEvent::Progress(upper) => {
+                        snapshot_upper = upper;
                     }
-                }
+                };
             }
 
             for (_, value, diff) in events.iter_mut() {
@@ -791,6 +755,7 @@ where
                         // `resume_upper`, which we ignore above. We don't want our output capability to make
                         // it further than the `resume_upper`.
                         if !resume_upper.less_equal(&ts) {
+                            snapshot_cap.downgrade(&ts);
                             output_cap.downgrade(&ts);
                         }
                     }
@@ -807,8 +772,9 @@ where
         }
 
         drop(events);
-
         drop(previous_token);
+        drop(snapshot_cap);
+
         // Exchaust the previous input. It is expected to immediately reach the empty
         // antichain since we have dropped its token.
         //
@@ -862,18 +828,9 @@ where
 
         // Now can can resume consuming the collection
         let mut output_updates = vec![];
-        let mut post_snapshot = true;
+        let mut input_upper = Antichain::from_elem(Timestamp::minimum());
 
-        while let Some(event) = {
-            // Synthesize a `Progress` event that allows us to drain the `stash` of values
-            // obtained during snapshotting.
-            if post_snapshot {
-                post_snapshot = false;
-                Some(AsyncEvent::Progress(input_upper.clone()))
-            } else {
-                input.next().await
-            }
-        } {
+        while let Some(event) = input.next().await {
             // Buffer as many events as possible. This should be bounded, as new data can't be
             // produced in this worker until we yield to timely.
             let events = [event]
@@ -978,6 +935,7 @@ where
             Err(err) => Err(DataflowError::from(EnvelopeError::Upsert(err))),
         }),
         health_stream,
+        snapshot_stream,
         shutdown_button.press_on_drop(),
     )
 }

--- a/test/testdrive/source-tables.td
+++ b/test/testdrive/source-tables.td
@@ -32,6 +32,7 @@ contains: not supported
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_create_table_from_source = true
+ALTER SYSTEM SET enable_load_generator_key_value = true
 
 #
 # Multi-output load generator source using source-fed tables
@@ -283,9 +284,6 @@ contains:unknown catalog item 'mysql_table_3'
 # TODO(def-) Remove when database-issues#8515 and database-issues#8526 are fixed
 $ skip-end
 
-# TODO(def-) Remove when database-issues#8625 is fixed
-$ skip-if
-SELECT true
 
 #
 # Kafka source using source-fed tables
@@ -357,3 +355,42 @@ goose    1
 moose    1
 moose    2
 moose    42
+
+
+#
+# Key-value load generator source using source-fed tables
+#
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_create_table_from_source = true
+ALTER SYSTEM SET enable_load_generator_key_value = true
+
+> CREATE SOURCE keyvalue
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM LOAD GENERATOR KEY VALUE (
+    KEYS 16,
+    PARTITIONS 4,
+    SNAPSHOT ROUNDS 3,
+    SEED 123,
+    VALUE SIZE 10,
+    BATCH SIZE 2,
+    TICK INTERVAL '1s'
+  );
+
+> CREATE TABLE kv_1 FROM SOURCE keyvalue INCLUDE KEY ENVELOPE UPSERT;
+
+> CREATE TABLE kv_2 FROM SOURCE keyvalue INCLUDE KEY ENVELOPE NONE;
+
+> SELECT partition, count(*) FROM kv_1 GROUP BY partition
+0   4
+1   4
+2   4
+3   4
+
+> SELECT partition, count(*) > 10 FROM kv_2 GROUP BY partition
+0   true
+1   true
+2   true
+3   true
+
+> DROP SOURCE keyvalue CASCADE;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Reintroduces the key-value load-generator refactoring first introduced in https://github.com/MaterializeInc/materialize/pull/29600/

This also reintroduces *some* of the upsert operator refactoring from that PR. This refactoring was necessary to allow sources to have more than one export where at least one of them uses the upsert operator and resume at different resume_uppers.

However, that original PR did more than was actually necessary to make this work and it also introduced a memory regression.

The original PR refactored the source operator feedback control to use the `SignaledFuture` semaphore method, but that was not actually necessary for this change (though it is probably still worth doing, separately).

Instead, this PR just refactors the persist source feedback. The upsert operator now returns a `snapshot_progress` stream that is provided to the `persist_source` during upsert rehydration. This is done instead of monitoring the overall frontier of the upsert output stream, since that frontier will now be held back until rehydration is complete since it cannot progress if one or more exports resumes at the minimum frontier (unless we totally remove flow-control on the upstream source operator).

Additionally, that original PR would [drain the input stream](https://github.com/MaterializeInc/materialize/pull/29600/files#diff-a4f04d74cb239c03daf61015b8521472533837117cdf961def6a89a73ca9c61eR760-R779) before downgrading to the resume_upper, which is the cause of the memory increase detected in the feature benchmarks. It turns out that this wasn't actually necessary since the `stage_input` method already discards all input updates from before the resume_upper. I'm not 100% sure why this caused such an increase in memory usage but removing it fixes the problem.

Fixes https://github.com/MaterializeInc/database-issues/issues/8628

Feature benchmark test:
```
bin/mzcompose --find feature-benchmark down && bin/mzcompose --find feature-benchmark run default --scale=+1 --scenario=KafkaUpsertUnique  --runs-per-scenario 1 --max-measurements 1
...
+++ Benchmark Report for run 1:
NAME                                | TYPE            |      THIS       |      OTHER      |  UNIT  | THRESHOLD  |  Regression?  | 'THIS' is
--------------------------------------------------------------------------------------------------------------------------------------------------------
KafkaUpsertUnique                   | wallclock       |          19.273 |          18.332 |   s    |    10%     |      no       | worse:   5.1% slower
KafkaUpsertUnique                   | memory_mz       |        4663.467 |        4852.295 |   MB   |    20%     |      no       | better:  3.9% less
KafkaUpsertUnique                   | memory_clusterd |        4669.189 |        4856.110 |   MB   |    20%     |      no       | better:  3.8% less
```
release qual build: https://buildkite.com/materialize/release-qualification/builds/626#01926d94-1567-4724-a0a4-9ec0feadac4e

(when I ran the same regression while including the 'draining the input stream' code the memory increase was about 23% more)

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
