### PR TITLE
adapter: Update builtin tables in background

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2194,17 +2194,15 @@ impl Coordinator {
 
         let builtin_update_start = Instant::now();
         info!("startup: coordinator init: bootstrap: generate builtin updates beginning");
-        let builtin_updates_fut = if self.controller.read_only() {
+        if self.controller.read_only() {
             info!("coordinator init: bootstrap: stashing builtin table updates while in read-only mode");
 
             self.buffered_builtin_table_updates
                 .as_mut()
                 .expect("in read-only mode")
                 .append(&mut builtin_table_updates);
-
-            futures::future::ready(()).boxed()
         } else {
-            self.bootstrap_tables(&entries, builtin_table_updates).await
+            self.bootstrap_tables(&entries, builtin_table_updates).await;
         };
         info!(
             "startup: coordinator init: bootstrap: generate builtin updates complete in {:?}",
@@ -2283,9 +2281,9 @@ impl Coordinator {
         // Run all of our final steps concurrently.
         let final_steps_start = Instant::now();
         info!(
-            "startup: coordinator init: bootstrap: concurrently update builtin tables and migrate builtin tables beginning"
+            "startup: coordinator init: bootstrap: migrate builtin tables in read-only mode beginning"
         );
-        futures::future::join_all([migrated_updates_fut, builtin_updates_fut])
+        migrated_updates_fut
             .instrument(info_span!("coord::bootstrap::final"))
             .await;
 
@@ -2297,7 +2295,7 @@ impl Coordinator {
         self.bootstrap_introspection_subscribes().await;
 
         info!(
-            "startup: coordinator init: bootstrap: concurrently update builtin tables and migrate builtin tables complete in {:?}", final_steps_start.elapsed()
+            "startup: coordinator init: bootstrap: migrate builtin tables in read-only mode complete in {:?}", final_steps_start.elapsed()
         );
 
         info!(
@@ -2308,14 +2306,16 @@ impl Coordinator {
     }
 
     /// Prepares tables for writing by resetting them to a known state and
-    /// appending the given builtin table updates.
+    /// appending the given builtin table updates. The timestamp oracle
+    /// will be advanced to the write timestamp of the append when this
+    /// method returns.
     #[allow(clippy::async_yields_async)]
     #[instrument]
     async fn bootstrap_tables(
         &mut self,
         entries: &[CatalogEntry],
         mut builtin_table_updates: Vec<BuiltinTableUpdate>,
-    ) -> BuiltinTableAppendNotify {
+    ) {
         // Advance all tables to the current timestamp
         debug!("coordinator init: advancing all tables to current timestamp");
         let WriteTimestamp {
@@ -2394,11 +2394,13 @@ impl Coordinator {
             .unwrap_or_terminate("cannot fail to append");
 
         debug!("coordinator init: sending builtin table updates");
-        let builtin_updates_fut = self
+        let (_builtin_updates_fut, write_ts) = self
             .builtin_table_update()
             .execute(builtin_table_updates)
             .await;
-        builtin_updates_fut
+        if let Some(write_ts) = write_ts {
+            self.apply_local_write(write_ts).await;
+        }
     }
 
     /// Initializes all storage collections required by catalog objects in the storage controller.

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -588,7 +588,7 @@ impl Coordinator {
 
         // Append our builtin table updates, then return the notify so we can run other tasks in
         // parallel.
-        let builtin_update_notify = self
+        let (builtin_update_notify, _) = self
             .builtin_table_update()
             .execute(builtin_table_updates)
             .await;

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -323,7 +323,7 @@ impl Coordinator {
 
     #[mz_ore::instrument(level = "debug")]
     async fn storage_usage_prune(&mut self, expired: Vec<BuiltinTableUpdate>) {
-        let fut = self.builtin_table_update().execute(expired).await;
+        let (fut, _) = self.builtin_table_update().execute(expired).await;
         task::spawn(|| "storage_usage_pruning_apply", async move {
             fut.await;
         });
@@ -685,7 +685,9 @@ impl Coordinator {
                             .await;
                     }
                 }
-                Deferred::GroupCommit => self.group_commit(Some(write_lock_guard), None).await,
+                Deferred::GroupCommit => {
+                    self.group_commit(Some(write_lock_guard), None).await;
+                }
             }
         }
         // N.B. if no deferred plans, write lock is released by drop
@@ -800,6 +802,7 @@ impl Coordinator {
             self.builtin_table_update()
                 .execute(builtin_table_updates)
                 .await
+                .0
                 .instrument(info_span!("coord::message_cluster_event::table_updates"))
                 .await;
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4631,7 +4631,8 @@ impl Coordinator {
             Some(
                 self.builtin_table_update()
                     .execute(builtin_table_updates)
-                    .await,
+                    .await
+                    .0,
             )
         } else {
             // Save the metainfo.

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -263,7 +263,7 @@ impl Coordinator {
                     .with_label_values(&[session_type])
                     .inc();
 
-                self.builtin_table_update().execute(vec![update]).await
+                self.builtin_table_update().execute(vec![update]).await.0
             }
             ActiveComputeSink::CopyTo(_) => {
                 self.metrics


### PR DESCRIPTION
Previously, the adapter would block startup waiting for all updates to
builtin tables to complete. This commit moves this process to the
background and does not block waiting for the writes to complete.

However, we do block on applying the write timestamp with the timestamp
oracle. So anyone in Strict Serializable mode will have to wait until
the writes are complete to read the builtin tables. If someone is in
Serializable mode, they may be able to view the table in a state from
the previous version. This is technically correct, though maybe
slightly undesirable.

Works towards resolving #database-issues/issues/8384

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
