### PR TITLE
parallel-benchmark: Don't set autocommit twice

### DIFF
--- a/misc/python/materialize/parallel_benchmark/framework.py
+++ b/misc/python/materialize/parallel_benchmark/framework.py
@@ -237,7 +237,7 @@ class PooledQuery(Action):
                 print(f"Connection failed on query '{self.query}', reconnecting: {e}")
                 conn.close()
                 conn = self.conn_info.connect()
-                conn.autocommit = True
+                execute_query(cur, self.query)
         conns.task_done()
         conns.put(conn)
 


### PR DESCRIPTION
Seen failing in
https://buildkite.com/materialize/qa-canary/builds/277#01929cf0-282b-4c72-af50-0593d2d1e4e5
Green run: https://buildkite.com/materialize/qa-canary/builds/278#0192a1a7-0a51-42ff-b5c7-fc2ed2250314

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
