### PR TITLE
parallel-benchmark: Store data in SQLite for long runs

### DIFF
--- a/ci/qa-canary/pipeline.template.yml
+++ b/ci/qa-canary/pipeline.template.yml
@@ -46,10 +46,11 @@ steps:
     concurrency: 1
     concurrency_group: 'parallel-benchmark-canary'
     agents:
-      queue: linux-aarch64
+      queue: linux-aarch64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: parallel-benchmark
           args:
             - --benchmarking-env
             - --scenario=StagingBench
+            - --sqlite-store

--- a/misc/python/materialize/parallel_benchmark/framework.py
+++ b/misc/python/materialize/parallel_benchmark/framework.py
@@ -9,6 +9,7 @@
 
 import queue
 import random
+import sqlite3
 import threading
 import time
 from collections import defaultdict
@@ -20,6 +21,11 @@ import psycopg
 
 from materialize.mzcompose.composition import Composition
 from materialize.util import PgConnInfo
+
+DB_FILE = "parallel-benchmark.db"
+assert (
+    sqlite3.threadsafety == 3
+), f"Thread safety level 3 (serialized) required, but is: {sqlite3.threadsafety}"
 
 
 class Measurement:
@@ -34,9 +40,89 @@ class Measurement:
         return f"{self.timestamp} {self.duration}"
 
 
+class MeasurementsStore:
+    def add(self, action: str, measurement: Measurement) -> None:
+        raise NotImplementedError
+
+    def actions(self) -> list[str]:
+        raise NotImplementedError
+
+    def close(self) -> None:
+        raise NotImplementedError
+
+
+class MemoryStore(MeasurementsStore):
+    def __init__(self):
+        self.data: defaultdict[str, list[Measurement]] = defaultdict(list)
+
+    def add(self, action: str, measurement: Measurement) -> None:
+        self.data[action].append(measurement)
+
+    def actions(self) -> list[str]:
+        return list(self.data.keys())
+
+    def close(self) -> None:
+        pass
+
+
+class SQLiteStore(MeasurementsStore):
+    def __init__(self, scenario: str):
+        self.scenario = scenario
+        self.lock = threading.Lock()
+        self.conn = sqlite3.connect(
+            DB_FILE, check_same_thread=False, isolation_level=None
+        )
+        cursor = self.conn.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL;")
+        cursor.execute("PRAGMA synchronous=OFF;")
+        cursor.execute("PRAGMA cache_size=-64000;")  # 64 MB
+        cursor.execute("PRAGMA locking_mode=EXCLUSIVE;")
+        self.conn.commit()
+        cursor.execute(
+            "CREATE TABLE IF NOT EXISTS measurements (scenario TEXT NOT NULL, action TEXT NOT NULL, duration FLOAT NOT NULL, timestamp FLOAT NOT NULL);"
+        )
+        cursor.execute("DELETE FROM measurements WHERE scenario = ?", (self.scenario,))
+        cursor.close()
+
+    def add(self, action: str, measurement: Measurement) -> None:
+        with self.lock:
+            cursor = self.conn.cursor()
+            try:
+                cursor.execute(
+                    "INSERT INTO measurements VALUES (?, ?, ?, ?)",
+                    (
+                        self.scenario,
+                        action,
+                        measurement.duration,
+                        measurement.timestamp,
+                    ),
+                )
+            except Exception as e:
+                print(
+                    f"Caught exception {str(e)} with values: {self.scenario}, {action}, {measurement.duration}, {measurement.timestamp}"
+                )
+                raise
+            cursor.close()
+
+    def actions(self) -> list[str]:
+        with self.lock:
+            cursor = self.conn.cursor()
+            cursor.execute(
+                "SELECT DISTINCT action FROM measurements WHERE scenario = ?",
+                (self.scenario,),
+            )
+            result = [row[0] for row in cursor.fetchall()]
+            cursor.close()
+        return result
+
+    def close(self) -> None:
+        with self.lock:
+            self.conn.close()
+
+
 @dataclass
 class State:
