### PR TITLE
build: upload debug symbols to PolarSignals as separate step

### DIFF
--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import boto3
 
 from materialize import bazel, elf, mzbuild, spawn, ui
-from materialize.mzbuild import CargoBuild, ResolvedImage
+from materialize.mzbuild import CargoBuild, Repository, ResolvedImage
 from materialize.rustc_flags import Sanitizer
 from materialize.xcompile import Arch
 
@@ -71,35 +71,16 @@ def maybe_upload_debuginfo(
     DEBUGINFO_BINS were built."""
 
     # Find all binaries created by the `cargo-bin` pre-image.
-    bins: set[str] = set()
-    bazel_bins: dict[str, str] = dict()
-    for image in built_images:
-        for pre_image in image.image.pre_images:
-            if isinstance(pre_image, CargoBuild):
-                for bin in pre_image.bins:
-                    if bin in DEBUGINFO_BINS:
-                        bins.add(bin)
-                    if repo.rd.bazel:
-                        bazel_bins[bin] = pre_image.bazel_bins[bin]
-
-    if not bins:
+    bins, bazel_bins = find_binaries_created_by_cargo_bin(repo, built_images)
+    if len(bins) == 0:
         return
 
     ui.section(f"Uploading debuginfo for {', '.join(bins)}...")
 
-    s3 = boto3.client("s3")
     is_tag_build = ui.env_is_truthy("BUILDKITE_TAG")
-    polar_signals_api_token = os.environ["POLAR_SIGNALS_API_TOKEN"]
 
     for bin in bins:
-        if repo.rd.bazel:
-            options = repo.rd.bazel_config()
-            paths = bazel.output_paths(bazel_bins[bin], options)
-            assert len(paths) == 1, f"{bazel_bins[bin]} output more than 1 file"
-            bin_path = paths[0]
-        else:
-            cargo_profile = "release" if repo.rd.release_mode else "debug"
-            bin_path = repo.rd.cargo_target_dir() / cargo_profile / bin
+        bin_path = get_bin_path(repo, bin, bazel_bins)
 
         dbg_path = bin_path.with_suffix(bin_path.suffix + ".debug")
         spawn.runv(
@@ -113,101 +94,147 @@ def maybe_upload_debuginfo(
 
         # Upload binary and debuginfo to S3 bucket, regardless of whether this
         # is a tag build or not. S3 is cheap.
-        with open(bin_path, "rb") as exe, open(dbg_path, "rb") as dbg:
-            build_id = elf.get_build_id(exe)
-            assert build_id.isalnum()
-            assert len(build_id) > 0
-
-            dbg_build_id = elf.get_build_id(dbg)
-            assert build_id == dbg_build_id
-
-            for fileobj, name in [
-                (exe, "executable"),
-                (dbg, "debuginfo"),
-            ]:
-                key = f"buildid/{build_id}/{name}"
-                print(f"Uploading {name} to s3://{DEBUGINFO_S3_BUCKET}/{key}...")
-                fileobj.seek(0)
-                s3.upload_fileobj(
-                    Fileobj=fileobj,
-                    Bucket=DEBUGINFO_S3_BUCKET,
-                    Key=key,
-                    ExtraArgs={
-                        "Tagging": f"ephemeral={'false' if is_tag_build else 'true'}",
-                    },
-                )
+        build_id = upload_debuginfo_to_s3(bin_path, dbg_path, is_tag_build)
 
         # Upload debuginfo and sources to Polar Signals (our continuous
         # profiling provider), but only if this is a tag build. Polar Signals is
         # expensive, so we don't want to upload development or unstable builds
         # that won't ever be profiled by Polar Signals.
         if is_tag_build:
-            ui.section(f"Uploading debuginfo for {bin} to Polar Signals...")
-            spawn.run_with_retries(
-                lambda: spawn.runv(
-                    [
-                        "parca-debuginfo",
-                        "upload",
-                        "--store-address=grpc.polarsignals.com:443",
-                        "--no-extract",
-                        dbg_path,
-                    ],
-                    cwd=repo.rd.root,
-                    env=dict(
-                        os.environ, PARCA_DEBUGINFO_BEARER_TOKEN=polar_signals_api_token
-                    ),
-                )
+            upload_debuginfo_to_polarsignals(repo, build_id, bin_path, dbg_path)
+
+
+def find_binaries_created_by_cargo_bin(
+    repo: Repository, built_images: set[ResolvedImage]
+) -> tuple[set[str], dict[str, str]]:
+    bins: set[str] = set()
+    bazel_bins: dict[str, str] = dict()
+    for image in built_images:
+        for pre_image in image.image.pre_images:
+            if isinstance(pre_image, CargoBuild):
+                for bin in pre_image.bins:
+                    if bin in DEBUGINFO_BINS:
+                        bins.add(bin)
+                    if repo.rd.bazel:
+                        bazel_bins[bin] = pre_image.bazel_bins[bin]
+
+    return bins, bazel_bins
+
+
+def get_bin_path(repo: Repository, bin: str, bazel_bins: dict[str, str]) -> Path:
+    if repo.rd.bazel:
+        options = repo.rd.bazel_config()
+        paths = bazel.output_paths(bazel_bins[bin], options)
+        assert len(paths) == 1, f"{bazel_bins[bin]} output more than 1 file"
+        return paths[0]
+    else:
+        cargo_profile = "release" if repo.rd.release_mode else "debug"
+        return repo.rd.cargo_target_dir() / cargo_profile / bin
+
+
+def upload_debuginfo_to_s3(bin_path: Path, dbg_path: Path, is_tag_build: bool) -> str:
+    s3 = boto3.client("s3")
+
+    with open(bin_path, "rb") as exe, open(dbg_path, "rb") as dbg:
+        build_id = elf.get_build_id(exe)
+        assert build_id.isalnum()
+        assert len(build_id) > 0
+
+        dbg_build_id = elf.get_build_id(dbg)
+        assert build_id == dbg_build_id
+
+        for fileobj, name in [
+            (exe, "executable"),
+            (dbg, "debuginfo"),
+        ]:
+            key = f"buildid/{build_id}/{name}"
+            print(f"Uploading {name} to s3://{DEBUGINFO_S3_BUCKET}/{key}...")
+            fileobj.seek(0)
+            s3.upload_fileobj(
+                Fileobj=fileobj,
+                Bucket=DEBUGINFO_S3_BUCKET,
+                Key=key,
+                ExtraArgs={
+                    "Tagging": f"ephemeral={'false' if is_tag_build else 'true'}",
+                },
             )
 
-            print(f"Constructing source tarball for {bin}...")
-            with tempfile.NamedTemporaryFile() as tarball:
-                p1 = subprocess.Popen(
-                    ["llvm-dwarfdump", "--show-sources", bin_path],
-                    stdout=subprocess.PIPE,
-                )
-                p2 = subprocess.Popen(
-                    [
-                        "tar",
-                        "-cf",
-                        tarball.name,
-                        "--zstd",
-                        "-T",
-                        "-",
-                        "--ignore-failed-read",
-                    ],
-                    stdin=p1.stdout,
-                    # Suppress noisy warnings about missing files.
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                )
+        return build_id
 
-                # This causes p1 to receive SIGPIPE if p2 exits early,
-                # like in the shell.
-                assert p1.stdout
-                p1.stdout.close()
 
-                for p in [p1, p2]:
-                    if p.wait():
-                        raise subprocess.CalledProcessError(p.returncode, p.args)
+def upload_debuginfo_to_polarsignals(
+    repo: Repository,
+    build_id: str,
+    bin_path: Path,
+    dbg_path: Path,
+) -> None:
+    ui.section(f"Uploading debuginfo for {bin_path} to Polar Signals...")
 
-                print(f"Uploading source tarball for {bin} to Polar Signals...")
-                spawn.run_with_retries(
-                    lambda: spawn.runv(
-                        [
-                            "parca-debuginfo",
-                            "upload",
-                            "--store-address=grpc.polarsignals.com:443",
-                            "--type=sources",
-                            f"--build-id={build_id}",
-                            tarball.name,
-                        ],
-                        cwd=repo.rd.root,
-                        env=dict(
-                            os.environ,
-                            PARCA_DEBUGINFO_BEARER_TOKEN=polar_signals_api_token,
-                        ),
-                    )
-                )
+    polar_signals_api_token = os.environ["POLAR_SIGNALS_API_TOKEN"]
+
+    spawn.run_with_retries(
+        lambda: spawn.runv(
+            [
+                "parca-debuginfo",
+                "upload",
+                "--store-address=grpc.polarsignals.com:443",
+                "--no-extract",
+                dbg_path,
+            ],
+            cwd=repo.rd.root,
+            env=dict(os.environ, PARCA_DEBUGINFO_BEARER_TOKEN=polar_signals_api_token),
+        )
+    )
+
+    print(f"Constructing source tarball for {bin_path}...")
+    with tempfile.NamedTemporaryFile() as tarball:
+        p1 = subprocess.Popen(
+            ["llvm-dwarfdump", "--show-sources", bin_path],
+            stdout=subprocess.PIPE,
+        )
+        p2 = subprocess.Popen(
+            [
+                "tar",
+                "-cf",
+                tarball.name,
+                "--zstd",
+                "-T",
+                "-",
+                "--ignore-failed-read",
+            ],
+            stdin=p1.stdout,
+            # Suppress noisy warnings about missing files.
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        # This causes p1 to receive SIGPIPE if p2 exits early,
+        # like in the shell.
+        assert p1.stdout
+        p1.stdout.close()
+
+        for p in [p1, p2]:
+            if p.wait():
+                raise subprocess.CalledProcessError(p.returncode, p.args)
+
+        print(f"Uploading source tarball for {bin_path} to Polar Signals...")
+        spawn.run_with_retries(
+            lambda: spawn.runv(
+                [
+                    "parca-debuginfo",
+                    "upload",
+                    "--store-address=grpc.polarsignals.com:443",
+                    "--type=sources",
+                    f"--build-id={build_id}",
+                    tarball.name,
+                ],
+                cwd=repo.rd.root,
+                env=dict(
+                    os.environ,
+                    PARCA_DEBUGINFO_BEARER_TOKEN=polar_signals_api_token,
+                ),
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -73,6 +73,7 @@ def maybe_upload_debuginfo(
     # Find all binaries created by the `cargo-bin` pre-image.
     bins, bazel_bins = find_binaries_created_by_cargo_bin(repo, built_images)
     if len(bins) == 0:
+        print("No debuginfo bins were built")
         return
 
     ui.section(f"Uploading debuginfo for {', '.join(bins)}...")
@@ -95,6 +96,7 @@ def maybe_upload_debuginfo(
         # Upload binary and debuginfo to S3 bucket, regardless of whether this
         # is a tag build or not. S3 is cheap.
         build_id = upload_debuginfo_to_s3(bin_path, dbg_path, is_tag_build)
+        print(f"Uploaded debuginfo to S3 with build_id {build_id}")
 
         # Upload debuginfo and sources to Polar Signals (our continuous
         # profiling provider), but only if this is a tag build. Polar Signals is

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -43,6 +43,20 @@ steps:
         agents:
           queue: builder-linux-x86_64
 
+      - id: upload-debug-symbols-x86_64
+        label: "Upload debug symbols for x86_64"
+        env:
+          CI_BAZEL_BUILD: 0
+        command: bin/ci-builder run stable bin/pyactivate -m materialize.ci_util.upload_debug_symbols_to_polarsignals
+        inputs:
+          - "*"
+        depends_on: [rust-build-x86_64]
+        timeout_in_minutes: 10
+        priority: 50
+        if: build.tag != "" && build.branch =~ /^v.*\..*\$/
+        agents:
+          queue: builder-linux-x86_64
+
       - id: rust-build-aarch64
         label: ":rust: Build aarch64"
         env:
@@ -55,6 +69,21 @@ steps:
         timeout_in_minutes: 60
         agents:
           queue: builder-linux-aarch64-mem
+
+      - id: upload-debug-symbols-aarch64
+        label: "Upload debug symbols for aarch64"
+        env:
+          CI_BAZEL_BUILD: 0
+        command: bin/ci-builder run stable bin/pyactivate -m materialize.ci_util.upload_debug_symbols_to_polarsignals
+        inputs:
+          - "*"
+        depends_on: [rust-build-aarch64]
+        priority: 50
+        timeout_in_minutes: 10
+        if: build.tag != "" && build.branch =~ /^v.*\..*\$/
+        agents:
+          queue: builder-linux-aarch64-mem
+
 
       - id: build-x86_64
         label: ":bazel: Build x86_64"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -50,7 +50,7 @@ steps:
         command: bin/ci-builder run stable bin/pyactivate -m materialize.ci_util.upload_debug_symbols_to_polarsignals
         inputs:
           - "*"
-        depends_on: [rust-build-x86_64]
+        depends_on: [build-x86_64]
         timeout_in_minutes: 10
         priority: 50
         if: build.tag != "" && build.branch =~ /^v.*\..*\$/
@@ -77,7 +77,7 @@ steps:
         command: bin/ci-builder run stable bin/pyactivate -m materialize.ci_util.upload_debug_symbols_to_polarsignals
         inputs:
           - "*"
-        depends_on: [rust-build-aarch64]
+        depends_on: [build-aarch64]
         priority: 50
         timeout_in_minutes: 10
         if: build.tag != "" && build.branch =~ /^v.*\..*\$/

--- a/misc/python/materialize/ci_util/upload_debug_symbols_to_polarsignals.py
+++ b/misc/python/materialize/ci_util/upload_debug_symbols_to_polarsignals.py
@@ -1,0 +1,242 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from tempfile import _TemporaryFileWrapper
+
+import boto3
+
+from materialize import mzbuild, spawn, ui
+from materialize.ci_util.upload_debug_symbols_to_s3 import (
+    DEBUGINFO_BINS,
+    DEBUGINFO_S3_BUCKET,
+)
+from materialize.mzbuild import Repository, ResolvedImage
+from materialize.rustc_flags import Sanitizer
+
+# Upload debuginfo and sources to Polar Signals (our continuous
+# profiling provider).
+# This script is only invoked for build tags. Polar Signals is
+# expensive, so we don't want to upload development or unstable builds
+# that won't ever be profiled by Polar Signals.
+
+
+def main() -> None:
+    coverage = ui.env_is_truthy("CI_COVERAGE_ENABLED")
+    sanitizer = Sanitizer[os.getenv("CI_SANITIZER", "none")]
+    bazel = ui.env_is_truthy("CI_BAZEL_BUILD")
+    bazel_remote_cache = os.getenv("CI_BAZEL_REMOTE_CACHE")
+
+    repo = mzbuild.Repository(
+        Path("."),
+        coverage=coverage,
+        sanitizer=sanitizer,
+        bazel=bazel,
+        bazel_remote_cache=bazel_remote_cache,
+    )
+
+    collect_and_upload_debug_data_to_polarsignals(repo, DEBUGINFO_BINS)
+
+
+def collect_and_upload_debug_data_to_polarsignals(
+    repo: mzbuild.Repository, debuginfo_bins: set[str]
+) -> None:
+    ui.section("Collecting and uploading debug data to PolarSignals...")
+
+    relevant_images_by_name = get_build_images(repo, debuginfo_bins)
+
+    for image_name, image in relevant_images_by_name.items():
+        print(f"Copying binary from image {image_name} (spec: {image.spec()}")
+        path_to_binary = copy_binary_from_image(image_name, image)
+
+        build_id = get_build_id(repo, path_to_binary)
+        print(f"{image_name} has build_id {build_id}")
+
+        bin_path, dbg_path = fetch_debug_symbols_from_s3(build_id)
+        print("Fetched debug symbols from S3")
+
+        upload_debug_data_to_polarsignals(repo, build_id, bin_path, dbg_path)
+        print("Uploaded debug symbols to PolarSignals")
+
+
+def get_build_images(
+    repo: mzbuild.Repository, image_names: set[str]
+) -> dict[str, ResolvedImage]:
+    relevant_images = []
+    for image_name, image in repo.images.items():
+        if image_name in image_names:
+            relevant_images.append(image)
+
+    dependency_set = repo.resolve_dependencies(relevant_images)
+
+    resolved_images = dict()
+    for image_name in image_names:
+        resolved_images[image_name] = dependency_set[image_name]
+
+    return resolved_images
+
+
+def copy_binary_from_image(image_name: str, image: ResolvedImage) -> str:
+    try:
+        image_spec = image.spec()
+        docker_container_name = image_name
+        command = ["docker", "create", "--name", docker_container_name, image_spec]
+        subprocess.run(command, check=True)
+
+        source_path = f"/usr/local/bin/{image_name}"
+        target_path = f"./{image_name}"
+        command = [
+            "docker",
+            "cp",
+            f"{docker_container_name}:{source_path}",
+            target_path,
+        ]
+        subprocess.run(command, check=True)
+
+        return target_path
+    except subprocess.CalledProcessError as e:
+        print(f"Error copying file: {e}")
+        raise e
+
+
+def get_build_id(repo: mzbuild.Repository, path_to_binary: str) -> str:
+    return spawn.run_with_retries(
+        lambda: spawn.capture(
+            ["parca-debuginfo", "buildid", path_to_binary],
+            cwd=repo.rd.root,
+        ).strip()
+    )
+
+
+def fetch_debug_symbols_from_s3(build_id: str) -> tuple[str, str]:
+    s3 = boto3.client("s3")
+
+    file_names = [
+        "executable",
+        "debuginfo",
+    ]
+
+    downloaded_file_paths = dict()
+
+    for file_name in file_names:
+        key = f"buildid/{build_id}/{file_name}"
+        target_file_name = key.replace("/", "_")
+        print(
+            f"Downloading {file_name} from s3://{DEBUGINFO_S3_BUCKET}/{key} to {target_file_name}"
+        )
+
+        with open(target_file_name, "wb") as data:
+            s3.download_fileobj(DEBUGINFO_S3_BUCKET, key, data)
+
+        downloaded_file_paths[file_name] = target_file_name
+
+    return downloaded_file_paths["executable"], downloaded_file_paths["debuginfo"]
+
+
+def upload_debug_data_to_polarsignals(
+    repo: Repository,
+    build_id: str,
+    bin_path: Path | str,
+    dbg_path: Path | str,
+) -> None:
+    polar_signals_api_token = os.environ["POLAR_SIGNALS_API_TOKEN"]
+    _upload_debug_info_to_polarsignals(repo, dbg_path, polar_signals_api_token)
+
+    with tempfile.NamedTemporaryFile() as tarball:
+        _create_source_tarball(repo, bin_path, tarball)
+        _upload_source_tarball_to_polarsignals(
+            repo, bin_path, tarball, build_id, polar_signals_api_token
+        )
+
+
+def _upload_debug_info_to_polarsignals(
+    repo: mzbuild.Repository, dbg_path: Path | str, polar_signals_api_token: str
+) -> None:
+    print(f"Uploading debuginfo for {dbg_path} to Polar Signals...")
+    spawn.run_with_retries(
+        lambda: spawn.runv(
+            [
+                "parca-debuginfo",
+                "upload",
+                "--store-address=grpc.polarsignals.com:443",
+                "--no-extract",
+                dbg_path,
+            ],
+            cwd=repo.rd.root,
+            env=dict(os.environ, PARCA_DEBUGINFO_BEARER_TOKEN=polar_signals_api_token),
+        )
+    )
+
+
+def _create_source_tarball(
+    repo: mzbuild.Repository, bin_path: Path | str, tarball: _TemporaryFileWrapper
+) -> None:
+    print(f"Constructing source tarball for {bin_path}...")
+    p1 = subprocess.Popen(
+        ["llvm-dwarfdump", "--show-sources", bin_path],
+        stdout=subprocess.PIPE,
+    )
+    p2 = subprocess.Popen(
+        [
+            "tar",
+            "-cf",
+            tarball.name,
+            "--zstd",
+            "-T",
+            "-",
+            "--ignore-failed-read",
+        ],
+        stdin=p1.stdout,
+        # Suppress noisy warnings about missing files.
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    # This causes p1 to receive SIGPIPE if p2 exits early,
+    # like in the shell.
+    assert p1.stdout
+    p1.stdout.close()
+
+    for p in [p1, p2]:
+        if p.wait():
+            raise subprocess.CalledProcessError(p.returncode, p.args)
+
+
+def _upload_source_tarball_to_polarsignals(
+    repo: mzbuild.Repository,
+    bin_path: Path | str,
+    tarball: _TemporaryFileWrapper,
+    build_id: str,
+    polar_signals_api_token: str,
+) -> None:
+    print(f"Uploading source tarball for {bin_path} to Polar Signals...")
+    spawn.run_with_retries(
+        lambda: spawn.runv(
+            [
+                "parca-debuginfo",
+                "upload",
+                "--store-address=grpc.polarsignals.com:443",
+                "--type=sources",
+                f"--build-id={build_id}",
+                tarball.name,
+            ],
+            cwd=repo.rd.root,
+            env=dict(
+                os.environ,
+                PARCA_DEBUGINFO_BEARER_TOKEN=polar_signals_api_token,
+            ),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/misc/python/materialize/ci_util/upload_debug_symbols_to_s3.py
+++ b/misc/python/materialize/ci_util/upload_debug_symbols_to_s3.py
@@ -1,0 +1,50 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from pathlib import Path
+
+import boto3
+
+from materialize import elf
+
+# The S3 bucket in which to store debuginfo.
+DEBUGINFO_S3_BUCKET = "materialize-debuginfo"
+
+# The binaries for which debuginfo should be uploaded to S3 and Polar Signals.
+DEBUGINFO_BINS = {"environmentd", "clusterd", "balancerd"}
+
+
+def upload_debuginfo_to_s3(bin_path: Path, dbg_path: Path, is_tag_build: bool) -> str:
+    s3 = boto3.client("s3")
+
+    with open(bin_path, "rb") as exe, open(dbg_path, "rb") as dbg:
+        build_id = elf.get_build_id(exe)
+        assert build_id.isalnum()
+        assert len(build_id) > 0
+
+        dbg_build_id = elf.get_build_id(dbg)
+        assert build_id == dbg_build_id
+
+        for fileobj, name in [
+            (exe, "executable"),
+            (dbg, "debuginfo"),
+        ]:
+            key = f"buildid/{build_id}/{name}"
+            print(f"Uploading {name} to s3://{DEBUGINFO_S3_BUCKET}/{key}...")
+            fileobj.seek(0)
+            s3.upload_fileobj(
+                Fileobj=fileobj,
+                Bucket=DEBUGINFO_S3_BUCKET,
+                Key=key,
+                ExtraArgs={
+                    "Tagging": f"ephemeral={'false' if is_tag_build else 'true'}",
+                },
+            )
+
+        return build_id


### PR DESCRIPTION
This addresses https://github.com/MaterializeInc/database-issues/issues/8617.
It is currently blocked by https://github.com/MaterializeInc/database-issues/issues/8652.

### Commits
542e4b059e build: debug symbols: extract functions
f7691e6cfd build: debug symbols: add log output
49b08b934e build: debug symbols: extract upload to s3
**1f29b22035 build: debug symbols: extract and rework upload to PolarSignals
862ecd5c4f build: debug symbols: improve error handling and logging
af8d249e3f ci: add steps rust-upload-debug-symbols-x86_64 and rust-upload-debug-symbols-aarch64**
60279ee754 ci: depend on bazel build steps


