### PR TITLE
repr: Remove outdated jsonb packer comments

### DIFF
--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -281,8 +281,7 @@ pub struct StateUpdateKindJson(Jsonb);
 impl StateUpdateKindJson {
     pub(crate) fn from_serde<S: serde::Serialize>(s: S) -> Self {
         let serde_value = serde_json::to_value(s).expect("valid json");
-        let row =
-            Jsonb::from_serde_json(serde_value).expect("contained integers should fit in f64");
+        let row = Jsonb::from_serde_json(serde_value).expect("valid json");
         StateUpdateKindJson(row)
     }
 

--- a/src/catalog/src/expr_cache.rs
+++ b/src/catalog/src/expr_cache.rs
@@ -87,7 +87,7 @@ impl DurableCacheCodec for ExpressionCodec {
         let serde_key = serde_json::to_value(key).expect("valid json");
         JsonbPacker::new(&mut packer)
             .pack_serde_json(serde_key)
-            .expect("contained integers should fit in f64");
+            .expect("valid json");
 
         packer.push(Datum::String(val));
 

--- a/src/repr/src/adt/jsonb.rs
+++ b/src/repr/src/adt/jsonb.rs
@@ -101,9 +101,6 @@ pub struct Jsonb {
 
 impl Jsonb {
     /// Constructs a new `Jsonb` from a [`serde_json::Value`].
-    ///
-    /// Errors if any of the contained integers cannot be represented exactly as
-    /// an [`f64`].
     pub fn from_serde_json(val: serde_json::Value) -> Result<Self, anyhow::Error> {
         let mut row = Row::default();
         JsonbPacker::new(&mut row.packer()).pack_serde_json(val)?;
@@ -112,8 +109,7 @@ impl Jsonb {
 
     /// Parses a `Jsonb` from a byte slice `buf`.
     ///
-    /// Errors if the slice is not valid JSON or if any of the contained
-    /// integers cannot be represented exactly as an [`f64`].
+    /// Errors if the slice is not valid JSON.
     pub fn from_slice(buf: &[u8]) -> Result<Jsonb, anyhow::Error> {
         let binding = SharedRow::get();
         let mut row_builder = binding.borrow_mut();
@@ -241,9 +237,6 @@ impl<'a, 'row> JsonbPacker<'a, 'row> {
     }
 
     /// Packs a [`serde_json::Value`].
-    ///
-    /// Errors if any of the contained integers cannot be represented exactly as
-    /// an [`f64`].
     pub fn pack_serde_json(self, val: serde_json::Value) -> Result<(), serde_json::Error> {
         let mut commands = vec![];
         Collector(&mut commands).deserialize(val)?;
@@ -253,8 +246,7 @@ impl<'a, 'row> JsonbPacker<'a, 'row> {
 
     /// Parses and packs a JSON-formatted byte slice.
     ///
-    /// Errors if the slice is not valid JSON or if any of the contained
-    /// integers cannot be represented exactly as an [`f64`].
+    /// Errors if the slice is not valid JSON.
     pub fn pack_slice(self, buf: &[u8]) -> Result<(), serde_json::Error> {
         let mut commands = vec![];
         let mut deserializer = serde_json::Deserializer::from_slice(buf);
@@ -266,8 +258,7 @@ impl<'a, 'row> JsonbPacker<'a, 'row> {
 
     /// Parses and packs a JSON-formatted string.
     ///
-    /// Errors if the string is not valid JSON or if any of the contained
-    /// integers cannot be represented exactly as an [`f64`].
+    /// Errors if the string is not valid JSON.
     pub fn pack_str(self, s: &str) -> Result<(), serde_json::Error> {
         let mut commands = vec![];
         let mut deserializer = serde_json::Deserializer::from_str(s);


### PR DESCRIPTION
When the `JsonbPacker` was first implemented in
c8fa525c6df8bad86a46353208743d2c06466d92, the `JsonbPacker` would serialize integers by first converting them to an `f64`. If the integer didn't fit into an `f64`, then an error was returned. Many of the Jsonb serialize and deserialize methods include a comment of the form:

  /// Errors if any of the contained integers cannot be represented exactly as
  /// an [`f64`].

Later b7b1816eb9eeceafbf79603be4db1de5a3d35ba3, updated the serialization format to store all numbers as numerics, which have enough precision for all accepted integer types. As a result, the comment about integers and `f64` was no longer accurate, however, the comment was not removed.

This commit removes the outdated comment about integers and `f64`. It's very possible that some of the `JsonbPacker` methods can never return an `Err`. However, verifying this and updating the APIs is left as future work.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
