### PR TITLE
ct: update comment about as_of selection for builtin CTs

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2567,11 +2567,12 @@ impl Coordinator {
         }
     }
 
-    /// TODO(ct1): Hack to make as_of selection happy. It assumes that anything
-    /// with a zero upper has the since set to the initial as_of. Ideally we'd
-    /// write this down in the durable catalog, but that's hard because of boot
-    /// ordering and it's possible that a better long-term fix would be in as_of
-    /// selection itself.
+    /// Make as_of selection happy for builtin CTs. Ideally we'd write the
+    /// initial as_of down in the durable catalog, but that's hard because of
+    /// boot ordering. Instead, we set the since of the storage collection to
+    /// something that's a reasonable lower bound for the as_of. Then, if the
+    /// upper is 0, the as_of selection code will allow us to jump it forward to
+    /// this since.
     async fn bootstrap_builtin_continual_tasks(
         &mut self,
         mut collections: Vec<(GlobalId, CollectionDescription<Timestamp>)>,


### PR DESCRIPTION
We decided that this was a reasonable [long term fix], so remove the TODO and stop calling it a hack. Plus add a bit more detail.

[long term fix]: https://github.com/MaterializeInc/database-issues/issues/8631#issuecomment-2420596296

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
