### PR TITLE
compute: step back as-ofs of write-only collections

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2957,9 +2957,7 @@ pub fn plan_create_continual_task(
         placeholder_id,
         desc,
         input_id: input.id(),
-        // TODO(ct2): Flip the default to true once we've fixed the issue with
-        // snapshot + self-referencing CTs.
-        with_snapshot: snapshot.unwrap_or(false),
+        with_snapshot: snapshot.unwrap_or(true),
         continual_task: MaterializedView {
             create_sql,
             expr,


### PR DESCRIPTION
When rehydrating, CT dataflows need to be able to observe changes at there previous upper (i.e. the current write frontier of the output shard), to produce the correct output for this time. That means they need to start reading from their sources (with snapshot excluded) as of `upper - 1`, and the controller needs to set the dataflow `as_of` accordingly.

This PR ensures this by (a) adjusting how the compute controller downgrades read frontiers for write-only collections and (b) the bootstrap as-of selection process.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8699

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
