### PR TITLE
[persist] Spill long runs to separate blobs in S3

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -127,6 +127,9 @@ def get_default_system_parameters(
         "persist_batch_structured_key_lower_len": (
             "256" if version >= MzVersion.parse_mz("v0.117.0-dev") else "0"
         ),
+        "persist_batch_max_run_len": (
+            "4" if version >= MzVersion.parse_mz("v0.122.0-dev") else "1000000"
+        ),
         "persist_catalog_force_compaction_fuel": "1024",
         "persist_catalog_force_compaction_wait": "1s",
         "persist_fast_path_limit": "1000",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1029,6 +1029,13 @@ class FlipFlagsAction(Action):
             "1000",
             "50000",
         ]
+        self.flags_with_values["persist_batch_max_run_len"] = [
+            "2",
+            "3",
+            "4",
+            "16",
+            "1000",
+        ]
         self.flags_with_values["persist_part_decode_format"] = [
             "row_with_validate",
             "arrow",

--- a/src/persist-client/build.rs
+++ b/src/persist-client/build.rs
@@ -30,6 +30,10 @@ fn main() {
             "#[derive(serde::Deserialize)]",
         )
         .type_attribute(
+            ".mz_persist_client.internal.state.ProtoHollowRunRef",
+            "#[derive(serde::Deserialize)]",
+        )
+        .type_attribute(
             ".mz_persist_client.internal.state.ProtoRunMeta",
             "#[derive(serde::Deserialize)]",
         )

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -25,7 +25,7 @@ use bytes::Bytes;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
-use futures_util::stream::{ StreamExt};
+use futures_util::stream::StreamExt;
 use futures_util::{stream, FutureExt};
 use mz_dyncfg::Config;
 use mz_ore::cast::CastFrom;

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -318,6 +318,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::batch::STRUCTURED_ORDER)
         .add(&crate::batch::STRUCTURED_ORDER_UNTIL_SHARD)
         .add(&crate::batch::STRUCTURED_KEY_LOWER_LEN)
+        .add(&crate::batch::MAX_RUN_LEN)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL_STAGGER)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL)
         .add(&crate::cfg::CRDB_CONNECT_TIMEOUT)

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -335,7 +335,7 @@ pub async fn run(command: AdminArgs) -> Result<(), anyhow::Error> {
                 cfg.clone(),
                 Arc::clone(&consensus),
                 Arc::clone(&blob),
-                metrics,
+                Arc::clone(&metrics),
             );
 
             let not_restored: Vec<_> = consensus
