### PR TITLE
adapter: Remove the global write lock

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1644,7 +1644,7 @@ pub struct Coordinator {
     /// Active introspection subscribes.
     introspection_subscribes: BTreeMap<GlobalId, IntrospectionSubscribe>,
 
-    /// Locks that grant access to a specific object.
+    /// Locks that grant access to a specific object, populated lazily as objects are written to.
     write_locks: BTreeMap<GlobalId, Arc<tokio::sync::Mutex<()>>>,
     /// Plans that are currently deferred and waiting on a write lock.
     deferred_write_ops: BTreeMap<ConnectionId, DeferredWriteOp>,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -230,14 +230,6 @@ pub enum Message {
     TryDeferred {
         /// The connection that created this op.
         conn_id: ConnectionId,
-        /// The write lock that notified us our deferred op might be able to run.
-        ///
-        /// Note: While we never want to hold a partial set of locks, it's important that we hold
-        /// onto the _one_ that notified us our op might be ready. If there are multiple operations
-        /// waiting on a single collection, and we don't hold this lock through retyring the op,
-        /// then everything waiting on this collection will get retried causing traffic in the
-        /// Coordinator's message queue.
-        acquired_lock: Option<(GlobalId, tokio::sync::OwnedMutexGuard<()>)>,
     },
     /// Initiates a group commit.
     GroupCommitInitiate(Span, Option<GroupCommitPermit>),

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -171,7 +171,7 @@ use crate::client::{Client, Handle};
 use crate::command::{Command, ExecuteResponse};
 use crate::config::{SynchronizedParameters, SystemParameterFrontend, SystemParameterSyncConfig};
 use crate::coord::appends::{
-    BuiltinTableAppendNotify, Deferred, GroupCommitPermit, PendingWriteTxn,
+    BuiltinTableAppendNotify, DeferredWriteOp, GroupCommitPermit, PendingWriteTxn,
 };
 use crate::coord::caught_up::CaughtUpCheckContext;
 use crate::coord::cluster_scheduling::SchedulingDecision;
@@ -227,7 +227,18 @@ pub enum Message {
     PurifiedStatementReady(PurifiedStatementReady),
     CreateConnectionValidationReady(CreateConnectionValidationReady),
     AlterConnectionValidationReady(AlterConnectionValidationReady),
-    WriteLockGrant(tokio::sync::OwnedMutexGuard<()>),
+    TryDeferred {
+        /// The connection that created this op.
+        conn_id: ConnectionId,
+        /// The write lock that notified us our deferred op might be able to run.
+        ///
+        /// Note: While we never want to hold a partial set of locks, it's important that we hold
+        /// onto the _one_ that notified us our op might be ready. If there are multiple operations
+        /// waiting on a single collection, and we don't hold this lock through retyring the op,
+        /// then everything waiting on this collection will get retried causing traffic in the
+        /// Coordinator's message queue.
+        acquired_lock: Option<(GlobalId, tokio::sync::OwnedMutexGuard<()>)>,
+    },
     /// Initiates a group commit.
     GroupCommitInitiate(Span, Option<GroupCommitPermit>),
     DeferredStatementReady,
@@ -331,7 +342,7 @@ impl Message {
             Message::ControllerReady => "controller_ready",
             Message::PurifiedStatementReady(_) => "purified_statement_ready",
             Message::CreateConnectionValidationReady(_) => "create_connection_validation_ready",
-            Message::WriteLockGrant(_) => "write_lock_grant",
+            Message::TryDeferred { .. } => "try_deferred",
             Message::GroupCommitInitiate(..) => "group_commit_initiate",
             Message::AdvanceTimelines => "advance_timelines",
             Message::ClusterEvent(_) => "cluster_event",
@@ -1633,10 +1644,14 @@ pub struct Coordinator {
     /// Active introspection subscribes.
     introspection_subscribes: BTreeMap<GlobalId, IntrospectionSubscribe>,
 
-    /// Holds plans deferred due to write lock.
-    write_lock_wait_group: LockedVecDeque<Deferred>,
+    /// Locks that grant access to a specific object.
+    write_locks: BTreeMap<GlobalId, Arc<tokio::sync::Mutex<()>>>,
+    /// Plans that are currently deferred and waiting on a write lock.
+    deferred_write_ops: BTreeMap<ConnectionId, DeferredWriteOp>,
+
     /// Pending writes waiting for a group commit.
     pending_writes: Vec<PendingWriteTxn>,
+
     /// For the realtime timeline, an explicit SELECT or INSERT on a table will bump the
     /// table's timestamps, but there are cases where timestamps are not bumped but
     /// we expect the closed timestamps to advance (`AS OF X`, SUBSCRIBing views over
@@ -3750,7 +3765,8 @@ pub fn serve(
                     active_webhooks: BTreeMap::new(),
                     staged_cancellation: BTreeMap::new(),
                     introspection_subscribes: BTreeMap::new(),
-                    write_lock_wait_group: LockedVecDeque::new(),
+                    write_locks: BTreeMap::new(),
+                    deferred_write_ops: BTreeMap::new(),
                     pending_writes: Vec::new(),
                     advance_timelines_interval,
                     secrets_controller,
@@ -4040,10 +4056,6 @@ impl<T> LockedVecDeque<T> {
             items: VecDeque::new(),
             lock: Arc::new(tokio::sync::Mutex::new(())),
         }
-    }
-
-    pub fn mutex(&self) -> Arc<tokio::sync::Mutex<()>> {
-        Arc::clone(&self.lock)
     }
 
     pub fn try_lock_owned(&self) -> Result<OwnedMutexGuard<()>, tokio::sync::TryLockError> {

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -193,7 +193,7 @@ impl Coordinator {
         match op {
             DeferredWriteOp::Plan(mut deferred) => {
                 if let Err(e) = deferred.validity.check(self.catalog()) {
-                    return deferred.ctx.retire(Err(e));
+                    deferred.ctx.retire(Err(e))
                 } else {
                     // Write statements never need to track resolved IDs (NOTE: This is not the
                     // same thing as plan dependencies, which we do need to re-validate).

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -91,10 +91,7 @@ impl Coordinator {
                     .boxed_local()
                     .await
             }
-            Message::TryDeferred {
-                conn_id,
-                acquired_lock,
-            } => self.try_deferred(conn_id, acquired_lock).await,
+            Message::TryDeferred { conn_id } => self.try_deferred(conn_id).await,
             Message::GroupCommitInitiate(span, permit) => {
                 // Add an OpenTelemetry link to our current span.
                 tracing::Span::current().add_link(span.context().span().span_context().clone());

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -39,7 +39,6 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use crate::active_compute_sink::{ActiveComputeSink, ActiveComputeSinkRetireReason};
 use crate::catalog::{BuiltinTableUpdate, Op};
 use crate::command::Command;
-use crate::coord::appends::Deferred;
 use crate::coord::{
     AlterConnectionValidationReady, ClusterReplicaStatuses, Coordinator,
     CreateConnectionValidationReady, Message, PurifiedStatementReady, WatchSetResponse,
@@ -92,11 +91,10 @@ impl Coordinator {
                     .boxed_local()
                     .await
             }
-            Message::WriteLockGrant(write_lock_guard) => {
-                self.message_write_lock_grant(write_lock_guard)
-                    .boxed_local()
-                    .await;
-            }
+            Message::TryDeferred {
+                conn_id,
+                acquired_lock,
+            } => self.try_deferred(conn_id, acquired_lock).await,
             Message::GroupCommitInitiate(span, permit) => {
                 // Add an OpenTelemetry link to our current span.
                 tracing::Span::current().add_link(span.context().span().span_context().clone());
@@ -650,36 +648,6 @@ impl Coordinator {
             .sequence_alter_connection_stage_finish(ctx.session_mut(), connection_gid, conn)
             .await;
         ctx.retire(result);
-    }
-
-    #[mz_ore::instrument(level = "debug")]
-    async fn message_write_lock_grant(
-        &mut self,
-        write_lock_guard: tokio::sync::OwnedMutexGuard<()>,
-    ) {
-        // It's possible to have more incoming write lock grants
-        // than pending writes because of cancellations.
-        if let Some(ready) = self.write_lock_wait_group.pop_front() {
-            match ready {
-                Deferred::Plan(mut ready) => {
-                    ready.ctx.session_mut().grant_write_lock(write_lock_guard);
-                    if let Err(e) = ready.validity.check(self.catalog()) {
-                        ready.ctx.retire(Err(e))
-                    } else {
-                        // Write statements never need to track resolved IDs (NOTE: This is not the
-                        // same thing as plan dependencies, which we do need to re-validate).
-                        let resolved_ids = ResolvedIds(BTreeSet::new());
-                        self.sequence_plan(ready.ctx, ready.plan, resolved_ids)
-                            .await;
-                    }
-                }
-                Deferred::GroupCommit => {
-                    self.group_commit(Some(write_lock_guard), None).await;
-                }
-            }
-        }
-        // N.B. if no deferred plans, write lock is released by drop
-        // here.
     }
 
     #[mz_ore::instrument(level = "debug")]

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -393,7 +393,7 @@ impl AdapterError {
             AdapterError::StatementTimeout => Some(
                 "Consider increasing the maximum allowed statement duration for this session by \
                  setting the statement_timeout session variable. For example, `SET \
-                 statement_timeout = '60s'`."
+                 statement_timeout = '120s'`."
                     .into(),
             ),
             AdapterError::PlanError(e) => e.hint(),

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -136,6 +136,8 @@ pub enum AdapterError {
     ResultSize(String),
     /// The specified feature is not permitted in safe mode.
     SafeModeViolation(String),
+    /// The current transaction had the wrong set of write locks.
+    WrongSetOfLocks,
     /// Waiting on a query timed out.
     ///
     /// Note this differs slightly from PG's implementation/semantics.
@@ -478,6 +480,7 @@ impl AdapterError {
             AdapterError::ReadOnlyTransaction => SqlState::READ_ONLY_SQL_TRANSACTION,
             AdapterError::ReadWriteUnavailable => SqlState::INVALID_TRANSACTION_STATE,
             AdapterError::SingleStatementTransaction => SqlState::INVALID_TRANSACTION_STATE,
+            AdapterError::WrongSetOfLocks => SqlState::LOCK_NOT_AVAILABLE,
             AdapterError::StatementTimeout => SqlState::QUERY_CANCELED,
             AdapterError::Canceled => SqlState::QUERY_CANCELED,
             AdapterError::IdleInTransactionSessionTimeout => {
@@ -638,6 +641,9 @@ impl fmt::Display for AdapterError {
             }
             AdapterError::ReadWriteUnavailable => {
                 f.write_str("transaction read-write mode must be set before any query")
+            }
+            AdapterError::WrongSetOfLocks => {
+                write!(f, "internal error, wrong set of locks acquired")
             }
             AdapterError::StatementTimeout => {
                 write!(f, "canceling statement due to statement timeout")

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -12,7 +12,7 @@
 #![warn(missing_docs)]
 
 use std::collections::btree_map::Entry;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 use std::mem;
 use std::net::IpAddr;
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
+use itertools::Itertools;
 use mz_adapter_types::connection::ConnectionId;
 use mz_build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use mz_controller_types::ClusterId;
@@ -46,7 +47,6 @@ use qcell::{QCell, QCellOwner};
 use rand::Rng;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::watch;
-use tokio::sync::OwnedMutexGuard;
 use uuid::Uuid;
 
 use crate::catalog::CatalogState;
@@ -377,7 +377,7 @@ impl<T: TimestampManipulation> Session<T> {
                 self.transaction = TransactionStatus::InTransaction(Transaction {
                     pcx: self.new_pcx(wall_time),
                     ops: TransactionOps::None,
-                    write_lock_guard: None,
+                    write_lock_guards: None,
                     access,
                     id,
                 });
@@ -411,7 +411,7 @@ impl<T: TimestampManipulation> Session<T> {
             let txn = Transaction {
                 pcx: self.new_pcx(wall_time),
                 ops: TransactionOps::None,
-                write_lock_guard: None,
+                write_lock_guards: None,
                 access: None,
                 id,
             };
@@ -581,7 +581,7 @@ impl<T: TimestampManipulation> Session<T> {
             Some(Transaction {
                 pcx: _,
                 ops: TransactionOps::Peeks { determination, .. },
-                write_lock_guard: _,
+                write_lock_guards: _,
                 access: _,
                 id: _,
             }) => Some(determination.clone()),
@@ -602,7 +602,7 @@ impl<T: TimestampManipulation> Session<T> {
                     },
                     ..
                 },
-                write_lock_guard: _,
+                write_lock_guards: _,
                 access: _,
                 id: _,
             })
@@ -793,22 +793,13 @@ impl<T: TimestampManipulation> Session<T> {
         &mut self.vars
     }
 
-    /// Grants the coordinator's write lock guard to this session's inner
-    /// transaction.
+    /// Grants a set of write locks to this session's inner [`Transaction`].
     ///
     /// # Panics
-    /// If the inner transaction is idle. See
-    /// [`TransactionStatus::grant_write_lock`].
-    pub fn grant_write_lock(&mut self, guard: OwnedMutexGuard<()>) {
-        self.transaction.grant_write_lock(guard);
-    }
-
-    /// Returns whether or not this session currently holds the write lock.
-    pub fn has_write_lock(&self) -> bool {
-        match self.transaction.inner() {
-            None => false,
-            Some(txn) => txn.write_lock_guard.is_some(),
-        }
+    /// If the inner transaction is idle. See [`TransactionStatus::try_grant_write_locks`].
+    ///
+    pub fn try_grant_write_locks(&mut self, guards: WriteLocks) -> Result<(), &WriteLocks> {
+        self.transaction.try_grant_write_locks(guards)
     }
 
     /// Drains any external metadata updates and applies the changes from the latest update.
@@ -987,15 +978,13 @@ pub enum TransactionStatus<T> {
 
 impl<T: TimestampManipulation> TransactionStatus<T> {
     /// Extracts the inner transaction ops and write lock guard if not failed.
-    pub fn into_ops_and_lock_guard(
-        self,
-    ) -> (Option<TransactionOps<T>>, Option<OwnedMutexGuard<()>>) {
+    pub fn into_ops_and_lock_guard(self) -> (Option<TransactionOps<T>>, Option<WriteLocks>) {
         match self {
             TransactionStatus::Default | TransactionStatus::Failed(_) => (None, None),
             TransactionStatus::Started(txn)
             | TransactionStatus::InTransaction(txn)
             | TransactionStatus::InTransactionImplicit(txn) => {
-                (Some(txn.ops), txn.write_lock_guard)
+                (Some(txn.ops), txn.write_lock_guards)
             }
         }
     }
@@ -1063,19 +1052,32 @@ impl<T: TimestampManipulation> TransactionStatus<T> {
         self.is_in_multi_statement_transaction() && when == &QueryWhen::Immediately
     }
 
-    /// Grants the write lock to the inner transaction.
+    /// Grants the writes lock to the inner transaction, returning an error if the transaction
+    /// has already been granted write locks.
     ///
     /// # Panics
     /// If `self` is `TransactionStatus::Default`, which indicates that the
     /// transaction is idle, which is not appropriate to assign the
     /// coordinator's write lock to.
-    pub fn grant_write_lock(&mut self, guard: OwnedMutexGuard<()>) {
+    ///
+    pub fn try_grant_write_locks(&mut self, guards: WriteLocks) -> Result<(), &WriteLocks> {
         match self {
             TransactionStatus::Default => panic!("cannot grant write lock to txn not yet started"),
             TransactionStatus::Started(txn)
             | TransactionStatus::InTransaction(txn)
             | TransactionStatus::InTransactionImplicit(txn)
-            | TransactionStatus::Failed(txn) => txn.grant_write_lock(guard),
+            | TransactionStatus::Failed(txn) => txn.try_grant_write_locks(guards),
+        }
+    }
+
+    /// Returns the currently held [`WriteLocks`], if this transaction holds any.
+    pub fn write_locks(&self) -> Option<&WriteLocks> {
+        match self {
+            TransactionStatus::Default => None,
+            TransactionStatus::Started(txn)
+            | TransactionStatus::InTransaction(txn)
+            | TransactionStatus::InTransactionImplicit(txn)
+            | TransactionStatus::Failed(txn) => txn.write_lock_guards.as_ref(),
         }
     }
 
@@ -1273,16 +1275,23 @@ pub struct Transaction<T> {
     /// same ID.
     /// If all IDs have been exhausted, this will wrap around back to 0.
     pub id: TransactionId,
-    /// Holds the coordinator's write lock.
-    write_lock_guard: Option<OwnedMutexGuard<()>>,
+    /// Locks for objects this transaction will operate on.
+    write_lock_guards: Option<WriteLocks>,
     /// Access mode (read only, read write).
     access: Option<TransactionAccessMode>,
 }
 
 impl<T> Transaction<T> {
-    /// Grants the write lock to this transaction for the remainder of its lifetime.
-    fn grant_write_lock(&mut self, guard: OwnedMutexGuard<()>) {
-        self.write_lock_guard = Some(guard);
+    /// Tries to grant the write lock to this transaction for the remainder of its lifetime. Errors
+    /// if this [`Transaction`] has already been granted write locks.
+    fn try_grant_write_locks(&mut self, guards: WriteLocks) -> Result<(), &WriteLocks> {
+        match &mut self.write_lock_guards {
+            Some(existing) => Err(existing),
+            locks @ None => {
+                *locks = Some(guards);
+                Ok(())
+            }
+        }
     }
 
     /// The timeline of the transaction, if one exists.
@@ -1454,6 +1463,97 @@ impl From<&ExplainContext> for RequireLinearization {
                 RequireLinearization::Required
             }
             _ => RequireLinearization::NotRequired,
+        }
+    }
+}
+
+/// A complete set of exclusive locks for writing to collections identified by [`GlobalId`]s.
+///
+/// To prevent deadlocks between two sessions, we do not allow acquiring a partial set of locks.
+#[derive(Debug)]
+pub struct WriteLocks {
+    locks: BTreeMap<GlobalId, tokio::sync::OwnedMutexGuard<()>>,
+    /// Connection that currently holds these locks, used for tracing purposes only.
+    conn_id: ConnectionId,
+}
+
+impl WriteLocks {
+    /// Create a [`WriteLocksBuilder`] pre-defining all of the locks we need.
+    ///
+    /// When "finishing" the builder with [`WriteLocksBuilder::all_or_nothing`], if we haven't
+    /// acquired all of the necessary locks we drop any partially acquired ones.
+    pub fn builder(sources: impl IntoIterator<Item = GlobalId>) -> WriteLocksBuilder {
+        let locks = sources.into_iter().map(|gid| (gid, None)).collect();
+        WriteLocksBuilder { locks }
+    }
+
+    /// Validate this set of [`WriteLocks`] is sufficient for the provided collections.Dropping the
+    /// currently held locks if it's not.
+    pub fn validate(
+        self,
+        collections: impl Iterator<Item = GlobalId>,
+    ) -> Result<Self, BTreeSet<GlobalId>> {
+        let mut missing = BTreeSet::new();
+        for collection in collections {
+            if !self.locks.contains_key(&collection) {
+                missing.insert(collection);
+            }
+        }
+
+        if missing.is_empty() {
+            Ok(self)
+        } else {
+            // Explicitly drop the already acquired locks.
+            drop(self);
+            Err(missing)
+        }
+    }
+}
+
+impl Drop for WriteLocks {
+    fn drop(&mut self) {
+        tracing::info!(
+            conn_id = %self.conn_id,
+            locks = ?self.locks,
+            "dropping write locks",
+        );
+    }
+}
+
+/// A builder struct that helps us acquire all of the locks we need, or none of them.
+///
+/// See [`WriteLocks::builder`].
+#[derive(Debug)]
+pub struct WriteLocksBuilder {
+    locks: BTreeMap<GlobalId, Option<tokio::sync::OwnedMutexGuard<()>>>,
+}
+
+impl WriteLocksBuilder {
+    /// Adds a lock to this builder.
+    pub fn insert_lock(&mut self, id: GlobalId, lock: tokio::sync::OwnedMutexGuard<()>) {
+        self.locks.insert(id, Some(lock));
+    }
+
+    /// Finish this builder by returning either all of the necessary locks, or none of them.
+    pub fn all_or_nothing(self, conn_id: &ConnectionId) -> Result<WriteLocks, BTreeSet<GlobalId>> {
+        let (locks, missing): (BTreeMap<_, _>, BTreeSet<_>) =
+            self.locks
+                .into_iter()
+                .partition_map(|(gid, lock)| match lock {
+                    Some(lock) => itertools::Either::Left((gid, lock)),
+                    None => itertools::Either::Right(gid),
+                });
+
+        if missing.is_empty() {
+            tracing::info!(%conn_id, ?locks, "acquired write locks");
+            Ok(WriteLocks {
+                locks,
+                conn_id: conn_id.clone(),
+            })
+        } else {
+            // Explicitly drop the already acquired locks.
+            drop(locks);
+            Err(missing)
         }
     }
 }

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -1608,7 +1608,7 @@ impl WriteLocksBuilder {
 ///
 /// [`group_commit`]: super::coord::Coordinator::group_commit
 #[derive(Debug, Default)]
-pub struct GroupCommitWriteLocks {
+pub(crate) struct GroupCommitWriteLocks {
     locks: BTreeMap<GlobalId, tokio::sync::OwnedMutexGuard<()>>,
 }
 

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -364,7 +364,7 @@ pub static SEARCH_PATH: VarDefinition = VarDefinition::new_lazy(
 
 pub static STATEMENT_TIMEOUT: VarDefinition = VarDefinition::new(
     "statement_timeout",
-    value!(Duration; Duration::from_secs(10)),
+    value!(Duration; Duration::from_secs(60)),
     "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations. \
     If this value is specified without units, it is taken as milliseconds.",
     true,

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -72,7 +72,7 @@ standard_conforming_strings         on                      "Causes '...' string
 statement_logging_default_sample_rate 0.01                  "The default value of `statement_logging_sample_rate` for new sessions (Materialize)."
 statement_logging_max_sample_rate   0.01                    "The maximum rate at which statements may be logged. If this value is less than that of `statement_logging_sample_rate`, the latter is ignored (Materialize)."
 statement_logging_sample_rate       0.01                    "User-facing session variable indicating how many statement executions should be logged, subject to constraint by the system variable `statement_logging_max_sample_rate` (Materialize)."
-statement_timeout                   "10 s"                  "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations. If this value is specified without units, it is taken as milliseconds."
+statement_timeout                   "1 min"                  "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations. If this value is specified without units, it is taken as milliseconds."
 superuser_reserved_connections      3                       "The number of connections that are reserved for superusers (PostgreSQL)."
 TimeZone                            UTC                     "Sets the time zone for displaying and interpreting time stamps (PostgreSQL)."
 transaction_isolation               "strict serializable"   "Sets the current transaction's isolation level (PostgreSQL)."


### PR DESCRIPTION
This PR removes the global write lock we currently maintain in the Coordinator, and replaces it with table level locks. This allows concurrent writes to different tables.

The Coordinator maintains two new maps:

1. `write_locks: BTreeMap<GlobalId, Arc<tokio::sync::Mutex<()>>>`
2. `deferred_write_ops: BTreeMap<ConnectionId, DeferredWriteOp>`

The `write_locks` map maintains the table level locks and the `deferred_write_ops` map tracks all ops that have been deferred because they're waiting on a lock. When running a read then write plan, or when committing a transaction, we attempt to acquire all of the necessary locks via `WriteLocksBuilder`. This new type asserts we either get all locks or none of them, this helps prevents two sessions deadlocking. When we fail to acquire a lock we spawn a tokio task that waits for the lock to become available and then notifies the Coordinator that it should retry the deferred plan.

There are probably more complex strategies we could use instead of "all or nothing" w.r.t. acquiring locks, but this is easy enough to reason about and improve on the current behavior.

### Motivation

Progress towards https://github.com/MaterializeInc/database-issues/issues/6896

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
