### PR TITLE
storage, DNM: continual feedback upsert operator with partial updates

### DIFF
--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -302,7 +302,7 @@ where
                         )
                     };
                     let (upsert, health_update, snapshot_progress, upsert_token) =
-                        crate::upsert::upsert(
+                        crate::upsert::upsert::<_, _, mz_repr::Timestamp>(
                             &upsert_input.enter(scope),
                             upsert_envelope.clone(),
                             refine_antichain(&resume_upper),

--- a/src/storage/src/statistics.rs
+++ b/src/storage/src/statistics.rs
@@ -767,6 +767,22 @@ impl SourceStatistics {
         }
     }
 
+    /// Set the `envelope_state_tombstones` stat to the given value
+    pub fn set_envelope_state_tombstones(&self, value: i64) {
+        let mut cur = self.stats.borrow_mut();
+        let value = if value < 0 {
+            tracing::warn!(
+                "Unexpected negative value for envelope_state_tombstones {}",
+                value
+            );
+            0
+        } else {
+            value.unsigned_abs()
+        };
+        cur.stats.envelope_state_tombstones = value;
+        cur.prom.envelope_state_tombstones.set(value);
+    }
+
     /// Set the `rehydration_latency_ms` stat based on the reported upper.
     pub fn update_rehydration_latency_ms(&self, upper: &Antichain<Timestamp>) {
         let mut cur = self.stats.borrow_mut();

--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -622,7 +622,8 @@ async fn drain_staged_input<S, G, T, FromTime, E>(
         let existing_value = &mut command_state.get_mut().value;
 
         if let Some(cs) = existing_value.as_mut() {
-            cs.ensure_decoded(bincode_opts);
+            cs.ensure_decoded(bincode_opts)
+                .expect("invalid upsert state");
         }
 
         // Skip this command if its order key is below the one in the upsert state.

--- a/src/storage/src/upsert/autospill.rs
+++ b/src/storage/src/upsert/autospill.rs
@@ -74,6 +74,15 @@ where
         }
     }
 
+    async fn clear(&mut self) -> Result<(), anyhow::Error> {
+        let res = match &mut self.backend_type {
+            BackendType::InMemory(backend) => backend.clear().await,
+            BackendType::RocksDb(backend) => backend.clear().await,
+        };
+
+        Ok(res?)
+    }
+
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
         P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<O>>)>,

--- a/src/storage/src/upsert/autospill.rs
+++ b/src/storage/src/upsert/autospill.rs
@@ -24,23 +24,23 @@ use super::types::{
 };
 use super::UpsertKey;
 
