### PR TITLE
adapter/catalog: Switch back to storing available source_references as separate in-memory catalog map

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -582,15 +582,6 @@ impl CatalogState {
                     source.create_sql.as_ref(),
                 );
 
-                // Emit available source reference table updates here
-                // so that we can retract them when a source is removed correctly.
-                if let Some(source_references) = &source.available_source_references {
-                    updates.extend(self.pack_source_references_update(
-                        &source_references.clone().to_durable(id),
-                        diff,
-                    ));
-                }
-
                 updates.extend(match &source.data_source {
                     DataSourceDesc::Ingestion { ingestion_desc, .. } => {
                         match &ingestion_desc.desc.connection {

--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -110,6 +110,12 @@ impl CatalogState {
             }
         }
 
+        for (source_id, _references) in &self.source_references {
+            if !self.entry_by_id.contains_key(source_id) {
+                inconsistencies.push(InternalFieldsInconsistency::SourceReferences(*source_id));
+            }
+        }
+
         if inconsistencies.is_empty() {
             Ok(())
         } else {
@@ -590,6 +596,7 @@ enum InternalFieldsInconsistency {
     AmbientSchema(String, SchemaId),
     Cluster(String, ClusterId),
     Role(String, RoleId),
+    SourceReferences(GlobalId),
 }
 
 #[derive(Debug, Serialize, Clone, PartialEq)]

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -235,6 +235,7 @@ impl Catalog {
             default_privileges: DefaultPrivileges::default(),
             system_privileges: PrivilegeMap::default(),
             comments: CommentsMap::default(),
+            source_references: BTreeMap::new(),
             storage_metadata: Default::default(),
             temporary_schemas: BTreeMap::new(),
             config: mz_sql::catalog::CatalogConfig {

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -1176,6 +1176,10 @@ impl Catalog {
                         storage_collections_to_drop.insert(item_id);
                     }
 
+                    if state.source_references.contains_key(&item_id) {
+                        tx.remove_source_references(item_id)?;
+                    }
+
                     if Self::should_audit_log_item(entry.item()) {
                         CatalogState::add_to_audit_log(
                             &state.system_configuration,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -340,7 +340,7 @@ impl Coordinator {
                 });
             }
 
-            let source = Source::new(plan, resolved_ids, None, false, available_source_references);
+            let source = Source::new(plan, resolved_ids, None, false);
             ops.push(catalog::Op::CreateItem {
                 id: source_id,
                 name,
@@ -3779,10 +3779,6 @@ impl Coordinator {
                     resolved_ids,
                     cur_source.custom_logical_compaction_window,
                     cur_source.is_retained_metrics_object,
-                    cur_source
-                        .available_source_references
-                        .clone()
-                        .map(Into::into),
                 );
 
                 let source_compaction_window = source.custom_logical_compaction_window;

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -968,33 +968,6 @@ impl<'a> Transaction<'a> {
         Ok(())
     }
 
-    /// Removes the cluster `id` from the transaction.
-    ///
-    /// Returns an error if `id` is not found.
-    ///
-    /// Runtime is linear with respect to the total number of clusters in the catalog.
-    /// DO NOT call this function in a loop, use [`Self::remove_clusters`] instead.
-    pub fn remove_cluster(&mut self, id: ClusterId) -> Result<(), CatalogError> {
-        let deleted = self
-            .clusters
-            .delete_by_key(ClusterKey { id }, self.op_id)
-            .is_some();
-        if deleted {
-            Err(SqlCatalogError::UnknownCluster(id.to_string()).into())
-        } else {
-            // Cascade delete introspection sources and cluster replicas.
-            //
-            // TODO(benesch): this doesn't seem right. Cascade deletions should
-            // be entirely the domain of the higher catalog layer, not the
-            // storage layer.
-            self.cluster_replicas
-                .delete(|_k, v| v.cluster_id == id, self.op_id);
-            self.introspection_sources
-                .delete(|k, _v| k.cluster_id == id, self.op_id);
-            Ok(())
-        }
-    }
-
     /// Removes all cluster in `clusters` from the transaction.
     ///
     /// Returns an error if any id in `clusters` is not found.

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -905,6 +905,18 @@ impl<'a> Transaction<'a> {
         Ok(())
     }
 
+    pub fn remove_source_references(&mut self, source_id: GlobalId) -> Result<(), CatalogError> {
+        let deleted = self
+            .source_references
+            .delete_by_key(SourceReferencesKey { source_id }, self.op_id)
+            .is_some();
+        if deleted {
+            Ok(())
+        } else {
+            Err(SqlCatalogError::UnknownItem(source_id.to_string()).into())
+        }
+    }
+
     /// Removes the role `name` from the transaction.
     ///
     /// Returns an error if `name` is not found.

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -722,8 +722,6 @@ pub struct Source {
     /// Whether the source's logical compaction window is controlled by
     /// METRICS_RETENTION
     pub is_retained_metrics_object: bool,
-    /// An optional list of all available source references for this source.
-    pub available_source_references: Option<SourceReferences>,
 }
 
 impl Source {
@@ -738,7 +736,6 @@ impl Source {
         resolved_ids: ResolvedIds,
         custom_logical_compaction_window: Option<CompactionWindow>,
         is_retained_metrics_object: bool,
-        available_source_references: Option<mz_sql::plan::SourceReferences>,
     ) -> Source {
         Source {
             create_sql: Some(plan.source.create_sql),
@@ -796,7 +793,6 @@ impl Source {
                 .compaction_window
                 .or(custom_logical_compaction_window),
             is_retained_metrics_object,
-            available_source_references: available_source_references.map(Into::into),
         }
     }
 
@@ -1818,16 +1814,6 @@ impl CatalogEntry {
                 _ => None,
             },
             _ => None,
-        }
-    }
-
-    /// Update the available references for a source from the durable catalog
-    pub fn update_source_available_references(
-        &mut self,
-        available_source_references: Option<SourceReferences>,
-    ) {
-        if let CatalogItem::Source(source) = &mut self.item {
-            source.available_source_references = available_source_references;
         }
     }
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This revisits the discussion from a previous PR here https://github.com/MaterializeInc/materialize/pull/29749#discussion_r1777169138 by switching back to storing the `source_references` map as its own `CatalogState` field rather than including as a sub-field of the relevant `Source` object. This now closely mirrors the durable catalog state which stores the `source_references` field separately, too.

The reason I switched back to this approach is that it's difficult to reason about this logic if the durable catalog structure is different than the in-memory catalog structure since it requires extra handling to ensure the source-field is kept in-sync with the durable catalog field.
It also resulted in broken catalog consistency checks whenever a source object was renamed, and I could have tried to fix the renaming issue but it felt like I was bandaid-ing a brittle structure that would inevitably lead to another issue in the future. I discovered this while working on the code to populate this table in https://github.com/MaterializeInc/materialize/pull/29857

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

I've tested this locally combined with the code + tests in https://github.com/MaterializeInc/materialize/pull/29857 to ensure the `source_references` are correctly added and removed when a source is added/removed/renamed. 

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
