### PR TITLE
ci: Allow more variation in logged password

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -186,7 +186,7 @@ PASSWORD_IGNORE_RE = re.compile(
     # running in the same materialized container. Example:
     # > password: Some("%3C2024-10-18T17:11:36.445784450Z redacted%3E")
     # rb"^ ( < | %3[Cc] ) redacted ( > | %3[Ee] ) $",
-    rb".*redacted.*",
+    rb".*r.*e.*d.*a.*c.*t.*e.*d.*",
     re.VERBOSE,
 )
 


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/10077#0192b401-39d1-4da9-8820-1951308a0ce8

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
