### PR TITLE
ore: introduce SensitiveUrl type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5624,6 +5624,7 @@ dependencies = [
  "tracing-capture",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
  "uuid",
  "workspace-hack",
  "yansi",

--- a/misc/wasm/Cargo.lock
+++ b/misc/wasm/Cargo.lock
@@ -95,6 +95,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +197,7 @@ dependencies = [
  "stacker",
  "thiserror",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -345,6 +365,12 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phf"
@@ -647,6 +673,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,16 +775,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "url"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "valuable"

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -72,6 +72,7 @@ use ipnet::IpNet;
 use mz_adapter_types::dyncfgs::WITH_0DT_DEPLOYMENT_CAUGHT_UP_CHECK_INTERVAL;
 use mz_compute_client::as_of_selection;
 use mz_ore::channel::trigger::Trigger;
+use mz_ore::url::SensitiveUrl;
 use mz_sql::names::{ResolvedIds, SchemaSpecifier};
 use mz_sql::session::user::User;
 use mz_storage_types::read_holds::ReadHold;
@@ -954,7 +955,7 @@ pub struct Config {
     pub controller_config: ControllerConfig,
     pub controller_envd_epoch: NonZeroI64,
     pub storage: Box<dyn mz_catalog::durable::DurableCatalogState>,
-    pub timestamp_oracle_url: Option<String>,
+    pub timestamp_oracle_url: Option<SensitiveUrl>,
     pub unsafe_mode: bool,
     pub all_features: bool,
     pub build_info: &'static BuildInfo,

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -44,6 +44,7 @@ use mz_ore::collections::HashSet;
 use mz_ore::error::ErrorExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
+use mz_ore::url::SensitiveUrl;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::cfg::PersistConfig;
 use mz_persist_client::rpc::PubSubClientConnection;
@@ -55,7 +56,6 @@ use mz_sql::session::vars::ConnectionCounter;
 use mz_storage_types::connections::ConnectionContext;
 use serde::{Deserialize, Serialize};
 use tracing::{error, Instrument};
-use url::Url;
 use uuid::Uuid;
 
 pub const BUILD_INFO: BuildInfo = build_info!();
@@ -70,10 +70,10 @@ pub struct Args {
     organization_id: Uuid,
     /// Where the persist library should store its blob data.
     #[clap(long, env = "PERSIST_BLOB_URL")]
-    persist_blob_url: Url,
+    persist_blob_url: SensitiveUrl,
     /// Where the persist library should perform consensus.
     #[clap(long, env = "PERSIST_CONSENSUS_URL")]
-    persist_consensus_url: Url,
+    persist_consensus_url: SensitiveUrl,
     // === Cloud options. ===
     /// An external ID to be supplied to all AWS AssumeRole operations.
     ///
@@ -198,8 +198,8 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         PubSubClientConnection::noop()
     });
     let persist_location = PersistLocation {
-        blob_uri: args.persist_blob_url.to_string(),
-        consensus_uri: args.persist_consensus_url.to_string(),
+        blob_uri: args.persist_blob_url.clone(),
+        consensus_uri: args.persist_consensus_url.clone(),
     };
     let persist_client = persist_clients.open(persist_location).await?;
     let organization_id = args.organization_id;

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -52,6 +52,7 @@ use mz_ore::metric;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_ore::task::RuntimeExt;
+use mz_ore::url::SensitiveUrl;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::cfg::PersistConfig;
 use mz_persist_client::rpc::{
@@ -68,7 +69,6 @@ use opentelemetry::trace::TraceContextExt;
 use prometheus::IntGauge;
 use tracing::{error, info, info_span, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-use url::Url;
 
 mod sys;
 
@@ -367,10 +367,10 @@ pub struct Args {
     // === Storage options. ===
     /// Where the persist library should store its blob data.
     #[clap(long, env = "PERSIST_BLOB_URL")]
-    persist_blob_url: Url,
+    persist_blob_url: SensitiveUrl,
     /// Where the persist library should perform consensus.
     #[clap(long, env = "PERSIST_CONSENSUS_URL")]
-    persist_consensus_url: Url,
+    persist_consensus_url: SensitiveUrl,
     /// The Persist PubSub URL.
     ///
     /// This URL is passed to `clusterd` for discovery of the Persist PubSub service.
@@ -402,7 +402,7 @@ pub struct Args {
     // === Adapter options. ===
     /// The PostgreSQL URL for the Postgres-backed timestamp oracle.
     #[clap(long, env = "TIMESTAMP_ORACLE_URL", value_name = "POSTGRES_URL")]
-    timestamp_oracle_url: Option<String>,
+    timestamp_oracle_url: Option<SensitiveUrl>,
     /// Availability zones in which storage and compute resources may be
     /// deployed.
     #[clap(long, env = "AVAILABILITY_ZONE", use_value_delimiter = true)]
@@ -907,8 +907,8 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         build_info: &mz_environmentd::BUILD_INFO,
         orchestrator,
         persist_location: PersistLocation {
-            blob_uri: args.persist_blob_url.to_string(),
-            consensus_uri: args.persist_consensus_url.to_string(),
+            blob_uri: args.persist_blob_url,
+            consensus_uri: args.persist_consensus_url,
         },
         persist_clients: Arc::clone(&persist_clients),
         clusterd_image: args.clusterd_image.expect("clap enforced"),

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -40,6 +40,7 @@ use mz_ore::future::OreFutureExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 use mz_ore::tracing::TracingHandle;
+use mz_ore::url::SensitiveUrl;
 use mz_ore::{instrument, task};
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::usage::StorageUsageClient;
@@ -126,7 +127,7 @@ pub struct Config {
     /// A map from size name to resource allocations for cluster replicas.
     pub cluster_replica_sizes: ClusterReplicaSizeMap,
     /// The PostgreSQL URL for the Postgres-backed timestamp oracle.
-    pub timestamp_oracle_url: Option<String>,
+    pub timestamp_oracle_url: Option<SensitiveUrl>,
     /// An API key for Segment. Enables export of audit events to Segment.
     pub segment_api_key: Option<String>,
     /// Whether the Segment client is being used on the client side

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -363,8 +363,12 @@ impl Listeners {
                 ))
                 .await?;
             (
-                format!("{cockroach_url}?options=--search_path=consensus_{seed}"),
-                format!("{cockroach_url}?options=--search_path=tsoracle_{seed}"),
+                format!("{cockroach_url}?options=--search_path=consensus_{seed}")
+                    .parse()
+                    .expect("invalid consensus URI"),
+                format!("{cockroach_url}?options=--search_path=tsoracle_{seed}")
+                    .parse()
+                    .expect("invalid timestamp oracle URI"),
             )
         };
         let metrics_registry = config.metrics_registry.unwrap_or_else(MetricsRegistry::new);
@@ -477,7 +481,9 @@ impl Listeners {
                     init_container_image: None,
                     deploy_generation: config.deploy_generation,
                     persist_location: PersistLocation {
-                        blob_uri: format!("file://{}/persist/blob", data_directory.display()),
+                        blob_uri: format!("file://{}/persist/blob", data_directory.display())
+                            .parse()
+                            .expect("invalid blob URI"),
                         consensus_uri,
                     },
                     persist_clients,

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -73,6 +73,7 @@ tracing-subscriber = { version = "0.3.16", default-features = false, features = 
   "tracing-log",
 ], optional = true }
 uuid = { version = "1.7.0", optional = true }
+url = { version = "2.3.1", features = ["serde"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 # For the `tracing` feature

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -98,6 +98,7 @@ pub mod time;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "tracing_")))]
 #[cfg(feature = "tracing_")]
 pub mod tracing;
+pub mod url;
 pub mod vec;
 
 pub use mz_ore_proc::{instrument, static_list, test};

--- a/src/ore/src/url.rs
+++ b/src/ore/src/url.rs
@@ -1,0 +1,88 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! URL utilities.
+
+use std::fmt;
+use std::ops::Deref;
+use std::str::FromStr;
+
+#[cfg(feature = "proptest")]
+use proptest::prelude::{Arbitrary, BoxedStrategy, Strategy};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+/// A URL that redacts its password when formatted.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SensitiveUrl(pub Url);
+
+impl SensitiveUrl {
+    /// Converts into the underlying URL with the password redacted if it
+    /// exists.
+    pub fn into_redacted(mut self) -> Url {
+        if self.0.password().is_some() {
+            self.0.set_password(Some("<redacted>")).unwrap();
+        }
+        self.0
+    }
+
+    /// Formats as a string without redacting the password.
+    pub fn to_string_unredacted(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl fmt::Display for SensitiveUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.clone().into_redacted().fmt(f)
+    }
+}
+
+impl fmt::Debug for SensitiveUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.clone().into_redacted().fmt(f)
+    }
+}
+
+impl FromStr for SensitiveUrl {
+    type Err = url::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Url::from_str(s)?))
+    }
+}
+
+impl Deref for SensitiveUrl {
+    type Target = Url;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(feature = "proptest")]
+impl Arbitrary for SensitiveUrl {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        proptest::sample::select(vec![
+            SensitiveUrl::from_str("http://user:pass@example.com").unwrap(),
+            SensitiveUrl::from_str("http://user@example.com").unwrap(),
+            SensitiveUrl::from_str("http://example.com").unwrap(),
+        ])
+        .boxed()
+    }
+}

