### PR TITLE
controller/compute: sequence external read hold changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4903,6 +4903,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "crossbeam-channel",
+ "derivative",
  "differential-dataflow",
  "futures",
  "http 1.1.0",

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -119,7 +119,7 @@ impl TimestampProvider for Frontiers {
 
         let mock_read_hold = |id, frontier| {
             let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-            ReadHold::new(id, frontier, tx)
+            ReadHold::with_channel(id, frontier, tx)
         };
 
         for (instance_id, ids) in id_bundle.compute_ids.iter() {

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -17,6 +17,7 @@ bytes = "1.3.0"
 bytesize = "1.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.8"
+derivative = "2.2.0"
 differential-dataflow = "0.13.2"
 futures = "0.3.25"
 http = "1.1.0"

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -944,7 +944,7 @@ mod tests {
                     .get(&id)
                     .ok_or(ReadHoldError::CollectionMissing(id))?;
                 let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-                holds.push(ReadHold::new(id, read.clone(), tx));
+                holds.push(ReadHold::with_channel(id, read.clone(), tx));
             }
             Ok(holds)
         }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -1177,7 +1177,7 @@ impl<T: ComputeControllerTimestamp> InstanceState<T> {
             since
         });
 
-        let hold = ReadHold::new(id, since, self.read_holds_tx.clone());
+        let hold = ReadHold::with_channel(id, since, self.read_holds_tx.clone());
         Ok(hold)
     }
 

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -2182,8 +2182,8 @@ impl<T: ComputeControllerTimestamp> CollectionState<T> {
         // Initialize collection read holds.
         // Note that the implied read hold was already added to the `read_capabilities` when
         // `shared` was created, so we only need to add the warmup read hold here.
-        let implied_read_hold = ReadHold::new(collection_id, since.clone(), read_holds_tx.clone());
-        let warmup_read_hold = ReadHold::new(collection_id, since.clone(), read_holds_tx);
+        let implied_read_hold = ReadHold::with_channel(collection_id, since.clone(), read_holds_tx.clone());
+        let warmup_read_hold = ReadHold::with_channel(collection_id, since.clone(), read_holds_tx);
 
         let updates = warmup_read_hold.since().iter().map(|t| (t.clone(), 1));
         shared.lock_read_capabilities(|c| {

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -38,7 +38,7 @@ use mz_repr::adt::interval::Interval;
 use mz_repr::refresh_schedule::RefreshSchedule;
 use mz_repr::{Datum, Diff, GlobalId, Row};
 use mz_storage_client::controller::IntrospectionType;
-use mz_storage_types::read_holds::ReadHold;
+use mz_storage_types::read_holds::{self, ReadHold};
 use mz_storage_types::read_policy::ReadPolicy;
 use serde::Serialize;
 use thiserror::Error;
@@ -130,15 +130,23 @@ impl From<CollectionMissing> for ReadPolicyError {
 pub type Command<T> = Box<dyn FnOnce(&mut Instance<T>) + Send>;
 
 /// A client for an [`Instance`] task.
-#[derive(Debug, Clone)]
+#[derive(Clone, derivative::Derivative)]
+#[derivative(Debug)]
 pub(super) struct Client<T: ComputeControllerTimestamp> {
     /// A sender for commands for the instance.
     command_tx: mpsc::UnboundedSender<Command<T>>,
+    /// A sender for read hold changes for collections installed on the instance.
+    #[derivative(Debug = "ignore")]
+    read_hold_tx: read_holds::ChangeTx<T>,
 }
 
 impl<T: ComputeControllerTimestamp> Client<T> {
     pub fn send(&self, command: Command<T>) -> Result<(), SendError<Command<T>>> {
         self.command_tx.send(command)
+    }
+
+    pub fn read_hold_tx(&self) -> read_holds::ChangeTx<T> {
+        Arc::clone(&self.read_hold_tx)
     }
 }
 
@@ -162,6 +170,17 @@ where
     ) -> Self {
         let (command_tx, command_rx) = mpsc::unbounded_channel();
 
+        let read_hold_tx: read_holds::ChangeTx<_> = {
+            let command_tx = command_tx.clone();
+            Arc::new(move |id, change: ChangeBatch<_>| {
+                let cmd: Command<_> = {
+                    let change = change.clone();
+                    Box::new(move |i| i.apply_read_hold_change(id, change.clone()))
+                };
+                command_tx.send(cmd).map_err(|_| SendError((id, change)))
+            })
+        };
+
         mz_ore::task::spawn(
             || format!("compute-instance-{id}"),
             Instance::new(
@@ -175,12 +194,16 @@ where
                 dyncfg,
                 command_rx,
                 response_tx,
+                Arc::clone(&read_hold_tx),
                 introspection_tx,
             )
             .run(),
         );
 
-        Self { command_tx }
+        Self {
+            command_tx,
+            read_hold_tx,
+        }
     }
 }
 
@@ -273,11 +296,7 @@ pub(super) struct Instance<T: ComputeControllerTimestamp> {
     ///
     /// Copies of this sender are given to [`ReadHold`]s that are created in
     /// [`CollectionState::new`].
-    read_holds_tx: mpsc::UnboundedSender<(GlobalId, ChangeBatch<T>)>,
-    /// Receiver for updates to collection read holds.
-    ///
-    /// Received updates are applied by [`Instance::apply_read_hold_changes`].
-    read_holds_rx: mpsc::UnboundedReceiver<(GlobalId, ChangeBatch<T>)>,
+    read_hold_tx: read_holds::ChangeTx<T>,
     /// A sender for responses from replicas.
     replica_tx: mz_ore::channel::InstrumentedUnboundedSender<ReplicaResponse<T>, IntCounter>,
     /// A receiver for responses from replicas.
@@ -355,7 +374,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
             shared,
             storage_dependencies,
             compute_dependencies,
-            self.read_holds_tx.clone(),
+            Arc::clone(&self.read_hold_tx),
             introspection,
         );
         // If the collection is write-only, clear its read policy to reflect that.
@@ -720,17 +739,6 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
             .expect("Cannot error if target_replica_ids is None")
     }
 
-    /// Report an external read hold change.
-    ///
-    /// Changes to externally held read holds are sequenced through `command_rx`, to ensure that,
-    /// e.g., we don't receive changes for a collection before we have seen its creation command.
-    #[mz_ore::instrument(level = "debug")]
-    pub fn report_read_hold_change(&self, id: GlobalId, changes: ChangeBatch<T>) {
-        self.read_holds_tx
-            .send((id, changes))
-            .expect("rx is held by `self`");
-    }
-
     /// Clean up collection state that is not needed anymore.
     ///
     /// Three conditions need to be true before we can remove state for a collection:
@@ -798,8 +806,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
             now: _,
             wallclock_lag: _,
             wallclock_lag_last_refresh,
-            read_holds_tx: _,
-            read_holds_rx: _,
+            read_hold_tx: _,
             replica_tx: _,
             replica_rx: _,
         } = self;
