### PR TITLE
Reorganize EquivalenceClasses to use more efficient algorithms

### DIFF
--- a/src/transform/src/analysis/equivalences.rs
+++ b/src/transform/src/analysis/equivalences.rs
@@ -683,7 +683,7 @@ impl EquivalenceClasses {
     }
 
     /// Perform any simplification, report if effective.
-    pub fn reduce_expr(&self, expr: &mut MirScalarExpr) -> bool {
+    fn reduce_expr(&self, expr: &mut MirScalarExpr) -> bool {
         let mut simplified = false;
         simplified = simplified || self.reduce_child(expr);
         simplified = simplified || self.replace(expr);
@@ -691,7 +691,7 @@ impl EquivalenceClasses {
     }
 
     /// Perform any simplification on children, report if effective.
-    pub fn reduce_child(&self, expr: &mut MirScalarExpr) -> bool {
+    fn reduce_child(&self, expr: &mut MirScalarExpr) -> bool {
         let mut simplified = false;
         match expr {
             MirScalarExpr::CallBinary { expr1, expr2, .. } => {
@@ -735,22 +735,26 @@ impl EquivalenceClasses {
     }
 
     /// Returns a map that can be used to replace (sub-)expressions.
-    pub fn reducer(&self) -> BTreeMap<&MirScalarExpr, &MirScalarExpr> {
-        self.classes
-            .iter()
-            .flat_map(|c| c.iter().map(|e| (e, &c[0])))
-            .collect()
+    pub fn reducer(&self) -> &BTreeMap<MirScalarExpr, MirScalarExpr> {
+        &self.remap
     }
 }
 
-trait ExpressionReducer {
+/// A type capable of simplifying `MirScalarExpr`s.
+pub trait ExpressionReducer {
+    /// Attempt to replace `expr` itself with another expression.
+    /// Returns true if it does so.
     fn replace(&self, expr: &mut MirScalarExpr) -> bool;
+    /// Attempt to replace any subexpressions of `expr` with other expressions.
+    /// Returns true if it does so.
     fn reduce_expr(&self, expr: &mut MirScalarExpr) -> bool {
         let mut simplified = false;
         simplified = simplified || self.reduce_child(expr);
         simplified = simplified || self.replace(expr);
         simplified
     }
+    /// Attempt to replace any subexpressions of `expr`'s children with other expressions.
+    /// Returns true if it does so.
     fn reduce_child(&self, expr: &mut MirScalarExpr) -> bool {
         let mut simplified = false;
         match expr {


### PR DESCRIPTION
This PR updates `EquivalenceClasses` to form and use a map from expressions to expressions when it attempts to simplify its own expressions. Minimization starts with a `self.tidy()` to ensure the equivalence classes are equivalence *relations*, in fact as well as in name. It then repeatedly calls `minimize_once`, which does:
1. Form a map from expression to the representative of its class.
2. Locally update expressions in each class, using first the map, and then optionally column-type based reduction.
3. Identify idioms and extend classes with equivalences we can derive from those that exist.
4. Restore the equivalence class invariant.

For me, this is much simpler algorithmically, vs wobbling the stages around. It also has the advantage that we can compare the map from step 1. with the equivalence classes in step 4., and if they are identical we are done. No need to do the extra round of validation.

There isn't much improvement in running times on the incident 217 reproduction. The outlier times for `minimize()` calls go down by ~4x (in debug builds from ~320ms to ~80ms), but they seem to not be as impactful as the overall work done on the query. There are several additional optimizations that are available, though:
1. We can use the same map for calls to `reduce_expr` that would be served (linearly) by the equivalence classes.
2. We can actually save the map, halving the computation of the map (I tried, but had a bug, so stopped for now).

I'm not sure how much more we'd sneak out of this without some more careful thought. It's not much more than linear time at the moment, and we need to take linear time at least just to look at and record the classes. The larger problem seems to be around needing to do the work at all, and figuring how to not show up with 6k+ expressions that are variously equated (in the repro). The query optimizes in about 7s on a release build, but no more than a few milliseconds are taken in any call to `minimize()`.

Update: both of the follow-on items were implemented, both maintaining the map and using it to serve `reduce_expr` calls. There is still some lingering inefficiency in `union` and `project` that we'll address in follow-on work.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
