### PR TITLE
compute/persist_sink: remove some dead code

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -1887,10 +1887,6 @@ impl UpdateDelta {
 /// abstraction boundary of the client, it's convenient to manage them together.
 #[derive(Debug, Clone)]
 pub struct SinkMetrics {
-    /// Number of small batches that were forwarded to the central append operator
-    pub forwarded_batches: Counter,
-    /// Number of updates that were forwarded to the centralized append operator
-    pub forwarded_updates: Counter,
     /// Cumulative record insertions made to the correction buffer across workers
     correction_insertions_total: IntCounter,
     /// Cumulative record deletions made to the correction buffer across workers
@@ -1908,14 +1904,6 @@ pub struct SinkMetrics {
 impl SinkMetrics {
     fn new(registry: &MetricsRegistry) -> Self {
         SinkMetrics {
-            forwarded_batches: registry.register(metric!(
-                name: "mz_persist_sink_forwarded_batches",
-                help: "number of batches forwarded to the central append operator",
-            )),
-            forwarded_updates: registry.register(metric!(
-                name: "mz_persist_sink_forwarded_updates",
-                help: "number of updates forwarded to the central append operator",
-            )),
             correction_insertions_total: registry.register(metric!(
                 name: "mz_persist_sink_correction_insertions_total",
                 help: "The cumulative insertions observed on the correction buffer across workers and persist sinks.",


### PR DESCRIPTION
This was left over after removing the small-batches optimization in #29846.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