@@ -867,17 +874,16 @@ where
         dyncfg: Arc<ConfigSet>,
         command_rx: mpsc::UnboundedReceiver<Command<T>>,
         response_tx: mpsc::UnboundedSender<ComputeControllerResponse<T>>,
+        read_hold_tx: read_holds::ChangeTx<T>,
         introspection_tx: crossbeam_channel::Sender<IntrospectionUpdates>,
     ) -> Self {
-        let (read_holds_tx, read_holds_rx) = mpsc::unbounded_channel();
-
         let mut collections = BTreeMap::new();
         let mut log_sources = BTreeMap::new();
         for (log, id, shared) in arranged_logs {
             let collection = CollectionState::new_log_collection(
                 id,
                 shared,
-                read_holds_tx.clone(),
+                Arc::clone(&read_hold_tx),
                 introspection_tx.clone(),
             );
             collections.insert(id, collection);
@@ -912,8 +918,7 @@ where
             now,
             wallclock_lag,
             wallclock_lag_last_refresh: Instant::now(),
-            read_holds_tx,
-            read_holds_rx,
+            read_hold_tx,
             replica_tx,
             replica_rx,
         }
@@ -994,14 +999,11 @@ where
 
         // Apply all outstanding read hold changes. This might cause read hold downgrades to be
         // added to `command_tx`, so we need to apply those in a loop.
-        while !self.read_holds_rx.is_empty() {
-            self.apply_read_hold_changes();
-
-            // TODO(teskje): Make `Command` an enum and assert that all received commands are read
-            // hold downgrades.
-            while let Ok(cmd) = command_rx.try_recv() {
-                cmd(self);
-            }
+        //
+        // TODO(teskje): Make `Command` an enum and assert that all received commands are read
+        // hold downgrades.
+        while let Ok(cmd) = command_rx.try_recv() {
+            cmd(self);
         }
 
         // Collections might have been dropped but not cleaned up yet.
@@ -1670,86 +1672,62 @@ where
         });
     }
 
