### PR TITLE
slt: Allow overriding default system parameters while keeping the defaults

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -279,10 +279,14 @@ def main() -> int:
                 f"{key}={value}"
                 for key, value in get_default_system_parameters().items()
             ]
-            env["MZ_SYSTEM_PARAMETER_DEFAULT"] = ";".join(formatted_params)
+            system_parameter_default = ";".join(formatted_params)
             # Connect to the database to ensure it exists.
             _connect_sql(args.postgres)
-            command += [f"--postgres-url={args.postgres}", *args.args]
+            command += [
+                f"--postgres-url={args.postgres}",
+                f"--system-parameter-default={system_parameter_default}",
+                *args.args,
+            ]
     elif args.program == "test":
         if args.bazel:
             raise UIError(


### PR DESCRIPTION
Noticed by Dan in https://materializeinc.slack.com/archives/C01LKF361MZ/p1729266971048909

Diff is also by Dan

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
