### PR TITLE
durable-cache: Ensure retractions match insertion

### DIFF
--- a/src/catalog/src/expr_cache.rs
+++ b/src/catalog/src/expr_cache.rs
@@ -56,7 +56,7 @@ struct CacheKey {
     id: GlobalId,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 struct ExpressionCodec;
 
 impl DurableCacheCodec for ExpressionCodec {

--- a/src/catalog/src/expr_cache.rs
+++ b/src/catalog/src/expr_cache.rs
@@ -95,8 +95,11 @@ impl DurableCacheCodec for ExpressionCodec {
         (source_data, ())
     }
 
-    fn decode(key: Self::KeyCodec, (): Self::ValCodec) -> (Self::Key, Self::Val) {
-        let row = key.0.expect("only Ok values stored in expression cache");
+    fn decode(key: &Self::KeyCodec, (): &Self::ValCodec) -> (Self::Key, Self::Val) {
+        let row = key
+            .0
+            .as_ref()
+            .expect("only Ok values stored in expression cache");
         let datums = row.unpack();
         assert_eq!(datums.len(), 2, "Row should have 2 columns: {datums:?}");
 
@@ -591,7 +594,7 @@ mod tests {
         fn expr_cache_roundtrip((key, val) in any::<(CacheKey, Expressions)>()) {
             let serde_val = serde_json::to_string(&val).expect("valid json");
             let (encoded_key, encoded_val) = ExpressionCodec::encode(&key, &serde_val);
-            let (decoded_key, decoded_val) = ExpressionCodec::decode(encoded_key, encoded_val);
+            let (decoded_key, decoded_val) = ExpressionCodec::decode(&encoded_key, &encoded_val);
             let decoded_val: Expressions = serde_json::from_str(&decoded_val).expect("expressions should roundtrip");
 
             assert_eq!(key, decoded_key);

--- a/src/durable-cache/src/lib.rs
+++ b/src/durable-cache/src/lib.rs
@@ -24,11 +24,11 @@ use mz_persist_types::{Codec, ShardId};
 use timely::progress::Antichain;
 use tracing::debug;
 
-pub trait DurableCacheCodec {
+pub trait DurableCacheCodec: Debug + Eq {
     type Key: Ord + Hash + Clone + Debug;
     type Val: Eq + Debug;
-    type KeyCodec: Codec + Ord + Debug;
-    type ValCodec: Codec + Ord + Debug;
+    type KeyCodec: Codec + Ord + Debug + Clone;
+    type ValCodec: Codec + Ord + Debug + Clone;
 
     fn schemas() -> (
         <Self::KeyCodec as Codec>::Schema,
@@ -51,12 +51,19 @@ impl std::fmt::Display for Error {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct LocalVal<C: DurableCacheCodec> {
+    encoded_key: C::KeyCodec,
+    decoded_val: C::Val,
+    encoded_val: C::ValCodec,
+}
+
 #[derive(Debug)]
 pub struct DurableCache<C: DurableCacheCodec> {
     write: WriteHandle<C::KeyCodec, C::ValCodec, u64, i64>,
     subscribe: Subscribe<C::KeyCodec, C::ValCodec, u64, i64>,
 
-    local: BTreeMap<C::Key, C::Val>,
+    local: BTreeMap<C::Key, LocalVal<C>>,
     local_progress: u64,
 }
 
@@ -113,14 +120,29 @@ impl<C: DurableCacheCodec> DurableCache<C> {
                 match event {
                     ListenEvent::Updates(x) => {
                         for ((k, v), t, d) in x {
-                            let (key, val) = C::decode(k.unwrap(), v.unwrap());
+                            let encoded_key = k.unwrap();
+                            let encoded_val = v.unwrap();
+                            let (decoded_key, decoded_val) =
+                                C::decode(encoded_key.clone(), encoded_val.clone());
+                            let val = LocalVal {
+                                encoded_key,
+                                decoded_val,
+                                encoded_val,
+                            };
+
                             if d == 1 {
-                                self.local.expect_insert(key, val, "duplicate cache entry");
+                                self.local
+                                    .expect_insert(decoded_key, val, "duplicate cache entry");
                             } else if d == -1 {
-                                let prev = self.local.expect_remove(&key, "entry does not exist");
+                                let prev = self
+                                    .local
+                                    .expect_remove(&decoded_key, "entry does not exist");
                                 assert_eq!(val, prev, "removed val does not match expected val");
                             } else {
-                                panic!("unexpected diff: (({key:?}, {val:?}), {t}, {d})");
+                                panic!(
+                                    "unexpected diff: (({:?}, {:?}), {}, {})",
+                                    decoded_key, val.decoded_val, t, d
+                                );
                             }
                         }
                     }
@@ -137,7 +159,7 @@ impl<C: DurableCacheCodec> DurableCache<C> {
     /// Get and return the value associated with `key` if it exists, without syncing with the
     /// durable store.
     pub fn get_local(&self, key: &C::Key) -> Option<&C::Val> {
-        self.local.get(key)
+        self.local.get(key).map(|val| &val.decoded_val)
     }
 
     /// Get and return the value associated with `key`, syncing with the durable store if
@@ -148,14 +170,14 @@ impl<C: DurableCacheCodec> DurableCache<C> {
         // N.B. This pattern of calling `contains_key` followed by `expect` is required to appease
         // the borrow checker.
         if self.local.contains_key(key) {
-            return self.local.get(key).expect("checked above");
+            return self.get_local(key).expect("checked above");
         }
 
         // Reduce wasted work by ensuring we're caught up to at least the
         // pubsub-updated shared_upper, and then trying again.
         self.sync_to(self.write.shared_upper().into_option()).await;
         if self.local.contains_key(key) {
-            return self.local.get(key).expect("checked above");
+            return self.get_local(key).expect("checked above");
         }
 
         // Okay compute it and write it durably to the cache.
@@ -181,7 +203,7 @@ impl<C: DurableCacheCodec> DurableCache<C> {
                 Err(err) => {
                     expected_upper = self.sync_to(err.current.into_option()).await;
                     if self.local.contains_key(key) {
-                        return self.local.get(key).expect("checked above");
+                        return self.get_local(key).expect("checked above");
                     }
                     continue;
                 }
@@ -191,7 +213,7 @@ impl<C: DurableCacheCodec> DurableCache<C> {
 
     /// Return all entries stored in the cache, without syncing with the durable store.
     pub fn entries_local(&self) -> impl Iterator<Item = (&C::Key, &C::Val)> {
-        self.local.iter()
+        self.local.iter().map(|(key, val)| (key, &val.decoded_val))
     }
 
     /// Durably set `key` to `value`. A `value` of `None` deletes the entry from the cache.
@@ -238,7 +260,11 @@ impl<C: DurableCacheCodec> DurableCache<C> {
             // If there are duplicate keys we ignore all but the first one.
             if seen_keys.insert(key) {
                 if let Some(prev) = self.local.get(key) {
-                    updates.push((C::encode(key, prev), expected_upper, -1));
+                    updates.push((
+                        (prev.encoded_key.clone(), prev.encoded_val.clone()),
+                        expected_upper,
+                        -1,
+                    ));
                 }
                 if let Some(val) = val {
                     updates.push((C::encode(key, val), expected_upper, 1));
@@ -279,6 +305,7 @@ mod tests {
 
     use super::*;
 
+    #[derive(Debug, PartialEq, Eq)]
     struct TestCodec;
 
     impl DurableCacheCodec for TestCodec {

--- a/src/durable-cache/src/lib.rs
+++ b/src/durable-cache/src/lib.rs
@@ -35,7 +35,7 @@ pub trait DurableCacheCodec: Debug + Eq {
         <Self::ValCodec as Codec>::Schema,
     );
     fn encode(key: &Self::Key, val: &Self::Val) -> (Self::KeyCodec, Self::ValCodec);
-    fn decode(key: Self::KeyCodec, val: Self::ValCodec) -> (Self::Key, Self::Val);
+    fn decode(key: &Self::KeyCodec, val: &Self::ValCodec) -> (Self::Key, Self::Val);
 }
 
 #[derive(Debug)]
@@ -122,8 +122,7 @@ impl<C: DurableCacheCodec> DurableCache<C> {
                         for ((k, v), t, d) in x {
                             let encoded_key = k.unwrap();
                             let encoded_val = v.unwrap();
-                            let (decoded_key, decoded_val) =
-                                C::decode(encoded_key.clone(), encoded_val.clone());
+                            let (decoded_key, decoded_val) = C::decode(&encoded_key, &encoded_val);
                             let val = LocalVal {
                                 encoded_key,
                                 decoded_val,
@@ -325,8 +324,8 @@ mod tests {
             (key.clone(), val.clone())
         }
 
-        fn decode(key: Self::KeyCodec, val: Self::ValCodec) -> (Self::Key, Self::Val) {
-            (key, val)
+        fn decode(key: &Self::KeyCodec, val: &Self::ValCodec) -> (Self::Key, Self::Val) {
+            (key.clone(), val.clone())
         }
     }
 


### PR DESCRIPTION
Previously, when interacting with the durable cache, entries would have
roughly the following lifecycle:

1. Encode `(key, value)` to `(encoded_key, encoded_value)`.
2. Write down in persist `((encoded_key, encoded_value), ts, 1)`.
3. Read `(encoded_key, encoded_value)` from persist.
4. Decode `(encoded_key, encoded_value)` into
   `(decoded_key, decoded_value)`.
5. Re-encode `(decoded_key, decoded_value)` into
   `(re_encoded_key, re_encoded_value)`.
6. Write down in persist
   `((re_encoded_key, re_encoded_value), ts, -1)`.

In order for compaction to work correctly, `encoded_key` must match
`re_encoded_key` byte for byte and `encoded_value` must match
`re_encoded_value` byte for byte. However, many serialization formats
do not provide this guarantee.

To resolve this issue, the durable cache keeps in memory the exact
encoded representations of all keys and values. When an entry is
retracted, the original encoded representation is used instead of
re-encoding the key and value.

Works towards resolving #MaterializeInc/database-issues/8384

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
