### PR TITLE
mzcompose: Higher stop grace periods for materialized/clusterd

### DIFF
--- a/misc/python/materialize/mzcompose/service.py
+++ b/misc/python/materialize/mzcompose/service.py
@@ -168,6 +168,9 @@ class ServiceConfig(TypedDict, total=False):
     publish: bool | None
     """Override whether an image is publishable. Unpublishable images can be built during normal test runs in CI."""
 
+    stop_grace_period: str | None
+    """Time to wait when stopping a container."""
+
 
 class Service:
     """A Docker Compose service in a `Composition`.

--- a/misc/python/materialize/mzcompose/services/clusterd.py
+++ b/misc/python/materialize/mzcompose/services/clusterd.py
@@ -25,6 +25,7 @@ class Clusterd(Service):
         memory: str | None = None,
         options: list[str] = [],
         restart: str = "no",
+        stop_grace_period: str = "60s",
     ) -> None:
         environment = [
             "CLUSTERD_LOG_FILTER",
@@ -60,6 +61,7 @@ class Clusterd(Service):
                 "environment": environment,
                 "volumes": DEFAULT_MZ_VOLUMES,
                 "restart": restart,
+                "stop_grace_period": stop_grace_period,
             }
         )
 

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -59,6 +59,7 @@ class Materialized(Service):
         deploy_generation: int | None = None,
         force_migrations: str | None = None,
         publish: bool | None = None,
+        stop_grace_period: str = "60s",
     ) -> None:
         if name is None:
             name = "materialized"
@@ -260,6 +261,7 @@ class Materialized(Service):
                     # A fully loaded Materialize can take a long time to start.
                     "start_period": "600s",
                 },
+                "stop_grace_period": stop_grace_period,
             }
         )
 


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/release-qualification/builds/644#01929d98-489f-4cb5-86c7-1368f303e512
So far so good: https://buildkite.com/materialize/release-qualification/builds/657

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
