### PR TITLE
adapter: Add `OfflineReason::Initializing` for cluster replicas

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -123,7 +123,7 @@ use mz_ore::task::{spawn, JoinHandle};
 use mz_ore::thread::JoinHandleExt;
 use mz_ore::tracing::{OpenTelemetryContext, TracingHandle};
 use mz_ore::vec::VecExt;
-use mz_ore::{instrument, soft_assert_or_log, soft_panic_or_log, stack};
+use mz_ore::{assert_none, instrument, soft_assert_or_log, soft_panic_or_log, stack};
 use mz_persist_client::usage::{ShardsUsageReferenced, StorageUsageClient};
 use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::global_id::TransientIdGen;
@@ -1448,8 +1448,8 @@ impl ClusterReplicaStatuses {
             })
             .collect();
         let prev = replica_statuses.insert(replica_id, process_statuses);
-        assert_eq!(
-            prev, None,
+        assert_none!(
+            prev,
             "cluster replica {cluster_id}.{replica_id} statuses already initialized"
         );
     }

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -231,7 +231,8 @@ impl AdapterNotice {
             AdapterNotice::DroppedActiveCluster { name: _ } => Some("Choose a new active cluster by executing SET CLUSTER = <name>.".into()),
             AdapterNotice::ClusterReplicaStatusChanged { status, .. } => {
                 match status {
-                    ServiceStatus::Offline(None) => Some("The cluster replica may be restarting or going offline.".into()),
+                    ServiceStatus::Offline(None)
+                    | ServiceStatus::Offline(Some(OfflineReason::Initializing)) => Some("The cluster replica may be restarting or going offline.".into()),
                     ServiceStatus::Offline(Some(OfflineReason::OomKilled)) => Some("The cluster replica may have run out of memory and been killed.".into()),
                     ServiceStatus::Online => None,
                 }

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -99,12 +99,14 @@ pub struct ServiceEvent {
 #[derive(Debug, Clone, Copy, Serialize, Eq, PartialEq)]
 pub enum OfflineReason {
     OomKilled,
+    Initializing,
 }
 
 impl fmt::Display for OfflineReason {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             OfflineReason::OomKilled => f.write_str("oom-killed"),
+            OfflineReason::Initializing => f.write_str("initializing"),
         }
     }
 }


### PR DESCRIPTION
This PR adds an new offline reason for cluster replicas of "initializing". When the DDL that creates a new cluster replica completes, that replica starts with a status of `offline` and a `reason: null`, once Kubernetes creates the replica it gets updates to a status of `online`.

This change should make that initializing period more obvious.

### Motivation

We recently saw an issue where the `mz_internal.mz_cluster_replica_statuses` history was incorrect, and I'm hoping this PR should help us debug the issue a bit further if we see it again. ([Slack](https://materializeinc.slack.com/archives/CTESPM7FU/p1728918400855429?thread_ts=1728914425.382739&cid=CTESPM7FU))

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
