### PR TITLE
sql: fix purification of sinks with separate key/value formats

### DIFF
--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -215,7 +215,7 @@ pub struct AvroDocOn<T: AstInfo> {
     pub identifier: DocOnIdentifier<T>,
     pub for_schema: DocOnSchema,
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DocOnSchema {
     KeyOnly,
     ValueOnly,

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -601,7 +601,11 @@ pub fn plan_explain_schema(
         ident!("mz_explain_schema"),
     ]));
 
-    crate::pure::add_materialize_comments(scx.catalog, &mut statement)?;
+    crate::pure::purify_create_sink_avro_doc_on_options(
+        scx.catalog,
+        *statement.from.item_id(),
+        &mut statement.format,
+    )?;
     let default_strategy = DEFAULT_SINK_PARTITION_STRATEGY.get(scx.catalog.system_vars().dyncfgs());
     statement.with_options.push(CreateSinkOption {
         name: CreateSinkOptionName::PartitionStrategy,


### PR DESCRIPTION
When sinks learned to take separate key and value formats (#27982), the logic for purification didn't get wired up quite right for the case where both the key and value format required purification.

This is necessary prep work for supporting EXCLUDE COLUMNS for sinks (MaterializeInc/database-issues#8160).

The issues fixed here are such edge cases that I'm not fussed about adding test cases for them in this commit. I'll add some test cases in a future refaactoring PR to provide broad coverage of separate key/value formats.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code in preparation for a new feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
