### PR TITLE
Replace local.mtrlz.dev with local.mtrlz.com as an allowed host

### DIFF
--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -74,7 +74,7 @@ pub struct Args {
 
     #[clap(
         long,
-        default_values = &["http://local.dev.materialize.com:3000", "http://local.mtrlz.dev:3000", "http://localhost:3000", "https://staging.console.materialize.com"],
+        default_values = &["http://local.dev.materialize.com:3000", "http://local.mtrlz.com:3000", "http://localhost:3000", "https://staging.console.materialize.com"],
     )]
     environmentd_allowed_origins: Vec<HeaderValue>,
     #[clap(long, default_value = "https://console.materialize.com")]


### PR DESCRIPTION
### Motivation

local.mtrlz.dev will not work for testing HTTP connections to the console hosted at localhost due to *.dev being in the HSTS preload list.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
