### PR TITLE
Make some functions non-mutable

### DIFF
--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -324,7 +324,7 @@ impl crate::coord::Coordinator {
     /// Will panic if any of the referenced collections in `id_bundle` don't
     /// exist.
     pub(crate) fn acquire_read_holds(
-        &mut self,
+        &self,
         id_bundle: &CollectionIdBundle,
     ) -> ReadHolds<Timestamp> {
         let mut read_holds = ReadHolds::new();

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2193,7 +2193,7 @@ impl Coordinator {
     /// Checks to see if the session needs a real time recency timestamp and if so returns
     /// a future that will return the timestamp.
     pub(super) async fn determine_real_time_recent_timestamp(
-        &mut self,
+        &self,
         session: &Session,
         source_ids: impl Iterator<Item = GlobalId>,
     ) -> Result<Option<BoxFuture<'static, Result<Timestamp, StorageError<Timestamp>>>>, AdapterError>

--- a/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
+++ b/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
@@ -157,7 +157,7 @@ impl Coordinator {
 
     #[instrument]
     async fn explain_timestamp_real_time_recency(
-        &mut self,
+        &self,
         session: &Session,
         ExplainTimestampRealTimeRecency {
             validity,

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -729,7 +729,7 @@ impl Coordinator {
 
     #[instrument]
     async fn peek_real_time_recency(
-        &mut self,
+        &self,
         session: &Session,
         PeekStageRealTimeRecency {
             validity,

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -183,7 +183,7 @@ impl TimestampProvider for Coordinator {
             .expect("missing collections")
     }
 
-    fn acquire_read_holds(&mut self, id_bundle: &CollectionIdBundle) -> ReadHolds<Timestamp> {
+    fn acquire_read_holds(&self, id_bundle: &CollectionIdBundle) -> ReadHolds<Timestamp> {
         self.acquire_read_holds(id_bundle)
     }
 
@@ -253,7 +253,7 @@ pub trait TimestampProvider {
     ///
     /// The timeline that `id_bundle` belongs to is also returned, if one exists.
     fn determine_timestamp_for(
-        &mut self,
+        &self,
         session: &Session,
         id_bundle: &CollectionIdBundle,
         when: &QueryWhen,
@@ -441,10 +441,7 @@ pub trait TimestampProvider {
 
     /// Acquires [ReadHolds], for the given `id_bundle` at the earliest possible
     /// times.
-    fn acquire_read_holds(
-        &mut self,
-        id_bundle: &CollectionIdBundle,
-    ) -> ReadHolds<mz_repr::Timestamp>;
+    fn acquire_read_holds(&self, id_bundle: &CollectionIdBundle) -> ReadHolds<mz_repr::Timestamp>;
 
     /// The smallest common valid write frontier among the specified collections.
     ///
@@ -539,7 +536,7 @@ impl Coordinator {
     /// The caller is responsible for eventually dropping those read holds.
     #[mz_ore::instrument(level = "debug")]
     pub(crate) fn determine_timestamp(
-        &mut self,
+        &self,
         session: &Session,
         id_bundle: &CollectionIdBundle,
         when: &QueryWhen,

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -869,7 +869,7 @@ where
 
     /// Initiate a peek request for the contents of the given collection at `timestamp`.
     pub fn peek(
-        &mut self,
+        &self,
         instance_id: ComputeInstanceId,
         peek_target: PeekTarget,
         literal_constraints: Option<Vec<Row>>,

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -600,7 +600,7 @@ where
     /// If no items in `ids` connect to external systems, this function will
     /// return `Ok(T::minimum)`.
     pub async fn determine_real_time_recent_timestamp(
-        &mut self,
+        &self,
         ids: BTreeSet<GlobalId>,
         timeout: Duration,
     ) -> Result<BoxFuture<'static, Result<T, StorageError<T>>>, StorageError<T>> {

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -641,7 +641,7 @@ pub trait StorageController: Debug {
     /// Acquires and returns the desired read holds, advancing them to the since
     /// frontier when necessary.
     fn acquire_read_holds(
-        &mut self,
+        &self,
         desired_holds: Vec<GlobalId>,
     ) -> Result<Vec<ReadHold<Self::Timestamp>>, ReadHoldError>;
 
@@ -725,7 +725,7 @@ pub trait StorageController: Debug {
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
     async fn real_time_recent_timestamp(
-        &mut self,
+        &self,
         source_ids: BTreeSet<GlobalId>,
         timeout: Duration,
     ) -> Result<

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1772,7 +1772,7 @@ where
     }
 
     fn acquire_read_holds(
-        &mut self,
+        &self,
         desired_holds: Vec<GlobalId>,
     ) -> Result<Vec<ReadHold<Self::Timestamp>>, ReadHoldError> {
         self.storage_collections.acquire_read_holds(desired_holds)
@@ -2130,7 +2130,7 @@ where
     }
 
     async fn real_time_recent_timestamp(
-        &mut self,
+        &self,
         timestamp_objects: BTreeSet<GlobalId>,
         timeout: Duration,
     ) -> Result<


### PR DESCRIPTION
Pure cleanup, change some functions to take `self` immutably when no mutable access is needed anymore. Also, this is not complete, just a few places that I found while reading the implementation.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
