### PR TITLE
qa canary: Improve load test

### DIFF
--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -114,10 +114,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
             except (OperationalError, ReadTimeout, ConnectionError) as e:
                 error_msg_str = str(e)
-                if "Read timed out" in error_msg_str:
-                    print("Read timed out, retrying")
-                elif "closed connection" in error_msg_str:
-                    print("Remote end closed connection, retrying")
+                if (
+                    "Read timed out" in error_msg_str
+                    or "closed connection" in error_msg_str
+                    or "terminating connection due to idle-in-transaction timeout"
+                    in error_msg_str
+                ):
+                    print(f"Failed: {e}; retrying")
                 else:
                     raise
             except FailedTestExecutionError as e:


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/qa-canary/builds/277#01929cf0-2829-448b-b1f6-1878a16573af

New run without that failure: https://buildkite.com/materialize/qa-canary/builds/279#0192a1ba-2710-4842-9134-5a928f7d0e6e
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
