### PR TITLE
ci: Adapt to changed error messages

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -557,7 +557,7 @@ steps:
       - id: pg-cdc-old-syntax
         label: Postgres CDC tests (before source versioning)
         depends_on: build-aarch64
-        timeout_in_minutes: 30
+        timeout_in_minutes: 60
         plugins:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc-old-syntax

--- a/test/mysql-cdc-old-syntax/privileges.td
+++ b/test/mysql-cdc-old-syntax/privileges.td
@@ -52,8 +52,7 @@ GRANT ALL ON public.* TO priv;
 ! CREATE SOURCE mz_source
   FROM MYSQL CONNECTION mysql_conn
   FOR SCHEMAS (public, other);
-contains:No tables found in referenced schemas
-detail:missing schemas: other
+contains:no tables found in referenced schemas: "other"
 
 #
 # SELECT errors
@@ -67,8 +66,7 @@ GRANT ALL ON other TO priv;
 ! CREATE SOURCE mz_source
   FROM MYSQL CONNECTION mysql_conn
   FOR SCHEMAS (public, other);
-contains:No tables found in referenced schemas
-detail:missing schemas: other
+contains:no tables found in referenced schemas: "other"
 
 $ mysql-execute name=mysql
 CREATE TABLE other.u (a int);


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
