### PR TITLE
also create balancers in orchestratord

### DIFF
--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -41,15 +41,16 @@ The following table lists the configurable parameters of the Materialize operato
 | `environmentd.nodeSelector` |  | ``{}`` |
 | `namespace.create` |  | ``false`` |
 | `namespace.name` |  | ``"materialize"`` |
-| `networkPolicies.enabled` | Whether to install any network policies. | ``true`` |
-| `networkPolicies.internal.enabled` | Whether to install network policies allowing communication between Materialize pods. | ``true`` |
-| `networkPolicies.ingress.enabled` | Whether to install network policies allowing communication from external locations to environmentd or balancerd SQL or HTTP ports. | ``true`` |
-| `networkPolicies.ingress.cidrs` | List of CIDR blocks to allow to reach environmentd or balancerd. | ``["0.0.0.0/0"]`` |
-| `networkPolicies.egress.enabled` | Whether to install network policies allowing communication from Materialize pods to external sources and sinks. | ``true`` |
-| `networkPolicies.egress.cidrs` | List of CIDR blocks to allow Materialize pods to reach for sources and sinks. | ``["0.0.0.0/0"]`` |
+| `networkPolicies.egress.cidrs[0]` |  | ``"0.0.0.0/0"`` |
+| `networkPolicies.egress.enabled` |  | ``true`` |
+| `networkPolicies.enabled` |  | ``true`` |
+| `networkPolicies.ingress.cidrs[0]` |  | ``"0.0.0.0/0"`` |
+| `networkPolicies.ingress.enabled` |  | ``true`` |
+| `networkPolicies.internal.enabled` |  | ``true`` |
 | `observability.enabled` |  | ``false`` |
 | `observability.prometheus.enabled` |  | ``false`` |
 | `operator.args.cloudProvider` |  | ``"local"`` |
+| `operator.args.createBalancers` |  | ``true`` |
 | `operator.args.localDevelopment` |  | ``true`` |
 | `operator.args.region` |  | ``"kind"`` |
 | `operator.args.startupLogFilter` |  | ``"INFO,mz_orchestratord=TRACE"`` |
