### PR TITLE
[persist] Bugfix and cleanup for removing run meta

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -118,9 +118,6 @@ def get_default_system_parameters(
         ),
         "persist_batch_columnar_format_percent": "100",
         "persist_batch_delete_enabled": "true",
-        "persist_batch_record_run_meta": (
-            "true" if version >= MzVersion.parse_mz("v0.115.0-dev") else "false"
-        ),
         "persist_batch_structured_order": (
             "true" if version >= MzVersion.parse_mz("v0.119.0-dev") else "false"
         ),

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1020,7 +1020,6 @@ class FlipFlagsAction(Action):
             "75",
             "100",
         ]
-        self.flags_with_values["persist_batch_record_run_meta"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_order"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [
             "0",

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -314,7 +314,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::batch::INLINE_WRITES_SINGLE_MAX_BYTES)
         .add(&crate::batch::ENCODING_ENABLE_DICTIONARY)
         .add(&crate::batch::ENCODING_COMPRESSION_FORMAT)
-        .add(&crate::batch::RECORD_RUN_META)
         .add(&crate::batch::STRUCTURED_ORDER)
         .add(&crate::batch::STRUCTURED_ORDER_UNTIL_SHARD)
         .add(&crate::batch::STRUCTURED_KEY_LOWER_LEN)

--- a/src/persist-client/src/project.rs
+++ b/src/persist-client/src/project.rs
@@ -13,6 +13,7 @@ use differential_dataflow::trace::Description;
 use mz_dyncfg::{Config, ConfigSet};
 use mz_ore::cast::CastFrom;
 use mz_persist::indexed::columnar::ColumnarRecordsBuilder;
+use mz_persist::indexed::encoding::BlobTraceUpdates;
 use mz_persist_types::stats::PartStats;
 use mz_persist_types::Codec64;
 use mz_proto::RustType;
