### PR TITLE
tests: bounded memory: fix

### DIFF
--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -22,6 +22,7 @@ from materialize.mzcompose.composition import Composition, WorkflowArgumentParse
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mysql import MySql
+from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.redpanda import Redpanda
 from materialize.mzcompose.services.testdrive import Testdrive
@@ -58,6 +59,7 @@ SERVICES = [
     Postgres(),
     MySql(),
     Clusterd(),
+    Mz(app_password=""),
 ]
 
 


### PR DESCRIPTION
This addresses https://buildkite.com/materialize/nightly/builds/10077#0192b401-3942-4603-a0e4-ed829ef07cc7:
```
builtins.AssertionError: Service mz not found in SERVICES: ['materialized', 'testdrive', 'redpanda', 'postgres', 'mysql', 'clusterd']
```

caused by https://github.com/MaterializeInc/materialize/pull/30052.