### PR TITLE
testdrive: Try reenabling source-tables.td in td SIZE=8

### DIFF
--- a/test/testdrive-old-kafka-src-syntax/source-tables.td
+++ b/test/testdrive-old-kafka-src-syntax/source-tables.td
@@ -10,10 +10,6 @@
 $ set-arg-default default-replica-size=1
 $ set-arg-default single-replica-cluster=quickstart
 
-# TODO(def-) Remove when database-issues#8515 and database-issues#8526 are fixed
-$ skip-if
-SELECT true
-
 #
 # Validate feature flag
 #
@@ -339,9 +335,6 @@ contains:unknown catalog item 'mysql_table_3'
 
 > SELECT count(*) FROM mz_internal.mz_source_references;
 0
-
-# TODO(def-) Remove when database-issues#8515 and database-issues#8526 are fixed
-$ skip-end
 
 #
 # Kafka source using source-fed tables

--- a/test/testdrive/source-tables.td
+++ b/test/testdrive/source-tables.td
@@ -10,10 +10,6 @@
 $ set-arg-default default-replica-size=1
 $ set-arg-default single-replica-cluster=quickstart
 
-# TODO(def-) Remove when database-issues#8515 and database-issues#8526 are fixed
-$ skip-if
-SELECT '${arg.default-replica-size}' = '8'
-
 #
 # Validate feature flag
 #
@@ -339,9 +335,6 @@ contains:unknown catalog item 'mysql_table_3'
 
 > SELECT count(*) FROM mz_internal.mz_source_references;
 0
-
-# TODO(def-) Remove when database-issues#8515 and database-issues#8526 are fixed
-$ skip-end
 
 #
 # Kafka source using source-fed tables


### PR DESCRIPTION
Related to discussion in https://github.com/MaterializeInc/database-issues/issues/8526

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
