### PR TITLE
ci: Increase timeout for devsite deploy

### DIFF
--- a/ci/deploy/pipeline.template.yml
+++ b/ci/deploy/pipeline.template.yml
@@ -17,7 +17,7 @@ env:
 steps:
   - command: bin/ci-builder run nightly ci/deploy/devsite.sh
     branches: main
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     agents:
       queue: linux-x86_64
     concurrency: 1


### PR DESCRIPTION
Timed out in https://buildkite.com/materialize/deploy/builds/16536#0192e0f7-92ec-4650-beac-7f4d62e79b93

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
