### PR TITLE
postgres consistency: extend ignore entry

### DIFF
--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -889,10 +889,8 @@ class PgPostExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("value out of range")
 
-        if "coalesce could not convert type integer[] to numeric[]" in mz_error_msg:
-            return YesIgnore(
-                "database-issues#8648: coalesce could not convert type integer[] to numeric[]"
-            )
+        if "coalesce could not convert type" in mz_error_msg:
+            return YesIgnore("database-issues#8648: coalesce could not convert type")
 
         return NoIgnore()
 


### PR DESCRIPTION
This addresses https://buildkite.com/materialize/nightly/builds/10121#0192ba0a-b4d7-4213-91ad-5b098be0935a:

```
SUCCESS_MISMATCH: Outcome differs.
Expression: coalesce(array_agg(int2_null ORDER BY ARRAY[row_index]::INT[], int2_null), array_agg(decimal_39_8_max ORDER BY ARRAY[row_index]::INT[], decimal_39_8_max))
  Value 1 (Materialize evaluation): 'QueryFailure' (type: <class 'str'>)
  Value 2 (Postgres evaluation): 'QueryResult' (type: <class 'str'>)
  Error 1: 'coalesce could not convert type numeric[] to smallint[]'
```