### PR TITLE
sources/mysql: Allow MySQL sources to reference tables in system schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5393,6 +5393,7 @@ dependencies = [
  "fancy-regex",
  "indexmap 1.9.1",
  "itertools 0.10.5",
+ "maplit",
  "mysql_async",
  "mysql_common",
  "mz-build-tools",

--- a/src/mysql-util/Cargo.toml
+++ b/src/mysql-util/Cargo.toml
@@ -14,16 +14,22 @@ anyhow = "1.0.66"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 itertools = "0.10.5"
+maplit = "1.0.2"
 mz-cloud-resources = { path = "../cloud-resources" }
 mz-ore = { path = "../ore", features = ["async"] }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }
 mz-ssh-util = { path = "../ssh-util" }
-mysql_common = { version = "0.32.4", default-features = false, features = ["chrono"] }
-mysql_async = { version = "0.34.1", default-features = false, features = ["minimal", "tracing"] }
+mysql_common = { version = "0.32.4", default-features = false, features = [
+    "chrono",
+] }
+mysql_async = { version = "0.34.1", default-features = false, features = [
+    "minimal",
+    "tracing",
+] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
-proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
+proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 fancy-regex = "0.11.0"
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }

--- a/src/mysql-util/src/lib.rs
+++ b/src/mysql-util/src/lib.rs
@@ -28,7 +28,9 @@ pub use replication::{
 };
 
 pub mod schemas;
-pub use schemas::{schema_info, MySqlTableSchema, QualifiedTableRef, SchemaRequest};
+pub use schemas::{
+    schema_info, MySqlTableSchema, QualifiedTableRef, SchemaRequest, SYSTEM_SCHEMAS,
+};
 
 pub mod privileges;
 pub use privileges::validate_source_privileges;

--- a/test/mysql-cdc/table-in-mysql-schema.td
+++ b/test/mysql-cdc/table-in-mysql-schema.td
@@ -28,33 +28,34 @@ $ mysql-execute name=mysql
 DROP DATABASE IF EXISTS public;
 DROP DATABASE IF EXISTS another_schema;
 USE mysql;
-
-# Insert data pre-snapshot
 CREATE TABLE t_in_mysql (f1 INT);
 INSERT INTO t_in_mysql VALUES (1), (2);
+CREATE DATABASE public;
+USE public;
+CREATE TABLE time_zone (f1 INT);
 
 > DROP SOURCE IF EXISTS mz_source;
 
-# TODO(database-issues#8624): Uncomment when addressed
+> CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn;
 
-! CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn;
-contains:No tables found
+! CREATE TABLE timezone FROM SOURCE mz_source (REFERENCE public.timezone);
+contains:reference to public.timezone not found in source
 
-# ! CREATE TABLE timezone FROM SOURCE mz_source (REFERENCE public.timezone);
-# contains:No tables found
+> CREATE TABLE t_in_mysql FROM SOURCE mz_source (REFERENCE mysql.t_in_mysql);
 
-# > CREATE TABLE t_in_mysql FROM SOURCE mz_source (REFERENCE mysql.t_in_mysql);
+> SELECT * FROM t_in_mysql;
+1
+2
 
-# > SELECT * FROM t_in_mysql;
-# 1
-# 2
+> DROP SOURCE mz_source CASCADE;
 
-# > DROP SOURCE mz_source CASCADE;
+> CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn;
 
-# > CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn;
-
-# ! CREATE TABLE t_in_mysql FROM SOURCE mz_source (REFERENCE mysql.time_zone);
-# contains:referenced tables use unsupported types
+! CREATE TABLE t_in_mysql FROM SOURCE mz_source (REFERENCE mysql.time_zone);
+contains:referenced tables use unsupported types
 
 $ mysql-execute name=mysql
+USE mysql;
 DROP TABLE t_in_mysql;
+USE public;
+DROP TABLE time_zone;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug. Fixes https://github.com/MaterializeInc/database-issues/issues/8624 and fixes https://github.com/MaterializeInc/database-issues/issues/8672

I had removed this ability during the refactoring done in https://github.com/MaterializeInc/materialize/pull/29857 with the intent to reintroduce it at some point in the future. However we discovered today that it broke some nightly tests, so here is the fix!

The downside to this solution is that when a user specifies a table to replicate within a mysql system schema, we will retrieve and store _all_ tables in all system schemas in our `mz_internal.mz_source_references' catalog table, which includes dozens of tables. However this seems like an acceptable tradeoff to avoid a more complicated approach.

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
