### PR TITLE
lints: Retry bazel check on network errors

### DIFF
--- a/ci/test/lint-main/checks/check-bazel.sh
+++ b/ci/test/lint-main/checks/check-bazel.sh
@@ -18,7 +18,15 @@ cd "$(dirname "$0")/../../../.."
 . misc/shlib/shlib.bash
 
 if [[ ! "${MZDEV_NO_BAZEL_CHECK:-}" ]]; then
-  try bin/bazel gen
+  if try bin/bazel gen; then
+      :
+  else
+      if [ $? -eq 32 ]; then
+          # Network problems, retry in a bit
+          sleep 20
+          try bin/bazel gen
+      fi
+  fi
 
   # Make sure we didn't generate any changes.
   try git diff --compact-summary --exit-code -- '*/BUILD.bazel'

--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -76,9 +76,11 @@ try() {
 
     # Try the command.
     if "$@"; then
+        result=$?
         try_last_failed=false
         ((++ci_try_passed))
     else
+        result=$?
         try_last_failed=true
         # The command failed. Tell Buildkite to uncollapse this log section, so
         # that the errors are immediately visible.
@@ -86,6 +88,7 @@ try() {
         echo "^^^ 🚨 Failed: $*"
     fi
     ((++ci_try_total))
+    return $result
 }
 try_last_failed=false
 


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/test/builds/92661#019299fe-14a8-41dd-a101-3e426d0c4495

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
