### PR TITLE
expiration: use Option type to differentiate unset vs false

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -479,7 +479,7 @@ impl Coordinator {
                 df_desc.dataflow_expiration_desc.transitive_upper = Some(transitive_upper);
                 df_desc
                     .dataflow_expiration_desc
-                    .has_transitive_refresh_schedule = has_transitive_refresh_schedule;
+                    .has_transitive_refresh_schedule = Some(has_transitive_refresh_schedule);
 
                 coord
                     .ship_dataflow_and_notice_builtin_table_updates(

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -677,7 +677,7 @@ impl Coordinator {
                 df_desc.dataflow_expiration_desc.transitive_upper = Some(transitive_upper);
                 df_desc
                     .dataflow_expiration_desc
-                    .has_transitive_refresh_schedule = has_transitive_refresh_schedule;
+                    .has_transitive_refresh_schedule = Some(has_transitive_refresh_schedule);
 
                 let storage_metadata = coord.catalog.state().storage_metadata();
 

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -368,7 +368,7 @@ impl Coordinator {
         df_desc.dataflow_expiration_desc.transitive_upper = Some(transitive_upper);
         df_desc
             .dataflow_expiration_desc
-            .has_transitive_refresh_schedule = has_transitive_refresh_schedule;
+            .has_transitive_refresh_schedule = Some(has_transitive_refresh_schedule);
 
         // Emit notices.
         self.emit_optimizer_notices(ctx.session(), &df_meta.optimizer_notices);

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -168,7 +168,7 @@ impl Optimize<Index> for Optimizer {
         };
         let mut df_desc = MirDataflowDescription::new(full_name.to_string());
 
-        df_desc.dataflow_expiration_desc.is_timeline_epoch_ms = index.is_timeline_epoch_ms;
+        df_desc.dataflow_expiration_desc.is_timeline_epoch_ms = Some(index.is_timeline_epoch_ms);
 
         df_builder.import_into_dataflow(&index.on, &mut df_desc, &self.config.features)?;
         df_builder.maybe_reoptimize_imported_views(&mut df_desc, &self.config)?;

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -229,7 +229,7 @@ impl Optimize<LocalMirPlan> for Optimizer {
         };
         let mut df_desc = MirDataflowDescription::new(self.debug_name.clone());
 
-        df_desc.dataflow_expiration_desc.is_timeline_epoch_ms = self.is_timeline_epoch_ms;
+        df_desc.dataflow_expiration_desc.is_timeline_epoch_ms = Some(self.is_timeline_epoch_ms);
 
         df_desc.refresh_schedule.clone_from(&self.refresh_schedule);
 

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -315,7 +315,7 @@ impl GlobalMirPlan<Unresolved> {
         self.df_desc.set_as_of(as_of);
 
         // Detect the timeline type.
-        self.df_desc.dataflow_expiration_desc.is_timeline_epoch_ms = is_timeline_epoch_ms;
+        self.df_desc.dataflow_expiration_desc.is_timeline_epoch_ms = Some(is_timeline_epoch_ms);
 
         // The only outputs of the dataflow are sinks, so we might be able to
         // turn off the computation early, if they all have non-trivial

--- a/src/compute-types/src/dataflows.proto
+++ b/src/compute-types/src/dataflows.proto
@@ -50,8 +50,8 @@ message ProtoDataflowDescription {
 
   message ProtoDataflowExpirationDesc {
     optional mz_repr.antichain.ProtoU64Antichain transitive_upper = 1;
-    bool has_transitive_refresh_schedule = 2;
-    bool is_timeline_epoch_ms = 3;
+    optional bool has_transitive_refresh_schedule = 2;
+    optional bool is_timeline_epoch_ms = 3;
   }
 
   repeated ProtoSourceImport source_imports = 1;


### PR DESCRIPTION
I spent a little time reproducing the issue locally, now that we know what to look for, and immediately noticed that the logs would have been not that helpful anyway since we currently can't distinguish between unset (which is the actual issue) and the default value (e.g., `true` for `has_transitive_refresh_schedule`).

Changing the types to explicitly use Option, which helps indicate unset data with a `None`.

Also fixed a bug where the debug log in `expire_dataflow_at` is actually skipped on failed checks. 