### PR TITLE
build: Trim the Cargo builds of Materialize if no Sanitizer is specified

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -205,6 +205,11 @@ so it is executed.""",
             if step.get("sanitizer") == "only":
                 step["skip"] = True
 
+            # Skip the Cargo driven builds if the Sanitizers aren't specified since everything
+            # relies on the Bazel builds.
+            if step.get("id") in ("rust-build-x86_64", "rust-build-aarch64"):
+                step["skip"] = True
+
         for step in pipeline["steps"]:
             visit(step)
             if "group" in step:


### PR DESCRIPTION
Everything uses the Bazel builds, so we can skip the Cargo builds, if no Sanitizer is specified.

### Motivation

Reduce cost of CI

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
