### PR TITLE
ci: Retry first dockerhub pull for ci-builder

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -36,7 +36,8 @@ date +"%Y-%m-%d %H:%M:%S" > step_start_timestamp
 # interfere with this build.
 ci_collapsed_heading ":docker: Purging containers and volumes from previous builds"
 sudo systemctl restart docker
-mzcompose --mz-quiet kill
+# First time we are using ci-builder, allow retrying a few times in case dockerhub has network problems
+mzcompose --mz-quiet kill || mzcompose --mz-quiet kill || mzcompose --mz-quiet kill
 mzcompose --mz-quiet rm --force -v
 mzcompose --mz-quiet down --volumes
 killall -9 clusterd || true # There might be remaining processes from a previous cargo-test run


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/test/builds/92367#01928ff9-c031-4630-813f-0f648268bcd7
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
