### PR TITLE
adapter: Remove dead code

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -107,11 +107,6 @@ impl Coordinator {
                     .boxed_local()
                     .await
             }
-            Message::GroupCommitApply(timestamp, responses, write_lock_guard, permit) => {
-                self.group_commit_apply(timestamp, responses, write_lock_guard, permit)
-                    .boxed_local()
-                    .await;
-            }
             Message::AdvanceTimelines => {
                 self.advance_timelines().boxed_local().await;
             }
@@ -690,10 +685,7 @@ impl Coordinator {
                             .await;
                     }
                 }
-                Deferred::GroupCommit => {
-                    self.group_commit_initiate(Some(write_lock_guard), None)
-                        .await
-                }
+                Deferred::GroupCommit => self.group_commit(Some(write_lock_guard), None).await,
             }
         }
         // N.B. if no deferred plans, write lock is released by drop


### PR DESCRIPTION
### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
