### PR TITLE
Do the nullability tweaking in `EquivalenceClasses::minimize` only once

### DIFF
--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -714,6 +714,10 @@ impl MirScalarExpr {
     /// long as this information continues to hold (nullability may not hold
     /// as expressions migrate around).
     ///
+    /// (If you'd like to not use nullability information here, then you can
+    /// tweak the nullabilities in `column_types` before passing it to this
+    /// function, see e.g. in `EquivalenceClasses::minimize`.)
+    ///
     /// Also performs partial canonicalization on the expression.
     ///
     /// ```rust
@@ -1472,19 +1476,6 @@ impl MirScalarExpr {
         }
 
         /* #endregion */
-    }
-
-    /// Reduces a complex expression where possible.
-    ///
-    /// This function is like `reduce` except that it does not rely on nullability
-    /// information present in `column_types`, and it should only apply reductions
-    /// that are safe in all contexts.
-    pub fn reduce_safely(&mut self, column_types: &[ColumnType]) {
-        let mut column_types = column_types.to_vec();
-        for column in column_types.iter_mut() {
-            column.nullable = true;
-        }
-        self.reduce(&column_types[..])
     }
 
     /// Decompose an IsNull expression into a disjunction of


### PR DESCRIPTION
In incident-217, PolarSignals showed that making the local copies in `reduce_safely` accounts for 80+% of CPU time during the optimizer hang. This PR pulls that out to the beginning of `minimize`, so that we do it only once per `minimize`, instead of once per `minimize_once` _and per class_. There were thousands of classes in the incident, so this reduces this overhead by several orders of magnitudes. On the ["smaller repro"](https://docs.google.com/document/d/10GuKeUcmK-LIRWc4EEro7jZHz5v1z-MwhQOB4PXOzK8/edit?usp=sharing), this results in a ~2x speedup end-to-end in debug mode on my laptop.

I wrote two versions. The one in the PR is slightly more complex, but it also incorporates the optimization from @antiguru, that we don't allocate a new Vec if everything is already nullable. This doesn't give a measurable speedup on the "smaller repro" from the incident, but it might make a difference in other scenarios. The simpler version is [here](https://github.com/ggevay/materialize/commit/01dcdfa4452d723bbf5995e73febe43119271e2b) for comparison. I'm fine with merging either version.

Edit: Changed to the simpler version, see below.

### Motivation

   * This PR refactors existing code to make the optimizer faster.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
