### PR TITLE
ci: Switch jobs to AWS if Hetzner is overloaded

### DIFF
--- a/misc/python/materialize/checks/all_checks/pg_cdc.py
+++ b/misc/python/materialize/checks/all_checks/pg_cdc.py
@@ -363,14 +363,14 @@ class PgCdcMzNow(Check):
                 DELETE FROM postgres_mz_now_table WHERE f2 = 'B3';
                 UPDATE postgres_mz_now_table SET f1 = NOW() WHERE f2 = 'E1'
 
-                # Expect some rows newer than 60 seconds in view
+                # Expect some rows newer than 90 seconds in view
                 > SELECT COUNT(*) >= 6 FROM postgres_mz_now_view
-                  WHERE f1 > NOW() - INTERVAL '60' SECOND;
+                  WHERE f1 > NOW() - INTERVAL '90' SECOND;
                 true
 
-                # Expect no rows older than 60 seconds in view
+                # Expect no rows older than 90 seconds in view
                 > SELECT COUNT(*) FROM postgres_mz_now_view
-                  WHERE f1 < NOW() - INTERVAL '60' SECOND;
+                  WHERE f1 < NOW() - INTERVAL '90' SECOND;
                 0
 
                 # Rollback the last INSERTs so that validate() can be called multiple times


### PR DESCRIPTION
This is not perfect, builds can be triggered quickly and we wouldn't notice. Successful test run with everything switched to AWS: https://buildkite.com/materialize/test/builds/92724 Nightly still running: https://buildkite.com/materialize/nightly/builds/10031

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
