### PR TITLE
catalog: Allocate intro sources IDs in single txn

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -22,7 +22,7 @@ use mz_adapter_types::connection::ConnectionId;
 use mz_audit_log::{EventType, FullNameV1, ObjectType, VersionedStorageUsage};
 use mz_build_info::DUMMY_BUILD_INFO;
 use mz_catalog::builtin::{
-    BuiltinCluster, BuiltinLog, BuiltinSource, BuiltinTable, BUILTINS, BUILTIN_PREFIXES,
+    BuiltinCluster, BuiltinLog, BuiltinSource, BuiltinTable, BUILTIN_PREFIXES,
     MZ_CATALOG_SERVER_CLUSTER,
 };
 use mz_catalog::config::{BuiltinItemMigrationConfig, ClusterReplicaSizeMap, Config, StateConfig};
@@ -1145,22 +1145,6 @@ impl Catalog {
         ),
     > {
         self.state.default_privileges.iter()
-    }
-
-    /// Allocate ids for introspection sources. Called once per cluster creation.
-    pub async fn allocate_introspection_sources(&self) -> Vec<(&'static BuiltinLog, GlobalId)> {
-        let log_amount = BUILTINS::logs().count();
-        let system_ids = self
-            .storage()
-            .await
-            .allocate_system_ids(
-                log_amount
-                    .try_into()
-                    .expect("builtin logs should fit into u64"),
-            )
-            .await
-            .unwrap_or_terminate("cannot fail to allocate system ids");
-        BUILTINS::logs().zip(system_ids.into_iter()).collect()
     }
 
     pub fn pack_item_update(&self, id: GlobalId, diff: Diff) -> Vec<BuiltinTableUpdate> {

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -13,6 +13,7 @@ use std::time::{Duration, Instant};
 use itertools::Itertools;
 use maplit::btreeset;
 use mz_adapter_types::compaction::CompactionWindow;
+use mz_catalog::builtin::BUILTINS;
 use mz_catalog::memory::objects::{
     ClusterConfig, ClusterReplica, ClusterVariant, ClusterVariantManaged,
 };
@@ -600,7 +601,7 @@ impl Coordinator {
         // of a compute instance, so we create them unconditionally during instance creation.
         // Whether a replica actually maintains introspection arrangements is determined by the
         // per-replica introspection configuration.
-        let introspection_sources = self.catalog_mut().allocate_introspection_sources().await;
+        let introspection_sources = BUILTINS::logs().collect();
         let cluster_variant = match &variant {
             CreateClusterVariant::Managed(plan) => {
                 let logging = if let Some(config) = plan.compute.introspection {


### PR DESCRIPTION
Previously, creating a cluster collections would execute 3 catalog transactions. One to allocate the cluster ID, one to allocate the introspection source IDs, and to create the cluster. This commit combines the introspection source IDs transaction and cluster creation transaction into a single catalog transaction.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
