### PR TITLE
docs: tweak ingest-data menu for mysql/postgres

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -29,18 +29,6 @@ name = "Ingest data"
 weight= 11
 
 [[menu.main]]
-name = "MySQL"
-parent = 'ingest-data'
-identifier = 'mysql'
-weight = 5
-
-[[menu.main]]
-name = "PostgreSQL"
-parent = 'ingest-data'
-identifier = 'postgresql'
-weight = 10
-
-[[menu.main]]
 name = "SQL Server"
 parent = 'ingest-data'
 identifier = 'sql-server'

--- a/doc/user/content/ingest-data/mysql/_index.md
+++ b/doc/user/content/ingest-data/mysql/_index.md
@@ -1,12 +1,12 @@
 ---
-title: "Overview"
+title: "MySQL"
 description: "Connecting Materialize to a MySQL database for Change Data Capture (CDC)."
 disable_list: true
 menu:
   main:
-    parent: 'mysql'
-    weight: 1
-    identifier: 'mysql-overview'
+    parent: 'ingest-data'
+    identifier: 'mysql'
+    weight: 5
 ---
 
 ## Change Data Capture (CDC)

--- a/doc/user/content/ingest-data/postgres/_index.md
+++ b/doc/user/content/ingest-data/postgres/_index.md
@@ -1,12 +1,12 @@
 ---
-title: "Overview"
+title: "PostgreSQL"
 description: "Connecting Materialize to a PostgreSQL database for Change Data Capture (CDC)."
 disable_list: true
 menu:
   main:
-    parent: 'postgresql'
-    weight: 1
-    identifier: 'postgresql-overview'
+    parent: 'ingest-data'
+    weight: 10
+    identifier: 'postgresql'
 ---
 
 ## Change Data Capture (CDC)


### PR DESCRIPTION
In Ingest data, make MySQL and Postgres landing pages - instead of having separate Overview page.
Future work will involve making Ingest data also a landing page with meaningful content, instead of just a list of content.
