### PR TITLE
adapter: Add `CatalogItemId` type

### DIFF
--- a/src/repr/BUILD.bazel
+++ b/src/repr/BUILD.bazel
@@ -116,6 +116,7 @@ filegroup(
         "src/adt/timestamp.proto",
         "src/adt/varchar.proto",
         "src/antichain.proto",
+        "src/catalog_item_id.proto",
         "src/global_id.proto",
         "src/refresh_schedule.proto",
         "src/relation_and_scalar.proto",

--- a/src/repr/build.rs
+++ b/src/repr/build.rs
@@ -18,6 +18,7 @@ fn main() {
         .compile_protos(
             &[
                 "repr/src/antichain.proto",
+                "repr/src/catalog_item_id.proto",
                 "repr/src/global_id.proto",
                 "repr/src/row.proto",
                 "repr/src/row/collection.proto",

--- a/src/repr/src/catalog_item_id.proto
+++ b/src/repr/src/catalog_item_id.proto
@@ -1,0 +1,22 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+package mz_repr.catalog_item_id;
+
+import "google/protobuf/empty.proto";
+
+message ProtoCatalogItemId {
+  oneof kind {
+    uint64 system = 1;
+    uint64 user = 2;
+    uint64 transient = 3;
+  }
+}

--- a/src/repr/src/catalog_item_id.rs
+++ b/src/repr/src/catalog_item_id.rs
@@ -1,0 +1,129 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt;
+use std::str::FromStr;
+
+use anyhow::{anyhow, Error};
+use mz_lowertest::MzReflect;
+use mz_proto::{RustType, TryFromProtoError};
+use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
+
+include!(concat!(env!("OUT_DIR"), "/mz_repr.catalog_item_id.rs"));
+
+/// The identifier for an item within the Catalog.
+#[derive(
+    Arbitrary,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    MzReflect,
+)]
+pub enum CatalogItemId {
+    /// System namespace.
+    System(u64),
+    /// User namespace.
+    User(u64),
+    /// Transient item.
+    Transient(u64),
+}
+
+impl CatalogItemId {
+    /// Reports whether this ID is in the system namespace.
+    pub fn is_system(&self) -> bool {
+        matches!(self, CatalogItemId::System(_))
+    }
+
+    /// Reports whether this ID is in the user namespace.
+    pub fn is_user(&self) -> bool {
+        matches!(self, CatalogItemId::User(_))
+    }
+
+    /// Reports whether this ID is for a transient item.
+    pub fn is_transient(&self) -> bool {
+        matches!(self, CatalogItemId::Transient(_))
+    }
+}
+
+impl FromStr for CatalogItemId {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() < 2 {
+            return Err(anyhow!("couldn't parse id {}", s));
+        }
+        let val: u64 = s[1..].parse()?;
+        match s.chars().next().unwrap() {
+            's' => Ok(CatalogItemId::System(val)),
+            'u' => Ok(CatalogItemId::User(val)),
+            't' => Ok(CatalogItemId::Transient(val)),
+            _ => Err(anyhow!("couldn't parse id {}", s)),
+        }
+    }
+}
+
+impl fmt::Display for CatalogItemId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CatalogItemId::System(id) => write!(f, "s{}", id),
+            CatalogItemId::User(id) => write!(f, "u{}", id),
+            CatalogItemId::Transient(id) => write!(f, "t{}", id),
+        }
+    }
+}
+
+impl RustType<ProtoCatalogItemId> for CatalogItemId {
+    fn into_proto(&self) -> ProtoCatalogItemId {
+        use proto_catalog_item_id::Kind::*;
+        ProtoCatalogItemId {
+            kind: Some(match self {
+                CatalogItemId::System(x) => System(*x),
+                CatalogItemId::User(x) => User(*x),
+                CatalogItemId::Transient(x) => Transient(*x),
+            }),
+        }
+    }
+
+    fn from_proto(proto: ProtoCatalogItemId) -> Result<Self, TryFromProtoError> {
+        use proto_catalog_item_id::Kind::*;
+        match proto.kind {
+            Some(System(x)) => Ok(CatalogItemId::System(x)),
+            Some(User(x)) => Ok(CatalogItemId::User(x)),
+            Some(Transient(x)) => Ok(CatalogItemId::Transient(x)),
+            None => Err(TryFromProtoError::missing_field("ProtoCatalogItemId::kind")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[mz_ore::test]
+    fn proptest_catalog_item_id_roundtrips() {
+        fn testcase(og: CatalogItemId) {
+            let s = og.to_string();
+            let rnd: CatalogItemId = s.parse().unwrap();
+            assert_eq!(og, rnd);
+        }
+
+        proptest!(|(id in any::<CatalogItemId>())| {
+            testcase(id);
+        })
+    }
+}

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -32,6 +32,7 @@ mod scalar;
 pub mod adt;
 pub mod antichain;
 pub mod bytes;
+pub mod catalog_item_id;
 pub mod explain;
 pub mod fixed_length;
 pub mod global_id;
@@ -46,6 +47,7 @@ pub mod timestamp;
 pub mod url;
 pub mod user;
 
+pub use crate::catalog_item_id::CatalogItemId;
 pub use crate::datum_vec::{DatumVec, DatumVecBorrow};
 pub use crate::diff::Diff;
 pub use crate::global_id::GlobalId;


### PR DESCRIPTION
As it says on the tin, adds a new type called `CatalogItemId` which will be used as a stable identifier for Catalog items.

Figured splitting this out into its own PR was a good first step.

### Motivation

Progress towards https://github.com/MaterializeInc/database-issues/issues/8233

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
