### PR TITLE
allow just setting the resource requirements directly

### DIFF
--- a/misc/helm-charts/environmentd/README.md
+++ b/misc/helm-charts/environmentd/README.md
@@ -46,10 +46,14 @@ The following table lists the configurable parameters of the Materialize environ
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `environment.environmentdCpuAllocation` |  | ``1`` |
+| `environment.balancerdResourceRequirements.limits.memory` |  | ``"256Mi"`` |
+| `environment.balancerdResourceRequirements.requests.cpu` |  | ``"100m"`` |
+| `environment.balancerdResourceRequirements.requests.memory` |  | ``"256Mi"`` |
 | `environment.environmentdExtraArgs[0]` |  | ``"--orchestrator-kubernetes-ephemeral-volume-class=hostpath"`` |
 | `environment.environmentdImageRef` |  | ``"materialize/environmentd:v0.122.0-dev.0--pr.g47923ddb1bb4f3fb38d152b8aa86a77514599b29"`` |
-| `environment.environmentdMemoryAllocation` |  | ``"1Gi"`` |
+| `environment.environmentdResourceRequirements.limits.memory` |  | ``"512Mi"`` |
+| `environment.environmentdResourceRequirements.requests.cpu` |  | ``"250m"`` |
+| `environment.environmentdResourceRequirements.requests.memory` |  | ``"512Mi"`` |
 | `environment.forceRollout` |  | ``"33333333-3333-3333-3333-333333333333"`` |
 | `environment.inPlaceRollout` |  | ``false`` |
 | `environment.name` |  | ``"12345678-1234-1234-1234-123456789012"`` |

--- a/misc/helm-charts/environmentd/templates/environmentd.yaml
+++ b/misc/helm-charts/environmentd/templates/environmentd.yaml
@@ -18,11 +18,13 @@ spec:
   environmentdExtraArgs:
     {{- toYaml .Values.environment.environmentdExtraArgs | nindent 4 }}
   {{- end }}
-  {{- if .Values.environment.environmentdCpuAllocation }}
-  environmentdCpuAllocation: {{ .Values.environment.environmentdCpuAllocation | quote }}
+  {{- if .Values.environment.environmentdResourceRequirements }}
+  environmentdResourceRequirements:
+    {{- toYaml .Values.environment.environmentdResourceRequirements | nindent 4 }}
   {{- end }}
-  {{- if .Values.environment.environmentdMemoryAllocation }}
-  environmentdMemoryAllocation: {{ .Values.environment.environmentdMemoryAllocation | quote }}
+  {{- if .Values.environment.balancerdResourceRequirements }}
+  balancerdResourceRequirements:
+    {{- toYaml .Values.environment.balancerdResourceRequirements | nindent 4 }}
   {{- end }}
   {{- if .Values.environment.requestRollout }}
   requestRollout: {{ .Values.environment.requestRollout }}

--- a/misc/helm-charts/environmentd/values.yaml
+++ b/misc/helm-charts/environmentd/values.yaml
@@ -23,10 +23,20 @@ environment:
   # Optional additional arguments to be passed to `environmentd`
   environmentdExtraArgs:
     - "--orchestrator-kubernetes-ephemeral-volume-class=hostpath" # Use hostpath for ephemeral storage in testing
-  # CPU allocation for the `environmentd` service (in cores)
-  environmentdCpuAllocation: 1
-  # Memory allocation for the `environmentd` service (e.g., "1Gi" for 1 GB)
-  environmentdMemoryAllocation: "1Gi"
+  # Resource requirements for the environmentd pod
+  environmentdResourceRequirements:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      memory: "512Mi"
+  # Resource requirements for the balancerd pod
+  balancerdResourceRequirements:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      memory: "256Mi"
   # UUID for managing rollouts of the environment, this triggers rollouts when changed
   requestRollout: 22222222-2222-2222-2222-222222222222
   # UUID to force a rollout of the environment, typically for emergency or specific updates

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -71,14 +71,6 @@ pub struct Args {
     bootstrap_builtin_catalog_server_cluster_replica_size: String,
     #[clap(long, default_value = "25cc")]
     bootstrap_builtin_analytics_cluster_replica_size: String,
-    #[clap(long, default_value = "250m")]
-    default_environmentd_cpu_allocation: String,
-    #[clap(long, default_value = "512Mi")]
-    default_environmentd_memory_allocation: String,
-    #[clap(long, default_value = "100m")]
-    default_balancerd_cpu_allocation: String,
-    #[clap(long, default_value = "256Mi")]
-    default_balancerd_memory_allocation: String,
 
     #[clap(
         long,


### PR DESCRIPTION
### Motivation

simplify, and make this more flexible

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
