### PR TITLE
bazel: Upgrade `rules_rust v0.53`, re-enable pipelined compilation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -125,7 +125,7 @@ build --@rules_rust//:extra_rustc_flag="-Csymbol-mangling-version=v0"
 build --@rules_rust//:extra_rustc_flag="-Ccodegen-units=64"
 # Enabling pipelined builds allows dependent libraries to begin compiling with
 # just `.rmeta` instead of the full `.rlib`.
-#build --@rules_rust//rust/settings:pipelined_compilation=True
+build --@rules_rust//rust/settings:pipelined_compilation=True
 
 # As of Jan 2024 all of the x86-64 and aarch64 hardware we run on support these
 # CPU targets.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -311,9 +311,9 @@ c_repositories()
 # Rules for building Rust crates, and several convienence macros for building all transitive
 # dependencies.
 
-RULES_RUST_VERSION = "0.51.0"
+RULES_RUST_VERSION = "0.53.0"
 
-RULES_RUST_INTEGRITY = "sha256-BCrPtzRpstGEj+FI2Bw0IsYepHqeGQDxyew29R6OcZM="
+RULES_RUST_INTEGRITY = "sha256-heIBNyerJvsiq9/+SyrAwnotW2KWFnumPY9uExQPUfk="
 
 maybe(
     http_archive,


### PR DESCRIPTION
As it says in the title, upgrade Bazel's `rules_rust` from `0.51` to `0.53` and re-enables pipelined compilation. 

Previously we disabled pipelined compilation because of some build failures, I wanted to try re-enabling it since there have been changes made to how build scripts work, which I think were causing the original failures.

### Motivation

Speed up CI

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
