### PR TITLE
Support dataflow expiration for materialized views with `REFRESH`

### DIFF
--- a/doc/developer/design/20240919_dataflow_expiration.md
+++ b/doc/developer/design/20240919_dataflow_expiration.md
@@ -106,7 +106,7 @@ More concretely, this feature involves the following changes:
   `replica_expiration = now() + offset`. This value indicates the maximum
   time for which the replica is expected to be running.
   * Existing replicas should be restarted to enable or disable replica
-    expiration for them. 
+    expiration for them.
 * When building a dataflow, compute `dataflow_expiration` as per the logic
   described above. If non-empty, the `dataflow_expiration` is added to the
   dataflow `until` that ensures that any diff beyond this limit is dropped in

--- a/doc/developer/design/20240919_dataflow_expiration.md
+++ b/doc/developer/design/20240919_dataflow_expiration.md
@@ -105,8 +105,8 @@ More concretely, this feature involves the following changes:
 * If the offset is configured with a non-zero value, compute
   `replica_expiration = now() + offset`. This value indicates the maximum
   time for which the replica is expected to be running.
-  * For running replicas, the `compute_replica_expiration_offset` can only be
-    updated to a value lower than the one currently set.
+  * Existing replicas should be restarted to enable or disable replica
+    expiration for them. 
 * When building a dataflow, compute `dataflow_expiration` as per the logic
   described above. If non-empty, the `dataflow_expiration` is added to the
   dataflow `until` that ensures that any diff beyond this limit is dropped in

--- a/src/adapter/src/catalog/dataflow_expiration.rs
+++ b/src/adapter/src/catalog/dataflow_expiration.rs
@@ -5,9 +5,11 @@
 
 //! Helper function for dataflow expiration checks.
 
-use mz_repr::GlobalId;
-
 use crate::catalog::Catalog;
+use differential_dataflow::lattice::Lattice;
+use mz_catalog::memory::objects::CatalogItem;
+use mz_expr::CollectionPlan;
+use mz_repr::{GlobalId, Timestamp};
 
 impl Catalog {
     /// Whether the catalog entry `id` or any of its transitive dependencies is a materialized view
@@ -24,5 +26,58 @@ impl Catalog {
                 .state()
                 .transitive_uses(id)
                 .any(test_has_transitive_refresh_schedule)
+    }
+    /// Recursive function.
+    pub(crate) fn compute_expiration_with_refresh(
+        &self,
+        id: GlobalId,
+        replica_expiration: Timestamp,
+    ) -> Timestamp {
+        let entry = self.get_entry(&id);
+        // TODO: use a queue to deduplicate work.
+        // TODO: don't use Timestamp::MAX as the initial value.
+        match &entry.item {
+            CatalogItem::MaterializedView(mv) => {
+                let mut new_expiration = mv.raw_expr.depends_on().into_iter().fold(
+                    Timestamp::MAX,
+                    |new_expiration, dep| {
+                        // Pick the minimum refresh time of all dependencies.
+                        new_expiration
+                            .meet(&self.compute_expiration_with_refresh(dep, replica_expiration))
+                    },
+                );
+                if let Some(refresh_schedule) = &mv.refresh_schedule {
+                    if let Some(next_refresh) = refresh_schedule.round_up_timestamp(new_expiration)
+                    {
+                        new_expiration = next_refresh;
+                    }
+                }
+                new_expiration
+            }
+            CatalogItem::View(view) => view.raw_expr.depends_on().into_iter().fold(
+                Timestamp::MAX,
+                |new_expiration, dep| {
+                    new_expiration
+                        .meet(&self.compute_expiration_with_refresh(dep, replica_expiration))
+                },
+            ),
+            CatalogItem::Index(index) => {
+                self.compute_expiration_with_refresh(index.on, replica_expiration)
+            }
+            CatalogItem::Func(_) => {
+                todo!()
+            }
+            CatalogItem::ContinualTask(_) => {
+                todo!()
+            }
+            // These will not have a transitive dependency on REFRESH.
+            CatalogItem::Table(_)
+            | CatalogItem::Source(_)
+            | CatalogItem::Sink(_)
+            | CatalogItem::Log(_)
+            | CatalogItem::Type(_)
+            | CatalogItem::Secret(_)
+            | CatalogItem::Connection(_) => replica_expiration,
+        }
     }
 }

--- a/src/adapter/src/catalog/dataflow_expiration.rs
+++ b/src/adapter/src/catalog/dataflow_expiration.rs
@@ -6,78 +6,32 @@
 //! Helper function for dataflow expiration checks.
 
 use crate::catalog::Catalog;
