### PR TITLE
output-consistency: Remove jsonb with geo data

### DIFF
--- a/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
@@ -6,16 +6,9 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
-from textwrap import dedent
 
-from materialize.output_consistency.expression.expression_characteristics import (
-    ExpressionCharacteristics,
-)
 from materialize.output_consistency.input_data.params.any_operation_param import (
     AnyOperationParam,
-)
-from materialize.output_consistency.input_data.params.date_time_operation_param import (
-    DateTimeOperationParam,
 )
 from materialize.output_consistency.input_data.params.enum_constant_operation_params import (
     JSON_FIELD_INDEX_PARAM,
@@ -24,9 +17,6 @@ from materialize.output_consistency.input_data.params.enum_constant_operation_pa
 )
 from materialize.output_consistency.input_data.params.jsonb_operation_param import (
     JsonbOperationParam,
-)
-from materialize.output_consistency.input_data.params.number_operation_param import (
-    NumericOperationParam,
 )
 from materialize.output_consistency.input_data.params.record_operation_param import (
     RecordOperationParam,
@@ -256,28 +246,3 @@ JSONB_OPERATION_TYPES.append(
         comment="additional overlapping variant only for records",
     ),
 )
-
-CREATE_JSON_WITH_GEO_DATA_OP = DbOperation(
-    dedent(
-        """concat('{
-              "@timestamp":"', $, '",
-              "latitude":', $, ',
-              "longitude":', $, ',
-              "location":[', $, ',', $, ']
-            }')::JSONB"""
-    ),
-    [
-        DateTimeOperationParam(support_time=False),
-        NumericOperationParam(),
-        NumericOperationParam(),
-        NumericOperationParam(),
-        NumericOperationParam(),
-    ],
-    JsonbReturnTypeSpec(),
-    tags={TAG_JSONB_OBJECT_GENERATION},
-    comment="JSONB value with geo data",
-)
-CREATE_JSON_WITH_GEO_DATA_OP.added_characteristics.add(
-    ExpressionCharacteristics.JSON_WITH_GEO_DATA
-)
-JSONB_OPERATION_TYPES.append(CREATE_JSON_WITH_GEO_DATA_OP)


### PR DESCRIPTION
Hard to keep track of where differences come from after having concatenated the results. Seen failing because of a precision difference: https://buildkite.com/materialize/nightly/builds/10218#0192dfc5-f0ef-4f63-acf5-3a1b807c5c10

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
