### PR TITLE
dataflow expiration: log on/off reason

### DIFF
--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -73,6 +73,7 @@ impl TimelineContext {
 
     /// Whether the context contains a timeline of type [`Timeline::EpochMilliseconds`].
     pub fn is_timeline_epoch_ms(&self) -> bool {
+        debug!(timeline_ctx = ?self, "checking if timeline context is EpochMilliseconds");
         matches!(self, &Self::TimelineDependent(Timeline::EpochMilliseconds))
     }
 }

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -26,7 +26,7 @@ use mz_sql::session::vars::IsolationLevel;
 use mz_storage_types::sources::Timeline;
 use serde::{Deserialize, Serialize};
 use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
-use tracing::{event, Level};
+use tracing::{debug, event, Level};
 
 use crate::catalog::CatalogState;
 use crate::coord::id_bundle::CollectionIdBundle;
@@ -135,6 +135,7 @@ impl<T: TimestampManipulation> TimestampContext<T> {
 
     /// Whether the context contains a timestamp of type [`Timeline::EpochMilliseconds`].
     pub fn is_timeline_epoch_ms(&self) -> bool {
+        debug!(timeline_ctx = ?self, "checking if timeline context is EpochMilliseconds");
         matches!(
             self,
             &Self::TimelineTimestamp {

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -123,6 +123,12 @@ impl<P, S> DataflowDescription<P, S, mz_repr::Timestamp> {
     ) -> Antichain<mz_repr::Timestamp> {
         let dataflow_expiration_desc = &self.dataflow_expiration_desc;
 
+        tracing::debug!(
+            replica_expiration = ?replica_expiration.elements(),
+            dataflow_expiration_desc = ?dataflow_expiration_desc,
+            "computing dataflow expiration",
+        );
+
         // Disable dataflow expiration if `replica_expiration` is unset, the current dataflow has a
         // refresh schedule, has a transitive dependency with a refresh schedule, or the dataflow's
         // timeline is not `Timeline::EpochMilliSeconds`.

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -126,6 +126,7 @@ impl<P, S> DataflowDescription<P, S, mz_repr::Timestamp> {
         tracing::debug!(
             replica_expiration = ?replica_expiration.elements(),
             dataflow_expiration_desc = ?dataflow_expiration_desc,
+            self_refresh_schedule = ?self.refresh_schedule,
             "computing dataflow expiration",
         );
 

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -120,15 +120,9 @@ impl<P, S> DataflowDescription<P, S, mz_repr::Timestamp> {
     pub fn expire_dataflow_at(
         &self,
         replica_expiration: &Antichain<mz_repr::Timestamp>,
+        dataflow_debug_name: &str,
     ) -> Antichain<mz_repr::Timestamp> {
         let dataflow_expiration_desc = &self.dataflow_expiration_desc;
-
-        tracing::debug!(
-            replica_expiration = ?replica_expiration.elements(),
-            dataflow_expiration_desc = ?dataflow_expiration_desc,
-            self_refresh_schedule = ?self.refresh_schedule,
-            "computing dataflow expiration",
-        );
 
         // Disable dataflow expiration if `replica_expiration` is unset, the current dataflow has a
         // refresh schedule, has a transitive dependency with a refresh schedule, or the dataflow's
@@ -141,12 +135,23 @@ impl<P, S> DataflowDescription<P, S, mz_repr::Timestamp> {
             return Antichain::default();
         }
 
-        if let Some(upper) = &dataflow_expiration_desc.transitive_upper {
+        let dataflow_expiration = if let Some(upper) = &dataflow_expiration_desc.transitive_upper {
             // Returns empty if `upper` is empty, else the max of `upper` and `replica_expiration`.
             upper.join(replica_expiration)
         } else {
             replica_expiration.clone()
-        }
+        };
+
+        tracing::debug!(
+            dataflow_name = %dataflow_debug_name,
+            replica_expiration = ?replica_expiration.elements(),
+            dataflow_expiration_desc = ?dataflow_expiration_desc,
+            self_refresh_schedule = ?self.refresh_schedule,
+            output_dataflow_expiration = ?dataflow_expiration.elements(),
+            "computing dataflow expiration",
+        );
+
+        dataflow_expiration
     }
 }
 

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -463,8 +463,8 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         let as_of = dataflow.as_of.clone().unwrap();
 
         // Determine the dataflow expiration, if any.
-        let dataflow_expiration =
-            dataflow.expire_dataflow_at(&self.compute_state.replica_expiration);
+        let dataflow_expiration = dataflow
+            .expire_dataflow_at(&self.compute_state.replica_expiration, &dataflow.debug_name);
 
         // Add the dataflow expiration to `until`.
         let until = dataflow.until.meet(&dataflow_expiration);


### PR DESCRIPTION
Log some basic information about why dataflow expiration was turned on or off.

### Motivation

The additional information will help understand why dataflow expiration is not enabled even if replica expiration is set.
Currently occurring in a customer's environment: https://github.com/MaterializeInc/database-issues/issues/8647

### Tips for reviewer

* What other information can we log that would be helpful in debugging?
