### PR TITLE
DNM: Check which cargo tests are close to failing because of stack overflows

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -210,6 +210,7 @@ case "$cmd" in
             --env REDPANDA_CLOUD_CLIENT_ID
             --env REDPANDA_CLOUD_CLIENT_SECRET
             --env QA_BENCHMARKING_APP_PASSWORD
+            --env RUST_MIN_STACK
         )
 
         if [[ $detach_container == "true" ]]; then

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -296,6 +296,7 @@ steps:
       AWS_DEFAULT_REGION: "us-east-1"
       # cargo-test's coverage is handled separately by cargo-llvm-cov
       BUILDKITE_MZCOMPOSE_PLUGIN_SKIP_COVERAGE: "true"
+      RUST_MIN_STACK: "1048576"
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:


### PR DESCRIPTION
Maybe we should have something like this in nightly to catch them earlier?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
