### PR TITLE
testdrive: Adapt old syntax tests to new CT/Network Policy objects

### DIFF
--- a/test/testdrive-old-kafka-src-syntax/catalog.td
+++ b/test/testdrive-old-kafka-src-syntax/catalog.td
@@ -358,6 +358,7 @@ table
 source
 view
 materialized-view
+continual-task
 sink
 index
 connection
@@ -603,6 +604,8 @@ mz_pending_cluster_replicas              ""
 mz_kafka_source_tables                   ""
 mz_materialized_view_refresh_strategies  ""
 mz_mysql_source_tables                   ""
+mz_network_policies                      ""
+mz_network_policy_rules                  ""
 mz_object_dependencies                   ""
 mz_optimizer_notices                     ""
 mz_postgres_sources                      ""
@@ -783,11 +786,11 @@ test_table ""
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-59
+61
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'
-241
+242
 
 # Create a second schema with the same table name as above
 > CREATE SCHEMA tester2

--- a/test/testdrive-old-kafka-src-syntax/distinct-arrangements.td
+++ b/test/testdrive-old-kafka-src-syntax/distinct-arrangements.td
@@ -735,8 +735,8 @@ ReduceMinsMaxes
 "ArrangeBy[[Column(0), Column(2)]]" 3
 "ArrangeBy[[Column(0), Column(3)]]" 4
 "ArrangeBy[[Column(0), Column(4)]]" 1
-"ArrangeBy[[Column(0)]]" 150
-"ArrangeBy[[Column(0)]]-errors" 41
+"ArrangeBy[[Column(0)]]" 152
+"ArrangeBy[[Column(0)]]-errors" 42
 "ArrangeBy[[Column(1), Column(0)]]" 1
 "ArrangeBy[[Column(1), Column(2)]]" 1
 "ArrangeBy[[Column(1), Column(3)]]" 1

--- a/test/testdrive-old-kafka-src-syntax/indexes.td
+++ b/test/testdrive-old-kafka-src-syntax/indexes.td
@@ -311,6 +311,7 @@ mz_compute_import_frontiers_per_worker_s2_primary_idx       mz_compute_import_fr
 mz_compute_operator_durations_histogram_raw_s2_primary_idx  mz_compute_operator_durations_histogram_raw  mz_catalog_server    {id,worker_id,duration_ns}                  ""
 mz_connections_ind                                          mz_connections                               mz_catalog_server    {schema_id}                                 ""
 mz_console_cluster_utilization_overview_ind                 mz_console_cluster_utilization_overview      mz_catalog_server    {cluster_id}                                ""
+mz_continual_tasks_ind                                      mz_continual_tasks                           mz_catalog_server    {id}                                        ""
 mz_databases_ind                                            mz_databases                                 mz_catalog_server    {name}                                      ""
 mz_dataflow_addresses_per_worker_s2_primary_idx             mz_dataflow_addresses_per_worker             mz_catalog_server    {id,worker_id}                              ""
 mz_dataflow_channels_per_worker_s2_primary_idx              mz_dataflow_channels_per_worker              mz_catalog_server    {id,worker_id}                              ""


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/10187

This really shows why we don't want to have these duplicated tests for a longer period of time, it will be a mess to keep them in sync since they are not running in the Test pipeline.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
