### PR TITLE
ct: resolve another round of adapter TODOs

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -879,16 +879,17 @@ fn handle_mutation_using_clause(
     Ok(get.filter(vec![using_rel_expr.exists()]))
 }
 
-struct CastRelationError {
-    column: usize,
-    source_type: ScalarType,
-    target_type: ScalarType,
+#[derive(Debug)]
+pub(crate) struct CastRelationError {
+    pub(crate) column: usize,
+    pub(crate) source_type: ScalarType,
+    pub(crate) target_type: ScalarType,
 }
 
 /// Cast a relation from one type to another using the specified type of cast.
 ///
 /// The length of `target_types` must match the arity of `expr`.
-fn cast_relation<'a, I>(
+pub(crate) fn cast_relation<'a, I>(
     qcx: &QueryContext,
     ccx: CastContext,
     expr: HirRelationExpr,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -127,7 +127,8 @@ use crate::names::{
 use crate::normalize::{self, ident};
 use crate::plan::error::PlanError;
 use crate::plan::query::{
-    plan_expr, scalar_type_from_catalog, scalar_type_from_sql, CteDesc, ExprContext, QueryLifetime,
+    cast_relation, plan_expr, scalar_type_from_catalog, scalar_type_from_sql, CteDesc, ExprContext,
+    QueryLifetime,
 };
 use crate::plan::scope::Scope;
 use crate::plan::statement::ddl::connection::{INALTERABLE_OPTIONS, MUTUALLY_EXCLUSIVE_SETS};
@@ -2773,31 +2774,47 @@ pub fn plan_create_continual_task(
     };
 
     let mut exprs = Vec::new();
-    for stmt in &stmt.stmts {
-        let query = continual_task_query(&ct_name, stmt).ok_or_else(|| sql_err!("TODO(ct2)"))?;
+    for (idx, stmt) in stmt.stmts.iter().enumerate() {
+        let query = continual_task_query(&ct_name, stmt).ok_or_else(|| sql_err!("TODO(ct3)"))?;
         let query::PlannedRootQuery {
             mut expr,
             desc: desc_query,
             finishing,
             scope: _,
         } = query::plan_ct_query(&mut qcx, query)?;
-        // We get back a trivial finishing, see comment in `plan_view`.
+        // We get back a trivial finishing because we plan with a "maintained"
+        // QueryLifetime, see comment in `plan_view`.
         assert!(finishing.is_trivial(expr.arity()));
-        // TODO(ct2): Is this right?
         expr.bind_parameters(params)?;
-        // TODO(ct2): Make this error message more closely match the various ones
-        // given for INSERT/DELETE.
-        if desc_query
-            .iter_types()
-            .map(|x| &x.scalar_type)
-            .ne(desc.iter_types().map(|x| &x.scalar_type))
-        {
+
+        // We specify the columns for DELETE, so if any columns types don't
+        // match, it's because it's an INSERT.
+        if desc_query.arity() > desc.arity() {
             sql_bail!(
-                "CONTINUAL TASK query columns did not match: {:?} vs {:?}",
-                desc_query.iter().collect::<Vec<_>>(),
-                desc.iter().collect::<Vec<_>>()
+                "statement {}: INSERT has more expressions than target columns",
+                idx
             );
         }
+        if desc_query.arity() < desc.arity() {
+            sql_bail!(
+                "statement {}: INSERT has more target columns than expressions",
+                idx
+            );
+        }
+        // Ensure the types of the source query match the types of the target table,
+        // installing assignment casts where necessary and possible.
+        let target_types = desc.iter_types().map(|x| &x.scalar_type);
+        let expr = cast_relation(&qcx, CastContext::Assignment, expr, target_types);
+        let expr = expr.map_err(|e| {
+            sql_err!(
+                "statement {}: column {} is of type {} but expression is of type {}",
+                idx,
+                desc.get_name(e.column).as_str().quoted(),
+                qcx.humanize_scalar_type(&e.target_type),
+                qcx.humanize_scalar_type(&e.source_type),
+            )
+        })?;
+
         // Update ct nullability as necessary. The `ne` above verified that the
         // types are the same len.
         let zip_types = || desc.iter_types().zip(desc_query.iter_types());
@@ -2817,12 +2834,12 @@ pub fn plan_create_continual_task(
             ast::ContinualTaskStmt::Delete(_) => exprs.push(expr.negate()),
         }
     }
-    // TODO(ct2): Collect things by output and assert that there is only one (or
+    // TODO(ct3): Collect things by output and assert that there is only one (or
     // support multiple outputs).
     let expr = exprs
         .into_iter()
         .reduce(|acc, expr| acc.union(expr))
-        .ok_or_else(|| sql_err!("TODO(ct2)"))?;
+        .ok_or_else(|| sql_err!("TODO(ct3)"))?;
 
     let column_names: Vec<ColumnName> = desc.iter_names().cloned().collect();
     if let Some(dup) = column_names.iter().duplicates().next() {

--- a/test/sqllogictest/ct_errors.slt
+++ b/test/sqllogictest/ct_errors.slt
@@ -28,7 +28,17 @@ ALTER SYSTEM SET enable_create_continual_task = true
 COMPLETE 0
 
 # INSERT columns do not match
-statement error CONTINUAL TASK query columns did not match
-CREATE CONTINUAL TASK nope (key STRING) ON INPUT foo AS (
+statement error statement 0: column "key" is of type boolean but expression is of type integer
+CREATE CONTINUAL TASK nope (key BOOL) ON INPUT foo AS (
     INSERT INTO nope SELECT * FROM foo;
+)
+
+statement error statement 0: INSERT has more target columns than expressions
+CREATE CONTINUAL TASK nope (key INT) ON INPUT foo AS (
+    INSERT INTO nope SELECT FROM foo;
+)
+
+statement error statement 0: INSERT has more expressions than target columns
+CREATE CONTINUAL TASK nope (key INT) ON INPUT foo AS (
+    INSERT INTO nope SELECT *, 'nope' FROM foo;
 )

--- a/test/sqllogictest/ct_errors.slt
+++ b/test/sqllogictest/ct_errors.slt
@@ -42,3 +42,13 @@ statement error statement 0: INSERT has more expressions than target columns
 CREATE CONTINUAL TASK nope (key INT) ON INPUT foo AS (
     INSERT INTO nope SELECT *, 'nope' FROM foo;
 )
+
+# Cannot use a VIEW (or other things not directly backed by a persist shard) as
+# an input.
+statement ok
+CREATE VIEW some_view AS SELECT *, 'bar' FROM foo;
+
+statement error CONTINUAL TASK cannot use view as an input
+CREATE CONTINUAL TASK nope (key INT, val STRING) ON INPUT some_view AS (
+    INSERT INTO nope SELECT * FROM foo;
+)

--- a/test/sqllogictest/ct_various.slt
+++ b/test/sqllogictest/ct_various.slt
@@ -73,3 +73,17 @@ CREATE CONTINUAL TASK no_input_refs (key INT) ON INPUT input AS (
 query I
 SELECT * FROM no_input_refs;
 ----
+
+# INSERT will put in a cast if necessary
+statement ok
+CREATE CONTINUAL TASK cast_int_to_string (key STRING) ON INPUT input AS (
+    INSERT INTO cast_int_to_string SELECT * FROM input WHERE key > 1;
+)
+
+statement ok
+INSERT INTO input VALUES (2);
+
+query T
+SELECT * FROM cast_int_to_string;
+----
+2


### PR DESCRIPTION
Touches https://github.com/MaterializeInc/database-issues/issues/8427

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
