### PR TITLE
adapter: Don't panic if number of connections is greater than our limit

### DIFF
--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -45,10 +45,11 @@ impl SystemParameterBackend {
     pub async fn push(&mut self, params: &mut SynchronizedParameters) {
         for param in params.modified() {
             let mut vars = BTreeMap::new();
+            info!(name = param.name, value = param.value, "updating parameter");
             vars.insert(param.name.clone(), param.value.clone());
             match self.session_client.set_system_vars(vars).await {
                 Ok(()) => {
-                    info!(name = param.name, value = param.value, "sync parameter");
+                    info!(name = param.name, value = param.value, "update success");
                 }
                 Err(error) => match error {
                     AdapterError::ReadOnly => {


### PR DESCRIPTION
Observed this with a user. When changing their `max_connection` limit there seems to have been a brief period where we got a value that was less than their current number of connections which caused a panic.

I'm not exactly sure what values caused the panic because we didn't log it, but I'm guessing we got the default for a moment before the updated value came through.

### Motivation

Fix an issue with max connections, context [Sentry](https://materializeinc.sentry.io/issues/5979946058/events/ff772de8c8b34c3bb11b240b93745222/?project=6780145).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
