### PR TITLE
unused deps: Fix mz-orchestratord

### DIFF
--- a/src/orchestratord/Cargo.toml
+++ b/src/orchestratord/Cargo.toml
@@ -48,3 +48,6 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [features]
 default = ["mz-alloc-default"]
 jemalloc = ["mz-alloc/jemalloc"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["mz-alloc", "mz-alloc-default", "workspace-hack"]


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/9938#01927c64-2ee4-4202-b1bb-75f7513fa51c
```
`mz-orchestratord v0.120.0-dev.0 (/var/lib/buildkite-agent/builds/hetzner-aarch64-8cpu-16gb-3baf4980/materialize/nightly/src/orchestratord)`
└─── dependencies
     ├─── "mz-alloc"
     ├─── "mz-alloc-default"
     └─── "workspace-hack"
```
@doy-materialize Does this make sense?

Follow-up to https://github.com/MaterializeInc/materialize/pull/29922
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
