### PR TITLE
feature-benchmark: Don't measure messages

### DIFF
--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -47,7 +47,6 @@ class Benchmark:
         self._filter = filter
         self._termination_conditions = termination_conditions
         self._performance_aggregation = aggregation_class()
-        self._messages_aggregation = aggregation_class()
         self._default_size = default_size
         self._seed = seed
 
@@ -97,7 +96,6 @@ class Benchmark:
             if self.shall_terminate(performance_measurement):
                 return [
                     self._performance_aggregation,
-                    self._messages_aggregation,
                     self._memory_mz_aggregation,
                     self._memory_clusterd_aggregation,
                 ]
@@ -168,7 +166,6 @@ class Benchmark:
         )
 
         self._collect_performance_measurement(i, performance_measurement)
-        self._collect_message_count(i)
 
         if self._memory_mz_aggregation:
             self._collect_memory_measurement(
@@ -201,18 +198,6 @@ class Benchmark:
         if not self._filter or not self._filter.filter(performance_measurement):
             print(f"{i} {performance_measurement}")
             self._performance_aggregation.append_measurement(performance_measurement)
-
-    def _collect_message_count(self, i: int) -> None:
-        messages = self._executor.Messages()
-        if messages is not None:
-            messages_measurement = Measurement(
-                type=MeasurementType.MESSAGES,
-                value=messages,
-                unit=MeasurementUnit.COUNT,
-            )
-            print(f"{i}: {messages_measurement}")
-            if not self._filter or not self._filter.filter(messages_measurement):
-                self._messages_aggregation.append_measurement(messages_measurement)
 
     def _collect_memory_measurement(
         self, i: int, memory_measurement_type: MeasurementType, aggregation: Aggregation

--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -18,7 +18,7 @@ FEATURE_BENCHMARK_SCENARIOS_DIR = FEATURE_BENCHMARK_FRAMEWORK_DIR / "scenarios"
 
 # Consider increasing the #FEATURE_BENCHMARK_FRAMEWORK_VERSION if changes are expected to impact results!
 SHA256_OF_FRAMEWORK: dict[str, str] = {
-    "*": "83ac95bbe391e9cdcab5cabafbae59f95c17c7f50e8c5b66c7705ce8cd6f1f93",
+    "*": "c13ba2db3cccea214fbf946ef9037a307dd64b1b2d837611fc407c82cb5d8cfc",
 }
 
 # Consider increasing the scenario's class #version() if changes are expected to impact results!
@@ -26,7 +26,7 @@ SHA256_BY_SCENARIO_FILE: dict[str, str] = {
     "benchmark_main.py": "aca597f4eedb9c3e9ea08327b9997dab9ccb7202a0fe7df35181958d7413356b",
     "concurrency.py": "2e9c149c136b83b3853abc923a1adbdaf55a998ab4557712f8424c8b16f2adb1",
     "customer.py": "d1e72837a342c3ebf1f4a32ec583b1b78a78644cdba495030a6df45ebbffe703",
-    "optbench.py": "ae411afe1ba595021f2f9d2d21500ba0c1c6941561493eabcae113373f493bfa",
+    "optbench.py": "e0aa427c4af0467a408ebd11fcff55b75da910bae035cf272bebd3924ebc3483",
     "scale.py": "c4c8749d166e4df34e0b0e92220434fdb508c5c2ac56eb80c07043be0048dded",
     "skew.py": "bf60802205fc51ebf94fb008bbdb6b2ccce3c9ed88a6188fa7f090f2c84b120f",
     "subscribe.py": "66b6ba61daed10a0e78291f6251e62dcb41f206228028bc0cbd0d738ad76252b",

--- a/misc/python/materialize/feature_benchmark/executor.py
+++ b/misc/python/materialize/feature_benchmark/executor.py
@@ -7,9 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-import time
 from collections.abc import Callable
-from textwrap import dedent
 from typing import Any
 
 from materialize.mzcompose.composition import Composition
@@ -43,9 +41,6 @@ class Executor:
         raise NotImplementedError
 
     def DockerMemClusterd(self) -> int:
-        raise NotImplementedError
-
-    def Messages(self) -> int | None:
         raise NotImplementedError
 
 
@@ -95,55 +90,6 @@ class Docker(Executor):
 
     def DockerMemClusterd(self) -> int:
         return self._composition.mem("clusterd")
-
-    def Messages(self) -> int | None:
-        """Return the sum of all messages in the system from mz_internal.mz_message_counts_per_worker"""
-
-        def one_count(e: Docker) -> int | None:
-            result = e._composition.sql_query(
-                dedent(
-                    """
-                    SELECT SUM(sent) as cnt
-                    FROM
-                        mz_internal.mz_message_counts_per_worker mc,
-                        mz_internal.mz_dataflow_channel_operators_per_worker c
-                    WHERE
-                        c.id = mc.channel_id AND
-                        c.worker_id = mc.from_worker_id AND
-                        from_operator_id IN (
-                            SELECT dod.id
-                            FROM mz_internal.mz_dataflow_operator_dataflows dod
-                            WHERE dod.dataflow_name NOT LIKE '%oneshot-select%'
-                            AND dod.dataflow_name NOT LIKE '%subscribe%'
-                        )
-                    """
-                )
-            )
-            if len(result) == 0:
-                return None
-            elif result[0][0] is None:
-                return None
-            else:
-                return int(result[0][0])
-
-        # Loop until the message count converges
-        prev_count: int | None = None
-        for i in range(50):
-            new_count = one_count(self)
-            if new_count is not None and prev_count is not None:
-                pct = (max(prev_count, new_count) / min(prev_count, new_count)) - 1
-                # It has converged
-                if pct < 0.05 and i > 2:
-                    return new_count
-
-            # No message count data available
-            if new_count is None and i > 2:
-                return new_count
-
-            prev_count = new_count
-            time.sleep(0.1)
-
-        return None
 
 
 class MzCloud(Executor):

--- a/misc/python/materialize/feature_benchmark/measurement.py
+++ b/misc/python/materialize/feature_benchmark/measurement.py
@@ -38,7 +38,6 @@ class MeasurementType(Enum):
     WALLCLOCK = auto()
     MEMORY_MZ = auto()
     MEMORY_CLUSTERD = auto()
-    MESSAGES = auto()
 
     def __str__(self) -> str:
         return self.name.lower()
@@ -47,7 +46,6 @@ class MeasurementType(Enum):
         return self in {
             MeasurementType.MEMORY_MZ,
             MeasurementType.MEMORY_CLUSTERD,
-            MeasurementType.MESSAGES,
         }
 
     def is_lower_value_better(self) -> bool:

--- a/misc/python/materialize/feature_benchmark/scenario.py
+++ b/misc/python/materialize/feature_benchmark/scenario.py
@@ -25,7 +25,6 @@ class RootScenario:
         MeasurementType.WALLCLOCK: 0.10,
         # Increased the other measurements since they are easy to regress now
         # that we take the run with the minimum wallclock time:
-        MeasurementType.MESSAGES: 0.20,
         MeasurementType.MEMORY_MZ: 0.20,
         MeasurementType.MEMORY_CLUSTERD: 0.20,
     }

--- a/misc/python/materialize/feature_benchmark/scenarios/optbench.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/optbench.py
@@ -111,8 +111,6 @@ class OptbenchTPCH(Scenario):
     QUERY = 1
     RELATIVE_THRESHOLD: dict[MeasurementType, float] = {
         MeasurementType.WALLCLOCK: 0.20,  # increased because it's easy to regress
-        # optimizer-only, we don't care if there are a few more messages at times (32 vs 4)
-        MeasurementType.MESSAGES: 100,
         MeasurementType.MEMORY_MZ: 0.20,
         MeasurementType.MEMORY_CLUSTERD: 0.20,
     }

--- a/misc/python/materialize/test_analytics/data/feature_benchmark/feature_benchmark_result_storage.py
+++ b/misc/python/materialize/test_analytics/data/feature_benchmark/feature_benchmark_result_storage.py
@@ -24,7 +24,6 @@ class FeatureBenchmarkResultEntry:
     scale: str
     is_regression: bool
     wallclock: ReportMeasurement[float]
-    messages: ReportMeasurement[int]
     memory_mz: ReportMeasurement[float]
     memory_clusterd: ReportMeasurement[float]
 
@@ -73,7 +72,7 @@ class FeatureBenchmarkResultStorage(BaseDataStorage):
                     {as_sanitized_literal(result_entry.scale)},
                     {result_entry.is_regression},
                     {result_entry.wallclock.result or 'NULL::DOUBLE'},
-                    {result_entry.messages.result or 'NULL::INT'},
+                    NULL,  -- to be removed when we remove the "messages" column
                     {result_entry.memory_mz.result or 'NULL::DOUBLE'},
                     {result_entry.memory_clusterd.result or 'NULL::DOUBLE'},
                     {result_entry.wallclock.min or 'NULL::DOUBLE'},
@@ -122,7 +121,7 @@ class FeatureBenchmarkResultStorage(BaseDataStorage):
                     {discarded_entry.cycle},
                     {discarded_entry.is_regression},
                     {discarded_entry.wallclock.result or 'NULL::DOUBLE'},
-                    {discarded_entry.messages.result or 'NULL::INT'},
+                    NULL,  -- to be removed when we remove the "messages" column
                     {discarded_entry.memory_mz.result or 'NULL::DOUBLE'},
                     {discarded_entry.memory_clusterd.result or 'NULL::DOUBLE'},
                     {discarded_entry.wallclock.min or 'NULL::DOUBLE'},

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -9,8 +9,8 @@
 
 """
 Simple benchmark of mostly individual queries using testdrive. Can find
-wallclock/memory/messages regressions in single-connection query executions,
-not suitable for concurrency.
+wallclock/memorys regressions in single-connection query executions, not
+suitable for concurrency.
 """
 
 import argparse
@@ -154,7 +154,7 @@ def run_one_scenario(
     scenario_name = scenario_class.__name__
     print(f"--- Now benchmarking {scenario_name} ...")
 
-    measurement_types = [MeasurementType.WALLCLOCK, MeasurementType.MESSAGES]
+    measurement_types = [MeasurementType.WALLCLOCK]
     if args.measure_memory:
         measurement_types.append(MeasurementType.MEMORY_MZ)
         measurement_types.append(MeasurementType.MEMORY_CLUSTERD)
@@ -796,7 +796,6 @@ def _create_feature_benchmark_result_entry(
         scale=scale or "default",
         is_regression=is_regression,
         wallclock=measurements[MeasurementType.WALLCLOCK],
-        messages=measurements[MeasurementType.MESSAGES],
         memory_mz=measurements[MeasurementType.MEMORY_MZ],
         memory_clusterd=measurements[MeasurementType.MEMORY_CLUSTERD],
     )


### PR DESCRIPTION
Hasn't been very useful so far. Slack discussion: https://materializeinc.slack.com/archives/C01LKF361MZ/p1728891862180139

Previous instance where it wasn't particularly useful: https://github.com/MaterializeInc/database-issues/issues/7575

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
