### PR TITLE
bazel: Run `cargo-gazelle` with Bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -66,6 +66,11 @@ common --bes_upload_mode=fully_async
 # Tells `xz` to use all available cores.
 action_env=XZ_OPT=-T0
 
+#
+# Config when running Bazel from a script.
+#
+# Silence most UI output since it's noisy.
+run:script --ui_event_filters=-info,-stdout,-stderr --noshow_progress
 
 # LLVM's libc++ has different assertion modes which can be configured to catch
 # undefined behavior. See: <https://libcxx.llvm.org/Hardening.html>

--- a/misc/bazel/cargo-gazelle/src/args.rs
+++ b/misc/bazel/cargo-gazelle/src/args.rs
@@ -15,7 +15,7 @@ use clap::Parser;
 #[clap(author, version, about, long_about = None)]
 pub struct Args {
     /// Path to an executable that can be used to format `BUILD.bazel` files.
-    #[clap(long, value_name = "FORMATTER")]
+    #[clap(long, value_name = "FORMATTER", env = "FORMATTER")]
     pub formatter: Option<PathBuf>,
     /// Doesn't actually update any files, just checks if they would have changed.
     #[clap(long)]

--- a/misc/bazel/tools/BUILD.bazel
+++ b/misc/bazel/tools/BUILD.bazel
@@ -33,6 +33,16 @@ sh_binary(
     ),
 )
 
+# Convience wrapper around `cargo-gazelle` that specifies our formatter.
+sh_binary(
+    name = "cargo-gazelle",
+    srcs = ["@//misc/bazel/cargo-gazelle:main"],
+    data = ["@//misc/bazel/tools:buildifier"],
+    env = {
+        "FORMATTER": "$(location @//misc/bazel/tools:buildifier)",
+    },
+)
+
 # We alias some tools from the Clang toolchain for easy consumption from other
 # parts of our build system, e.g. `mzbuild.py`.
 #


### PR DESCRIPTION
This PR switches `bin/bazel gen` to run cargo-gazelle with Bazel instead of Cargo. This should provide the following benefits:

* Faster linting in CI, `cargo-gazelle` can be pulled from the remote cache instead of built locally.
* More stable execution. Gets rid of the `HACK` to make sure `buildifier` was already downloaded, hopefully fixing the flakiness we've seen recently.

It also adds a config to our `.bazelrc` called `script` which reduces output and makes running Bazel actions less noisy.

Note: We already effectively ran `bin/bazel gen` with Bazel previously since we required it to run the BUILD file formatter, so I don't expect this to impact developers much if at all.

### Motivation

Linting has been flaking in CI lately, this should help stabilize it.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
