### PR TITLE
feature-benchmark: fix message filtering, clusterd memory computation, ReplicaExpiration scenario

### DIFF
--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -211,14 +211,21 @@ class Benchmark:
                 unit=MeasurementUnit.COUNT,
             )
             print(f"{i}: {messages_measurement}")
-            self._messages_aggregation.append_measurement(messages_measurement)
+            if not self._filter or not self._filter.filter(messages_measurement):
+                self._messages_aggregation.append_measurement(messages_measurement)
 
     def _collect_memory_measurement(
         self, i: int, memory_measurement_type: MeasurementType, aggregation: Aggregation
     ) -> None:
+        if memory_measurement_type == MeasurementType.MEMORY_MZ:
+            value = self._executor.DockerMemMz()
+        elif memory_measurement_type == MeasurementType.MEMORY_CLUSTERD:
+            value = self._executor.DockerMemClusterd()
+        else:
+            raise ValueError(f"Unknown measurement type {memory_measurement_type}")
         memory_measurement = Measurement(
             type=memory_measurement_type,
-            value=self._executor.DockerMemMz() / 2**20,  # Convert to Mb
+            value=value / 2**20,  # Convert to Mb
             unit=MeasurementUnit.MEGABYTE,
         )
 

--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from materialize import MZ_ROOT
 
-FEATURE_BENCHMARK_FRAMEWORK_VERSION = "1.3.0"
+FEATURE_BENCHMARK_FRAMEWORK_VERSION = "1.4.0"
 FEATURE_BENCHMARK_FRAMEWORK_HASH_FILE = Path(__file__).relative_to(MZ_ROOT)
 
 FEATURE_BENCHMARK_FRAMEWORK_DIR = Path(__file__).resolve().parent
@@ -18,12 +18,12 @@ FEATURE_BENCHMARK_SCENARIOS_DIR = FEATURE_BENCHMARK_FRAMEWORK_DIR / "scenarios"
 
 # Consider increasing the #FEATURE_BENCHMARK_FRAMEWORK_VERSION if changes are expected to impact results!
 SHA256_OF_FRAMEWORK: dict[str, str] = {
-    "*": "d999cf93ce56bf54b8cf3c1e425410303b6fb1f511aa646b2fc6998f50e179bd"
+    "*": "83ac95bbe391e9cdcab5cabafbae59f95c17c7f50e8c5b66c7705ce8cd6f1f93",
 }
 
 # Consider increasing the scenario's class #version() if changes are expected to impact results!
 SHA256_BY_SCENARIO_FILE: dict[str, str] = {
-    "benchmark_main.py": "c17e514f96b2ec00bee85c55b2132713ffca98d8772797c881c2cfce9ef89745",
+    "benchmark_main.py": "aca597f4eedb9c3e9ea08327b9997dab9ccb7202a0fe7df35181958d7413356b",
     "concurrency.py": "2e9c149c136b83b3853abc923a1adbdaf55a998ab4557712f8424c8b16f2adb1",
     "customer.py": "d1e72837a342c3ebf1f4a32ec583b1b78a78644cdba495030a6df45ebbffe703",
     "optbench.py": "ae411afe1ba595021f2f9d2d21500ba0c1c6941561493eabcae113373f493bfa",

--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -23,7 +23,7 @@ SHA256_OF_FRAMEWORK: dict[str, str] = {
 
 # Consider increasing the scenario's class #version() if changes are expected to impact results!
 SHA256_BY_SCENARIO_FILE: dict[str, str] = {
-    "benchmark_main.py": "0e328994c56b9bae2a9da0db10974b4fa30dd8c825e3290e00f5cecbb32ec338",
+    "benchmark_main.py": "c17e514f96b2ec00bee85c55b2132713ffca98d8772797c881c2cfce9ef89745",
     "concurrency.py": "2e9c149c136b83b3853abc923a1adbdaf55a998ab4557712f8424c8b16f2adb1",
     "customer.py": "d1e72837a342c3ebf1f4a32ec583b1b78a78644cdba495030a6df45ebbffe703",
     "optbench.py": "ae411afe1ba595021f2f9d2d21500ba0c1c6941561493eabcae113373f493bfa",

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -2199,6 +2199,10 @@ class ReplicaExpiration(Scenario):
   WHERE mz_now() <= event_ts + INTERVAL '30 days';
 
 > CREATE DEFAULT INDEX ON last_30_days
+
+$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET max_result_size = '20GB'
 """
             ),
         ]

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -2185,24 +2185,26 @@ class SwapSchema(Scenario):
 
 
 class ReplicaExpiration(Scenario):
+    # Too slow with larger scale
+    FIXED_SCALE = True
+
     def init(self) -> list[Action]:
         return [
             TdAction(
                 """
-> CREATE TABLE events (
-    content TEXT,
-    event_ts TIMESTAMP
+> CREATE TABLE events_scale (
+    scale INT NOT NULL,
+    event_ts TIMESTAMP NOT NULL
   );
-> CREATE VIEW last_30_days AS
+> CREATE VIEW events AS
+    SELECT concat('somelongstringthatdoesntmattermuchatallbutrequiresmemorytostoreXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', x::text) AS content, (SELECT event_ts FROM events_scale LIMIT 1) AS event_ts FROM generate_series(1, (SELECT scale FROM events_scale LIMIT 1)) x;
+
+> CREATE MATERIALIZED VIEW last_30_days AS
   SELECT event_ts, content
   FROM events
   WHERE mz_now() <= event_ts + INTERVAL '30 days';
 
 > CREATE DEFAULT INDEX ON last_30_days
-
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-$ postgres-execute connection=mz_system
-ALTER SYSTEM SET max_result_size = '20GB'
 """
             ),
         ]
@@ -2211,7 +2213,7 @@ ALTER SYSTEM SET max_result_size = '20GB'
         return Td(
             dedent(
                 f"""
-                > DELETE FROM events;
+                > DELETE FROM events_scale;
 
                 > SELECT COUNT(*) FROM last_30_days
                 0
@@ -2220,7 +2222,7 @@ ALTER SYSTEM SET max_result_size = '20GB'
                   /* A */
                 1
 
-                > INSERT INTO events SELECT concat('somelongstringthatdoesntmattermuchatallbutrequiresmemorytostoreXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', x::text), now() FROM generate_series(1, {self.n()}) AS x
+                > INSERT INTO events_scale VALUES ({self.n()}, now());
 
                 > SELECT COUNT(*) FROM last_30_days
                 {self.n()}


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/release-qualification/builds/627#01927989-33ea-448b-af26-6ef13de7d27e

Verifying: https://buildkite.com/materialize/release-qualification/builds/628

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
