### PR TITLE
tests: disable durable_cache in Miri

### DIFF
--- a/src/durable-cache/src/lib.rs
+++ b/src/durable-cache/src/lib.rs
@@ -267,6 +267,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
     async fn durable_cache() {
         let persist = PersistClientCache::new_no_metrics();
         let persist = persist


### PR DESCRIPTION
@jkosh44, can you look into this test whether it should work in Miri or whether we can make it work? It [failed in Nightly.](https://buildkite.com/materialize/nightly/builds/10074#0192b171-397d-4d40-b95a-232c862bbeac)