### PR TITLE
compute: rename PersistSink to MaterializedViewSink

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/create_continual_task.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_continual_task.rs
@@ -15,7 +15,7 @@ use mz_catalog::memory::objects::{
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::plan::Plan;
 use mz_compute_types::sinks::{
-    ComputeSinkConnection, ContinualTaskConnection, PersistSinkConnection,
+    ComputeSinkConnection, ContinualTaskConnection, MaterializedViewSinkConnection,
 };
 use mz_expr::OptimizedMirRelationExpr;
 use mz_ore::collections::CollectionExt;
@@ -209,8 +209,9 @@ impl Coordinator {
         // configuration for this.
         for sink in physical_plan.sink_exports.values_mut() {
             match &mut sink.connection {
-                ComputeSinkConnection::Persist(PersistSinkConnection {
-                    storage_metadata, ..
+                ComputeSinkConnection::MaterializedView(MaterializedViewSinkConnection {
+                    storage_metadata,
+                    ..
                 }) => {
                     sink.connection =
                         ComputeSinkConnection::ContinualTask(ContinualTaskConnection {

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -29,7 +29,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use mz_compute_types::plan::Plan;
-use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc, PersistSinkConnection};
+use mz_compute_types::sinks::{
+    ComputeSinkConnection, ComputeSinkDesc, MaterializedViewSinkConnection,
+};
 use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
 use mz_repr::explain::trace_plan;
 use mz_repr::refresh_schedule::RefreshSchedule;
@@ -242,7 +244,7 @@ impl Optimize<LocalMirPlan> for Optimizer {
         let sink_description = ComputeSinkDesc {
             from: self.view_id,
             from_desc: rel_desc.clone(),
-            connection: ComputeSinkConnection::Persist(PersistSinkConnection {
+            connection: ComputeSinkConnection::MaterializedView(MaterializedViewSinkConnection {
                 value_desc: rel_desc,
                 storage_metadata: (),
             }),

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -747,7 +747,7 @@ mod tests {
     use mz_compute_types::dataflows::{DataflowExpirationDesc, IndexDesc};
     use mz_compute_types::sinks::ComputeSinkConnection;
     use mz_compute_types::sinks::ComputeSinkDesc;
-    use mz_compute_types::sinks::PersistSinkConnection;
+    use mz_compute_types::sinks::MaterializedViewSinkConnection;
     use mz_compute_types::sources::SourceInstanceArguments;
     use mz_compute_types::sources::SourceInstanceDesc;
     use mz_persist_client::stats::{SnapshotPartsStats, SnapshotStats};
@@ -981,10 +981,12 @@ mod tests {
                 let desc = ComputeSinkDesc {
                     from: GlobalId::Transient(0),
                     from_desc: RelationDesc::empty(),
-                    connection: ComputeSinkConnection::Persist(PersistSinkConnection {
-                        value_desc: RelationDesc::empty(),
-                        storage_metadata: Default::default(),
-                    }),
+                    connection: ComputeSinkConnection::MaterializedView(
+                        MaterializedViewSinkConnection {
+                            value_desc: RelationDesc::empty(),
+                            storage_metadata: Default::default(),
+                        },
+                    ),
                     with_snapshot: Default::default(),
                     up_to: Default::default(),
                     non_null_assertions: Default::default(),

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -22,7 +22,7 @@ use mz_compute_types::dataflows::{BuildDesc, DataflowDescription};
 use mz_compute_types::plan::flat_plan::FlatPlan;
 use mz_compute_types::plan::LirId;
 use mz_compute_types::sinks::{
-    ComputeSinkConnection, ComputeSinkDesc, ContinualTaskConnection, PersistSinkConnection,
+    ComputeSinkConnection, ComputeSinkDesc, ContinualTaskConnection, MaterializedViewSinkConnection,
 };
 use mz_compute_types::sources::SourceInstanceDesc;
 use mz_compute_types::ComputeInstanceId;
@@ -1258,17 +1258,17 @@ where
         let mut sink_exports = BTreeMap::new();
         for (id, se) in dataflow.sink_exports {
             let connection = match se.connection {
-                ComputeSinkConnection::Persist(conn) => {
+                ComputeSinkConnection::MaterializedView(conn) => {
                     let metadata = self
                         .storage_collections
                         .collection_metadata(id)
                         .map_err(|_| CollectionMissing(id))?
                         .clone();
-                    let conn = PersistSinkConnection {
+                    let conn = MaterializedViewSinkConnection {
                         value_desc: conn.value_desc,
                         storage_metadata: metadata,
                     };
-                    ComputeSinkConnection::Persist(conn)
+                    ComputeSinkConnection::MaterializedView(conn)
                 }
                 ComputeSinkConnection::ContinualTask(conn) => {
                     let metadata = self

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -369,7 +369,7 @@ impl<P, S, T> DataflowDescription<P, S, T> {
         self.sink_exports
             .iter()
             .filter_map(|(id, desc)| match desc.connection {
-                ComputeSinkConnection::Persist(_) => Some(*id),
+                ComputeSinkConnection::MaterializedView(_) => Some(*id),
                 _ => None,
             })
     }

--- a/src/compute-types/src/sinks.proto
+++ b/src/compute-types/src/sinks.proto
@@ -35,13 +35,13 @@ message ProtoComputeSinkDesc {
 message ProtoComputeSinkConnection {
   oneof kind {
     google.protobuf.Empty subscribe = 1;
-    ProtoPersistSinkConnection persist = 2;
+    ProtoMaterializedViewSinkConnection materialized_view = 2;
     ProtoCopyToS3OneshotSinkConnection copy_to_s3_oneshot = 3;
     ProtoContinualTaskConnection continual_task = 4;
   }
 }
 
-message ProtoPersistSinkConnection {
+message ProtoMaterializedViewSinkConnection {
   mz_repr.relation_and_scalar.ProtoRelationDesc value_desc = 1;
   mz_storage_types.controller.ProtoCollectionMetadata storage_metadata = 2;
 }

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -129,9 +129,11 @@ where
 
         let region_name = match sink.connection {
             ComputeSinkConnection::Subscribe(_) => format!("SubscribeSink({:?})", sink_id),
-            ComputeSinkConnection::Persist(_) => format!("PersistSink({:?})", sink_id),
+            ComputeSinkConnection::MaterializedView(_) => {
+                format!("MaterializedViewSink({:?})", sink_id)
+            }
             ComputeSinkConnection::ContinualTask(_) => {
-                format!("ContinualTask({:?})", sink_id)
+                format!("ContinualTaskSink({:?})", sink_id)
             }
             ComputeSinkConnection::CopyToS3Oneshot(_) => {
                 format!("CopyToS3OneshotSink({:?})", sink_id)
@@ -192,7 +194,7 @@ where
 {
     match connection {
         ComputeSinkConnection::Subscribe(connection) => Box::new(connection.clone()),
-        ComputeSinkConnection::Persist(connection) => Box::new(connection.clone()),
+        ComputeSinkConnection::MaterializedView(connection) => Box::new(connection.clone()),
         ComputeSinkConnection::ContinualTask(connection) => Box::new(connection.clone()),
         ComputeSinkConnection::CopyToS3Oneshot(connection) => Box::new(connection.clone()),
     }

--- a/src/compute/src/sink.rs
+++ b/src/compute/src/sink.rs
@@ -9,7 +9,7 @@
 
 mod copy_to_s3_oneshot;
 mod correction;
-mod persist_sink;
+mod materialized_view;
 mod refresh;
 mod subscribe;
 

--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{Collection, Hashable};
 use futures::StreamExt;
-use mz_compute_types::sinks::{ComputeSinkDesc, PersistSinkConnection};
+use mz_compute_types::sinks::{ComputeSinkDesc, MaterializedViewSinkConnection};
 use mz_ore::cast::CastFrom;
 use mz_persist_client::batch::{Batch, ProtoBatch};
 use mz_persist_client::cache::PersistClientCache;
@@ -44,7 +44,7 @@ use crate::render::StartSignal;
 use crate::sink::correction::Correction;
 use crate::sink::refresh::apply_refresh;
 
-impl<G> SinkRender<G> for PersistSinkConnection<CollectionMetadata>
+impl<G> SinkRender<G> for MaterializedViewSinkConnection<CollectionMetadata>
 where
     G: Scope<Timestamp = Timestamp>,
 {


### PR DESCRIPTION
There are now two sinks that write to persist but with different behavior (conflict resolution, only at input times, etc). Rename PersistSink to something that reflects the differences.

Touches https://github.com/MaterializeInc/database-issues/issues/8427

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
