### PR TITLE
ci: Switch to CRDB on release branches

### DIFF
--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -21,7 +21,7 @@ from materialize.cli.run import SANITIZER_TARGET
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.minio import Minio
-from materialize.mzcompose.services.postgres import Postgres, PostgresAsCockroach
+from materialize.mzcompose.services.postgres import CockroachOrPostgres, Postgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.zookeeper import Zookeeper
 from materialize.rustc_flags import Sanitizer
@@ -41,7 +41,7 @@ SERVICES = [
     ),
     SchemaRegistry(),
     Postgres(image="postgres:14.2"),
-    PostgresAsCockroach(),
+    CockroachOrPostgres(),
     Minio(
         # We need a stable port exposed to the host since we can't pass any arguments
         # to the .pt files used in the tests.

--- a/misc/python/materialize/mzcompose/services/postgres.py
+++ b/misc/python/materialize/mzcompose/services/postgres.py
@@ -15,6 +15,7 @@ from materialize.mzcompose.service import (
     Service,
     ServiceConfig,
 )
+from materialize.mzcompose.services.cockroach import Cockroach
 
 
 class Postgres(Service):
@@ -78,3 +79,8 @@ class PostgresAsCockroach(Postgres):
         self,
     ) -> None:
         super().__init__(name="cockroach", setup_materialize=True, ports=["26257"])
+
+
+CockroachOrPostgres = (
+    Cockroach if os.getenv("BUILDKITE_TAG", "").startswith("v") else PostgresAsCockroach
+)

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -27,7 +27,7 @@ from materialize.mzcompose.services.materialized import (
     Materialized,
 )
 from materialize.mzcompose.services.mysql import MySql
