### PR TITLE
adapter: Cleanup orphaned secrets in background

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2216,7 +2216,7 @@ impl Coordinator {
         // Cleanup orphaned secrets. Errors during list() or delete() do not
         // need to prevent bootstrap from succeeding; we will retry next
         // startup.
-        let secrets_cleanup_fut = {
+        {
             // Destructure Self so we can selectively move fields into the async
             // task.
             let Self {
@@ -2228,8 +2228,14 @@ impl Coordinator {
             let next_user_item_id = catalog.get_next_user_item_id().await?;
             let next_system_item_id = catalog.get_next_system_item_id().await?;
             let read_only = self.controller.read_only();
+            // Fetch all IDs from the catalog to future-proof against other
+            // things using secrets. Today, SECRET and CONNECTION objects use
+            // secrets_controller.ensure, but more things could in the future
+            // that would be easy to miss adding here.
+            let catalog_ids: BTreeSet<GlobalId> =
+                catalog.entries().map(|entry| entry.id()).collect();
 
-            async move {
+            spawn(|| "cleanup-orphaned-secrets", async move {
                 if read_only {
                     info!("coordinator init: not cleaning up orphaned secrets while in read-only mode");
                     return;
@@ -2238,12 +2244,6 @@ impl Coordinator {
 
                 match secrets_controller.list().await {
                     Ok(controller_secrets) => {
-                        // Fetch all IDs from the catalog to future-proof against other
-                        // things using secrets. Today, SECRET and CONNECTION objects use
-                        // secrets_controller.ensure, but more things could in the future
-                        // that would be easy to miss adding here.
-                        let catalog_ids: BTreeSet<GlobalId> =
-                            catalog.entries().map(|entry| entry.id()).collect();
                         let controller_secrets: BTreeSet<GlobalId> =
                             controller_secrets.into_iter().collect();
                         let orphaned = controller_secrets.difference(&catalog_ids);
@@ -2272,8 +2272,8 @@ impl Coordinator {
                     }
                     Err(e) => warn!("Failed to list secrets during orphan cleanup: {:?}", e),
                 }
-            }
-        };
+            });
+        }
         info!(
             "startup: coordinator init: bootstrap: generate secret cleanup complete in {:?}",
             cleanup_secrets_start.elapsed()
@@ -2282,15 +2282,11 @@ impl Coordinator {
         // Run all of our final steps concurrently.
         let final_steps_start = Instant::now();
         info!(
-            "startup: coordinator init: bootstrap: concurrently update builtin tables, migrate builtin tables, and cleanup secrets beginning"
+            "startup: coordinator init: bootstrap: concurrently update builtin tables and migrate builtin tables beginning"
         );
-        futures::future::join_all([
-            migrated_updates_fut,
-            builtin_updates_fut,
-            Box::pin(secrets_cleanup_fut),
-        ])
-        .instrument(info_span!("coord::bootstrap::final"))
-        .await;
+        futures::future::join_all([migrated_updates_fut, builtin_updates_fut])
+            .instrument(info_span!("coord::bootstrap::final"))
+            .await;
 
         debug!("startup: coordinator init: bootstrap: announcing completion of initialization to controller");
         // Announce the completion of initialization.
@@ -2300,7 +2296,7 @@ impl Coordinator {
         self.bootstrap_introspection_subscribes().await;
 
         info!(
-            "startup: coordinator init: bootstrap: concurrently update builtin tables, migrate builtin tables, and cleanup secrets complete in {:?}", final_steps_start.elapsed()
+            "startup: coordinator init: bootstrap: concurrently update builtin tables and migrate builtin tables complete in {:?}", final_steps_start.elapsed()
         );
 
         info!(

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2234,6 +2234,7 @@ impl Coordinator {
             // that would be easy to miss adding here.
             let catalog_ids: BTreeSet<GlobalId> =
                 catalog.entries().map(|entry| entry.id()).collect();
+            let secrets_controller = Arc::clone(secrets_controller);
 
             spawn(|| "cleanup-orphaned-secrets", async move {
                 if read_only {


### PR DESCRIPTION
Previously, the adapter would block on cleaning up orphaned secrets during startup. This was unnecessary, so this commit moves the secret cleanup into the background.

Works towards resolving #MaterializeInc/database-issues/issues/8384


### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
