### PR TITLE
[persist] Exception for empty batches in the debug validator

### DIFF
--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -1136,7 +1136,10 @@ impl<T> Default for ReferencedBlobValidator<T> {
 impl<T: Timestamp + Lattice + Codec64> ReferencedBlobValidator<T> {
     fn add_inc_blob(&mut self, x: HollowBlobRef<'_, T>) {
         match x {
-            HollowBlobRef::Batch(x) => assert!(self.inc_batches.insert(x.clone())),
+            HollowBlobRef::Batch(x) => assert!(
+                self.inc_batches.insert(x.clone()) || x.desc.lower() == x.desc.upper(),
+                "non-empty batches should only be appended once; duplicate: {x:?}"
+            ),
             HollowBlobRef::Rollup(x) => assert!(self.inc_rollups.insert(x.clone())),
         }
     }


### PR DESCRIPTION
As of recently, we've started writing down batches that are "instantaneous", which means that it's possible for two batches to be totally identical. (Which is useful for the new force-compaction machinery - it wants to trigger compaction like adding a normal batch would, but without advancing the frontier.) However, a debug-time state validation assumed all batches were unique.

Ideally we could thread through the spine id and preserve uniqueness here, but since this isn't the essential part of the validation, it's much easier to just check that the duplicate batch is of the expected sort.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Fixes: https://github.com/MaterializeInc/database-issues/issues/7460

(Debatable, since the first instance of this error was from February, long before the empty-batch change. But this does fix the repro etc.)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
