### PR TITLE
storage/copy-to-s3: Upload a 'UPLOAD-START' file in all uploads

### DIFF
--- a/src/storage-operators/src/s3_oneshot_sink/parquet.rs
+++ b/src/storage-operators/src/s3_oneshot_sink/parquet.rs
@@ -212,11 +212,6 @@ impl CopyToS3Uploader for ParquetUploader {
         }
         Ok(())
     }
-
-    async fn force_new_file(&mut self) -> Result<(), anyhow::Error> {
-        self.start_new_file().await?;
-        Ok(())
-    }
 }
 
 impl ParquetUploader {

--- a/src/storage-operators/src/s3_oneshot_sink/pgcopy.rs
+++ b/src/storage-operators/src/s3_oneshot_sink/pgcopy.rs
@@ -119,10 +119,6 @@ impl CopyToS3Uploader for PgCopyUploader {
             Err(e) => Err(e.into()),
         }
     }
-
-    async fn force_new_file(&mut self) -> Result<(), anyhow::Error> {
-        self.start_new_file_upload().await
-    }
 }
 
 impl PgCopyUploader {

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -89,6 +89,7 @@ pub async fn run_verify_data(
                 actual_body.lines().map(|l| l.to_string()).collect()
             }
             key if key.ends_with(".parquet") => rows_from_parquet(bytes),
+            key if key.ends_with("UPLOAD-START") => continue,
             key => bail!("unexpected file type: {key}"),
         };
         rows.extend(new_rows);

--- a/test/testdrive/copy-to-s3-minio.td
+++ b/test/testdrive/copy-to-s3-minio.td
@@ -175,9 +175,7 @@ $ s3-verify-data bucket=copytos3 key=test/2 sort-rows=true
 1
 2
 
-# The double `a` here is a result of the header being written once per file.
 $ s3-verify-data bucket=copytos3 key=test/2_5 sort-rows=true
-a
 a
 1
 
@@ -189,7 +187,7 @@ array;int4;jsonb;timestamp
 {1,2};83647;`{"s":"ab``c"}`;2010-10-10 10:10:10
 
 # Ensure that at least one file is written even when the input is empty.
-$ s3-verify-keys bucket=copytos3 prefix-path=test/5 key-pattern=^test/5/mz.*\.csv$
+$ s3-verify-keys bucket=copytos3 prefix-path=test/5 key-pattern=^test/5/mz.*UPLOAD-START
 
 # Copy a large amount of data in the background and check to see that the INCOMPLETE
 # sentinel object is written during the copy
@@ -243,7 +241,7 @@ $ s3-verify-data bucket=copytos3 key=parquet_test/3 sort-rows=true
 {items: [1, 2], dimensions: 1} {items: [1, 2, , 4], dimensions: 2} false inf {"s":"abc"} 85907cb9ac9b4e3584b860dc69368aca 1 32767 2147483647 9223372036854775807 1234567890123456789012.4567890123456789 2010-10-10 10:10:10 2010-10-10T10:10:10 2010-10-10T08:10:10Z aaaa 5c7841414141 това е d182d0b5d0bad181d182
 
 # Ensure that at least one file is written even when the input is empty.
-$ s3-verify-keys bucket=copytos3 prefix-path=parquet_test/4 key-pattern=^parquet_test/4/mz.*\.parquet$
+$ s3-verify-keys bucket=copytos3 prefix-path=parquet_test/4 key-pattern=^parquet_test/4/mz.*UPLOAD-START
 
 # Confirm that unimplemented types will early exit before writing to s3
 ! COPY (SELECT '0 day'::interval)  TO 's3://copytos3/parquet_test/5'


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/8634 and replaces https://github.com/MaterializeInc/materialize/pull/29895

That previous PR makes an assumption that batch 0 will always be assigned to worker 0, which is not explicitly guaranteed. To avoid that problem entirely, this simply implements a new upload of a default-empty file at the start of each upload that will be left in the path after the upload is complete. It is separate from the files containing data from the upload.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
