### PR TITLE
ct: triage all currently remaining TODO(ct)s in adapter

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/create_continual_task.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_continual_task.rs
@@ -42,7 +42,6 @@ use crate::optimize::{self, Optimize, OptimizerCatalog};
 use crate::session::Session;
 use crate::util::ResultExt;
 
-// TODO(ct): Big oof. Dedup a bunch of this with MVs.
 impl Coordinator {
     #[instrument]
     pub(crate) async fn sequence_create_continual_task(
@@ -295,7 +294,7 @@ fn update_create_sql(
 
 /// An [OptimizerCatalog] impl that ignores any indexes that exist.
 ///
-/// TODO(ct): At the moment, the dataflow rendering for CTs only knows how to
+/// TODO(ct3): At the moment, the dataflow rendering for CTs only knows how to
 /// turn persist_sources into CT inputs. If the optimizer decides to use an
 /// existing index in the cluster, it won't work. It seems tricky/invasive to
 /// fix the render bug, so for now pretend indexes don't exist for CTs. Remove

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1414,7 +1414,6 @@ pub struct CreateContinualTaskStatement<T: AstInfo> {
 pub enum ContinualTaskStmt<T: AstInfo> {
     Delete(DeleteStatement<T>),
     Insert(InsertStatement<T>),
-    // TODO(ct): Update/upsert?
 }
 
 impl<T: AstInfo> AstDisplay for CreateContinualTaskStatement<T> {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3580,14 +3580,13 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_create_continual_task(&mut self) -> Result<Statement<Raw>, ParserError> {
-        // TODO(ct): If exists.
+        // TODO(ct3): OR REPLACE/IF NOT EXISTS.
         self.expect_keywords(&[CONTINUAL, TASK])?;
 
-        // TODO(ct): Multiple outputs.
+        // TODO(ct3): Multiple outputs.
         let name = RawItemName::Name(self.parse_item_name()?);
         self.expect_token(&Token::LParen)?;
         let columns = self.parse_comma_separated(|parser| {
-            // TODO(ct): NOT NULL, etc.
             Ok(CteMutRecColumnDef {
                 name: parser.parse_identifier()?,
                 data_type: parser.parse_data_type()?,
@@ -3596,10 +3595,10 @@ impl<'a> Parser<'a> {
         self.expect_token(&Token::RParen)?;
         let in_cluster = self.parse_optional_in_cluster()?;
 
-        // TODO(ct): Multiple inputs.
+        // TODO(ct3): Multiple inputs.
         self.expect_keywords(&[ON, INPUT])?;
         let input_table = self.parse_raw_name()?;
-        // TODO(ct): Allow renaming the inserts/deletes so that we can use
+        // TODO(ct3): Allow renaming the inserts/deletes so that we can use
         // something as both an "input" and a "reference".
 
         self.expect_keyword(AS)?;
@@ -3607,7 +3606,7 @@ impl<'a> Parser<'a> {
         let mut stmts = Vec::new();
         let mut expecting_statement_delimiter = false;
         self.expect_token(&Token::LParen)?;
-        // TODO(ct): Dedup this with parse_statements?
+        // TODO(ct2): Dedup this with parse_statements?
         loop {
             // ignore empty statements (between successive statement delimiters)
             while self.consume_token(&Token::Semicolon) {

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -735,10 +735,8 @@ pub struct CreateContinualTaskPlan {
     // `continual_task.expr`. None on restart.
     pub placeholder_id: Option<mz_expr::LocalId>,
     pub desc: RelationDesc,
-    // TODO(ct): Multiple inputs.
     pub input_id: GlobalId,
     pub continual_task: MaterializedView,
-    // TODO(ct): replace, drop_ids, if_not_exists
 }
 
 #[derive(Debug, Clone)]

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -165,7 +165,7 @@ pub fn plan_root_query(
     })
 }
 
-/// TODO(ct): Dedup this with [plan_root_query].
+/// TODO(ct2): Dedup this with [plan_root_query].
 #[mz_ore::instrument(target = "compiler", level = "trace", name = "ast_to_hir")]
 pub fn plan_ct_query(
     qcx: &mut QueryContext,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2789,7 +2789,7 @@ pub fn plan_create_continual_task(
 
     let mut exprs = Vec::new();
     for stmt in &stmt.stmts {
-        let query = continual_task_query(&ct_name, stmt).ok_or_else(|| sql_err!("TODO(ct)"))?;
+        let query = continual_task_query(&ct_name, stmt).ok_or_else(|| sql_err!("TODO(ct2)"))?;
         let query::PlannedRootQuery {
             mut expr,
             desc: desc_query,
@@ -2798,9 +2798,9 @@ pub fn plan_create_continual_task(
         } = query::plan_ct_query(&mut qcx, query)?;
         // We get back a trivial finishing, see comment in `plan_view`.
         assert!(finishing.is_trivial(expr.arity()));
-        // TODO(ct): Is this right?
+        // TODO(ct2): Is this right?
         expr.bind_parameters(params)?;
-        // TODO(ct): Make this error message more closely match the various ones
+        // TODO(ct2): Make this error message more closely match the various ones
         // given for INSERT/DELETE.
         if desc_query
             .iter_types()
@@ -2832,12 +2832,12 @@ pub fn plan_create_continual_task(
             ast::ContinualTaskStmt::Delete(_) => exprs.push(expr.negate()),
         }
     }
-    // TODO(ct): Collect things by output and assert that there is only one (or
+    // TODO(ct2): Collect things by output and assert that there is only one (or
     // support multiple outputs).
     let expr = exprs
         .into_iter()
         .reduce(|acc, expr| acc.union(expr))
-        .ok_or_else(|| sql_err!("TODO(ct)"))?;
+        .ok_or_else(|| sql_err!("TODO(ct2)"))?;
 
     let column_names: Vec<ColumnName> = desc.iter_names().cloned().collect();
     if let Some(dup) = column_names.iter().duplicates().next() {

--- a/test/sqllogictest/ct_errors.slt
+++ b/test/sqllogictest/ct_errors.slt
@@ -29,7 +29,7 @@ CREATE CONTINUAL TASK nope (key STRING) ON INPUT foo AS (
     INSERT INTO nope SELECT * FROM foo;
 )
 
-# TODO(ct): Make this error (or work!) instead of panic
+# TODO(ct2): Make this error (or work!) instead of panic
 # statement error something
 # CREATE CONTINUAL TASK nope (key INT) ON INPUT foo AS (
 #    INSERT INTO nope SELECT null::INT


### PR DESCRIPTION
The numbers correspond to which [milestone] that they need to be fixed by.

[milestone]: https://github.com/MaterializeInc/database-issues/issues/8427

Touches MaterializeInc/database-issues#8427

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

The priority here is finding if there are any M1 items left, would love a second set of eyes on this in particular. Some of the M2 vs M3 decisions feel like they could go either way, definitely open to feedback. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
