### PR TITLE
cargo-test: Bump RUST_MIN_STACK

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -191,6 +191,7 @@ case "$cmd" in
             --env PRODUCTION_ANALYTICS_USERNAME
             --env PRODUCTION_ANALYTICS_APP_PASSWORD
             --env PYPI_TOKEN
+            --env RUST_MIN_STACK
             --env MZ_DEV_BUILD_SHA
             # For Miri with nightly Rust
             --env ZOOKEEPER_ADDR

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -296,6 +296,8 @@ steps:
       AWS_DEFAULT_REGION: "us-east-1"
       # cargo-test's coverage is handled separately by cargo-llvm-cov
       BUILDKITE_MZCOMPOSE_PLUGIN_SKIP_COVERAGE: "true"
+      # some tests run into stack overflows
+      RUST_MIN_STACK: "4194304"
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -313,6 +313,8 @@ def main() -> int:
             command += ["--test", test]
         command += args.args
         env["COCKROACH_URL"] = args.postgres
+        # some tests run into stack overflows
+        env["RUST_MIN_STACK"] = "4194304"
         dbconn = _connect_sql(args.postgres)
     else:
         raise UIError(f"unknown program {args.program}")


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
