### PR TITLE
adapter/sources: Support custom timelines on source tables to handle CdCv2 envelope type correctly

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -346,7 +346,7 @@ impl Catalog {
     }
 
     /// For the Sources ids in `ids`, return the read policies for all `ids` and additional ids that
-    /// propagate from them. Specifically, `ids` contains a source, it and all of its subsources
+    /// propagate from them. Specifically, if `ids` contains a source, it and all of its source exports
     /// will be added to the result.
     pub fn source_read_policies(
         &self,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2495,9 +2495,10 @@ impl Coordinator {
                         TableDataSource::TableWrites { defaults: _ } => {
                             CollectionDescription::for_table(table.desc.clone())
                         }
-                        TableDataSource::DataSource(data_source_desc) => {
-                            source_desc(data_source_desc, &table.desc)
-                        }
+                        TableDataSource::DataSource {
+                            desc: data_source_desc,
+                            timeline: _,
+                        } => source_desc(data_source_desc, &table.desc),
                     };
                     collections.push((id, collection_desc));
                 }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -908,18 +908,24 @@ impl Coordinator {
             plan::TableDataSource::TableWrites { defaults } => {
                 TableDataSource::TableWrites { defaults }
             }
-            plan::TableDataSource::DataSource(data_source_plan) => match data_source_plan {
+            plan::TableDataSource::DataSource {
+                desc: data_source_plan,
+                timeline,
+            } => match data_source_plan {
                 plan::DataSourceDesc::IngestionExport {
                     ingestion_id,
                     external_reference,
                     details,
                     data_config,
-                } => TableDataSource::DataSource(DataSourceDesc::IngestionExport {
-                    ingestion_id,
-                    external_reference,
-                    details,
-                    data_config,
-                }),
+                } => TableDataSource::DataSource {
+                    desc: DataSourceDesc::IngestionExport {
+                        ingestion_id,
+                        external_reference,
+                        details,
+                        data_config,
+                    },
+                    timeline,
+                },
                 o => {
                     unreachable!("CREATE TABLE data source got {:?}", o)
                 }
@@ -990,7 +996,10 @@ impl Coordinator {
                             )
                             .await;
                     }
-                    TableDataSource::DataSource(data_source) => {
+                    TableDataSource::DataSource {
+                        desc: data_source,
+                        timeline: _,
+                    } => {
                         match data_source {
                             DataSourceDesc::IngestionExport {
                                 ingestion_id,

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1575,6 +1575,8 @@ pub enum TableFromSourceOptionName {
     TextColumns,
     /// Columns you want to exclude when ingesting data
     ExcludeColumns,
+    /// The timeline to use for this table
+    Timeline,
     /// Hex-encoded protobuf of a `ProtoSourceExportStatementDetails`
     /// message, which includes details necessary for planning this
     /// table as a Source Export
@@ -1586,6 +1588,7 @@ impl AstDisplay for TableFromSourceOptionName {
         f.write_str(match self {
             TableFromSourceOptionName::TextColumns => "TEXT COLUMNS",
             TableFromSourceOptionName::ExcludeColumns => "EXCLUDE COLUMNS",
+            TableFromSourceOptionName::Timeline => "TIMELINE",
             TableFromSourceOptionName::Details => "DETAILS",
         })
     }
@@ -1602,7 +1605,8 @@ impl WithOptionName for TableFromSourceOptionName {
         match self {
             TableFromSourceOptionName::Details
             | TableFromSourceOptionName::TextColumns
-            | TableFromSourceOptionName::ExcludeColumns => false,
+            | TableFromSourceOptionName::ExcludeColumns
+            | TableFromSourceOptionName::Timeline => false,
         }
     }
 }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1366,7 +1366,10 @@ pub enum TableDataSource {
 
     /// The table receives its data from the identified `DataSourceDesc`.
     /// This table type does not support INSERT/UPDATE/DELETE statements.
-    DataSource(DataSourceDesc),
+    DataSource {
+        desc: DataSourceDesc,
+        timeline: Timeline,
+    },
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1532,6 +1532,7 @@ generate_extracted_config!(
     TableFromSourceOption,
     (TextColumns, Vec::<Ident>, Default(vec![])),
     (ExcludeColumns, Vec::<Ident>, Default(vec![])),
+    (Timeline, String),
     (Details, String)
 );
 
@@ -1560,6 +1561,7 @@ pub fn plan_create_table_from_source(
         text_columns,
         exclude_columns,
         details,
+        timeline,
         seen: _,
     } = with_options.clone().try_into()?;
 
@@ -1720,6 +1722,26 @@ pub fn plan_create_table_from_source(
         source_connection,
     )?;
 
+    let name = scx.allocate_qualified_name(normalize::unresolved_item_name(name.clone())?)?;
+
+    // Allow users to specify a timeline. If they do not, determine a default
+    // timeline for the source.
+    let timeline = match timeline {
+        None => match envelope {
+            SourceEnvelope::CdcV2 => {
+                Timeline::External(scx.catalog.resolve_full_name(&name).to_string())
+            }
+            _ => Timeline::EpochMilliseconds,
+        },
+        // TODO(benesch): if we stabilize this, can we find a better name than
+        // `mz_epoch_ms`? Maybe just `mz_system`?
+        Some(timeline) if timeline == "mz_epoch_ms" => Timeline::EpochMilliseconds,
+        Some(timeline) if timeline.starts_with("mz_") => {
+            return Err(PlanError::UnacceptableTimelineName(timeline));
+        }
+        Some(timeline) => Timeline::User(timeline),
+    };
+
     let data_source = DataSourceDesc::IngestionExport {
         ingestion_id,
         external_reference: external_reference
@@ -1730,7 +1752,6 @@ pub fn plan_create_table_from_source(
         data_config: SourceExportDataConfig { envelope, encoding },
     };
 
-    let name = scx.allocate_qualified_name(normalize::unresolved_item_name(name.clone())?)?;
     let if_not_exists = *if_not_exists;
 
     let create_sql = normalize::create_statement(scx, Statement::CreateTableFromSource(stmt))?;
@@ -1740,7 +1761,10 @@ pub fn plan_create_table_from_source(
         desc,
         temporary: false,
         compaction_window: None,
-        data_source: TableDataSource::DataSource(data_source),
+        data_source: TableDataSource::DataSource {
+            desc: data_source,
+            timeline,
+        },
     };
 
     Ok(Plan::CreateTable(CreateTablePlan {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1416,6 +1416,7 @@ async fn purify_create_table_from_source(
         text_columns,
         exclude_columns,
         details,
+        timeline: _,
         seen: _,
     } = with_options.clone().try_into()?;
     assert_none!(details, "details cannot be explicitly set");

--- a/test/sqllogictest/retain_history.slt
+++ b/test/sqllogictest/retain_history.slt
@@ -99,7 +99,7 @@ idx_c  FOR  240000
 # Test subsource propagation. Test sources with and without subsources and view dependencies to
 # ensure the alter code correctly ignores the views.
 statement ok
-CREATE SOURCE auction_house FROM LOAD GENERATOR AUCTION WITH (RETAIN HISTORY = FOR '1m')
+CREATE SOURCE auction_house FROM LOAD GENERATOR AUCTION
 ----
 
 statement ok
@@ -130,22 +130,13 @@ CREATE VIEW counter_view AS SELECT * FROM counter
 ----
 
 query TTT
-SELECT o.name, h.strategy, h.value
-FROM mz_internal.mz_history_retention_strategies h
+SELECT o.name, h.strategy, h.value FROM mz_internal.mz_history_retention_strategies h
 JOIN mz_objects o ON o.id = h.id
-LEFT OUTER JOIN mz_sources s ON s.id = o.id
-LEFT OUTER JOIN mz_tables t ON t.id = o.id
 WHERE o.id LIKE 'u%'
-AND (
-    o.oid IN (SELECT oid FROM mz_sources)
-    OR o.oid IN (SELECT oid FROM mz_tables WHERE source_id IN (SELECT id FROM mz_sources WHERE name = 'auction_house'))
-    OR o.oid IN (SELECT oid FROM mz_indexes WHERE on_id IN (SELECT id FROM mz_views WHERE id like 'u%'))
-    OR o.name = 'tab_a'
-)
 ORDER BY o.name
 ----
 accounts  FOR  1000
-auction_house  FOR  60000
+auction_house  FOR  1000
 auction_house_progress  FOR  1000
 auctions  FOR  1000
 bids  FOR  1000
@@ -172,19 +163,19 @@ JOIN mz_objects o ON o.id = h.id
 WHERE o.id LIKE 'u%'
 ORDER BY o.name
 ----
-accounts  FOR  1000
+accounts  FOR  60000
 auction_house  FOR  60000
 auction_house_progress  FOR  1000
-auctions  FOR  1000
-bids  FOR  1000
+auctions  FOR  60000
+bids  FOR  60000
 counter  FOR  60000
 counter_progress  FOR  1000
 idx_a  FOR  420000
 idx_b  FOR  360000
 idx_c  FOR  240000
-organizations  FOR  1000
+organizations  FOR  60000
 tab_a  FOR  1000
-users  FOR  1000
+users  FOR  60000
 
 statement ok
 ALTER SOURCE counter RESET (RETAIN HISTORY)


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug. Fixes https://github.com/MaterializeInc/database-issues/issues/8649

The above bug demonstrated hung queries whenever using a `CREATE TABLE .. FROM SOURCE .. ENVELOPE MATERIALIZE` statement, since `ENVELOPE MATERIALIZE` (also known as `Envelope::CdcV2`) uses a non-default timeline by default.

This PR introduces the ability to set a custom timeline on `CREATE TABLE .. FROM SOURCE` and to correct the default timeline when using `ENVELOPE MATERIALIZE`, matching the existing timeline handling semantics of `CREATE SOURCE` statements.

The tests for this are in @nrainer-materialize 's PR https://github.com/MaterializeInc/materialize/pull/29801 and I tested this change on his branch locally to verify the fix.

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
