### PR TITLE
[persist] Bound the number of runs a batch builder generates

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -358,6 +358,9 @@ pub struct BatchBuilderConfig {
     pub(crate) preferred_order: RunOrder,
     pub(crate) structured_key_lower_len: usize,
     pub(crate) run_length_limit: usize,
+    /// The number of runs to cap the built batch at, or None if we should
+    /// continue to generate one run per part for unordered batches.
+    /// See the config definition for details.
     pub(crate) max_runs: Option<usize>,
 }
 

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -318,6 +318,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::batch::STRUCTURED_ORDER_UNTIL_SHARD)
         .add(&crate::batch::STRUCTURED_KEY_LOWER_LEN)
         .add(&crate::batch::MAX_RUN_LEN)
+        .add(&crate::batch::MAX_RUNS)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL_STAGGER)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL)
         .add(&crate::cfg::CRDB_CONNECT_TIMEOUT)

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -717,12 +717,11 @@ where
     /// Compacts runs together. If the input runs are sorted, a single run will be created as output.
     ///
     /// Maximum possible memory usage is `(# runs + 2) * [crate::PersistConfig::blob_target_size]`
-    async fn compact_runs<'a>(
-        // note: 'a cannot be elided due to https://github.com/rust-lang/rust/issues/63033
-        cfg: &'a CompactConfig,
-        shard_id: &'a ShardId,
-        desc: &'a Description<T>,
-        runs: Vec<(&'a Description<T>, &'a RunMeta, &'a [RunPart<T>])>,
+    async fn compact_runs(
+        cfg: &CompactConfig,
+        shard_id: &ShardId,
+        desc: &Description<T>,
+        runs: Vec<(&Description<T>, &RunMeta, &[RunPart<T>])>,
         blob: Arc<dyn Blob>,
         metrics: Arc<Metrics>,
         shard_metrics: Arc<ShardMetrics>,

--- a/src/persist-client/src/internal/merge.rs
+++ b/src/persist-client/src/internal/merge.rs
@@ -1,0 +1,164 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt::{Debug, Formatter};
+use std::mem;
+
+/// A merge tree.
+///
+/// Invariants and guarantees:
+/// - This structure preserves the order in which elements are `push`ed.
+/// - Merging also preserves order: only adjacent elements will be merged together,
+///   and the result will have the same place in the ordering as the input did.
+/// - The tree will store at most `O(K log N)` elements at once, where `K` is the provided max len
+///   and `N` is the number of elements pushed.
+/// - `finish` will return at most `K` elements.
+/// - The "depth" of the merge tree - the number of merges any particular element may undergo -
+///   is `O(log N)`.
+pub struct MergeTree<T> {
+    pub(crate) max_len: usize,
+    pub(crate) levels: Vec<Vec<T>>,
+    merge_fn: Box<dyn Fn(Vec<T>) -> T + Sync + Send>,
+}
+
+impl<T: Debug> Debug for MergeTree<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            max_len,
+            levels,
+            merge_fn: _,
+        } = self;
+        f.debug_struct("MergeTree")
+            .field("max_len", max_len)
+            .field("levels", levels)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> MergeTree<T> {
+    /// Create a new merge tree. `max_len` limits both the number of parts to keep at each level of
+    /// the tree, and the number of parts that `Self::finish` will return... and if we exceed that
+    /// limit, the provided `merge_fn` is used to combine adjacent elements together.
+    pub fn new(max_len: usize, merge_fn: impl Fn(Vec<T>) -> T + Send + Sync + 'static) -> Self {
+        let new = Self {
+            max_len,
+            levels: vec![vec![]],
+            merge_fn: Box::new(merge_fn),
+        };
+        new.assert_invariants();
+        new
+    }
+
+    /// Iterate over (references to) the parts in this tree in first-to-latest order.
+    #[allow(unused)]
+    pub fn iter(&self) -> impl Iterator<Item = &T> + DoubleEndedIterator {
+        self.levels.iter().rev().flat_map(|l| l.iter())
+    }
+
+    /// Iterate over (mutable references to) the parts in this tree in first-to-latest order.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> + DoubleEndedIterator {
+        self.levels.iter_mut().rev().flat_map(|l| l.iter_mut())
+    }
+
+    /// Push a new part onto the end of this tree, possibly triggering a merge.
+    pub fn push(&mut self, mut part: T) {
+        // Normally, all levels have strictly less than max_len elements.
+        // However, the _deepest_ level is allowed to have exactly max_len elements,
+        // since that can save us an unnecessary merge in some cases.
+        // (For example, when precisely max_len elements are added.)
+        if let Some(last) = self.levels.last_mut() {
+            if last.len() == self.max_len {
+                let merged = (self.merge_fn)(mem::take(last));
+                self.levels.push(vec![merged]);
+            }
+        }
+
+        // At this point, all levels have room. Add our new part, then continue
+        // merging up the tree until either there's still room in the current level
+        // or we've reached the top.
+        let max_level = self.levels.len() - 1;
+        for depth in 0..=max_level {
+            let level = &mut self.levels[depth];
+            level.push(part);
+
+            if level.len() < self.max_len || depth == max_level {
+                break;
+            }
+
+            part = (self.merge_fn)(mem::take(level));
+        }
+    }
+
+    /// Return the contents of this merge tree, flattened into at most `max_len` parts.
+    pub fn finish(self) -> Vec<T> {
+        self.levels
+            .into_iter()
+            .reduce(|mut shallower, mut deeper| {
+                if shallower.len() + deeper.len() <= self.max_len {
+                    // Optimization: if there's enough room in the next level for everything at the
+                    // current level, add it directly.
+                    deeper.append(&mut shallower);
+                } else {
+                    // Otherwise, merge this up as if it were a full level.
+                    let merged = (self.merge_fn)(shallower);
+                    deeper.push(merged);
+                }
+                deeper
+            })
+            .expect("non-empty level array")
+    }
+
+    pub(crate) fn assert_invariants(&self) {
+        assert!(self.max_len >= 2, "max_len must be at least 2");
+
+        let (deepest, shallow) = self.levels.split_last().expect("non-empty level array");
+        for (depth, level) in shallow.iter().enumerate() {
+            assert!(
+                level.len() < self.max_len,
+                "strictly less than max elements at level {depth}"
+            );
+        }
+        assert!(
+            deepest.len() <= self.max_len,
+            "at most max elements at deepest level"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn test_merge_tree() {
+        // Exhaustively test the merge tree for small sizes.
+        for max_len in 2..8 {
+            for items in 0..100 {
+                let mut merge_tree = MergeTree::new(max_len, |vals: Vec<Vec<usize>>| {
+                    // Merge sequences by concatenation.
+                    vals.into_iter().flatten().collect()
+                });
+                for i in 0..items {
+                    merge_tree.push(vec![i]);
+                    assert!(
+                        merge_tree.iter().flatten().copied().eq(0..=i),
+                        "no parts should be lost"
+                    );
+                    merge_tree.assert_invariants();
+                }
+                let parts = merge_tree.finish();
+                assert!(
+                    parts.len() <= max_len,
+                    "no more than {max_len} finished parts"
+                );
+                assert!(parts.into_iter().flatten().eq(0..items), "no parts lost");
+            }
+        }
+    }
+}

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -101,6 +101,7 @@ mod internal {
     pub mod gc;
     pub mod machine;
     pub mod maintenance;
+    pub mod merge;
     pub mod metrics;
     pub mod paths;
     pub mod restore;

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -952,7 +952,7 @@ mod tests {
         let mut b1 = write.expect_batch(&data[..2], 0, 3).await;
         let mut b2 = write.expect_batch(&data[2..], 2, 5).await;
         if backpressure_would_flush {
-            let cfg = BatchBuilderConfig::new(&client.cfg, shard_id, false);
+            let cfg = BatchBuilderConfig::new(&client.cfg, shard_id);
             b1.flush_to_blob(
                 &cfg,
                 &client.metrics.user,

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -35,14 +35,14 @@ use uuid::Uuid;
 
 use crate::batch::{
     validate_truncate_batch, Added, Batch, BatchBuilder, BatchBuilderConfig, BatchBuilderInternal,
-    ProtoBatch, BATCH_DELETE_ENABLED,
+    BatchParts, ProtoBatch, BATCH_DELETE_ENABLED,
 };
 use crate::error::{InvalidUsage, UpperMismatch};
 use crate::internal::compact::Compactor;
 use crate::internal::encoding::{check_data_version, Schemas};
 use crate::internal::machine::{CompareAndAppendRes, ExpireFn, Machine};
 use crate::internal::metrics::Metrics;
-use crate::internal::state::{HandleDebugState, HollowBatch};
+use crate::internal::state::{HandleDebugState, HollowBatch, RunOrder};
 use crate::read::ReadHandle;
 use crate::{parse_id, GarbageCollector, IsolatedRuntime, PersistConfig, ShardId};
 
@@ -537,7 +537,7 @@ where
                     assert_eq!(received_inline_backpressure, false);
                     received_inline_backpressure = true;
 
-                    let cfg = BatchBuilderConfig::new(&self.cfg, self.shard_id(), false);
+                    let cfg = BatchBuilderConfig::new(&self.cfg, self.shard_id());
                     // We could have a large number of inline parts (imagine the
                     // sharded persist_sink), do this flushing concurrently.
                     let flush_batches = batches
@@ -607,15 +607,25 @@ where
     /// enough that we can reasonably chunk them up: O(KB) is definitely fine,
     /// O(MB) come talk to us.
     pub fn builder(&self, lower: Antichain<T>) -> BatchBuilder<K, V, T, D> {
-        let builder = BatchBuilderInternal::new(
-            BatchBuilderConfig::new(&self.cfg, self.shard_id(), false),
+        let cfg = BatchBuilderConfig::new(&self.cfg, self.shard_id());
+        let parts = BatchParts::new_ordered(
+            cfg,
+            RunOrder::Unordered,
             Arc::clone(&self.metrics),
-            self.write_schemas.clone(),
             Arc::clone(&self.machine.applier.shard_metrics),
-            self.metrics.user.clone(),
-            lower,
+            self.shard_id(),
+            lower.clone(),
             Arc::clone(&self.blob),
             Arc::clone(&self.isolated_runtime),
+            &self.metrics.user,
+        );
+        let builder = BatchBuilderInternal::new(
+            BatchBuilderConfig::new(&self.cfg, self.shard_id()),
+            parts,
+            Arc::clone(&self.metrics),
+            self.write_schemas.clone(),
+            lower,
+            Arc::clone(&self.blob),
             self.machine.shard_id().clone(),
             self.cfg.build_version.clone(),
             Antichain::from_elem(T::minimum()),


### PR DESCRIPTION
In https://github.com/MaterializeInc/materialize/pull/30094, we added the ability to spill very long runs out to external state, to limit the amount of data we needed to keep in memory at once. However, there is another way that state can grow large: by appending individual batches with many runs. (Those runs will ~eventually get compacted together, but the state will be large in the meantime.)

This PR adds a new limit to the number of runs that a batch builder will produce. It does this by triggering background compactions whenever the number of runs grows large: so a source that is accumulating a large snapshot, for example, will start consolidating the data in the background as it's being built up.

### Motivation

https://github.com/MaterializeInc/database-issues/issues/8401

### Tips for reviewer

Should review fine commit-by-commit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
