### PR TITLE
canary envrionment: Grant privileges on table

### DIFF
--- a/test/canary-environment/mzcompose.py
+++ b/test/canary-environment/mzcompose.py
@@ -207,6 +207,8 @@ def workflow_create(c: Composition, parser: WorkflowArgumentParser) -> None:
             > CREATE TABLE IF NOT EXISTS public_table.table (c INT);
 
             > GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public_table.table TO "infra+qacanaryload@materialize.io"
+            > GRANT SELECT ON TABLE public_table.table TO "dennis.felsing@materialize.com"
+            > GRANT SELECT ON TABLE public_table.table TO "rainer@materialize.com"
             """
             )
         )


### PR DESCRIPTION
Seen failing in
https://buildkite.com/materialize/qa-canary/builds/292#0192d073-ec4c-4821-8231-de67790d2979 after recreating the objects:

> The 'dennis.felsing@materialize.com' role needs SELECT privileges on TABLE "qa_canary_environment.public_table.table": ERROR: permission denied for TABLE "qa_canary_environment.public_table.table"

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
