### PR TITLE
persist: include shard name (usually the GlobalId) in snapshot logging

### DIFF
--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -899,7 +899,8 @@ where
             if !logged_at_info && start.elapsed() >= Duration::from_millis(1024) {
                 logged_at_info = true;
                 info!(
-                    "snapshot {} as of {:?} not yet available for {} upper {:?}",
+                    "snapshot {} {} as of {:?} not yet available for {} upper {:?}",
+                    self.applier.shard_metrics.name,
                     self.shard_id(),
                     as_of.elements(),
                     seqno,
@@ -907,7 +908,8 @@ where
                 );
             } else {
                 debug!(
-                    "snapshot {} as of {:?} not yet available for {} upper {:?}",
+                    "snapshot {} {} as of {:?} not yet available for {} upper {:?}",
+                    self.applier.shard_metrics.name,
                     self.shard_id(),
                     as_of.elements(),
                     seqno,
@@ -932,7 +934,8 @@ where
                 Ok(x) => {
                     if logged_at_info {
                         info!(
-                            "snapshot {} as of {:?} now available",
+                            "snapshot {} {} as of {:?} now available",
+                            self.applier.shard_metrics.name,
                             self.shard_id(),
                             as_of.elements(),
                         );
@@ -957,7 +960,8 @@ where
                 )),
                 Wake::Sleep(sleeps) => {
                     debug!(
-                        "snapshot {} sleeping for {:?}",
+                        "snapshot {} {} sleeping for {:?}",
+                        self.applier.shard_metrics.name,
                         self.shard_id(),
                         sleeps.next_sleep()
                     );
@@ -1080,8 +1084,10 @@ where
                 )),
                 Wake::Sleep(sleeps) => {
                     debug!(
-                        "{:?}: next_listen_batch didn't find new data, retrying in {:?}",
+                        "{:?}: {} {} next_listen_batch didn't find new data, retrying in {:?}",
                         reader_id,
+                        self.applier.shard_metrics.name,
+                        self.shard_id(),
                         sleeps.next_sleep()
                     );
                     wakes.push(Box::pin(


### PR DESCRIPTION
Motivation is for ease of local development (e.g. right now while I'm iterating on CT stuff and debugging some WIP local branch). This probably would have been there in the first place, except this log message long predates having the shard names plumbed around.

Really only doing this for the info logging in snapshot, but also include it for all the similar debug logs in snapshot and next_listen_batch.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