-    measurements: defaultdict[str, list[Measurement]]
+    measurements: MeasurementsStore
     load_phase_duration: int | None
     periodic_dists: dict[str, int]
 
@@ -68,7 +154,7 @@ class Action:
     ):
         self._run(conns)
         duration = time.time() - start_time
-        state.measurements[str(self)].append(Measurement(duration, start_time))
+        state.measurements.add(str(self), Measurement(duration, start_time))
 
     def _run(self, conns: queue.Queue):
         raise NotImplementedError
@@ -145,7 +231,13 @@ class PooledQuery(Action):
     def _run(self, conns: queue.Queue):
         conn = conns.get()
         with conn.cursor() as cur:
-            execute_query(cur, self.query)
+            try:
+                execute_query(cur, self.query)
+            except psycopg.OperationalError as e:
+                print(f"Connection failed on query '{self.query}', reconnecting: {e}")
+                conn.close()
+                conn = self.conn_info.connect()
+                conn.autocommit = True
         conns.task_done()
         conns.put(conn)
 

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -15,7 +15,6 @@ actions concurrently, measures various kinds of statistics.
 import gc
 import os
 import time
-from collections import defaultdict
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -44,9 +43,12 @@ from materialize.mzcompose.test_result import (
     TestFailureDetails,
 )
 from materialize.parallel_benchmark.framework import (
+    DB_FILE,
     LoadPhase,
-    Measurement,
+    MeasurementsStore,
+    MemoryStore,
     Scenario,
+    SQLiteStore,
     State,
 )
 from materialize.parallel_benchmark.scenarios import *  # noqa: F401 F403
