### PR TITLE
output consistency: fix ambiguous row index

### DIFF
--- a/misc/python/materialize/output_consistency/data_value/data_column.py
+++ b/misc/python/materialize/output_consistency/data_value/data_column.py
@@ -31,11 +31,17 @@ class DataColumn(LeafExpression):
 
     def __init__(self, data_type: DataType, row_values_of_column: list[DataValue]):
         column_name = f"{data_type.internal_identifier.lower()}_val"
+        # data_source will be assigned later
         super().__init__(
-            column_name, data_type, set(), ValueStorageLayout.VERTICAL, False, False
+            column_name,
+            data_type,
+            set(),
+            ValueStorageLayout.VERTICAL,
+            data_source=None,
+            is_aggregate=False,
+            is_expect_error=False,
         )
         self.values = row_values_of_column
-        self.data_source: DataSource | None = None
 
     def assign_data_source(self, data_source: DataSource, force: bool) -> None:
         if self.data_source is not None:

--- a/misc/python/materialize/output_consistency/data_value/data_value.py
+++ b/misc/python/materialize/output_consistency/data_value/data_value.py
@@ -47,8 +47,9 @@ class DataValue(LeafExpression):
             data_type,
             characteristics,
             ValueStorageLayout.HORIZONTAL,
-            False,
-            False,
+            data_source=DataSource(table_index=None),
+            is_aggregate=False,
+            is_expect_error=False,
         )
         self.value = value
         self.vertical_table_indices: set[int] = set()
@@ -71,9 +72,6 @@ class DataValue(LeafExpression):
 
     def collect_vertical_table_indices(self) -> set[int]:
         return self.vertical_table_indices
-
-    def get_data_source(self) -> DataSource | None:
-        return DataSource(table_index=None)
 
     def get_source_column_identifier(self) -> SourceColumnIdentifier:
         source_column_identifier = super().get_source_column_identifier()

--- a/misc/python/materialize/output_consistency/expression/constant_expression.py
+++ b/misc/python/materialize/output_consistency/expression/constant_expression.py
@@ -45,8 +45,9 @@ class ConstantExpression(LeafExpression):
             data_type,
             characteristics,
             ValueStorageLayout.ANY,
-            is_aggregate,
-            False,
+            data_source=None,
+            is_aggregate=is_aggregate,
+            is_expect_error=False,
         )
         self.value = value
         self.add_quotes = add_quotes

--- a/misc/python/materialize/output_consistency/expression/expression.py
+++ b/misc/python/materialize/output_consistency/expression/expression.py
@@ -194,16 +194,21 @@ class LeafExpression(Expression):
     def to_sql(
         self, sql_adjuster: SqlDialectAdjuster, include_alias: bool, is_root_level: bool
     ) -> str:
-        return self.to_sql_as_column(sql_adjuster, include_alias)
+        return self.to_sql_as_column(
+            sql_adjuster, include_alias, self.column_name, self.get_data_source()
+        )
 
     def to_sql_as_column(
-        self, sql_adjuster: SqlDialectAdjuster, include_alias: bool
+        self,
+        sql_adjuster: SqlDialectAdjuster,
+        include_alias: bool,
+        column_name: str,
+        data_source: DataSource | None,
     ) -> str:
         if include_alias:
-            data_source = self.get_data_source()
             assert data_source is not None, "data source is None"
-            return f"{data_source.alias()}.{self.column_name}"
-        return self.column_name
+            return f"{data_source.alias()}.{column_name}"
+        return column_name
 
     def collect_leaves(self) -> list[LeafExpression]:
         return [self]

--- a/misc/python/materialize/output_consistency/expression/expression.py
+++ b/misc/python/materialize/output_consistency/expression/expression.py
@@ -175,12 +175,14 @@ class LeafExpression(Expression):
         data_type: DataType,
         characteristics: set[ExpressionCharacteristics],
         storage_layout: ValueStorageLayout,
+        data_source: DataSource | None,
         is_aggregate: bool = False,
         is_expect_error: bool = False,
     ):
         super().__init__(characteristics, storage_layout, is_aggregate, is_expect_error)
         self.column_name = column_name
         self.data_type = data_type
+        self.data_source = data_source
 
     def hash(self) -> int:
         return stable_int_hash(self.column_name)
@@ -226,7 +228,7 @@ class LeafExpression(Expression):
         return self.own_characteristics
 
     def get_data_source(self) -> DataSource | None:
-        raise NotImplementedError
+        return self.data_source
 
     def get_source_column_identifier(self) -> SourceColumnIdentifier | None:
         data_source = self.get_data_source()

