### PR TITLE
parallel-benchmark: Ignore nan in standard deviation

### DIFF
--- a/misc/python/materialize/test_analytics/data/parallel_benchmark/parallel_benchmark_result_storage.py
+++ b/misc/python/materialize/test_analytics/data/parallel_benchmark/parallel_benchmark_result_storage.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 from dataclasses import dataclass
+from math import isfinite
 
 from materialize import buildkite
 from materialize.buildkite import BuildkiteEnvVar
@@ -99,7 +100,7 @@ class ParallelBenchmarkResultStorage(BaseDataStorage):
                     {result_entry.p99_9999},
                     {result_entry.p99_99999},
                     {result_entry.p99_999999},
-                    {result_entry.std},
+                    {result_entry.std if isfinite(result_entry.std) else 'NULL::FLOAT'},
                     {result_entry.slope}
                 ;
                 """


### PR DESCRIPTION
Can happen if only one query run. Seen in https://materializeinc.slack.com/archives/C05CQUVHY48/p1728968596628669

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