@@ -351,6 +351,7 @@ pub async fn run(command: AdminArgs) -> Result<(), anyhow::Error> {
                             blob.as_ref(),
                             &cfg.build_version,
                             shard_id,
+                            &*metrics,
                         )
                         .await?;
                         info!(

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -393,7 +393,8 @@ async fn consolidated_size(args: &StateArgs) -> Result<(), anyhow::Error> {
 
     let mut updates = Vec::new();
     for batch in state.collections.trace.batches() {
-        let mut part_stream = pin!(batch.part_stream(shard_id, &*state_versions.blob));
+        let mut part_stream =
+            pin!(batch.part_stream(shard_id, &*state_versions.blob, &*state_versions.metrics));
         while let Some(part) = part_stream.try_next().await? {
             tracing::info!("fetching {}", part.printable_name());
             let encoded_part = EncodedPart::fetch(
@@ -595,7 +596,8 @@ pub async fn unreferenced_blobs(args: &StateArgs) -> Result<impl serde::Serializ
             // TODO: this may end up refetching externally-stored runs once per batch...
             // but if we have enough parts for this to be a problem, we may need to track a more
             // efficient state representation.
-            let mut parts = pin!(batch.part_stream(shard_id, &*state_versions.blob));
+            let mut parts =
+                pin!(batch.part_stream(shard_id, &*state_versions.blob, &*state_versions.metrics));
             while let Some(batch_part) = parts.next().await {
                 match &*batch_part? {
                     BatchPart::Hollow(x) => known_parts.insert(x.key.clone()),

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -12,6 +12,7 @@
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
+use std::pin::pin;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
@@ -20,6 +21,7 @@ use bytes::{BufMut, Bytes};
 use differential_dataflow::difference::{IsZero, Semigroup};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
+use futures_util::{StreamExt, TryStreamExt};
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
@@ -391,7 +393,8 @@ async fn consolidated_size(args: &StateArgs) -> Result<(), anyhow::Error> {
 
     let mut updates = Vec::new();
     for batch in state.collections.trace.batches() {
-        for part in batch.parts.iter() {
+        let mut part_stream = pin!(batch.part_stream(shard_id, &*state_versions.blob));
+        while let Some(part) = part_stream.try_next().await? {
             tracing::info!("fetching {}", part.printable_name());
             let encoded_part = EncodedPart::fetch(
                 &shard_id,
@@ -400,7 +403,7 @@ async fn consolidated_size(args: &StateArgs) -> Result<(), anyhow::Error> {
                 &shard_metrics,
                 &state_versions.metrics.read.snapshot,
                 &batch.desc,
-                part,
+                &part,
             )
             .await
             .expect("part exists");
@@ -534,11 +537,7 @@ pub async fn shard_stats(blob_uri: &SensitiveUrl) -> anyhow::Result<()> {
                 empty_batches += 1;
             }
             for (_meta, run) in b.runs() {
-                let largest_part = run
-                    .iter()
-                    .map(|p| p.encoded_size_bytes())
-                    .max()
-                    .unwrap_or(0);
+                let largest_part = run.iter().map(|p| p.max_part_bytes()).max().unwrap_or(0);
                 runs += 1;
                 longest_run = longest_run.max(run.len());
                 byte_width += largest_part;
@@ -593,8 +592,12 @@ pub async fn unreferenced_blobs(args: &StateArgs) -> Result<impl serde::Serializ
             known_writers.insert(writer_id.clone());
         }
         for batch in v.collections.trace.batches() {
-            for batch_part in &batch.parts {
-                match batch_part {
+            // TODO: this may end up refetching externally-stored runs once per batch...
+            // but if we have enough parts for this to be a problem, we may need to track a more
+            // efficient state representation.
+            let mut parts = pin!(batch.part_stream(shard_id, &*state_versions.blob));
+            while let Some(batch_part) = parts.next().await {
+                match &*batch_part? {
                     BatchPart::Hollow(x) => known_parts.insert(x.key.clone()),
                     BatchPart::Inline { .. } => continue,
                 };

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -368,8 +368,13 @@ where
                         }
                         let () = part_deletes
                             .delete(
-                                &machine.applier.state_versions.blob,
+                                machine.applier.state_versions.blob.as_ref(),
                                 machine.shard_id(),
+                                machine
+                                    .applier
+                                    .cfg
+                                    .dynamic
+                                    .gc_blob_delete_concurrency_limit(),
                                 &metrics.retries.external.compaction_noop_delete,
                             )
                             .await;

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -375,6 +375,7 @@ where
                                     .cfg
                                     .dynamic
                                     .gc_blob_delete_concurrency_limit(),
+                                &*metrics,
                                 &metrics.retries.external.compaction_noop_delete,
                             )
                             .await;

--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -17,7 +17,7 @@ use timely::progress::Antichain;
 use tokio::sync::Mutex;
 
 use crate::internal::paths::PartialBatchKey;
-use crate::internal::state::{BatchPart, HollowBatch, HollowBatchPart};
+use crate::internal::state::{BatchPart, HollowBatch, HollowBatchPart, RunPart};
 
 /// A [datadriven::TestCase] wrapper with helpers for parsing.
 #[derive(Debug)]
@@ -102,7 +102,7 @@ impl<'a> DirectiveArgs<'a> {
             desc,
             keys.iter()
                 .map(|x| {
-                    BatchPart::Hollow(HollowBatchPart {
+                    RunPart::Single(BatchPart::Hollow(HollowBatchPart {
                         key: PartialBatchKey((*x).to_owned()),
                         encoded_size_bytes: 0,
                         key_lower: vec![],
@@ -112,7 +112,7 @@ impl<'a> DirectiveArgs<'a> {
                         diffs_sum: None,
                         format: None,
                         schema_id: None,
-                    })
+                    }))
                 })
                 .collect(),
             len,

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -571,6 +571,7 @@ where
                     .cfg
                     .dynamic
                     .gc_blob_delete_concurrency_limit(),
+                &*machine.applier.metrics,
                 &machine.applier.metrics.retries.external.batch_delete,
             )
             .instrument(debug_span!("batch::delete"))

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -36,7 +36,7 @@ use crate::internal::machine::{retry_external, Machine};
 use crate::internal::maintenance::RoutineMaintenance;
 use crate::internal::metrics::{GcStepTimings, RetryMetrics};
 use crate::internal::paths::{BlobKey, PartialBlobKey, PartialRollupKey};
-use crate::internal::state::{BatchPart, HollowBlobRef, RunPart};
+use crate::internal::state::HollowBlobRef;
 use crate::internal::state_versions::{InspectDiff, StateVersionsIter};
 use crate::ShardId;
 
@@ -467,13 +467,7 @@ where
             states.state().blobs().for_each(|blob| match blob {
                 HollowBlobRef::Batch(batch) => {
                     for live_part in &batch.parts {
-                        match live_part {
-                            RunPart::Single(BatchPart::Hollow(x)) => {
-                                assert_eq!(batch_parts_to_delete.get(&x.key), None)
-                            }
-                            RunPart::Single(BatchPart::Inline { .. }) => {}
-                            RunPart::Many(_) => todo!("runs: contains method in part deletes!"),
-                        }
+                        assert!(!batch_parts_to_delete.contains(live_part));
                     }
                 }
                 HollowBlobRef::Rollup(live_rollup) => {
@@ -516,7 +510,7 @@ where
         truncate_lt: SeqNo,
         metrics: &GcStepTimings,
         timer: &mut F,
-        batch_parts_to_delete: &mut PartDeletes,
+        batch_parts_to_delete: &mut PartDeletes<T>,
         rollups_to_delete: &mut BTreeSet<PartialRollupKey>,
     ) where
         F: FnMut(&Counter),
@@ -551,7 +545,7 @@ where
     /// Truncates Consensus to `truncate_lt`.
     async fn delete_and_truncate<F>(
         truncate_lt: SeqNo,
-        batch_parts: &mut PartDeletes,
+        batch_parts: &mut PartDeletes<T>,
         rollups: &mut BTreeSet<PartialRollupKey>,
         machine: &Machine<K, V, T, D>,
         timer: &mut F,
@@ -567,15 +561,20 @@ where
                 .gc_blob_delete_concurrency_limit(),
         );
 
-        Self::delete_all(
-            machine.applier.state_versions.blob.borrow(),
-            batch_parts.iter().map(|k| k.complete(&shard_id)),
-            &machine.applier.metrics.retries.external.batch_delete,
-            debug_span!("batch::delete"),
-            &delete_semaphore,
-        )
-        .await;
-        *batch_parts = PartDeletes::default();
+        let batch_parts = std::mem::take(batch_parts);
+        batch_parts
+            .delete(
+                machine.applier.state_versions.blob.borrow(),
+                shard_id,
+                machine
+                    .applier
+                    .cfg
+                    .dynamic
+                    .gc_blob_delete_concurrency_limit(),
+                &machine.applier.metrics.retries.external.batch_delete,
+            )
+            .instrument(debug_span!("batch::delete"))
+            .await;
         timer(&machine.applier.metrics.gc.steps.delete_batch_part_seconds);
 
         Self::delete_all(

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -36,7 +36,7 @@ use crate::internal::machine::{retry_external, Machine};
 use crate::internal::maintenance::RoutineMaintenance;
 use crate::internal::metrics::{GcStepTimings, RetryMetrics};
 use crate::internal::paths::{BlobKey, PartialBlobKey, PartialRollupKey};
-use crate::internal::state::{BatchPart, HollowBlobRef};
+use crate::internal::state::{BatchPart, HollowBlobRef, RunPart};
 use crate::internal::state_versions::{InspectDiff, StateVersionsIter};
 use crate::ShardId;
 
@@ -468,10 +468,11 @@ where
                 HollowBlobRef::Batch(batch) => {
                     for live_part in &batch.parts {
                         match live_part {
-                            BatchPart::Hollow(x) => {
+                            RunPart::Single(BatchPart::Hollow(x)) => {
                                 assert_eq!(batch_parts_to_delete.get(&x.key), None)
                             }
-                            BatchPart::Inline { .. } => {}
+                            RunPart::Single(BatchPart::Inline { .. }) => {}
+                            RunPart::Many(_) => todo!("runs: contains method in part deletes!"),
                         }
                     }
                 }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1833,7 +1833,11 @@ pub mod datadriven {
 
         let mut s = String::new();
         let mut stream = pin!(batch
-            .part_stream(datadriven.shard_id, &*datadriven.state_versions.blob)
+            .part_stream(
+                datadriven.shard_id,
+                &*datadriven.state_versions.blob,
+                &*datadriven.state_versions.metrics
+            )
             .enumerate());
         while let Some((idx, part)) = stream.next().await {
             let part = &*part?;
@@ -2029,6 +2033,7 @@ pub mod datadriven {
             datadriven.client.blob.as_ref(),
             &datadriven.client.cfg.build_version,
             datadriven.shard_id,
+            &*datadriven.state_versions.metrics,
         )
         .await?;
         let mut out = String::new();
@@ -2111,8 +2116,11 @@ pub mod datadriven {
             for (run, (_meta, parts)) in batch.runs().enumerate() {
                 writeln!(result, "<run {run}>");
                 let mut stream = pin!(futures::stream::iter(parts)
-                    .flat_map(|part| part
-                        .part_stream(datadriven.shard_id, &*datadriven.state_versions.blob))
+                    .flat_map(|part| part.part_stream(
+                        datadriven.shard_id,
+                        &*datadriven.state_versions.blob,
+                        &*datadriven.state_versions.metrics
+                    ))
                     .enumerate());
                 while let Some((idx, part)) = stream.next().await {
                     let part = &*part?;

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -464,6 +464,8 @@ impl MetricsVecs {
                 rollup_delete: self.retry_metrics("rollup::delete"),
                 rollup_get: self.retry_metrics("rollup::get"),
                 rollup_set: self.retry_metrics("rollup::set"),
+                hollow_run_get: self.retry_metrics("hollow_run::get"),
+                hollow_run_set: self.retry_metrics("hollow_run::set"),
                 storage_usage_shard_size: self.retry_metrics("storage_usage::shard_size"),
             },
             compare_and_append_idempotent: self.retry_metrics("compare_and_append_idempotent"),
@@ -672,6 +674,8 @@ pub struct RetryExternal {
     pub(crate) rollup_delete: RetryMetrics,
     pub(crate) rollup_get: RetryMetrics,
     pub(crate) rollup_set: RetryMetrics,
+    pub(crate) hollow_run_get: RetryMetrics,
+    pub(crate) hollow_run_set: RetryMetrics,
     pub(crate) storage_usage_shard_size: RetryMetrics,
 }
 

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -30,14 +30,23 @@ message ProtoU64Description {
   ProtoU64Antichain since = 3;
 }
 
+message ProtoHollowRunRef {
+  // The location of the run struct in the blob store.
+  string key = 1;
+  // The largest size in bytes of any part in the run.
+  // This is useful to limit memory use during compaction.
+  uint64 max_part_bytes = 2;
+}
+
 message ProtoHollowBatchPart {
   oneof kind {
     string key = 1;
     bytes inline = 5;
+    ProtoHollowRunRef run_ref = 11;
   }
   ProtoU64Antichain ts_rewrite = 4;
 
-  // Only set when Kind is Key
+  // Only set when Kind is Key or RunRef
   uint64 encoded_size_bytes = 2;
   bytes key_lower = 3;
   optional bytes structured_key_lower = 10;
@@ -75,6 +84,10 @@ enum ProtoRunOrder {
 message ProtoRunMeta {
   ProtoRunOrder order = 1;
   optional uint64 schema_id = 2;
+}
+
+message ProtoHollowRun {
+  repeated ProtoHollowBatchPart parts = 4;
 }
 
 message ProtoHollowBatch {

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0.
 
 use anyhow::ensure;
+use async_stream::{stream, try_stream};
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Formatter};
@@ -23,17 +25,20 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::implementations::BatchContainer;
 use differential_dataflow::trace::Description;
 use differential_dataflow::Hashable;
+use futures::Stream;
+use futures_util::StreamExt;
 use mz_dyncfg::Config;
 use mz_ore::cast::CastFrom;
 use mz_ore::now::EpochMillis;
 use mz_ore::soft_panic_or_log;
 use mz_ore::vec::PartialOrdVecExt;
 use mz_persist::indexed::encoding::BatchColumnarFormat;
-use mz_persist::location::SeqNo;
+use mz_persist::location::{Blob, SeqNo};
 use mz_persist_types::arrow::{ArrayBound, ProtoArrayData};
 use mz_persist_types::columnar::{ColumnEncoder, Schema2};
 use mz_persist_types::schema::{backward_compatible, SchemaId};
 use mz_persist_types::{Codec, Codec64, Opaque};
+use mz_proto::ProtoType;
 use mz_proto::RustType;
 use proptest_derive::Arbitrary;
 use semver::Version;
@@ -49,7 +54,7 @@ use crate::critical::CriticalReaderId;
 use crate::error::InvalidUsage;
 use crate::internal::encoding::{parse_id, LazyInlineBatchPart, LazyPartStats, LazyProto};
 use crate::internal::gc::GcReq;
-use crate::internal::paths::{PartialBatchKey, PartialRollupKey, WriterKey};
+use crate::internal::paths::{BlobKey, PartId, PartialBatchKey, PartialRollupKey, WriterKey};
 use crate::internal::trace::{
     ActiveCompaction, ApplyMergeResult, FueledMergeReq, FueledMergeRes, Trace,
 };
@@ -204,6 +209,25 @@ pub enum BatchPart<T> {
     },
 }
 
+fn decode_structured_lower(lower: &LazyProto<ProtoArrayData>) -> Option<ArrayBound> {
+    let try_decode = |lower: &LazyProto<ProtoArrayData>| {
+        let proto = lower.decode()?;
+        let data = ArrayData::from_proto(proto)?;
+        ensure!(data.len() == 1);
+        Ok(ArrayBound::new(make_array(data), 0))
+    };
+
+    let decoded: anyhow::Result<ArrayBound> = try_decode(lower);
+
+    match decoded {
+        Ok(bound) => Some(bound),
+        Err(e) => {
+            soft_panic_or_log!("failed to decode bound: {e:#?}");
+            None
+        }
+    }
+}
+
 impl<T> BatchPart<T> {
     pub fn hollow_bytes(&self) -> usize {
         match self {
@@ -272,22 +296,7 @@ impl<T> BatchPart<T> {
             BatchPart::Inline { .. } => return None,
         };
 
-        let try_decode = |lower: &LazyProto<ProtoArrayData>| {
-            let proto = lower.decode()?;
-            let data = ArrayData::from_proto(proto)?;
-            ensure!(data.len() == 1);
-            Ok(ArrayBound::new(make_array(data), 0))
-        };
-
-        let decoded: anyhow::Result<ArrayBound> = try_decode(part.structured_key_lower.as_ref()?);
-
-        match decoded {
-            Ok(bound) => Some(bound),
-            Err(e) => {
-                soft_panic_or_log!("failed to decode bound: {e:#?}");
-                None
-            }
-        }
+        decode_structured_lower(part.structured_key_lower.as_ref()?)
     }
 
     pub fn ts_rewrite(&self) -> Option<&Antichain<T>> {
@@ -301,6 +310,265 @@ impl<T> BatchPart<T> {
         match self {
             BatchPart::Hollow(x) => x.schema_id,
             BatchPart::Inline { schema_id, .. } => *schema_id,
+        }
+    }
+}
+
+/// An ordered list of parts, generally stored as part of a larger run.
+#[derive(Debug, Clone)]
+pub struct HollowRun<T> {
+    /// Pointers usable to retrieve the updates.
+    pub(crate) parts: Vec<RunPart<T>>,
+}
+
+/// A reference to a [HollowRun], including the key in the blob store and some denormalized
+/// metadata.
+#[derive(Debug, Eq, PartialEq, Clone, Serialize)]
+pub struct HollowRunRef<T> {
+    pub key: PartialBatchKey,
+
+    /// The size of the referenced run object, plus all of the hollow objects it contains.
+    pub hollow_bytes: usize,
+
+    /// The size of the largest individual part in the run; useful for sizing compaction.
+    pub max_part_bytes: usize,
+
+    /// The lower bound of the data in this part, ordered by the codec ordering.
+    pub key_lower: Vec<u8>,
+
+    /// The lower bound of the data in this part, ordered by the structured ordering.
+    pub structured_key_lower: Option<LazyProto<ProtoArrayData>>,
+
+    pub(crate) _phantom_data: PhantomData<T>,
+}
+impl<T: Eq> PartialOrd<Self> for HollowRunRef<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: Eq> Ord for HollowRunRef<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.key.cmp(&other.key)
+    }
+}
+
+impl<T> HollowRunRef<T> {
+    pub fn writer_key(&self) -> Option<WriterKey> {
+        Some(self.key.split()?.0)
+    }
+}
+
+impl<T: Timestamp + Codec64> HollowRunRef<T> {
+    /// Stores the given runs and returns a [HollowRunRef] that points to them.
+    pub async fn set(
+        shard_id: ShardId,
+        blob: &dyn Blob,
+        writer: &WriterKey,
+        data: HollowRun<T>,
+    ) -> anyhow::Result<Self> {
+        let hollow_bytes = data.parts.iter().map(|p| p.hollow_bytes()).sum();
+        let max_part_bytes = data
+            .parts
+            .iter()
+            .map(|p| p.max_part_bytes())
+            .max()
+            .unwrap_or(0);
+        let key_lower = data
+            .parts
+            .first()
+            .map_or(vec![], |p| p.key_lower().to_vec());
+        let structured_key_lower = match data.parts.first() {
+            Some(RunPart::Many(r)) => r.structured_key_lower.clone(),
+            Some(RunPart::Single(BatchPart::Hollow(p))) => p.structured_key_lower.clone(),
+            Some(RunPart::Single(BatchPart::Inline { .. })) | None => None,
+        };
+
+        let key = PartialBatchKey::new(writer, &PartId::new());
+        let blob_key = key.complete(&shard_id);
+        let bytes = Bytes::from(prost::Message::encode_to_vec(&data.into_proto()));
+        blob.set(&blob_key, bytes).await.expect("FIXME: retry loop");
+        Ok(Self {
+            key,
+            hollow_bytes,
+            max_part_bytes,
+            key_lower,
+            structured_key_lower,
+            _phantom_data: Default::default(),
+        })
+    }
+
+    /// Retrieve the [HollowRun] that this reference points to.
+    /// The caller is expected to ensure that this ref is the result of calling [HollowRunRef::set]
+    /// with the same shard id and backing store.
+    pub async fn get(&self, shard_id: ShardId, blob: &dyn Blob) -> Option<HollowRun<T>> {
+        let blob_key = self.key.complete(&shard_id);
+        let mut bytes = blob.get(&blob_key).await.expect("FIXME: retry loop")?;
+        let proto_runs: ProtoHollowRun =
+            prost::Message::decode(&mut bytes).expect("illegal state: invalid proto bytes");
+        let runs = proto_runs
+            .into_rust()
+            .expect("illegal state: invalid encoded runs proto");
+        Some(runs)
+    }
+}
+
+/// Part of the updates in a run.
+///
+/// Either a pointer to ones stored in Blob or a single part stored inline.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
+pub enum RunPart<T> {
+    Single(BatchPart<T>),
+    Many(HollowRunRef<T>),
+}
+
+impl<T: Ord> PartialOrd<Self> for RunPart<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: Ord> Ord for RunPart<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (RunPart::Single(a), RunPart::Single(b)) => a.cmp(b),
+            (RunPart::Single(_), RunPart::Many(_)) => Ordering::Less,
+            (RunPart::Many(_), RunPart::Single(_)) => Ordering::Greater,
+            (RunPart::Many(a), RunPart::Many(b)) => a.cmp(b),
+        }
+    }
+}
+
+impl<T> RunPart<T> {
+    #[cfg(test)]
+    pub fn expect_hollow_part(&self) -> &HollowBatchPart<T> {
+        match self {
+            RunPart::Single(BatchPart::Hollow(hollow)) => hollow,
+            _ => panic!("expected hollow part!"),
+        }
+    }
+
+    pub fn hollow_bytes(&self) -> usize {
+        match self {
+            Self::Single(p) => p.hollow_bytes(),
+            Self::Many(r) => r.hollow_bytes,
+        }
+    }
+
+    pub fn is_inline(&self) -> bool {
+        match self {
+            Self::Single(p) => p.is_inline(),
+            Self::Many(_) => false,
+        }
+    }
+
+    pub fn inline_bytes(&self) -> usize {
+        match self {
+            Self::Single(p) => p.inline_bytes(),
+            Self::Many(_) => 0,
+        }
+    }
+
+    pub fn max_part_bytes(&self) -> usize {
+        match self {
+            Self::Single(p) => p.encoded_size_bytes(),
+            Self::Many(r) => r.max_part_bytes,
+        }
+    }
+
+    pub fn writer_key(&self) -> Option<WriterKey> {
+        match self {
+            Self::Single(p) => p.writer_key(),
+            Self::Many(r) => r.writer_key(),
+        }
+    }
+
+    pub fn encoded_size_bytes(&self) -> usize {
+        match self {
+            Self::Single(p) => p.encoded_size_bytes(),
+            Self::Many(r) => r.hollow_bytes,
+        }
+    }
+
+    pub fn schema_id(&self) -> Option<SchemaId> {
+        match self {
+            Self::Single(p) => p.schema_id(),
+            Self::Many(_) => None,
+        }
+    }
+
+    // A user-interpretable identifier or description of the part (for logs and
+    // such).
+    pub fn printable_name(&self) -> &str {
+        match self {
+            Self::Single(p) => p.printable_name(),
+            Self::Many(r) => r.key.0.as_str(),
+        }
+    }
+
+    pub fn stats(&self) -> Option<&LazyPartStats> {
+        match self {
+            Self::Single(p) => p.stats(),
+            // TODO: if we kept stats we could avoid fetching the metadata here.
+            Self::Many(_) => None,
+        }
+    }
+
+    pub fn key_lower(&self) -> &[u8] {
+        match self {
+            Self::Single(p) => p.key_lower(),
+            Self::Many(r) => r.key_lower.as_slice(),
+        }
+    }
+
+    pub fn structured_key_lower(&self) -> Option<ArrayBound> {
+        match self {
+            Self::Single(p) => p.structured_key_lower(),
+            Self::Many(_) => None,
+        }
+    }
+
+    pub fn ts_rewrite(&self) -> Option<&Antichain<T>> {
+        match self {
+            Self::Single(p) => p.ts_rewrite(),
+            Self::Many(_) => None,
+        }
+    }
+}
+
+/// A blob was missing!
+#[derive(Clone, Debug)]
+pub struct MissingBlob(BlobKey);
+
+impl std::fmt::Display for MissingBlob {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unexpectedly missing key: {}", self.0)
+    }
+}
+
+impl std::error::Error for MissingBlob {}
+
+impl<T: Timestamp + Codec64> RunPart<T> {
+    pub fn part_stream<'a>(
+        &'a self,
+        shard_id: ShardId,
+        blob: &'a dyn Blob,
+    ) -> impl Stream<Item = Result<Cow<'a, BatchPart<T>>, MissingBlob>> + Send + 'a {
+        try_stream! {
+            match self {
+                RunPart::Single(p) => {
+                    yield Cow::Borrowed(p);
+                }
+                RunPart::Many(r) => {
+                    let fetched = r.get(shard_id, blob).await.ok_or_else(|| MissingBlob(r.key.complete(&shard_id)))?;
+                    for run_part in fetched.parts {
+                        for await batch_part in run_part.part_stream(shard_id, blob).boxed() {
+                            yield Cow::Owned(batch_part?.into_owned());
+                        }
+                    }
+                }
+            }
         }
     }
 }
@@ -418,7 +686,7 @@ pub struct HollowBatch<T> {
     /// The number of updates in the batch.
     pub len: usize,
     /// Pointers usable to retrieve the updates.
-    pub(crate) parts: Vec<BatchPart<T>>,
+    pub(crate) parts: Vec<RunPart<T>>,
     /// Runs of sequential sorted batch parts, stored as indices into `parts`.
     /// ex.
     /// ```text
@@ -523,6 +791,21 @@ impl<T: Ord> Ord for HollowBatch<T> {
     }
 }
 
+impl<T: Timestamp + Codec64> HollowBatch<T> {
+    pub fn part_stream<'a>(
+        &'a self,
+        shard_id: ShardId,
+        blob: &'a (dyn Blob + Send + Sync),
+    ) -> impl Stream<Item = Result<Cow<'a, BatchPart<T>>, MissingBlob>> + 'a {
+        stream! {
+            for part in &self.parts {
+                for await part in part.part_stream(shard_id, blob) {
+                    yield part;
+                }
+            }
+        }
+    }
+}
 impl<T> HollowBatch<T> {
     /// Construct an in-memory hollow batch from the given metadata.
     ///
@@ -532,7 +815,7 @@ impl<T> HollowBatch<T> {
     /// `len` should represent the number of valid updates in the referenced parts.
     pub(crate) fn new(
         desc: Description<T>,
-        parts: Vec<BatchPart<T>>,
+        parts: Vec<RunPart<T>>,
         len: usize,
         run_meta: Vec<RunMeta>,
         run_splits: Vec<usize>,
@@ -564,7 +847,7 @@ impl<T> HollowBatch<T> {
     }
 
     /// Construct a batch of a single run with default metadata. Mostly interesting for tests.
-    pub(crate) fn new_run(desc: Description<T>, parts: Vec<BatchPart<T>>, len: usize) -> Self {
+    pub(crate) fn new_run(desc: Description<T>, parts: Vec<RunPart<T>>, len: usize) -> Self {
         let run_meta = if parts.is_empty() {
             vec![]
         } else {
@@ -590,7 +873,7 @@ impl<T> HollowBatch<T> {
         }
     }
 
-    pub(crate) fn runs(&self) -> impl Iterator<Item = (&RunMeta, &[BatchPart<T>])> {
+    pub(crate) fn runs(&self) -> impl Iterator<Item = (&RunMeta, &[RunPart<T>])> {
         let run_ends = self
             .run_splits
             .iter()
@@ -609,13 +892,7 @@ impl<T> HollowBatch<T> {
     }
 
     pub(crate) fn inline_bytes(&self) -> usize {
-        self.parts
-            .iter()
-            .map(|x| match x {
-                BatchPart::Inline { updates, .. } => updates.encoded_size_bytes(),
-                BatchPart::Hollow(_) => 0,
-            })
-            .sum()
+        self.parts.iter().map(|x| x.inline_bytes()).sum()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -690,8 +967,17 @@ impl<T: Timestamp + TotalOrder> HollowBatch<T> {
         );
         for part in &mut self.parts {
             match part {
-                BatchPart::Hollow(part) => part.ts_rewrite = Some(frontier.clone()),
-                BatchPart::Inline { ts_rewrite, .. } => *ts_rewrite = Some(frontier.clone()),
+                RunPart::Single(BatchPart::Hollow(part)) => {
+                    part.ts_rewrite = Some(frontier.clone())
+                }
+                RunPart::Single(BatchPart::Inline { ts_rewrite, .. }) => {
+                    *ts_rewrite = Some(frontier.clone())
+                }
+                RunPart::Many(runs) => {
+                    // Currently unreachable: we only apply rewrites to user batches, and we don't
+                    // ever generate runs of >1 part for those.
+                    panic!("unexpected rewrite of a hollow runs ref: {runs:?}");
+                }
             }
         }
         Ok(())
@@ -2236,7 +2522,7 @@ pub(crate) mod tests {
                 any::<T>(),
                 any::<T>(),
                 any::<T>(),
-                proptest::collection::vec(any_batch_part::<T>(), 0..3),
+                proptest::collection::vec(any_run_part::<T>(), 0..3),
                 any::<usize>(),
                 any::<bool>(),
             ),
@@ -2285,6 +2571,10 @@ pub(crate) mod tests {
                 }
             },
         )
+    }
+
+    pub fn any_run_part<T: Arbitrary + Timestamp>() -> impl Strategy<Value = RunPart<T>> {
+        Strategy::prop_map(any_batch_part(), |part| RunPart::Single(part))
     }
 
     pub fn any_hollow_batch_part<T: Arbitrary + Timestamp>(
@@ -2483,7 +2773,7 @@ pub(crate) mod tests {
             ),
             keys.iter()
                 .map(|x| {
-                    BatchPart::Hollow(HollowBatchPart {
+                    RunPart::Single(BatchPart::Hollow(HollowBatchPart {
                         key: PartialBatchKey((*x).to_owned()),
                         encoded_size_bytes: 0,
                         key_lower: vec![],
@@ -2493,7 +2783,7 @@ pub(crate) mod tests {
                         diffs_sum: None,
                         format: None,
                         schema_id: None,
-                    })
+                    }))
                 })
                 .collect(),
             len,

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -39,7 +39,7 @@ use crate::internal::paths::{BlobKey, PartialBlobKey, PartialRollupKey, RollupId
 #[cfg(debug_assertions)]
 use crate::internal::state::HollowBatch;
 use crate::internal::state::{
-    BatchPart, HollowBlobRef, HollowRollup, NoOpStateTransition, State, TypedState,
+    BatchPart, HollowBlobRef, HollowRollup, NoOpStateTransition, RunPart, State, TypedState,
 };
 use crate::internal::state_diff::{StateDiff, StateFieldValDiff};
 use crate::{Metrics, PersistConfig, ShardId};
@@ -351,20 +351,20 @@ impl StateVersions {
                     .trace
                     .batches()
                     .flat_map(|x| x.parts.iter())
-                    .flat_map(|x| match x {
-                        BatchPart::Hollow(x) => {
-                            // Carefully avoid any String allocs by splitting.
-                            let writer_key =
-                                x.key.0.split_once('/').map(|(writer_key, _)| writer_key);
-                            writer_key.and_then(|s| match &s[..1] {
-                                "w" => Some(("old", x.encoded_size_bytes)),
-                                "n" => Some((&s[1..], x.encoded_size_bytes)),
-                                _ => None,
-                            })
+                    .flat_map(|part| {
+                        let key = match part {
+                            RunPart::Many(x) => Some(&x.key),
+                            RunPart::Single(BatchPart::Hollow(x)) => Some(&x.key),
+                            // TODO: Would be nice to include these too, but we lose the info atm.
+                            RunPart::Single(BatchPart::Inline { .. }) => None,
+                        }?;
+                        // Carefully avoid any String allocs by splitting.
+                        let (writer_key, _) = key.0.split_once('/')?;
+                        match &writer_key[..1] {
+                            "w" => Some(("old", part.encoded_size_bytes())),
+                            "n" => Some((&writer_key[1..], part.encoded_size_bytes())),
+                            _ => None,
                         }
-                        // TODO: Would be nice to include these too, but we lose the
-                        // info atm.
-                        BatchPart::Inline { .. } => None,
                     });
                 shard_metrics.set_batch_part_versions(batch_parts_by_version);
 
@@ -1176,19 +1176,19 @@ impl<T: Timestamp + Lattice + Codec64> ReferencedBlobValidator<T> {
         assert_eq!(inc_lower, full_lower);
         assert_eq!(inc_upper, full_upper);
 
-        fn part_unique<T: Hash>(x: &BatchPart<T>) -> String {
+        fn part_unique<T: Hash>(x: &RunPart<T>) -> String {
             match x {
-                BatchPart::Hollow(x) => x.key.to_string(),
-                BatchPart::Inline {
+                RunPart::Single(BatchPart::Inline {
                     updates,
                     ts_rewrite,
                     ..
-                } => {
+                }) => {
                     let mut h = DefaultHasher::new();
                     updates.hash(&mut h);
                     ts_rewrite.as_ref().map(|x| x.elements()).hash(&mut h);
                     h.finish().to_string()
                 }
+                other => other.printable_name().to_string(),
             }
         }
 

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -41,7 +41,7 @@ use crate::fetch::{EncodedPart, FetchBatchFilter};
 use crate::internal::encoding::Schemas;
 use crate::internal::metrics::{ReadMetrics, ShardMetrics};
 use crate::internal::paths::WriterKey;
-use crate::internal::state::{RunMeta, RunOrder, RunPart};
+use crate::internal::state::{HollowRun, RunMeta, RunOrder, RunPart};
 use crate::metrics::Metrics;
 use crate::ShardId;
 
@@ -295,6 +295,8 @@ impl<K: Codec, V: Codec, T: Codec64, D: Codec64> RowSort<T, D> for StructuredSor
     }
 }
 
+type FetchResult<T> = Result<EncodedPart<T>, HollowRun<T>>;
+
 impl<T: Codec64 + Timestamp + Lattice> FetchData<T> {
     async fn fetch(
         self,
@@ -303,21 +305,30 @@ impl<T: Codec64 + Timestamp + Lattice> FetchData<T> {
         metrics: &Metrics,
         shard_metrics: &ShardMetrics,
         read_metrics: &ReadMetrics,
-    ) -> anyhow::Result<EncodedPart<T>> {
-        let RunPart::Single(part) = self.part else {
-            todo!("run ref: recursively fetch the run data")
-        };
-        EncodedPart::fetch(
-            &shard_id,
-            &*blob,
-            metrics,
-            shard_metrics,
-            read_metrics,
-            &self.part_desc,
-            &part,
-        )
-        .await
-        .map_err(|blob_key| anyhow!("missing unleased key {blob_key}"))
+    ) -> anyhow::Result<FetchResult<T>> {
+        match self.part {
+            RunPart::Single(part) => {
+                let part = EncodedPart::fetch(
+                    &shard_id,
+                    &*blob,
+                    metrics,
+                    shard_metrics,
+                    read_metrics,
+                    &self.part_desc,
+                    &part,
+                )
+                .await
+                .map_err(|blob_key| anyhow!("missing unleased key {blob_key}"))?;
+                Ok(Ok(part))
+            }
+            RunPart::Many(run_ref) => {
+                let runs = run_ref
+                    .get(shard_id, blob)
+                    .await
+                    .ok_or_else(|| anyhow!("missing run ref {}", run_ref.key))?;
+                Ok(Err(runs))
+            }
+        }
     }
 }
 
@@ -350,7 +361,7 @@ impl PartIndices {
 enum ConsolidationPart<T, D, Sort: RowSort<T, D> = CodecSort<T, D>> {
     Queued {
         data: FetchData<T>,
-        task: Option<JoinHandle<anyhow::Result<EncodedPart<T>>>>,
+        task: Option<JoinHandle<anyhow::Result<FetchResult<T>>>>,
     },
     Encoded {
         part: Sort::Updates,
@@ -621,8 +632,18 @@ where
         let mut ready_futures: FuturesUnordered<_> = self.runs[0..first_larger]
             .iter_mut()
             .map(|run| async {
-                let part = &mut run.front_mut().expect("trimmed run should be nonempty").0;
-                if let ConsolidationPart::Queued { data, task } = part {
+                // It's possible for there to be multiple layers of indirection between us and the first available encoded part:
+                // if the first part is a `HollowRuns`, we'll need to fetch both that and the first part in the run to have data
+                // to consolidate. So: we loop, and bail out of the loop when either the first part in the run is available or we
+                // hit some unrecoverable error.
+                loop {
+                    let (mut part, size) = run.pop_front().expect("trimmed run should be nonempty");
+
+                    let ConsolidationPart::Queued { data, task } = &mut part else {
+                        run.push_front((part, size));
+                        return Ok(true);
+                    };
+
                     let is_prefetched = task.as_ref().map_or(false, |t| t.is_finished());
                     if is_prefetched {
                         self.metrics.compaction.parts_prefetched.inc();
@@ -632,8 +653,10 @@ where
                     self.metrics.consolidation.parts_fetched.inc();
 
                     let wrong_sort = !Sort::desired_sort(data);
-                    let encoded_part = match task.take() {
-                        Some(handle) => handle.await??,
+                    let fetch_result: anyhow::Result<FetchResult<T>> = match task.take() {
+                        Some(handle) => handle
+                            .await
+                            .unwrap_or_else(|join_err| Err(anyhow!(join_err))),
                         None => {
                             data.clone()
                                 .fetch(
@@ -643,18 +666,47 @@ where
                                     &*self.shard_metrics,
                                     &self.read_metrics,
                                 )
-                                .await?
+                                .await
                         }
                     };
-                    *part = ConsolidationPart::from_encoded(
-                        encoded_part,
-                        wrong_sort,
-                        &self.metrics.columnar,
-                        &self.sort,
-                    );
+                    match fetch_result {
+                        Err(err) => {
+                            run.push_front((part, size));
+                            return Err(err);
+                        }
+                        Ok(Err(run_part)) => {
+                            // Since we're pushing these onto the _front_ of the queue, we need to
+                            // iterate in reverse order.
+                            for part in run_part.parts.into_iter().rev() {
+                                let structured_lower = part.structured_key_lower();
+                                let size = part.max_part_bytes();
+                                run.push_front((
+                                    ConsolidationPart::Queued {
+                                        data: FetchData {
+                                            run_meta: data.run_meta.clone(),
+                                            part_desc: data.part_desc.clone(),
+                                            part,
+                                            structured_lower,
+                                        },
+                                        task: None,
+                                    },
+                                    size,
+                                ));
+                            }
+                        }
+                        Ok(Ok(part)) => {
+                            run.push_front((
+                                ConsolidationPart::from_encoded(
+                                    part,
+                                    wrong_sort,
+                                    &self.metrics.columnar,
+                                    &self.sort,
+                                ),
+                                size,
+                            ));
+                        }
+                    }
                 }
-
-                Ok::<_, anyhow::Error>(true)
             })
             .collect();
 

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -323,7 +323,7 @@ impl<T: Codec64 + Timestamp + Lattice> FetchData<T> {
             }
             RunPart::Many(run_ref) => {
                 let runs = run_ref
-                    .get(shard_id, blob)
+                    .get(shard_id, blob, metrics)
                     .await
                     .ok_or_else(|| anyhow!("missing run ref {}", run_ref.key))?;
                 Ok(Err(runs))

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -126,7 +126,12 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                     let mut x = ::mz_dyncfg::ConfigUpdates::default();
                     x.add_dynamic("persist_encoding_enable_dictionary", ::mz_dyncfg::ConfigVal::Bool(true));
                     x
-                }
+                },
+                {
+                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
+                    x.add_dynamic("persist_batch_max_run_len", ::mz_dyncfg::ConfigVal::Usize(4));
+                    x
+                },
             ];
 
             for (idx, dyncfgs) in dyncfgs.into_iter().enumerate() {

--- a/src/persist-types/src/arrow.rs
+++ b/src/persist-types/src/arrow.rs
@@ -567,6 +567,14 @@ pub struct ArrayBound {
     index: usize,
 }
 
+impl PartialEq for ArrayBound {
+    fn eq(&self, other: &Self) -> bool {
+        self.get().eq(&other.get())
+    }
+}
+
+impl Eq for ArrayBound {}
+
 impl ArrayBound {
     /// Create a new `ArrayBound` for this array, with the bound at the provided index.
     pub fn new(array: ArrayRef, index: usize) -> Self {


### PR DESCRIPTION
See comments in https://github.com/MaterializeInc/database-issues/issues/7975 for important background and design.

The core change in this PR is
[Add RunPart enum and HollowRuns](https://github.com/MaterializeInc/materialize/pull/30094/commits/e0214a95d4d500f10b2fd72e12baad9b897a860e), which:
- Adds a new `HollowRun` type with a list of parts, and a `HollowRunRef` type with a pointer and a small amount of denormalized metadata.
- Adds a `RunPart` enum with variants for that and the existing `BatchPart` enum.
- Adapts ~all of persist to handle the new variant, including adapting many iterators to streams and otherways async-ifying things.

### Motivation

Implements: https://github.com/MaterializeInc/database-issues/issues/8401

### Tips for reviewer

It's a big PR! I attempted to split up a few chunkier changes into their own commits, but there's still a 500-liner that adds the new enum/variant and adapts many of the smaller usages. Let me know if it's worth taking time to walk through anything live.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
