### PR TITLE
canary environment: update queries

### DIFF
--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -1124,7 +1124,7 @@ class StagingBench(Scenario):
                         # ),
                         # ClosedLoop(
                         #    action=ReuseConnQuery(
-                        #        "SELECT COUNT(DISTINCT a_name) FROM qa_canary_environment.public_pg_cdc.wmr WHERE degree > 1",
+                        #        "SELECT COUNT(DISTINCT a_name) FROM qa_canary_environment.public_pg_cdc.pg_wmr WHERE degree > 1",
                         #        conn_info=conn_infos["materialized"],
                         #    ),
                         # ),

--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -268,7 +268,7 @@ def validate_updated_data(c: Composition, i: int) -> None:
                 # > SELECT COUNT(DISTINCT c_name) FROM qa_canary_environment.public_tpch.tpch_q18 WHERE o_orderdate >= '2023-01-01'
                 # 0
 
-                > SELECT COUNT(DISTINCT a_name) FROM qa_canary_environment.public_pg_cdc.wmr WHERE degree > 10
+                > SELECT COUNT(DISTINCT a_name) FROM qa_canary_environment.public_pg_cdc.pg_wmr WHERE degree > 10
                 0
 
                 > SELECT COUNT(DISTINCT a_name) FROM qa_canary_environment.public_mysql_cdc.mysql_wmr WHERE degree > 10
@@ -350,7 +350,7 @@ def validate_data_through_http_connection(
 
     result = http_sql_query(
         host,
-        "SELECT COUNT(DISTINCT a_name) FROM qa_canary_environment.public_pg_cdc.wmr WHERE degree > 10",
+        "SELECT COUNT(DISTINCT a_name) FROM qa_canary_environment.public_pg_cdc.pg_wmr WHERE degree > 10",
         token,
     )
     assert result == [["0"]]


### PR DESCRIPTION
This addresses

```
> SELECT COUNT(DISTINCT a_name) FROM qa_canary_environment.public_pg_cdc.wmr WHERE degree > 10 rows didn't match; sleeping to see if dataflow catches up 50ms 75ms 113ms 169ms 253ms 380ms 570ms 854ms 1s 2s 3s 4s 6s 10s 15s 22s 33s 49s 74s 111s 166s 101s ^^^ +++ 9:1: error: preparing query failed: db error: ERROR: unknown catalog item 'qa_canary_environment.public_pg_cdc.wmr': ERROR: unknown catalog item 'qa_canary_environment.public_pg_cdc.wmr'      |    8 |     9 | > SELECT COUNT(DISTINCT a_name) FROM qa_canary_environment.public_pg_cdc.wmr WHERE degree > 10      | ^ +++ !!! Error Report 1 errors were encountered during execution source: /var/lib/buildkite-agent/builds/buildkite-aarch64-small-d306b64-i-01444d5464d99fc66-1/materialize/qa-canary/test/canary-load/mzcompose.py:261 
```