### PR TITLE
ct: triage all currently remaining TODO(ct)s in compute

### DIFF
--- a/src/compute-types/src/sinks.rs
+++ b/src/compute-types/src/sinks.rs
@@ -119,9 +119,10 @@ pub enum ComputeSinkConnection<S: 'static = ()> {
     Subscribe(SubscribeSinkConnection),
     /// TODO(database-issues#7533): Add documentation.
     Persist(PersistSinkConnection<S>),
-    /// TODO(database-issues#7533): Add documentation.
+    /// ContinualTask-specific information necessary for rendering a
+    /// ContinualTask sink.
     ///
-    /// TODO(ct): This also writes to persist, but with different behavior
+    /// TODO(ct2): This also writes to persist, but with different behavior
     /// (conflict resolution, only at input times, etc). It might be time to
     /// rename PersistSink to something that reflects the differences.
     ContinualTask(ContinualTaskConnection<S>),
@@ -257,15 +258,16 @@ impl RustType<ProtoPersistSinkConnection> for PersistSinkConnection<CollectionMe
     }
 }
 
-/// TODO(ct): Add documentation.
+/// ContinualTask-specific information necessary for rendering a ContinualTask
+/// sink. (Shared-sink information is instead stored on ComputeSinkConnection.)
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ContinualTaskConnection<S> {
-    /// TODO(database-issues#7533): Add documentation.
+    /// The id of the (for now) single input to this CT.
     //
-    // TODO(ct): This can be removed once we render the "input" sources without
+    // TODO(ct3): This can be removed once we render the "input" sources without
     // the hack.
     pub input_id: GlobalId,
-    /// TODO(ct): Add documentation.
+    /// The necessary storage information for writing to the output collection.
     pub storage_metadata: S,
 }
 

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -206,7 +206,7 @@ pub fn build_compute_dataflow<A: Allocate>(
     let build_name = format!("BuildRegion: {}", &dataflow.debug_name);
 
     timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, scope| {
-        // TODO(ct): This should be a config of the source instead, but at least try
+        // TODO(ct3): This should be a config of the source instead, but at least try
         // to contain the hacks.
         let mut ct_ctx = ContinualTaskCtx::new(&dataflow);
 
@@ -276,8 +276,8 @@ pub fn build_compute_dataflow<A: Allocate>(
                                 ok_stream.as_collection(),
                                 err_stream.as_collection(),
                             );
-                            // TODO(ct): Ideally this would be encapsulated by ContinualTaskCtx, but
-                            // the types are tricky.
+                            // TODO(ct3): Ideally this would be encapsulated by
+                            // ContinualTaskCtx, but the types are tricky.
                             ct_ctx.ct_times.push(ct_times.leave_region().leave_region());
                             (oks.inner, errs.inner)
                         }

--- a/src/compute/src/render/continual_task.rs
+++ b/src/compute/src/render/continual_task.rs
@@ -170,8 +170,8 @@ impl<G: Scope<Timestamp = Timestamp>> ContinualTaskCtx<G> {
                 let name = source_id.to_string();
                 // Keep only the inserts.
                 //
-                // TODO(ct): At some point this will become a user option to instead
-                // keep only deletes.
+                // At some point this will become a user option to instead keep
+                // only deletes.
                 let oks = oks.inner.filter(|(_, _, diff)| *diff > 0);
                 // Grab the original times for use in the sink operator.
                 let times = oks.map(|(_row, ts, diff)| ((), ts, diff));
@@ -261,7 +261,7 @@ where
         let sink_write_frontier = Rc::new(RefCell::new(Antichain::from_elem(Timestamp::minimum())));
         collection.sink_write_frontier = Some(Rc::clone(&sink_write_frontier));
 
-        // TODO(ct): Obey `compute_state.read_only_rx`
+        // TODO(ct1): Obey `compute_state.read_only_rx`
         //
         // Seemingly, the read-only env needs to tail the output shard and keep
         // historical updates around until it sees that the output frontier
@@ -291,7 +291,7 @@ fn continual_task_sink<G: Scope<Timestamp = Timestamp>>(
     let scope = to_append.scope();
     let mut op = AsyncOperatorBuilder::new(format!("ct_sink({})", name), scope.clone());
 
-    // TODO(ct): This all works perfectly well data parallel (assuming we
+    // TODO(ct2): This all works perfectly well data parallel (assuming we
     // broadcast the append_times). We just need to hook it up to the
     // multi-worker persist-sink, but that requires some refactoring. This would
     // also remove the need for this to be an async timely operator.
@@ -456,8 +456,6 @@ impl<D: Ord> SinkState<D, Timestamp> {
     }
 
     /// Returns data to write to the output, if any, and the new upper to use.
-    ///
-    /// TODO(ct): Remove the Vec allocation here.
     fn process(&mut self) -> Option<(Antichain<Timestamp>, Vec<((&D, &()), &Timestamp, &Diff)>)> {
         // We can only append at times >= the output_progress, so pop off
         // anything unnecessary.
@@ -511,7 +509,7 @@ impl<D: Ord> SinkState<D, Timestamp> {
         for ((_, t), _) in self.to_append.iter_mut() {
             t.advance_by(AntichainRef::new(as_of))
         }
-        // TODO(ct): Metrics for vec len and cap.
+        // TODO(ct2): Metrics for vec len and cap.
         self.to_append.consolidate();
 
         let append_data = self
@@ -523,7 +521,7 @@ impl<D: Ord> SinkState<D, Timestamp> {
     }
 }
 
-// TODO(ct): Write this as a non-async operator.
+// TODO(ct2): Write this as a non-async operator.
 //
 // Unfortunately, we can _almost_ use the stock `delay` operator, but not quite.
 // This must advance both data and the output frontier forward, while delay only
@@ -569,7 +567,7 @@ where
     output_stream.as_collection()
 }
 
-// TODO(ct): Write this as a non-async operator.
+// TODO(ct2): Write this as a non-async operator.
 fn step_forward<G, D, R>(name: &str, input: Collection<G, D, R>) -> Collection<G, D, R>
 where
     G: Scope<Timestamp = Timestamp>,

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -178,7 +178,7 @@ where
         start_signal: StartSignal,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
-        // TODO(ct): Figure out a better way to smuggle this in, potentially by
+        // TODO(ct2): Figure out a better way to smuggle this in, potentially by
         // removing the `SinkRender` trait entirely.
         ct_times: Option<Collection<G, (), Diff>>,
     ) -> Option<Rc<dyn Any>>;


### PR DESCRIPTION
The numbers correspond to which [milestone] that they need to be fixed by.

[milestone]: https://github.com/MaterializeInc/database-issues/issues/8427

Touches MaterializeInc/database-issues#8427

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

The priority here is finding if there are any M1 items left, would love a second set of eyes on this in particular. Some of the M2 vs M3 decisions feel like they could go either way, definitely open to feedback. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
