### PR TITLE
bazel: Add a `cargo check` like behavior

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -127,6 +127,11 @@ build --@rules_rust//:extra_rustc_flag="-Ccodegen-units=64"
 # just `.rmeta` instead of the full `.rlib`.
 build --@rules_rust//rust/settings:pipelined_compilation=True
 
+# `cargo check` like config, still experimental!
+#
+# Ignores all outputs other than `.rmeta`, requires pipelied_compilation to be enabled!
+build:check --output_groups=build_metadata
+
 # CI Build Configuration
 #
 # Note: This shouldn't change any config of the built binary, just the way it

--- a/misc/python/materialize/cli/bazel.py
+++ b/misc/python/materialize/cli/bazel.py
@@ -35,10 +35,23 @@ def main() -> int:
         fmt_cmd(sub_args)
     elif args.action == "output_path":
         output_path_cmd(sub_args)
+    elif args.action == "check":
+        check_cmd(sub_args)
     else:
         bazel_cmd([args.action] + sub_args)
 
     return 0
+
+
+def check_cmd(args: list[str]):
+    """
+    Invokes a `bazel build` with `cargo check` like behavior.
+
+    Still experimental, is known to fail with crates that have pipelined compilation explicitly
+    disabled.
+    """
+    check_args = ["build", "--config=check", *args]
+    bazel_cmd(check_args)
 
 
 def gen_cmd(args: list[str]):


### PR DESCRIPTION
Compliments of @antiguru, this PR adds a cargo check like behavior to our Bazel build. Users can now run either `bin/bazel check <target>` which de-sugars to `bazel build --config=check <target>`

### Motivation

Improve our Bazel setup

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
