### PR TITLE
sources: Ignored `GENERATED` columns for Postgres sources

### DIFF
--- a/src/postgres-util/src/schemas.rs
+++ b/src/postgres-util/src/schemas.rs
@@ -85,6 +85,7 @@ pub async fn publication_info(
                         AND a.attnum = ANY (b.conkey)
                     WHERE a.attnum > 0::pg_catalog.int2
                         AND NOT a.attisdropped
+                        AND a.attgenerated = ''
                         AND a.attrelid = $1
                     ORDER BY a.attnum",
                 &[&oid],

--- a/src/postgres-util/src/schemas.rs
+++ b/src/postgres-util/src/schemas.rs
@@ -69,28 +69,61 @@ pub async fn publication_info(
     for row in tables {
         let oid = row.get("oid");
 
-        let columns = client
-            .query(
-                "SELECT
-                        a.attname AS name,
-                        a.atttypid AS typoid,
-                        a.attnum AS colnum,
-                        a.atttypmod AS typmod,
-                        a.attnotnull AS not_null,
-                        b.oid IS NOT NULL AS primary_key
-                    FROM pg_catalog.pg_attribute a
-                    LEFT JOIN pg_catalog.pg_constraint b
-                        ON a.attrelid = b.conrelid
-                        AND b.contype = 'p'
-                        AND a.attnum = ANY (b.conkey)
-                    WHERE a.attnum > 0::pg_catalog.int2
-                        AND NOT a.attisdropped
-                        AND a.attgenerated = ''
-                        AND a.attrelid = $1
-                    ORDER BY a.attnum",
-                &[&oid],
-            )
-            .await
+        // The Postgres replication protocol does not support GENERATED columns
+        // so we exclude them from this query. But not all Postgres-like
+        // databases have the `pg_attribute.attgenerated` column, so we maintain
+        // two different versions of the query.
+        let pg_columns_check_generated = "
+        SELECT
+            a.attname AS name,
+            a.atttypid AS typoid,
+            a.attnum AS colnum,
+            a.atttypmod AS typmod,
+            a.attnotnull AS not_null,
+            b.oid IS NOT NULL AS primary_key
+        FROM pg_catalog.pg_attribute a
+        LEFT JOIN pg_catalog.pg_constraint b
+            ON a.attrelid = b.conrelid
+            AND b.contype = 'p'
+            AND a.attnum = ANY (b.conkey)
+        WHERE a.attnum > 0::pg_catalog.int2
+            AND NOT a.attisdropped
+            AND a.attgenerated = ''
+            AND a.attrelid = $1
+        ORDER BY a.attnum";
+
+        let pg_columns_no_check_generated = "
+        SELECT
+            a.attname AS name,
+            a.atttypid AS typoid,
+            a.attnum AS colnum,
+            a.atttypmod AS typmod,
+            a.attnotnull AS not_null,
+            b.oid IS NOT NULL AS primary_key
+        FROM pg_catalog.pg_attribute a
+        LEFT JOIN pg_catalog.pg_constraint b
+            ON a.attrelid = b.conrelid
+            AND b.contype = 'p'
+            AND a.attnum = ANY (b.conkey)
+        WHERE a.attnum > 0::pg_catalog.int2
+            AND NOT a.attisdropped
+            AND a.attrelid = $1
+        ORDER BY a.attnum";
+
+        let columns_result = match client.query(pg_columns_check_generated, &[&oid]).await {
+            Ok(result) => Ok(result),
+            // Not all Postgres-like databases have the `attgenerated` column
+            // so issue a second query without the check if so.
+            Err(e)
+                if e.to_string()
+                    .contains("column a.attgenerated does not exist") =>
+            {
+                client.query(pg_columns_no_check_generated, &[&oid]).await
+            }
+            other => other,
+        };
+
+        let columns = columns_result
             .map_err(PostgresError::from)?
             .into_iter()
             .map(|row| {

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -46,7 +46,7 @@ INSERT INTO pk_table VALUES (2, 'two');
 
 INSERT INTO pk_table VALUES (3, 'three');
 
-CREATE TABLE nonpk_table (f1 INTEGER, f2 INTEGER);
+CREATE TABLE nonpk_table (f1 INTEGER, f2 INTEGER, f3 INTEGER GENERATED ALWAYS AS (f1 * 2) STORED);
 INSERT INTO nonpk_table VALUES (1, 1), (1, 1);
 ALTER TABLE nonpk_table REPLICA IDENTITY FULL;
 INSERT INTO nonpk_table VALUES (2, 2), (2, 2);


### PR DESCRIPTION
This PR excludes generated columns from the publication info we generate for an upstream table in a Postgres source. Generated columns are not included in the replication stream, nor in the `COPY` protocol that we use for the initial snapshot.

### Motivation

Allow users to depend on upstream tables that have generated columns

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