-from materialize.mzcompose.services.postgres import Postgres, PostgresAsCockroach
+from materialize.mzcompose.services.postgres import CockroachOrPostgres, Postgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
@@ -43,7 +43,7 @@ SERVICES = [
     Zookeeper(),
     Kafka(),
     SchemaRegistry(),
-    PostgresAsCockroach(),
+    CockroachOrPostgres(),
     Materialized(
         name="mz_old",
         sanity_restart=False,

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -35,7 +35,7 @@ from materialize.mzcompose.composition import (
 )
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mz import Mz
-from materialize.mzcompose.services.postgres import PostgresAsCockroach
+from materialize.mzcompose.services.postgres import CockroachOrPostgres
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.redpanda_cloud import RedpandaCloud
 from materialize.ui import UIError
@@ -193,7 +193,7 @@ class Redpanda:
 
 
 SERVICES = [
-    PostgresAsCockroach(),
+    CockroachOrPostgres(),
     Materialized(
         # We use materialize/environmentd and not materialize/materialized here
         # in order to ensure a perfect match to the container that should be

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -40,7 +40,7 @@ from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.localstack import Localstack
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Minio
-from materialize.mzcompose.services.postgres import Postgres, PostgresAsCockroach
+from materialize.mzcompose.services.postgres import CockroachOrPostgres, Postgres
 from materialize.mzcompose.services.redpanda import Redpanda
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
@@ -62,7 +62,7 @@ SERVICES = [
         propagate_crashes=False,
         external_cockroach=True,
     ),
-    PostgresAsCockroach(),
+    CockroachOrPostgres(),
     Postgres(),
     Redpanda(),
     Toxiproxy(),

--- a/test/data-ingest/mzcompose.py
+++ b/test/data-ingest/mzcompose.py
@@ -30,7 +30,7 @@ from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Minio
 from materialize.mzcompose.services.mysql import MySql
-from materialize.mzcompose.services.postgres import Postgres, PostgresAsCockroach
+from materialize.mzcompose.services.postgres import CockroachOrPostgres, Postgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.zookeeper import Zookeeper
 
@@ -48,7 +48,7 @@ SERVICES = [
         ],
     ),
     SchemaRegistry(),
-    PostgresAsCockroach(),
+    CockroachOrPostgres(),
     Minio(setup_materialize=True),
     # Fixed port so that we keep the same port after restarting Mz in disruptions
     Materialized(

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -33,7 +33,7 @@ from launchdarkly_api.model.variation import Variation  # type: ignore
 from materialize.mzcompose import DEFAULT_MZ_ENVIRONMENT_ID, DEFAULT_ORG_ID
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.materialized import Materialized
-from materialize.mzcompose.services.postgres import PostgresAsCockroach
+from materialize.mzcompose.services.postgres import CockroachOrPostgres
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.ui import UIError
 
@@ -53,7 +53,7 @@ LD_CONTEXT_KEY = DEFAULT_MZ_ENVIRONMENT_ID
 LD_FEATURE_FLAG_KEY = f"ci-test-{BUILDKITE_JOB_ID}"
 
 SERVICES = [
-    PostgresAsCockroach(),
+    CockroachOrPostgres(),
     Materialized(
         environment_extra=[
             f"MZ_LAUNCHDARKLY_SDK_KEY={LAUNCHDARKLY_SDK_KEY}",

--- a/test/output-consistency/mzcompose.py
+++ b/test/output-consistency/mzcompose.py
@@ -15,7 +15,7 @@ dataflow rendering and constant folding).
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mz import Mz
-from materialize.mzcompose.services.postgres import PostgresAsCockroach
+from materialize.mzcompose.services.postgres import CockroachOrPostgres
 from materialize.mzcompose.test_result import FailedTestExecutionError
 from materialize.output_consistency.execution.query_output_mode import QueryOutputMode
 from materialize.output_consistency.output_consistency_test import (
@@ -24,7 +24,7 @@ from materialize.output_consistency.output_consistency_test import (
 )
 
 SERVICES = [
-    PostgresAsCockroach(),
+    CockroachOrPostgres(),
     Materialized(propagate_crashes=True, external_cockroach=True),
     Mz(app_password=""),
 ]

--- a/test/postgres-consistency/mzcompose.py
+++ b/test/postgres-consistency/mzcompose.py
@@ -14,7 +14,7 @@ Test the consistency of Materialize against Postgres as an oracle.
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mz import Mz
-from materialize.mzcompose.services.postgres import Postgres, PostgresAsCockroach
+from materialize.mzcompose.services.postgres import CockroachOrPostgres, Postgres
 from materialize.mzcompose.test_result import FailedTestExecutionError
 from materialize.output_consistency.execution.query_output_mode import QueryOutputMode
 from materialize.output_consistency.output_consistency_test import (
@@ -25,7 +25,7 @@ from materialize.postgres_consistency.postgres_consistency_test import (
 )
 
 SERVICES = [
-    PostgresAsCockroach(),
+    CockroachOrPostgres(),
     Materialized(propagate_crashes=True, external_cockroach=True),
     Postgres(),
     Mz(app_password=""),

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -23,7 +23,7 @@ from psycopg.errors import OperationalError
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
-from materialize.mzcompose.services.postgres import PostgresAsCockroach
+from materialize.mzcompose.services.postgres import CockroachOrPostgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
@@ -42,7 +42,7 @@ SERVICES = [
         ],
     ),
     testdrive_no_reset,
-    PostgresAsCockroach(),
+    CockroachOrPostgres(),
 ]
 
 

--- a/test/retain-history/mzcompose.py
+++ b/test/retain-history/mzcompose.py
@@ -15,11 +15,11 @@ from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.materialized import Materialized
-from materialize.mzcompose.services.postgres import PostgresAsCockroach
+from materialize.mzcompose.services.postgres import CockroachOrPostgres
 from materialize.mzcompose.services.testdrive import Testdrive
 
 SERVICES = [
-    PostgresAsCockroach(),
+    CockroachOrPostgres(),
     Materialized(propagate_crashes=True, external_cockroach=True),
     Testdrive(no_reset=True, default_timeout="5s"),
 ]

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -21,10 +21,10 @@ from pathlib import Path
 
 from materialize import MZ_ROOT, buildkite, ci_util, file_util
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
-from materialize.mzcompose.services.postgres import PostgresAsCockroach
+from materialize.mzcompose.services.postgres import CockroachOrPostgres
 from materialize.mzcompose.services.sql_logic_test import SqlLogicTest
 
-SERVICES = [PostgresAsCockroach(), SqlLogicTest()]
+SERVICES = [CockroachOrPostgres(), SqlLogicTest()]
 
 COCKROACH_DEFAULT_PORT = 26257
 

--- a/test/txn-wal-fencing/mzcompose.py
+++ b/test/txn-wal-fencing/mzcompose.py
@@ -22,7 +22,7 @@ from materialize import buildkite
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Minio
-from materialize.mzcompose.services.postgres import PostgresAsCockroach
+from materialize.mzcompose.services.postgres import CockroachOrPostgres
 
 
 class Operation(Enum):
@@ -87,7 +87,7 @@ WORKLOADS = [
 
 SERVICES = [
     Minio(setup_materialize=True),
-    PostgresAsCockroach(),
+    CockroachOrPostgres(),
     # Overriden below
     Materialized(name="mz_first"),
     Materialized(name="mz_second"),


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
