### PR TITLE
testdrive: Add CT append-only test

### DIFF
--- a/test/testdrive/continual-tasks.td
+++ b/test/testdrive/continual-tasks.td
@@ -1,0 +1,61 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set-arg-default default-storage-size=1
+
+$ kafka-create-topic topic=append_only partitions=1
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+
+> CREATE CLUSTER ct_cluster SIZE '${arg.default-storage-size}';
+> CREATE SOURCE append_only
+  IN CLUSTER ct_cluster
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-append_only-${testdrive.seed}')
+
+> CREATE TABLE append_only_tbl FROM SOURCE append_only (REFERENCE "testdrive-append_only-${testdrive.seed}")
+  KEY FORMAT TEXT
+  VALUE FORMAT TEXT
+  INCLUDE KEY
+  ENVELOPE NONE
+
+$ kafka-ingest topic=append_only format=bytes key-format=bytes key-terminator=:
+x:0
+
+> CREATE CONTINUAL TASK ct_max FROM TRANSFORM append_only_tbl USING
+    (SELECT max(text::int) FROM append_only_tbl)
+
+$ kafka-ingest topic=append_only format=bytes key-format=bytes key-terminator=:
+a:1
+
+> SELECT * FROM ct_max
+1
+
+$ kafka-ingest topic=append_only format=bytes key-format=bytes key-terminator=:
+b:2
+
+> SELECT * FROM ct_max
+1
+2
+
+$ kafka-ingest topic=append_only format=bytes key-format=bytes key-terminator=:
+c:3
+
+> SELECT * FROM ct_max
+1
+2
+3
+
+$ kafka-ingest topic=append_only format=bytes key-format=bytes key-terminator=:
+d:1
+
+> SELECT * FROM ct_max
+1
+2
+3


### PR DESCRIPTION
Failed with wrong results before https://github.com/MaterializeInc/materialize/pull/30219

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
