### PR TITLE
Rename rnd-mz-introspection-council slack channel to rnd-mz-catalog-server-council 

### DIFF
--- a/.github/workflows/slack_notify_mz_catalog_server.yml
+++ b/.github/workflows/slack_notify_mz_catalog_server.yml
@@ -19,7 +19,7 @@
 #
 #     https://github.com/actions-ecosystem/action-slack-notifier/blob/fc778468d09c43a6f4d1b8cccaca59766656996a/README.md
 
-# Send a notification to the #rnd-mz-introspection-council Slack channel when a change
+# Send a notification to the #rnd-mz-catalog-server-council Slack channel when a change
 # is made that adds or modifies an index on the mz_catalog_server cluster, or
 # adds or modifies an object on which those indices depend.
 # Also detects changes to catalog object retention.
@@ -74,7 +74,7 @@ jobs:
         uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
-          channel: rnd-mz-introspection-council
+          channel: rnd-mz-catalog-server-council
           custom_payload: |
             {
               "blocks": [


### PR DESCRIPTION
Do this rename since the `mz_introspection` cluster was previously renamed to `mz_catalog_server`.
I will coordinate updating the channel name at the same time that this PR is merged.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
