### PR TITLE
testdrive: Unflake new append-only CT test

### DIFF
--- a/test/testdrive/continual-tasks.td
+++ b/test/testdrive/continual-tasks.td
@@ -28,6 +28,11 @@ $ kafka-create-topic topic=append_only partitions=1
 $ kafka-ingest topic=append_only format=bytes key-format=bytes key-terminator=:
 x:0
 
+# Wait for the ingestion to have completed before creating the CT, we want the x:0
+# value to be in the continual task, since it only starts after it is ingested already.
+> SELECT * FROM append_only_tbl
+x 0
+
 > CREATE CONTINUAL TASK ct_max FROM TRANSFORM append_only_tbl USING
     (SELECT max(text::int) FROM append_only_tbl)
 
@@ -35,12 +40,14 @@ $ kafka-ingest topic=append_only format=bytes key-format=bytes key-terminator=:
 a:1
 
 > SELECT * FROM ct_max
+0
 1
 
 $ kafka-ingest topic=append_only format=bytes key-format=bytes key-terminator=:
 b:2
 
 > SELECT * FROM ct_max
+0
 1
 2
 
@@ -48,6 +55,7 @@ $ kafka-ingest topic=append_only format=bytes key-format=bytes key-terminator=:
 c:3
 
 > SELECT * FROM ct_max
+0
 1
 2
 3
@@ -56,6 +64,7 @@ $ kafka-ingest topic=append_only format=bytes key-format=bytes key-terminator=:
 d:1
 
 > SELECT * FROM ct_max
+0
 1
 2
 3


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/10218#0192dfc5-f058-4d4f-9810-dd927ff8dcd9

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
