### PR TITLE
build: Fix `llvm-dwarfdump` usage

### DIFF
--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -162,7 +162,7 @@ def maybe_upload_debuginfo(
             print(f"Constructing source tarball for {bin}...")
             with tempfile.NamedTemporaryFile() as tarball:
                 p1 = subprocess.Popen(
-                    [*repo.rd.tool("llvm-dwarfdump"), "--show-sources", bin_path],
+                    ["llvm-dwarfdump", "--show-sources", bin_path],
                     stdout=subprocess.PIPE,
                 )
                 p2 = subprocess.Popen(


### PR DESCRIPTION
Previously I switched our main `build.py` script that CI uses to call `llvm-dwarfdump` via `xcompile.py` or Bazel. What I didn't realize is `llvm-dwarfdump` isn't in our xcompile toolchain which prevents Cargo driven builds of Materialize from generating a source tarball. The fix is to just directly call `llvm-dwarfdump` which exists in the CI builder image.

Note: Primarily we use Bazel to build Materialize but Cargo builds still exist for when we want to build with Sanitizers

### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/8652

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
