### PR TITLE
adapter/0dt: check hydration status in new-style caught-up check

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -408,6 +408,25 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
         result
     }
 
+    /// Returns `true` iff the given collection has been hydrated.
+    ///
+    /// For this check, zero-replica clusters are always considered hydrated.
+    /// Their collections would never normally be considered hydrated but it's
+    /// clearly intentional that they have no replicas.
+    pub async fn collection_hydrated(
+        &self,
+        instance_id: ComputeInstanceId,
+        collection_id: GlobalId,
+    ) -> Result<bool, anyhow::Error> {
+        let instance = self.instance(instance_id)?;
+
+        let res = instance
+            .call_sync(move |i| i.collection_hydrated(collection_id))
+            .await?;
+
+        Ok(res)
+    }
+
     /// Returns `true` if all non-transient, non-excluded collections are hydrated on any of the
     /// provided replicas.
     ///

--- a/src/compute/src/render/continual_task.rs
+++ b/src/compute/src/render/continual_task.rs
@@ -92,7 +92,7 @@ use mz_storage_types::sources::SourceData;
 use mz_timely_util::builder_async::{Button, Event, OperatorBuilder as AsyncOperatorBuilder};
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::operators::{Filter, FrontierNotificator, Map, Operator};
-use timely::dataflow::{ProbeHandle, Scope};
+use timely::dataflow::Scope;
 use timely::progress::frontier::AntichainRef;
 use timely::progress::{Antichain, Timestamp as _};
 use timely::{Data, PartialOrder};
@@ -254,10 +254,9 @@ where
             }
         };
 
+        // We don't report a `compute_probe`, our output frontier is equal to
+        // our write frontier, which we report directly.
         let collection = compute_state.expect_collection_mut(sink_id);
-        let mut probe = ProbeHandle::default();
-        let to_append = to_append.probe_with(&mut probe);
-        collection.compute_probe = Some(probe);
         let sink_write_frontier = Rc::new(RefCell::new(Antichain::from_elem(Timestamp::minimum())));
         collection.sink_write_frontier = Some(Rc::clone(&sink_write_frontier));
 


### PR DESCRIPTION
Turns out that we initialize the collection upper to the latest upper when bootstrapping, so the caught-up check would always see compute collections as caught up.

Now, we additionally check that they are hydrated, meaning that we have heard back at least one frontiers/uppers response back from the cluster/replicas.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
