### PR TITLE
bazel: Mirror `buildifier` the Bazel formatter

### DIFF
--- a/misc/bazel/tools/repositories.bzl
+++ b/misc/bazel/tools/repositories.bzl
@@ -41,5 +41,8 @@ def buildifier(version, targets):
             name = "buildifier-{0}".format(target),
             executable = True,
             integrity = integrity,
-            urls = ["https://github.com/bazelbuild/buildtools/releases/download/v{VERSION}/buildifier-{TARGET}".format(VERSION = version, TARGET = target)],
+            urls = [
+                "https://github.com/MaterializeInc/toolchains/releases/download/buildifier-{VERSION}/buildifier-{TARGET}".format(VERSION = version, TARGET = target),
+                "https://github.com/bazelbuild/buildtools/releases/download/v{VERSION}/buildifier-{TARGET}".format(VERSION = version, TARGET = target),
+            ],
         )


### PR DESCRIPTION
We've been getting some flakes in CI recently for exit code 32 when trying to run `buildifier`. I asked about this in the [Bazel Slack](https://bazelbuild.slack.com/archives/CA31HN1T3/p1729021370076269) and figured in the meantime it wouldn't hurt to add a mirror for `buildifier`, in case the issue is being rate limited by upstream.

I added a new [Mirror action](https://github.com/MaterializeInc/toolchains/actions/workflows/mirror.yml) to our toolchains repo that powers this.

### Motivation

Stabilize CI

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
