### PR TITLE
build: Remove CPU specific build config for maximum compatibility

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -127,14 +127,6 @@ build --@rules_rust//:extra_rustc_flag="-Ccodegen-units=64"
 # just `.rmeta` instead of the full `.rlib`.
 #build --@rules_rust//rust/settings:pipelined_compilation=True
 
-# As of Jan 2024 all of the x86-64 and aarch64 hardware we run on support these
-# CPU targets.
-build:linux-amd64 --copt="-m64"
-build:linux-amd64 --copt="-march=x86-64-v3"
-build:linux-amd64 --@rules_rust//:extra_rustc_flag="-Ctarget-cpu=x86-64-v3"
-build:linux-arm64 --copt="-mcpu=neoverse-n1"
-build:linux-arm64 --@rules_rust//:extra_rustc_flag="-Ctarget-cpu=neoverse-n1"
-
 # CI Build Configuration
 #
 # Note: This shouldn't change any config of the built binary, just the way it

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -17,8 +17,6 @@ rustflags = [
     "-Clink-arg=-Wl,-O2",
     "-Clink-arg=-fuse-ld=lld",
     "-Csymbol-mangling-version=v0",
-    "-Ctarget-cpu=x86-64-v3",
-    "-Ctarget-feature=+aes,+pclmulqdq",
     "--cfg=tokio_unstable",
 ]
 
@@ -36,8 +34,6 @@ rustflags = [
     "-Clink-arg=-Wl,-O2",
     "-Clink-arg=-fuse-ld=lld",
     "-Csymbol-mangling-version=v0",
-    "-Ctarget-cpu=neoverse-n1",
-    "-Ctarget-feature=+aes,+sha2",
     "--cfg=tokio_unstable",
 ]
 

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -67,38 +67,6 @@ else
     rust_components+=,clippy-preview,rustfmt-preview
 fi
 
-# Target a specific CPU to get better performance, i.e. use more modern instructions.
-#
-# All of the x86-64 and ARM hardware we run in production support the v3 and neoverse-n1 micro
-# architectures, respectively.
-#
-# Sync: This target-cpu should be kept in sync with the one in ci-builder and .cargo/config.
-x86_64_target_cpu="x86-64-v3"
-aarch64_target_cpu="neoverse-n1"
-
-rust_cpu_target=""
-case "$arch_gcc" in
-    x86_64) rust_cpu_target="$x86_64_target_cpu" ;;
-    aarch64) rust_cpu_target="$aarch64_target_cpu" ;;
-    *) die "unknown host architecture \"$arch\"" ;;
-esac
-
-# Enable specific CPU features that we know our cloud infra supports.
-#
-# Note: specifying a target_cpu enables many features, these are specific ones that target_cpu
-# might miss.
-#
-# Sync: This list of features should be kept in sync with the one in xcompile and .cargo/config.
-x86_64_target_features="+aes,+pclmulqdq"
-aaarch64_target_features="+aes,+sha2"
-
-rust_target_features=""
-case "$arch_gcc" in
-    x86_64) rust_target_features="$x86_64_target_features" ;;
-    aarch64) rust_target_features="$aaarch64_target_features" ;;
-    *) die "unknown host architecture \"$arch\"" ;;
-esac
-
 bazel_version=$(cat .bazelversion)
 
 uid=$(id -u)