-    /// Apply collection read hold changes pending in `read_holds_rx`.
-    fn apply_read_hold_changes(&mut self) {
-        let mut allowed_compaction = BTreeMap::new();
-
-        // It's more efficient to apply updates for greater IDs before updates for smaller IDs,
-        // since ID order usually matches dependency order and downgrading read holds on a
-        // collection can cause downgrades on its dependencies. So instead of processing changes as
-        // they come in, we batch them up as much as we can and process them in reverse ID order.
-        let mut recv_batch = || {
-            let mut batch = BTreeMap::<_, ChangeBatch<_>>::new();
-            while let Ok((id, mut update)) = self.read_holds_rx.try_recv() {
-                batch
-                    .entry(id)
-                    .and_modify(|e| e.extend(update.drain()))
-                    .or_insert(update);
-            }
-
-            let has_updates = !batch.is_empty();
-            has_updates.then_some(batch)
+    /// Apply a collection read hold change.
+    fn apply_read_hold_change(&mut self, id: GlobalId, mut update: ChangeBatch<T>) {
+        let Some(collection) = self.collections.get_mut(&id) else {
+            soft_panic_or_log!(
+                "read hold change for absent collection (id={id}, changes={update:?})"
+            );
+            return;
         };
 
-        while let Some(batch) = recv_batch() {
-            for (id, mut update) in batch.into_iter().rev() {
-                let Some(collection) = self.collections.get_mut(&id) else {
-                    soft_panic_or_log!(
-                        "read hold change for absent collection (id={id}, changes={update:?})"
-                    );
-                    continue;
-                };
-
-                let new_since = collection.shared.lock_read_capabilities(|caps| {
-                    // Sanity check to prevent corrupted `read_capabilities`, which can cause hard-to-debug
-                    // issues (usually stuck read frontiers).
-                    let read_frontier = caps.frontier();
-                    for (time, diff) in update.iter() {
-                        let count = caps.count_for(time) + diff;
-                        assert!(
-                            count >= 0,
-                            "invalid read capabilities update: negative capability \
-                     (id={id:?}, read_capabilities={caps:?}, update={update:?})",
-                        );
-                        assert!(
-                            count == 0 || read_frontier.less_equal(time),
-                            "invalid read capabilities update: frontier regression \
-                     (id={id:?}, read_capabilities={caps:?}, update={update:?})",
-                        );
-                    }
-
-                    // Apply read capability updates and learn about resulting changes to the read
-                    // frontier.
-                    let changes = caps.update_iter(update.drain());
-
-                    let changed = changes.count() > 0;
-                    changed.then(|| caps.frontier().to_owned())
-                });
-
-                let Some(new_since) = new_since else {
-                    continue; // read frontier did not change
-                };
-
-                // Propagate read frontier update to dependencies.
-                for read_hold in collection.compute_dependencies.values_mut() {
-                    read_hold
-                        .try_downgrade(new_since.clone())
-                        .expect("frontiers don't regress");
-                }
-                for read_hold in collection.storage_dependencies.values_mut() {
-                    read_hold
-                        .try_downgrade(new_since.clone())
-                        .expect("frontiers don't regress");
-                }
-
-                allowed_compaction.insert(id, new_since);
+        let new_since = collection.shared.lock_read_capabilities(|caps| {
+            // Sanity check to prevent corrupted `read_capabilities`, which can cause hard-to-debug
+            // issues (usually stuck read frontiers).
+            let read_frontier = caps.frontier();
+            for (time, diff) in update.iter() {
+                let count = caps.count_for(time) + diff;
+                assert!(
+                    count >= 0,
+                    "invalid read capabilities update: negative capability \
+             (id={id:?}, read_capabilities={caps:?}, update={update:?})",
+                );
+                assert!(
+                    count == 0 || read_frontier.less_equal(time),
+                    "invalid read capabilities update: frontier regression \
+             (id={id:?}, read_capabilities={caps:?}, update={update:?})",
+                );
             }
+
+            // Apply read capability updates and learn about resulting changes to the read
+            // frontier.
+            let changes = caps.update_iter(update.drain());
+
+            let changed = changes.count() > 0;
+            changed.then(|| caps.frontier().to_owned())
+        });
+
+        let Some(new_since) = new_since else {
+            return; // read frontier did not change
+        };
+
+        // Propagate read frontier update to dependencies.
+        for read_hold in collection.compute_dependencies.values_mut() {
+            read_hold
+                .try_downgrade(new_since.clone())
+                .expect("frontiers don't regress");
+        }
+        for read_hold in collection.storage_dependencies.values_mut() {
+            read_hold
+                .try_downgrade(new_since.clone())
+                .expect("frontiers don't regress");
         }
 
-        // Produce `AllowCompaction` commands.
-        for (id, frontier) in allowed_compaction {
-            self.send(ComputeCommand::AllowCompaction { id, frontier });
-        }
+        // Produce `AllowCompaction` command.
+        self.send(ComputeCommand::AllowCompaction {
+            id,
+            frontier: new_since,
+        });
     }
 
     /// Fulfills a registered peek and cleans up associated state.
@@ -2098,7 +2076,6 @@ where
     pub fn maintain(&mut self) {
         self.rehydrate_failed_replicas();
         self.downgrade_warmup_capabilities();
-        self.apply_read_hold_changes();
         self.schedule_collections();
         self.cleanup_collections();
         self.update_frontier_introspection();
@@ -2171,7 +2148,7 @@ impl<T: ComputeControllerTimestamp> CollectionState<T> {
         shared: SharedCollectionState<T>,
         storage_dependencies: BTreeMap<GlobalId, ReadHold<T>>,
         compute_dependencies: BTreeMap<GlobalId, ReadHold<T>>,
-        read_holds_tx: mpsc::UnboundedSender<(GlobalId, ChangeBatch<T>)>,
+        read_hold_tx: read_holds::ChangeTx<T>,
         introspection: CollectionIntrospection<T>,
     ) -> Self {
         // A collection is not readable before the `as_of`.
@@ -2187,8 +2164,8 @@ impl<T: ComputeControllerTimestamp> CollectionState<T> {
         // Note that the implied read hold was already added to the `read_capabilities` when
         // `shared` was created, so we only need to add the warmup read hold here.
         let implied_read_hold =
-            ReadHold::with_channel(collection_id, since.clone(), read_holds_tx.clone());
-        let warmup_read_hold = ReadHold::with_channel(collection_id, since.clone(), read_holds_tx);
+            ReadHold::new(collection_id, since.clone(), Arc::clone(&read_hold_tx));
+        let warmup_read_hold = ReadHold::new(collection_id, since.clone(), read_hold_tx);
 
         let updates = warmup_read_hold.since().iter().map(|t| (t.clone(), 1));
         shared.lock_read_capabilities(|c| {
@@ -2213,7 +2190,7 @@ impl<T: ComputeControllerTimestamp> CollectionState<T> {
     fn new_log_collection(
         id: GlobalId,
         shared: SharedCollectionState<T>,
-        read_holds_tx: mpsc::UnboundedSender<(GlobalId, ChangeBatch<T>)>,
+        read_hold_tx: read_holds::ChangeTx<T>,
         introspection_tx: crossbeam_channel::Sender<IntrospectionUpdates>,
     ) -> Self {
         let since = Antichain::from_elem(T::minimum());
@@ -2225,7 +2202,7 @@ impl<T: ComputeControllerTimestamp> CollectionState<T> {
             shared,
             Default::default(),
             Default::default(),
-            read_holds_tx,
+            read_hold_tx,
             introspection,
         );
         state.log_collection = true;
@@ -2277,7 +2254,7 @@ pub(super) struct SharedCollectionState<T> {
     /// This accumulation contains the capabilities held by all [`ReadHold`]s given out for the
     /// collection, including `implied_read_hold` and `warmup_read_hold`.
     ///
-    /// NOTE: This field may only be modified by [`Instance::apply_read_hold_changes`] and
+    /// NOTE: This field may only be modified by [`Instance::apply_read_hold_change`] and
     /// `ComputeController::acquire_read_hold`. Nobody else should modify read capabilities
     /// directly. Instead, collection users should manage read holds through [`ReadHold`] objects
     /// acquired through `ComputeController::acquire_read_hold`.

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1996,7 +1996,7 @@ where
 
         let acquired_holds = advanced_holds
             .into_iter()
-            .map(|(id, since)| ReadHold::new(id, since, self.holds_tx.clone()))
+            .map(|(id, since)| ReadHold::with_channel(id, since, self.holds_tx.clone()))
             .collect_vec();
 
         trace!(?desired_holds, ?acquired_holds, "acquire_read_holds");


### PR DESCRIPTION
Changes to `ReadHold`s on compute collections are now sequenced through the `command_{tx,rx}` channels of the respective `Instance` controllers. This ensures that `Instance`s observe read hold changes always after they have observed the creation of the affected collection, which wasn't the case previously.

The implementation includes a change to the `ReadHold` type, which now contains a sender closure, rather than a channel sender directly. The closure enables the construction of `ReadHold`s that communicate changes on a channel with an item type different from `(GlobalId, ChangeBatch)`.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8679

### Tips for reviewer

This PR required touching a lot more parts than I initially expected, so it ended up quite busy. I managed to split out sensible commits though, looking at those separately makes the reviewing experience much better!

The above mentioned bug has already been mitigated in https://github.com/MaterializeInc/materialize/pull/30109. This PR delivers an alternative fix that requires more restructuring but lets us end up in a saner state with fewer things moving concurrently. For example, with the other fix we have to always assume read hold changes for unknown collections are for future collections, which would make us miss bugs where we wrongly issue read hold changes for already dropped collections.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
