### PR TITLE
bazel: Use `bazel` provided `cargo` when generating BUILD files

### DIFF
--- a/misc/bazel/cargo-gazelle/src/args.rs
+++ b/misc/bazel/cargo-gazelle/src/args.rs
@@ -17,6 +17,9 @@ pub struct Args {
     /// Path to an executable that can be used to format `BUILD.bazel` files.
     #[clap(long, value_name = "FORMATTER", env = "FORMATTER")]
     pub formatter: Option<PathBuf>,
+    /// Path to the Cargo binary for gathering metadata about a crate.
+    #[clap(long, value_name = "CARGO_BINARY", env = "CARGO_BINARY")]
+    pub cargo: Option<PathBuf>,
     /// Doesn't actually update any files, just checks if they would have changed.
     #[clap(long)]
     pub check: bool,

--- a/misc/bazel/tools/BUILD.bazel
+++ b/misc/bazel/tools/BUILD.bazel
@@ -20,16 +20,33 @@ This should only be used for non-essential tools like linters! Anything is used
 for building or running code should be included via a Bazel toolchain.
 """
 
-sh_binary(
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+native_binary(
     name = "buildifier",
-    srcs = select(
+    src = select(
         {
-            "@//misc/bazel/platforms:macos_x86_64": ["@buildifier-darwin-amd64//file"],
-            "@//misc/bazel/platforms:macos_arm": ["@buildifier-darwin-arm64//file"],
-            "@//misc/bazel/platforms:linux_x86_64": ["@buildifier-linux-amd64//file"],
-            "@//misc/bazel/platforms:linux_arm": ["@buildifier-linux-arm64//file"],
+            "@//misc/bazel/platforms:macos_x86_64": "@buildifier-darwin-amd64//file",
+            "@//misc/bazel/platforms:macos_arm": "@buildifier-darwin-arm64//file",
+            "@//misc/bazel/platforms:linux_x86_64": "@buildifier-linux-amd64//file",
+            "@//misc/bazel/platforms:linux_arm": "@buildifier-linux-arm64//file",
         },
         no_match_error = "`buildifier` is not supported on the current platform.",
+    ),
+)
+
+# Note: We don't use `cargo` for building code, but some tools require it for generating metadata
+# for crates in our repo.
+native_binary(
+    name = "cargo",
+    src = select(
+        {
+            "@//misc/bazel/platforms:macos_x86_64": "@rust_darwin_x86_64__x86_64-apple-darwin__stable_tools//:cargo",
+            "@//misc/bazel/platforms:macos_arm": "@rust_darwin_aarch64__aarch64-apple-darwin__stable_tools//:cargo",
+            "@//misc/bazel/platforms:linux_x86_64": "@rust_linux_x86_64__x86_64-apple-darwin__stable_tools//:cargo",
+            "@//misc/bazel/platforms:linux_arm": "@rust_linux_aarch64__aarch64-apple-darwin__stable_tools//:cargo",
+        },
+        no_match_error = "`cargo` is not supported on the current platform.",
     ),
 )
 
@@ -37,9 +54,13 @@ sh_binary(
 sh_binary(
     name = "cargo-gazelle",
     srcs = ["@//misc/bazel/cargo-gazelle:main"],
-    data = ["@//misc/bazel/tools:buildifier"],
+    data = [
+        "@//misc/bazel/tools:buildifier",
+        "@//misc/bazel/tools:cargo",
+    ],
     env = {
         "FORMATTER": "$(location @//misc/bazel/tools:buildifier)",
+        "CARGO_BINARY": "$(location @//misc/bazel/tools:cargo)",
     },
 )
 


### PR DESCRIPTION
The tool we use to generate `BUILD.bazel` files from `Cargo.toml` files, calls `cargo` to get metadata about a crate. Across versions of Cargo the returned metadata can differ, e.g. `1.78.0` of cargo returned a library name with dashes, meanwhile `1.80.1` returned it with underscores. This PR has Bazel provide the `cargo` binary to `cargo-gazelle` so when running `bin/bazel gen` everyone is using the same version of Cargo.

### Motivation

Fixes an issue @bosconi ran into today with the release

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
