### PR TITLE
bazel: Disable pipelined compilation again

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -125,7 +125,8 @@ build --@rules_rust//:extra_rustc_flag="-Csymbol-mangling-version=v0"
 build --@rules_rust//:extra_rustc_flag="-Ccodegen-units=64"
 # Enabling pipelined builds allows dependent libraries to begin compiling with
 # just `.rmeta` instead of the full `.rlib`.
-build --@rules_rust//rust/settings:pipelined_compilation=True
+# TODO: Reenable when fixed, currently still sometimes fails, see for example: https://buildkite.com/materialize/test/builds/93445#0192d426-ff4e-4658-b48a-9473843ae116
+#build --@rules_rust//rust/settings:pipelined_compilation=True
 
 # `cargo check` like config, still experimental!
 #


### PR DESCRIPTION
Failed here: https://buildkite.com/materialize/test/builds/93445#0192d426-ff4e-4658-b48a-9473843ae116

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