-pub enum BackendType<O> {
-    InMemory(InMemoryHashMap<O>),
-    RocksDb(RocksDB<O>),
+pub enum BackendType<T, O> {
+    InMemory(InMemoryHashMap<T, O>),
+    RocksDb(RocksDB<T, O>),
 }
 
-pub struct AutoSpillBackend<O, F> {
-    backend_type: BackendType<O>,
+pub struct AutoSpillBackend<T, O, F> {
+    backend_type: BackendType<T, O>,
     auto_spill_threshold_bytes: usize,
     rocksdb_autospill_in_use: Arc<DeleteOnDropGauge<'static, AtomicU64, Vec<String>>>,
     rocksdb_init_fn: Option<F>,
 }
 
-impl<O, F, Fut> AutoSpillBackend<O, F>
+impl<T, O, F, Fut> AutoSpillBackend<T, O, F>
 where
     O: Clone + Send + Sync + Serialize + DeserializeOwned + 'static,
     F: FnOnce() -> Fut + 'static,
-    Fut: std::future::Future<Output = RocksDB<O>>,
+    Fut: std::future::Future<Output = RocksDB<T, O>>,
 {
     pub(crate) fn new(
         rocksdb_init_fn: F,
@@ -59,11 +59,12 @@ where
 }
 
 #[async_trait::async_trait(?Send)]
-impl<O, F, Fut> UpsertStateBackend<O> for AutoSpillBackend<O, F>
+impl<T, O, F, Fut> UpsertStateBackend<T, O> for AutoSpillBackend<T, O, F>
 where
     O: Clone + Send + Sync + Serialize + DeserializeOwned + 'static,
+    T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static,
     F: FnOnce() -> Fut + 'static,
-    Fut: std::future::Future<Output = RocksDB<O>>,
+    Fut: std::future::Future<Output = RocksDB<T, O>>,
 {
     fn supports_merge(&self) -> bool {
         // We only support merge if the backend supports it; the in-memory backend does not
@@ -85,7 +86,7 @@ where
 
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
-        P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<O>>)>,
+        P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<T, O>>)>,
     {
         // Note that we never revert back to memory if the size shrinks below the threshold.
         // That case is considered rare and not worth the complexity.
@@ -132,7 +133,7 @@ where
 
     async fn multi_merge<M>(&mut self, merges: M) -> Result<MergeStats, anyhow::Error>
     where
-        M: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<O>>)>,
+        M: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<T, O>>)>,
     {
         match &mut self.backend_type {
             BackendType::InMemory(_) => {
@@ -149,7 +150,7 @@ where
     ) -> Result<GetStats, anyhow::Error>
     where
         G: IntoIterator<Item = UpsertKey>,
-        R: IntoIterator<Item = &'r mut UpsertValueAndSize<O>>,
+        R: IntoIterator<Item = &'r mut UpsertValueAndSize<T, O>>,
         O: 'r,
     {
         match &mut self.backend_type {

--- a/src/storage/src/upsert/memory.rs
+++ b/src/storage/src/upsert/memory.rs
@@ -64,6 +64,12 @@ where
         false
     }
 
+    async fn clear(&mut self) -> Result<(), anyhow::Error> {
+        self.state.clear();
+
+        Ok(())
+    }
+
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
         P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<O>>)>,

--- a/src/storage/src/upsert/memory.rs
+++ b/src/storage/src/upsert/memory.rs
@@ -26,14 +26,14 @@ use super::types::{
 use super::UpsertKey;
 
 /// A `HashMap` tracking its total size
-pub struct InMemoryHashMap<O> {
-    state: HashMap<UpsertKey, StateValue<O>>,
+pub struct InMemoryHashMap<T, O> {
+    state: HashMap<UpsertKey, StateValue<T, O>>,
     total_size: i64,
 }
 
-impl<O> InMemoryHashMap<O> {
+impl<T, O> InMemoryHashMap<T, O> {
     /// Drain the map, returning the last total size as well.
-    pub fn drain(&mut self) -> (i64, Drain<'_, UpsertKey, StateValue<O>>) {
+    pub fn drain(&mut self) -> (i64, Drain<'_, UpsertKey, StateValue<T, O>>) {
         let last_size = self.total_size;
         self.total_size = 0;
 
@@ -46,7 +46,7 @@ impl<O> InMemoryHashMap<O> {
     }
 }
 
-impl<O> Default for InMemoryHashMap<O> {
+impl<T, O> Default for InMemoryHashMap<T, O> {
     fn default() -> Self {
         Self {
             state: HashMap::new(),
@@ -56,9 +56,10 @@ impl<O> Default for InMemoryHashMap<O> {
 }
 
 #[async_trait::async_trait(?Send)]
-impl<O> UpsertStateBackend<O> for InMemoryHashMap<O>
+impl<T, O> UpsertStateBackend<T, O> for InMemoryHashMap<T, O>
 where
     O: Clone + 'static,
+    T: Clone + 'static,
 {
     fn supports_merge(&self) -> bool {
         false
@@ -72,7 +73,7 @@ where
 
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
-        P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<O>>)>,
+        P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<T, O>>)>,
     {
         let mut stats = PutStats::default();
         for (key, p_value) in puts {
@@ -84,7 +85,7 @@ where
                     self.state.insert(key, value);
                 }
                 None => {
-                    stats.adjust::<O>(None, None, &p_value.previous_value_metadata);
+                    stats.adjust::<T, O>(None, None, &p_value.previous_value_metadata);
                     self.state.remove(&key);
                 }
             }
@@ -95,7 +96,7 @@ where
 
     async fn multi_merge<M>(&mut self, _merges: M) -> Result<MergeStats, anyhow::Error>
     where
-        M: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<O>>)>,
+        M: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<T, O>>)>,
     {
         anyhow::bail!("InMemoryHashMap does not support merging");
     }
@@ -107,7 +108,7 @@ where
     ) -> Result<GetStats, anyhow::Error>
     where
         G: IntoIterator<Item = UpsertKey>,
-        R: IntoIterator<Item = &'r mut UpsertValueAndSize<O>>,
+        R: IntoIterator<Item = &'r mut UpsertValueAndSize<T, O>>,
     {
         let mut stats = GetStats::default();
         for (key, result_out) in gets.into_iter().zip_eq(results_out) {

--- a/src/storage/src/upsert/rocksdb.rs
+++ b/src/storage/src/upsert/rocksdb.rs
@@ -39,6 +39,11 @@ where
         self.rocksdb.supports_merges
     }
 
+    async fn clear(&mut self) -> Result<(), anyhow::Error> {
+        let _ = self.rocksdb.clear().await?;
+        Ok(())
+    }
+
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
         P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<O>>)>,

--- a/src/storage/src/upsert/rocksdb.rs
+++ b/src/storage/src/upsert/rocksdb.rs
@@ -20,20 +20,21 @@ use super::UpsertKey;
 
 /// A `UpsertStateBackend` implementation backed by RocksDB.
 /// This is currently untested, and simply compiles.
-pub struct RocksDB<O> {
-    rocksdb: RocksDBInstance<UpsertKey, StateValue<O>>,
+pub struct RocksDB<T, O> {
+    rocksdb: RocksDBInstance<UpsertKey, StateValue<T, O>>,
 }
 
-impl<O> RocksDB<O> {
-    pub fn new(rocksdb: RocksDBInstance<UpsertKey, StateValue<O>>) -> Self {
+impl<T, O> RocksDB<T, O> {
+    pub fn new(rocksdb: RocksDBInstance<UpsertKey, StateValue<T, O>>) -> Self {
         Self { rocksdb }
     }
 }
 
 #[async_trait::async_trait(?Send)]
-impl<O> UpsertStateBackend<O> for RocksDB<O>
+impl<T, O> UpsertStateBackend<T, O> for RocksDB<T, O>
 where
     O: Send + Sync + Serialize + DeserializeOwned + 'static,
+    T: Send + Sync + Serialize + DeserializeOwned + 'static,
 {
     fn supports_merge(&self) -> bool {
         self.rocksdb.supports_merges
@@ -46,7 +47,7 @@ where
 
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
-        P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<O>>)>,
+        P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<T, O>>)>,
     {
         let mut p_stats = PutStats::default();
         let stats = self
@@ -77,7 +78,7 @@ where
 
     async fn multi_merge<M>(&mut self, merges: M) -> Result<MergeStats, anyhow::Error>
     where
-        M: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<O>>)>,
+        M: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<T, O>>)>,
     {
         let mut m_stats = MergeStats::default();
         let stats =
@@ -101,7 +102,7 @@ where
     ) -> Result<GetStats, anyhow::Error>
     where
         G: IntoIterator<Item = UpsertKey>,
-        R: IntoIterator<Item = &'r mut UpsertValueAndSize<O>>,
+        R: IntoIterator<Item = &'r mut UpsertValueAndSize<T, O>>,
     {
         let mut g_stats = GetStats::default();
         let stats = self

--- a/src/storage/src/upsert/types.rs
+++ b/src/storage/src/upsert/types.rs
@@ -1215,10 +1215,8 @@ where
                     stats.deletes += 1;
                 }
                 let entry = self.consolidate_upsert_scratch.get_mut(&key).unwrap();
-                tracing::info!("entry: {:?}", entry);
                 let val = entry.value.get_or_insert_with(Default::default);
 
-                tracing::info!("merging {:?} into {:?}", value, val);
                 if val.merge_update(value, diff, self.bincode_opts, &mut self.bincode_buffer) {
                     entry.value = None;
                 }

--- a/src/storage/src/upsert_continual_feedback.rs
+++ b/src/storage/src/upsert_continual_feedback.rs
@@ -736,7 +736,16 @@ where
         let existing_value = &mut command_state.get_mut().value;
 
         if let Some(cs) = existing_value.as_mut() {
-            cs.ensure_decoded(bincode_opts);
+            match cs.ensure_decoded(bincode_opts) {
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::error!(
+                        worker_id = %source_config.worker_id,
+                        source_id = %source_config.id,
+                        "invalid upsert state: {}", e);
+                    panic!("invalid upsert state: {}", e);
+                }
+            }
         }
 
         // Skip this command if its order key is below the one in the upsert state.

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -480,7 +480,7 @@ def workflow_autospill(c: Composition) -> None:
                 additional_system_parameter_defaults={
                     "disk_cluster_replicas_default": "true",
                     "upsert_rocksdb_auto_spill_to_disk": "true",
-                    "upsert_rocksdb_auto_spill_threshold_bytes": "250",
+                    "upsert_rocksdb_auto_spill_threshold_bytes": "266",
                     "enable_unorchestrated_cluster_replicas": "true",
                     "storage_dataflow_delay_sources_past_rehydration": "true",
                 },
@@ -495,7 +495,7 @@ def workflow_autospill(c: Composition) -> None:
                 additional_system_parameter_defaults={
                     "disk_cluster_replicas_default": "true",
                     "upsert_rocksdb_auto_spill_to_disk": "true",
-                    "upsert_rocksdb_auto_spill_threshold_bytes": "250",
+                    "upsert_rocksdb_auto_spill_threshold_bytes": "266",
                     "enable_unorchestrated_cluster_replicas": "true",
                     "storage_dataflow_delay_sources_past_rehydration": "true",
                     # Enable the RocksDB merge operator


### PR DESCRIPTION
For running CI on the partial updates change.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
