### PR TITLE
images/materialized-base: simplify postgres database/user creation

### DIFF
--- a/misc/images/materialized-base/Dockerfile
+++ b/misc/images/materialized-base/Dockerfile
@@ -27,6 +27,12 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean \
     && mkdir -p /mzdata /scratch /var/lib/postgresql/data /var/run/postgresql \
-    && chown -R materialize /mzdata /scratch /var/lib/postgresql/data /var/run/postgresql /var/lib/postgresql/16/main
+    && chown -R materialize /mzdata /scratch /var/lib/postgresql/data /var/run/postgresql /var/log/postgresql /var/lib/postgresql/16/main
 
 COPY postgresql.conf pg_hba.conf /etc/postgresql/16/main/
+
+USER materialize
+
+RUN pg_ctlcluster 16 main start \
+    && psql -U postgres -c "CREATE ROLE root WITH LOGIN PASSWORD 'root'" \
+    && psql -U postgres -c "CREATE DATABASE root OWNER root"

--- a/misc/images/materialized/Dockerfile
+++ b/misc/images/materialized/Dockerfile
@@ -11,6 +11,4 @@ MZFROM materialized-base
 
 COPY clusterd environmentd entrypoint.sh /usr/local/bin/
 
-USER materialize
-
 ENTRYPOINT ["tini", "--", "entrypoint.sh"]

--- a/misc/images/materialized/entrypoint.sh
+++ b/misc/images/materialized/entrypoint.sh
@@ -40,12 +40,7 @@ hosted offering we run these services scaled across many machines.
 EOF
 
 if [ -z "${MZ_NO_BUILTIN_POSTGRES:-}" ]; then
-  /usr/lib/postgresql/16/bin/pg_ctl -D /var/lib/postgresql/16/main start -o "-c config_file=/etc/postgresql/16/main/postgresql.conf"
-
-  psql -U postgres -c "SELECT 1 FROM pg_roles WHERE rolname = 'root'" | grep -q 1 || ( \
-    psql -U postgres -c "CREATE ROLE root WITH LOGIN PASSWORD 'root'" && \
-    psql -U postgres -c "CREATE DATABASE root" && \
-    psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE root TO root")
+  pg_ctlcluster 16 main start
   psql -U root -c "CREATE SCHEMA IF NOT EXISTS consensus"
   psql -U root -c "CREATE SCHEMA IF NOT EXISTS storage"
   psql -U root -c "CREATE SCHEMA IF NOT EXISTS adapter"


### PR DESCRIPTION
Creating the necessary PostgreSQL user/database when building the image simplifies the entrypoint script, since it can assume that these objects exist rather than needing to create them.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