--- a/misc/python/materialize/output_consistency/expression/row_indices_expression.py
+++ b/misc/python/materialize/output_consistency/expression/row_indices_expression.py
@@ -1,0 +1,94 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from __future__ import annotations
+
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.execution.sql_dialect_adjuster import (
+    SqlDialectAdjuster,
+)
+from materialize.output_consistency.execution.value_storage_layout import (
+    ROW_INDEX_COL_NAME,
+    ValueStorageLayout,
+)
+from materialize.output_consistency.expression.expression import (
+    Expression,
+    LeafExpression,
+)
+from materialize.output_consistency.input_data.types.array_type_provider import (
+    ArrayDataType,
+)
+from materialize.output_consistency.operation.return_type_spec import ReturnTypeSpec
+from materialize.output_consistency.query.data_source import DataSource
+
+_INT_ARRAY_TYPE = ArrayDataType(
+    "INT_ARRAY",
+    type_name="INT[]",
+    array_entry_value_1="1",
+    array_entry_value_2="2",
+    value_type_category=DataTypeCategory.NUMERIC,
+)
+
+
+class RowIndicesExpression(LeafExpression):
+
+    def __init__(self, expression_to_share_data_source: Expression):
+        # data source will be derived dynamically
+        super().__init__(
+            column_name="<row_indices>",
+            data_type=_INT_ARRAY_TYPE,
+            characteristics=set(),
+            storage_layout=ValueStorageLayout.ANY,
+            data_source=None,
+        )
+        self.expression_to_share_data_source = expression_to_share_data_source
+
+    def resolve_return_type_spec(self) -> ReturnTypeSpec:
+        return self.data_type.resolve_return_type_spec(self.own_characteristics)
+
+    def resolve_return_type_category(self) -> DataTypeCategory:
+        return self.data_type.category
+
+    def get_data_source(self) -> DataSource | None:
+        data_sources = self.expression_to_share_data_source.collect_data_sources()
+
+        if len(data_sources) == 0:
+            # this happens when the expression is a constant
+            return None
+
+        # we can only return one data source here but that does not really matter because we only reuse already used
+        # data sources
+        return data_sources[0]
+
+    def to_sql(
+        self, sql_adjuster: SqlDialectAdjuster, include_alias: bool, is_root_level: bool
+    ) -> str:
+        data_sources = self.expression_to_share_data_source.collect_data_sources()
+
+        if len(data_sources) == 0:
+            # We won't use row_index in this case but a constant instead to avoid a potentially ambiguous column
+            # reference
+            return "0"
+
+        expressions = []
+        for data_source in data_sources:
+            expressions.append(
+                super().to_sql_as_column(
+                    sql_adjuster, include_alias, ROW_INDEX_COL_NAME, data_source
+                )
+            )
+
+        array_elements = ",".join(expressions)
+        return f"ARRAY[{array_elements}]::INT[]"
+
+    def collect_vertical_table_indices(self) -> set[int]:
+        # not relevant because this is already handled by the column sharing the data source
+        return set()
+
+    def __str__(self) -> str:
+        return f"RowIndicesExpression (expression_to_share_data_source={self.expression_to_share_data_source})"

