### PR TITLE
ci: Disable password check for now

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -734,27 +734,30 @@ def _get_errors_from_log_file(log_file_name: str) -> list[ErrorLog]:
         error_logs.extend(_collect_errors_in_logs(data, log_file_name))
         data.seek(0)
         error_logs.extend(_collect_service_panics_in_logs(data, log_file_name))
+        # TODO(def-) Figure out a way to reenable, currently log lines in the
+        # same container can intersect in any way, so there is no reliable way
+        # to detect if a password is in the logs or not
         # Passwords are expected in these files, ignore them
-        if log_file_name not in {
-            "run.log",
-            "docker-inspect.log",
-            "docker-ps-a.log",
-            "ps-aux.log",
-            "kubectl-describe-all.log",
-            # TODO(def-): Remove when we have 4 versions released without leaking passwords to logs
-        } and os.getenv("BUILDKITE_STEP_KEY") not in {
-            "checks-upgrade-clusterd-compute-first",
-            "checks-upgrade-clusterd-compute-last",
-            "checks-upgrade-entire-mz-two-versions",
-            "checks-upgrade-entire-mz-four-versions",
-            "checks-preflight-check-rollback",
-            "checks-0dt-upgrade-entire-mz-two-versions",
-            "checks-0dt-upgrade-entire-mz-four-versions",
-            "cloudtest-upgrade",
-            "feature-benchmark",
-        }:
-            data.seek(0)
-            error_logs.extend(_collect_passwords_in_logs(data, log_file_name))
+        # if log_file_name not in {
+        #     "run.log",
+        #     "docker-inspect.log",
+        #     "docker-ps-a.log",
+        #     "ps-aux.log",
+        #     "kubectl-describe-all.log",
+        #     # TODO(def-): Remove when we have 4 versions released without leaking passwords to logs
+        # } and os.getenv("BUILDKITE_STEP_KEY") not in {
+        #     "checks-upgrade-clusterd-compute-first",
+        #     "checks-upgrade-clusterd-compute-last",
+        #     "checks-upgrade-entire-mz-two-versions",
+        #     "checks-upgrade-entire-mz-four-versions",
+        #     "checks-preflight-check-rollback",
+        #     "checks-0dt-upgrade-entire-mz-two-versions",
+        #     "checks-0dt-upgrade-entire-mz-four-versions",
+        #     "cloudtest-upgrade",
+        #     "feature-benchmark",
+        # }:
+        #     data.seek(0)
+        #     error_logs.extend(_collect_passwords_in_logs(data, log_file_name))
 
     return error_logs
 


### PR DESCRIPTION
Unfortunately failed again: https://buildkite.com/materialize/nightly/builds/10115#0192b926-306b-49aa-9654-1e10e0154aac

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
