### PR TITLE
storage/mysql: Don't error if no non-system tables are found when MySQL sources are created

### DIFF
--- a/src/sql/src/pure/mysql.rs
+++ b/src/sql/src/pure/mysql.rs
@@ -375,7 +375,7 @@ pub(super) async fn purify_source_exports(
 
     if requested_exports.is_empty() {
         sql_bail!(
-            "[internal error]: MySQL source must ingest at least one table, but {} matched none",
+            "MySQL source must ingest at least one table, but {} matched none",
             requested_references.as_ref().unwrap().to_ast_string()
         );
     }

--- a/test/mysql-cdc-old-syntax/table-in-mysql-schema.td
+++ b/test/mysql-cdc-old-syntax/table-in-mysql-schema.td
@@ -38,7 +38,7 @@ INSERT INTO t_in_mysql VALUES (1), (2);
 ! CREATE SOURCE mz_source
   FROM MYSQL CONNECTION mysql_conn
   FOR ALL TABLES;
-contains:No tables found
+contains:MySQL source must ingest at least one table, but FOR ALL TABLES matched none
 
 ! CREATE SOURCE mz_source
   FROM MYSQL CONNECTION mysql_conn


### PR DESCRIPTION
https://github.com/MaterializeInc/materialize/pull/30064#issuecomment-2420156881

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
