### PR TITLE
ci: skip "upload debug symbols" in coverage builds

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -56,6 +56,7 @@ steps:
         if: build.tag != "" && build.branch =~ /^v.*\..*\$/
         agents:
           queue: builder-linux-x86_64
+        coverage: skip
 
       - id: rust-build-aarch64
         label: ":rust: Build aarch64"
@@ -83,6 +84,7 @@ steps:
         if: build.tag != "" && build.branch =~ /^v.*\..*\$/
         agents:
           queue: builder-linux-aarch64-mem
+        coverage: skip
 
 
       - id: build-x86_64


### PR DESCRIPTION
Not strictly necessary because you anyway need to set a build tag but it confused me to have it listed in "Trigger CI builds".