### PR TITLE
doc/user: promote bulk exports to Public Preview

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -231,7 +231,7 @@ weight = 15
 
 [[menu.main]]
 identifier = "releases-previews"
-name = "Releases and Previews"
+name = "Releases and previews"
 weight = 65
 
 #

--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -24,7 +24,7 @@ Emulator](/get-started/install-materialize-emulator/).
 
 - [Release Notes/Changelogs](/releases/)
 
-- [Private/Public Previews](/releases/previews/)
+- [Previews features](/releases/previews/)
 
 {{</ callout >}}
 

--- a/doc/user/content/releases/previews.md
+++ b/doc/user/content/releases/previews.md
@@ -1,5 +1,5 @@
 ---
-title: "Previews"
+title: "Preview features"
 description: ""
 disable_list: true
 menu:
@@ -49,23 +49,6 @@ to physical time.
 
 For more information, see [Real-time
 recency](/get-started/isolation-level/#real-time-recency).
-
-### Support Amazon S3 as a sink
-
-Materialize supports exporting results to Amazon S3.
-
-For more information, see:
-
-- [Serve results: Amazon S3](/serve-results/s3/).
-
-- [Copy to Amazon S3](/sql/copy-to/#copy-to-s3).
-
-### Support Snowflake as a sink
-
-Materialize supports exporting results to Snowflake, using Amazon S3 ([Private
-Preview](#support-amazon-s3-as-a-sink)) as the intermediate object store.
-
-For more information, see [Serve results: Snowflake](/serve-results/snowflake/).
 
 ### Refresh strategies for materialized views
 
@@ -168,6 +151,29 @@ For more information, see:
   `retention_period`](/sql/create-source/postgres/#with_options)
 
 ## Public preview
+
+### Bulk exports to object storage
+
+Bulk exports allow you to periodically dump results computed in Materialize to
+object storage. This is useful to perform tasks like periodic **backups for
+auditing**, and additional downstream processing in **analytical data
+warehouses** like Snowflake, Databricks or BigQuery.
+
+| Object storage service                      | Supported? |
+| ------------------------------------------- |:----------:|
+| Amazon S3                                   | ✓          |
+| Google Cloud Storage                        | ✓          |
+| Azure Blob Storage                          |            |
+
+For more information on bulk exports to object storage, see the
+[reference documentation](/sql/copy-to/#copy-to-s3) and the warehouse-specific
+integration guides:
+
+| Cloud data warehouse service                | Integration guide                                                                     |
+| ------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Snowflake                                   | [Snowflake via object storage](https://materialize.com/docs/serve-results/snowflake/) |
+| BigQuery                                    | Coming soon!                                                                          |
+| Databricks                                  | Coming soon!                                                                          |
 
 ### Health Dashboard
 

--- a/doc/user/content/releases/previews.md
+++ b/doc/user/content/releases/previews.md
@@ -204,7 +204,8 @@ Materialize supports the use of an AWS Connection to perform:
 
 - IAM authentication with an Amazon MSK cluster.
 
-- Bulk exports to Amazon S3 [(Private Preview)](#support-amazon-s3-as-a-sink).
+- Bulk exports to Amazon S3. See [Bulk exports to object
+  storage](#bulk-exports-to-object-storage).
 
 For more information, see [`CREATE Connection:
 AWS`](/sql/create-connection/#aws).

--- a/doc/user/content/serve-results/s3.md
+++ b/doc/user/content/serve-results/s3.md
@@ -8,7 +8,7 @@ menu:
     weight: 10
 ---
 
-{{< private-preview />}}
+{{< public-preview />}}
 
 This guide walks you through the steps required to export results from
 Materialize to Amazon S3. Copying results to S3 is

--- a/doc/user/content/serve-results/snowflake.md
+++ b/doc/user/content/serve-results/snowflake.md
@@ -12,7 +12,7 @@ menu:
 Snowflake continuously using the Snowflake connector for Kafka. We should also
 document that approach."
 
-{{< private-preview />}}
+{{< public-preview />}}
 
 This guide walks you through the steps required to bulk-export results from
 Materialize to Snowflake using Amazon S3 as the intermediate object store.


### PR DESCRIPTION
S3 bulk exports are ready for Public Preview, so promoting it in the documentation after enabling the feature flag across all environments.