### PR TITLE
product-limits: Still measure wallclock and explain wallclock

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -78,7 +78,7 @@ class Generator:
 
     EXPLAIN: str | None = None
 
-    FIND_NEW_LIMITS: bool = True
+    MAX_COUNT: int | None = None
 
     @classmethod
     def header(cls) -> None:
@@ -142,7 +142,7 @@ class Connections(Generator):
 class Tables(Generator):
     COUNT = 90  # https://github.com/MaterializeInc/database-issues/issues/3675 and https://github.com/MaterializeInc/database-issues/issues/7830
 
-    FIND_NEW_LIMITS = False  # Too long-running with 11k tables
+    MAX_COUNT = 6500  # Too long-running with 11k tables
 
     @classmethod
     def body(cls) -> None:
@@ -190,7 +190,7 @@ class Subscribe(Generator):
 
 
 class Indexes(Generator):
-    FIND_NEW_LIMITS = False  # Too long-running with count=2562
+    MAX_COUNT = 2000  # Too long-running with count=2562
 
     @classmethod
     def body(cls) -> None:
@@ -261,7 +261,7 @@ class KafkaTopics(Generator):
 class KafkaSourcesSameTopic(Generator):
     COUNT = 500  # high memory consumption
 
-    FIND_NEW_LIMITS = False  # Too long-running with 750 sources
+    MAX_COUNT = COUNT  # Too long-running with 750 sources
 
     @classmethod
     def body(cls) -> None:
@@ -372,7 +372,7 @@ class KafkaPartitions(Generator):
 class KafkaRecordsEnvelopeNone(Generator):
     COUNT = Generator.COUNT * 10_000
 
-    FIND_NEW_LIMITS = False  # Only runs into max unsigned int size, takes a while
+    MAX_COUNT = COUNT  # Only runs into max unsigned int size, takes a while
 
     @classmethod
     def body(cls) -> None:
@@ -418,7 +418,7 @@ class KafkaRecordsEnvelopeNone(Generator):
 class KafkaRecordsEnvelopeUpsertSameValue(Generator):
     COUNT = Generator.COUNT * 10_000
 
-    FIND_NEW_LIMITS = False  # Only runs into max unsigned int size, takes a while
+    MAX_COUNT = COUNT  # Only runs into max unsigned int size, takes a while
 
     @classmethod
     def body(cls) -> None:
@@ -530,7 +530,7 @@ class KafkaRecordsEnvelopeUpsertDistinctValues(Generator):
 class KafkaSinks(Generator):
     COUNT = min(Generator.COUNT, 50)  # $ kafka-verify-data is slow
 
-    FIND_NEW_LIMITS = False  # Too long-running with 6400 sinks
+    MAX_COUNT = 3200  # Too long-running with 6400 sinks
 
     @classmethod
     def body(cls) -> None:
@@ -581,7 +581,7 @@ class KafkaSinks(Generator):
 class KafkaSinksSameSource(Generator):
     COUNT = min(Generator.COUNT, 50)  # $ kafka-verify-data is slow
 
-    FIND_NEW_LIMITS = False  # Too long-running with 6400 sinks
+    MAX_COUNT = 3200  # Too long-running with 6400 sinks
 
     @classmethod
     def body(cls) -> None:
@@ -642,7 +642,7 @@ class Columns(Generator):
 class TablesCommaJoinNoCondition(Generator):
     COUNT = 100  # https://github.com/MaterializeInc/database-issues/issues/3682
 
-    FIND_NEW_LIMITS = False  # Too long-running with 400 conditions
+    MAX_COUNT = 200  # Too long-running with 400 conditions
 
     @classmethod
     def body(cls) -> None:
@@ -656,7 +656,7 @@ class TablesCommaJoinNoCondition(Generator):
 class TablesCommaJoinWithJoinCondition(Generator):
     COUNT = 20  # Otherwise is very slow
 
-    FIND_NEW_LIMITS = False  # Too long-running with 640 conditions
+    MAX_COUNT = 320  # Too long-running with 640 conditions
 
     @classmethod
     def body(cls) -> None:
@@ -850,7 +850,7 @@ class ViewsMaterializedNested(Generator):
         Generator.COUNT, 25
     )  # https://github.com/MaterializeInc/database-issues/issues/3958
 
-    FIND_NEW_LIMITS = False  # Too long-running with 800 views
+    MAX_COUNT = 400  # Too long-running with 800 views
 
     @classmethod
     def body(cls) -> None:
@@ -877,7 +877,7 @@ class CTEs(Generator):
         Generator.COUNT, 10
     )  # https://github.com/MaterializeInc/database-issues/issues/2628
 
-    FIND_NEW_LIMITS = False  # Too long-running with count=480
+    MAX_COUNT = 240  # Too long-running with count=480
 
     @classmethod
     def body(cls) -> None:
@@ -952,7 +952,7 @@ class Lateral(Generator):
         Generator.COUNT, 10
     )  # https://github.com/MaterializeInc/database-issues/issues/2631
 
-    FIND_NEW_LIMITS = False  # Too long-running with count=320
+    MAX_COUNT = 160  # Too long-running with count=320
 
     @classmethod
     def body(cls) -> None:
@@ -1525,7 +1525,7 @@ class PostgresSources(Generator):
 class MySqlSources(Generator):
     COUNT = 300  # high memory consumption, slower with source tables
 
-    FIND_NEW_LIMITS = False  # Too long-running with count=473
+    MAX_COUNT = 400  # Too long-running with count=473
 
     @classmethod
     def body(cls) -> None:
@@ -1577,7 +1577,7 @@ class MySqlSources(Generator):
 class WebhookSources(Generator):
     COUNT = 100  # TODO: Remove when database-issues#8508 is fixed
 
-    FIND_NEW_LIMITS = False  # Too long-running with count=2800
+    MAX_COUNT = 1400  # Too long-running with count=2800
 
     @classmethod
     def body(cls) -> None:
@@ -1862,8 +1862,6 @@ def workflow_main(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     for scenario in scenarios:
         if args.find_limit:
-            if not scenario.FIND_NEW_LIMITS:
-                continue
             good_count = None
             bad_count = None
             while True:
@@ -1935,11 +1933,12 @@ def workflow_main(c: Composition, parser: WorkflowArgumentParser) -> None:
                         wallclock, explain_wallclock
                     )
                 good_count = scenario.COUNT
-                scenario.COUNT = (
-                    scenario.COUNT * 2
-                    if bad_count is None
-                    else (good_count + bad_count) // 2
-                )
+                if bad_count is None:
+                    scenario.COUNT *= 2
+                else:
+                    scenario.COUNT = (good_count + bad_count) // 2
+                if scenario.MAX_COUNT is not None:
+                    scenario.COUNT = max(scenario.COUNT, scenario.MAX_COUNT)
                 if scenario.COUNT <= good_count:
                     break
             print(f"Final good count: {good_count}")


### PR DESCRIPTION
at highest known good values

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
