### PR TITLE
tests: Use introspection tables in new source table model

### DIFF
--- a/test/mysql-cdc/alter-source.td
+++ b/test/mysql-cdc/alter-source.td
@@ -272,13 +272,12 @@ INSERT INTO table_a VALUES (3);
 ! SELECT * FROM table_a;
 contains:incompatible schema change
 
-# TODO: source status support with database-issues#8511
-# > SELECT error ~~ '%incompatible schema change%' FROM mz_internal.mz_source_statuses WHERE name = 'table_a';
-# true
-#
-# # Subsource errors not propagated to primary source
-# > SELECT error IS NULL FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
-# true
+> SELECT error ~~ '%incompatible schema change%' FROM mz_internal.mz_source_statuses WHERE name = 'table_a';
+true
+
+# Subsource errors not propagated to primary source
+> SELECT error IS NULL FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
+true
 
 > DROP TABLE table_a;
 

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -557,9 +557,8 @@ true
 2 two_two
 5 five
 
-# TODO: database-issues#8511 (introspection tables)
-# > SELECT status = 'running' FROM mz_internal.mz_source_statuses WHERE name = 'large_cluster_source_pk_table' and type = 'table';
-# true
+> SELECT status = 'running' FROM mz_internal.mz_source_statuses WHERE name = 'large_cluster_source_pk_table' and type = 'table';
+true
 
 > DROP SOURCE large_cluster_source CASCADE;
 

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -290,9 +290,8 @@ INSERT INTO table_a VALUES (3);
 ! SELECT * FROM table_a;
 contains:incompatible schema change
 
-# TODO: database-issues#8511 (introspection tables)
-# > SELECT error ~~ '%incompatible schema change%' FROM mz_internal.mz_source_statuses WHERE name = 'table_a' and type = 'table';
-# true
+> SELECT error ~~ '%incompatible schema change%' FROM mz_internal.mz_source_statuses WHERE name = 'table_a' and type = 'table';
+true
 
 # Subsource errors not propagated to primary source
 > SELECT error IS NULL FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -337,7 +337,6 @@ public          trailing_space_nopk
 public          "\"\"\"literal_quotes\"\"\""
 conflict_schema conflict_table
 
-# TODO: database-issues#8511 (introspection tables)
 # Ensure all ingestion export subsources have an ID greater than the primary source ID
 > SELECT bool_and(primary_source_id < subsource_id)
   FROM
@@ -593,9 +592,8 @@ true
 2 two_two
 5 five
 
-# TODO: database-issues#8511 (introspection tables)
-# > SELECT status = 'running' FROM mz_internal.mz_source_statuses WHERE name = 'large_cluster_source_pk_table' AND type = 'table';
-# true
+> SELECT status = 'running' FROM mz_internal.mz_source_statuses WHERE name = 'large_cluster_source_pk_table' AND type = 'table';
+true
 
 > DROP SOURCE large_cluster_source CASCADE;
 

--- a/test/pg-cdc/statistics.td
+++ b/test/pg-cdc/statistics.td
@@ -72,19 +72,18 @@ SELECT
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 INSERT INTO t1 VALUES ('three');
 
-# TODO: database-issues#8511 (introspection tables)
-# > SELECT
-#     s.name,
-#     SUM(u.offset_committed) > ${previous-offset-committed},
-#     SUM(u.offset_known) >= SUM(u.offset_committed),
-#     SUM(u.snapshot_records_known),
-#     SUM(u.snapshot_records_staged)
-#   FROM mz_sources s
-#   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
-#   WHERE s.name IN ('mz_source')
-#   GROUP BY s.name
-#   ORDER BY s.name
-# mz_source true true 2 2
+> SELECT
+    s.name,
+    SUM(u.offset_committed) > ${previous-offset-committed},
+    SUM(u.offset_known) >= SUM(u.offset_committed),
+    SUM(u.snapshot_records_known),
+    SUM(u.snapshot_records_staged)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('mz_source')
+  GROUP BY s.name
+  ORDER BY s.name
+mz_source true true 2 2
 
 $ set-from-sql var=pre-restart-offset-committed
 SELECT
@@ -137,17 +136,16 @@ true
   ORDER BY s.name
 mz_source 1 1
 
