### PR TITLE
testdrive: get rid of failed writing row to mz_aws_connections table

### DIFF
--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -175,8 +175,14 @@ impl ConnectionContext {
         ConnectionContext {
             environment_id: "test-environment-id".into(),
             librdkafka_log_level: tracing::Level::INFO,
-            aws_external_id_prefix: None,
-            aws_connection_role_arn: None,
+            aws_external_id_prefix: Some(
+                AwsExternalIdPrefix::new_from_cli_argument_or_environment_variable(
+                    "test-aws-external-id-prefix",
+                ),
+            ),
+            aws_connection_role_arn: Some(
+                "arn:aws:iam::123456789000:role/MaterializeConnection".into(),
+            ),
             secrets_reader,
             cloud_resource_reader: None,
             ssh_tunnel_manager: SshTunnelManager::default(),


### PR DESCRIPTION
This addresses https://github.com/MaterializeInc/database-issues/issues/8653.

Get rid of
```
[2m2024-10-11T06:09:53.863297Z[0m [31mERROR[0m [2mmz_adapter::catalog::builtin_table_updates[0m[2m:[0m failed writing row to mz_aws_connections table [3mid[0m[2m=[0ms759 [3me[0m[2m=[0minternal error: no AWS external ID prefix configured
```