@@ -57,10 +58,9 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.image.repository` |  | ``"materialize/orchestratord"`` |
 | `operator.image.tag` |  | ``"v0.122.0-dev.0--pr.g8bb641fc00c77f98ba5556dcdca43670776eacfa"`` |
 | `operator.nodeSelector` |  | ``{}`` |
-| `operator.resources.limits.cpu` |  | ``"500m"`` |
 | `operator.resources.limits.memory` |  | ``"512Mi"`` |
 | `operator.resources.requests.cpu` |  | ``"100m"`` |
-| `operator.resources.requests.memory` |  | ``"128Mi"`` |
+| `operator.resources.requests.memory` |  | ``"512Mi"`` |
 | `rbac.create` |  | ``true`` |
 | `serviceAccount.create` |  | ``true`` |
 | `serviceAccount.name` |  | ``"orchestratord"`` |
@@ -91,17 +91,7 @@ To enable observability features, set `observability.enabled=true`. This will cr
 
 ### Network Policies
 
-Network policies can be enabled by setting `networkPolicies.enabled=true`.
-
-To enable policies for internal communication between Materialize pods, set `networkPolicies.internal.enabled=true`.
-
-To enable policies for ingress HTTP or SQL communication to Materialize environmentd or balancerd pods, set `networkPolicies.ingress.enabled=true`.
-
-Ingress policies can configure the list of CIDR blocks to allow with `networkPolicies.ingress.cidrs`.
-
-To enable policies for egress communication from Materialize pods to sources and sinks, set `networkPolicies.egress.enabled=true`.
-
-Egress policies can configure the list of CIDR blocks to allow with `networkPolicies.ingress.cidrs`.
+Network policies can be enabled by setting `networkPolicies.enabled=true`. By default, the chart uses native Kubernetes network policies. To use Cilium network policies instead, set `networkPolicies.useNativeKubernetesPolicy=false`.
 
 ## Troubleshooting
 

--- a/misc/helm-charts/operator/templates/clusterrole.yaml
+++ b/misc/helm-charts/operator/templates/clusterrole.yaml
@@ -63,6 +63,7 @@ rules:
   - environmentd
 - apiGroups: ["apps"]
   resources:
+  - deployments
   - statefulsets
   verbs:
   - create

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
         {{- if .Values.operator.args.localDevelopment }}
         - "--local-development"
         {{- end }}
+        {{- if .Values.operator.args.createBalancers }}
+        - "--create-balancers"
+        {{- end }}
         - "--image-pull-policy={{ kebabcase .Values.operator.image.pullPolicy }}"
         {{- range $key, $value := .Values.environmentd.nodeSelector }}
         - "--environmentd-node-selector={{ $key }}={{ $value }}"

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -25,6 +25,8 @@ operator:
     region: "kind"
     # Flag to indicate whether the environment is for local development
     localDevelopment: true
+    # Flag to indicate whether to create balancerd pods for the environments
+    createBalancers: true
   # Node selector to use for the operator pod
   nodeSelector: {}
   resources:

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -49,6 +49,10 @@ pub mod v1alpha1 {
         pub environmentd_cpu_allocation: Option<String>,
         // Value for the memory request and limit for the environmentd pod
         pub environmentd_memory_allocation: Option<String>,
+        // Value for the cpu request and limit for the balancerd pod
+        pub balancerd_cpu_allocation: Option<String>,
+        // Value for the memory request and limit for the balancerd pod
+        pub balancerd_memory_allocation: Option<String>,
 
         // When changes are made to the environmentd resources (either via
         // modifying fields in the spec here or by deploying a new
@@ -110,6 +114,14 @@ pub mod v1alpha1 {
             format!("environmentd-{}-{generation}", self.name_unchecked())
         }
 
+        pub fn balancerd_deployment_name(&self) -> String {
+            format!("balancerd-{}", self.name_unchecked())
+        }
+
+        pub fn balancerd_service_name(&self) -> String {
+            format!("balancerd-{}", self.name_unchecked())
+        }
+
         pub fn persist_pubsub_service_name(&self, generation: u64) -> String {
             format!("persist-pubsub-{}-{generation}", self.name_unchecked())
         }
@@ -141,6 +153,20 @@ pub mod v1alpha1 {
         pub fn environmentd_memory_allocation(&self, default_allocation: &str) -> String {
             self.spec
                 .environmentd_memory_allocation
+                .clone()
+                .unwrap_or_else(|| default_allocation.to_string())
+        }
+
+        pub fn balancerd_cpu_allocation(&self, default_allocation: &str) -> String {
+            self.spec
+                .balancerd_cpu_allocation
+                .clone()
+                .unwrap_or_else(|| default_allocation.to_string())
+        }
+
+        pub fn balancerd_memory_allocation(&self, default_allocation: &str) -> String {
+            self.spec
+                .balancerd_memory_allocation
                 .clone()
                 .unwrap_or_else(|| default_allocation.to_string())
         }

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -35,6 +35,8 @@ pub struct Args {
     region: String,
     #[clap(long)]
     local_development: bool,
+    #[clap(long)]
+    create_balancers: bool,
 
     #[clap(flatten)]
     aws_info: AwsInfo,
@@ -48,6 +50,8 @@ pub struct Args {
     environmentd_node_selector: Vec<KeyValueArg<String, String>>,
     #[clap(long)]
     clusterd_node_selector: Vec<KeyValueArg<String, String>>,
+    #[clap(long)]
+    balancerd_node_selector: Vec<KeyValueArg<String, String>>,
     #[clap(long, default_value = "always", arg_enum)]
     image_pull_policy: KubernetesImagePullPolicy,
     #[clap(flatten)]
@@ -71,6 +75,10 @@ pub struct Args {
     default_environmentd_cpu_allocation: String,
     #[clap(long, default_value = "512Mi")]
     default_environmentd_memory_allocation: String,
+    #[clap(long, default_value = "100m")]
+    default_balancerd_cpu_allocation: String,
+    #[clap(long, default_value = "256Mi")]
+    default_balancerd_memory_allocation: String,
 
     #[clap(
         long,
@@ -92,6 +100,17 @@ pub struct Args {
     environmentd_internal_http_host_override: Option<String>,
     #[clap(long, default_value = "6879")]
     environmentd_internal_persist_pubsub_port: i32,
+    #[clap(long, default_value = "6880")]
+    environmentd_balancer_sql_port: i32,
+    #[clap(long, default_value = "6881")]
+    environmentd_balancer_http_port: i32,
+
+    #[clap(long, default_value = "6875")]
+    balancerd_sql_port: i32,
+    #[clap(long, default_value = "6876")]
+    balancerd_http_port: i32,
+    #[clap(long, default_value = "8080")]
+    balancerd_internal_http_port: i32,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]


### PR DESCRIPTION
### Motivation

we want the helm chart to still use the balancer layer, because we have future plans of moving more logic into it

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
