### PR TITLE
ci: increase timeout of SLT logic tests

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -305,7 +305,7 @@ steps:
     label: "Fast SQL logic tests %N"
     depends_on: build-aarch64
     timeout_in_minutes: 30
-    parallelism: 3
+    parallelism: 5
     inputs: [test/sqllogictest]
     plugins:
       - ./ci/plugins/mzcompose:

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -1547,6 +1547,7 @@ query TTT
 SELECT name, cs.type, cs.refresh_hydration_time_estimate
 FROM mz_internal.mz_cluster_schedules cs, mz_catalog.mz_clusters c
 WHERE c.id = cs.cluster_id
+AND name LIKE 'c_schedule_%'
 ORDER BY name;
 ----
 c_schedule_1  on-refresh  00:00:00
@@ -1555,12 +1556,6 @@ c_schedule_3  on-refresh  00:00:00
 c_schedule_4  manual  NULL
 c_schedule_5  manual  NULL
 c_schedule_hydration_time_estimate  on-refresh  00:16:35
-mz_analytics  manual  NULL
-mz_catalog_server  manual  NULL
-mz_probe  manual  NULL
-mz_support  manual  NULL
-mz_system  manual  NULL
-quickstart  manual  NULL
 
 statement ok
 SELECT mz_unsafe.mz_sleep(4);


### PR DESCRIPTION
We had a few timeouts recently:
* https://buildkite.com/materialize/test/builds/92290
* https://buildkite.com/materialize/test/builds/92268
* https://buildkite.com/materialize/test/builds/92240
* https://buildkite.com/materialize/test/builds/92231