### PR TITLE
feature-benchmark: Reduce scale of extremely slow scenarios

### DIFF
--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -7,8 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import time
 
-from materialize import ui
 from materialize.feature_benchmark.aggregation import Aggregation
 from materialize.feature_benchmark.executor import Executor
 from materialize.feature_benchmark.filter import Filter
@@ -76,9 +76,10 @@ class Benchmark:
     def run(self) -> list[Aggregation]:
         scenario = self.create_scenario_instance()
 
-        ui.header(
-            f"Running scenario {scenario.name()}, scale = {scenario.scale()}, N = {scenario.n()}"
+        print(
+            f"--- Running scenario {scenario.name()}, scale = {scenario.scale()}, N = {scenario.n()}"
         )
+        start_time = time.time()
 
         # Run the shared() section once for both Mzs under measurement
         self.run_shared(scenario)
@@ -101,6 +102,11 @@ class Benchmark:
                 ]
 
             i = i + 1
+
+        duration = time.time() - start_time
+        print(
+            f"Scenario {scenario.name()}, scale = {scenario.scale()}, N = {scenario.n()} took {duration:.0f}s to run"
+        )
 
     def run_shared(self, scenario: Scenario) -> None:
         shared = scenario.shared()

--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -18,12 +18,12 @@ FEATURE_BENCHMARK_SCENARIOS_DIR = FEATURE_BENCHMARK_FRAMEWORK_DIR / "scenarios"
 
 # Consider increasing the #FEATURE_BENCHMARK_FRAMEWORK_VERSION if changes are expected to impact results!
 SHA256_OF_FRAMEWORK: dict[str, str] = {
-    "*": "c13ba2db3cccea214fbf946ef9037a307dd64b1b2d837611fc407c82cb5d8cfc",
+    "*": "feae83511adb03063ca85e519fae6fed66cee33544e6798d47287d4f749adafb",
 }
 
 # Consider increasing the scenario's class #version() if changes are expected to impact results!
 SHA256_BY_SCENARIO_FILE: dict[str, str] = {
-    "benchmark_main.py": "aca597f4eedb9c3e9ea08327b9997dab9ccb7202a0fe7df35181958d7413356b",
+    "benchmark_main.py": "a898f6d8990476422ef99a6f156a36571d52fab9b10414664d32c023ad591357",
     "concurrency.py": "2e9c149c136b83b3853abc923a1adbdaf55a998ab4557712f8424c8b16f2adb1",
     "customer.py": "d1e72837a342c3ebf1f4a32ec583b1b78a78644cdba495030a6df45ebbffe703",
     "optbench.py": "e0aa427c4af0467a408ebd11fcff55b75da910bae035cf272bebd3924ebc3483",

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -344,10 +344,10 @@ class Update(DML):
 class ManySmallUpdates(DML):
     """Measure the time it takes for several small UPDATE statements to return to client"""
 
-    SCALE = 3  # runs > 4 hours with SCALE = 4
+    SCALE = 2  # runs ~2.5 hours with SCALE = 3
 
     def version(self) -> ScenarioVersion:
-        return ScenarioVersion.create(1, 1, 0)
+        return ScenarioVersion.create(1, 2, 0)
 
     def init(self) -> list[Action]:
         return [
@@ -1387,10 +1387,14 @@ $ kafka-verify-topic sink=materialize.public.sink1 await-value-schema=true await
 class ManyKafkaSourcesOnSameCluster(Scenario):
     """Measure the time it takes to ingest data from many Kafka sources"""
 
-    SCALE = 2.5  # 316 sources
+    # Runs ~2 hours with 300 sources
+    SCALE = 2  # 100 sources
     FIXED_SCALE = True
 
     COUNT_SOURCE_ENTRIES = 100000
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
 
     def shared(self) -> Action:
         create_topics = "\n".join(
@@ -1949,10 +1953,11 @@ ALTER SYSTEM SET max_clusters = {self.n() * 6};
 class StartupTpch(Scenario):
     """Measure the time it takes to restart a Mz instance populated with TPC-H and have all the dataflows be ready to return something"""
 
-    SCALE = 1.2  # 25ish objects of each kind
-    FIXED_SCALE = (
-        True  # Can not scale to 100s of objects, so --size=+N will have no effect
-    )
+    # Runs ~3 hours with SCALE = 1.2
+    SCALE = 0.1  # 1 object of each kind
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
 
     def init(self) -> Action:
         # We need to massage the SQL statements so that Testdrive doesn't get confused.


### PR DESCRIPTION
Also add logging to make it easier to find slow scenarios in the future
New run: https://buildkite.com/materialize/nightly/builds/9998
![Screenshot 2024-10-16 at 07 38 28](https://github.com/user-attachments/assets/5f6bee5c-fa49-4c44-b903-1b27b259f549)


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
