### PR TITLE
adapter,compute: fixes for continual tasks

### DIFF
--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -382,6 +382,7 @@ impl<P, S, T> DataflowDescription<P, S, T> {
             .iter()
             .filter_map(|(id, desc)| match desc.connection {
                 ComputeSinkConnection::MaterializedView(_) => Some(*id),
+                ComputeSinkConnection::ContinualTask(_) => Some(*id),
                 _ => None,
             })
     }

--- a/test/testdrive/controller-frontiers.td
+++ b/test/testdrive/controller-frontiers.td
@@ -88,6 +88,36 @@ idx1 r2
     frontiers.write_frontier > 0
 idx1
 
+# Test that frontiers of continual tasks are reported.
+
+> CREATE CONTINUAL TASK ct1 (a int) ON INPUT t1 AS (
+    INSERT INTO ct1 SELECT * FROM t1
+  )
+
+> SELECT
+    cts.name,
+    replicas.name
+  FROM mz_cluster_replica_frontiers frontiers
+  JOIN mz_internal.mz_continual_tasks cts
+    ON frontiers.object_id = cts.id
+  LEFT JOIN mz_cluster_replicas replicas
+    ON frontiers.replica_id = replicas.id
+  WHERE
+    frontiers.object_id LIKE 'u%' AND
+    frontiers.write_frontier > 0
+ct1 r1
+ct1 r2
+
+> SELECT
+    cts.name
+  FROM mz_internal.mz_frontiers frontiers
+  JOIN mz_internal.mz_continual_tasks cts
+    ON frontiers.object_id = cts.id
+  WHERE
+    frontiers.object_id LIKE 'u%' AND
+    frontiers.read_frontier > 0 AND
+    frontiers.write_frontier > 0
+ct1
 
 # Test that frontiers of sources are reported.
 
@@ -317,6 +347,7 @@ r3 <null>
 > DROP MATERIALIZED VIEW mv1
 > DROP MATERIALIZED VIEW mv2
 > DROP INDEX idx1
+> DROP CONTINUAL TASK ct1
 > DROP SOURCE source1 CASCADE
 > DROP SINK sink1
 > DROP TABLE t1
@@ -329,7 +360,7 @@ r3 <null>
   FROM mz_internal.mz_frontiers frontiers
   WHERE object_id LIKE 'u%'
 
-# Test that frontiers are correctly initialized on for collections on clusters
+# Test that frontiers are correctly initialized for collections on clusters
 # with zero replicas.
 
 > CREATE CLUSTER empty SIZE '1', REPLICATION FACTOR 0


### PR DESCRIPTION
This PR fixes two issues around CTs I discovered while poking at them. See commit messages for details.

### Motivation

  * This PR fixes a previously unreported bug.

Two bugs: 
* Frontiers for CTs are reported twice in `mz_frontiers` and `mz_cluster_replica_frontiers`.
* `DROP CONTINUAL TASK` only partially drops the CT state.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
