### PR TITLE
Support optional duration dyncfg

### DIFF
--- a/src/dyncfg/src/dyncfg.proto
+++ b/src/dyncfg/src/dyncfg.proto
@@ -37,6 +37,7 @@ message ProtoConfigVal {
     double f64 = 9;
     string string = 4;
     mz_proto.ProtoDuration duration = 5;
+    ProtoOptionDuration opt_duration = 10;
     // Switch to Protobuf's native JSON representation,
     // google.protobuf.Value, once prost supports it.
     // See: https://github.com/tokio-rs/prost/issues/404
@@ -47,4 +48,8 @@ message ProtoConfigVal {
 
 message ProtoOptionU64 {
   optional uint64 val = 1;
+}
+
+message ProtoOptionDuration {
+  optional mz_proto.ProtoDuration val = 1;
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1325,6 +1325,9 @@ impl SystemVars {
                 ConfigVal::Duration(default) => {
                     VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), false)
                 }
+                ConfigVal::OptDuration(default) => {
+                    VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), false)
+                }
                 ConfigVal::Json(default) => {
                     VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), false)
                 }
@@ -2001,6 +2004,9 @@ impl SystemVars {
                 }
                 ConfigVal::Duration(_) => {
                     ConfigVal::from(*self.expect_config_value::<Duration>(name))
+                }
+                ConfigVal::OptDuration(_) => {
+                    ConfigVal::from(*self.expect_config_value::<Option<Duration>>(name))
                 }
                 ConfigVal::Json(_) => {
                     ConfigVal::from(self.expect_config_value::<serde_json::Value>(name).clone())


### PR DESCRIPTION
DNM: More of a thought experiment.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
