### PR TITLE
dev: include example RustRover run configurations, update nix-shell docs

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -216,9 +216,16 @@ and needs to be installed separately, as described above. Also, IDEs will not be
 dependencies unless they are started from within the `nix-shell` environment:
 
 ```bash
-code . # Linux
-/Applications/Visual\ Studio\ Code.app/Contents/MacOS/Electron # MacOS
+# Linux
+[nix-shell]$ code .
+# macOS
+[nix-shell]$ open -na "RustRover"
+[nix-shell]$ open -na "Visual Studio Code"
 ```
+
+Note that on macOS, the `mzcompose` tests fail to run from within `nix-shell`,
+as our config does not yet set up [cross-compilation support](/misc/python/materialize/xcompile.py)
+for `x86-64` needed to run `mzcompose`.
 
 ## Building Materialize
 
@@ -539,6 +546,8 @@ version = "0.26.0"
 
 In principle, any text editor can be used to edit Rust code.
 
+#### Visual Studio Code
+
 By default, we recommend that developers without a strong preference of an editor use
 [Visual Studio Code] with the [rust-analyzer] plugin.
 This is the most mainstream
@@ -570,13 +579,16 @@ If you are using Rust-Analyzer, you should configure it to conform to our
 * `imports.granularity.group` = `module`
 * `imports.prefix` = `crate`
 
+#### RustRover
+
 [RustRover] is another option for an IDE with good code navigation features.
-This is a good choice for developers who prefer
-the JetBrains ecosystem, but we no longer recommend it by default, since
-Rust-Analyzer has long since caught up to it in maturity. If you are a
-Materialize employee, ask Nikhil Benesch on Slack for access to our corporate
-JetBrains license. If you're not yet sure you want to use RustRover, you can
-use the 30-day free trial.
+This is a good choice for developers who prefer the JetBrains ecosystem. This
+folder provides some [example run configurations](/misc/editor/rustrover)
+to help get started with running and debugging Materialize in RustRover.
+
+If you are a Materialize employee, ask in the #jetbrains channel on Slack for
+access to a corporate JetBrains license. If you're not yet sure you want to use
+RustRover, you can use the 30-day free trial.
 
 ### Editor add-ons
 

--- a/misc/editor/rustrover/run-bin-environmentd.run.xml
+++ b/misc/editor/rustrover/run-bin-environmentd.run.xml
@@ -1,6 +1,16 @@
+<!--
+Copyright Materialize, Inc. and contributors. All rights reserved.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file at the root of this repository.
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0.
+-->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="run-bin-environmentd" type="ShConfigurationType">
-    <option name="SCRIPT_TEXT" value="bin/environmentd --reset --enable-mac-codesigning" />
+    <option name="SCRIPT_TEXT" value="bin/environmentd --reset" />
     <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
     <option name="SCRIPT_PATH" value="" />
     <option name="SCRIPT_OPTIONS" value="" />

--- a/misc/editor/rustrover/run-bin-environmentd.run.xml
+++ b/misc/editor/rustrover/run-bin-environmentd.run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run-bin-environmentd" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="bin/environmentd --reset --enable-mac-codesigning" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/nix/store/k69pyqgx9bzzwr24jg7v0bfiibhs2qmv-bash-interactive-5.2p32/bin/bash" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/misc/editor/rustrover/run-pre-push-lints.run.xml
+++ b/misc/editor/rustrover/run-pre-push-lints.run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run-pre-push-lints" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="bin/pre-push" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/nix/store/k69pyqgx9bzzwr24jg7v0bfiibhs2qmv-bash-interactive-5.2p32/bin/bash" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/misc/editor/rustrover/run-pre-push-lints.run.xml
+++ b/misc/editor/rustrover/run-pre-push-lints.run.xml
@@ -1,3 +1,13 @@
+<!--
+Copyright Materialize, Inc. and contributors. All rights reserved.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file at the root of this repository.
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0.
+-->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="run-pre-push-lints" type="ShConfigurationType">
     <option name="SCRIPT_TEXT" value="bin/pre-push" />


### PR DESCRIPTION
Running the equivalent of `bin/environmentd --reset` is not simple in RustRover. Include example run configuration in the repo for new developers to easily get started.