### PR TITLE
coverage: Adapt file paths to bazel

### DIFF
--- a/misc/python/materialize/cli/ci_coverage_pr_report.py
+++ b/misc/python/materialize/cli/ci_coverage_pr_report.py
@@ -25,7 +25,12 @@ from materialize import MZ_ROOT, buildkite, ci_util
 # - Negative values indicate that the line has only been covered in unit tests.
 Coverage = dict[str, OrderedDict[int, int | None]]
 SOURCE_RE = re.compile(
-    "^/var/lib/buildkite-agent/builds/buildkite-.*/materialize/coverage/(.*$)"
+    r"""
+    ( src/(.*$)"
+    | bazel-out/.*/bin/(.*$)
+    | external/(.*$)
+    )""",
+    re.VERBOSE,
 )
 # * Deriving generates more code, but we don't expect to cover this in most
 # cases, so ignore such lines.
@@ -44,7 +49,7 @@ IGNORE_SRC_LINE_RE = re.compile(
 
 IGNORE_FILE_PATH_RE = re.compile(
     r"""
-    (  /maelstrom/
+    ( /maelstrom/
     )
     """,
     re.VERBOSE,


### PR DESCRIPTION
This should address

```
  File "/var/lib/buildkite-agent/builds/hetzner-aarch64-16cpu-32gb-7bbedb06/materialize/coverage/misc/python/materialize/cli/ci_coverage_pr_report.py", line 99, in mark_covered_lines
    assert result, f"Unexpected file {content}"
           ^^^^^^
AssertionError: Unexpected file bazel-out/aarch64-opt/bin/external/crates_io__chrono-tz-0.8.1/_bs.out_dir/timezones.rs
```

observed in https://buildkite.com/materialize/coverage/builds/445#019277ed-7c4d-4f2c-901a-527f73039a73.

### Coverage builds
https://buildkite.com/materialize/coverage/builds?branch=nrainer-materialize%3Acoverage%2Ffix-computation