### PR TITLE
ci: Parallelise platform-checks 0dt scenarios

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -784,9 +784,10 @@ steps:
               args: [--scenario=UpgradeEntireMzFourVersions, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-restart-entire-mz
-        label: "Checks 0dt restart of the entire Mz"
+        label: "Checks 0dt restart of the entire Mz %N"
         depends_on: build-aarch64
         timeout_in_minutes: 240
+        parallelism: 4
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -796,9 +797,10 @@ steps:
               args: [--scenario=ZeroDowntimeRestartEntireMz, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-restart-entire-mz-forced-migrations
-        label: "Checks 0dt restart of the entire Mz with forced migrations"
+        label: "Checks 0dt restart of the entire Mz with forced migrations %N"
         depends_on: build-aarch64
         timeout_in_minutes: 240
+        parallelism: 4
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -808,9 +810,10 @@ steps:
               args: [--scenario=ZeroDowntimeRestartEntireMzForcedMigrations, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-upgrade-entire-mz
-        label: "Checks 0dt upgrade, whole-Mz restart"
+        label: "Checks 0dt upgrade, whole-Mz restart %N"
         depends_on: build-aarch64
         timeout_in_minutes: 240
+        parallelism: 4
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -820,9 +823,10 @@ steps:
               args: [--scenario=ZeroDowntimeUpgradeEntireMz, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-upgrade-entire-mz-two-versions
-        label: "Checks 0dt upgrade across two versions"
+        label: "Checks 0dt upgrade across two versions %N"
         depends_on: build-aarch64
         timeout_in_minutes: 240
+        parallelism: 4
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -832,9 +836,10 @@ steps:
               args: [--scenario=ZeroDowntimeUpgradeEntireMzTwoVersions, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-upgrade-entire-mz-four-versions
-        label: "Checks 0dt upgrade across four versions"
+        label: "Checks 0dt upgrade across four versions %N"
         depends_on: build-aarch64
         timeout_in_minutes: 240
+        parallelism: 4
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large

--- a/misc/python/materialize/checks/actions.py
+++ b/misc/python/materialize/checks/actions.py
@@ -124,3 +124,12 @@ class BumpVersion(Action):
 
     def join(self, e: Executor) -> None:
         pass
+
+
+class GitResetHard(Action):
+    def execute(self, e: Executor) -> None:
+        MzVersion.parse_cargo().bump_minor()
+        spawn.runv(["git", "reset", "--hard"], cwd=MZ_ROOT)
+
+    def join(self, e: Executor) -> None:
+        pass

--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -1302,6 +1302,9 @@ class SinkPartitionByDebezium(Check):
         return Testdrive(
             dedent(
                 """
+                # Can be slow in 0dt upgrade scenarios
+                $ set-sql-timeout duration=120s
+
                 $ schema-registry-verify schema-type=avro subject=testdrive-sink-partition-by-debezium-sink-${testdrive.seed}-value
                 {"type":"record","name":"envelope","fields":[{"name":"before","type":["null",{"type":"record","name":"row","fields":[{"name":"f1","type":"int"},{"name":"f2","type":["null","string"]}]}]},{"name":"after","type":["null","row"]}]}
 

--- a/misc/python/materialize/checks/scenarios_zero_downtime.py
+++ b/misc/python/materialize/checks/scenarios_zero_downtime.py
@@ -11,6 +11,7 @@
 from materialize.checks.actions import (
     Action,
     BumpVersion,
+    GitResetHard,
     Initialize,
     Manipulate,
     Validate,
@@ -194,6 +195,7 @@ class ZeroDowntimeBumpedVersion(Scenario):
             Validate(self, mz_service="mz_2"),
             *wait_ready_and_promote("mz_3"),
             Validate(self, mz_service="mz_3"),
+            GitResetHard(),  # Undo the previous version bump in case we need to run the mz container
         ]
 
 


### PR DESCRIPTION
Should unflake them: https://buildkite.com/materialize/nightly/builds/10187 and https://buildkite.com/materialize/nightly/builds/10179
```
thread 'timely:work-0' panicked at src/persist-client/src/internal/state.rs:1842:17: LeasedReaderId(r136e0830-75d8-4385-914c-cca1bc0e0f8b) was expired due to inactivity. Did the machine go to sleep?
```


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
