### PR TITLE
testdrive: Disable status check in source-tables.td

### DIFF
--- a/test/testdrive-old-kafka-src-syntax/source-tables.td
+++ b/test/testdrive-old-kafka-src-syntax/source-tables.td
@@ -47,8 +47,15 @@ ALTER SYSTEM SET enable_load_generator_key_value = true
 > SELECT count(*) FROM bids
 255
 
+# TODO(def-) Reenable when database-issues#8703 is fixed
+$ skip-if
+SELECT true
+
 > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'bids';
 running
+
+# TODO(def-) Reenable when database-issues#8703 is fixed
+$ skip-end
 
 # Create another table from the same bids upstream using a less qualified reference
 > CREATE TABLE bids2 FROM SOURCE auction_house (REFERENCE "bids");

--- a/test/testdrive/source-tables.td
+++ b/test/testdrive/source-tables.td
@@ -47,8 +47,15 @@ ALTER SYSTEM SET enable_load_generator_key_value = true
 > SELECT count(*) FROM bids
 255
 
+# TODO(def-) Reenable when database-issues#8703 is fixed
+$ skip-if
+SELECT true
+
 > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'bids';
 running
+
+# TODO(def-) Reenable when database-issues#8703 is fixed
+$ skip-end
 
 # Create another table from the same bids upstream using a less qualified reference
 > CREATE TABLE bids2 FROM SOURCE auction_house (REFERENCE "bids");


### PR DESCRIPTION
To unflake https://github.com/MaterializeInc/database-issues/issues/8703

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
