### PR TITLE
ct: fix panic when input is not referenced

### DIFF
--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -370,7 +370,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                         sink_id,
                         &sink,
                         start_signal.clone(),
-                        ct_ctx.input_times(),
+                        ct_ctx.input_times(&context.scope.parent),
                     );
                 }
             });
@@ -439,7 +439,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                         sink_id,
                         &sink,
                         start_signal.clone(),
-                        ct_ctx.input_times(),
+                        ct_ctx.input_times(&context.scope.parent),
                     );
                 }
             });

--- a/test/sqllogictest/ct_errors.slt
+++ b/test/sqllogictest/ct_errors.slt
@@ -32,9 +32,3 @@ statement error CONTINUAL TASK query columns did not match
 CREATE CONTINUAL TASK nope (key STRING) ON INPUT foo AS (
     INSERT INTO nope SELECT * FROM foo;
 )
-
-# TODO(ct2): Make this error (or work!) instead of panic
-# statement error something
-# CREATE CONTINUAL TASK nope (key INT) ON INPUT foo AS (
-#    INSERT INTO nope SELECT null::INT
-# )

--- a/test/sqllogictest/ct_various.slt
+++ b/test/sqllogictest/ct_various.slt
@@ -63,3 +63,13 @@ query T
 SELECT * FROM y.z.ct;
 ----
 1
+
+# Regression test for a bug where we'd panic if no CT inputs were referenced.
+statement ok
+CREATE CONTINUAL TASK no_input_refs (key INT) ON INPUT input AS (
+    INSERT INTO no_input_refs SELECT null::INT
+)
+
+query I
+SELECT * FROM no_input_refs;
+----


### PR DESCRIPTION
It's unclear how valuable this is, we could also reasonably return an
error instead of panic. We can still decide to do the planning error too
later, but compute shouldn't panic when presented with a valid dataflow
description. The alternative would be to declare a dataflow description
for a CT that doesn't reference any inputs invalid, but doing that in
the type system seems difficult and doing it in a comment seems brittle.

Touches https://github.com/MaterializeInc/database-issues/issues/8427

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
