### PR TITLE
adapter: Optimize table bootstrapping

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2330,13 +2330,15 @@ impl Coordinator {
             .filter(|entry| entry.is_table())
             .map(|entry| (entry.id(), Vec::new()))
             .collect();
-        self.controller
+        // Append the tables in the background. We apply the write timestamp before getting a read
+        // timestamp and reading a snapshot of each table, so the snapshots will block on their own
+        // until the appends are complete.
+        let table_fence_rx = self
+            .controller
             .storage
             .append_table(write_ts.clone(), advance_to, appends)
-            .expect("invalid updates")
-            .await
-            .expect("One-shot shouldn't be dropped during bootstrap")
-            .unwrap_or_terminate("cannot fail to append");
+            .expect("invalid updates");
+
         self.apply_local_write(write_ts).await;
 
         // Add builtin table updates the clear the contents of all system tables
@@ -2387,6 +2389,12 @@ impl Coordinator {
             let retractions = retractions.expect("cannot fail to fetch snapshot");
             builtin_table_updates.extend(retractions);
         }
+
+        // Now that the snapshots are complete, the appends must also be complete.
+        table_fence_rx
+            .await
+            .expect("One-shot shouldn't be dropped during bootstrap")
+            .unwrap_or_terminate("cannot fail to append");
 
         debug!("coordinator init: sending builtin table updates");
         let builtin_updates_fut = self


### PR DESCRIPTION
This commit has a small optimization for `bootstrap_tables` that appends to tables and interacts with the timestamp oracle concurrently.

Works towards resolving #MaterializeInc/database-issues/issues/8384

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
