### PR TITLE
Copy over the 'IGNORE KEYS' option from CREATE SOURCE to CREATE TABLE FROM SOURCE statements

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1581,6 +1581,8 @@ pub enum TableFromSourceOptionName {
     /// message, which includes details necessary for planning this
     /// table as a Source Export
     Details,
+
+    IgnoreKeys,
 }
 
 impl AstDisplay for TableFromSourceOptionName {
@@ -1590,6 +1592,7 @@ impl AstDisplay for TableFromSourceOptionName {
             TableFromSourceOptionName::ExcludeColumns => "EXCLUDE COLUMNS",
             TableFromSourceOptionName::Timeline => "TIMELINE",
             TableFromSourceOptionName::Details => "DETAILS",
+            TableFromSourceOptionName::IgnoreKeys => "IGNORE KEYS",
         })
     }
 }
@@ -1606,7 +1609,8 @@ impl WithOptionName for TableFromSourceOptionName {
             TableFromSourceOptionName::Details
             | TableFromSourceOptionName::TextColumns
             | TableFromSourceOptionName::ExcludeColumns
-            | TableFromSourceOptionName::Timeline => false,
+            | TableFromSourceOptionName::Timeline
+            | TableFromSourceOptionName::IgnoreKeys => false,
         }
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4541,7 +4541,7 @@ impl<'a> Parser<'a> {
         &mut self,
     ) -> Result<TableFromSourceOption<Raw>, ParserError> {
         let option = match self.expect_one_of_keywords(&[TEXT, EXCLUDE, IGNORE, DETAILS])? {
-            ref keyword @ (TEXT | IGNORE | EXCLUDE) => {
+            ref keyword @ (TEXT | EXCLUDE) => {
                 self.expect_keyword(COLUMNS)?;
 
                 let _ = self.consume_token(&Token::Eq);
@@ -4557,8 +4557,7 @@ impl<'a> Parser<'a> {
                 TableFromSourceOption {
                     name: match *keyword {
                         TEXT => TableFromSourceOptionName::TextColumns,
-                        // IGNORE is historical syntax for this option.
-                        EXCLUDE | IGNORE => TableFromSourceOptionName::ExcludeColumns,
+                        EXCLUDE => TableFromSourceOptionName::ExcludeColumns,
                         _ => unreachable!(),
                     },
                     value,
@@ -4568,6 +4567,31 @@ impl<'a> Parser<'a> {
                 name: TableFromSourceOptionName::Details,
                 value: self.parse_optional_option_value()?,
             },
+            IGNORE => {
+                match self.expect_one_of_keywords(&[COLUMNS, KEYS])? {
+                    COLUMNS => {
+                        let _ = self.consume_token(&Token::Eq);
+
+                        let value =
+                            self.parse_option_sequence(Parser::parse_identifier)?
+                                .map(|inner| {
+                                    WithOptionValue::Sequence(
+                                        inner.into_iter().map(WithOptionValue::Ident).collect_vec(),
+                                    )
+                                });
+                        TableFromSourceOption {
+                            // IGNORE is historical syntax for this option.
+                            name: TableFromSourceOptionName::ExcludeColumns,
+                            value,
+                        }
+                    }
+                    KEYS => TableFromSourceOption {
+                        name: TableFromSourceOptionName::IgnoreKeys,
+                        value: self.parse_optional_option_value()?,
+                    },
+                    _ => unreachable!(),
+                }
+            }
             _ => unreachable!(),
         };
         Ok(option)

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -306,6 +306,13 @@ CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) FORMAT PROTOBUF USING CONFLUENT
 CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("baz")])), with_options: [], include_metadata: [], format: Some(Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, seed: Some(CsrSeedProtobuf { key: Some(CsrSeedProtobufSchema { schema: "{\"some\": \"seed\"}", message_name: "Batch" }), value: CsrSeedProtobufSchema { schema: "123", message_name: "M" } }) } }))), envelope: Some(Upsert { value_decode_err_policy: [] }) })
 
 parse-statement
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (IGNORE KEYS 'true')
+----
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (IGNORE KEYS = 'true')
+=>
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("baz")])), with_options: [TableFromSourceOption { name: IgnoreKeys, value: Some(Value(String("true"))) }], include_metadata: [], format: None, envelope: None })
+
+parse-statement
 CREATE DATABASE IF EXISTS foo
 ----
 error: Expected NOT, found EXISTS

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1533,6 +1533,7 @@ generate_extracted_config!(
     (TextColumns, Vec::<Ident>, Default(vec![])),
     (ExcludeColumns, Vec::<Ident>, Default(vec![])),
     (Timeline, String),
+    (IgnoreKeys, bool),
     (Details, String)
 );
 
@@ -1562,6 +1563,7 @@ pub fn plan_create_table_from_source(
         exclude_columns,
         details,
         timeline,
+        ignore_keys,
         seen: _,
     } = with_options.clone().try_into()?;
 
@@ -1721,7 +1723,7 @@ pub fn plan_create_table_from_source(
         format,
         key_desc,
         value_desc,
-        None,
+        ignore_keys,
         include_metadata,
         metadata_columns_desc,
         source_connection,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1560,6 +1560,7 @@ async fn purify_create_table_from_source(
         text_columns,
         exclude_columns,
         details,
+        ignore_keys: _,
         timeline: _,
         seen: _,
     } = with_options.clone().try_into()?;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

While writing the migration for `CREATE SOURCE` -> `CREATE TABLE .. FROM SOURE` statements for kafka sources, I realized that I had forgotten to add the `IGNORE KEYS` option to the table statements. This implements the option type so that we don't lose any option configuration during the migration.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
