### PR TITLE
storage/sources: Ensure we propagate kafka source errors to all source outputs

### DIFF
--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -616,14 +616,14 @@ def workflow_bound_size_mz_status_history(c: Composition) -> None:
     c.up("materialized")
 
     # Verify that we have fewer events now
-    # 13 resp. because the truncation default is 5, and the restarted
+    # 14 resp. because the truncation default is 5, and the restarted
     # objects produce a new starting and running event.
     c.testdrive(
         service="testdrive_no_reset",
         input=dedent(
             """
             > SELECT COUNT(*) FROM mz_internal.mz_source_status_history
-            13
+            14
 
             > SELECT COUNT(*) FROM mz_internal.mz_sink_status_history
             7

--- a/test/testdrive/kafka-recreate-topic.td
+++ b/test/testdrive/kafka-recreate-topic.td
@@ -50,9 +50,8 @@ $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
 
 $ kafka-create-topic topic=topic0 partitions=2
 
-# TODO: database-issues#8621
-# ! SELECT * FROM source0_tbl
-# contains:topic was recreated: partition count regressed from 4 to 2
+! SELECT * FROM source0_tbl
+contains:topic was recreated: partition count regressed from 4 to 2
 
 # We can also detect that a topic got recreated by observing the high watermark regressing
 
@@ -89,9 +88,8 @@ $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
 
 $ kafka-create-topic topic=topic1 partitions=1
 
-# TODO: database-issues#8621
-# ! SELECT * FROM source1_tbl
-# contains:topic was recreated: high watermark of partition 0 regressed from 1 to 0
+! SELECT * FROM source1_tbl
+contains:topic was recreated: high watermark of partition 0 regressed from 1 to 0
 
 # Test a pathological topic recreation observed in the wild.
 # See incidents-and-escalations#98.
@@ -175,18 +173,14 @@ text
 ----
 1
 
-# wait for appropriate status values
-$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
-
-# TODO: database-issues#8691: update status values
 > SELECT name, status, error FROM mz_internal.mz_source_statuses WHERE type != 'progress'
 name            status    error
 -------------------------------
 good_source_tbl running <null>
-source0_tbl starting <null>
-source1 running <null>
-source1_tbl starting <null>
-source2_tbl starting <null>
+source0_tbl stalled "kafka: Source error: source must be dropped and recreated due to failure: topic was recreated: partition count regressed from 4 to 2"
+source1 paused <null>
+source1_tbl stalled "kafka: Source error: source must be dropped and recreated due to failure: topic was recreated: high watermark of partition 0 regressed from 1 to 0"
+source2_tbl running <null>
 good_source running <null>
 source0 paused <null>
 source2 running <null>


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.
 Fixes https://github.com/MaterializeInc/database-issues/issues/8621 and fixes https://github.com/MaterializeInc/database-issues/issues/8691

Also reverts some of the test changes made in https://github.com/MaterializeInc/materialize/commit/3027f6c363b688e52966d3e938a8370928730a90 to match the expected correct behavior.


<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

@petrosagg it's somewhat unclear to me when we should output errors to each output vs only the primary source output. For example, I've left 'connection' / ssh errors to only be reported to output 0, but now all others will be reported to each output. Would appreciate any context you have on this.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
