### PR TITLE
Timely logging: Boxed slice to count messages

### DIFF
--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -317,10 +317,10 @@ struct DemuxState {
     dataflow_channels: BTreeMap<usize, Vec<ChannelsEvent>>,
     /// Information about the last requested park.
     last_park: Option<Park>,
-    /// Maps channel IDs to vectors counting the messages sent to each target worker.
-    messages_sent: BTreeMap<usize, Vec<MessageCount>>,
-    /// Maps channel IDs to vectors counting the messages received from each source worker.
-    messages_received: BTreeMap<usize, Vec<MessageCount>>,
+    /// Maps channel IDs to boxed slices counting the messages sent to each target worker.
+    messages_sent: BTreeMap<usize, Box<[MessageCount]>>,
+    /// Maps channel IDs to boxed slices counting the messages received from each source worker.
+    messages_received: BTreeMap<usize, Box<[MessageCount]>>,
     /// Stores for scheduled operators the time when they were scheduled.
     schedule_starts: BTreeMap<usize, Duration>,
     /// Maps operator IDs to a vector recording the (count, elapsed_ns) values in each histogram
@@ -631,7 +631,7 @@ impl DemuxHandler<'_, '_> {
                 .state
                 .messages_sent
                 .entry(event.channel)
-                .or_insert_with(|| vec![Default::default(); self.peers]);
+                .or_insert_with(|| vec![Default::default(); self.peers].into_boxed_slice());
             sent_counts[event.target].records += count;
             sent_counts[event.target].batches += 1;
         } else {
@@ -646,7 +646,7 @@ impl DemuxHandler<'_, '_> {
                 .state
                 .messages_received
                 .entry(event.channel)
-                .or_insert_with(|| vec![Default::default(); self.peers]);
+                .or_insert_with(|| vec![Default::default(); self.peers].into_boxed_slice());
             received_counts[event.source].records += count;
             received_counts[event.source].batches += 1;
         }


### PR DESCRIPTION
Use a boxed slice instead of a vector to maintain per-channel message counts. Not expecting a dramatic improvement, but it should shave two times eight bytes per channel, for the send and receive counts.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
