### PR TITLE
adapter: Delete dead code

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -605,7 +605,6 @@ impl ExecuteResponse {
             | AlterOwner
             | AlterItemRename
             | AlterRetainHistory
-            | AlterItemSwap
             | AlterNoop
             | AlterSchemaRename
             | AlterSchemaSwap

--- a/src/adapter/src/coord/catalog_serving.rs
+++ b/src/adapter/src/coord/catalog_serving.rs
@@ -115,7 +115,6 @@ pub fn auto_run_on_catalog_server<'a, 's, 'p>(
         | Plan::AlterSource(_)
         | Plan::AlterSetCluster(_)
         | Plan::AlterItemRename(_)
-        | Plan::AlterItemSwap(_)
         | Plan::AlterRetainHistory(_)
         | Plan::AlterSchemaRename(_)
         | Plan::AlterSchemaSwap(_)

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -426,11 +426,6 @@ impl Coordinator {
                         .await;
                     ctx.retire(result);
                 }
-                Plan::AlterItemSwap(_plan) => {
-                    // Note: we should never reach this point because we return an unsupported error in
-                    // planning.
-                    ctx.retire(Err(AdapterError::Unsupported("ALTER ... SWAP ...")));
-                }
                 Plan::AlterSchemaRename(plan) => {
                     let result = self
                         .sequence_alter_schema_rename(ctx.session_mut(), plan)

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -175,7 +175,6 @@ pub enum Plan {
     AlterClusterRename(AlterClusterRenamePlan),
     AlterClusterReplicaRename(AlterClusterReplicaRenamePlan),
     AlterItemRename(AlterItemRenamePlan),
-    AlterItemSwap(AlterItemSwapPlan),
     AlterSchemaRename(AlterSchemaRenamePlan),
     AlterSchemaSwap(AlterSchemaSwapPlan),
     AlterSecret(AlterSecretPlan),
@@ -223,7 +222,6 @@ impl Plan {
             ],
             StatementKind::AlterObjectSwap => &[
                 PlanKind::AlterClusterSwap,
-                PlanKind::AlterItemSwap,
                 PlanKind::AlterSchemaSwap,
                 PlanKind::AlterNoop,
             ],
@@ -401,7 +399,6 @@ impl Plan {
             Plan::AlterConnection(_) => "alter connection",
             Plan::AlterSource(_) => "alter source",
             Plan::AlterItemRename(_) => "rename item",
-            Plan::AlterItemSwap(_) => "swap item",
             Plan::AlterSchemaRename(_) => "alter rename schema",
             Plan::AlterSchemaSwap(_) => "alter swap schema",
             Plan::AlterSecret(_) => "alter secret",
@@ -1186,15 +1183,6 @@ pub struct AlterClusterSwapPlan {
     pub name_a: String,
     pub name_b: String,
     pub name_temp: String,
-}
-
-#[derive(Debug)]
-pub struct AlterItemSwapPlan {
-    pub id_a: GlobalId,
-    pub id_b: GlobalId,
-    pub full_name_a: FullItemName,
-    pub full_name_b: FullItemName,
-    pub object_type: ObjectType,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -1076,16 +1076,6 @@ fn generate_rbac_requirements(
             ownership: vec![ObjectId::Item(*id)],
             ..Default::default()
         },
-        Plan::AlterItemSwap(plan::AlterItemSwapPlan {
-            id_a,
-            id_b,
-            full_name_a: _,
-            full_name_b: _,
-            object_type: _,
-        }) => RbacRequirements {
-            ownership: vec![ObjectId::Item(*id_a), ObjectId::Item(*id_b)],
-            ..Default::default()
-        },
         Plan::AlterSchemaRename(plan::AlterSchemaRenamePlan {
             cur_schema_spec,
             new_schema_name: _,


### PR DESCRIPTION
As it says in the title!

### Motivation

Code cleanup

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
