### PR TITLE
[persist] Structured testing update, round 2

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -111,7 +111,7 @@ def get_default_system_parameters(
         "persist_batch_columnar_format": (
             "both_v2" if version >= MzVersion.parse_mz("v0.112.0-dev") else "row"
         ),
-        "persist_batch_columnar_format_percent": "10",
+        "persist_batch_columnar_format_percent": "100",
         "persist_batch_delete_enabled": "true",
         "persist_batch_record_run_meta": (
             "true" if version >= MzVersion.parse_mz("v0.115.0-dev") else "false"

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -116,6 +116,12 @@ def get_default_system_parameters(
         "persist_batch_record_run_meta": (
             "true" if version >= MzVersion.parse_mz("v0.115.0-dev") else "false"
         ),
+        "persist_batch_structured_order": (
+            "true" if version >= MzVersion.parse_mz("v0.119.0-dev") else "false"
+        ),
+        "persist_batch_structured_key_lower_len": (
+            "256" if version >= MzVersion.parse_mz("v0.117.0-dev") else "0"
+        ),
         "persist_catalog_force_compaction_fuel": "1024",
         "persist_catalog_force_compaction_wait": "1s",
         "persist_fast_path_limit": "1000",

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1415,7 +1415,7 @@ pub mod datadriven {
 
     use crate::batch::{
         validate_truncate_batch, Batch, BatchBuilder, BatchBuilderConfig, BatchBuilderInternal,
-        BLOB_TARGET_SIZE,
+        BLOB_TARGET_SIZE, STRUCTURED_ORDER,
     };
     use crate::fetch::{Cursor, EncodedPart};
     use crate::internal::compact::{CompactConfig, CompactReq, Compactor};
@@ -1455,6 +1455,12 @@ pub mod datadriven {
             client
                 .cfg
                 .set_config(&BLOB_TARGET_SIZE, *BLOB_TARGET_SIZE.default());
+            // Our structured compaction code uses slightly different estimates
+            // for array size than the old path, which can affect the results of
+            // some compaction tests.
+            client
+                .cfg
+                .set_config(&STRUCTURED_ORDER, *STRUCTURED_ORDER.default());
             let state_versions = Arc::new(StateVersions::new(
                 client.cfg.clone(),
                 Arc::clone(&client.consensus),

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -116,6 +116,14 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                 },
                 {
                     let mut x = ::mz_dyncfg::ConfigUpdates::default();
+                    x.add_dynamic("persist_batch_columnar_format", ::mz_dyncfg::ConfigVal::String("both_v2".into()));
+                    x.add_dynamic("persist_batch_columnar_format_percent", ::mz_dyncfg::ConfigVal::Usize(100));
+                    x.add_dynamic("persist_batch_structured_key_lower_len", ::mz_dyncfg::ConfigVal::Usize(256));
+                    x.add_dynamic("persist_batch_structured_order", ::mz_dyncfg::ConfigVal::Bool(true));
+                    x
+                },
+                {
+                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
                     x.add_dynamic("persist_encoding_enable_dictionary", ::mz_dyncfg::ConfigVal::Bool(true));
                     x
                 }


### PR DESCRIPTION
## Motivation

Additional test coverage for https://github.com/MaterializeInc/database-issues/issues/7411.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
