### PR TITLE
ci: Detect plain-text passwords in log files

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -169,6 +169,27 @@ IGNORE_RE = re.compile(
     re.VERBOSE | re.MULTILINE,
 )
 
+# We don't want any plaintext passwords in our logs, fail the test if it contains any
+PASSWORD_RE = re.compile(
+    rb"""
+    ( password:\ Some\("(?P<pw_config_some>[^"]*)"\) # From a Rust config object being dumped
+    | password:\ "(?P<pw_config_plain>[^"]*)"        # From a Rust config object being dumped
+    | ://[^:@\s]+:(?P<pw_url>[^:@\s]+)@              # Inside a URL string
+    )
+    """,
+    re.VERBOSE,
+)
+
+PASSWORD_IGNORE_RE = re.compile(
+    # We actually want this to be the exact ignored string, but unfortunately
+    # log lines from clusterd and environmentd can interfer when they are
+    # running in the same materialized container. Example:
+    # > password: Some("%3C2024-10-18T17:11:36.445784450Z redacted%3E")
+    # rb"^ ( < | %3[Cc] ) redacted ( > | %3[Ee] ) $",
+    rb".*redacted.*",
+    re.VERBOSE,
+)
+
 
 @dataclass
 class ErrorLog:
@@ -713,8 +734,50 @@ def _get_errors_from_log_file(log_file_name: str) -> list[ErrorLog]:
         error_logs.extend(_collect_errors_in_logs(data, log_file_name))
         data.seek(0)
         error_logs.extend(_collect_service_panics_in_logs(data, log_file_name))
+        # Passwords are expected in these files, ignore them
+        if log_file_name not in {
+            "run.log",
+            "docker-inspect.log",
+            "docker-ps-a.log",
+            "ps-aux.log",
+            "kubectl-describe-all.log",
+            # TODO(def-): Remove when we have 4 versions released without leaking passwords to logs
+        } and os.getenv("BUILDKITE_STEP_KEY") not in {
+            "checks-upgrade-clusterd-compute-first",
+            "checks-upgrade-clusterd-compute-last",
+            "checks-upgrade-entire-mz-two-versions",
+            "checks-upgrade-entire-mz-four-versions",
+            "checks-preflight-check-rollback",
+            "checks-0dt-upgrade-entire-mz-two-versions",
+            "checks-0dt-upgrade-entire-mz-four-versions",
+            "cloudtest-upgrade",
+            "feature-benchmark",
+        }:
+            data.seek(0)
+            error_logs.extend(_collect_passwords_in_logs(data, log_file_name))
 
     return error_logs
+
+
+def _collect_passwords_in_logs(data: Any, log_file_name: str) -> list[ErrorLog]:
+    collected_passwords = []
+
+    for match in PASSWORD_RE.finditer(data):
+        password = (
+            match.group("pw_config_some")
+            or match.group("pw_config_plain")
+            or match.group("pw_url")
+        )
+        if PASSWORD_IGNORE_RE.match(password):
+            continue
+        collected_passwords.append(
+            ErrorLog(
+                b'Plain-text password "' + password + b'"',
+                log_file_name,
+            )
+        )
+
+    return collected_passwords
 
 
 def _collect_errors_in_logs(data: Any, log_file_name: str) -> list[ErrorLog]:


### PR DESCRIPTION
Got lost in https://github.com/MaterializeInc/materialize/pull/30071, so submitting separately. Will wait for that PR to land first, then rebase.

