### PR TITLE
Add local.mtrlz.dev:3000 as default origin for local development

### DIFF
--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -74,7 +74,7 @@ pub struct Args {
 
     #[clap(
         long,
-        default_values = &["http://local.dev.materialize.com:3000", "http://localhost:3000", "https://staging.console.materialize.com"],
+        default_values = &["http://local.dev.materialize.com:3000", "http://local.mtrlz.dev:3000", "http://localhost:3000", "https://staging.console.materialize.com"],
     )]
     environmentd_allowed_origins: Vec<HeaderValue>,
     #[clap(long, default_value = "https://console.materialize.com")]


### PR DESCRIPTION
This adds local.mtrlz.dev:3000 as a default origin to support local development of the console.

### Motivation

This change facilitates the deprecation of HTTP on materialize.com by providing an alternative localhost origin in DNS.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
