### PR TITLE
ci: Move further jobs to Hetzner now that we have more servers

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -86,9 +86,7 @@ steps:
         timeout_in_minutes: 720
         parallelism: 8
         agents:
-          # TODO(def-) Switch back to Hetzner? Might not have as consistent performance
           queue: linux-aarch64-medium
-          # queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: feature-benchmark
@@ -101,9 +99,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 240
         agents:
-          # TODO(def-) Switch back to Hetzner? Might not have as consistent performance
           queue: linux-aarch64
-          # queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: scalability
@@ -123,9 +119,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 1200
         agents:
-          # TODO(def-) Switch back to Hetzner? Might not have as consistent performance
           queue: linux-aarch64
-          # queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: scalability
@@ -149,9 +143,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          # TODO(def-) Switch back to Hetzner? Might not have as consistent performance
           queue: linux-aarch64-medium
-          # queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: scalability
@@ -173,9 +165,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          # TODO(def-) Switch back to Hetzner? Might not have as consistent performance
           queue: linux-aarch64-medium
-          # queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-benchmark

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -58,8 +58,7 @@ steps:
       # 48h
       timeout_in_minutes: 2880
       agents:
-        # TODO: Move back to Hetzner when agent lost issues are fixed
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -72,8 +71,7 @@ steps:
       # 24h
       timeout_in_minutes: 1440
       agents:
-        # TODO: Move back to Hetzner when agent lost issues are fixed
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -85,8 +83,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        # TODO: Move back to Hetzner when agent lost issues are fixed
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -99,8 +96,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1440
       agents:
-        # TODO: Move back to Hetzner when agent lost issues are fixed
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -111,8 +107,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        # TODO: Move back to Hetzner when agent lost issues are fixed
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -124,8 +119,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        # TODO: Move back to Hetzner when agent lost issues are fixed
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -136,8 +130,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1440
       agents:
-        # TODO: Move back to Hetzner when agent lost issues are fixed
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -149,8 +142,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        # TODO: Move back to Hetzner when agent lost issues are fixed
-        queue: linux-aarch64
+        queue: hetzner-aarch64-8cpu-16gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -162,8 +154,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1440
       agents:
-        # TODO: Move back to Hetzner when agent lost issues are fixed
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -179,9 +170,7 @@ steps:
         timeout_in_minutes: 2880
         parallelism: 8
         agents:
-          # TODO(def-) Switch back to Hetzner? Might not have as consistent performance
           queue: linux-aarch64-medium
-          # queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: feature-benchmark
@@ -192,9 +181,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 1200
         agents:
-          # TODO(def-) Switch back to Hetzner? Might not have as consistent performance
           queue: linux-aarch64-medium
-          # queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-benchmark
@@ -262,10 +249,8 @@ steps:
         timeout_in_minutes: 30
         agents:
           # no matching manifest of MySQL 5.7.x for linux/arm64/v8 in the manifest list entries
-          # TODO(def-) Switch back to Hetzner when we have increased server limit
           # Increased memory usage following new source syntax
-          queue: linux-x86_64
-          # queue: hetzner-x86-64-8cpu-16gb
+          queue: hetzner-x86-64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -220,9 +220,7 @@ steps:
         timeout_in_minutes: 30
         agents:
           # hugo: command not found
-          # TODO(def-) Switch back to Hetzner when we have increased server limit
-          queue: linux-x86_64-small
-          # queue: hetzner-x86-64-4cpu-8gb
+          queue: hetzner-x86-64-4cpu-8gb
         coverage: skip
         sanitizer: skip
 
@@ -297,9 +295,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: cluster
     agents:
-      # TODO(def-): Investigate timeout in `SELECT * from remote1`
-      # queue: hetzner-aarch64-8cpu-16gb
-      queue: linux-aarch64
+      queue: hetzner-aarch64-8cpu-16gb
 
   - id: sqllogictest-fast
     label: "Fast SQL logic tests %N"
@@ -362,9 +358,7 @@ steps:
               run: sql-server
         agents:
           # too slow to run emulated on aarch64, SQL Server's docker image is not yet available for aarch64 natively yet: https://github.com/microsoft/mssql-docker/issues/802
-          # TODO(def-) Switch back to Hetzner when we have increased server limit
-          queue: linux-x86_64-small
-          # queue: hetzner-x86-64-4cpu-8gb
+          queue: hetzner-x86-64-4cpu-8gb
 
       - id: debezium-mysql
         label: "Debezium MySQL tests"
@@ -626,9 +620,7 @@ steps:
             ]
     coverage: skip
     agents:
-      # TODO(def-) Switch back to Hetzner? Might not have as consistent performance
       queue: linux-aarch64-small
-      # queue: hetzner-aarch64-4cpu-8gb
 
   # Fast tests closer to the end, doesn't matter as much if they have to wait
   # for an agent
@@ -686,9 +678,7 @@ steps:
           composition: metabase
     agents:
       # too slow to run emulated on aarch64, Metabase'ss docker image is not yet available for aarch64 natively yet: https://github.com/metabase/metabase/issues/13119
-      # TODO(def-) Switch back to Hetzner when we have increased server limit
-      queue: linux-x86_64-small
-      # queue: hetzner-x86-64-4cpu-8gb
+      queue: hetzner-x86-64-4cpu-8gb
 
   - id: dbt-materialize
     label: dbt-materialize tests


### PR DESCRIPTION
Related to https://github.com/MaterializeInc/i2/pull/2232

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
