### PR TITLE
ct: rework timestamp behavior pt 1

### DIFF
--- a/src/compute/src/render/continual_task.rs
+++ b/src/compute/src/render/continual_task.rs
@@ -7,10 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! A continual task presents as something like a `BEFORE TRIGGER`: it watches
-//! some _input_ and whenever it changes at time `T`, executes a SQL txn,
-//! writing to some _output_ at the same time `T`. It can also read anything in
-//! materialize as a _reference_, most notably including the output.
+//! A continual task presents as something like a `TRIGGER`: it watches some
+//! _input_ and whenever it changes at time `T`, executes a SQL txn, writing to
+//! some _output_ at the same time `T`. It can also read anything in materialize
+//! as a _reference_, most notably including the output.
 //!
 //! Only reacting to new inputs (and not the full history) makes a CT's
 //! rehydration time independent of the size of the inputs (NB this is not true
@@ -47,9 +47,9 @@
 //!   - NB: A full collection for the input can always be recovered by also
 //!     using the input as a "reference" (see below) and applying the diffs.
 //! - The task logic is expressed as a SQL transaction that does all reads at
-//!   time `T-1` and commits all writes at `T`
-//!   - Intuition is that the logic runs before the input is written, like a
-//!     `CREATE TRIGGER ... BEFORE`.
+//!   commits all writes at `T`
+//!   - The notable exception to this is self-referential reads of the CT
+//!     output. See below for how that works.
 //! - This logic can _reference_ any nameable object in the system, not just the
 //!   inputs.
 //!   - However, the logic/transaction can mutate only the outputs.
@@ -58,8 +58,6 @@
 //!     dataflow inputs today) but only changes for inputs.
 //!   - The task only produces output in response to changes in the inputs but
 //!     not in response to changes in the references.
-//!   - Inputs are reclocked by subtracting 1 from their timestamps, references
-//!     are not.
 //! - Instead of re-evaluating the task logic from scratch for each input time,
 //!   we maintain the collection representing desired writes to the output(s) as
 //!   a dataflow.
@@ -67,7 +65,41 @@
 //!   - HA strategy: multi-replica clusters race to commit and the losers throw
 //!     away the result.
 //!
-//! WIP need to update this to reflect the new timestamp behavior
+//! ## Self-References
+//!
+//! Self-references must be handled differently from other reads. When computing
+//! the proposed write to some output at `T`, we can only know the contents of
+//! it through `T-1` (the exclusive upper is `T`).
+//!
+//! We address this by initially assuming that the output contains no changes at
+//! `T`, then evaluating each of the statements in order, allowing them to see
+//! the proposed output changes made by the previous statements. By default,
+//! this is stopped after one iteration and proposed output diffs are committed
+//! if possible. (We could also add options for iterating to a fixpoint,
+//! stop/error after N iters, etc.) Then to compute the changes at `T+1`, we
+//! read in what was actually written to the output at `T` (maybe some other
+//! replica wrote something different) and begin again.
+//!
+//! The above is very similar to how timely/differential dataflow iteration
+//! works, except that our feedback loop goes through persist and the loop
+//! timestamp is already `mz_repr::Timestamp`.
+//!
+//! This is implemented as follows:
+//! - `let I = persist_source(self-reference)`
+//! - Transform `I` such that the contents at `T-1` are presented at `T` (i.e.
+//!   initially assume `T` is unchanged from `T-1`).
+//! - TODO(ct3): Actually implement the following.
+//! - In an iteration sub-scope:
+//!   - Bring `I` into the sub-scope and `let proposed = Variable`.
+//!   - We need a collection that at `(T, 0)` is always the contents of `I` at
+//!     `T`, but at `(T, 1...)` contains the proposed diffs by the CT logic. We
+//!     can construct it by concatenating `I` with `proposed` except that we
+//!     also need to retract everything in `proposed` for the next `(T+1, 0)`
+//!     (because `I` is the source of truth for what actually committed).
+//!  - `let R = retract_at_next_outer_ts(proposed)`
+//!  - `let result = logic(concat(I, proposed, R))`
+//!  - `proposed.set(result)`
+//! - Then we return `proposed.leave()` for attempted write to persist.
 
 use std::any::Any;
 use std::cell::RefCell;