--- a/src/persist-cli/src/maelstrom.rs
+++ b/src/persist-cli/src/maelstrom.rs
@@ -9,7 +9,7 @@
 
 //! An adaptor to Jepsen Maelstrom's txn-list-append workload
 
-use mz_ore::task::RuntimeExt;
+use mz_ore::{task::RuntimeExt, url::SensitiveUrl};
 use tokio::runtime::Handle;
 use tracing::Span;
 
@@ -34,11 +34,11 @@ pub mod txn_list_append_single;
 pub struct Args {
     /// Blob to use, defaults to Maelstrom lin-kv service
     #[clap(long)]
-    blob_uri: Option<String>,
+    blob_uri: Option<SensitiveUrl>,
 
     /// Consensus to use, defaults to Maelstrom lin-kv service
     #[clap(long)]
-    consensus_uri: Option<String>,
+    consensus_uri: Option<SensitiveUrl>,
 
     /// How much unreliability to inject into Blob and Consensus usage
     ///

--- a/src/persist-cli/src/open_loop.rs
+++ b/src/persist-cli/src/open_loop.rs
@@ -21,6 +21,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_ore::task::JoinHandle;
+use mz_ore::url::SensitiveUrl;
 use mz_persist::workload::DataGenerator;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::cfg::PersistConfig;
@@ -58,11 +59,11 @@ pub struct Args {
 
     /// Handle to the persist consensus system.
     #[clap(long, value_name = "CONSENSUS_URI")]
-    consensus_uri: String,
+    consensus_uri: SensitiveUrl,
 
     /// Handle to the persist blob storage.
     #[clap(long, value_name = "BLOB_URI")]
-    blob_uri: String,
+    blob_uri: SensitiveUrl,
 
     /// The type of benchmark to run
     #[clap(arg_enum, long, default_value_t = BenchmarkType::RawWriter)]

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -22,6 +22,7 @@ use futures_util::{stream, StreamExt, TryStreamExt};
 use mz_dyncfg::{Config, ConfigSet};
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
+use mz_ore::url::SensitiveUrl;
 use mz_persist::location::{Blob, Consensus, ExternalError};
 use mz_persist_types::codec_impls::TodoSchema;
 use mz_persist_types::{Codec, Codec64};
@@ -413,8 +414,8 @@ pub async fn force_compaction<K, V, T, D>(
     cfg: PersistConfig,
     metrics_registry: &MetricsRegistry,
     shard_id: ShardId,
-    consensus_uri: &str,
-    blob_uri: &str,
+    consensus_uri: &SensitiveUrl,
+    blob_uri: &SensitiveUrl,
     key_schema: Arc<K::Schema>,
     val_schema: Arc<V::Schema>,
     commit: bool,
@@ -636,8 +637,8 @@ async fn force_gc(
     cfg: PersistConfig,
     metrics_registry: &MetricsRegistry,
     shard_id: ShardId,
-    consensus_uri: &str,
-    blob_uri: &str,
+    consensus_uri: &SensitiveUrl,
+    blob_uri: &SensitiveUrl,
     commit: bool,
     expected_version: Option<Version>,
 ) -> anyhow::Result<Box<dyn Any>> {

--- a/src/persist-client/src/cli/args.rs
+++ b/src/persist-client/src/cli/args.rs
@@ -20,6 +20,7 @@ use mz_build_info::BuildInfo;
 use mz_ore::bytes::SegmentedBytes;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
+use mz_ore::url::SensitiveUrl;
 use mz_persist::cfg::{BlobConfig, ConsensusConfig};
 use mz_persist::location::{
     Blob, BlobMetadata, CaSResult, Consensus, ExternalError, ResultStream, SeqNo, Tasked,
@@ -49,7 +50,7 @@ pub struct StoreArgs {
     /// ```
     ///
     #[clap(long, verbatim_doc_comment, env = "CONSENSUS_URI")]
-    pub(crate) consensus_uri: String,
+    pub(crate) consensus_uri: SensitiveUrl,
 
     /// Blob to use
     ///
@@ -57,7 +58,7 @@ pub struct StoreArgs {
     /// place. e.g. for S3, sign into SSO, set AWS_PROFILE and AWS_REGION appropriately, with a blob
     /// URI scoped to the environment's bucket prefix.
     #[clap(long, env = "BLOB_URI")]
-    pub(crate) blob_uri: String,
+    pub(crate) blob_uri: SensitiveUrl,
 }
 
 /// Arguments for viewing the current state of a given shard
@@ -82,7 +83,7 @@ pub struct StateArgs {
     /// ```
     ///
     #[clap(long, verbatim_doc_comment, env = "CONSENSUS_URI")]
-    pub(crate) consensus_uri: String,
+    pub(crate) consensus_uri: SensitiveUrl,
 
     /// Blob to use
     ///
@@ -90,7 +91,7 @@ pub struct StateArgs {
     /// place. e.g. for S3, sign into SSO, set AWS_PROFILE and AWS_REGION appropriately, with a blob
     /// URI scoped to the environment's bucket prefix.
     #[clap(long, env = "BLOB_URI")]
-    pub(crate) blob_uri: String,
+    pub(crate) blob_uri: SensitiveUrl,
 }
 
 // BuildInfo with a larger version than any version we expect to see in prod,
@@ -122,7 +123,7 @@ impl StateArgs {
 
 pub(super) async fn make_consensus(
     cfg: &PersistConfig,
-    consensus_uri: &str,
+    consensus_uri: &SensitiveUrl,
     commit: bool,
     metrics: Arc<Metrics>,
 ) -> anyhow::Result<Arc<dyn Consensus>> {
@@ -144,7 +145,7 @@ pub(super) async fn make_consensus(
 
 pub(super) async fn make_blob(
     cfg: &PersistConfig,
-    blob_uri: &str,
+    blob_uri: &SensitiveUrl,
     commit: bool,
     metrics: Arc<Metrics>,
 ) -> anyhow::Result<Arc<dyn Blob>> {

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -23,6 +23,7 @@ use differential_dataflow::trace::Description;
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
+use mz_ore::url::SensitiveUrl;
 use mz_persist::indexed::encoding::BlobTraceBatchPart;
 use mz_persist_types::codec_impls::TodoSchema;
 use mz_persist_types::{Codec, Codec64, Opaque};
@@ -294,7 +295,7 @@ pub struct BlobBatchPartArgs {
     /// place. e.g. for S3, sign into SSO, set AWS_PROFILE and AWS_REGION appropriately, with a blob
     /// URI scoped to the environment's bucket prefix.
     #[clap(long)]
-    blob_uri: String,
+    blob_uri: SensitiveUrl,
 
     /// Number of updates to output. Default is unbounded.
     #[clap(long, default_value = "18446744073709551615")]
@@ -329,7 +330,7 @@ impl fmt::Debug for PrettyBytes<'_> {
 
 /// Fetches the updates in a blob batch part
 pub async fn blob_batch_part(
-    blob_uri: &str,
+    blob_uri: &SensitiveUrl,
     shard_id: ShardId,
     partial_key: String,
     limit: usize,
@@ -430,7 +431,7 @@ pub struct BlobArgs {
     /// place. e.g. for S3, sign into SSO, set AWS_PROFILE and AWS_REGION appropriately, with a blob
     /// URI scoped to the environment's bucket prefix.
     #[clap(long)]
-    blob_uri: String,
+    blob_uri: SensitiveUrl,
 }
 
 #[derive(Debug, Default, serde::Serialize)]
@@ -442,7 +443,7 @@ struct BlobCounts {
 }
 
 /// Fetches the blob count for given path
-pub async fn blob_counts(blob_uri: &str) -> Result<impl serde::Serialize, anyhow::Error> {
+pub async fn blob_counts(blob_uri: &SensitiveUrl) -> Result<impl serde::Serialize, anyhow::Error> {
     let cfg = PersistConfig::new_default_configs(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
     let blob = make_blob(&cfg, blob_uri, NO_COMMIT, metrics).await?;
@@ -472,7 +473,7 @@ pub async fn blob_counts(blob_uri: &str) -> Result<impl serde::Serialize, anyhow
 }
 
 /// Rummages through S3 to find the latest rollup for each shard, then calculates summary stats.
-pub async fn shard_stats(blob_uri: &str) -> anyhow::Result<()> {
+pub async fn shard_stats(blob_uri: &SensitiveUrl) -> anyhow::Result<()> {
     let cfg = PersistConfig::new_default_configs(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
     let blob = make_blob(&cfg, blob_uri, NO_COMMIT, metrics).await?;

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -17,6 +17,7 @@
 )]
 
 use bytes::{BufMut, Bytes};
+use mz_ore::url::SensitiveUrl;
 use mz_proto::{RustType, TryFromProtoError};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -169,18 +170,18 @@ pub trait Codec64: Sized + Clone + 'static {
 #[derive(Arbitrary, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub struct PersistLocation {
     /// Uri string that identifies the blob store.
-    pub blob_uri: String,
+    pub blob_uri: SensitiveUrl,
 
     /// Uri string that identifies the consensus system.
-    pub consensus_uri: String,
+    pub consensus_uri: SensitiveUrl,
 }
 
 impl PersistLocation {
     /// Returns a PersistLocation indicating in-mem blob and consensus.
     pub fn new_in_mem() -> Self {
         PersistLocation {
-            blob_uri: "mem://".to_owned(),
-            consensus_uri: "mem://".to_owned(),
+            blob_uri: "mem://".parse().unwrap(),
+            consensus_uri: "mem://".parse().unwrap(),
         }
     }
 }

--- a/src/postgres-client/src/lib.rs
+++ b/src/postgres-client/src/lib.rs
@@ -32,6 +32,7 @@ use deadpool_postgres::{
 };
 use mz_ore::cast::{CastFrom, CastLossy};
 use mz_ore::now::SYSTEM_TIME;
+use mz_ore::url::SensitiveUrl;
 use tracing::debug;
 
 use crate::error::PostgresError;
@@ -58,7 +59,7 @@ pub trait PostgresClientKnobs: std::fmt::Debug + Send + Sync {
 /// Configuration for creating a [PostgresClient].
 #[derive(Clone, Debug)]
 pub struct PostgresClientConfig {
-    url: String,
+    url: SensitiveUrl,
     knobs: Arc<dyn PostgresClientKnobs>,
     metrics: PostgresClientMetrics,
 }
@@ -66,7 +67,7 @@ pub struct PostgresClientConfig {
 impl PostgresClientConfig {
     /// Returns a new [PostgresClientConfig] for use in production.
     pub fn new(
-        url: String,
+        url: SensitiveUrl,
         knobs: Arc<dyn PostgresClientKnobs>,
         metrics: PostgresClientMetrics,
     ) -> Self {
@@ -93,7 +94,7 @@ impl std::fmt::Debug for PostgresClient {
 impl PostgresClient {
     /// Open a [PostgresClient] using the given `config`.
     pub fn open(config: PostgresClientConfig) -> Result<Self, PostgresError> {
-        let mut pg_config: Config = config.url.parse()?;
+        let mut pg_config: Config = config.url.to_string_unredacted().parse()?;
         pg_config.connect_timeout(config.knobs.connect_timeout());
         pg_config.tcp_user_timeout(config.knobs.tcp_user_timeout());
 

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -2739,6 +2739,7 @@ pub(crate) enum SnapshotStatsAsOf<T: TimelyTimestamp + Lattice + Codec64> {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
     use std::sync::Arc;
 
     use mz_build_info::DUMMY_BUILD_INFO;
@@ -2746,6 +2747,7 @@ mod tests {
     use mz_ore::assert_err;
     use mz_ore::metrics::{MetricsRegistry, UIntGauge};
     use mz_ore::now::SYSTEM_TIME;
+    use mz_ore::url::SensitiveUrl;
     use mz_persist_client::cache::PersistClientCache;
     use mz_persist_client::cfg::PersistConfig;
     use mz_persist_client::rpc::PubSubClientConnection;
@@ -2760,8 +2762,8 @@ mod tests {
     #[cfg_attr(miri, ignore)] // unsupported operation: integer-to-pointer casts and `ptr::from_exposed_addr`
     async fn test_snapshot_stats(&self) {
         let persist_location = PersistLocation {
-            blob_uri: "mem://".to_owned(),
-            consensus_uri: "mem://".to_owned(),
+            blob_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
+            consensus_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
         };
         let persist_client = PersistClientCache::new(
             PersistConfig::new_default_configs(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone()),

--- a/src/storage-controller/src/history.rs
+++ b/src/storage-controller/src/history.rs
@@ -201,7 +201,10 @@ impl<T: std::fmt::Debug> CommandHistory<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use mz_ore::metrics::MetricsRegistry;
+    use mz_ore::url::SensitiveUrl;
     use mz_persist_types::PersistLocation;
     use mz_repr::{GlobalId, RelationDesc, RelationType};
     use mz_storage_client::client::{RunIngestionCommand, RunSinkCommand};
@@ -248,8 +251,8 @@ mod tests {
                 let export = SourceExport {
                     storage_metadata: CollectionMetadata {
                         persist_location: PersistLocation {
-                            blob_uri: Default::default(),
-                            consensus_uri: Default::default(),
+                            blob_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
+                            consensus_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
                         },
                         remap_shard: Default::default(),
                         data_shard: Default::default(),
@@ -291,8 +294,8 @@ mod tests {
             },
             ingestion_metadata: CollectionMetadata {
                 persist_location: PersistLocation {
-                    blob_uri: Default::default(),
-                    consensus_uri: Default::default(),
+                    blob_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
+                    consensus_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
                 },
                 remap_shard: Default::default(),
                 data_shard: Default::default(),
@@ -363,8 +366,8 @@ mod tests {
             status_id: Default::default(),
             from_storage_metadata: CollectionMetadata {
                 persist_location: PersistLocation {
-                    blob_uri: Default::default(),
-                    consensus_uri: Default::default(),
+                    blob_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
+                    consensus_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
                 },
                 remap_shard: Default::default(),
                 data_shard: Default::default(),

--- a/src/storage-types/src/controller.rs
+++ b/src/storage-types/src/controller.rs
@@ -9,9 +9,11 @@
 
 use std::error::Error;
 use std::fmt::{self, Debug, Display};
+use std::str::FromStr;
 
 use itertools::Itertools;
 use mz_ore::assert_none;
+use mz_ore::url::SensitiveUrl;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::stats::PartStats;
 use mz_persist_types::txn::{TxnsCodec, TxnsEntry};
@@ -98,8 +100,8 @@ impl crate::AlterCompatible for CollectionMetadata {
 impl RustType<ProtoCollectionMetadata> for CollectionMetadata {
     fn into_proto(&self) -> ProtoCollectionMetadata {
         ProtoCollectionMetadata {
-            blob_uri: self.persist_location.blob_uri.clone(),
-            consensus_uri: self.persist_location.consensus_uri.clone(),
+            blob_uri: self.persist_location.blob_uri.to_string_unredacted(),
+            consensus_uri: self.persist_location.consensus_uri.to_string_unredacted(),
             data_shard: self.data_shard.to_string(),
             remap_shard: self.remap_shard.map(|s| s.to_string()),
             status_shard: self.status_shard.map(|s| s.to_string()),
@@ -111,8 +113,8 @@ impl RustType<ProtoCollectionMetadata> for CollectionMetadata {
     fn from_proto(value: ProtoCollectionMetadata) -> Result<Self, TryFromProtoError> {
         Ok(CollectionMetadata {
             persist_location: PersistLocation {
-                blob_uri: value.blob_uri,
-                consensus_uri: value.consensus_uri,
+                blob_uri: SensitiveUrl::from_str(&value.blob_uri)?,
+                consensus_uri: SensitiveUrl::from_str(&value.consensus_uri)?,
             },
             remap_shard: value
                 .remap_shard

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -599,6 +599,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::str::FromStr;
     use std::sync::Arc;
     use std::sync::LazyLock;
     use std::time::Duration;
@@ -607,6 +608,7 @@ mod tests {
     use mz_build_info::DUMMY_BUILD_INFO;
     use mz_ore::metrics::MetricsRegistry;
     use mz_ore::now::SYSTEM_TIME;
+    use mz_ore::url::SensitiveUrl;
     use mz_persist_client::cache::PersistClientCache;
     use mz_persist_client::cfg::PersistConfig;
     use mz_persist_client::rpc::PubSubClientConnection;
@@ -661,8 +663,8 @@ mod tests {
     ) {
         let metadata = CollectionMetadata {
             persist_location: PersistLocation {
-                blob_uri: "mem://".to_owned(),
-                consensus_uri: "mem://".to_owned(),
+                blob_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
+                consensus_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
             },
             remap_shard: Some(shard),
             data_shard: ShardId::new(),
@@ -818,8 +820,8 @@ mod tests {
     #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
     async fn test_reclock_frontier() {
         let persist_location = PersistLocation {
-            blob_uri: "mem://".to_owned(),
-            consensus_uri: "mem://".to_owned(),
+            blob_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
+            consensus_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
         };
 
         let remap_shard = ShardId::new();
@@ -1226,8 +1228,8 @@ mod tests {
     #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
     async fn test_compaction() {
         let persist_location = PersistLocation {
-            blob_uri: "mem://".to_owned(),
-            consensus_uri: "mem://".to_owned(),
+            blob_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
+            consensus_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
         };
 
         let remap_shard = ShardId::new();
@@ -1538,8 +1540,8 @@ mod tests {
     #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
     async fn test_inversion() {
         let persist_location = PersistLocation {
-            blob_uri: "mem://".to_owned(),
-            consensus_uri: "mem://".to_owned(),
+            blob_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
+            consensus_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
         };
 
         let remap_shard = ShardId::new();
@@ -1788,8 +1790,8 @@ mod tests {
 
         // Also manually assert the since of the remap shard.
         let persist_location = PersistLocation {
-            blob_uri: "mem://".to_owned(),
-            consensus_uri: "mem://".to_owned(),
+            blob_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
+            consensus_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
         };
 
         let persist_client = PERSIST_CACHE

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -30,6 +30,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_ore::retry::Retry;
 use mz_ore::task;
+use mz_ore::url::SensitiveUrl;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::cfg::PersistConfig;
 use mz_persist_client::rpc::PubSubClientConnection;
@@ -135,9 +136,9 @@ pub struct Config {
 
     // === Persist options. ===
     /// Handle to the persist consensus system.
-    pub persist_consensus_url: Option<String>,
+    pub persist_consensus_url: Option<SensitiveUrl>,
     /// Handle to the persist blob storage.
-    pub persist_blob_url: Option<String>,
+    pub persist_blob_url: Option<SensitiveUrl>,
 
     // === Confluent options. ===
     /// The address of the Kafka broker that testdrive will interact with.
@@ -210,8 +211,8 @@ pub struct State {
     materialize: MaterializeState,
 
     // === Persist state. ===
-    persist_consensus_url: Option<String>,
-    persist_blob_url: Option<String>,
+    persist_consensus_url: Option<SensitiveUrl>,
+    persist_blob_url: Option<SensitiveUrl>,
     build_info: &'static BuildInfo,
     persist_clients: PersistClientCache,
 
@@ -358,8 +359,8 @@ impl State {
         F: FnOnce(ConnCatalog) -> T,
     {
         async fn persist_client(
-            persist_consensus_url: String,
-            persist_blob_url: String,
+            persist_consensus_url: SensitiveUrl,
+            persist_blob_url: SensitiveUrl,
             persist_clients: &PersistClientCache,
         ) -> Result<PersistClient, anyhow::Error> {
             let persist_location = PersistLocation {
@@ -675,9 +676,9 @@ impl State {
 #[derive(Debug, Clone)]
 pub struct CatalogConfig {
     /// Handle to the persist consensus system.
-    pub persist_consensus_url: String,
+    pub persist_consensus_url: SensitiveUrl,
     /// Handle to the persist blob storage.
-    pub persist_blob_url: String,
+    pub persist_blob_url: SensitiveUrl,
 }
 
 pub enum ControlFlow {

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -21,6 +21,7 @@ use itertools::Itertools;
 use mz_build_info::{build_info, BuildInfo};
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::path::PathExt;
+use mz_ore::url::SensitiveUrl;
 use mz_testdrive::{CatalogConfig, Config, ConsistencyCheckLevel};
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
@@ -166,14 +167,14 @@ struct Args {
         value_name = "PERSIST_CONSENSUS_URL",
         required_if_eq("validate-catalog-store", "true")
     )]
-    persist_consensus_url: Option<String>,
+    persist_consensus_url: Option<SensitiveUrl>,
     /// Handle to the persist blob storage.
     #[clap(
         long,
         value_name = "PERSIST_BLOB_URL",
         required_if_eq("validate-catalog-store", "true")
     )]
-    persist_blob_url: Option<String>,
+    persist_blob_url: Option<SensitiveUrl>,
 
     // === Confluent options. ===
     /// Address of the Kafka broker that testdrive will interact with.

--- a/src/timestamp-oracle/src/postgres_oracle.rs
+++ b/src/timestamp-oracle/src/postgres_oracle.rs
@@ -434,7 +434,7 @@ where
         next: N,
         read_only: bool,
     ) -> Self {
-        info!("opening PostgresTimestampOracle");
+        info!(config = ?config, "opening PostgresTimestampOracle");
 
         let fallible = || async {
             let metrics = Arc::clone(&config.metrics);


### PR DESCRIPTION
That automatically redacts passwords when displayed/debugged. This will
prevent us from revealing the password, if present, in
consensus/blob/timestamp oracle connection URLs.

### Motivation

  * This PR addresses an incident.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
