### PR TITLE
ct: fix bugs in frontier reporting

### DIFF
--- a/src/compute/src/render/continual_task.rs
+++ b/src/compute/src/render/continual_task.rs
@@ -92,7 +92,7 @@ use mz_storage_types::sources::SourceData;
 use mz_timely_util::builder_async::{Button, Event, OperatorBuilder as AsyncOperatorBuilder};
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::operators::{Filter, FrontierNotificator, Map, Operator};
-use timely::dataflow::Scope;
+use timely::dataflow::{ProbeHandle, Scope};
 use timely::progress::frontier::AntichainRef;
 use timely::progress::{Antichain, Timestamp as _};
 use timely::{Data, PartialOrder};
@@ -254,9 +254,10 @@ where
             }
         };
 
-        // We don't report a `compute_probe`, our output frontier is equal to
-        // our write frontier, which we report directly.
         let collection = compute_state.expect_collection_mut(sink_id);
+        let mut probe = ProbeHandle::default();
+        let to_append = to_append.probe_with(&mut probe);
+        collection.compute_probe = Some(probe);
         let sink_write_frontier = Rc::new(RefCell::new(Antichain::from_elem(Timestamp::minimum())));
         collection.sink_write_frontier = Some(Rc::clone(&sink_write_frontier));
 


### PR DESCRIPTION
We we running the `step_backward` operator before
`suppress_early_progress`, which made the frontiers not directly
comparable to the `as_of` given to `suppress_early_progress`. Similarly,
we were reporting incorrect input frontiers (no idea what effect this
has).

This is the easy fix (swap `step_backward` to be later), but adding this
this to the increasing pile of evidence against the weirdness of the
`T-1` idea. While Jan was out, I had an idea for how to make this all
[more normal], but I've been holding off on doing anything it until he
was back. Probably time to hash that out, but since this fix is so
simple, I'd love to get it merged in the interim.

[more normal]: https://materializeinc.slack.com/archives/C075B00521K/p1727808293914569

Touches https://github.com/MaterializeInc/database-issues/issues/8427

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
