### PR TITLE
Remove last traces of abomonation

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -114,10 +114,6 @@ skip = [
     { name = "sync_wrapper", version = "0.1.2" },
 ]
 
-# We don't want to use abomonation anymore.
-[[bans.deny]]
-name = "abomonation"
-
 # Use `tracing` instead.
 [[bans.deny]]
 name = "env_logger"

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -1511,12 +1511,6 @@ who = "Parker Timmerman <parker.timmerman@materialize.com>"
 criteria = "safe-to-deploy"
 delta = "6.0.6 -> 7.0.0"
 
-[[trusted.abomonation]]
-criteria = "safe-to-deploy"
-user-id = 704
-start = "2019-05-27"
-end = "2024-11-21"
-
 [[trusted.aho-corasick]]
 criteria = "safe-to-deploy"
 user-id = 189 # Andrew Gallant (BurntSushi)


### PR DESCRIPTION
We have no transitive dependency on it anymore, so remove all mentions from our repo.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