--- a/misc/python/materialize/output_consistency/generators/expression_generator.py
+++ b/misc/python/materialize/output_consistency/generators/expression_generator.py
@@ -30,8 +30,14 @@ from materialize.output_consistency.expression.expression import (
 from materialize.output_consistency.expression.expression_with_args import (
     ExpressionWithArgs,
 )
+from materialize.output_consistency.expression.row_indices_expression import (
+    RowIndicesExpression,
+)
 from materialize.output_consistency.input_data.operations.equality_operations_provider import (
     EQUALS_OPERATION,
+)
+from materialize.output_consistency.input_data.params.row_indices_param import (
+    RowIndicesParam,
 )
 from materialize.output_consistency.input_data.params.same_operation_param import (
     SameOperationParam,
@@ -342,6 +348,12 @@ class ExpressionGenerator:
             expression_to_use = arg_context.args[param.index_of_previous_param]
             expression_to_use.recursively_mark_as_shared()
             return expression_to_use
+
+        if isinstance(param, RowIndicesParam):
+            expression_to_share_data_source = arg_context.args[
+                param.index_of_param_to_share_data_source
+            ]
+            return RowIndicesExpression(expression_to_share_data_source)
 
         create_complex_arg = (
             arg_context.requires_aggregation()

--- a/misc/python/materialize/output_consistency/input_data/operations/aggregate_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/aggregate_operations_provider.py
@@ -16,6 +16,9 @@ from materialize.output_consistency.input_data.params.boolean_operation_param im
 from materialize.output_consistency.input_data.params.number_operation_param import (
     NumericOperationParam,
 )
+from materialize.output_consistency.input_data.params.row_indices_param import (
+    RowIndicesParam,
+)
 from materialize.output_consistency.input_data.params.same_operation_param import (
     SameOperationParam,
 )
@@ -148,11 +151,12 @@ AGGREGATE_OPERATION_TYPES.append(
 AGGREGATE_OPERATION_TYPES.append(
     DbFunctionWithCustomPattern(
         "string_agg",
-        {3: "string_agg($, $ ORDER BY row_index, $)"},
+        {4: "string_agg($, $ ORDER BY $, $)"},
         [
             StringOperationParam(),
             # separator value
             StringOperationParam(),
+            RowIndicesParam(index_of_param_to_share_data_source=0),
             SameOperationParam(index_of_previous_param=0),
         ],
         StringReturnTypeSpec(),

--- a/misc/python/materialize/output_consistency/input_data/operations/aggregate_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/aggregate_operations_provider.py
@@ -151,12 +151,13 @@ AGGREGATE_OPERATION_TYPES.append(
 AGGREGATE_OPERATION_TYPES.append(
     DbFunctionWithCustomPattern(
         "string_agg",
-        {4: "string_agg($, $ ORDER BY $, $)"},
+        {5: "string_agg($, $ ORDER BY $, $, $)"},
         [
             StringOperationParam(),
             # separator value
             StringOperationParam(),
             RowIndicesParam(index_of_param_to_share_data_source=0),
+            RowIndicesParam(index_of_param_to_share_data_source=1),
             SameOperationParam(index_of_previous_param=0),
         ],
         StringReturnTypeSpec(),

--- a/misc/python/materialize/output_consistency/input_data/operations/array_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/array_operations_provider.py
@@ -27,6 +27,9 @@ from materialize.output_consistency.input_data.params.enum_constant_operation_pa
 from materialize.output_consistency.input_data.params.number_operation_param import (
     NumericOperationParam,
 )
+from materialize.output_consistency.input_data.params.row_indices_param import (
+    RowIndicesParam,
+)
 from materialize.output_consistency.input_data.params.same_operation_param import (
     SameOperationParam,
 )
@@ -172,8 +175,12 @@ ARRAY_OPERATION_TYPES.append(
 ARRAY_OPERATION_TYPES.append(
     DbFunctionWithCustomPattern(
         "array_agg",
-        {2: "array_agg($ ORDER BY row_index, $)"},
-        [AnyOperationParam(), SameOperationParam(index_of_previous_param=0)],
+        {3: "array_agg($ ORDER BY $, $)"},
+        [
+            AnyOperationParam(),
+            RowIndicesParam(index_of_param_to_share_data_source=0),
+            SameOperationParam(index_of_previous_param=0),
+        ],
         ArrayReturnTypeSpec(array_value_type_category=DataTypeCategory.DYNAMIC),
         is_aggregation=True,
     ),

--- a/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
@@ -31,6 +31,9 @@ from materialize.output_consistency.input_data.params.number_operation_param imp
 from materialize.output_consistency.input_data.params.record_operation_param import (
     RecordOperationParam,
 )
+from materialize.output_consistency.input_data.params.row_indices_param import (
+    RowIndicesParam,
+)
 from materialize.output_consistency.input_data.params.same_operation_param import (
     SameOperationParam,
 )
@@ -181,9 +184,10 @@ JSONB_OPERATION_TYPES.append(
 JSONB_OPERATION_TYPES.append(
     DbFunctionWithCustomPattern(
         "jsonb_agg",
-        {2: "jsonb_agg($ ORDER BY row_index, $)"},
+        {3: "jsonb_agg($ ORDER BY $, $)"},
         [
             AnyOperationParam(include_record_type=False),
+            RowIndicesParam(index_of_param_to_share_data_source=0),
             SameOperationParam(index_of_previous_param=0),
         ],
         JsonbReturnTypeSpec(),
@@ -197,8 +201,12 @@ JSONB_OPERATION_TYPES.append(
 JSONB_OPERATION_TYPES.append(
     DbFunctionWithCustomPattern(
         "jsonb_agg",
-        {2: "jsonb_agg($ ORDER BY row_index, $)"},
-        [RecordOperationParam(), SameOperationParam(index_of_previous_param=0)],
+        {3: "jsonb_agg($ ORDER BY $, $)"},
+        [
+            RecordOperationParam(),
+            RowIndicesParam(index_of_param_to_share_data_source=0),
+            SameOperationParam(index_of_previous_param=0),
+        ],
         JsonbReturnTypeSpec(),
         is_aggregation=True,
         tags={TAG_JSONB_AGGREGATION},
@@ -209,12 +217,13 @@ JSONB_OPERATION_TYPES.append(
 JSONB_OPERATION_TYPES.append(
     DbFunctionWithCustomPattern(
         "jsonb_object_agg",
-        {4: "jsonb_object_agg($, $ ORDER BY row_index, $, $)"},
+        {5: "jsonb_object_agg($, $ ORDER BY $, $, $)"},
         [
             # key
             AnyOperationParam(),
             # value
             AnyOperationParam(include_record_type=False),
+            RowIndicesParam(index_of_param_to_share_data_source=0),
             SameOperationParam(index_of_previous_param=0),
             SameOperationParam(index_of_previous_param=1),
         ],
@@ -229,12 +238,13 @@ JSONB_OPERATION_TYPES.append(
 JSONB_OPERATION_TYPES.append(
     DbFunctionWithCustomPattern(
         "jsonb_object_agg",
-        {3: "jsonb_object_agg($, $ ORDER BY row_index, $)"},
+        {4: "jsonb_object_agg($, $ ORDER BY $, $)"},
         [
             # key
             AnyOperationParam(),
             # value
             RecordOperationParam(),
+            RowIndicesParam(index_of_param_to_share_data_source=0),
             SameOperationParam(index_of_previous_param=0),
         ],
         JsonbReturnTypeSpec(),

--- a/misc/python/materialize/output_consistency/input_data/operations/list_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/list_operations_provider.py
@@ -22,6 +22,9 @@ from materialize.output_consistency.input_data.params.list_operation_param impor
     ListOfOtherElementOperationParam,
     ListOperationParam,
 )
+from materialize.output_consistency.input_data.params.row_indices_param import (
+    RowIndicesParam,
+)
 from materialize.output_consistency.input_data.params.same_operation_param import (
     SameOperationParam,
 )
@@ -99,10 +102,11 @@ LIST_OPERATION_TYPES.append(
     DbFunctionWithCustomPattern(
         "list_agg",
         {
-            2: "list_agg($ ORDER BY row_index, $)",
+            3: "list_agg($ ORDER BY $, $)",
         },
         [
             AnyOperationParam(include_record_type=True),
+            RowIndicesParam(index_of_param_to_share_data_source=0),
             SameOperationParam(index_of_previous_param=0),
         ],
         ListReturnTypeSpec(),

--- a/misc/python/materialize/output_consistency/input_data/operations/map_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/map_operations_provider.py
@@ -24,6 +24,9 @@ from materialize.output_consistency.input_data.params.map_operation_param import
 from materialize.output_consistency.input_data.params.record_operation_param import (
     RecordOperationParam,
 )
+from materialize.output_consistency.input_data.params.row_indices_param import (
+    RowIndicesParam,
+)
 from materialize.output_consistency.input_data.params.same_operation_param import (
     SameOperationParam,
 )
@@ -112,12 +115,13 @@ MAP_OPERATION_TYPES.append(
 MAP_OPERATION_TYPES.append(
     DbFunctionWithCustomPattern(
         "map_agg",
-        {3: "map_agg($, $ ORDER BY row_index, $)"},
+        {4: "map_agg($, $ ORDER BY $, $)"},
         [
             # key
             StringOperationParam(only_type_text=True),
             # value
             AnyOperationParam(),
+            RowIndicesParam(index_of_param_to_share_data_source=0),
             # order within aggregated values
             SameOperationParam(index_of_previous_param=1),
         ],

--- a/misc/python/materialize/output_consistency/input_data/params/row_indices_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/row_indices_param.py
@@ -1,0 +1,37 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.data_type.data_type import DataType
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.expression.expression import Expression
+from materialize.output_consistency.operation.operation_param import OperationParam
+
+
+class RowIndicesParam(OperationParam):
+    """
+    This is mostly used to support sorting in aggregation functions (e.g., "string_agg($, $ ORDER BY $, $)").
+    While sorting should ideally happen by the actual expression, sorting behavior differs between mz and Postgres
+    so that including the row_index stabilizes results.
+    """
+
+    def __init__(
+        self,
+        index_of_param_to_share_data_source: int,
+        optional: bool = False,
+    ):
+        super().__init__(
+            DataTypeCategory.ANY,
+            optional,
+        )
+        self.index_of_param_to_share_data_source = index_of_param_to_share_data_source
+
+    def supports_type(
+        self, data_type: DataType, previous_args: list[Expression]
+    ) -> bool:
+        return False

--- a/misc/python/materialize/postgres_consistency/custom/predefined_pg_queries.py
+++ b/misc/python/materialize/postgres_consistency/custom/predefined_pg_queries.py
@@ -55,11 +55,14 @@ def create_custom_pg_consistency_queries() -> list[QueryTemplate]:
 
 
 def create_pg_timezone_abbrevs_query() -> QueryTemplate:
-    abbrev_col_expr = _create_simple_leaf_expression("abbrev", TEXT_DATA_TYPE)
+    data_source = DataSource(custom_db_object_name="pg_catalog.pg_timezone_abbrevs")
+    abbrev_col_expr = _create_simple_leaf_expression(
+        "abbrev", TEXT_DATA_TYPE, data_source
+    )
     pg_timezone_abbrevs_cols: list[Expression] = [
         abbrev_col_expr,
-        _create_simple_leaf_expression("utc_offset", INTERVAL_TYPE),
-        _create_simple_leaf_expression("is_dst", BOOLEAN_DATA_TYPE),
+        _create_simple_leaf_expression("utc_offset", INTERVAL_TYPE, data_source),
+        _create_simple_leaf_expression("is_dst", BOOLEAN_DATA_TYPE, data_source),
     ]
     pg_timezone_abbrevs = QueryTemplate(
         expect_error=False,
@@ -68,7 +71,7 @@ def create_pg_timezone_abbrevs_query() -> QueryTemplate:
         storage_layout=ValueStorageLayout.VERTICAL,
         contains_aggregations=False,
         row_selection=ALL_ROWS_SELECTION,
-        data_source=DataSource(custom_db_object_name="pg_catalog.pg_timezone_abbrevs"),
+        data_source=data_source,
         custom_order_expressions=[abbrev_col_expr],
     )
 
@@ -76,15 +79,18 @@ def create_pg_timezone_abbrevs_query() -> QueryTemplate:
 
 
 def create_pg_timezone_names_query() -> QueryTemplate:
-    pg_timezone_name_col_expr = _create_simple_leaf_expression("name", TEXT_DATA_TYPE)
+    data_source = DataSource(custom_db_object_name="pg_catalog.pg_timezone_names")
+    pg_timezone_name_col_expr = _create_simple_leaf_expression(
+        "name", TEXT_DATA_TYPE, data_source
+    )
     pg_timezone_abbrev_col_expr = _create_simple_leaf_expression(
-        "abbrev", TEXT_DATA_TYPE
+        "abbrev", TEXT_DATA_TYPE, data_source
     )
     pg_timezone_names_cols: list[Expression] = [
         pg_timezone_name_col_expr,
         pg_timezone_abbrev_col_expr,
-        _create_simple_leaf_expression("utc_offset", INTERVAL_TYPE),
-        _create_simple_leaf_expression("is_dst", BOOLEAN_DATA_TYPE),
+        _create_simple_leaf_expression("utc_offset", INTERVAL_TYPE, data_source),
+        _create_simple_leaf_expression("is_dst", BOOLEAN_DATA_TYPE, data_source),
     ]
 
     no_posix_timezones = ExpressionWithArgs(
@@ -182,7 +188,7 @@ def create_pg_timezone_names_query() -> QueryTemplate:
         storage_layout=ValueStorageLayout.VERTICAL,
         contains_aggregations=False,
         row_selection=ALL_ROWS_SELECTION,
-        data_source=DataSource(custom_db_object_name="pg_catalog.pg_timezone_names"),
+        data_source=data_source,
         custom_order_expressions=[
             order_by_sanitized_name_expr,
             pg_timezone_abbrev_col_expr,
@@ -193,11 +199,12 @@ def create_pg_timezone_names_query() -> QueryTemplate:
 
 
 def _create_simple_leaf_expression(
-    column_name: str, data_type: DataType
+    column_name: str, data_type: DataType, data_source: DataSource
 ) -> LeafExpression:
     return LeafExpression(
         column_name=column_name,
         data_type=data_type,
+        data_source=data_source,
         characteristics=set(),
         storage_layout=ValueStorageLayout.VERTICAL,
     )


### PR DESCRIPTION
Fix framework issue `column reference "row_index" is ambiguous` in generated queries:

```
SELECT
  array_agg(s0.bpchar_8_val ORDER BY row_index, s0.bpchar_8_val)
FROM
  <source>_vert_0 s0
FULL OUTER JOIN <source>_vert_3 s3
  ON TRUE::BOOL
WHERE (s0.row_index IN (7, 9));
```