@@ -105,24 +107,70 @@ SERVICES = [
 
 
 class Statistics:
-    def __init__(self, times: list[float], durations: list[float]):
-        assert len(times) == len(durations)
-        self.queries: int = len(times)
-        self.qps: float = len(times) / max(times)
-        self.max: float = max(durations)
-        self.min: float = min(durations)
-        self.avg: float = float(numpy.mean(durations))
-        self.p50: float = float(numpy.median(durations))
-        self.p95: float = float(numpy.percentile(durations, 95))
-        self.p99: float = float(numpy.percentile(durations, 99))
-        self.p99_9: float = float(numpy.percentile(durations, 99.9))
-        self.p99_99: float = float(numpy.percentile(durations, 99.99))
-        self.p99_999: float = float(numpy.percentile(durations, 99.999))
-        self.p99_9999: float = float(numpy.percentile(durations, 99.9999))
-        self.p99_99999: float = float(numpy.percentile(durations, 99.99999))
-        self.p99_999999: float = float(numpy.percentile(durations, 99.999999))
-        self.std: float = float(numpy.std(durations, ddof=1))
-        self.slope: float = float(numpy.polyfit(times, durations, 1)[0])
+    def __init__(self, action: str, m: MeasurementsStore, start_time: float):
+        if isinstance(m, MemoryStore):
+            times: list[float] = [x.timestamp - start_time for x in m.data[action]]
+            durations: list[float] = [x.duration * 1000 for x in m.data[action]]
+            self.queries: int = len(times)
+            self.qps: float = len(times) / max(times)
+            self.max: float = max(durations)
+            self.min: float = min(durations)
+            self.avg: float = float(numpy.mean(durations))
+            self.p50: float = float(numpy.median(durations))
+            self.p95: float = float(numpy.percentile(durations, 95))
+            self.p99: float = float(numpy.percentile(durations, 99))
+            self.p99_9: float = float(numpy.percentile(durations, 99.9))
+            self.p99_99: float = float(numpy.percentile(durations, 99.99))
+            self.p99_999: float = float(numpy.percentile(durations, 99.999))
+            self.p99_9999: float = float(numpy.percentile(durations, 99.9999))
+            self.p99_99999: float = float(numpy.percentile(durations, 99.99999))
+            self.p99_999999: float = float(numpy.percentile(durations, 99.999999))
+            self.std: float = float(numpy.std(durations, ddof=1))
+            self.slope: float = float(numpy.polyfit(times, durations, 1)[0])
+        elif isinstance(m, SQLiteStore):
+            cursor = m.conn.cursor()
+            cursor.execute(
+                "SELECT count(*) FROM measurements WHERE scenario = ? AND action = ?",
+                (m.scenario, action),
+            )
+            self.queries: int = cursor.fetchall()[0][0]
+            cursor.execute(
+                f"SELECT count(*) / (max(timestamp) - {start_time}) FROM measurements WHERE scenario = ? AND action = ?",
+                (m.scenario, action),
+            )
+            self.qps: float = cursor.fetchall()[0][0]
+            cursor.execute(
+                "SELECT max(duration) * 1000 FROM measurements WHERE scenario = ? AND action = ?",
+                (m.scenario, action),
+            )
+            self.max: float = cursor.fetchall()[0][0]
+            cursor.execute(
+                "SELECT min(duration) * 1000 FROM measurements WHERE scenario = ? AND action = ?",
+                (m.scenario, action),
+            )
+            self.min: float = cursor.fetchall()[0][0]
+            cursor.execute(
+                "SELECT avg(duration) * 1000 FROM measurements WHERE scenario = ? AND action = ?",
+                (m.scenario, action),
+            )
+            self.avg: float = cursor.fetchall()[0][0]
+            # TODO: Rest
+            self.median = 0.0
+            self.p50 = 0.0
+            self.p95 = 0.0
+            self.p99 = 0.0
+            self.p99_9 = 0.0
+            self.p99_99 = 0.0
+            self.p99_999 = 0.0
+            self.p99_9999 = 0.0
+            self.p99_99999 = 0.0
+            self.p99_999999 = 0.0
+            self.std = 0.0
+            self.slope = 0.0
+        else:
+            raise ValueError(
+                f"Unknown measurements store (for action {action}): {type(m)}"
+            )
 
     def __str__(self) -> str:
         return f"""  queries: {self.queries:>5}
@@ -171,7 +219,7 @@ def upload_plot(
 def report(
     mz_string: str,
     scenario: Scenario,
-    measurements: dict[str, list[Measurement]],
+    measurements: MeasurementsStore,
     start_time: float,
     guarantees: bool,
     suffix: str,
@@ -179,63 +227,73 @@ def report(
     scenario_name = type(scenario).name()
     stats: dict[str, Statistics] = {}
     failures: list[TestFailureDetails] = []
-    plt.figure(figsize=(10, 6))
-    for key, m in measurements.items():
-        times: list[float] = [x.timestamp - start_time for x in m]
-        durations: list[float] = [x.duration * 1000 for x in m]
-        stats[key] = Statistics(times, durations)
-        plt.scatter(times, durations, label=key[:60], marker=MarkerStyle("+"))
-        print(f"Statistics for {key}:\n{stats[key]}")
-        if key in scenario.guarantees and guarantees:
-            for stat, guarantee in scenario.guarantees[key].items():
-                duration = getattr(stats[key], stat)
+
+    plot = isinstance(measurements, MemoryStore)
+
+    if plot:
+        plt.figure(figsize=(10, 6))
+    for action in measurements.actions():
+        stats[action] = Statistics(action, measurements, start_time)
+        if plot:
+            times: list[float] = [
+                x.timestamp - start_time for x in measurements.data[action]
+            ]
+            durations: list[float] = [
+                x.duration * 1000 for x in measurements.data[action]
+            ]
+            plt.scatter(times, durations, label=action[:60], marker=MarkerStyle("+"))
+        print(f"Statistics for {action}:\n{stats[action]}")
+        if action in scenario.guarantees and guarantees:
+            for stat, guarantee in scenario.guarantees[action].items():
+                duration = getattr(stats[action], stat)
                 less_than = less_than_is_regression(stat)
                 if duration < guarantee if less_than else duration > guarantee:
-                    failure = f"Scenario {scenario_name} failed: {key}: {stat}: {duration:.2f} {'<' if less_than else '>'} {guarantee:.2f}"
+                    failure = f"Scenario {scenario_name} failed: {action}: {stat}: {duration:.2f} {'<' if less_than else '>'} {guarantee:.2f}"
                     print(failure)
                     failures.append(
                         TestFailureDetails(
                             message=failure,
-                            details=str(stats[key]),
+                            details=str(stats[action]),
                             test_class_name_override=scenario_name,
                         )
                     )
                 else:
                     print(
-                        f"Scenario {scenario_name} succeeded: {key}: {stat}: {duration:.2f} {'>=' if less_than else '<='} {guarantee:.2f}"
+                        f"Scenario {scenario_name} succeeded: {action}: {stat}: {duration:.2f} {'>=' if less_than else '<='} {guarantee:.2f}"
                     )
 
-    plt.xlabel("time [s]")
-    plt.ylabel("latency [ms]")
-    plt.yscale("log")
-    plt.title(f"{scenario_name} against {mz_string}")
-    plt.legend(loc="best")
-    plt.grid(True)
-    plt.ylim(bottom=0)
-    plot_path = f"plots/{scenario_name}_{suffix}_timeline.png"
-    plt.savefig(MZ_ROOT / plot_path, dpi=300)
-    upload_plot(plot_path, scenario_name, "timeline")
+    if plot:
+        plt.xlabel("time [s]")
+        plt.ylabel("latency [ms]")
+        plt.yscale("log")
+        plt.title(f"{scenario_name} against {mz_string}")
+        plt.legend(loc="best")
+        plt.grid(True)
+        plt.ylim(bottom=0)
+        plot_path = f"plots/{scenario_name}_{suffix}_timeline.png"
+        plt.savefig(MZ_ROOT / plot_path, dpi=300)
+        upload_plot(plot_path, scenario_name, "timeline")
 
-    plt.clf()
+        plt.clf()
 
-    # Plot CCDF
-    plt.grid(True, which="both")
-    plt.xscale("log")
-    plt.yscale("log")
-    plt.ylabel("CCDF")
-    plt.xlabel("latency [ms]")
-    plt.title(f"{scenario_name} against {mz_string}")
-    for key, m in measurements.items():
-        durations = [x.duration * 1000.0 for x in m]
-        durations.sort()
-        (uniqu_durations, counts) = numpy.unique(durations, return_counts=True)
-        counts = numpy.cumsum(counts)
-        plt.plot(uniqu_durations, 1 - counts / counts.max(), label=key)
-    plt.legend(loc="best")
+        # Plot CCDF
+        plt.grid(True, which="both")
+        plt.xscale("log")
+        plt.yscale("log")
+        plt.ylabel("CCDF")
+        plt.xlabel("latency [ms]")
+        plt.title(f"{scenario_name} against {mz_string}")
+        for key, m in measurements.data.items():
+            durations = [x.duration * 1000.0 for x in m]
+            durations.sort()
+            (uniqu_durations, counts) = numpy.unique(durations, return_counts=True)
+            counts = numpy.cumsum(counts)
+            plt.plot(uniqu_durations, 1 - counts / counts.max(), label=key)
+        plt.legend(loc="best")
 
-    plot_path = f"plots/{scenario_name}_{suffix}_ccdf.png"
-    plt.savefig(MZ_ROOT / plot_path, dpi=300)
-    upload_plot(plot_path, scenario_name, "ccdf")
+        plot_path = f"plots/{scenario_name}_{suffix}_ccdf.png"
+        plt.savefig(MZ_ROOT / plot_path, dpi=300)
+        upload_plot(plot_path, scenario_name, "ccdf")
 
     return stats, failures
 
@@ -248,6 +306,7 @@ def run_once(
     params: str | None,
     args,
     suffix: str,
+    sqlite_store: bool,
 ) -> tuple[dict[Scenario, dict[str, Statistics]], list[TestFailureDetails]]:
     stats: dict[Scenario, dict[str, Statistics]] = {}
     failures: list[TestFailureDetails] = []
@@ -365,7 +424,9 @@ def run_once(
             scenario_name = scenario_class.name()
             print(f"--- Running scenario {scenario_name}")
             state = State(
-                measurements=defaultdict(list),
+                measurements=(
+                    SQLiteStore(scenario_name) if sqlite_store else MemoryStore()
+                ),
                 load_phase_duration=args.load_phase_duration,
                 periodic_dists={pd[0]: int(pd[1]) for pd in args.periodic_dist or []},
             )
@@ -392,6 +453,7 @@ def run_once(
                 )
                 failures.extend(new_failures)
                 stats[scenario] = new_stats
+                state.measurements.close()
 
             if not target:
                 print(
@@ -441,7 +503,10 @@ def check_regressions(
                 this_value = getattr(this_stats[scenario][query], stat)
                 other_value = getattr(other_stats[other_scenario][query], stat)
                 less_than = less_than_is_regression(stat)
-                percentage = f"{(this_value / other_value - 1) * 100:.2f}%"
+                try:
+                    percentage = f"{(this_value / other_value - 1) * 100:.2f}%"
+                except ZeroDivisionError:
+                    percentage = ""
                 threshold = (
                     None
                     if query in ignored_queries
@@ -636,6 +701,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         help="Run against QA Benchmarking staging environment",
     )
 
+    parser.add_argument(
+        "--sqlite-store",
+        action="store_true",
+        help="Store results in SQLite instead of in memory",
+    )
+
     args = parser.parse_args()
 
     if args.scenario:
@@ -651,6 +722,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     sharded_scenarios = buildkite.shard_list(scenarios, lambda s: s.name())
 
+    if not sharded_scenarios:
+        return
+
+    if args.sqlite_store and os.path.exists(DB_FILE):
+        os.remove(DB_FILE)
+
     service_names = ["materialized", "postgres", "mysql"] + (
         ["redpanda"] if args.redpanda else ["zookeeper", "kafka", "schema-registry"]
     )
@@ -663,6 +740,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         params=args.this_params,
         args=args,
         suffix="this",
+        sqlite_store=args.sqlite_store,
     )
     if args.other_tag:
         assert not args.mz_url, "Can't set both --mz-url and --other-tag"
@@ -677,6 +755,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             params=args.other_params,
             args=args,
             suffix="other",
+            sqlite_store=args.sqlite_store,
         )
         failures.extend(other_failures)
         failures.extend(check_regressions(this_stats, other_stats, tag))

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -130,30 +130,10 @@ class Statistics:
         elif isinstance(m, SQLiteStore):
             cursor = m.conn.cursor()
             cursor.execute(
-                "SELECT count(*) FROM measurements WHERE scenario = ? AND action = ?",
+                f"SELECT count(*), count(*) / (max(timestamp) - {start_time}), max(duration) * 1000, min(duration) * 1000, avg(duration) * 1000 FROM measurements WHERE scenario = ? AND action = ?",
                 (m.scenario, action),
             )
-            self.queries: int = cursor.fetchall()[0][0]
-            cursor.execute(
-                f"SELECT count(*) / (max(timestamp) - {start_time}) FROM measurements WHERE scenario = ? AND action = ?",
-                (m.scenario, action),
-            )
-            self.qps: float = cursor.fetchall()[0][0]
-            cursor.execute(
-                "SELECT max(duration) * 1000 FROM measurements WHERE scenario = ? AND action = ?",
-                (m.scenario, action),
-            )
-            self.max: float = cursor.fetchall()[0][0]
-            cursor.execute(
-                "SELECT min(duration) * 1000 FROM measurements WHERE scenario = ? AND action = ?",
-                (m.scenario, action),
-            )
-            self.min: float = cursor.fetchall()[0][0]
-            cursor.execute(
-                "SELECT avg(duration) * 1000 FROM measurements WHERE scenario = ? AND action = ?",
-                (m.scenario, action),
-            )
-            self.avg: float = cursor.fetchall()[0][0]
+            self.queries, self.qps, self.max, self.min, self.avg = cursor.fetchone()
             # TODO: Rest
             self.median = 0.0
             self.p50 = 0.0


### PR DESCRIPTION
Seems not to cause a performance difference, but lacks some features currently

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
