### PR TITLE
ct: fix bug in sink impl

### DIFF
--- a/test/sqllogictest/ct_liveness.slt
+++ b/test/sqllogictest/ct_liveness.slt
@@ -1,0 +1,167 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+# Start from a pristine state
+reset-server
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_create_continual_task = true
+----
+COMPLETE 0
+
+query T
+SHOW CLUSTER;
+----
+quickstart
+
+simple conn=mz_system,user=mz_system
+ALTER CLUSTER quickstart OWNER TO materialize
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE append_only (key INT, val STRING)
+
+statement ok
+CREATE CONTINUAL TASK upsert (key INT, val STRING) ON INPUT append_only AS (
+    DELETE FROM upsert WHERE key IN (SELECT key FROM append_only);
+    INSERT INTO upsert SELECT key, max(val) FROM append_only GROUP BY key;
+)
+
+statement ok
+INSERT INTO append_only VALUES (1, now()::STRING);
+
+query I
+SELECT COUNT(*) FROM upsert
+----
+1
+
+# The upsert CT and restarting the dataflow repeatedly turns out to be a great
+# way to shake out liveness issues without the full overhead of testdrive.
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 0);
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
+
+statement ok
+INSERT INTO append_only VALUES (1, now()::STRING);
+
+query I
+SELECT COUNT(*) FROM upsert
+----
+1
+
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 0);
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
+
+statement ok
+INSERT INTO append_only VALUES (1, now()::STRING);
+
+query I
+SELECT COUNT(*) FROM upsert
+----
+1
+
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 0);
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
+
+statement ok
+INSERT INTO append_only VALUES (1, now()::STRING);
+
+query I
+SELECT COUNT(*) FROM upsert
+----
+1
+
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 0);
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
+
+statement ok
+INSERT INTO append_only VALUES (1, now()::STRING);
+
+query I
+SELECT COUNT(*) FROM upsert
+----
+1
+
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 0);
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
+
+statement ok
+INSERT INTO append_only VALUES (1, now()::STRING);
+
+query I
+SELECT COUNT(*) FROM upsert
+----
+1
+
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 0);
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
+
+statement ok
+INSERT INTO append_only VALUES (1, now()::STRING);
+
+query I
+SELECT COUNT(*) FROM upsert
+----
+1
+
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 0);
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
+
+statement ok
+INSERT INTO append_only VALUES (1, now()::STRING);
+
+query I
+SELECT COUNT(*) FROM upsert
+----
+1
+
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 0);
+
+statement ok
+ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
+
+statement ok
+INSERT INTO append_only VALUES (1, now()::STRING);
+
+query I
+SELECT COUNT(*) FROM upsert
+----
+1


### PR DESCRIPTION
The `state.output_progress` field is meant to track the largest value
we've seen for the output shard's upper. This fixes two cases where this
was failing to happen (which was causing the hangs in my latest attempt
to get Dennis's initial tests passing):
- One if the write is before the current upper (received via pubsub from
  the `shared_upper` call immediately before the loop).
- Another if we got an expectation mismatch.

Touches MaterializeInc/database-issues#8427

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

The first two commits are the new tests added in #29745.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
