### PR TITLE
postgres consistency: add ignore for evaluation shortcut

### DIFF
--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -717,9 +717,20 @@ class PgPostExecutionInconsistencyIgnoreFilter(
         ) and ExpressionCharacteristics.NULL in query_template.get_involved_characteristics(
             ALL_QUERY_COLUMNS_BY_INDEX_SELECTION
         ):
-            # known at least for unnest: where condition will not be evaluated if mz knows that the number of resulting
+            # where condition will not be evaluated if mz knows that the number of resulting
             # rows is zero
             return YesIgnore("Evaluation shortcut for table functions")
+
+        if (
+            query_template.matches_any_expression(
+                partial(
+                    matches_fun_by_name, function_name_in_lower_case="jsonb_object_agg"
+                ),
+                True,
+            )
+            and mz_outcome.row_count() == 0
+        ):
+            return YesIgnore("Evaluation shortcut")
 
         return NoIgnore()
 


### PR DESCRIPTION
This addresses https://buildkite.com/materialize/nightly/builds/10152#0192c376-f152-481a-a4c1-360fb1b091e8:
```
SUCCESS_MISMATCH: Outcome differs.
Expression: jsonb_object_agg(s0.uuid_val, (UUID 'invalid_value_123') ORDER BY ARRAY[s0.row_index]::INT[], 0, s0.uuid_val, (UUID 'invalid_value_123'))
  Value 1 (Materialize evaluation): 'QueryResult' (type: <class 'str'>)
  Value 2 (Postgres evaluation): 'QueryFailure' (type: <class 'str'>)
  Error 2: 'invalid input syntax for type uuid: "invalid_value_123"'
```