### PR TITLE
bazel: skip building symlink forest for runfiles, i.e. set  `--nobuild_runfile_links`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -47,6 +47,8 @@ build:macos --experimental_inprocess_symlink_creation
 #
 # Bazel's sandbox performance on macOS doesn't scale very well, see: <https://github.com/bazelbuild/bazel/issues/8230>
 build --experimental_inmemory_sandbox_stashes
+# Don't build runfile symlink forests, unless required.
+build --nobuild_runfile_links
 
 # Always have Bazel output why it rebuilt something, should make debugging builds easier.
 #


### PR DESCRIPTION
Sets `--nobuild_runfile_links` for our build which skips building the symlink forest for Bazel's "runfiles", unless it's required.

This is a small change but it reduces the amount of I/O Bazel needs to do. I've been dogfooding it locally for months and haven't run into any issues so it should be good to go. The reason this isn't the default in Bazel is because some legacy rules rely on the old behavior.

### Motivation

Less I/O in the Bazel build

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
