### PR TITLE
testdrive: No limit in source-statistics.td load gen

### DIFF
--- a/test/testdrive/source-statistics.td
+++ b/test/testdrive/source-statistics.td
@@ -91,7 +91,7 @@ $ set-sql-timeout duration=2minutes
 # for sources created by previous tests.
 > CREATE SOURCE auction_house_in_source_statistics_td
   IN CLUSTER ${arg.single-replica-cluster}
-  FROM LOAD GENERATOR AUCTION (UP TO 100);
+  FROM LOAD GENERATOR AUCTION;
 
 > CREATE TABLE accounts FROM SOURCE auction_house_in_source_statistics_td (REFERENCE accounts);
 > CREATE TABLE auctions FROM SOURCE auction_house_in_source_statistics_td (REFERENCE auctions);


### PR DESCRIPTION
Caused failure in https://buildkite.com/materialize/nightly/builds/9968#01928c36-2385-4371-9f90-de38897767d4
```
source-statistics.td:119:1: error: non-matching rows: expected: [["auction_house_in_source_statistics_td", "true", "true", "false", "false", "true", "true"]] got:
[["auction_house_in_source_statistics_td", "true", "true", "false", "false", "true", "false"]]
```
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
