### PR TITLE
tests: Prefer uv over pip

### DIFF
--- a/bin/pyactivate
+++ b/bin/pyactivate
@@ -89,28 +89,39 @@ def activate_venv(py_dir: Path) -> Path:
             )
             logger.info("python exec error: %s", e)
         print(f"==> Initializing virtualenv in {venv_dir}", file=sys.stderr)
-        # Install Python into the virtualenv via a symlink rather than copying,
-        # except on Windows. This matches the behavior of the `python -m venv`
-        # command line tool. This is important on macOS, where the default
-        # `symlinks=False` is broken with the system Python.
-        # See: https://bugs.python.org/issue38705
-        symlinks = os.name != "nt"
-        # Work around Debian's packaging of Python, which doesn't include the
-        # `ensurepip` module that `venv` uses under the hood.
         try:
-            import ensurepip
-        except ImportError:
-            raise AssertionError(
-                "It appears you're on a Debian-derived system. Please install `python3-venv`, otherwise this will fail annoyingly."
-            )
+            subprocess.check_call(["uv", "venv", venv_dir])
+        except FileNotFoundError:
+            # Install Python into the virtualenv via a symlink rather than copying,
+            # except on Windows. This matches the behavior of the `python -m venv`
+            # command line tool. This is important on macOS, where the default
+            # `symlinks=False` is broken with the system Python.
+            # See: https://bugs.python.org/issue38705
+            symlinks = os.name != "nt"
+            # Work around Debian's packaging of Python, which doesn't include the
+            # `ensurepip` module that `venv` uses under the hood.
+            try:
+                import ensurepip
+            except ImportError:
+                raise AssertionError(
+                    "It appears you're on a Debian-derived system. Please install `python3-venv`, otherwise this will fail annoyingly."
+                )
 
-        venv.create(venv_dir, with_pip=True, clear=True, symlinks=symlinks)
-        # Work around a Debian bug which incorrectly makes pip think that we've
-        # installed wheel in the virtual environment when we haven't. This is
-        # a no-op on systems without the bug.
-        # See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=959997
-        for path in venv_dir.glob("share/python-wheels/wheel*"):
-            path.unlink()
+            venv.create(venv_dir, with_pip=True, clear=True, symlinks=symlinks)
+            # Work around a Debian bug which incorrectly makes pip think that we've
+            # installed wheel in the virtual environment when we haven't. This is
+            # a no-op on systems without the bug.
+            # See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=959997
+            for path in venv_dir.glob("share/python-wheels/wheel*"):
+                path.unlink()
+
+            # Work around a Debian bug which incorrectly makes pip think that we've
+            # installed wheel in the virtual environment when we haven't. This is
+            # a no-op on systems without the bug.
+            # See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=959997
+
+            for path in venv_dir.glob("share/python-wheels/wheel*"):
+                path.unlink()
 
     # The Python that ships with Xcode 12 is broken and attempts to compile
     # Python extensions for ARM when it shouldn't. Detect this known-broken
@@ -172,14 +183,22 @@ def acquire_deps(venv_dir: Path, variant: Optional[str] = None, use_pep517: bool
 
     # Update dependencies, if necessary.
     if stamp_mtime <= requirements_mtime:
-        print(f"==> Updating {variant + ' ' if variant else ''}dependencies with pip", file=sys.stderr)
-        subprocess.check_call([
+        print(f"==> Updating {variant + ' ' if variant else ''}dependencies", file=sys.stderr)
+        try:
+            subprocess.check_call([
+                    "uv", "pip", "install", "-r", requirements_path,
+                ],
+                stdout=sys.stderr,
+                cwd=venv_dir
+            )
+        except FileNotFoundError:
+            subprocess.check_call([
                 venv_dir / "bin" / "pip", "install", "-r", requirements_path,
                 "--disable-pip-version-check",
                 *(["--use-pep517"] if use_pep517 else []),
-            ],
-            stdout=sys.stderr
-        )
+                ],
+                stdout=sys.stderr,
+            )
         stamp_path.touch()
 
 

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -113,7 +113,6 @@ RUN apt-get update --fix-missing && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-ge
     postgresql-client \
     python3 \
     python3-dev \
-    python3-pip \
     python3-setuptools \
     qemu-system \
     qemu-user-static \
@@ -214,6 +213,8 @@ RUN mkdir rust \
 RUN ln -s /usr/bin/lld /opt/x-tools/$ARCH_GCC-unknown-linux-gnu/bin/$ARCH_GCC-unknown-linux-gnu-ld.lld \
     && ln -s /usr/bin/lld /opt/x-tools/$ARCH_GCC-unknown-linux-gnu/bin/$ARCH_GCC-unknown-linux-gnu-lld
 
+RUN curl -LsSf https://astral.sh/uv/0.4.25/install.sh | UV_INSTALL_DIR=/usr/local UV_UNMANAGED_INSTALL=1 sh
+
 # Shims for sanitizers
 COPY sanshim/$ARCH_GCC /sanshim
 
@@ -228,7 +229,7 @@ RUN npx pyright@$(sh /workdir/pyright-version.sh) --help
 
 COPY requirements.txt /workdir/
 
-RUN pip3 install --break-system-packages -r /workdir/requirements.txt && rm /workdir/requirements*.txt
+RUN uv pip install --system --break-system-packages -r /workdir/requirements.txt && rm /workdir/requirements*.txt
 
 # Install APT repo generator.
 


### PR DESCRIPTION
10-100x faster

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
