### PR TITLE
platform-checks: Parallelism didn't help, adapt timeouts and ignore panic instead

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -784,10 +784,9 @@ steps:
               args: [--scenario=UpgradeEntireMzFourVersions, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-restart-entire-mz
-        label: "Checks 0dt restart of the entire Mz %N"
+        label: "Checks 0dt restart of the entire Mz"
         depends_on: build-aarch64
         timeout_in_minutes: 240
-        parallelism: 4
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -797,10 +796,9 @@ steps:
               args: [--scenario=ZeroDowntimeRestartEntireMz, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-restart-entire-mz-forced-migrations
-        label: "Checks 0dt restart of the entire Mz with forced migrations %N"
+        label: "Checks 0dt restart of the entire Mz with forced migrations"
         depends_on: build-aarch64
         timeout_in_minutes: 240
-        parallelism: 4
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -810,10 +808,9 @@ steps:
               args: [--scenario=ZeroDowntimeRestartEntireMzForcedMigrations, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-upgrade-entire-mz
-        label: "Checks 0dt upgrade, whole-Mz restart %N"
+        label: "Checks 0dt upgrade, whole-Mz restart"
         depends_on: build-aarch64
         timeout_in_minutes: 240
-        parallelism: 4
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -823,10 +820,9 @@ steps:
               args: [--scenario=ZeroDowntimeUpgradeEntireMz, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-upgrade-entire-mz-two-versions
-        label: "Checks 0dt upgrade across two versions %N"
+        label: "Checks 0dt upgrade across two versions"
         depends_on: build-aarch64
         timeout_in_minutes: 240
-        parallelism: 4
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -836,10 +832,9 @@ steps:
               args: [--scenario=ZeroDowntimeUpgradeEntireMzTwoVersions, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-upgrade-entire-mz-four-versions
-        label: "Checks 0dt upgrade across four versions %N"
+        label: "Checks 0dt upgrade across four versions"
         depends_on: build-aarch64
         timeout_in_minutes: 240
-        parallelism: 4
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large

--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -247,7 +247,7 @@ class SinkTables(Check):
                 > INSERT INTO sink_large_transaction_table SELECT generate_series, REPEAT('x', 1024) FROM generate_series(1, 100000);
 
                 # Can be slow with a large transaction
-                $ set-sql-timeout duration=120s
+                $ set-sql-timeout duration=240s
 
                 > CREATE MATERIALIZED VIEW sink_large_transaction_view AS SELECT f1 - 1 AS f1 , f2 FROM sink_large_transaction_table;
 
@@ -296,7 +296,7 @@ class SinkTables(Check):
                   ENVELOPE NONE
 
                 # Can be slow with a large transaction
-                $ set-sql-timeout duration=120s
+                $ set-sql-timeout duration=240s
 
                 > CREATE MATERIALIZED VIEW sink_large_transaction_view2
                   AS
@@ -1303,7 +1303,7 @@ class SinkPartitionByDebezium(Check):
             dedent(
                 """
                 # Can be slow in 0dt upgrade scenarios
-                $ set-sql-timeout duration=120s
+                $ set-sql-timeout duration=240s
 
                 $ schema-registry-verify schema-type=avro subject=testdrive-sink-partition-by-debezium-sink-${testdrive.seed}-value
                 {"type":"record","name":"envelope","fields":[{"name":"before","type":["null",{"type":"record","name":"row","fields":[{"name":"f1","type":"int"},{"name":"f2","type":["null","string"]}]}]},{"name":"after","type":["null","row"]}]}

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -163,8 +163,10 @@ IGNORE_RE = re.compile(
     # TODO(def-) Remove in ~3 weeks
     | .* incompatible\ persist\ version\ \d+\.\d+\.\d+(-dev\.\d+)?,\ current:\ \d+\.\d+\.\d+(-dev\.\d+)?,\ make\ sure\ to\ upgrade\ the\ catalog\ one\ version\ forward\ at\ a\ time
     # Fences without incrementing deploy generation
-    | txn-wal-fencing-mz_first-.* \| .*unable\ to\ confirm\ leadership
-    | txn-wal-fencing-mz_first-.* \| .*fenced\ by\ envd
+    | txn-wal-fencing-mz_first-.* \| .* unable\ to\ confirm\ leadership
+    | txn-wal-fencing-mz_first-.* \| .* fenced\ by\ envd
+    # 0dt platform-checks have two envds running in parallel, thus high load, tests still succeed, so ignore noise
+    | platform-checks-mz_.* \| .* was\ expired\ due\ to\ inactivity\.\ Did\ the\ machine\ go\ to\ sleep\?
     )
     """,
     re.VERBOSE | re.MULTILINE,


### PR DESCRIPTION
See https://github.com/MaterializeInc/database-issues/issues/8704

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
