### PR TITLE
testdrive: Revert limited load generator for materialization-lag.td

### DIFF
--- a/test/testdrive/materialization-lag.td
+++ b/test/testdrive/materialization-lag.td
@@ -31,7 +31,7 @@ ALTER SYSTEM SET max_clusters = 15
 
 > CREATE SOURCE src
   IN CLUSTER source
-  FROM LOAD GENERATOR counter (UP TO 100)
+  FROM LOAD GENERATOR counter
 
 > CREATE TABLE tbl (a int)
 
@@ -172,10 +172,6 @@ snk
 
 # Test that when there are multiple inputs to a materialization the right one
 # is reported as the "slowest".
-
-# TODO(def-) Reenable when database-issues#8626 is fixed
-$ skip-if
-SELECT true
 
 > ALTER CLUSTER source SET (REPLICATION FACTOR 0)
 


### PR DESCRIPTION
Fixes: https://github.com/MaterializeInc/database-issues/issues/8626

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
