### PR TITLE
storage/adapter: Introduce 'ALTER SOURCE .. REFRESH REFERENCES' statement for refreshing available upstream refs

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -531,6 +531,15 @@ impl Coordinator {
                 )
                 .await
             }
+            PurifiedStatement::PurifiedAlterSourceRefreshReferences {
+                source_name,
+                available_source_references,
+            } => self.plan_purified_alter_source_refresh_references(
+                ctx.session(),
+                params,
+                source_name,
+                available_source_references,
+            ),
             o @ (PurifiedStatement::PurifiedAlterSource { .. }
             | PurifiedStatement::PurifiedCreateSink(..)
             | PurifiedStatement::PurifiedCreateTableFromSource { .. }) => {
@@ -544,7 +553,8 @@ impl Coordinator {
                     }
                     PurifiedStatement::PurifiedCreateSink(stmt) => Statement::CreateSink(stmt),
                     PurifiedStatement::PurifiedCreateSource { .. }
-                    | PurifiedStatement::PurifiedAlterSourceAddSubsources { .. } => {
+                    | PurifiedStatement::PurifiedAlterSourceAddSubsources { .. }
+                    | PurifiedStatement::PurifiedAlterSourceRefreshReferences { .. } => {
                         unreachable!("not part of exterior match stmt")
                     }
                 };

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2701,6 +2701,7 @@ pub enum AlterSourceAction<T: AstInfo> {
         cascade: bool,
         names: Vec<UnresolvedItemName>,
     },
+    RefreshReferences,
 }
 
 impl<T: AstInfo> AstDisplay for AlterSourceAction<T> {
@@ -2748,6 +2749,9 @@ impl<T: AstInfo> AstDisplay for AlterSourceAction<T> {
                     f.write_node(&display::comma_separated(options));
                     f.write_str(")");
                 }
+            }
+            AlterSourceAction::RefreshReferences => {
+                f.write_str("REFRESH REFERENCES");
             }
         }
     }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5161,7 +5161,7 @@ impl<'a> Parser<'a> {
 
         Ok(
             match self
-                .expect_one_of_keywords(&[ADD, DROP, RESET, SET, RENAME, OWNER])
+                .expect_one_of_keywords(&[ADD, DROP, RESET, SET, RENAME, OWNER, REFRESH])
                 .map_no_statement_parser_err()?
             {
                 ADD => {
@@ -5285,6 +5285,15 @@ impl<'a> Parser<'a> {
                         if_exists,
                         name: UnresolvedObjectName::Item(source_name),
                         new_owner,
+                    })
+                }
+                REFRESH => {
+                    self.expect_keyword(REFERENCES)
+                        .map_parser_err(StatementKind::AlterSource)?;
+                    Statement::AlterSource(AlterSourceStatement {
+                        source_name,
+                        if_exists,
+                        action: AlterSourceAction::RefreshReferences,
                     })
                 }
                 _ => unreachable!(),

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -3188,6 +3188,27 @@ ALTER SOURCE * SET CLUSTER
              ^
 
 parse-statement
+ALTER SOURCE src REFRESH REFERENCES db.clsname
+----
+error: Expected end of statement, found identifier "db"
+ALTER SOURCE src REFRESH REFERENCES db.clsname
+                                    ^
+
+parse-statement
+ALTER SOURCE db.src REFRESH REFERENCES
+----
+ALTER SOURCE db.src REFRESH REFERENCES
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("db"), Ident("src")]), if_exists: false, action: RefreshReferences })
+
+parse-statement
+ALTER SOURCE IF EXISTS src REFRESH REFERENCES
+----
+ALTER SOURCE IF EXISTS src REFRESH REFERENCES
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("src")]), if_exists: true, action: RefreshReferences })
+
+parse-statement
 ALTER SINK snk SET CLUSTER clsname
 ----
 ALTER SINK snk SET CLUSTER clsname

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1114,6 +1114,9 @@ pub enum AlterSourceAction {
         subsources: Vec<CreateSourcePlanBundle>,
         options: Vec<AlterSourceAddSubsourceOption<Aug>>,
     },
+    RefreshReferences {
+        references: SourceReferences,
+    },
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -6567,6 +6567,9 @@ pub fn plan_alter_source(
         AlterSourceAction::AddSubsources { .. } => {
             unreachable!("ALTER SOURCE...ADD SUBSOURCE must be purified")
         }
+        AlterSourceAction::RefreshReferences => {
+            unreachable!("ALTER SOURCE...REFRESH REFERENCES must be purified")
+        }
     };
 }
 

--- a/test/testdrive/source-tables.td
+++ b/test/testdrive/source-tables.td
@@ -304,11 +304,41 @@ var1 5678 <null>
 var0 5555 6666
 var1 4444 12
 
+# Validate that the available source references table reflects the state of the upstream
+# when the create source was run
+> SELECT u.name, u.namespace, u.columns
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_references u ON s.id = u.source_id
+  WHERE
+  s.name = 'mysql_source'
+  ORDER BY u.name;
+mysql_table public {a,b}
+
+# Create a new table in MySQL and refresh to see if the new available reference is picked up
+$ mysql-execute name=mysql
+USE public;
+CREATE TABLE mysql_table_new (foo INTEGER, bar INTEGER);
+
+> ALTER SOURCE mysql_source REFRESH REFERENCES;
+
+> SELECT u.name, u.namespace, u.columns
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_references u ON s.id = u.source_id
+  WHERE
+  s.name = 'mysql_source'
+  ORDER BY u.name;
+mysql_table public {a,b,c}
+mysql_table_new public {foo,bar}
+
+
 > DROP SOURCE mysql_source CASCADE;
 
 # ensure that CASCADE propagates to the tables
 ! SELECT * FROM mysql_table_3;
 contains:unknown catalog item 'mysql_table_3'
+
+> SELECT count(*) FROM mz_internal.mz_source_references;
+0
 
 # TODO(def-) Remove when database-issues#8515 and database-issues#8526 are fixed
 $ skip-end


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR adds a known-desirable feature: Fixes https://github.com/MaterializeInc/database-issues/issues/8633

Also replaces https://github.com/MaterializeInc/materialize/pull/29923

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
