### PR TITLE
ci: Bump some timeouts

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -44,7 +44,7 @@ steps:
     key: linters
     steps:
       - id: closed-issues-detect
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         label: Detect references to already closed issues
         command: bin/ci-builder run stable bin/ci-closed-issues-detect
         depends_on: []
@@ -1599,7 +1599,7 @@ steps:
       - id: lang-csharp
         label: ":csharp: tests"
         depends_on: build-aarch64
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         plugins:
           - ./ci/plugins/mzcompose:
               composition: csharp
@@ -1609,7 +1609,7 @@ steps:
       - id: lang-js
         label: ":js: tests"
         depends_on: build-aarch64
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         plugins:
           - ./ci/plugins/mzcompose:
               composition: js
@@ -1619,7 +1619,7 @@ steps:
       - id: lang-java
         label: ":java: tests"
         depends_on: build-aarch64
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         plugins:
           - ./ci/plugins/mzcompose:
               composition: java
@@ -1629,7 +1629,7 @@ steps:
       - id: lang-python
         label: ":python: tests"
         depends_on: build-aarch64
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         plugins:
           - ./ci/plugins/mzcompose:
               composition: python
@@ -1639,7 +1639,7 @@ steps:
       - id: lang-ruby
         label: ":ruby: tests"
         depends_on: build-aarch64
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         plugins:
           - ./ci/plugins/mzcompose:
               composition: ruby


### PR DESCRIPTION
Docker pull is still sometimes slow, seen in https://buildkite.com/materialize/nightly/builds/9951#01928084-3b54-4c94-8bf1-8e6ed1ed7d92

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
