### PR TITLE
mzcompose: Improved sql command

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -887,23 +887,32 @@ class ResolvedImage:
             return True
         return False
 
-    def run(self, args: list[str] = [], docker_args: list[str] = []) -> None:
+    def run(
+        self,
+        args: list[str] = [],
+        docker_args: list[str] = [],
+        env: dict[str, str] = {},
+    ) -> None:
         """Run a command in the image.
 
         Creates a container from the image and runs the command described by
         `args` in the image.
         """
+        envs = []
+        for key, val in env.items():
+            envs.extend(["--env", f"{key}={val}"])
         spawn.runv(
             [
                 "docker",
                 "run",
                 "--tty",
                 "--rm",
+                *envs,
                 "--init",
                 *docker_args,
                 self.spec(),
                 *args,
-            ]
+            ],
         )
 
     def list_dependencies(self, transitive: bool = False) -> set[str]:


### PR DESCRIPTION
Convenient for local debugging

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
