### PR TITLE
tests: fix pretty.slt

### DIFF
--- a/test/sqllogictest/pretty.slt
+++ b/test/sqllogictest/pretty.slt
@@ -68,9 +68,9 @@ statement ok
 CREATE DEFAULT INDEX ON t
 
 query T multiline
-SELECT pretty_sql(create_sql) FROM mz_indexes WHERE name = 't_primary_idx'
+SELECT replace(pretty_sql(create_sql), on_id, '<on_id>') FROM mz_indexes WHERE name = 't_primary_idx'
 ----
-CREATE INDEX t_primary_idx IN CLUSTER [u1] ON [u2 AS materialize.public.t] (i);
+CREATE INDEX t_primary_idx IN CLUSTER [u1] ON [<on_id> AS materialize.public.t] (i);
 EOF
 
 statement ok


### PR DESCRIPTION
This addresses https://buildkite.com/materialize/slt/builds/6075#0192b925-5c6a-4c13-8974-0bd776a5aa5e:
```
OutputFailure:test/sqllogictest/pretty.slt:71
        expected: Values(["CREATE INDEX t_primary_idx IN CLUSTER [u1] ON [u2 AS materialize.public.t] (i);"])
        actually: Values(["CREATE INDEX t_primary_idx IN CLUSTER [u1] ON [u18 AS materialize.public.t] (i);"])
        actual raw: [Row { columns: [Column { name: "pretty_sql", table_oid: None, column_id: None, type: Text }] }]
```