### PR TITLE
feature-benchmark: Bump threshold for clusterd memory even further

### DIFF
--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -18,7 +18,7 @@ FEATURE_BENCHMARK_SCENARIOS_DIR = FEATURE_BENCHMARK_FRAMEWORK_DIR / "scenarios"
 
 # Consider increasing the #FEATURE_BENCHMARK_FRAMEWORK_VERSION if changes are expected to impact results!
 SHA256_OF_FRAMEWORK: dict[str, str] = {
-    "*": "d805dc0566e2daa9450ea0c560ef15d4016e44c40c95a6b3f2302d25fc2e031d",
+    "*": "56baba5e5efe24da35b8365089c59557f482aef630edeeaa358f7f3bb52a663f",
 }
 
 # Consider increasing the scenario's class #version() if changes are expected to impact results!
@@ -26,7 +26,7 @@ SHA256_BY_SCENARIO_FILE: dict[str, str] = {
     "benchmark_main.py": "a898f6d8990476422ef99a6f156a36571d52fab9b10414664d32c023ad591357",
     "concurrency.py": "2e9c149c136b83b3853abc923a1adbdaf55a998ab4557712f8424c8b16f2adb1",
     "customer.py": "d1e72837a342c3ebf1f4a32ec583b1b78a78644cdba495030a6df45ebbffe703",
-    "optbench.py": "9e60513af0b4df5f2580555c8775e3758a66158e03c257e9f3c303bd972fa625",
+    "optbench.py": "b78682659b2f6f405e158643e50e4d68481174b9353af19907719c21f573a7a1",
     "scale.py": "c4c8749d166e4df34e0b0e92220434fdb508c5c2ac56eb80c07043be0048dded",
     "skew.py": "bf60802205fc51ebf94fb008bbdb6b2ccce3c9ed88a6188fa7f090f2c84b120f",
     "subscribe.py": "66b6ba61daed10a0e78291f6251e62dcb41f206228028bc0cbd0d738ad76252b",

--- a/misc/python/materialize/feature_benchmark/scenario.py
+++ b/misc/python/materialize/feature_benchmark/scenario.py
@@ -26,7 +26,7 @@ class RootScenario:
         # Increased the other measurements since they are easy to regress now
         # that we take the run with the minimum wallclock time:
         MeasurementType.MEMORY_MZ: 0.20,
-        MeasurementType.MEMORY_CLUSTERD: 0.30,
+        MeasurementType.MEMORY_CLUSTERD: 0.50,
     }
 
     def __init__(

--- a/misc/python/materialize/feature_benchmark/scenarios/optbench.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/optbench.py
@@ -112,7 +112,7 @@ class OptbenchTPCH(Scenario):
     RELATIVE_THRESHOLD: dict[MeasurementType, float] = {
         MeasurementType.WALLCLOCK: 0.20,  # increased because it's easy to regress
         MeasurementType.MEMORY_MZ: 0.20,
-        MeasurementType.MEMORY_CLUSTERD: 0.30,
+        MeasurementType.MEMORY_CLUSTERD: 0.50,
     }
 
     def init(self) -> list[Action]:


### PR DESCRIPTION
Not a real solution, just to unflake CI a bit. Example failures: https://buildkite.com/materialize/nightly/builds/10054 https://buildkite.com/materialize/nightly/builds/10052

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
