### PR TITLE
feature-benchmark: git fetch less often

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -287,11 +287,18 @@ def run_one_scenario(
     return result
 
 
+resolved_tags: dict[tuple[str, frozenset[tuple[str, MzVersion]]], str] = {}
+
+
 def resolve_tag(tag: str, scenario_class: type[Scenario], scale: str | None) -> str:
     if tag == "common-ancestor":
-        return resolve_ancestor_image_tag(
-            get_ancestor_overrides_for_performance_regressions(scenario_class, scale)
+        overrides = get_ancestor_overrides_for_performance_regressions(
+            scenario_class, scale
         )
+        key = (tag, frozenset(overrides.items()))
+        if key not in resolved_tags:
+            resolved_tags[key] = resolve_ancestor_image_tag(overrides)
+        return resolved_tags[key]
 
     return tag
 


### PR DESCRIPTION
See https://materializeinc.slack.com/archives/C01LKF361MZ/p1729636270892819 for context
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
