### PR TITLE
Propagate record field information

### DIFF
--- a/src/transform/src/analysis/equivalences.rs
+++ b/src/transform/src/analysis/equivalences.rs
@@ -545,6 +545,24 @@ impl EquivalenceClasses {
                     }
                 });
             }
+
+            for expr in class.iter() {
+                // Record-building expressions introduce equivalences between their members and accessors of this.
+                if let MirScalarExpr::CallVariadic {
+                    func: mz_expr::VariadicFunc::RecordCreate { .. },
+                    exprs,
+                } = expr
+                {
+                    for (index, e) in exprs.iter().enumerate() {
+                        to_add.push(vec![
+                            e.clone(),
+                            expr.clone().call_unary(mz_expr::UnaryFunc::RecordGet(
+                                mz_expr::func::RecordGet(index),
+                            )),
+                        ]);
+                    }
+                }
+            }
         }
         self.classes.extend(to_add);
 


### PR DESCRIPTION
This PR introduces equivalences when it observes an `expr` of the form `record(a, b, c, ..)`, producing as equivalent `[a, expr.get(0)]`, `[b, expr.get(1)]`, `[c, expr.get(2)]`, and `..`. Generally, communicating that anything equivalent to `expr` (e.g. the column where the record lands), can when subjected to accessors provide clearer information about properties of its contents.

As an example, the following query has a property that is true of its fields, but which risks being lost when we tuple up columns and try and use them.
```sql
select (c).f1 > (c).f2 from (select distinct row(a, b) c from foo where a > b);
```
In the PR, this now optimizes to 
```
                Optimized Plan                
----------------------------------------------
 Explained Query:                            +
   Project (#1)                              +
     Map (true)                              +
       Distinct project=[row(#0, #1)]        +
         Filter (#0 > #1)                    +
           ReadStorage materialize.public.foo+
```
The example is carefully constructed, in the sense that if it were instead `where (c).f1 > (c).f2`, we seem to be able to push down this predicate through the `row` forming expression. Moreover, if we have `row(a, b).f1` we'll directly optimize that to `a`, calling for an intermediate operator like `distinct` to confound that rewrite. So, it's unclear how dramatic the impact will be.  However, this equivalence is I think the most general way to do a thing that we have spot-fixed elsewhere.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