-use differential_dataflow::lattice::Lattice;
-use mz_catalog::memory::objects::CatalogItem;
-use mz_expr::CollectionPlan;
-use mz_repr::{GlobalId, Timestamp};
+use mz_compute_types::dataflows::{RefreshDep, RefreshDepIndex};
+use mz_repr::GlobalId;
 
 impl Catalog {
-    /// Whether the catalog entry `id` or any of its transitive dependencies is a materialized view
-    /// with a refresh schedule. Used to disable dataflow expiration if found.
-    pub(crate) fn item_has_transitive_refresh_schedule(&self, id: GlobalId) -> bool {
-        let test_has_transitive_refresh_schedule = |dep: GlobalId| -> bool {
-            if let Some(mv) = self.get_entry(&dep).materialized_view() {
-                return mv.refresh_schedule.is_some();
-            }
-            false
-        };
-        test_has_transitive_refresh_schedule(id)
-            || self
-                .state()
-                .transitive_uses(id)
-                .any(test_has_transitive_refresh_schedule)
-    }
     /// Recursive function.
-    pub(crate) fn compute_expiration_with_refresh(
+    pub(crate) fn get_refresh_dependencies(
         &self,
-        id: GlobalId,
-        replica_expiration: Timestamp,
-    ) -> Timestamp {
-        let entry = self.get_entry(&id);
-        // TODO: use a queue to deduplicate work.
-        // TODO: don't use Timestamp::MAX as the initial value.
-        match &entry.item {
-            CatalogItem::MaterializedView(mv) => {
-                let mut new_expiration = mv.raw_expr.depends_on().into_iter().fold(
-                    Timestamp::MAX,
-                    |new_expiration, dep| {
-                        // Pick the minimum refresh time of all dependencies.
-                        new_expiration
-                            .meet(&self.compute_expiration_with_refresh(dep, replica_expiration))
-                    },
-                );
-                if let Some(refresh_schedule) = &mv.refresh_schedule {
-                    if let Some(next_refresh) = refresh_schedule.round_up_timestamp(new_expiration)
-                    {
-                        new_expiration = next_refresh;
-                    }
-                }
-                new_expiration
+        deps: impl Iterator<Item = GlobalId>,
+        deps_tree: &mut Vec<RefreshDep>,
+    ) -> Option<RefreshDepIndex> {
+        let start = deps_tree.len();
+        for dep in deps {
+            let entry = self.get_entry(&dep);
+            let refresh_dep_index =
+                self.get_refresh_dependencies(entry.uses().into_iter(), deps_tree);
+            let refresh_schedule = entry
+                .materialized_view()
+                .and_then(|mv| mv.refresh_schedule.clone());
+            if refresh_dep_index.is_some() || refresh_schedule.is_some() {
+                deps_tree.push(RefreshDep {
+                    refresh_dep_index,
+                    refresh_schedule,
+                });
             }
-            CatalogItem::View(view) => view.raw_expr.depends_on().into_iter().fold(
-                Timestamp::MAX,
-                |new_expiration, dep| {
-                    new_expiration
-                        .meet(&self.compute_expiration_with_refresh(dep, replica_expiration))
-                },
-            ),
-            CatalogItem::Index(index) => {
-                self.compute_expiration_with_refresh(index.on, replica_expiration)
-            }
-            CatalogItem::Func(_) => {
-                todo!()
-            }
-            CatalogItem::ContinualTask(_) => {
-                todo!()
-            }
-            // These will not have a transitive dependency on REFRESH.
-            CatalogItem::Table(_)
-            | CatalogItem::Source(_)
-            | CatalogItem::Sink(_)
-            | CatalogItem::Log(_)
-            | CatalogItem::Type(_)
-            | CatalogItem::Secret(_)
-            | CatalogItem::Connection(_) => replica_expiration,
         }
+        let end = deps_tree.len();
+        (end > start).then_some(RefreshDepIndex { start, end })
     }
 }

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -442,7 +442,6 @@ impl Coordinator {
 
         // Collect properties for `DataflowExpirationDesc`.
         let transitive_upper = self.least_valid_write(&id_bundle);
-        let has_transitive_refresh_schedule = self.catalog.item_has_transitive_refresh_schedule(on);
 
         // Pre-allocate a vector of transient GlobalIds for each notice.
         let notice_ids = std::iter::repeat_with(|| self.allocate_transient_id())
@@ -477,9 +476,6 @@ impl Coordinator {
                 df_desc.set_as_of(since);
 
                 df_desc.dataflow_expiration_desc.transitive_upper = Some(transitive_upper);
-                df_desc
-                    .dataflow_expiration_desc
-                    .has_transitive_refresh_schedule = has_transitive_refresh_schedule;
 
                 coord
                     .ship_dataflow_and_notice_builtin_table_updates(

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -21,7 +21,7 @@ use mz_repr::explain::{ExprHumanizerExt, TransientItem};
 use mz_repr::optimize::OptimizerFeatures;
 use mz_repr::optimize::OverrideFrom;
 use mz_repr::refresh_schedule::RefreshSchedule;
-use mz_repr::{Datum, GlobalId, Row};
+use mz_repr::{Datum, GlobalId, Row, Timestamp};
 use mz_sql::ast::ExplainStage;
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::ResolvedIds;
@@ -580,6 +580,28 @@ impl Coordinator {
                 .depends_on()
                 .into_iter()
                 .any(|id| self.catalog.item_has_transitive_refresh_schedule(id));
+
+        // Collect properties for `DataflowExpirationDesc`.
+        let transitive_upper = self.least_valid_write(&id_bundle);
+        let replica_expiration = Timestamp::default(); // TODO: Can we get replica_expiration information here somehow?
+
+        let mut expiration_with_refresh =
+            raw_expr
+                .depends_on()
+                .into_iter()
+                .fold(Timestamp::MAX, |new_expiration, id| {
+                    new_expiration.meet(
+                        &self
+                            .catalog
+                            .compute_expiration_with_refresh(id, replica_expiration),
+                    )
+                });
+        if let Some(refresh_schedule) = &refresh_schedule {
+            if let Some(next_refresh) = refresh_schedule.round_up_timestamp(expiration_with_refresh)
+            {
+                expiration_with_refresh = next_refresh;
+            }
+        }
 
         let read_holds_owned;
         let read_holds = if let Some(txn_reads) = self.txn_read_holds.get(session.conn_id()) {

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -324,7 +324,6 @@ impl Coordinator {
             cluster_id,
             plan:
                 plan::SubscribePlan {
-                    from,
                     copy_to,
                     emit_progress,
                     output,
@@ -339,10 +338,6 @@ impl Coordinator {
 
         // Collect properties for `DataflowExpirationDesc`.
         let transitive_upper = self.least_valid_write(&id_bundle);
-        let has_transitive_refresh_schedule = from
-            .depends_on()
-            .into_iter()
-            .any(|id| self.catalog.item_has_transitive_refresh_schedule(id));
 
         let sink_id = global_lir_plan.sink_id();
 
@@ -366,9 +361,6 @@ impl Coordinator {
         let (mut df_desc, df_meta) = global_lir_plan.unapply();
 
         df_desc.dataflow_expiration_desc.transitive_upper = Some(transitive_upper);
-        df_desc
-            .dataflow_expiration_desc
-            .has_transitive_refresh_schedule = has_transitive_refresh_schedule;
 
         // Emit notices.
         self.emit_optimizer_notices(ctx.session(), &df_meta.optimizer_notices);

--- a/src/compute-types/src/dataflows.proto
+++ b/src/compute-types/src/dataflows.proto
@@ -49,9 +49,18 @@ message ProtoDataflowDescription {
   }
 
   message ProtoDataflowExpirationDesc {
+    message ProtoRefreshDepIndex {
+      uint64 start = 1;
+      uint64 end = 2;
+    }
+    message ProtoRefreshDep {
+      optional ProtoRefreshDepIndex refresh_dep_index = 1;
+      optional mz_repr.refresh_schedule.ProtoRefreshSchedule refresh_schedule = 2;
+    }
     optional mz_repr.antichain.ProtoU64Antichain transitive_upper = 1;
-    bool has_transitive_refresh_schedule = 2;
     bool is_timeline_epoch_ms = 3;
+    repeated ProtoRefreshDep refresh_deps = 4;
+    optional ProtoRefreshDepIndex refresh_deps_index = 5;
   }
 
   repeated ProtoSourceImport source_imports = 1;

--- a/src/compute-types/src/dataflows.proto
+++ b/src/compute-types/src/dataflows.proto
@@ -48,15 +48,17 @@ message ProtoDataflowDescription {
     sinks.ProtoComputeSinkDesc sink_desc = 2;
   }
 
+  message ProtoRefreshDepIndex {
+    uint64 start = 1;
+    uint64 end = 2;
+  }
+
+  message ProtoRefreshDep {
+    optional ProtoRefreshDepIndex refresh_dep_index = 1;
+    optional mz_repr.refresh_schedule.ProtoRefreshSchedule refresh_schedule = 2;
+  }
+
   message ProtoDataflowExpirationDesc {
-    message ProtoRefreshDepIndex {
-      uint64 start = 1;
-      uint64 end = 2;
-    }
-    message ProtoRefreshDep {
-      optional ProtoRefreshDepIndex refresh_dep_index = 1;
-      optional mz_repr.refresh_schedule.ProtoRefreshSchedule refresh_schedule = 2;
-    }
     optional mz_repr.antichain.ProtoU64Antichain transitive_upper = 1;
     bool is_timeline_epoch_ms = 3;
     repeated ProtoRefreshDep refresh_deps = 4;

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -132,22 +132,18 @@ impl<P, S> DataflowDescription<P, S, Timestamp> {
         let Some(&replica_expiration_ts) = replica_expiration.as_option() else {
             return Antichain::default();
         };
-
-        let expiration_with_refresh =
+        let mut expiration_with_refresh_ts =
             if let Some(refresh_deps_index) = dataflow_expiration_desc.refresh_deps_index {
-                let mut expiration_with_refresh_ts = get_expiration_with_refresh(
+                get_expiration_with_refresh(
                     refresh_deps_index,
                     &dataflow_expiration_desc.refresh_deps,
                     replica_expiration_ts,
-                );
-                apply_optional_refresh_schedule(
-                    &mut expiration_with_refresh_ts,
-                    &self.refresh_schedule,
-                );
-                Antichain::from_elem(expiration_with_refresh_ts)
+                )
             } else {
-                replica_expiration.clone()
+                replica_expiration_ts
             };
+        apply_optional_refresh_schedule(&mut expiration_with_refresh_ts, &self.refresh_schedule);
+        let expiration_with_refresh = Antichain::from_elem(expiration_with_refresh_ts);
 
         if let Some(upper) = &dataflow_expiration_desc.transitive_upper {
             // Returns empty if `upper` is empty, else the max of `upper` and `replica_expiration`.

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -26,11 +26,9 @@ use serde::{Deserialize, Serialize};
 use timely::progress::Antichain;
 use timely::Container;
 
-use crate::dataflows::proto_dataflow_description::proto_dataflow_expiration_desc::ProtoRefreshDep;
-use crate::dataflows::proto_dataflow_description::proto_dataflow_expiration_desc::ProtoRefreshDepIndex;
 use crate::dataflows::proto_dataflow_description::{
-    ProtoDataflowExpirationDesc, ProtoIndexExport, ProtoIndexImport, ProtoSinkExport,
-    ProtoSourceImport,
+    ProtoDataflowExpirationDesc, ProtoIndexExport, ProtoIndexImport, ProtoRefreshDep,
+    ProtoRefreshDepIndex, ProtoSinkExport, ProtoSourceImport,
 };
 use crate::plan::flat_plan::FlatPlan;
 use crate::plan::Plan;

--- a/test/testdrive/replica-expiration.td
+++ b/test/testdrive/replica-expiration.td
@@ -239,3 +239,20 @@ ALTER SYSTEM SET compute_replica_expiration_offset = '30d';
 1000
 > DROP MATERIALIZED VIEW events_mv CASCADE;
 > DROP CLUSTER test CASCADE;
+
+# Test refresh schedules
+
+## CREATE TABLE t (id int, ts timestamp);
+## CREATE MATERIALIZED VIEW mv1 with (refresh at creation, refresh EVERY '7 days' ALIGNED TO '2024-06-04 12:00:00') as select * from t where id < 10;
+##     - `2024-10-15 12:00:00.000`
+## CREATE MATERIALIZED VIEW mv2 with (refresh at creation, refresh EVERY '30 days' ALIGNED TO '2024-06-04 12:00:00') as select * from t where id < 15;
+##     - `2024-11-01 12:00:00.000`
+## CREATE MATERIALIZED VIEW mv3 with (refresh at creation, refresh EVERY '60 days' ALIGNED TO '2024-06-04 12:00:00') as select * from mv2 where id < 15;
+##     - `2024-12-01 12:00:00.000`
+
+## CREATE VIEW v1 as select * from mv1 union all select * from mv2 where mz_now() <= ts + interval '4 days';
+## CREATE VIEW v2 as select * from mv2 union all select * from mv3 where mz_now() <= ts + interval '4 days';
+## CREATE VIEW v3 as select * from mv2 union all select * from mv3 where mz_now() <= ts + interval '4 days';
+
+# Test dataflows multiple inputs (unions/joins), each of which can have a refresh schedule: meet(inputs)
+# Test dataflows that recursively depend on MVs with refresh schedules


### PR DESCRIPTION
WIP.

Initial planning for eventual full support of MVs with non-default REFRESH schedules.

Fixes https://github.com/MaterializeInc/database-issues/issues/8646 https://github.com/MaterializeInc/database-issues/issues/8645

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
