### PR TITLE
Do not create ClusterRoleBinding in orchestratord

### DIFF
--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -117,14 +117,6 @@ pub mod v1alpha1 {
             self.name_unchecked()
         }
 
-        pub fn cluster_role_name() -> String {
-            "environmentd".to_string()
-        }
-
-        pub fn cluster_role_binding_name(&self) -> String {
-            self.name_unchecked()
-        }
-
         pub fn environmentd_statefulset_name(generation: u64) -> String {
             format!("environmentd-{generation}")
         }


### PR DESCRIPTION
Do not create ClusterRoleBinding for environmentd in orchestratord.

This ClusterRole is only used by the init container to query node labels, and the init container is also not managed by orchestratord.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


  * This PR adds a known-desirable feature.
Part of https://github.com/MaterializeInc/cloud/issues/10285

### Tips for reviewer

Context discussion at https://materializeinc.slack.com/archives/CL68GT3AT/p1729163180743349

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