@@ -149,7 +150,7 @@ impl ProjectionPushdown {
 
         let mut faked_data = ColumnarRecordsBuilder::default();
         assert!(faked_data.push(((key_bytes, val_bytes), T::encode(as_of), diffs_sum)));
-        let updates = faked_data.finish(&metrics.columnar).into_proto(None);
+        let updates = BlobTraceUpdates::Row(faked_data.finish(&metrics.columnar)).into_proto();
         let faked_data = LazyInlineBatchPart::from(&ProtoInlineBatchPart {
             desc: Some(desc.into_proto()),
             index: 0,

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -96,12 +96,6 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                     x
                 },
                 {
-                    // Write the format of a Part in State.
-                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
-                    x.add_dynamic("persist_batch_record_run_meta", ::mz_dyncfg::ConfigVal::Bool(true));
-                    x
-                },
-                {
                     let mut x = ::mz_dyncfg::ConfigUpdates::default();
                     x.add_dynamic("persist_batch_columnar_format", ::mz_dyncfg::ConfigVal::String("both_v2".into()));
                     x.add_dynamic("persist_batch_columnar_format_percent", ::mz_dyncfg::ConfigVal::Usize(100));

--- a/src/persist-types/src/arrow.rs
+++ b/src/persist-types/src/arrow.rs
@@ -399,6 +399,32 @@ impl ArrayOrd {
         }
     }
 
+    /// Returns the rough amount of space required for the data in this array in bytes.
+    /// (Not counting nulls, dictionary encoding, or other space optimizations.)
+    pub fn goodbytes(&self) -> usize {
+        match self {
+            ArrayOrd::Null(_) => 0,
+            // This is, strictly speaking, wrong - but consistent with `ArrayIdx::goodbytes`,
+            // which counts one byte per bool.
+            ArrayOrd::Bool(b) => b.len(),
+            ArrayOrd::Int8(a) => a.values().inner().len(),
+            ArrayOrd::Int16(a) => a.values().inner().len(),
+            ArrayOrd::Int32(a) => a.values().inner().len(),
+            ArrayOrd::Int64(a) => a.values().inner().len(),
+            ArrayOrd::UInt8(a) => a.values().inner().len(),
+            ArrayOrd::UInt16(a) => a.values().inner().len(),
+            ArrayOrd::UInt32(a) => a.values().inner().len(),
+            ArrayOrd::UInt64(a) => a.values().inner().len(),
+            ArrayOrd::Float32(a) => a.values().inner().len(),
+            ArrayOrd::Float64(a) => a.values().inner().len(),
+            ArrayOrd::String(a) => a.values().len(),
+            ArrayOrd::Binary(a) => a.values().len(),
+            ArrayOrd::FixedSizeBinary(a) => a.values().len(),
+            ArrayOrd::List(_, _, nested) => nested.goodbytes(),
+            ArrayOrd::Struct(_, nested) => nested.iter().map(|a| a.goodbytes()).sum(),
+        }
+    }
+
     /// Return a struct representing the value at a particular index in this array.
     pub fn at(&self, idx: usize) -> ArrayIdx {
         ArrayIdx { idx, array: self }

--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -450,29 +450,6 @@ impl ColumnarRecordsBuilder {
 }
 
 impl ColumnarRecords {
-    /// See [RustType::into_proto].
-    pub fn into_proto(
-        &self,
-        structured_ext: Option<ColumnarRecordsStructuredExt>,
-    ) -> ProtoColumnarRecords {
-        let (k_struct, v_struct) = match structured_ext.map(|x| x.into_proto()) {
-            None => (None, None),
-            Some((k, v)) => (Some(k), Some(v)),
-        };
-
-        ProtoColumnarRecords {
-            len: self.len.into_proto(),
-            key_offsets: self.key_data.offsets().to_vec(),
-            key_data: Bytes::copy_from_slice(self.key_data.value_data()),
-            val_offsets: self.val_data.offsets().to_vec(),
-            val_data: Bytes::copy_from_slice(self.val_data.value_data()),
-            timestamps: self.timestamps.values().to_vec(),
-            diffs: self.diffs.values().to_vec(),
-            key_structured: k_struct,
-            val_structured: v_struct,
-        }
-    }
-
     /// See [RustType::from_proto].
     pub fn from_proto(
         lgbytes: &ColumnarMetrics,

--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -19,7 +19,7 @@ use ::arrow::array::{
 use ::arrow::buffer::OffsetBuffer;
 use ::arrow::datatypes::ToByteSlice;
 use bytes::Bytes;
-use mz_persist_types::arrow::ProtoArrayData;
+use mz_persist_types::arrow::{ArrayOrd, ProtoArrayData};
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
 
 use crate::gen::persist::ProtoColumnarRecords;
@@ -540,6 +540,11 @@ impl ColumnarRecordsStructuredExt {
             (None, None) => None,
         };
         Ok(ext)
+    }
+
+    /// The "goodput" of these arrays, excluding overhead like offsets etc.
+    pub fn goodbytes(&self) -> usize {
+        ArrayOrd::new(self.key.as_ref()).goodbytes() + ArrayOrd::new(self.val.as_ref()).goodbytes()
     }
 }
 

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -19,7 +19,7 @@ use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use bytes::BufMut;
+use bytes::{BufMut, Bytes};
 use differential_dataflow::trace::Description;
 use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::CastFrom;
@@ -29,6 +29,7 @@ use mz_persist_types::columnar::{codec_to_schema2, data_type};
 use mz_persist_types::parquet::EncodingConfig;
 use mz_persist_types::schema::backward_compatible;
 use mz_persist_types::{Codec, Codec64};
+use mz_proto::RustType;
 use proptest::arbitrary::Arbitrary;
 use proptest::prelude::*;
 use proptest::strategy::{BoxedStrategy, Just};
@@ -41,7 +42,8 @@ use tracing::error;
 use crate::error::Error;
 use crate::gen::persist::proto_batch_part_inline::FormatMetadata as ProtoFormatMetadata;
 use crate::gen::persist::{
-    ProtoBatchFormat, ProtoBatchPartInline, ProtoU64Antichain, ProtoU64Description,
+    ProtoBatchFormat, ProtoBatchPartInline, ProtoColumnarRecords, ProtoU64Antichain,
+    ProtoU64Description,
 };
 use crate::indexed::columnar::parquet::{decode_trace_parquet, encode_trace_parquet};
 use crate::indexed::columnar::{ColumnarRecords, ColumnarRecordsStructuredExt};
@@ -317,6 +319,27 @@ impl BlobTraceUpdates {
             .concat_bytes
             .inc_by(u64::cast_from(out.goodbytes()));
         Ok(out)
+    }
+
+    /// See [RustType::into_proto].
+    pub fn into_proto(&self) -> ProtoColumnarRecords {
+        let records = self.records();
+        let (k_struct, v_struct) = match self.structured().map(|x| x.into_proto()) {
+            None => (None, None),
+            Some((k, v)) => (Some(k), Some(v)),
+        };
+
+        ProtoColumnarRecords {
+            len: records.len().into_proto(),
+            key_offsets: records.keys().offsets().to_vec(),
+            key_data: Bytes::copy_from_slice(records.keys().value_data()),
+            val_offsets: records.vals().offsets().to_vec(),
+            val_data: Bytes::copy_from_slice(records.vals().value_data()),
+            timestamps: records.timestamps().values().to_vec(),
+            diffs: records.diffs().values().to_vec(),
+            key_structured: k_struct,
+            val_structured: v_struct,
+        }
     }
 }
 

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -228,10 +228,7 @@ impl BlobTraceUpdates {
 
     /// Return the estimated memory usage of the raw data.
     pub fn goodbytes(&self) -> usize {
-        self.records().goodbytes()
-            + self.structured().map_or(0, |e| {
-                e.key.get_buffer_memory_size() + e.val.get_buffer_memory_size()
-            })
+        self.records().goodbytes() + self.structured().map_or(0, |e| e.goodbytes())
     }
 
     /// Return the [`ColumnarRecordsStructuredExt`] of the blob.

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -2232,6 +2232,13 @@ mod tests {
         let ord_col = ::arrow::compute::take(&col, &indices, None).expect("takeable");
         assert_eq!(row_col.as_ref(), ord_col.as_ref());
 
+        // Check that our size estimates are consistent.
+        assert_eq!(
+            ord.goodbytes(),
+            (0..col.len()).map(|i| ord.at(i).goodbytes()).sum::<usize>(),
+            "total size should match the sum of the sizes at each index"
+        );
+
         // Check that our lower bounds work as expected.
         if !ord_col.is_empty() {
             let min_idx = indices.values()[0].as_usize();


### PR DESCRIPTION
Remove the `record_run_meta` flag, since it's enabled very widely.

Since it was previously enabled in only some tests, this causes test coverage of the structured order code to go up and exposes some test failures. 😬 Fixes include:
- Fix a bug affecting structured data / inline writes. (Since user parts never have structured data currently - it normally gets first added at encode time - this hasn't come up outside unit tests AFAICT.)
- Add a `goodbytes` method, and use it instead of `get_buffer_memory_size` when estimating part size.

AFAICT these only show up in the unusual configs or small limits that we run our unit tests with, and not real environments or CI more broadly... but anyways best to fix.

### Motivation

https://github.com/MaterializeInc/database-issues/issues/7411

### Tips for reviewer

May be easiest to review commit-by-commit.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
