### PR TITLE
testdrive: Disable flaky part of coord-read-holds.td

### DIFF
--- a/test/testdrive/coord-read-holds.td
+++ b/test/testdrive/coord-read-holds.td
@@ -48,6 +48,10 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 > CREATE TABLE t1 (a int);
 > INSERT INTO t1 VALUES (201), (202), (203);
 
+# TODO: Reenable when database-issues#8619 is fixed
+$ skip-if
+SELECT true
+
 # Note: the important bit is making sure this EXPLAIN returns "can respond immediately: true"
 $ set-regex match=(\d{13}|([\d\-]{10}\s[\d:.]{12})|u\d+) replacement=<NON_CONSTANT>
 > EXPLAIN TIMESTAMP FOR SELECT COUNT(t1.a) FROM t1, pg_t1;


### PR DESCRIPTION
Keeps flaking: https://buildkite.com/materialize/nightly/builds/10054#_
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
