### PR TITLE
parallel-benchmark: Mark stddev as nullable

### DIFF
--- a/misc/python/materialize/test_analytics/setup/tables/12-parallel-benchmark.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/12-parallel-benchmark.sql
@@ -30,7 +30,7 @@ CREATE TABLE parallel_benchmark_result (
    p99_9999 DOUBLE,
    p99_99999 DOUBLE,
    p99_999999 DOUBLE,
-   std DOUBLE NOT NULL,
+   std DOUBLE,
    slope DOUBLE NOT NULL
 );
 


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
