### PR TITLE
[persist] Structured builder goodput

### DIFF
--- a/src/adapter/src/catalog/open/builtin_item_migration.rs
+++ b/src/adapter/src/catalog/open/builtin_item_migration.rs
@@ -577,6 +577,10 @@ mod persist_schema {
         type ArrowBuilder = StringBuilder;
         type ArrowColumn = StringArray;
 
+        fn goodput(builder: &Self::ArrowBuilder) -> usize {
+            builder.values_slice().len()
+        }
+
         fn push(&self, builder: &mut Self::ArrowBuilder) {
             builder.append_value(&self.to_string());
         }

--- a/src/persist-cli/src/maelstrom/txn_list_append_single.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_single.rs
@@ -717,6 +717,7 @@ impl Service for TransactorService {
 
 mod codec_impls {
     use arrow::array::{BinaryArray, BinaryBuilder, UInt64Array, UInt64Builder};
+    use arrow::datatypes::ToByteSlice;
     use bytes::Bytes;
     use mz_persist_types::codec_impls::{
         SimpleColumnarData, SimpleColumnarDecoder, SimpleColumnarEncoder,
@@ -762,6 +763,10 @@ mod codec_impls {
     impl SimpleColumnarData for MaelstromKey {
         type ArrowBuilder = UInt64Builder;
         type ArrowColumn = UInt64Array;
+
+        fn goodput(builder: &Self::ArrowBuilder) -> usize {
+            builder.values_slice().to_byte_slice().len()
+        }
 
         fn push(&self, builder: &mut Self::ArrowBuilder) {
             builder.append_value(self.0);
@@ -829,6 +834,10 @@ mod codec_impls {
     impl SimpleColumnarData for MaelstromVal {
         type ArrowBuilder = BinaryBuilder;
         type ArrowColumn = BinaryArray;
+
+        fn goodput(builder: &Self::ArrowBuilder) -> usize {
+            builder.values_slice().to_byte_slice().len()
+        }
 
         fn push(&self, builder: &mut Self::ArrowBuilder) {
             builder.append_value(&self.encode_to_vec());

--- a/src/persist-client/src/schema.rs
+++ b/src/persist-client/src/schema.rs
@@ -540,6 +540,10 @@ mod tests {
     impl ColumnEncoder<Strings> for StringsEncoder {
         type FinishedColumn = StructArray;
 
+        fn goodput(&self) -> usize {
+            self.arrays.iter().map(|a| a.values_slice().len()).sum()
+        }
+
         fn append(&mut self, val: &Strings) {
             for (idx, val) in val.0.iter().enumerate() {
                 if val.is_empty() {

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -100,6 +100,10 @@ impl ColumnDecoder<()> for UnitColumnar {
 impl ColumnEncoder<()> for UnitColumnar {
     type FinishedColumn = NullArray;
 
+    fn goodput(&self) -> usize {
+        0
+    }
+
     fn append(&mut self, _val: &()) {
         self.len += 1;
     }
@@ -136,6 +140,9 @@ pub trait SimpleColumnarData {
     /// Type of [`arrow`] array the we decode data from.
     type ArrowColumn: arrow::array::Array + Clone + 'static;
 
+    /// The number of actual data bytes this item represents.
+    fn goodput(builder: &Self::ArrowBuilder) -> usize;
+
     /// Encode `self` into `builder`.
     fn push(&self, builder: &mut Self::ArrowBuilder);
     /// Encode a null value into `builder`.
@@ -148,6 +155,10 @@ pub trait SimpleColumnarData {
 impl SimpleColumnarData for String {
     type ArrowBuilder = StringBuilder;
     type ArrowColumn = StringArray;
+
+    fn goodput(builder: &Self::ArrowBuilder) -> usize {
+        builder.values_slice().len()
+    }
 
     fn push(&self, builder: &mut Self::ArrowBuilder) {
         builder.append_value(self.as_str())
@@ -165,6 +176,10 @@ impl SimpleColumnarData for Vec<u8> {
     type ArrowBuilder = BinaryBuilder;
     type ArrowColumn = BinaryArray;
 
+    fn goodput(builder: &Self::ArrowBuilder) -> usize {
+        builder.values_slice().len()
+    }
+
     fn push(&self, builder: &mut Self::ArrowBuilder) {
         builder.append_value(self.as_slice())
     }
@@ -180,6 +195,10 @@ impl SimpleColumnarData for Vec<u8> {
 impl SimpleColumnarData for ShardId {
     type ArrowBuilder = StringBuilder;
     type ArrowColumn = StringArray;
+
+    fn goodput(builder: &Self::ArrowBuilder) -> usize {
+        builder.values_slice().len()
+    }
 
     fn push(&self, builder: &mut Self::ArrowBuilder) {
         builder.append_value(&self.to_string());
@@ -198,6 +217,10 @@ pub struct SimpleColumnarEncoder<T: SimpleColumnarData>(T::ArrowBuilder);
 
 impl<T: SimpleColumnarData> ColumnEncoder<T> for SimpleColumnarEncoder<T> {
     type FinishedColumn = T::ArrowColumn;
+
+    fn goodput(&self) -> usize {
+        T::goodput(&self.0)
+    }
 
     fn append(&mut self, val: &T) {
         T::push(val, &mut self.0);
@@ -479,6 +502,10 @@ pub struct TodoColumnarEncoder<T>(PhantomData<T>);
 
 impl<T> ColumnEncoder<T> for TodoColumnarEncoder<T> {
     type FinishedColumn = StructArray;
+
+    fn goodput(&self) -> usize {
+        panic!("TODO")
+    }
 
     fn append(&mut self, _val: &T) {
         panic!("TODO")

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -89,6 +89,9 @@ pub trait ColumnEncoder<T> {
     /// Type of column that this encoder returns when finalized.
     type FinishedColumn: arrow::array::Array + Debug + 'static;
 
+    /// The amount of "actual data" encoded by this encoder so far.
+    fn goodput(&self) -> usize;
+
     /// Appends `val` onto this encoder.
     fn append(&mut self, val: &T);
 

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -53,6 +53,11 @@ impl<K, KS: Schema2<K>, V, VS: Schema2<V>> PartBuilder2<K, KS, V, VS> {
         }
     }
 
+    /// Estimate the size of the part this builder will build.
+    pub fn goodput(&self) -> usize {
+        self.key.goodput() + self.val.goodput() + self.time.goodput() + self.diff.goodput()
+    }
+
     /// Push a new row onto this [`PartBuilder2`].
     pub fn push<T: Codec64, D: Codec64>(&mut self, key: &K, val: &V, t: T, d: D) {
         self.key.append(key);
@@ -89,6 +94,11 @@ impl<K, KS: Schema2<K>, V, VS: Schema2<V>> PartBuilder2<K, KS, V, VS> {
 pub struct Codec64Mut(Vec<i64>);
 
 impl Codec64Mut {
+    /// Returns the overall size of the stored data in bytes.
+    pub fn goodput(&self) -> usize {
+        self.0.len() * size_of::<i64>()
+    }
+
     /// Returns the length of the column.
     pub fn len(&self) -> usize {
         self.0.len()

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1813,6 +1813,13 @@ pub enum SourceDataRowColumnarEncoder {
 }
 
 impl SourceDataRowColumnarEncoder {
+    pub(crate) fn goodput(&self) -> usize {
+        match self {
+            SourceDataRowColumnarEncoder::Row(e) => e.goodput(),
+            SourceDataRowColumnarEncoder::EmptyRow => 0,
+        }
+    }
+
     pub fn append(&mut self, row: &Row) {
         match self {
             SourceDataRowColumnarEncoder::Row(encoder) => encoder.append(row),
@@ -1859,6 +1866,10 @@ impl SourceDataColumnarEncoder {
 
 impl ColumnEncoder<SourceData> for SourceDataColumnarEncoder {
     type FinishedColumn = StructArray;
+
+    fn goodput(&self) -> usize {
+        self.row_encoder.goodput() + self.err_encoder.values_slice().len()
+    }
 
     #[inline]
     fn append(&mut self, val: &SourceData) {


### PR DESCRIPTION
### Motivation

Soon we're going to want to build up structured parts directly instead of converting the data from codec-encoded form, which means we need some way to know when a part's getting too big.

The actual change will probably land after we're dual-writing everything -- it's more efficient once we're writing structured data, not before -- but in the meantime let's get this tedious bit in so it doesn't bitrot.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
