### PR TITLE
parallel-workload: Handle commit properly

### DIFF
--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -81,16 +81,7 @@ class Executor:
 
     def commit(self, http: Http = Http.RANDOM) -> None:
         self.insert_table = None
-        try:
-            if self.use_ws and http != Http.NO:
-                self.execute("commit")
-            else:
-                self.log("commit")
-                self.cur.connection.commit()
-        except QueryError:
-            raise
-        except Exception as e:
-            raise QueryError(str(e), "commit")
+        self.execute("commit")
         # TODO(def-): Enable when things are stable
         # self.use_ws = self.rng.choice([True, False]) if self.ws else False
 
@@ -151,7 +142,11 @@ class Executor:
                         raise QueryError(str(e), query)
                 else:
                     try:
-                        self.cur.execute(query.encode())
+                        if query == "commit":
+                            self.log("commit")
+                            self.cur.connection.commit()
+                        else:
+                            self.cur.execute(query.encode())
                     except Exception as e:
                         raise QueryError(str(e), query)
 


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/9981#01928efa-83ec-4264-87ca-7e32abcd3c79
```
ValueError: too many values to unpack (expected 1)
```
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
