### PR TITLE
adapter: Fix missing parser option for specifying timeline on source tables

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4623,60 +4623,65 @@ impl<'a> Parser<'a> {
     fn parse_table_from_source_option(
         &mut self,
     ) -> Result<TableFromSourceOption<Raw>, ParserError> {
-        let option = match self.expect_one_of_keywords(&[TEXT, EXCLUDE, IGNORE, DETAILS])? {
-            ref keyword @ (TEXT | EXCLUDE) => {
-                self.expect_keyword(COLUMNS)?;
+        let option =
+            match self.expect_one_of_keywords(&[TEXT, EXCLUDE, IGNORE, DETAILS, TIMELINE])? {
+                ref keyword @ (TEXT | EXCLUDE) => {
+                    self.expect_keyword(COLUMNS)?;
 
-                let _ = self.consume_token(&Token::Eq);
+                    let _ = self.consume_token(&Token::Eq);
 
-                let value = self
-                    .parse_option_sequence(Parser::parse_identifier)?
-                    .map(|inner| {
-                        WithOptionValue::Sequence(
-                            inner.into_iter().map(WithOptionValue::Ident).collect_vec(),
-                        )
-                    });
+                    let value =
+                        self.parse_option_sequence(Parser::parse_identifier)?
+                            .map(|inner| {
+                                WithOptionValue::Sequence(
+                                    inner.into_iter().map(WithOptionValue::Ident).collect_vec(),
+                                )
+                            });
 
-                TableFromSourceOption {
-                    name: match *keyword {
-                        TEXT => TableFromSourceOptionName::TextColumns,
-                        EXCLUDE => TableFromSourceOptionName::ExcludeColumns,
-                        _ => unreachable!(),
-                    },
-                    value,
+                    TableFromSourceOption {
+                        name: match *keyword {
+                            TEXT => TableFromSourceOptionName::TextColumns,
+                            EXCLUDE => TableFromSourceOptionName::ExcludeColumns,
+                            _ => unreachable!(),
+                        },
+                        value,
+                    }
                 }
-            }
-            DETAILS => TableFromSourceOption {
-                name: TableFromSourceOptionName::Details,
-                value: self.parse_optional_option_value()?,
-            },
-            IGNORE => {
-                match self.expect_one_of_keywords(&[COLUMNS, KEYS])? {
-                    COLUMNS => {
-                        let _ = self.consume_token(&Token::Eq);
+                DETAILS => TableFromSourceOption {
+                    name: TableFromSourceOptionName::Details,
+                    value: self.parse_optional_option_value()?,
+                },
+                IGNORE => {
+                    match self.expect_one_of_keywords(&[COLUMNS, KEYS])? {
+                        COLUMNS => {
+                            let _ = self.consume_token(&Token::Eq);
 
-                        let value =
-                            self.parse_option_sequence(Parser::parse_identifier)?
-                                .map(|inner| {
+                            let value = self.parse_option_sequence(Parser::parse_identifier)?.map(
+                                |inner| {
                                     WithOptionValue::Sequence(
                                         inner.into_iter().map(WithOptionValue::Ident).collect_vec(),
                                     )
-                                });
-                        TableFromSourceOption {
-                            // IGNORE is historical syntax for this option.
-                            name: TableFromSourceOptionName::ExcludeColumns,
-                            value,
+                                },
+                            );
+                            TableFromSourceOption {
+                                // IGNORE is historical syntax for this option.
+                                name: TableFromSourceOptionName::ExcludeColumns,
+                                value,
+                            }
                         }
+                        KEYS => TableFromSourceOption {
+                            name: TableFromSourceOptionName::IgnoreKeys,
+                            value: self.parse_optional_option_value()?,
+                        },
+                        _ => unreachable!(),
                     }
-                    KEYS => TableFromSourceOption {
-                        name: TableFromSourceOptionName::IgnoreKeys,
-                        value: self.parse_optional_option_value()?,
-                    },
-                    _ => unreachable!(),
                 }
-            }
-            _ => unreachable!(),
-        };
+                TIMELINE => TableFromSourceOption {
+                    name: TableFromSourceOptionName::Timeline,
+                    value: self.parse_optional_option_value()?,
+                },
+                _ => unreachable!(),
+            };
         Ok(option)
     }
 

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -36,11 +36,11 @@ $ kafka-create-topic topic=input-system
 > CREATE SOURCE source_system_user
   IN CLUSTER source_system_user_cluster
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-system-${testdrive.seed}')
-  WITH (TIMELINE '${testdrive.seed}-timelines')
 
 > CREATE TABLE source_system_user_tbl
   FROM SOURCE source_system_user (REFERENCE "testdrive-input-system-${testdrive.seed}")
   FORMAT BYTES
+  WITH (TIMELINE '${testdrive.seed}-timelines')
 
 $ set schema=[
   {
@@ -140,32 +140,33 @@ $ kafka-ingest format=avro topic=input-cdcv2 schema=${schema}
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE MATERIALIZE
 
-! CREATE SOURCE source_cdcv2_system
-  IN CLUSTER ${arg.single-replica-cluster}
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-cdcv2-${testdrive.seed}')
-  WITH (TIMELINE 'mz_foo')
-contains:unacceptable timeline name "mz_foo"
-
 > CREATE CLUSTER source_cdcv2_system_cluster SIZE '${arg.default-storage-size}';
 
 > CREATE SOURCE source_cdcv2_system
   IN CLUSTER ${arg.single-replica-cluster}
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-cdcv2-${testdrive.seed}')
-  WITH (TIMELINE 'mz_epoch_ms')
+
+! CREATE TABLE source_cdcv2_system_tbl FROM SOURCE source_cdcv2_system (REFERENCE "testdrive-input-cdcv2-${testdrive.seed}")
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE MATERIALIZE
+  WITH (TIMELINE 'mz_foo')
+contains:unacceptable timeline name "mz_foo"
+
 > CREATE TABLE source_cdcv2_system_tbl FROM SOURCE source_cdcv2_system (REFERENCE "testdrive-input-cdcv2-${testdrive.seed}")
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE MATERIALIZE
+  WITH (TIMELINE 'mz_epoch_ms')
 
 > CREATE CLUSTER source_cdcv2_user_cluster SIZE '${arg.default-storage-size}';
 > CREATE SOURCE source_cdcv2_user
   IN CLUSTER source_cdcv2_user_cluster
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-cdcv2-${testdrive.seed}')
-  WITH (TIMELINE '${testdrive.seed}-timelines')
 
 > CREATE TABLE source_cdcv2_user_tbl
   FROM SOURCE source_cdcv2_user (REFERENCE "testdrive-input-cdcv2-${testdrive.seed}")
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE MATERIALIZE
+  WITH (TIMELINE '${testdrive.seed}-timelines')
 
 > CREATE TABLE input_table (a bigint);
 
@@ -177,7 +178,7 @@ contains:unacceptable timeline name "mz_foo"
 contains:multiple timelines within one dataflow are not supported
 
 # Verify that user timelines don't allow things to be joinable with their non-user versions.
-! CREATE MATERIALIZED VIEW must_fail (a, b) AS SELECT * FROM source_system, source_system_user;
+! CREATE MATERIALIZED VIEW must_fail (a, b) AS SELECT * FROM source_system, source_system_user_tbl;
 contains:multiple timelines within one dataflow are not supported
 
 # Can join static view with anything.
@@ -217,15 +218,13 @@ contains:multiple timelines within one dataflow are not supported
 ! EXPLAIN SELECT * FROM source_system_tbl, source_cdcv2_tbl;
 contains:multiple timelines within one dataflow are not supported
 
-# TODO: database-issues#8693
 # Can join user-specified timelines.
-# > CREATE MATERIALIZED VIEW source_system_cdcv2_user (a, b, c)
-#   AS SELECT * FROM source_system_user_tbl, source_cdcv2_user_tbl;
+> CREATE MATERIALIZED VIEW source_system_cdcv2_user (a, b, c)
+  AS SELECT * FROM source_system_user_tbl, source_cdcv2_user_tbl;
 
 # CDCv2 can only be joined with system time stuff if specified
-# TODO: database-issues#8693
-# > CREATE MATERIALIZED VIEW source_cdcv2_table_system
-#     AS SELECT * FROM source_cdcv2_system_tbl, input_table;
+> CREATE MATERIALIZED VIEW source_cdcv2_table_system
+  AS SELECT * FROM source_cdcv2_system_tbl, input_table;
 ! CREATE MATERIALIZED VIEW must_fail AS SELECT * FROM source_cdcv2_tbl, input_table;
 contains:multiple timelines within one dataflow are not supported
 

--- a/test/testdrive/timestamps-debezium-kafka.td
+++ b/test/testdrive/timestamps-debezium-kafka.td
@@ -105,26 +105,22 @@ $ kafka-ingest format=avro topic=bar schema=${schema}
 > CREATE SOURCE data_foo
   IN CLUSTER ${arg.single-replica-cluster}
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-foo-${testdrive.seed}')
-  WITH (TIMELINE '${testdrive.seed}-timestamps-debezium-kafka')
 
 > CREATE TABLE data_foo_tbl FROM SOURCE data_foo (REFERENCE "testdrive-foo-${testdrive.seed}")
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
+  WITH (TIMELINE '${testdrive.seed}-timestamps-debezium-kafka')
 
 > CREATE SOURCE data_bar
   IN CLUSTER ${arg.single-replica-cluster}
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-bar-${testdrive.seed}')
-  WITH (TIMELINE '${testdrive.seed}-timestamps-debezium-kafka')
 
 > CREATE TABLE data_bar_tbl FROM SOURCE data_bar (REFERENCE "testdrive-bar-${testdrive.seed}")
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
+  WITH (TIMELINE '${testdrive.seed}-timestamps-debezium-kafka')
 
 > CREATE MATERIALIZED VIEW foo AS SELECT b, sum(a) FROM data_foo_tbl GROUP BY b
 
 > CREATE MATERIALIZED VIEW bar AS SELECT b, sum(a) FROM data_bar_tbl GROUP BY b
-
-# TODO: database-issues#8693
-$ skip-if
-SELECT true
 
 > CREATE MATERIALIZED VIEW join (b, foo_sum, bar_sum) AS SELECT * FROM foo JOIN bar USING (b);
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug. Fixes https://github.com/MaterializeInc/database-issues/issues/8693

I added the ability to plan a custom timeline on source tables here https://github.com/MaterializeInc/materialize/pull/30013 but forgot to add the relevant parsing code, which made it impossible to update these tests. This fixes that and the tests.

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
