### PR TITLE
tests: continual tasks: fix activation

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -93,6 +93,7 @@ def get_default_system_parameters(
         "enable_continual_task_create": "true",
         "enable_continual_task_transform": "true",
         "enable_copy_to_expr": "true",
+        "enable_create_continual_task": "true",
         "enable_create_table_from_source": "true",
         "enable_disk_cluster_replicas": "true",
         "enable_eager_delta_joins": "true",


### PR DESCRIPTION
This should fix the platform checks failing in https://buildkite.com/materialize/nightly/builds/10094.

It is not fully clear to me what happened here. Was `enable_create_continual_task` renamed to `enable_continual_task_create` so that we need this line for upgrade checks?

Nightly: https://buildkite.com/materialize/nightly/builds/10105