### PR TITLE
[persist] A couple useful features for the structured data rollout

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -1303,6 +1303,11 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
         batch_metrics.seconds.inc_by(start.elapsed().as_secs_f64());
         batch_metrics.bytes.inc_by(u64::cast_from(payload_len));
         batch_metrics.goodbytes.inc_by(u64::cast_from(goodbytes));
+        match cfg.expected_order {
+            RunOrder::Unordered => batch_metrics.unordered.inc(),
+            RunOrder::Codec => batch_metrics.codec_order.inc(),
+            RunOrder::Structured => batch_metrics.structured_order.inc(),
+        }
         let stats = stats.map(|(stats, stats_step_timing, trimmed_bytes)| {
             batch_metrics
                 .step_stats

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -316,6 +316,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::batch::ENCODING_COMPRESSION_FORMAT)
         .add(&crate::batch::RECORD_RUN_META)
         .add(&crate::batch::STRUCTURED_ORDER)
+        .add(&crate::batch::STRUCTURED_ORDER_UNTIL_SHARD)
         .add(&crate::batch::STRUCTURED_KEY_LOWER_LEN)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL_STAGGER)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL)

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -487,7 +487,7 @@ where
             };
 
             let res = Compactor::<K, V, T, D>::compact(
-                CompactConfig::new(&cfg, &writer_id),
+                CompactConfig::new(&cfg, shard_id),
                 Arc::clone(&blob),
                 Arc::clone(&metrics),
                 Arc::clone(&machine.applier.shard_metrics),
@@ -735,7 +735,6 @@ pub async fn dangerous_force_compaction_and_break_pushdown<K, V, T, D>(
             let res = Compactor::<K, V, T, D>::compact_and_apply(
                 &mut machine,
                 req,
-                write.writer_id.clone(),
                 write.write_schemas.clone(),
             )
             .await;

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -952,7 +952,7 @@ mod tests {
         let mut b1 = write.expect_batch(&data[..2], 0, 3).await;
         let mut b2 = write.expect_batch(&data[2..], 2, 5).await;
         if backpressure_would_flush {
-            let cfg = BatchBuilderConfig::new(&client.cfg, &write.writer_id, false);
+            let cfg = BatchBuilderConfig::new(&client.cfg, shard_id, false);
             b1.flush_to_blob(
                 &cfg,
                 &client.metrics.user,

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -145,7 +145,6 @@ where
             Compactor::new(
                 cfg.clone(),
                 Arc::clone(&metrics),
-                writer_id.clone(),
                 write_schemas.clone(),
                 gc.clone(),
             )
@@ -538,7 +537,7 @@ where
                     assert_eq!(received_inline_backpressure, false);
                     received_inline_backpressure = true;
 
-                    let cfg = BatchBuilderConfig::new(&self.cfg, &self.writer_id, false);
+                    let cfg = BatchBuilderConfig::new(&self.cfg, self.shard_id(), false);
                     // We could have a large number of inline parts (imagine the
                     // sharded persist_sink), do this flushing concurrently.
                     let flush_batches = batches
@@ -609,7 +608,7 @@ where
     /// O(MB) come talk to us.
     pub fn builder(&mut self, lower: Antichain<T>) -> BatchBuilder<K, V, T, D> {
         let builder = BatchBuilderInternal::new(
-            BatchBuilderConfig::new(&self.cfg, &self.writer_id, false),
+            BatchBuilderConfig::new(&self.cfg, self.shard_id(), false),
             Arc::clone(&self.metrics),
             self.write_schemas.clone(),
             Arc::clone(&self.machine.applier.shard_metrics),

--- a/src/persist-client/tests/machine/empty_since
+++ b/src/persist-client/tests/machine/empty_since
@@ -75,7 +75,7 @@ compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 v10 [3]
 
-compact output=b0_1 inputs=(b0,b1) lower=0 upper=2 since=0  writer_id=w11111111-1111-1111-1111-111111111111
+compact output=b0_1 inputs=(b0,b1) lower=0 upper=2 since=0
 ----
 parts=1 len=2
 

--- a/src/persist-client/tests/machine/gc
+++ b/src/persist-client/tests/machine/gc
@@ -108,7 +108,7 @@ write-rollup output=v6_last_b0_b1_reference
 state=v6 diffs=[v4, v7)
 
 # compact and merge b0 and b1 into b0_1
-compact output=b0_1 inputs=(b0,b1) lower=0 upper=2 since=0 writer_id=w11111111-1111-1111-1111-111111111111
+compact output=b0_1 inputs=(b0,b1) lower=0 upper=2 since=0
 ----
 parts=1 len=3
 

--- a/src/persist-client/tests/machine/regression_listen_compaction
+++ b/src/persist-client/tests/machine/regression_listen_compaction
@@ -39,7 +39,7 @@ compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 v5 [3]
 
-compact output=b0_1 inputs=(b0,b1)  lower=0 upper=3 since=0 writer_id=w11111111-1111-1111-1111-111111111111
+compact output=b0_1 inputs=(b0,b1)  lower=0 upper=3 since=0
 ----
 parts=1 len=2
 


### PR DESCRIPTION
- Add a metric for the number of parts written in each ordering.
- Add a flag for rolling out structured ordering shard-by-shard... might not need it but also it might be useful.
    - Also removes the `writer_id` argument, which is long unused. (Probably should have been a separate commit...)

### Motivation

Useful for the rollout of: https://github.com/MaterializeInc/database-issues/issues/7411

### Tips for reviewer

Deployed to staging, and checked that the metrics show up and that changing the system var changes the ratio of codec-ordering to structured-ordering at write time.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