@@ -116,21 +148,45 @@ pub(crate) struct ContinualTaskCtx<G: Scope<Timestamp = Timestamp>> {
     pub ct_times: Vec<Collection<G, (), Diff>>,
 }
 
+/// An encapsulation of the transformation logic necessary on data coming into a
+/// continual task.
+///
+/// NB: In continual task jargon, an "input" contains diffs and a "reference" is
+/// a normal source/collection.
 pub(crate) enum ContinualTaskSourceTransformer {
+    /// A collection containing, at each time T, exactly the inserts at time T
+    /// in the transformed collection.
+    ///
+    /// For example:
+    /// - Input: {} at 0, {1} at 1, {1} at 2, ...
+    /// - Output: {} at 0, {1} at 1, {} at 2, ...
+    ///
+    /// We'll presumably have the same for deletes eventually, but it's not
+    /// exposed in the SQL frontend yet.
     InsertsInput,
+    /// A self-reference to the continual task's output. This is essentially a
+    /// timely feedback loop via the persist shard. See module rustdoc for how
+    /// this works.
     SelfReference { source_id: GlobalId },
+    /// A normal collection (no-op transformation).
     NormalReference,
 }
 
 impl ContinualTaskSourceTransformer {
+    /// The persist_source `SnapshotMode` to use when reading this source.
     pub fn snapshot_mode(&self) -> SnapshotMode {
         use ContinualTaskSourceTransformer::*;
         match self {
             InsertsInput => SnapshotMode::Exclude,
-            SelfReference { .. } | NormalReference { .. } => SnapshotMode::Include,
+            SelfReference { .. } | NormalReference => SnapshotMode::Include,
         }
     }
 
+    /// Performs the necessary transformation on the source collection.
+    ///
+    /// Returns the transformed "oks" and "errs" collections. Also returns the
+    /// appropriate `ct_times` collection used to inform the sink which times
+    /// were changed in the inputs.
     pub fn transform<S: Scope<Timestamp = Timestamp>>(
         &self,
         oks: Collection<S, Row, Diff>,
@@ -146,17 +202,18 @@ impl ContinualTaskSourceTransformer {
             // contains the inserts at T.
             InsertsInput => {
                 // Keep only the inserts.
-                //
-                // At some point this will become a user option to instead keep
-                // only deletes.
                 let oks = oks.inner.filter(|(_, _, diff)| *diff > 0);
                 // Grab the original times for use in the sink operator.
+                //
+                // TODO(ct2): This clones every Row just to throw it away,
+                // wasting work and potentially doubling memory usage. The fix
+                // is a specialized 2-input 1-output operator.
                 let times = oks.map(|(_row, ts, diff)| ((), ts, diff));
                 // Then retract everything at the next timestamp.
                 let oks = oks.flat_map(|(row, ts, diff)| {
-                    let mut negation = diff.clone();
-                    differential_dataflow::Diff::negate(&mut negation);
-                    [(row.clone(), ts.step_forward(), negation), (row, ts, diff)]
+                    let retract_ts = ts.step_forward();
+                    let negation = -diff;
+                    [(row.clone(), ts, diff), (row, retract_ts, negation)]
                 });
                 (oks.as_collection(), errs, times.as_collection())
             }
@@ -164,48 +221,16 @@ impl ContinualTaskSourceTransformer {
                 let times = Collection::empty(&oks.scope());
                 (oks, errs, times)
             }
-            // Self-references must be handled differently. When computing the
-            // proposed write to some output at `T`, we can only know the
-            // contents of it through `T-1` (the exclusive upper is `T`).
-            //
-            // We address this by initially assuming that the output contains no
-            // changes at `T`, then evaluating each of the statements in order,
-            // allowing them to see the proposed output changes made by the
-            // previous statements. By default, this is stopped after one
-            // iteration and proposed output diffs are committed if possible.
-            // (We could also add options for iterating to a fixpoint,
-            // stop/error after N iters, etc.) Then to compute the changes at
-            // `T+1`, we read in what was actually written to the output at `T`
-            // (maybe some other replica wrote something different) and begin
-            // again.
-            //
-            // The above is very similar to how timely/differential dataflow
-            // iteration works, except that our feedback loop goes through
-            // persist and the loop timestamp is already `mz_repr::Timestamp`.
-            //
-            // This is implemented as follows:
-            // - `let I = persist_source(self-reference)`
-            // - Transform `I` such that the contents at `T-1` are presented at
-            //   `T` (i.e. initially assume `T` is unchanged from `T-1`).
-            // - TODO(ct3): Actually implement the following.
-            // - In an iteration sub-scope:
-            //   - Bring `I` into the sub-scope and `let proposed = Variable`.
-            //   - We need a collection that at `(T, 0)` is always the contents
-            //     of `I` at `T`, but at `(T, 1...)` contains the proposed diffs
-            //     by the CT logic. We can construct it by concatenating `I`
-            //     with `proposed` except that we also need to retract
-            //     everything in `proposed` for the next `(T+1, 0)` (because `I`
-            //     is the source of truth for what actually committed).
-            //  - `let R = retract_at_next_outer_ts(proposed)`
-            //  - `let result = logic(concat(I, proposed, R))`
-            //  - `proposed.set(result)`
-            // - Then we return `proposed.leave()` for attempted write to
-            //    persist.
+            // When computing an self-referential output at `T`, start by
+            // assuming there are no changes from the contents at `T-1`. See the
+            // module rustdoc for how this fits into the larger picture.
             SelfReference { source_id } => {
                 let name = source_id.to_string();
                 let times = Collection::empty(&oks.scope());
-                // For self-references only, we start by assuming that the
-                // output doesn't change at `T`.
+                // step_forward will panic at runtime if it receives a data or
+                // capability with a time that cannot be stepped forward (i.e.
+                // because it is already the max). We're safe here because this
+                // is stepping `T-1` forward to `T`.
                 let oks = step_forward(&name, oks);
                 let errs = step_forward(&name, errs);
                 (oks, errs, times)
@@ -269,7 +294,7 @@ impl<G: Scope<Timestamp = Timestamp>> ContinualTaskCtx<G> {
             (false, false) => ContinualTaskSourceTransformer::NormalReference,
             (false, true) => ContinualTaskSourceTransformer::SelfReference { source_id },
             (true, false) => ContinualTaskSourceTransformer::InsertsInput,
-            (true, true) => unreachable!("ct output is not allowed to be an input"),
+            (true, true) => panic!("ct output is not allowed to be an input"),
         };
         Some(transformer)
     }
@@ -619,6 +644,8 @@ impl<D: Ord> SinkState<D, Timestamp> {
 /// The caller is responsible for ensuring that all data and capabilities given
 /// to this operator can be stepped forward without panicking, otherwise the
 /// operator will panic at runtime.
+///
+/// TODO(ct3): Convert `step_forward` to an extension trait on `Collection`.
 fn step_forward<G, D, R>(name: &str, input: Collection<G, D, R>) -> Collection<G, D, R>
 where
     G: Scope<Timestamp = Timestamp>,
@@ -626,7 +653,7 @@ where
     R: Semigroup + 'static,
 {
     let name = format!("ct_step_forward({})", name);
-    let mut builder = OperatorBuilder::new(name.clone(), input.scope());
+    let mut builder = OperatorBuilder::new(name, input.scope());
     let (mut output, output_stream) = builder.new_output();
     // We step forward (by one) each data timestamp and capability. As a result
     // the output's frontier is guaranteed to be one past the input frontier, so

--- a/test/sqllogictest/ct_liveness.slt
+++ b/test/sqllogictest/ct_liveness.slt
@@ -32,12 +32,12 @@ CREATE CONTINUAL TASK upsert (key INT, val STRING) ON INPUT append_only AS (
 )
 
 statement ok
-INSERT INTO append_only VALUES (1, now()::STRING);
+INSERT INTO append_only VALUES (1, 'A');
 
-query I
-SELECT COUNT(*) FROM upsert
+query IT
+SELECT * FROM upsert
 ----
-1
+1 A
 
 # The upsert CT and restarting the dataflow repeatedly turns out to be a great
 # way to shake out liveness issues without the full overhead of testdrive.
@@ -49,12 +49,12 @@ statement ok
 ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
 
 statement ok
-INSERT INTO append_only VALUES (1, now()::STRING);
+INSERT INTO append_only VALUES (1, 'B');
 
-query I
-SELECT COUNT(*) FROM upsert
+query IT
+SELECT * FROM upsert
 ----
-1
+1 B
 
 
 statement ok
@@ -64,12 +64,12 @@ statement ok
 ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
 
 statement ok
-INSERT INTO append_only VALUES (1, now()::STRING);
+INSERT INTO append_only VALUES (1, 'C');
 
-query I
-SELECT COUNT(*) FROM upsert
+query IT
+SELECT * FROM upsert
 ----
-1
+1 C
 
 
 statement ok
@@ -79,12 +79,12 @@ statement ok
 ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
 
 statement ok
-INSERT INTO append_only VALUES (1, now()::STRING);
+INSERT INTO append_only VALUES (1, 'D');
 
-query I
-SELECT COUNT(*) FROM upsert
+query IT
+SELECT * FROM upsert
 ----
-1
+1 D
 
 
 statement ok
@@ -94,12 +94,12 @@ statement ok
 ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
 
 statement ok
-INSERT INTO append_only VALUES (1, now()::STRING);
+INSERT INTO append_only VALUES (1, 'E');
 
-query I
-SELECT COUNT(*) FROM upsert
+query IT
+SELECT * FROM upsert
 ----
-1
+1 E
 
 
 statement ok
@@ -109,12 +109,12 @@ statement ok
 ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
 
 statement ok
-INSERT INTO append_only VALUES (1, now()::STRING);
+INSERT INTO append_only VALUES (1, 'F');
 
-query I
-SELECT COUNT(*) FROM upsert
+query IT
+SELECT * FROM upsert
 ----
-1
+1 F
 
 
 statement ok
@@ -124,12 +124,12 @@ statement ok
 ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
 
 statement ok
-INSERT INTO append_only VALUES (1, now()::STRING);
+INSERT INTO append_only VALUES (1, 'G');
 
-query I
-SELECT COUNT(*) FROM upsert
+query IT
+SELECT * FROM upsert
 ----
-1
+1 G
 
 
 statement ok
@@ -139,12 +139,12 @@ statement ok
 ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
 
 statement ok
-INSERT INTO append_only VALUES (1, now()::STRING);
+INSERT INTO append_only VALUES (1, 'H');
 
-query I
-SELECT COUNT(*) FROM upsert
+query IT
+SELECT * FROM upsert
 ----
-1
+1 H
 
 
 statement ok
@@ -154,9 +154,9 @@ statement ok
 ALTER CLUSTER quickstart SET (REPLICATION FACTOR = 1);
 
 statement ok
-INSERT INTO append_only VALUES (1, now()::STRING);
+INSERT INTO append_only VALUES (1, 'I');
 
-query I
-SELECT COUNT(*) FROM upsert
+query IT
+SELECT * FROM upsert
 ----
-1
+1 I


### PR DESCRIPTION
This is part 1 of moving to the behavior described in the [third option]
of the "Read and Write Timestamps" open question. I'm splitting the work
up because this first bit fixes the vast majority of the wonky timestamp
behavior of CTs (including entirely removing the step_backward
operator).

[third option]: https://www.notion.so/materialize/Continual-Tasks-Decision-Log-7279978e873741ca83d0c2f8382dad5f

Summary is that all reads and writes occur at timestamp `T`, except
self-references, which must be handled differently. When computing the
proposed write to some output at `T`, we can only know the contents of
it through `T-1` (the exclusive upper is `T`).

We address this by initially assuming that the output contains no
changes at `T`, then evaluating each of the statements in order,
allowing them to see the proposed output changes made by the previous
statements. By default, this is stopped after one iteration and proposed
output diffs are committed if possible. (We could also add options for
iterating to a fixpoint, stop/error after N iters, etc.) Then to compute
the changes at `T+1`, we read in what was actually written to the output
at `T` (maybe some other replica wrote something different) and begin
again.

The above is very similar to how timely/differential dataflow iteration
works, except that our feedback loop goes through persist and the loop
timestamp is already `mz_repr::Timestamp`.

Touches #https://github.com/MaterializeInc/database-issues/issues/8427

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

I've gotta find the spots where comments have rotted, but otherwise good to go.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