@@ -115,8 +83,6 @@ build() {
         --build-arg "RUST_VERSION=$rust_version" \
         --build-arg "RUST_DATE=$rust_date" \
         --build-arg "RUST_COMPONENTS=$rust_components" \
-        --build-arg "RUST_CPU_TARGET=$rust_cpu_target" \
-        --build-arg "RUST_TARGET_FEATURES=$rust_target_features" \
         --build-arg "BAZEL_VERSION=$bazel_version" \
         --tag materialize/ci-builder:"$tag" \
         --tag materialize/ci-builder:"$cache_tag" \

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -173,8 +173,6 @@ RUN gpg --import rust.asc \
 ARG RUST_DATE
 ARG RUST_VERSION
 ARG RUST_COMPONENTS
-ARG RUST_CPU_TARGET
-ARG RUST_TARGET_FEATURES
 
 RUN mkdir rust \
     && curl -fsSL https://static.rust-lang.org/dist$RUST_DATE/rust-$RUST_VERSION-$ARCH_GCC-unknown-linux-gnu.tar.gz > rust.tar.gz \
@@ -304,7 +302,7 @@ ENV CC=$ARCH_GCC-unknown-linux-gnu-cc
 ENV CXX=$ARCH_GCC-unknown-linux-gnu-c++
 ENV CXXSTDLIB=static=stdc++
 ENV LDFLAGS="-fuse-ld=lld -static-libstdc++"
-ENV RUSTFLAGS="-Clink-arg=-Wl,--compress-debug-sections=zlib -Clink-arg=-fuse-ld=lld -L/opt/x-tools/$ARCH_GCC-unknown-linux-gnu/$ARCH_GCC-unknown-linux-gnu/sysroot/lib/ -Csymbol-mangling-version=v0 -Ctarget-cpu=$RUST_CPU_TARGET -Ctarget-feature=$RUST_TARGET_FEATURES --cfg=tokio_unstable"
+ENV RUSTFLAGS="-Clink-arg=-Wl,--compress-debug-sections=zlib -Clink-arg=-fuse-ld=lld -L/opt/x-tools/$ARCH_GCC-unknown-linux-gnu/$ARCH_GCC-unknown-linux-gnu/sysroot/lib/ -Csymbol-mangling-version=v0 --cfg=tokio_unstable"
 ENV TARGET_AR=$AR
 ENV TARGET_CC=$CC
 ENV TARGET_CXX=$CXX

--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -246,6 +246,9 @@ class SinkTables(Check):
 
                 > INSERT INTO sink_large_transaction_table SELECT generate_series, REPEAT('x', 1024) FROM generate_series(1, 100000);
 
+                # Can be slow with a large transaction
+                $ set-sql-timeout duration=120s
+
                 > CREATE MATERIALIZED VIEW sink_large_transaction_view AS SELECT f1 - 1 AS f1 , f2 FROM sink_large_transaction_table;
 
                 > CREATE CLUSTER sink_large_transaction_sink1_cluster SIZE '4';
@@ -291,6 +294,9 @@ class SinkTables(Check):
                 >[version>=11900] CREATE TABLE sink_large_transaction_source FROM SOURCE sink_large_transaction_source_src (REFERENCE "testdrive-sink-large-transaction-sink-${testdrive.seed}")
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE NONE
+
+                # Can be slow with a large transaction
+                $ set-sql-timeout duration=120s
 
                 > CREATE MATERIALIZED VIEW sink_large_transaction_view2
                   AS

--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -111,8 +111,6 @@ def bazel(
     ), "cross compiling to Linux x86_64 is not supported from macOS"
 
     bazel_flags = ["--config=linux"]
-    if sys.platform != "darwin":
-        bazel_flags += [f"--config=linux-{arch.go_str()}"]
 
     rustc_flags = [
         f"--@rules_rust//:extra_rustc_flag={flag}"
@@ -146,8 +144,6 @@ def cargo(
     """
     _target = target(arch)
     _target_env = _target.upper().replace("-", "_")
-    _target_cpu = target_cpu(arch)
-    _target_features = ",".join(target_features(arch))
 
     env = {
         **extra_env,
@@ -156,8 +152,6 @@ def cargo(
     rustflags += [
         "-Clink-arg=-Wl,--compress-debug-sections=zlib",
         "-Csymbol-mangling-version=v0",
-        f"-Ctarget-cpu={_target_cpu}",
-        f"-Ctarget-feature={_target_features}",
         "--cfg=tokio_unstable",
     ]
 


### PR DESCRIPTION
Our current build is optimized for hardware we run in prod by using the `target_cpu` and `target_features` build flags. These flags can enable newer CPU instructions for better runtime performance, but these instructions are not necessarily portable and might break the Docker image/Emulator when run locally.

The better longer term fix is probably a specific build step (maybe update `CargoPreImage` in mzbuild?) that has a "portable" config. I made a quick attempt at this but it's a bit non-trivial.

### Motivation

Better portability of the Emulator

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