-# TODO: database-issues#8511 (introspection tables)
-# # Ensure subsource stats show up, and then are removed when we drop subsources.
-# > SELECT
-#     t.name,
-#     SUM(u.updates_committed) > 0
-#   FROM mz_sources t
-#   JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
-#   WHERE t.name IN ('alt')
-#   GROUP BY t.name
-#   ORDER BY t.name
-# alt true
+# Ensure subsource stats show up, and then are removed when we drop subsources.
+> SELECT
+    t.name,
+    SUM(u.updates_committed) > 0
+  FROM mz_sources t
+  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  WHERE t.name IN ('alt')
+  GROUP BY t.name
+  ORDER BY t.name
+alt true
 
 > DROP TABLE alt;
 

--- a/test/pg-cdc/statistics.td
+++ b/test/pg-cdc/statistics.td
@@ -140,7 +140,7 @@ mz_source 1 1
 > SELECT
     t.name,
     SUM(u.updates_committed) > 0
-  FROM mz_sources t
+  FROM mz_tables t
   JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
   WHERE t.name IN ('alt')
   GROUP BY t.name

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -418,7 +418,9 @@ class PgDisruption:
                 # check that the latest stall has the error we expect.
                 > SELECT error ~* '{error}'
                     FROM mz_internal.mz_source_status_history
-                    JOIN mz_sources ON mz_sources.id = source_id
+                    JOIN (
+                      SELECT name, id FROM mz_sources UNION SELECT name, id FROM mz_tables
+                    ) ON id = source_id
                     WHERE (
                         name = 'source1' OR name = 'pg_source'
                     ) AND (status = 'stalled' OR status = 'ceased')

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -435,12 +435,11 @@ class PgDisruption:
                 $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO source1 VALUES (3);
 
-                # TODO: database-issues#8511 (introspection tables)
-                # > SELECT status, error
-                #   FROM mz_internal.mz_source_statuses
-                #   WHERE name = 'source1'
-                #   AND type = 'table'
-                # running <null>
+                > SELECT status, error
+                  FROM mz_internal.mz_source_statuses
+                  WHERE name = 'source1'
+                  AND type = 'table'
+                running <null>
 
                 > SELECT f1 FROM source1;
                 1
@@ -527,20 +526,18 @@ disruptions: list[Disruption] = [
         # Can't recover when publication state is deleted.
         fixage=None,
     ),
-    # TODO: database-issues#8511 (introspection tables)
-    # PgDisruption(
-    #     name="alter-postgres",
-    #     breakage=lambda c, _: alter_pg_table(c),
-    #     expected_error="source table source1 with oid .+ has been altered",
-    #     fixage=None,
-    # ),
-    # TODO: database-issues#8511 (introspection tables)
-    # PgDisruption(
-    #     name="unsupported-postgres",
-    #     breakage=lambda c, _: unsupported_pg_table(c),
-    #     expected_error="invalid input syntax for type array",
-    #     fixage=None,
-    # ),
+    PgDisruption(
+        name="alter-postgres",
+        breakage=lambda c, _: alter_pg_table(c),
+        expected_error="source table source1 with oid .+ has been altered",
+        fixage=None,
+    ),
+    PgDisruption(
+        name="unsupported-postgres",
+        breakage=lambda c, _: unsupported_pg_table(c),
+        expected_error="invalid input syntax for type array",
+        fixage=None,
+    ),
     # One-off disruption with a badly configured kafka sink
     KafkaTransactionLogGreaterThan1(
         name="bad-kafka-sink",

--- a/test/ssh-connection/pg-source-after-ssh-restart.td
+++ b/test/ssh-connection/pg-source-after-ssh-restart.td
@@ -22,12 +22,11 @@ INSERT INTO t1 VALUES (3);
 3
 
 
-# TODO: database-issues#8511 (introspection tables)
-# > SELECT name, type, error
-#   FROM mz_internal.mz_source_statuses
-#   WHERE
-#       name
-#       IN (
-#       SELECT name FROM mz_tables WHERE source_id IS NOT NULL
-#       );
-# t1 table <null>
+> SELECT name, type, error
+  FROM mz_internal.mz_source_statuses
+  WHERE
+      name
+      IN (
+      SELECT name FROM mz_tables WHERE source_id IS NOT NULL
+      );
+t1 table <null>


### PR DESCRIPTION
Since https://github.com/MaterializeInc/database-issues/issues/8511 has been fixed

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
