### PR TITLE
storage/adapter: Introduce 'REFRESH SOURCE REFERENCES' statement for refreshing upstream available references

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -357,6 +357,8 @@ pub enum ExecuteResponse {
     Prepare,
     /// A user-requested warning was raised.
     Raised,
+    /// The requested object was refreshed.
+    Refreshed,
     /// The requested objects were reassigned.
     ReassignOwned,
     /// The requested privilege was revoked.
@@ -502,6 +504,7 @@ impl TryInto<ExecuteResponse> for ExecuteResponseKind {
             ExecuteResponseKind::Inserted => Err(()),
             ExecuteResponseKind::Prepare => Ok(ExecuteResponse::Prepare),
             ExecuteResponseKind::Raised => Ok(ExecuteResponse::Raised),
+            ExecuteResponseKind::Refreshed => Ok(ExecuteResponse::Refreshed),
             ExecuteResponseKind::ReassignOwned => Ok(ExecuteResponse::ReassignOwned),
             ExecuteResponseKind::RevokedPrivilege => Ok(ExecuteResponse::RevokedPrivilege),
             ExecuteResponseKind::RevokedRole => Ok(ExecuteResponse::RevokedRole),
@@ -573,6 +576,7 @@ impl ExecuteResponse {
             }
             Prepare => Some("PREPARE".into()),
             Raised => Some("RAISE".into()),
+            Refreshed => Some("REFRESH".into()),
             ReassignOwned => Some("REASSIGN OWNED".into()),
             RevokedPrivilege => Some("REVOKE".into()),
             RevokedRole => Some("REVOKE ROLE".into()),
@@ -666,6 +670,8 @@ impl ExecuteResponse {
             Insert => &[Inserted, SendingRowsImmediate],
             PlanKind::Prepare => &[ExecuteResponseKind::Prepare],
             PlanKind::Raise => &[ExecuteResponseKind::Raised],
+            PlanKind::RefreshSourceReferencesPlan
+            | PlanKind::RefreshSourceReferencesPlanWrapper => &[ExecuteResponseKind::Refreshed],
             PlanKind::ReassignOwned => &[ExecuteResponseKind::ReassignOwned],
             RevokePrivileges => &[RevokedPrivilege],
             RevokeRole => &[RevokedRole],

--- a/src/adapter/src/coord/catalog_serving.rs
+++ b/src/adapter/src/coord/catalog_serving.rs
@@ -135,6 +135,8 @@ pub fn auto_run_on_catalog_server<'a, 's, 'p>(
         | Plan::Execute(_)
         | Plan::Deallocate(_)
         | Plan::Raise(_)
+        | Plan::RefreshSourceReferencesPlan(_)
+        | Plan::RefreshSourceReferencesPlanWrapper(_)
         | Plan::GrantRole(_)
         | Plan::RevokeRole(_)
         | Plan::GrantPrivileges(_)

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -687,6 +687,7 @@ impl Coordinator {
                     | Statement::ReassignOwned(_)
                     | Statement::RevokePrivileges(_)
                     | Statement::RevokeRole(_)
+                    | Statement::RefreshSourceReferences(_)
                     | Statement::Update(_)
                     | Statement::ValidateConnection(_)
                     | Statement::Comment(_) => {
@@ -1012,6 +1013,7 @@ impl Coordinator {
                 | Statement::AlterSource(_)
                 | Statement::CreateSink(_)
                 | Statement::CreateTableFromSource(_)
+                | Statement::RefreshSourceReferences(_)
         ) {
             return false;
         }

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -531,6 +531,15 @@ impl Coordinator {
                 )
                 .await
             }
+            PurifiedStatement::PurifiedRefreshSourceReferences {
+                stmt,
+                available_source_references,
+            } => self.plan_purified_refresh_source_references(
+                ctx.session(),
+                stmt,
+                &params,
+                available_source_references,
+            ),
             o @ (PurifiedStatement::PurifiedAlterSource { .. }
             | PurifiedStatement::PurifiedCreateSink(..)
             | PurifiedStatement::PurifiedCreateTableFromSource { .. }) => {
@@ -544,7 +553,8 @@ impl Coordinator {
                     }
                     PurifiedStatement::PurifiedCreateSink(stmt) => Statement::CreateSink(stmt),
                     PurifiedStatement::PurifiedCreateSource { .. }
-                    | PurifiedStatement::PurifiedAlterSourceAddSubsources { .. } => {
+                    | PurifiedStatement::PurifiedAlterSourceAddSubsources { .. }
+                    | PurifiedStatement::PurifiedRefreshSourceReferences { .. } => {
                         unreachable!("not part of exterior match stmt")
                     }
                 };

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -571,6 +571,15 @@ impl Coordinator {
                         .add_notice(AdapterNotice::UserRequested { severity });
                     ctx.retire(Ok(ExecuteResponse::Raised));
                 }
+                Plan::RefreshSourceReferencesPlan(_) => {
+                    ctx.retire(Ok(ExecuteResponse::Refreshed));
+                }
+                Plan::RefreshSourceReferencesPlanWrapper(plan) => {
+                    let result = self
+                        .sequence_refresh_source_references(ctx.session_mut(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
                 Plan::GrantPrivileges(plan) => {
                     let result = self
                         .sequence_grant_privileges(ctx.session_mut(), plan)

--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -222,6 +222,7 @@ impl From<&ExecuteResponse> for StatementEndedExecutionReason {
             | ExecuteResponse::Inserted(_)
             | ExecuteResponse::Prepare
             | ExecuteResponse::Raised
+            | ExecuteResponse::Refreshed
             | ExecuteResponse::ReassignOwned
             | ExecuteResponse::RevokedPrivilege
             | ExecuteResponse::RevokedRole

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -1236,6 +1236,7 @@ async fn execute_stmt<S: ResultSender>(
         | ExecuteResponse::Inserted(_)
         | ExecuteResponse::Copied(_)
         | ExecuteResponse::Raised
+        | ExecuteResponse::Refreshed
         | ExecuteResponse::ReassignOwned
         | ExecuteResponse::RevokedPrivilege
         | ExecuteResponse::AlteredDefaultPrivileges

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1759,6 +1759,7 @@ where
             | ExecuteResponse::Copied(..)
             | ExecuteResponse::Prepare
             | ExecuteResponse::Raised
+            | ExecuteResponse::Refreshed
             | ExecuteResponse::ReassignOwned
             | ExecuteResponse::RevokedPrivilege
             | ExecuteResponse::RevokedRole

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -102,6 +102,7 @@ pub enum Statement<T: AstInfo> {
     Execute(ExecuteStatement<T>),
     Deallocate(DeallocateStatement),
     Raise(RaiseStatement),
+    RefreshSourceReferences(RefreshSourceReferencesStatement<T>),
     GrantRole(GrantRoleStatement<T>),
     RevokeRole(RevokeRoleStatement<T>),
     GrantPrivileges(GrantPrivilegesStatement<T>),
@@ -176,6 +177,7 @@ impl<T: AstInfo> AstDisplay for Statement<T> {
             Statement::Execute(stmt) => f.write_node(stmt),
             Statement::Deallocate(stmt) => f.write_node(stmt),
             Statement::Raise(stmt) => f.write_node(stmt),
+            Statement::RefreshSourceReferences(stmt) => f.write_node(stmt),
             Statement::GrantRole(stmt) => f.write_node(stmt),
             Statement::RevokeRole(stmt) => f.write_node(stmt),
             Statement::GrantPrivileges(stmt) => f.write_node(stmt),
@@ -253,6 +255,7 @@ pub fn statement_kind_label_value(kind: StatementKind) -> &'static str {
         StatementKind::Execute => "execute",
         StatementKind::Deallocate => "deallocate",
         StatementKind::Raise => "raise",
+        StatementKind::RefreshSourceReferences => "refresh_source_references",
         StatementKind::GrantRole => "grant_role",
         StatementKind::RevokeRole => "revoke_role",
         StatementKind::GrantPrivileges => "grant_privileges",
@@ -1188,6 +1191,20 @@ impl<T: AstInfo> AstDisplay for CreateSubsourceStatement<T> {
     }
 }
 impl_display_t!(CreateSubsourceStatement);
+
+/// REFRESH SOURCE REFERENCES
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RefreshSourceReferencesStatement<T: AstInfo> {
+    pub source: T::ItemName,
+}
+
+impl<T: AstInfo> AstDisplay for RefreshSourceReferencesStatement<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str("REFRESH SOURCE REFERENCES ");
+        f.write_node(&self.source);
+    }
+}
+impl_display_t!(RefreshSourceReferencesStatement);
 
 /// An option in a `CREATE SINK` statement.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -194,6 +194,8 @@ pub enum Plan {
     Execute(ExecutePlan),
     Deallocate(DeallocatePlan),
     Raise(RaisePlan),
+    RefreshSourceReferencesPlan(RefreshSourceReferencesPlan),
+    RefreshSourceReferencesPlanWrapper(RefreshSourceReferencesPlanWrapper),
     GrantRole(GrantRolePlan),
     RevokeRole(RevokeRolePlan),
     GrantPrivileges(GrantPrivilegesPlan),
@@ -289,6 +291,7 @@ impl Plan {
             StatementKind::Insert => &[PlanKind::Insert],
             StatementKind::Prepare => &[PlanKind::Prepare],
             StatementKind::Raise => &[PlanKind::Raise],
+            StatementKind::RefreshSourceReferences => &[PlanKind::RefreshSourceReferencesPlan],
             StatementKind::ReassignOwned => &[PlanKind::ReassignOwned],
             StatementKind::ResetVariable => &[PlanKind::ResetVariable],
             StatementKind::RevokePrivileges => &[PlanKind::RevokePrivileges],
@@ -441,6 +444,9 @@ impl Plan {
             Plan::Execute(_) => "execute",
             Plan::Deallocate(_) => "deallocate",
             Plan::Raise(_) => "raise",
+            Plan::RefreshSourceReferencesPlan(_) | Plan::RefreshSourceReferencesPlanWrapper(_) => {
+                "refresh source references"
+            }
             Plan::GrantRole(_) => "grant role",
             Plan::RevokeRole(_) => "revoke role",
             Plan::GrantPrivileges(_) => "grant privilege",
@@ -668,6 +674,17 @@ pub struct CreateConnectionPlan {
     pub if_not_exists: bool,
     pub connection: Connection,
     pub validate: bool,
+}
+
+#[derive(Debug)]
+pub struct RefreshSourceReferencesPlan {
+    pub source_id: GlobalId,
+}
+
+#[derive(Debug)]
+pub struct RefreshSourceReferencesPlanWrapper {
+    pub plan: RefreshSourceReferencesPlan,
+    pub available_source_references: SourceReferences,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -44,6 +44,7 @@ mod acl;
 pub(crate) mod ddl;
 mod dml;
 mod raise;
+mod refresh;
 mod scl;
 pub(crate) mod show;
 mod tcl;
@@ -239,6 +240,9 @@ pub fn describe(
 
         // Other statements.
         Statement::Raise(stmt) => raise::describe_raise(&scx, stmt)?,
+        Statement::RefreshSourceReferences(stmt) => {
+            refresh::describe_refresh_source_references(&scx, stmt)?
+        }
         Statement::Show(ShowStatement::InspectShard(stmt)) => {
             scl::describe_inspect_shard(&scx, stmt)?
         }
@@ -414,6 +418,9 @@ pub fn plan(
 
         // Other statements.
         Statement::Raise(stmt) => raise::plan_raise(scx, stmt),
+        Statement::RefreshSourceReferences(stmt) => {
+            refresh::plan_refresh_source_references(scx, stmt)
+        }
         Statement::Show(ShowStatement::InspectShard(stmt)) => scl::plan_inspect_shard(scx, stmt),
         Statement::ValidateConnection(stmt) => validate::plan_validate_connection(scx, stmt),
     };
@@ -1110,6 +1117,7 @@ impl<T: mz_sql_parser::ast::AstInfo> From<&Statement<T>> for StatementClassifica
 
             // Other statements.
             Statement::Raise(_) => Other,
+            Statement::RefreshSourceReferences(_) => Other,
             Statement::Show(ShowStatement::InspectShard(_)) => Other,
             Statement::ValidateConnection(_) => Other,
         }

--- a/src/sql/src/plan/statement/refresh.rs
+++ b/src/sql/src/plan/statement/refresh.rs
@@ -1,0 +1,47 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Queries that REFRESH catalog objects.
+
+use crate::ast::RefreshSourceReferencesStatement;
+use crate::names::Aug;
+use crate::plan::statement::{StatementContext, StatementDesc};
+use crate::plan::{Plan, PlanError, RefreshSourceReferencesPlan};
+use crate::session::vars;
+
+pub fn describe_refresh_source_references(
+    _: &StatementContext,
+    _: RefreshSourceReferencesStatement<Aug>,
+) -> Result<StatementDesc, PlanError> {
+    Ok(StatementDesc::new(None))
+}
+
+pub fn plan_refresh_source_references(
+    scx: &StatementContext,
+    stmt: RefreshSourceReferencesStatement<Aug>,
+) -> Result<Plan, PlanError> {
+    scx.require_feature_flag(&vars::ENABLE_CREATE_TABLE_FROM_SOURCE)?;
+    let source_item = scx.get_item_by_resolved_name(&stmt.source)?;
+
+    // Validate the target of the refresh statement.
+    match source_item.source_desc() {
+        Ok(_) => Ok(Plan::RefreshSourceReferencesPlan(
+            RefreshSourceReferencesPlan {
+                source_id: source_item.id(),
+            },
+        )),
+        Err(_) => {
+            sql_bail!(
+                "{} '{}' is not a source",
+                source_item.item_type(),
+                stmt.source.full_name_str()
+            );
+        }
+    }
+}

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -29,7 +29,7 @@ use crate::names::{
     CommentObjectId, ObjectId, QualifiedItemName, ResolvedDatabaseSpecifier, ResolvedIds,
     SystemObjectId,
 };
-use crate::plan::{self, PlanKind};
+use crate::plan::{self, PlanKind, RefreshSourceReferencesPlan};
 use crate::plan::{
     DataSourceDesc, Explainee, MutationKind, Plan, SideEffectingFunc, UpdatePrivilege,
 };
@@ -1415,6 +1415,15 @@ fn generate_rbac_requirements(
                 ..Default::default()
             }
         }
+        Plan::RefreshSourceReferencesPlan(plan::RefreshSourceReferencesPlan { source_id })
+        | Plan::RefreshSourceReferencesPlanWrapper(plan::RefreshSourceReferencesPlanWrapper {
+            plan: RefreshSourceReferencesPlan { source_id },
+            ..
+        }) => RbacRequirements {
+            ownership: vec![ObjectId::Item(*source_id)],
+            item_usage: &CREATE_ITEM_USAGE,
+            ..Default::default()
+        },
         Plan::DiscardTemp
         | Plan::DiscardAll
         | Plan::EmptyQuery

--- a/test/testdrive/source-tables.td
+++ b/test/testdrive/source-tables.td
@@ -292,11 +292,40 @@ var1 5678 <null>
 var0 5555 6666
 var1 4444 12
 
+# Validate that the available source references table reflects the state of the upstream
+# when the create source was run
+> SELECT u.name, u.namespace, u.columns
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_references u ON s.id = u.source_id
+  WHERE
+  s.name = 'mysql_source'
+  ORDER BY u.name;
+mysql_table public {a,b}
+
+# Create a new table in MySQL and refresh to see if the new available reference is picked up
+$ mysql-execute name=mysql
+USE public;
+CREATE TABLE mysql_table_new (foo INTEGER, bar INTEGER);
+
+> REFRESH SOURCE REFERENCES mysql_source;
+
+> SELECT u.name, u.namespace, u.columns
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_references u ON s.id = u.source_id
+  WHERE
+  s.name = 'mysql_source'
+  ORDER BY u.name;
+mysql_table public {a,b,c}
+mysql_table_new public {foo,bar}
+
 > DROP SOURCE mysql_source CASCADE;
 
 # ensure that CASCADE propagates to the tables
 ! SELECT * FROM mysql_table_3;
 contains:unknown catalog item 'mysql_table_3'
+
+> SELECT count(*) FROM mz_internal.mz_source_references;
+0
 
 # TODO(def-) Remove when database-issues#8515 and database-issues#8526 are fixed
 $ skip-end


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature: Fixes https://github.com/MaterializeInc/database-issues/issues/8633

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