This seems to find one occurrence: https://buildkite.com/materialize/nightly/builds/10042
```
feature-benchmark-materialized-1     | cluster-u4-replica-u4-gen-0: 2024-10-18T10:36:59.867267Z  INFO mz_storage::storage_state: reconcile: received RunIngestions command worker_id=0 ingestions=[RunIngestionCommand { id: User(21), description: IngestionDescription { desc: SourceDesc { connection: Kafka(KafkaSourceConnection { connection: KafkaConnection { brokers: [KafkaBroker { address: "kafka:9092", tunnel: Direct }], default_tunnel: Direct, progress_topic: None, progress_topic_options: KafkaTopicOptions { replication_factor: None, partition_count: Some(NonNeg(1)), topic_config: {"cleanup.policy": "compact"} }, options: {}, tls: None, sasl: None }, connection_id: User(1), topic: "testdrive-startup-time-1729247675", start_offsets: {}, group_id_prefix: None, metadata_columns: [], topic_metadata_refresh_interval: 30s }), timestamp_interval: 1s, primary_export: SourceExportDataConfig { encoding: Some(SourceDataEncoding { key: None, value: Avro(AvroEncoding { schema: "{\"type\":\"record\",\"name\":\"test\",\"fields\":[{\"name\":\"f2\",\"type\":\"long\"}]}", csr_connection: Some(CsrConnection { url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("schema-registry")), port: Some(8081), path: "/", query: None, fragment: None }, tls_root_cert: None, tls_identity: None, http_auth: None, tunnel: Direct }), confluent_wire_format: true }) }), envelope: None(NoneEnvelope { key_envelope: None, key_arity: 0 }) } }, ingestion_metadata: CollectionMetadata { persist_location: PersistLocation { blob_uri: "s3://minioadmin:minioadmin@persist/persist?endpoint=http://minio:9000/&region=minio", consensus_uri: "postgres://root@cockroach:26257?options=--search_path=consensus" }, remap_shard: Some(ShardId(99f4faf5-70d7-4443-8fcd-be2673d1839b)), data_shard: ShardId(6be9d45a-bd4c-4c7c-94e6-1f8607b5fdb9), status_shard: Some(ShardId(2dc25e44-65bd-4772-b544-a3a7fa1b0f03)), relation_desc: RelationDesc { typ: RelationType { column_types: [ColumnType { scalar_type: Int64, nullable: false }], keys: [] }, metadata: {ColumnIndex(0): ColumnMetadata { name: ColumnName("f2"), typ_idx: 0, added: RelationVersion(0), dropped: None }} }, txns_shard: None }, source_exports: {User(21): SourceExport { storage_metadata: CollectionMetadata { persist_location: PersistLocation { blob_uri: "s3://minioadmin:minioadmin@persist/persist?endpoint=http://minio:9000/&region=minio", consensus_uri: "postgres://root@cockroach:26257?options=--search_path=consensus" }, remap_shard: Some(ShardId(99f4faf5-70d7-4443-8fcd-be2673d1839b)), data_shard: ShardId(6be9d45a-bd4c-4c7c-94e6-1f8607b5fdb9), status_shard: Some(ShardId(2dc25e44-65bd-4772-b544-a3a7fa1b0f03)), relation_desc: RelationDesc { typ: RelationType { column_types: [ColumnType { scalar_type: Int64, nullable: false }], keys: [] }, metadata: {ColumnIndex(0): ColumnMetadata { name: ColumnName("f2"), typ_idx: 0, added: RelationVersion(0), dropped: None }} }, txns_shard: None }, details: Kafka(KafkaSourceExportDetails { metadata_columns: [] }), data_config: SourceExportDataConfig { encoding: Some(SourceDataEncoding { key: None, value: Avro(AvroEncoding { schema: "{\"type\":\"record\",\"name\":\"test\",\"fields\":[{\"name\":\"f2\",\"type\":\"long\"}]}", csr_connection: Some(CsrConnection { url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("schema-registry")), port: Some(8081), path: "/", query: None, fragment: None }, tls_root_cert: None, tls_identity: None, http_auth: None, tunnel: Direct }), confluent_wire_format: true }) }), envelope: None(NoneEnvelope { key_envelope: None, key_arity: 0 }) } }}, instance_id: User(4), remap_collection_id: User(20) } }]
```
Edit: That's probably in the old version, so we should also ignore it in feature-benchmark for now.

No further failures in Nightly: https://buildkite.com/materialize/nightly/builds/10054, so hopefully good to go now, but I guess we'll have to see how bad it is to check interleaved strings in services.log.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
