### PR TITLE
Window aggregation fusion

### DIFF
--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -255,6 +255,7 @@ impl From<&OptimizerConfig> for mz_sql::plan::HirToMirConfig {
             enable_value_window_function_fusion: config
                 .features
                 .enable_value_window_function_fusion,
+            enable_window_aggregation_fusion: config.features.enable_window_aggregation_fusion,
         }
     }
 }

--- a/src/compute-types/src/plan/reduce.rs
+++ b/src/compute-types/src/plan/reduce.rs
@@ -1051,7 +1051,8 @@ pub fn reduction_type(func: &AggregateFunc) -> ReductionType {
         | AggregateFunc::FirstValue { .. }
         | AggregateFunc::LastValue { .. }
         | AggregateFunc::WindowAggregate { .. }
-        | AggregateFunc::FusedValueWindowFunc { .. } => ReductionType::Basic,
+        | AggregateFunc::FusedValueWindowFunc { .. }
+        | AggregateFunc::FusedWindowAggregate { .. } => ReductionType::Basic,
     }
 }
 

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -2519,7 +2519,8 @@ mod monoids {
             | AggregateFunc::FirstValue { .. }
             | AggregateFunc::LastValue { .. }
             | AggregateFunc::WindowAggregate { .. }
-            | AggregateFunc::FusedValueWindowFunc { .. } => None,
+            | AggregateFunc::FusedValueWindowFunc { .. }
+            | AggregateFunc::FusedWindowAggregate { .. } => None,
         }
     }
 }

--- a/src/expr/src/relation.proto
+++ b/src/expr/src/relation.proto
@@ -81,6 +81,12 @@ message ProtoAggregateFunc {
     mz_expr.relation.ProtoWindowFrame window_frame = 3;
   }
 
