### PR TITLE
Use official Timely, Differential, Columnation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,8 @@ dependencies = [
 [[package]]
 name = "columnation"
 version = "0.1.0"
-source = "git+https://github.com/MaterializeInc/columnation.git#2cd6d86e5ffabf98aef5cbef09a57f515eae7c55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ca68e419cae36821f2e1c9d62a25de900aad72e96b79c6f76eb47c65816d25"
 dependencies = [
  "paste",
 ]
@@ -2038,10 +2039,22 @@ dependencies = [
 
 [[package]]
 name = "differential-dataflow"
-version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#ea2e3e13bbd5cdd31f60f091a3625d954d7347f8"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f5ad19c6ddddedba008bf9626348810ff5171de9cad62406cd4e9ea291fa8d1"
 dependencies = [
  "fnv",
+ "serde",
+ "timely",
+]
+
+[[package]]
+name = "differential-dogs3"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd672f3f2167a08496c0ba47206e1c857b75abd14a7c560d1a7da2e07ee08cb1"
+dependencies = [
+ "differential-dataflow",
  "serde",
  "timely",
 ]
@@ -2089,17 +2102,6 @@ name = "doc-comment"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
-
-[[package]]
-name = "dogsdogsdogs"
-version = "0.1.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#ea2e3e13bbd5cdd31f60f091a3625d954d7347f8"
-dependencies = [
- "differential-dataflow",
- "serde",
- "serde_derive",
- "timely",
-]
 
 [[package]]
 name = "domain"
@@ -4690,7 +4692,7 @@ dependencies = [
  "crossbeam-channel",
  "dec",
  "differential-dataflow",
- "dogsdogsdogs",
+ "differential-dogs3",
  "futures",
  "itertools 0.10.5",
  "lgalloc",
@@ -9785,8 +9787,9 @@ dependencies = [
 
 [[package]]
 name = "timely"
-version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#14e2e994b99905e18dca4852e57d153a81f9f02e"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b6f390cec7160992fd8502fe02064a0f52dcfd2978544f4999f18664b709aa"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -9802,12 +9805,14 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#14e2e994b99905e18dca4852e57d153a81f9f02e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8a545b35b019b8b63afb913214695f542cbbf39032c7b7349e1a15b7f2a2cf"
 
 [[package]]
 name = "timely_communication"
-version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#14e2e994b99905e18dca4852e57d153a81f9f02e"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22d602b340fd8d5d4128660a577f7886070098b860dc9a9aa46512a2e0d683b4"
 dependencies = [
  "bincode",
  "byteorder",
@@ -9821,7 +9826,8 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#14e2e994b99905e18dca4852e57d153a81f9f02e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ddfa4639c9390c6fac4ff66e47aa1bcfbc5f5bba6d520d5a7c55978165e7b14"
 dependencies = [
  "columnation",
  "flatcontainer",
@@ -9830,8 +9836,9 @@ dependencies = [
 
 [[package]]
 name = "timely_logging"
-version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#14e2e994b99905e18dca4852e57d153a81f9f02e"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73a034d62792b507397701ee660001c8ba3e9dbffce29bc7a25319a36ebaa86"
 
 [[package]]
 name = "tiny-keccak"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,15 +270,6 @@ debug = 2
 # merged), after which point it becomes impossible to build that historical
 # version of Materialize.
 [patch.crates-io]
-# Projects that do not reliably release to crates.io.
-timely = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
-timely_bytes = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
-timely_communication = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
-timely_container = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
-timely_logging = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
-differential-dataflow = { git = "https://github.com/MaterializeInc/differential-dataflow.git" }
-dogsdogsdogs = { git = "https://github.com/MaterializeInc/differential-dataflow.git" }
-
 # Waiting on https://github.com/sfackler/rust-postgres/pull/752.
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
@@ -321,10 +312,6 @@ openssh = { git = "https://github.com/MaterializeInc/openssh.git" }
 # Removes dependencies required for WASM support that create duplicated deps.
 reqwest-middleware = { git = "https://github.com/MaterializeInc/reqwest-middleware.git" }
 reqwest-retry = { git = "https://github.com/MaterializeInc/reqwest-middleware.git" }
-
-[patch."https://github.com/frankmcsherry/columnation"]
-# Projects that do not reliably release to crates.io.
-columnation = { git = "https://github.com/MaterializeInc/columnation.git" }
 
 [workspace.metadata.vet]
 store = { path = "misc/cargo-vet" }

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -307,12 +307,6 @@ who = "Parker Timmerman <parker.timmerman@materialize.com>"
 criteria = "safe-to-deploy"
 version = "1.0.5"
 
-[[audits.differential-dataflow]]
-who = "Moritz Hoffmann <mh@materialize.com>"
-criteria = "safe-to-deploy"
-version = "0.12.0@git:ea2e3e13bbd5cdd31f60f091a3625d954d7347f8"
-importable = false
-
 [[audits.domain]]
 who = "Matt Jibson <matt.jibson@gmail.com>"
 criteria = "safe-to-deploy"
@@ -1216,30 +1210,6 @@ who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.6.0"
 
-[[audits.timely]]
-who = "Moritz Hoffmann <mh@materialize.com>"
-criteria = "safe-to-deploy"
-version = "0.12.0@git:14e2e994b99905e18dca4852e57d153a81f9f02e"
-importable = false
-
-[[audits.timely_bytes]]
-who = "Moritz Hoffmann <mh@materialize.com>"
-criteria = "safe-to-deploy"
-version = "0.12.0@git:14e2e994b99905e18dca4852e57d153a81f9f02e"
-importable = false
-
-[[audits.timely_communication]]
-who = "Moritz Hoffmann <mh@materialize.com>"
-criteria = "safe-to-deploy"
-version = "0.12.0@git:14e2e994b99905e18dca4852e57d153a81f9f02e"
-importable = false
-
-[[audits.timely_logging]]
-who = "Moritz Hoffmann <mh@materialize.com>"
-criteria = "safe-to-deploy"
-version = "0.12.0@git:14e2e994b99905e18dca4852e57d153a81f9f02e"
-importable = false
-
 [[audits.tokio]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
@@ -1709,6 +1679,18 @@ user-id = 1 # Alex Crichton (alexcrichton)
 start = "2019-03-26"
 end = "2024-11-16"
 
+[[trusted.columnation]]
+criteria = "safe-to-deploy"
+user-id = 704 # Frank McSherry (frankmcsherry)
+start = "2019-03-31"
+end = "2024-11-21"
+
+[[trusted.columnation]]
+criteria = "safe-to-deploy"
+user-id = 704 # Frank McSherry (frankmcsherry)
+start = "2024-10-29"
+end = "2029-10-28"
+
 [[trusted.compact_bytes]]
 criteria = "safe-to-deploy"
 user-id = 75844 # Parker Timmerman (ParkMyCar)
@@ -1753,7 +1735,13 @@ end = "2024-11-16"
 
 [[trusted.differential-dataflow]]
 criteria = "safe-to-deploy"
-user-id = 704
+user-id = 704 # Frank McSherry (frankmcsherry)
+start = "2019-03-31"
+end = "2024-11-21"
+
+[[trusted.differential-dogs3]]
+criteria = "safe-to-deploy"
+user-id = 704 # Frank McSherry (frankmcsherry)
 start = "2019-03-31"
 end = "2024-11-21"
 
@@ -2167,25 +2155,31 @@ end = "2024-11-16"
 
 [[trusted.timely]]
 criteria = "safe-to-deploy"
-user-id = 704
+user-id = 704 # Frank McSherry (frankmcsherry)
 start = "2019-03-31"
 end = "2024-11-21"
 
 [[trusted.timely_bytes]]
 criteria = "safe-to-deploy"
-user-id = 704
+user-id = 704 # Frank McSherry (frankmcsherry)
 start = "2019-03-31"
 end = "2024-11-21"
 
 [[trusted.timely_communication]]
 criteria = "safe-to-deploy"
-user-id = 704
+user-id = 704 # Frank McSherry (frankmcsherry)
 start = "2019-03-31"
 end = "2024-11-21"
 
+[[trusted.timely_container]]
+criteria = "safe-to-deploy"
+user-id = 704 # Frank McSherry (frankmcsherry)
+start = "2024-10-29"
+end = "2029-10-28"
+
 [[trusted.timely_logging]]
 criteria = "safe-to-deploy"
-user-id = 704
+user-id = 704 # Frank McSherry (frankmcsherry)
 start = "2019-03-31"
 end = "2024-11-21"
 

--- a/misc/cargo-vet/imports.lock
+++ b/misc/cargo-vet/imports.lock
@@ -203,6 +203,13 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
+[[publisher.columnation]]
+version = "0.1.0"
+when = "2024-10-29"
+user-id = 704
+user-login = "frankmcsherry"
+user-name = "Frank McSherry"
+
 [[publisher.compact_bytes]]
 version = "0.1.2"
 when = "2024-05-31"
@@ -265,6 +272,20 @@ when = "2024-05-07"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
+
+[[publisher.differential-dataflow]]
+version = "0.13.0"
+when = "2024-10-29"
+user-id = 704
+user-login = "frankmcsherry"
+user-name = "Frank McSherry"
+
+[[publisher.differential-dogs3]]
+version = "0.1.0"
+when = "2024-10-29"
+user-id = 704
+user-login = "frankmcsherry"
+user-name = "Frank McSherry"
 
 [[publisher.dyn-clone]]
 version = "1.0.9"
@@ -670,6 +691,41 @@ when = "2023-01-15"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
+
+[[publisher.timely]]
+version = "0.13.0"
+when = "2024-10-29"
+user-id = 704
+user-login = "frankmcsherry"
+user-name = "Frank McSherry"
+
+[[publisher.timely_bytes]]
+version = "0.12.0"
+when = "2021-03-10"
+user-id = 704
+user-login = "frankmcsherry"
+user-name = "Frank McSherry"
+
+[[publisher.timely_communication]]
+version = "0.13.0"
+when = "2024-10-29"
+user-id = 704
+user-login = "frankmcsherry"
+user-name = "Frank McSherry"
+
+[[publisher.timely_container]]
+version = "0.12.0"
+when = "2024-10-29"
+user-id = 704
+user-login = "frankmcsherry"
+user-name = "Frank McSherry"
+
+[[publisher.timely_logging]]
+version = "0.12.1"
+when = "2024-10-29"
+user-id = 704
+user-login = "frankmcsherry"
+user-name = "Frank McSherry"
 
 [[publisher.tokio-test]]
 version = "0.4.2"

--- a/src/adapter-types/Cargo.toml
+++ b/src/adapter-types/Cargo.toml
@@ -15,7 +15,7 @@ mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }
 mz-storage-types = { path = "../storage-types" }
 serde = "1.0.152"
-timely = "0.12.0"
+timely = "0.13.0"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 dec = "0.4.8"
 deadpool-postgres = "0.10.3"
 derivative = "2.2.0"
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 enum-kinds = "0.5.1"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
@@ -94,7 +94,7 @@ serde_plain = "1.0.1"
 sha2 = "0.10.6"
 smallvec = { version = "1.10.0", features = ["union"] }
 static_assertions = "1.1"
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = { version = "1.38.0", features = ["rt", "time"] }
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = "0.1.11"

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -17,7 +17,7 @@ bytesize = "1.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 clap = { version = "3.2.24", features = ["derive"] }
 derivative = "2.2.0"
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
 ipnet = "2.5.0"
@@ -62,7 +62,7 @@ smallvec = { version = "1.10.0", features = ["union"] }
 static_assertions = "1.1"
 sha2 = "0.10.6"
 thiserror = "1.0.37"
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = { version = "1.38.0" }
 tracing = "0.1.37"
 uuid = "1.2.2"

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -16,7 +16,7 @@ bytesize = "1.1.0"
 clap = { version = "3.2.24", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
 dec = { version = "0.4.8", features = ["serde"] }
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 futures = "0.3.25"
 mz-build-info = { path = "../build-info" }
 mz-cluster-client = { path = "../cluster-client" }
@@ -33,7 +33,7 @@ rocksdb = { version = "0.22.0", default-features = false, features = ["snappy", 
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -37,7 +37,7 @@ mz-storage-client = { path = "../storage-client" }
 mz-storage-types = { path = "../storage-types" }
 mz-timely-util = { path = "../timely-util" }
 mz-txn-wal = { path = "../txn-wal" }
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util"] }
 tower = "0.4.13"
 tracing = "0.1.37"

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -17,7 +17,7 @@ bytes = "1.3.0"
 bytesize = "1.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.8"
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 futures = "0.3.25"
 http = "1.1.0"
 mz-build-info = { path = "../build-info" }
@@ -28,7 +28,7 @@ mz-dyncfg = { path = "../dyncfg" }
 mz-dyncfgs = { path = "../dyncfgs" }
 mz-expr = { path = "../expr" }
 mz-orchestrator = { path = "../orchestrator" }
-mz-ore = { path = "../ore", features = ["tracing_","chrono"] }
+mz-ore = { path = "../ore", features = ["tracing_", "chrono"] }
 mz-persist = { path = "../persist" }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
@@ -40,14 +40,14 @@ mz-storage-types = { path = "../storage-types" }
 mz-timely-util = { path = "../timely-util" }
 mz-tracing = { path = "../tracing" }
 prometheus = { version = "0.13.3", default-features = false }
-proptest = { version = "1.0.0", default-features = false, features = ["std"]}
-proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
+proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.125"
 thiserror = "1.0.37"
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tonic = "0.12.1"

--- a/src/compute-types/Cargo.toml
+++ b/src/compute-types/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 workspace = true
 
 [dependencies]
-columnation = { git = "https://github.com/frankmcsherry/columnation" }
-differential-dataflow = "0.12.0"
+columnation = "0.1.0"
+differential-dataflow = "0.13.0"
 itertools = "0.10.5"
 mz-dyncfg = { path = "../dyncfg" }
 mz-expr = { path = "../expr" }
@@ -19,11 +19,11 @@ mz-ore = { path = "../ore", features = ["tracing_", "metrics"] }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr", features = ["tracing_"] }
 mz-storage-types = { path = "../storage-types" }
-proptest = { version = "1.0.0", default-features = false, features = ["std"]}
-proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
+proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
-timely = "0.12.0"
+timely = "0.13.0"
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -17,8 +17,8 @@ bytesize = "1.1.0"
 clap = { version = "3.2.24", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
 dec = { version = "0.4.8", features = ["serde"] }
-differential-dataflow = "0.12.0"
-dogsdogsdogs = "0.1.0"
+differential-dataflow = "0.13.0"
+differential-dogs3 = "0.1.0"
 futures = "0.3.25"
 itertools = "0.10.5"
 lgalloc = "0.3"
@@ -43,7 +43,7 @@ prometheus = { version = "0.13.3", default-features = false }
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -432,7 +432,7 @@ where
     let mut datums = DatumVec::new();
 
     if closure.could_error() {
-        let (oks, errs2) = dogsdogsdogs::operators::half_join::half_join_internal_unsafe(
+        let (oks, errs2) = differential_dogs3::operators::half_join::half_join_internal_unsafe(
             &updates,
             trace,
             |time, antichain| {
@@ -481,7 +481,7 @@ where
             errs.concat(&errs2.as_collection()),
         )
     } else {
-        let oks = dogsdogsdogs::operators::half_join::half_join_internal_unsafe(
+        let oks = differential_dogs3::operators::half_join::half_join_internal_unsafe(
             &updates,
             trace,
             |time, antichain| {

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.66"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 futures = "0.3.25"
 mz-build-info = { path = "../build-info" }
 mz-cluster-client = { path = "../cluster-client" }
@@ -33,7 +33,7 @@ mz-txn-wal = { path = "../txn-wal" }
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.125"
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tracing = "0.1.37"

--- a/src/durable-cache/Cargo.toml
+++ b/src/durable-cache/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1.68"
 bytes = { version = "1.3.0" }
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 futures = "0.3.25"
 itertools = { version = "0.10.5" }
 mz-ore = { path = "../ore", features = ["process"] }
@@ -23,7 +23,7 @@ mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = { version = "1.38.0", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -149,7 +149,7 @@ reqwest = { version = "0.11.13", features = ["blocking"] }
 serde_json = "1.0.125"
 serde_urlencoded = "0.7.1"
 similar-asserts = "1.4"
-timely = "0.12.0"
+timely = "0.13.0"
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4"] }
 
 [build-dependencies]

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -59,7 +59,7 @@ serde_json = "1.0.125"
 sha1 = "0.10.5"
 sha2 = "0.10.6"
 subtle = "2.4.1"
-timely = "0.12.0"
+timely = "0.13.0"
 tracing = "0.1.37"
 uncased = "0.9.7"
 uuid = { version = "1.7.0", features = ["v5"] }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -20,7 +20,7 @@ byteorder = "1.4.3"
 bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 clap = { version = "3.2.24", features = ["derive"] }
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 itertools = "0.10.5"
 maplit = "1.0.2"
 mz-avro = { path = "../avro", features = ["snappy"] }
@@ -33,7 +33,7 @@ prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 prost-reflect = "0.14.2"
 seahash = "4"
 serde_json = "1.0.125"
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = { version = "1.38.0", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde"] }

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -23,7 +23,7 @@ async-trait = "0.1.68"
 axum = "0.7.5"
 bytes = { version = "1.3.0", features = ["serde"] }
 clap = { version = "3.2.24", features = ["derive", "env"] }
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 futures = "0.3.25"
 humantime = "2.1.0"
 mz-http-util = { path = "../http-util" }
@@ -40,7 +40,7 @@ num_enum = "0.5.7"
 prometheus = { version = "0.13.3", default-features = false }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.125"
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 url = "2.3.1"

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -35,7 +35,7 @@ async-stream = "0.3.3"
 async-trait = "0.1.68"
 bytes = { version = "1.3.0", features = ["serde"] }
 clap = { version = "3.2.24", features = ["derive"] }
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 futures = "0.3.25"
 futures-util = "0.3"
 h2 = "0.3.13"
@@ -59,7 +59,7 @@ sentry-tracing = "0.29.1"
 semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.125"
-timely = "0.12.0"
+timely = "0.13.0"
 thiserror = "1.0.37"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tokio-metrics = "0.3.0"

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -26,7 +26,7 @@ proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
-timely = "0.12.0"
+timely = "0.13.0"
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -28,12 +28,12 @@ async-trait = "0.1.68"
 async-stream = "0.3.3"
 aws-config = { version = "1.2.0", default-features = false }
 aws-credential-types = { version = "1.1.1", features = ["hardcoded-credentials"] }
-aws-sdk-s3 = { version = "1.23.0", default-features = false, features = ["rt-tokio"]  }
+aws-sdk-s3 = { version = "1.23.0", default-features = false, features = ["rt-tokio"] }
 aws-types = "1.1.1"
 base64 = "0.13.1"
 bytes = "1.3.0"
 deadpool-postgres = "0.10.3"
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures-util = "0.3.25"
 md-5 = "0.10.5"
@@ -50,11 +50,11 @@ postgres-openssl = { version = "0.5.0" }
 postgres-protocol = { version = "0.6.5" }
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
-proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
+proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.152", features = ["derive"] }
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = { version = "1.38.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -31,12 +31,12 @@ arrow = { version = "51.0.0", default-features = false }
 bitflags = "1.3.2"
 bytes = "1.3.0"
 cfg-if = "1.0.0"
-columnation = { git = "https://github.com/frankmcsherry/columnation" }
+columnation = "0.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["serde", "std"] }
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
 compact_bytes = "0.1.2"
 dec = "0.4.8"
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 enum-kinds = "0.5.1"
 fast-float = "0.2.0"
 flatcontainer = "0.5.0"
@@ -69,7 +69,7 @@ serde_json = { version = "1.0.125", features = ["arbitrary_precision", "preserve
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
 static_assertions = "1.1"
 strsim = "0.10"
-timely = "0.12.0"
+timely = "0.13.0"
 tokio-postgres = { version = "0.7.8" }
 tracing-core = "0.1.30"
 url = { version = "2.3.1", features = ["serde"] }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -29,13 +29,13 @@ mz-orchestrator-kubernetes = { path = "../orchestrator-kubernetes" }
 mz-ore = { path = "../ore" }
 os_info = "3.5.1"
 prometheus = { version = "0.13.3", default-features = false }
-proptest = { version = "1.0.0", default-features = false, features = ["std"]}
-proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
+proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 semver = "1.0.16"
 serde = { version = "1.0.152", features = ["derive"] }
 sysinfo = "0.27.2"
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tonic = "0.12.1"

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 anyhow = "1.0.66"
 async-trait = "0.1.68"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 futures = "0.3.25"
 http = "1.1.0"
 itertools = { version = "0.10.5" }
@@ -45,7 +45,7 @@ rdkafka = { version = "0.29.0", features = [
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
 static_assertions = "1.1"
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = { version = "1.38.0", features = [
     "fs",
     "rt",

--- a/src/storage-controller/Cargo.toml
+++ b/src/storage-controller/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.68"
 bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 derivative = "2.2.0"
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 futures = "0.3.25"
 itertools = { version = "0.10.5" }
 mz-build-info = { path = "../build-info" }
@@ -38,7 +38,7 @@ proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -15,7 +15,7 @@ arrow = { version = "51.0.0", default-features = false }
 async-stream = "0.3.3"
 aws-types = "1.1.1"
 bytesize = "1.1.0"
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 futures = "0.3.25"
 http = "1.1.0"
 mz-aws-util = { path = "../aws-util" }
@@ -35,7 +35,7 @@ prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 sentry = { version = "0.29.1" }
 serde = { version = "1.0.152", features = ["derive"] }
-timely = "0.12.0"
+timely = "0.13.0"
 thiserror = "1.0.37"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tracing = "0.1.37"

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -22,10 +22,10 @@ aws-credential-types = { version = "1.1.1", features = ["hardcoded-credentials"]
 aws-sdk-sts = { version = "1.7.0", default-features = false, features = ["rt-tokio"] }
 aws-types = "1.1.1"
 bytes = "1.3.0"
-columnation = { git = "https://github.com/frankmcsherry/columnation" }
+columnation = "0.1.0"
 dec = "0.4.8"
 derivative = "2.2.0"
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 hex = "0.4.3"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
@@ -64,7 +64,7 @@ regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125", features = ["preserve_order"] }
 thiserror = "1.0.37"
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tracing = "0.1.37"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -22,11 +22,11 @@ bytesize = "1.1.0"
 bincode = "1"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 clap = { version = "3.2.24", features = ["derive", "env"] }
-columnation = { git = "https://github.com/frankmcsherry/columnation" }
+columnation = "0.1.0"
 crossbeam-channel = "0.5.8"
 csv-core = { version = "0.1.10" }
 dec = "0.4.8"
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 either = { version = "1.8.0", features = ["serde"] }
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
@@ -85,7 +85,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
 serde_bytes = { version = "0.11.14" }
 sha2 = "0.10.6"
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -10,13 +10,13 @@ publish = false
 workspace = true
 
 [dependencies]
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 either = "1"
 lgalloc = "0.3"
-columnation = { git = "https://github.com/frankmcsherry/columnation" }
+columnation = "0.1.0"
 futures-util = "0.3.25"
-proptest = { version = "1.0.0", default-features = false, features = ["std"]}
-timely = "0.12.0"
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
+timely = "0.13.0"
 serde = { version = "1.0.152", features = ["derive"] }
 mz-ore = { path = "../ore", features = ["async", "process", "tracing_", "test"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 enum-kinds = "0.5.1"
 itertools = "0.10.5"
 mz-compute-types = { path = "../compute-types" }

--- a/src/txn-wal/Cargo.toml
+++ b/src/txn-wal/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1.68"
 bytes = { version = "1.3.0" }
-differential-dataflow = "0.12.0"
+differential-dataflow = "0.13.0"
 futures = "0.3.25"
 itertools = { version = "0.10.5" }
 mz-ore = { path = "../ore", features = ["process"] }
@@ -23,7 +23,7 @@ mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
-timely = "0.12.0"
+timely = "0.13.0"
 tokio = { version = "1.38.0", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }


### PR DESCRIPTION
We've resumed publishing Timely, Differential, and Columnation to crates, which allows us to switch away from our own forks of said projects.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
