### PR TITLE
tests: Upgrade psycopg3 version

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -37,8 +37,8 @@ pdoc==14.6.0
 pg8000 @ git+https://github.com/benesch/pg8000@0e7d1fbe02bd47958f9cf0cf132d6d08fbcca18e
 prettytable==3.11.0
 psutil==5.9.4
-psycopg==3.1.12
-psycopg-binary==3.1.12
+psycopg==3.2.3
+psycopg-binary==3.2.3
 pydantic==2.7.1
 pyelftools==0.29
 pyjwt==2.8.0

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -137,7 +137,7 @@ steps:
         inputs:
           - "*"
         depends_on: []
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         agents:
           queue: hetzner-aarch64-4cpu-8gb
         coverage: skip

--- a/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
+++ b/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
@@ -74,6 +74,7 @@ class DatabaseConnector:
                 sslmode="require",
                 connect_timeout=timeout_in_seconds,
                 application_name=self.config.application_name,
+                options="-c tcp_keepalives_idle=30 -c tcp_keepalives_interval=10 -c tcp_keepalives_count=5",
             )
         except Exception:
             print(

--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -483,7 +483,7 @@ def workflow_balancerd_restarted(c: Composition) -> None:
     except OperationalError as e:
         msg = str(e)
         assert (
-            "consuming input failed: EOF detected" in msg
+            "EOF detected" in msg
             or "failed to lookup address information: Name or service not known" in msg
         )
     except:


### PR DESCRIPTION
To get `https://github.com/psycopg/psycopg/pull/670`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
