### PR TITLE
dbt-materialize: cascade drop seeds on `--full-refresh`

### DIFF
--- a/misc/dbt-materialize/Dockerfile
+++ b/misc/dbt-materialize/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM python:3.8.6
+FROM python:3.10.14
 
 COPY . dbt-materialize/
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -156,7 +156,7 @@
     -- Tables are not supported as a materialization type in dbt-materialize,
     -- but seeds and source tables are materialized as tables.
     {% elif relation.type == 'table' %}
-      drop table if exists {{ relation }}
+      drop table if exists {{ relation }} cascade
     {% endif %}
   {%- endcall %}
 {% endmacro %}

--- a/misc/dbt-materialize/tests/adapter/test_run_hooks.py
+++ b/misc/dbt-materialize/tests/adapter/test_run_hooks.py
@@ -20,6 +20,7 @@ from dbt.tests.adapter.hooks.test_run_hooks import (
     BaseAfterRunHooks,
     BasePrePostRunHooks,
 )
+from dbt.tests.util import run_dbt
 from fixtures import run_hook, test_run_operation
 
 
@@ -56,4 +57,7 @@ class TestPrePostRunHooksMaterialize(BasePrePostRunHooks):
 
 
 class TestAfterRunHooksMaterialize(BaseAfterRunHooks):
+    def test_missing_column_pre_hook(self, project):
+        run_dbt(["run"], expect_pass=False)
+
     pass

--- a/misc/dbt-materialize/tests/adapter/test_run_hooks.py
+++ b/misc/dbt-materialize/tests/adapter/test_run_hooks.py
@@ -16,11 +16,14 @@
 import os
 
 import pytest
-from dbt.tests.adapter.hooks import test_run_hooks as core_base
+from dbt.tests.adapter.hooks.test_run_hooks import (
+    BaseAfterRunHooks,
+    BasePrePostRunHooks,
+)
 from fixtures import run_hook, test_run_operation
 
 
-class TestPrePostRunHooksMaterialize(core_base.TestPrePostRunHooks):
+class TestPrePostRunHooksMaterialize(BasePrePostRunHooks):
     @pytest.fixture(scope="function")
     def setUp(self, project):
         project.run_sql(f"drop table if exists { project.test_schema }.on_run_hook")
@@ -52,5 +55,5 @@ class TestPrePostRunHooksMaterialize(core_base.TestPrePostRunHooks):
         ), "invocation_id was not set"
 
 
-class TestAfterRunHooksMaterialize(core_base.TestAfterRunHooks):
+class TestAfterRunHooksMaterialize(BaseAfterRunHooks):
     pass


### PR DESCRIPTION
In #28990, we missed adding a `cascade` to the `materialize__drop_relation` macro for the `table` relation type. This causes seed full refreshes to fail if there are downstream dependencies, as reported by @matthelm [on Slack](https://materializeinc.slack.com/archives/C06SXUZ77QF/p1729282078737079).