### PR TITLE
testdrive: Print everything to stdout

### DIFF
--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -271,7 +271,7 @@ async fn main() {
 
     tracing_subscriber::fmt()
         .with_env_filter(args.log_filter)
-        .with_writer(io::stderr)
+        .with_writer(io::stdout)
         .init();
 
     let (aws_config, aws_account) = match args.aws_region {
@@ -509,7 +509,7 @@ async fn main() {
             junit_suite.add_testcase(test_case);
         }
         if let Err(error) = res {
-            let _ = error.print_stderr();
+            let _ = error.print_error();
             error_count += 1;
             error_files.insert(file);
             if error_count >= args.max_errors {

--- a/src/testdrive/src/error.rs
+++ b/src/testdrive/src/error.rs
@@ -26,7 +26,7 @@ use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 /// An error produced when parsing or executing a testdrive script.
 ///
 /// Errors are optionally associated with a location in a testdrive script. When
-/// printed with the [`Error::print_stderr`] method, the location of the error
+/// printed with the [`Error::print_error`] method, the location of the error
 /// along with a snippet of the source code at that location will be printed
 /// alongside the error message.
 pub struct Error {
@@ -39,45 +39,45 @@ impl Error {
         Error { source, location }
     }
 
-    /// Prints the error to `stderr`, with coloring if the terminal supports it.
-    pub fn print_stderr(&self) -> io::Result<()> {
-        let color_choice = if std::io::stderr().is_terminal() {
+    /// Prints the error to `stdout`, with coloring if the terminal supports it.
+    pub fn print_error(&self) -> io::Result<()> {
+        let color_choice = if std::io::stdout().is_terminal() {
             ColorChoice::Auto
         } else {
             ColorChoice::Never
         };
-        let mut stderr = StandardStream::stderr(color_choice);
+        let mut stdout = StandardStream::stdout(color_choice);
         eprintln!("^^^ +++");
         match &self.location {
             Some(location) => {
                 let mut color_spec = ColorSpec::new();
                 color_spec.set_bold(true);
-                stderr.set_color(&color_spec)?;
+                stdout.set_color(&color_spec)?;
                 if let Some(filename) = &location.filename {
                     write!(
-                        &mut stderr,
+                        &mut stdout,
                         "{}:{}:{}: ",
                         filename.display(),
                         location.line,
                         location.col
                     )?;
                 } else {
-                    write!(&mut stderr, "{}:{}: ", location.line, location.col)?;
+                    write!(&mut stdout, "{}:{}: ", location.line, location.col)?;
                 }
-                write_error_heading(&mut stderr, &color_spec)?;
-                writeln!(&mut stderr, "{}", self.source.display_with_causes())?;
+                write_error_heading(&mut stdout, &color_spec)?;
+                writeln!(&mut stdout, "{}", self.source.display_with_causes())?;
                 color_spec.set_bold(false);
-                stderr.set_color(&color_spec)?;
-                write!(&mut stderr, "{}", location.snippet)?;
-                writeln!(&mut stderr, "{}^", " ".repeat(location.col - 1))?;
+                stdout.set_color(&color_spec)?;
+                write!(&mut stdout, "{}", location.snippet)?;
+                writeln!(&mut stdout, "{}^", " ".repeat(location.col - 1))?;
             }
             None => {
                 let color_spec = ColorSpec::new();
-                write_error_heading(&mut stderr, &color_spec)?;
-                writeln!(&mut stderr, "{}", self.source.display_with_causes())?;
+                write_error_heading(&mut stdout, &color_spec)?;
+                writeln!(&mut stdout, "{}", self.source.display_with_causes())?;
             }
         }
-        std::io::stderr().flush()
+        std::io::stdout().flush()
     }
 }
 

--- a/src/testdrive/src/util/text.rs
+++ b/src/testdrive/src/util/text.rs
@@ -22,12 +22,12 @@ pub fn trim_trailing_space(s: &str) -> String {
 
 /// Prints a colorized line diff of `expected` and `actual`.
 pub fn print_diff(expected: &str, actual: &str) {
-    let color_choice = if std::io::stderr().is_terminal() {
+    let color_choice = if std::io::stdout().is_terminal() {
         ColorChoice::Auto
     } else {
         ColorChoice::Never
     };
-    let mut stderr = StandardStream::stderr(color_choice);
+    let mut stdout = StandardStream::stdout(color_choice);
     let diff = TextDiff::from_lines(expected, actual);
     println!("--- expected");
     println!("+++ actual");
@@ -35,17 +35,17 @@ pub fn print_diff(expected: &str, actual: &str) {
         for change in diff.iter_changes(op) {
             let sign = match change.tag() {
                 ChangeTag::Delete => {
-                    let _ = stderr.set_color(ColorSpec::new().set_fg(Some(Color::Red)));
+                    let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Red)));
                     "-"
                 }
                 ChangeTag::Insert => {
-                    let _ = stderr.set_color(ColorSpec::new().set_fg(Some(Color::Green)));
+                    let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)));
                     "+"
                 }
                 ChangeTag::Equal => " ",
             };
             print!("{}{}", sign, change);
-            let _ = stderr.reset();
+            let _ = stdout.reset();
         }
     }
 }


### PR DESCRIPTION
We have had reports of devs being confused by errors in testdrive output not lining up with the normal output. This fixes it both in CI and locally (if it ever happened there).

An alternative would be to add a flag `--stdout-only` and use that in CI, while keeping stderr locally.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
