### PR TITLE
adapter/storage: Disallow old source statement usage based on migration feature flag

### DIFF
--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -303,7 +303,9 @@ impl<'a> DataflowBuilder<'a> {
                 ingestion_desc
                     .desc
                     .primary_export
-                    .monotonic(&ingestion_desc.desc.connection)
+                    .as_ref()
+                    .map(|e| e.monotonic(&ingestion_desc.desc.connection))
+                    .unwrap_or(false)
             }
             DataSourceDesc::Webhook { .. } => true,
             DataSourceDesc::IngestionExport {

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -717,10 +717,13 @@ impl DataSourceDesc {
     pub fn formats(&self) -> (Option<&str>, Option<&str>) {
         match &self {
             DataSourceDesc::Ingestion { ingestion_desc, .. } => {
-                match &ingestion_desc.desc.primary_export.encoding.as_ref() {
-                    Some(encoding) => match &encoding.key {
-                        Some(key) => (Some(key.type_()), Some(encoding.value.type_())),
-                        None => (None, Some(encoding.value.type_())),
+                match &ingestion_desc.desc.primary_export {
+                    Some(export) => match export.encoding.as_ref() {
+                        Some(encoding) => match &encoding.key {
+                            Some(key) => (Some(key.type_()), Some(encoding.value.type_())),
+                            None => (None, Some(encoding.value.type_())),
+                        },
+                        None => (None, None),
                     },
                     None => (None, None),
                 }
@@ -772,9 +775,11 @@ impl DataSourceDesc {
             // `SourceEnvelope` itself, but that one feels more like an internal
             // thing and adapter should own how we represent envelopes as a
             // string? It would not be hard to convince me otherwise, though.
-            DataSourceDesc::Ingestion { ingestion_desc, .. } => Some(envelope_string(
-                &ingestion_desc.desc.primary_export.envelope,
-            )),
+            DataSourceDesc::Ingestion { ingestion_desc, .. } => ingestion_desc
+                .desc
+                .primary_export
+                .as_ref()
+                .map(|export| envelope_string(&export.envelope)),
             DataSourceDesc::IngestionExport { data_config, .. } => {
                 Some(envelope_string(&data_config.envelope))
             }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -239,6 +239,7 @@ pub enum PlanError {
     LoadGeneratorSourcePurification(LoadGeneratorSourcePurificationError),
     CsrPurification(CsrPurificationError),
     MySqlSourcePurification(MySqlSourcePurificationError),
+    UseTablesForSources(String),
     MissingName(CatalogItemType),
     InvalidRefreshAt,
     InvalidRefreshEveryAlignedTo,
@@ -713,6 +714,7 @@ impl fmt::Display for PlanError {
             Self::KafkaSinkPurification(e) => write!(f, "KAFKA sink validation: {}", e),
             Self::CsrPurification(e) => write!(f, "CONFLUENT SCHEMA REGISTRY validation: {}", e),
             Self::MySqlSourcePurification(e) => write!(f, "MYSQL source validation: {}", e),
+            Self::UseTablesForSources(command) => write!(f, "{command} not supported; use CREATE TABLE .. FROM SOURCE instead"),
             Self::MangedReplicaName(name) => {
                 write!(f, "{name} is reserved for replicas of managed clusters")
             }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1542,7 +1542,9 @@ pub fn plan_create_table_from_source(
     scx: &StatementContext,
     stmt: CreateTableFromSourceStatement<Aug>,
 ) -> Result<Plan, PlanError> {
-    scx.require_feature_flag(&vars::ENABLE_CREATE_TABLE_FROM_SOURCE)?;
+    if !scx.catalog.system_vars().enable_create_table_from_source() {
+        sql_bail!("CREATE TABLE ... FROM SOURCE is not supported");
+    }
 
     let CreateTableFromSourceStatement {
         name,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -81,7 +81,6 @@ use crate::names::{
 use crate::plan::error::PlanError;
 use crate::plan::statement::ddl::load_generator_ast_to_generator;
 use crate::plan::{SourceReferences, StatementContext};
-use crate::session::vars;
 use crate::{kafka_util, normalize};
 
 use self::error::{
@@ -632,7 +631,7 @@ async fn purify_create_source(
     // If the user can use the `CREATE TABLE .. FROM SOURCE` statement to add tables
     // after this source is created, then we don't need to enforce that
     // any auto-generated subsources are created here.
-    let reference_policy = if scx.is_feature_flag_enabled(&vars::ENABLE_CREATE_TABLE_FROM_SOURCE) {
+    let reference_policy = if scx.catalog.system_vars().enable_create_table_from_source() {
         SourceReferencePolicy::Optional
     } else {
         SourceReferencePolicy::Required

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -581,6 +581,9 @@ where
 /// Defines whether purification should enforce that at least one valid source
 /// reference is provided on the provided statement.
 pub(crate) enum SourceReferencePolicy {
+    /// Don't allow source references to be provided. This is used for
+    /// enforcing that `CREATE SOURCE` statements don't create subsources.
+    NotAllowed,
     /// Allow empty references, such as when creating a source that
     /// will have tables added afterwards.
     Optional,
@@ -628,10 +631,14 @@ async fn purify_create_source(
     };
     let scx = StatementContext::new(None, &catalog);
 
-    // If the user can use the `CREATE TABLE .. FROM SOURCE` statement to add tables
-    // after this source is created, then we don't need to enforce that
-    // any auto-generated subsources are created here.
-    let reference_policy = if scx.catalog.system_vars().enable_create_table_from_source() {
+    // Depending on if the user must or can use the `CREATE TABLE .. FROM SOURCE` statement
+    // to add tables after this source is created we might need to enforce that
+    // auto-generated subsources are created or not created by this source statement.
+    let reference_policy = if scx.catalog.system_vars().enable_create_table_from_source()
+        && scx.catalog.system_vars().force_source_table_syntax()
+    {
+        SourceReferencePolicy::NotAllowed
+    } else if scx.catalog.system_vars().enable_create_table_from_source() {
         SourceReferencePolicy::Optional
     } else {
         SourceReferencePolicy::Required
@@ -1053,6 +1060,11 @@ async fn purify_create_source(
                 .collect::<Vec<_>>();
 
             match external_references {
+                Some(requested)
+                    if matches!(reference_policy, SourceReferencePolicy::NotAllowed) =>
+                {
+                    Err(PlanError::UseTablesForSources(requested.to_string()))?
+                }
                 Some(requested) => {
                     let requested_exports = retrieved_source_references
                         .requested_source_exports(Some(requested), source_name)?;
@@ -1107,9 +1119,6 @@ async fn purify_create_source(
     *external_references = None;
 
     // Generate progress subsource
-
-    // Create the targeted AST node for the original CREATE SOURCE statement
-    let scx = StatementContext::new(None, &catalog);
 
     // Take name from input or generate name
     let name = match progress_subsource {
@@ -1229,6 +1238,14 @@ async fn purify_alter_source(
             external_references,
             options,
         } => {
+            if scx.catalog.system_vars().enable_create_table_from_source()
+                && scx.catalog.system_vars().force_source_table_syntax()
+            {
+                Err(PlanError::UseTablesForSources(
+                    "ALTER SOURCE .. ADD SUBSOURCES ..".to_string(),
+                ))?;
+            }
+
             purify_alter_source_add_subsources(
                 external_references,
                 options,

--- a/src/sql/src/pure/mysql.rs
+++ b/src/sql/src/pure/mysql.rs
@@ -341,6 +341,9 @@ pub(super) async fn purify_source_exports(
     reference_policy: &SourceReferencePolicy,
 ) -> Result<PurifiedSourceExports, PlanError> {
     let requested_exports = match requested_references.as_ref() {
+        Some(requested) if matches!(reference_policy, SourceReferencePolicy::NotAllowed) => {
+            Err(PlanError::UseTablesForSources(requested.to_string()))?
+        }
         Some(requested) => retrieved_references
             .requested_source_exports(Some(requested), unresolved_source_name)?,
         None => {

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -344,6 +344,9 @@ pub(super) async fn purify_source_exports(
     reference_policy: &SourceReferencePolicy,
 ) -> Result<PurifiedSourceExports, PlanError> {
     let requested_exports = match requested_references.as_ref() {
+        Some(requested) if matches!(reference_policy, SourceReferencePolicy::NotAllowed) => {
+            Err(PlanError::UseTablesForSources(requested.to_string()))?
+        }
         Some(requested) => retrieved_references
             .requested_source_exports(Some(requested), unresolved_source_name)?,
         None => {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1298,6 +1298,8 @@ impl SystemVars {
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL,
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER,
             &USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION,
+            &ENABLE_CREATE_TABLE_FROM_SOURCE,
+            &FORCE_SOURCE_TABLE_SYNTAX,
         ];
 
         let dyncfgs = mz_dyncfgs::all_dyncfgs();
@@ -2244,6 +2246,14 @@ impl SystemVars {
     /// Returns the `user_storage_managed_collections_batch_duration` configuration parameter.
     pub fn user_storage_managed_collections_batch_duration(&self) -> Duration {
         *self.expect_value(&USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION)
+    }
+
+    pub fn enable_create_table_from_source(&self) -> bool {
+        *self.expect_value(&ENABLE_CREATE_TABLE_FROM_SOURCE)
+    }
+
+    pub fn force_source_table_syntax(&self) -> bool {
+        *self.expect_value(&FORCE_SOURCE_TABLE_SYNTAX)
     }
 
     /// Returns whether the named variable is a compute configuration parameter

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1496,6 +1496,20 @@ pub static DEFAULT_NETWORK_POLICY_ALLOW_LIST: VarDefinition = VarDefinition::new
     true,
 );
 
+pub static ENABLE_CREATE_TABLE_FROM_SOURCE: VarDefinition = VarDefinition::new(
+    "enable_create_table_from_source",
+    value!(bool; false),
+    "Whether to allow CREATE TABLE .. FROM SOURCE syntax.",
+    true,
+);
+
+pub static FORCE_SOURCE_TABLE_SYNTAX: VarDefinition = VarDefinition::new(
+    "force_source_table_syntax",
+    value!(bool; false),
+    "Force use of new source model (CREATE TABLE .. FROM SOURCE) and migrate existing sources",
+    true,
+);
+
 /// Configuration for gRPC client connections.
 pub mod grpc_client {
     use super::*;
@@ -1912,12 +1926,6 @@ feature_flags!(
     {
         name: enable_alter_set_cluster,
         desc: "ALTER ... SET CLUSTER syntax",
-        default: false,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_create_table_from_source,
-        desc: "CREATE TABLE .. FROM SOURCE",
         default: false,
         enable_for_item_parsing: true,
     },

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1519,12 +1519,14 @@ where
         let mut self_collections = self.collections.lock().expect("lock poisoned");
 
         for (id, mut description, write_handle, since_handle, metadata) in to_register {
-            // Ensure that the ingestion has an export for its primary source.
+            // Ensure that the ingestion has an export for its primary source if applicable.
             // This is done in an awkward spot to appease the borrow checker.
+            // TODO(database-issues#8620): This will be removed once sources no longer export
+            // to primary collections and only export to explicit SourceExports (tables).
             if let DataSource::Ingestion(ingestion) = &mut description.data_source {
-                ingestion
-                    .source_exports
-                    .insert(id, ingestion.desc.primary_source_export());
+                if let Some(export) = ingestion.desc.primary_source_export() {
+                    ingestion.source_exports.insert(id, export);
+                }
             }
 
             let write_frontier = write_handle.upper();

--- a/src/storage-controller/src/history.rs
+++ b/src/storage-controller/src/history.rs
@@ -286,10 +286,10 @@ mod tests {
                     as_of: Default::default(),
                     up_to: Default::default(),
                 }),
-                primary_export: SourceExportDataConfig {
+                primary_export: Some(SourceExportDataConfig {
                     encoding: Default::default(),
                     envelope: SourceEnvelope::CdcV2,
-                },
+                }),
                 timestamp_interval: Default::default(),
             },
             ingestion_metadata: CollectionMetadata {

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -620,12 +620,14 @@ where
             to_execute.insert(id);
             new_collections.insert(id);
 
-            // Ensure that the ingestion has an export for its primary source.
+            // Ensure that the ingestion has an export for its primary source if applicable.
             // This is done in an awkward spot to appease the borrow checker.
+            // TODO(database-issues#8620): This will be removed once sources no longer export
+            // to primary collections and only export to explicit SourceExports (tables).
             if let DataSource::Ingestion(ingestion) = &mut description.data_source {
-                ingestion
-                    .source_exports
-                    .insert(id, ingestion.desc.primary_source_export());
+                if let Some(export) = ingestion.desc.primary_source_export() {
+                    ingestion.source_exports.insert(id, export);
+                }
             }
 
             let write_frontier = write.upper();

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -79,6 +79,8 @@ transaction_isolation               "strict serializable"   "Sets the current tr
 unsafe_new_transaction_wall_time    ""                      "Sets the wall time for all new explicit or implicit transactions to control the value of `now()`. If not set, uses the system's clock."
 welcome_message                     on                      "Whether to send a notice with a welcome message after a successful connection (Materialize)."
 enable_consolidate_after_union_negate on                    "consolidation after Unions that have a Negated input (Materialize)."
+enable_create_table_from_source     on                      "Whether to allow CREATE TABLE .. FROM SOURCE syntax."
+force_source_table_syntax           off                     "Force use of new source model (CREATE TABLE .. FROM SOURCE) and migrate existing sources"
 
 > SET application_name = 'foo'
 

--- a/test/testdrive/source-tables.td
+++ b/test/testdrive/source-tables.td
@@ -473,3 +473,36 @@ running
 3   true
 
 > DROP SOURCE keyvalue CASCADE;
+
+
+#
+# Force usage of the new syntax and check that old statements are disallowed
+#
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET force_source_table_syntax = true
+
+! CREATE SOURCE auction_legacy
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM LOAD GENERATOR AUCTION (AS OF 300, UP TO 301)
+  FOR TABLES (bids AS bids_3);
+contains:not supported; use CREATE TABLE .. FROM SOURCE instead
+
+! CREATE SOURCE pg_source_2
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source', TEXT COLUMNS = (public.pg_table.a))
+  FOR ALL TABLES
+contains:not supported; use CREATE TABLE .. FROM SOURCE instead
+
+! CREATE SOURCE mysql_source_2
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM MYSQL CONNECTION mysql_conn
+  FOR SCHEMAS (public);
+contains:not supported; use CREATE TABLE .. FROM SOURCE instead
+
+! CREATE SOURCE avro_source_2
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-avroavro-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE UPSERT;
+contains:not supported; use CREATE TABLE .. FROM SOURCE instead


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.
 Fixes https://github.com/MaterializeInc/database-issues/issues/8678

This uses the same `force_source_table_syntax` flag introduced in the migration PR https://github.com/MaterializeInc/materialize/pull/30168 . This will completely restrict the use of statements using the 'old' source syntax and stop outputting data to the primary collection for kafka and single-output load generator sources, such that everything should be using tables only.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
