### PR TITLE
bin/environmentd: allow omitting database when running against Postgres

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -505,8 +505,6 @@ def _macos_codesign(path: str) -> None:
 def _connect_sql(urlstr: str) -> pg8000.native.Connection:
     url = urlparse(urlstr)
     database = url.path.removeprefix("/")
-    if not database:
-        raise UIError(f"database name is missing in the postgres URL: {urlstr}")
     try:
         dbconn = pg8000.native.Connection(
             host=url.hostname or "localhost",
@@ -534,6 +532,11 @@ For PostgreSQL:
     # PostgreSQL, the database must exist for us to connect to it at all--we
     # declare it to be the user's problem to create this database.
     if "crdb_version" in dbconn.parameter_statuses:
+        if not database:
+            raise UIError(
+                f"database name is missing in the postgres URL: {urlstr}",
+                hint="When connecting to CockroachDB, the database name is required.",
+            )
         _run_sql(dbconn, f"CREATE DATABASE IF NOT EXISTS {database}")
 
     return dbconn


### PR DESCRIPTION
PostgreSQL will automatically use the user name as the database if the database is omittted from the URL, so it's okay to omit it when running bin/environmentd against real PostgreSQL. CockroachDB has no such provisions, though, so we need to keep the restriction in place when running bin/environmentd against CockroachDB.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature @def- has found useful in local testing.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
