### PR TITLE
fix orchestratord helm chart resources

### DIFF
--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -39,4 +39,4 @@ spec:
         {{- end }}
         - "--environmentd-target-arch={{ .Values.operator.args.environmentdTargetArch }}"
         resources:
-          {{- toYaml .Values.operator.resources | nindent 12 }}
+          {{- toYaml .Values.operator.resources | nindent 10 }}

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -31,10 +31,9 @@ operator:
     # Resources requested by the operator for CPU and memory
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 512Mi
     # Resource limits for the operator's CPU and memory
     limits:
-      cpu: 500m
       memory: 512Mi
 
 # RBAC (Role-Based Access Control) settings


### PR DESCRIPTION
Fixes orchestratord helm chart resources specification.

1. Memory requests should always be equal to limits, as memory can generally not be reduced without killing the pod.
2. Limiting CPU is usually not useful, and prevents us from spiking briefly in periods of extremely rare load.
3. The indentation when templating the resources was a bit too deep.

### Motivation

Part of https://github.com/MaterializeInc/cloud/issues/10285

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
