### PR TITLE
compute: history: flip read_only flag

### DIFF
--- a/src/compute-client/src/protocol/history.rs
+++ b/src/compute-client/src/protocol/history.rs
@@ -100,7 +100,7 @@ where
         let mut final_configuration = ComputeParameters::default();
 
         let mut initialization_complete = false;
-        let mut read_only = true;
+        let mut allow_writes = false;
 
         for command in self.commands.drain(..) {
             match command {
@@ -135,7 +135,7 @@ where
                     live_peeks.remove(&uuid);
                 }
                 ComputeCommand::AllowWrites => {
-                    read_only = false;
+                    allow_writes = true;
                 }
             }
         }
@@ -243,7 +243,7 @@ where
             self.commands.push(ComputeCommand::InitializationComplete);
         }
 
-        if !read_only {
+        if allow_writes {
             self.commands.push(ComputeCommand::AllowWrites);
         }
 


### PR DESCRIPTION
This PR replaces the `read_only` flag in the compute history, which tracks whether an `AllowWrite` command should be emitted after a reduction, with a `write_only` flag. This gives a slight readability improvement and consistency with the storage command history.

### Motivation

   * This PR refactors existing code.

Follow-up from a discussion in https://github.com/MaterializeInc/materialize/pull/29699

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
