### PR TITLE
cluster test: Fix statement-logging.td

### DIFF
--- a/test/cluster/statement-logging/statement-logging.td
+++ b/test/cluster/statement-logging/statement-logging.td
@@ -277,6 +277,10 @@ ROLLBACK
 
 > INSERT INTO t_offset_limit SELECT generate_series(1, 5);
 
+# Make sure the table has its data already, otherwise Testdrive might execute it multiple times
+> SELECT COUNT(*) FROM t_offset_limit
+5
+
 > SELECT * FROM t_offset_limit ORDER BY a DESC OFFSET 4;
 1
 


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/test/builds/93457#0192d458-72b1-42b4-9dfd-512c1c0e1692

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