+  message ProtoFusedWindowAggregate {
+    repeated ProtoAggregateFunc wrapped_aggregates = 1;
+    ProtoColumnOrders order_by = 2;
+    mz_expr.relation.ProtoWindowFrame window_frame = 3;
+  }
+
   message ProtoFusedValueWindowFunc {
     repeated ProtoAggregateFunc funcs = 1;
     ProtoColumnOrders order_by = 2;
@@ -139,6 +145,7 @@ message ProtoAggregateFunc {
     ProtoFramedWindowFunc last_value = 42;
     ProtoWindowAggregate window_aggregate = 55;
     ProtoFusedValueWindowFunc fused_value_window_func = 57;
+    ProtoFusedWindowAggregate fused_window_aggregate = 68;
     google.protobuf.Empty max_uint16 = 43;
     google.protobuf.Empty max_uint32 = 44;
     google.protobuf.Empty max_uint64 = 45;

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -2484,7 +2484,9 @@ impl AggregateExpr {
         }
     }
 
-    /// Extracts unique input from aggregate type
+    /// Returns an expression that computes `self` on a group that has exactly one row.
+    /// Instead of performing a `Reduce` with `self`, one can perform a `Map` with the expression
+    /// returned by `on_unique`, which is cheaper. (See `ReduceElision`.)
     pub fn on_unique(&self, input_type: &[ColumnType]) -> MirScalarExpr {
         match &self.func {
             // Count is one if non-null, and zero if null.
@@ -3089,7 +3091,7 @@ impl AggregateExpr {
         return_type: ScalarType,
         wrapped_aggr: &AggregateFunc,
     ) -> (MirScalarExpr, ColumnName) {
-        // If the window frame includes the current (single) row, evaluate the aggregate on
+        // If the window frame includes the current (single) row, evaluate the wrapped aggregate on
         // that row. Otherwise, return the default value for the aggregate.
         let result_expr = if window_frame.includes_current_row() {
             AggregateExpr {

--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -121,6 +121,8 @@ optimizer_feature_flags!({
     enable_value_window_function_fusion: bool,
     // See the feature flag of the same name.
     enable_reduce_unnest_list_fusion: bool,
+    // See the feature flag of the same name.
+    enable_window_aggregation_fusion: bool,
 });
 
 /// A trait used to implement layered config construction.

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -28,6 +28,7 @@ Add
 Added
 Addresses
 Aggregate
+Aggregation
 Aligned
 All
 Alter

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2179,6 +2179,7 @@ pub enum ClusterFeatureName {
     EnableOuterJoinNullFilter,
     EnableValueWindowFunctionFusion,
     EnableReduceUnnestListFusion,
+    EnableWindowAggregationFusion,
 }
 
 impl WithOptionName for ClusterFeatureName {
@@ -2196,7 +2197,8 @@ impl WithOptionName for ClusterFeatureName {
             | Self::EnableLetrecFixpointAnalysis
             | Self::EnableOuterJoinNullFilter
             | Self::EnableValueWindowFunctionFusion
-            | Self::EnableReduceUnnestListFusion => false,
+            | Self::EnableReduceUnnestListFusion
+            | Self::EnableWindowAggregationFusion => false,
         }
     }
 }
@@ -3734,6 +3736,7 @@ pub enum ExplainPlanOptionName {
     EnableOuterJoinNullFilter,
     EnableValueWindowFunctionFusion,
     EnableReduceUnnestListFusion,
+    EnableWindowAggregationFusion,
 }
 
 impl WithOptionName for ExplainPlanOptionName {
@@ -3770,7 +3773,8 @@ impl WithOptionName for ExplainPlanOptionName {
             | Self::EnableLetrecFixpointAnalysis
             | Self::EnableOuterJoinNullFilter
             | Self::EnableValueWindowFunctionFusion
-            | Self::EnableReduceUnnestListFusion => false,
+            | Self::EnableReduceUnnestListFusion
+            | Self::EnableWindowAggregationFusion => false,
         }
     }
 }

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -138,7 +138,10 @@ pub struct Config {
     pub enable_variadic_left_join_lowering: bool,
     /// Enable the extra null filter implemented in materialize#28018.
     pub enable_outer_join_null_filter: bool,
+    /// See the feature flag of the same name.
     pub enable_value_window_function_fusion: bool,
+    /// See the feature flag of the same name.
+    pub enable_window_aggregation_fusion: bool,
 }
 
 impl From<&SystemVars> for Config {
@@ -148,6 +151,7 @@ impl From<&SystemVars> for Config {
             enable_variadic_left_join_lowering: vars.enable_variadic_left_join_lowering(),
             enable_outer_join_null_filter: vars.enable_outer_join_null_filter(),
             enable_value_window_function_fusion: vars.enable_value_window_function_fusion(),
+            enable_window_aggregation_fusion: vars.enable_window_aggregation_fusion(),
         }
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4165,7 +4165,8 @@ generate_extracted_config!(
     (EnableLetrecFixpointAnalysis, Option<bool>, Default(None)),
     (EnableOuterJoinNullFilter, Option<bool>, Default(None)),
     (EnableValueWindowFunctionFusion, Option<bool>, Default(None)),
-    (EnableReduceUnnestListFusion, Option<bool>, Default(None))
+    (EnableReduceUnnestListFusion, Option<bool>, Default(None)),
+    (EnableWindowAggregationFusion, Option<bool>, Default(None))
 );
 
 /// Convert a [`CreateClusterStatement`] into a [`Plan`].
@@ -4305,6 +4306,7 @@ pub fn plan_create_cluster_inner(
             enable_outer_join_null_filter,
             enable_value_window_function_fusion,
             enable_reduce_unnest_list_fusion,
+            enable_window_aggregation_fusion,
             seen: _,
         } = ClusterFeatureExtracted::try_from(features)?;
         let optimizer_feature_overrides = OptimizerFeatureOverrides {
@@ -4316,6 +4318,7 @@ pub fn plan_create_cluster_inner(
             enable_outer_join_null_filter,
             enable_value_window_function_fusion,
             enable_reduce_unnest_list_fusion,
+            enable_window_aggregation_fusion,
             ..Default::default()
         };
 
@@ -4413,6 +4416,7 @@ pub fn unplan_create_cluster(
                 enable_outer_join_null_filter,
                 enable_value_window_function_fusion,
                 enable_reduce_unnest_list_fusion,
+                enable_window_aggregation_fusion,
             } = optimizer_feature_overrides;
             let features_extracted = ClusterFeatureExtracted {
                 // Seen is ignored when unplanning.
@@ -4425,6 +4429,7 @@ pub fn unplan_create_cluster(
                 enable_outer_join_null_filter,
                 enable_value_window_function_fusion,
                 enable_reduce_unnest_list_fusion,
+                enable_window_aggregation_fusion,
             };
             let features = features_extracted.into_values(scx.catalog);
             let availability_zones = if availability_zones.is_empty() {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -371,7 +371,8 @@ generate_extracted_config!(
     (EnableLetrecFixpointAnalysis, Option<bool>, Default(None)),
     (EnableOuterJoinNullFilter, Option<bool>, Default(None)),
     (EnableValueWindowFunctionFusion, Option<bool>, Default(None)),
-    (EnableReduceUnnestListFusion, Option<bool>, Default(None))
+    (EnableReduceUnnestListFusion, Option<bool>, Default(None)),
+    (EnableWindowAggregationFusion, Option<bool>, Default(None))
 );
 
 impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
@@ -425,6 +426,7 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 reoptimize_imported_views: v.reoptimize_imported_views,
                 enable_value_window_function_fusion: v.enable_value_window_function_fusion,
                 enable_reduce_unnest_list_fusion: v.enable_reduce_unnest_list_fusion,
+                enable_window_aggregation_fusion: v.enable_window_aggregation_fusion,
             },
         })
     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2133,6 +2133,12 @@ feature_flags!(
         enable_for_item_parsing: false,
     },
     {
+        name: enable_window_aggregation_fusion,
+        desc: "Enables the window aggregation fusion optimization",
+        default: true,
+        enable_for_item_parsing: false,
+    },
+    {
         name: enable_reduce_unnest_list_fusion,
         desc: "Enables fusing `Reduce` with `FlatMap UnnestList` for better window function performance",
         default: true,
@@ -2165,6 +2171,7 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_outer_join_null_filter: vars.enable_outer_join_null_filter(),
             enable_value_window_function_fusion: vars.enable_value_window_function_fusion(),
             enable_reduce_unnest_list_fusion: vars.enable_reduce_unnest_list_fusion(),
+            enable_window_aggregation_fusion: vars.enable_window_aggregation_fusion(),
             persist_fast_path_limit: vars.persist_fast_path_limit(),
             reoptimize_imported_views: false,
         }

--- a/test/sqllogictest/transform/fold_constants.slt
+++ b/test/sqllogictest/transform/fold_constants.slt
@@ -159,8 +159,8 @@ statement ok
 DROP TABLE t2;
 
 ###
-# These tests are mostly the same as in from window_funcs.slt, but here it's WITH VALUES. These are good to have,
-# because constant folding is a different code path from the normal execution.
+# These tests were mostly copied (at some point) from `window_funcs.slt`, but here they have `WITH ... VALUES ...`, i.e.
+# constant inputs. These are good to have because constant folding is a different code path from the normal execution.
 ###
 
 mode cockroach
@@ -4196,3 +4196,24 @@ WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 18446744073709551614 FOLLOWING AND 18446744073709551615 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
+
+# Test window aggregations with and without fusion
+query III
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT
+  sum(f1)   OVER (ORDER BY f2) s,
+  max(f1)   OVER (ORDER BY f2) m,
+  count(f1) OVER (ORDER BY f3) c
+FROM t
+ORDER BY s, m, c;
+----
+8  3  1
+8  3  2
+8  3  3
+8  3  4
+16  4  5
+16  4  6
+22  4  7
+22  4  8
+22  4  9
+29  7  10

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -6147,7 +6147,7 @@ FROM (SELECT DISTINCT ON(x) * FROM t7);
 # - count's null handling
 # - count(*)
 # - FILTER clause
-# - Aggregations functions that are transformed away by `transform_ast.rs`: bool_and, bool_or.
+# - Aggregation functions that are transformed away by `transform_ast.rs`: bool_and, bool_or.
 # These are all supported by Postgres, and the output should be identical.
 query IIIIIITIIIITT
 SELECT
@@ -7089,6 +7089,23 @@ NULL
 NULL
 NULL
 
+query II
+SELECT
+  count(y) OVER (PARTITION BY x ROWS BETWEEN 2 PRECEDING AND 1 PRECEDING),
+  sum(y)   OVER (PARTITION BY x ROWS BETWEEN 2 PRECEDING AND 1 PRECEDING)
+FROM t9
+ORDER BY x;
+----
+0 NULL
+0 NULL
+0 NULL
+0 NULL
+0 NULL
+0 NULL
+0 NULL
+0 NULL
+0 NULL
+
 query T
 SELECT
   array_agg(y) OVER (PARTITION BY x ROWS BETWEEN 2 PRECEDING AND 1 PRECEDING)
@@ -7420,29 +7437,38 @@ SELECT
   lead(x,2,null)  OVER (PARTITION BY x ORDER BY -y NULLS FIRST),
   lead(x,2,null)  OVER (PARTITION BY x ORDER BY -y NULLS LAST),
   x+y,
-  lag(x+x,2,null) OVER (PARTITION BY x ORDER BY y)
+  lag(x+x,2,null) OVER (PARTITION BY x ORDER BY y),
+  sum(x)          OVER (ORDER BY x),
+  min(x)          OVER (ORDER BY x),
+  max(x)          OVER (ORDER BY y)
 FROM t7
 ORDER BY x,y;
 ----
 Explained Query:
-  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#11]
-    Project (#3, #4, #13, #12, #11, #14, #10, #6, #8, #7, #15, #5)
-      Map (record_get[1](#1), record_get[0](#2), record_get[1](#2), record_get[3](#2), record_get[4](#2), record_get[6](#2), record_get[8](#2), record_get[0](#1), record_get[0](#9), record_get[1](#9), record_get[2](#9), record_get[3](#9), (#3 * #4), (#3 + #4))
+  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#14]
+    Project (#3, #4, #16, #15, #14, #17, #13, #9, #11, #10, #18, #8, #7, #6, #5)
+      Map (record_get[1](#1), record_get[0](#2), record_get[1](#2), record_get[2](#2), record_get[4](#2), record_get[5](#2), record_get[7](#2), record_get[8](#2), record_get[10](#2), record_get[12](#2), record_get[0](#1), record_get[0](#12), record_get[1](#12), record_get[2](#12), record_get[3](#12), (#3 * #4), (#3 + #4))
         FlatMap unnest_list(#0)
-          Reduce aggregates=[fused_value_window_func[lag[order_by=[#0 asc nulls_last]], last_value[order_by=[#0 asc nulls_last]], first_value[order_by=[#0 asc nulls_last]], lag[order_by=[#0 asc nulls_last]] order_by=[#0 asc nulls_last]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[2](record_get[1](#0)), record_get[3](record_get[1](#0)), record_get[4](record_get[1](#0)), record_get[5](record_get[1](#0)), record_get[6](record_get[1](#0)), record_get[0](#0), record_get[0](#0)), row(row(record_get[1](record_get[1](#0)), 1, null), record_get[0](record_get[1](#0)), record_get[0](record_get[1](#0)), row(record_get[0](record_get[1](#0)), 1, null))), record_get[0](record_get[1](#0))))]
+          Reduce aggregates=[fused_value_window_func[lag[order_by=[#0 asc nulls_last]], last_value[order_by=[#0 asc nulls_last]], first_value[order_by=[#0 asc nulls_last]], lag[order_by=[#0 asc nulls_last]] order_by=[#0 asc nulls_last]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[2](record_get[1](#0)), record_get[3](record_get[1](#0)), record_get[4](record_get[1](#0)), record_get[5](record_get[1](#0)), record_get[6](record_get[1](#0)), record_get[7](record_get[1](#0)), record_get[8](record_get[1](#0)), record_get[9](record_get[1](#0)), record_get[10](record_get[1](#0)), record_get[0](#0), record_get[0](#0)), row(row(record_get[1](record_get[1](#0)), 1, null), record_get[0](record_get[1](#0)), record_get[0](record_get[1](#0)), row(record_get[0](record_get[1](#0)), 1, null))), record_get[0](record_get[1](#0))))]
             Project (#1)
               FlatMap unnest_list(#0)
                 Project (#1)
-                  Reduce group_by=[record_get[0](record_get[1](#0))] aggregates=[lead[order_by=[#0 asc nulls_first]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[2](record_get[1](#0)), record_get[3](record_get[1](#0)), record_get[4](record_get[1](#0)), record_get[0](#0), record_get[0](#0)), row(record_get[0](record_get[1](#0)), 2, null)), -(record_get[1](record_get[1](#0)))))]
+                  Reduce group_by=[record_get[0](record_get[1](#0))] aggregates=[lead[order_by=[#0 asc nulls_first]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[2](record_get[1](#0)), record_get[3](record_get[1](#0)), record_get[4](record_get[1](#0)), record_get[5](record_get[1](#0)), record_get[6](record_get[1](#0)), record_get[7](record_get[1](#0)), record_get[8](record_get[1](#0)), record_get[0](#0), record_get[0](#0)), row(record_get[0](record_get[1](#0)), 2, null)), -(record_get[1](record_get[1](#0)))))]
                     Project (#1)
                       FlatMap unnest_list(#0)
                         Project (#1)
-                          Reduce group_by=[record_get[0](record_get[1](#0))] aggregates=[lead[order_by=[#0 asc nulls_last]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[0](#0), record_get[0](record_get[0](#0)), record_get[1](record_get[0](#0))), row(record_get[0](record_get[1](#0)), 2, null)), -(record_get[1](record_get[1](#0)))))]
+                          Reduce group_by=[record_get[0](record_get[1](#0))] aggregates=[lead[order_by=[#0 asc nulls_last]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[2](record_get[1](#0)), record_get[3](record_get[1](#0)), record_get[4](record_get[1](#0)), record_get[5](record_get[1](#0)), record_get[0](#0), record_get[0](record_get[0](#0)), record_get[1](record_get[0](#0))), row(record_get[0](record_get[1](#0)), 2, null)), -(record_get[1](record_get[1](#0)))))]
                             Project (#1)
                               FlatMap unnest_list(#0)
                                 Project (#1)
-                                  Reduce group_by=[#0] aggregates=[fused_value_window_func[lag[order_by=[#0 asc nulls_last]], lag[order_by=[#0 asc nulls_last]] order_by=[#0 asc nulls_last]](row(row(row(#0, #1), row(row((#0 + #0), 2, null), row((#0 + #0), 1, null))), #1))]
-                                    ReadStorage materialize.public.t7
+                                  Reduce group_by=[record_get[0](record_get[1](#0))] aggregates=[fused_value_window_func[lag[order_by=[#0 asc nulls_last]], lag[order_by=[#0 asc nulls_last]] order_by=[#0 asc nulls_last]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[3](record_get[1](#0)), record_get[0](#0), record_get[0](record_get[0](#0)), record_get[1](record_get[0](#0))), row(row((record_get[0](record_get[1](#0)) + record_get[0](record_get[1](#0))), 2, null), row((record_get[0](record_get[1](#0)) + record_get[0](record_get[1](#0))), 1, null))), record_get[1](record_get[1](#0))))]
+                                    Project (#1)
+                                      FlatMap unnest_list(#0)
+                                        Reduce aggregates=[fused_window_agg(row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[0](#0), record_get[0](#0)), row(record_get[0](record_get[1](#0)), record_get[0](record_get[1](#0)))), record_get[0](record_get[1](#0))))]
+                                          Project (#1)
+                                            FlatMap unnest_list(#0)
+                                              Reduce aggregates=[window_agg[max order_by=[#0 asc nulls_last]](row(row(row(#0, #1), #0), #1))]
+                                                ReadStorage materialize.public.t7
 
 Source materialize.public.t7
 
@@ -7450,7 +7476,7 @@ Target cluster: quickstart
 
 EOF
 
-query IIIIIIIIIIII
+query IIIIIIIIIIIIIII
 SELECT
   *,
   lag(x)          OVER (ORDER BY x),
@@ -7462,21 +7488,24 @@ SELECT
   lead(x,2,null)  OVER (PARTITION BY x ORDER BY -y NULLS FIRST),
   lead(x,2,null)  OVER (PARTITION BY x ORDER BY -y NULLS LAST),
   x+y,
-  lag(x+x,2,null) OVER (PARTITION BY x ORDER BY y)
+  lag(x+x,2,null) OVER (PARTITION BY x ORDER BY y),
+  sum(x)          OVER (ORDER BY x),
+  min(x)          OVER (ORDER BY x),
+  max(x)          OVER (ORDER BY y)
 FROM t7
 ORDER BY x,y;
 ----
-1  2  NULL  1  1  2  NULL  NULL  NULL  NULL  3  NULL
-3  NULL  1  1  3  NULL  2  NULL  NULL  NULL  NULL  NULL
-5  6  3  1  5  30  NULL  NULL  NULL  NULL  11  NULL
-7  8  5  1  7  56  6  NULL  NULL  NULL  15  NULL
-9  NULL  7  1  9  NULL  8  NULL  NULL  NULL  NULL  NULL
-10  -50  9  1  10  -500  NULL  NULL  NULL  NULL  -40  NULL
-10  -40  10  1  10  -400  -50  20  NULL  NULL  -30  NULL
-11  NULL  10  1  11  NULL  -40  NULL  NULL  NULL  NULL  NULL
-13  14  11  1  13  182  NULL  NULL  NULL  NULL  27  NULL
-15  16  13  1  15  240  14  NULL  NULL  NULL  31  NULL
-17  18  15  1  17  306  16  NULL  NULL  NULL  35  NULL
+1  2  NULL  1  1  2  NULL  NULL  NULL  NULL  3  NULL  1  1  10
+3  NULL  1  1  3  NULL  2  NULL  NULL  NULL  NULL  NULL  4  1  17
+5  6  3  1  5  30  NULL  NULL  NULL  NULL  11  NULL  9  1  10
+7  8  5  1  7  56  6  NULL  NULL  NULL  15  NULL  16  1  10
+9  NULL  7  1  9  NULL  8  NULL  NULL  NULL  NULL  NULL  25  1  17
+10  -50  9  1  10  -500  NULL  NULL  NULL  NULL  -40  NULL  45  1  10
+10  -40  10  1  10  -400  -50  20  NULL  NULL  -30  NULL  45  1  10
+11  NULL  10  1  11  NULL  -40  NULL  NULL  NULL  NULL  NULL  56  1  17
+13  14  11  1  13  182  NULL  NULL  NULL  NULL  27  NULL  69  1  13
+15  16  13  1  15  240  14  NULL  NULL  NULL  31  NULL  84  1  15
+17  18  15  1  17  306  16  NULL  NULL  NULL  35  NULL  101  1  17
 
 # In the following query, currently we only fuse the two inner `lag`s.
 # In theory, we could also fuse the two `last_value`s.
@@ -7560,25 +7589,38 @@ ALTER SYSTEM SET enable_value_window_function_fusion = false
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_window_aggregation_fusion = false
+----
+COMPLETE 0
+
 query T multiline
 EXPLAIN
 SELECT
   *,
   lag(x) OVER (),
-  lag(y) OVER ()
+  lag(y) OVER (),
+  sum(x) OVER (),
+  min(x) OVER ()
 FROM t7
 ORDER BY x,y;
 ----
 Explained Query:
-  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#3]
-    Project (#3, #4, #6, #5)
-      Map (record_get[1](#1), record_get[0](#2), record_get[1](#2), record_get[3](#2), record_get[0](#1))
+  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#5]
+    Project (#3, #4, #8, #7, #6, #5)
+      Map (record_get[1](#1), record_get[0](#2), record_get[1](#2), record_get[3](#2), record_get[5](#2), record_get[7](#2), record_get[0](#1))
         FlatMap unnest_list(#0)
-          Reduce aggregates=[lag[order_by=[]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[0](#0), record_get[0](#0)), row(record_get[0](record_get[1](#0)), 1, null))))]
+          Reduce aggregates=[lag[order_by=[]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[2](record_get[1](#0)), record_get[3](record_get[1](#0)), record_get[4](record_get[1](#0)), record_get[5](record_get[1](#0)), record_get[0](#0), record_get[0](#0)), row(record_get[0](record_get[1](#0)), 1, null))))]
             Project (#1)
               FlatMap unnest_list(#0)
-                Reduce aggregates=[lag[order_by=[]](row(row(row(#0, #1), row(#1, 1, null))))]
-                  ReadStorage materialize.public.t7
+                Reduce aggregates=[lag[order_by=[]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[2](record_get[1](#0)), record_get[3](record_get[1](#0)), record_get[0](#0), record_get[0](#0)), row(record_get[1](record_get[1](#0)), 1, null))))]
+                  Project (#1)
+                    FlatMap unnest_list(#0)
+                      Reduce aggregates=[window_agg[sum order_by=[]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[0](#0), record_get[0](#0)), record_get[0](record_get[1](#0)))))]
+                        Project (#1)
+                          FlatMap unnest_list(#0)
+                            Reduce aggregates=[window_agg[min order_by=[]](row(row(row(#0, #1), #0)))]
+                              ReadStorage materialize.public.t7
 
 Source materialize.public.t7
 
@@ -7591,22 +7633,32 @@ ALTER SYSTEM SET enable_value_window_function_fusion = true
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_window_aggregation_fusion = true
+----
+COMPLETE 0
+
 query T multiline
 EXPLAIN
 SELECT
   *,
   lag(x) OVER (),
-  lag(y) OVER ()
+  lag(y) OVER (),
+  sum(x) OVER (),
+  min(x) OVER ()
 FROM t7
 ORDER BY x,y;
 ----
 Explained Query:
-  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#3]
-    Project (#3, #4, #7, #6)
-      Map (record_get[1](#1), record_get[0](#2), record_get[1](#2), record_get[0](#1), record_get[0](#5), record_get[1](#5))
+  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#5]
+    Project (#3, #4, #9, #8, #6, #5)
+      Map (record_get[1](#1), record_get[0](#2), record_get[1](#2), record_get[3](#2), record_get[4](#2), record_get[0](#1), record_get[0](#7), record_get[1](#7))
         FlatMap unnest_list(#0)
-          Reduce aggregates=[fused_value_window_func[lag[order_by=[]], lag[order_by=[]] order_by=[]](row(row(row(#0, #1), row(row(#1, 1, null), row(#0, 1, null)))))]
-            ReadStorage materialize.public.t7
+          Reduce aggregates=[fused_value_window_func[lag[order_by=[]], lag[order_by=[]] order_by=[]](row(row(row(record_get[0](record_get[1](#0)), record_get[1](record_get[1](#0)), record_get[0](#0), record_get[0](record_get[0](#0)), record_get[1](record_get[0](#0))), row(row(record_get[1](record_get[1](#0)), 1, null), row(record_get[0](record_get[1](#0)), 1, null)))))]
+            Project (#1)
+              FlatMap unnest_list(#0)
+                Reduce aggregates=[fused_window_agg(row(row(row(#0, #1), row(#0, #0))))]
+                  ReadStorage materialize.public.t7
 
 Source materialize.public.t7
 
@@ -7848,7 +7900,7 @@ ALTER SYSTEM SET enable_reduce_unnest_list_fusion = false
 COMPLETE 0
 
 # This is a new test.
-query IIIIIIIIIIIII
+query IIIIIIIIIIIIII
 SELECT
   *,
   first_value(
@@ -7865,21 +7917,22 @@ SELECT
   dense_rank() OVER (ORDER BY x),
   sum(y+3)     OVER (ORDER BY x),
   min(y+4)     OVER (PARTITION BY x%2 ORDER BY x),
-  x+y
+  x+y,
+  sum(y+5)     OVER (ORDER BY x)
 FROM t7
 ORDER BY x,y;
 ----
-1  2  1111  2  2222  3  NULL  1  1  1  5  6  3
-3  NULL  NULL  NULL  NULL  NULL  2  2  2  2  5  6  NULL
-5  6  1111  30  2222  11  NULL  3  3  3  14  6  11
-7  8  1111  56  2222  15  6  4  4  4  25  6  15
-9  NULL  NULL  NULL  NULL  NULL  8  5  5  5  25  6  NULL
-10  -50  1111  -500  2222  -40  NULL  6  6  6  -59  -46  -40
-10  -40  1111  -400  2222  -30  -50  7  6  6  -59  -46  -30
-11  NULL  NULL  NULL  NULL  NULL  -40  8  8  7  -59  6  NULL
-13  14  1111  182  2222  27  NULL  9  9  8  -42  6  27
-15  16  1111  240  2222  31  14  10  10  9  -23  6  31
-17  18  1111  306  2222  35  16  11  11  10  -2  6  35
+1  2  1111  2  2222  3  NULL  1  1  1  5  6  3  7
+3  NULL  NULL  NULL  NULL  NULL  2  2  2  2  5  6  NULL  7
+5  6  1111  30  2222  11  NULL  3  3  3  14  6  11  18
+7  8  1111  56  2222  15  6  4  4  4  25  6  15  31
+9  NULL  NULL  NULL  NULL  NULL  8  5  5  5  25  6  NULL  31
+10  -50  1111  -500  2222  -40  NULL  6  6  6  -59  -46  -40  -49
+10  -40  1111  -400  2222  -30  -50  7  6  6  -59  -46  -30  -49
+11  NULL  NULL  NULL  NULL  NULL  -40  8  8  7  -59  6  NULL  -49
+13  14  1111  182  2222  27  NULL  9  9  8  -42  6  27  -30
+15  16  1111  240  2222  31  14  10  10  9  -23  6  31  -9
+17  18  1111  306  2222  35  16  11  11  10  -2  6  35  14
 
 # These are copied from above.
 query III


### PR DESCRIPTION
This is the promised follow-up to https://github.com/MaterializeInc/materialize/pull/29276. That PR created an infrastructure for fusing groups of window functions, but implemented actual fusion only for value window functions. The current PR implements fusion also for window aggregations.

The HIR representation for fused window aggregations is somewhat different from fused value window functions, because window aggregations don't have an enum like `ValueWindowFunc`. I decided to add a fused variant to HIR's `AggregateFunc`. (Note that there are two `AggregateFunc`: one for HIR and one for MIR. MIR's `AggregateFunc` was also extended, but there is nothing surprising there.) I can't say that this is an elegant representation (especially since it's not possible to implement `identity_datum` for the new HIR aggregation), but I can't see a better approach. The alternatives that I considered are 1. create a new `WindowExprType` variant (say, `FusedAggregate`), 2. make `AggregateWindowExpr::aggregate_expr` a `Vec<AggregateExpr>`. Unfortunately, none of these alternatives would have less complications, as far as I can see.

In the HIR transform (`fuse_window_functions`), there is nothing surprising, despite the large diff. I just mechanically added window aggregations there; the fusion logic is the same as before (added in https://github.com/MaterializeInc/materialize/pull/29276).

In the rendering (`relation/func.rs`), the PR does a very similar code change as https://github.com/MaterializeInc/materialize/pull/29276 did: `window_aggr_inner` is factored out from `window_aggr_no_list`, and then called from both `window_aggr_no_list` and `fused_window_aggr`.

### Motivation

  * This PR adds a known-desirable optimization: https://github.com/MaterializeInc/database-issues/issues/8535 as part of https://github.com/MaterializeInc/database-issues/issues/6247. Note that this is important to https://github.com/MaterializeInc/accounts/issues/77.

### Tips for reviewer

The 1st commit just tweaks some comments.

The 2nd commit adds a feature flag for window aggregation fusion, but doesn't wire it up to any actual functionality yet.

The 3rd commit is the main one.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
  - `window_funcs.slt` has 37 occurrences of window aggregation fusion (including old and new tests).
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
