### PR TITLE
ci: Try using --release in cargo test

### DIFF
--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -213,7 +213,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                         "--workspace",
                         "--bin",
                         "clusterd",
-                        "--profile=ci",
+                        "--profile=release",
                     ],
                     env=env,
                 )
@@ -275,7 +275,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                         "--workspace",
                         "--all-features",
                         "--profile=ci",
-                        "--cargo-profile=ci",
+                        "--cargo-profile=release",
                         f"--partition=count:{partition}/{total}",
                         *args.args,
                     ],

--- a/src/http-util/src/lib.rs
+++ b/src/http-util/src/lib.rs
@@ -55,9 +55,6 @@ macro_rules! make_handle_static {
             fn get_static_file(path: &str) -> Option<Vec<u8>> {
                 use ::std::fs;
 
-                #[cfg(not(debug_assertions))]
-                compile_error!("cannot enable insecure `dev-web` feature in release mode");
-
                 // Prefer the unminified files in static-dev, if they exist.
                 let dev_path =
                     format!("{}/{}/{}", env!("CARGO_MANIFEST_DIR"), $dev_base_path, path);


### PR DESCRIPTION
This might make more sense when we have Bazel for cargo test to reduce build times.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
