### PR TITLE
orchestratord network policies

### DIFF
--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -41,8 +41,12 @@ The following table lists the configurable parameters of the Materialize operato
 | `environmentd.nodeSelector` |  | ``{}`` |
 | `namespace.create` |  | ``false`` |
 | `namespace.name` |  | ``"materialize"`` |
-| `networkPolicies.enabled` |  | ``false`` |
-| `networkPolicies.useNativeKubernetesPolicy` |  | ``true`` |
+| `networkPolicies.enabled` | Whether to install any network policies. | ``true`` |
+| `networkPolicies.internal.enabled` | Whether to install network policies allowing communication between Materialize pods. | ``true`` |
+| `networkPolicies.ingress.enabled` | Whether to install network policies allowing communication from external locations to environmentd or balancerd SQL or HTTP ports. | ``true`` |
+| `networkPolicies.ingress.cidrs` | List of CIDR blocks to allow to reach environmentd or balancerd. | ``["0.0.0.0/0"]`` |
+| `networkPolicies.egress.enabled` | Whether to install network policies allowing communication from Materialize pods to external sources and sinks. | ``true`` |
+| `networkPolicies.egress.cidrs` | List of CIDR blocks to allow Materialize pods to reach for sources and sinks. | ``["0.0.0.0/0"]`` |
 | `observability.enabled` |  | ``false`` |
 | `observability.prometheus.enabled` |  | ``false`` |
 | `operator.args.cloudProvider` |  | ``"local"`` |
@@ -87,7 +91,17 @@ To enable observability features, set `observability.enabled=true`. This will cr
 
 ### Network Policies
 
-Network policies can be enabled by setting `networkPolicies.enabled=true`. By default, the chart uses native Kubernetes network policies. To use Cilium network policies instead, set `networkPolicies.useNativeKubernetesPolicy=false`.
+Network policies can be enabled by setting `networkPolicies.enabled=true`.
+
+To enable policies for internal communication between Materialize pods, set `networkPolicies.internal.enabled=true`.
+
+To enable policies for ingress HTTP or SQL communication to Materialize environmentd or balancerd pods, set `networkPolicies.ingress.enabled=true`.
+
+Ingress policies can configure the list of CIDR blocks to allow with `networkPolicies.ingress.cidrs`.
+
+To enable policies for egress communication from Materialize pods to sources and sinks, set `networkPolicies.egress.enabled=true`.
+
+Egress policies can configure the list of CIDR blocks to allow with `networkPolicies.ingress.cidrs`.
 
 ## Troubleshooting
 

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -48,5 +48,22 @@ spec:
         {{- range $key, $value := .Values.clusterd.nodeSelector }}
         - "--clusterd-node-selector={{ $key }}={{ $value }}"
         {{- end }}
+        {{- if .Values.networkPolicies.enabled }}
+        {{- if .Values.networkPolicies.internal.enabled }}
+        - "--network-policies-internal-enabled=true"
+        {{- end }}
+        {{- if .Values.networkPolicies.ingress.enabled }}
+        - "--network-policies-ingress-enabled=true"
+        {{- range $cidr := .Values.networkPolicies.ingress.cidrs }}
+        - "--network-policies-ingress-cidrs={{$cidr}}"
+        {{- end }}
+        {{- end }}
+        {{- if .Values.networkPolicies.egress.enabled }}
+        - "--network-policies-egress-enabled=true"
+        {{- range $cidr := .Values.networkPolicies.egress.cidrs }}
+        - "--network-policies-egress-cidrs={{$cidr}}"
+        {{- end }}
+        {{- end }}
+        {{- end }}
         resources:
           {{- toYaml .Values.operator.resources | nindent 10 }}

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -66,9 +66,21 @@ observability:
 # Network policies configuration
 networkPolicies:
   # Whether to enable network policies for securing communication between pods
-  enabled: false
-  # Use native Kubernetes NetworkPolicies if enabled
-  useNativeKubernetesPolicy: true
+  enabled: true
+  # internal communication between Materialize pods
+  internal:
+    enabled: true
+  # ingress to the SQL and HTTP interfaces
+  # on environmentd or balancerd
+  ingress:
+    enabled: true
+    cidrs:
+      - 0.0.0.0/0
+  # egress from Materialize pods to sources and sinks
+  egress:
+    enabled: true
+    cidrs:
+      - 0.0.0.0/0
 
 # Namespace configuration
 namespace:

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -114,6 +114,10 @@ pub mod v1alpha1 {
             format!("persist-pubsub-{}-{generation}", self.name_unchecked())
         }
 
+        pub fn name_prefixed(&self, suffix: &str) -> String {
+            format!("{}-{}", self.name_unchecked(), suffix)
+        }
+
         pub fn default_labels(&self) -> BTreeMap<String, String> {
             BTreeMap::from_iter([
                 (

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -50,6 +50,8 @@ pub struct Args {
     clusterd_node_selector: Vec<KeyValueArg<String, String>>,
     #[clap(long, default_value = "always", arg_enum)]
     image_pull_policy: KubernetesImagePullPolicy,
+    #[clap(flatten)]
+    network_policies: NetworkPolicyConfig,
 
     #[clap(long, default_value_t = default_cluster_replica_sizes())]
     environmentd_cluster_replica_sizes: String,
@@ -133,6 +135,24 @@ pub struct AwsInfo {
     aws_secrets_controller_tags: Vec<String>,
     #[clap(long)]
     environmentd_availability_zones: Option<Vec<String>>,
+}
+
+#[derive(clap::Parser)]
+pub struct NetworkPolicyConfig {
+    #[clap(long = "network-policies-internal-enabled", default_value = "false")]
+    internal_enabled: bool,
+
+    #[clap(long = "network-policies-ingress-enabled", default_value = "false")]
+    ingress_enabled: bool,
+
+    #[clap(long = "network-policies-ingress-cidrs")]
+    ingress_cidrs: Vec<String>,
+
+    #[clap(long = "network-policies-egress-enabled", default_value = "false")]
+    egress_enabled: bool,
+
+    #[clap(long = "network-policies-egress-cidrs")]
+    egress_cidrs: Vec<String>,
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
Adds network policy support to orchestratord

### Motivation

Adds basic support for running orchestatord in clusters with network policy enforcement.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
