### PR TITLE
Main switch to disable replica expiration

### DIFF
--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 use anyhow::bail;
 use mz_build_info::BuildInfo;
 use mz_cluster_client::client::{ClusterReplicaLocation, ClusterStartupEpoch, TimelyConfig};
+use mz_compute_types::dyncfgs::ENABLE_COMPUTE_REPLICA_EXPIRATION;
 use mz_dyncfg::ConfigSet;
 use mz_ore::channel::InstrumentedUnboundedSender;
 use mz_ore::retry::Retry;
@@ -274,7 +275,9 @@ where
                 expiration_offset,
             }) => {
                 *logging = self.config.logging.clone();
-                *expiration_offset = self.config.expiration_offset;
+                if ENABLE_COMPUTE_REPLICA_EXPIRATION.get(&self.dyncfg) {
+                    *expiration_offset = self.config.expiration_offset;
+                }
             }
             _ => {}
         }

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -122,10 +122,20 @@ pub const COPY_TO_S3_MULTIPART_PART_SIZE_BYTES: Config<usize> = Config::new(
     "The size of each part in a multipart upload to S3.",
 );
 
+/// Main switch to enable or disable replica expiration.
+///
+/// Changes affect existing replicas only after restart.
+pub const ENABLE_COMPUTE_REPLICA_EXPIRATION: Config<bool> = Config::new(
+    "enable_compute_replica_expiration",
+    true,
+    "Main switch to disable replica expiration.",
+);
+
 /// The maximum lifetime of a replica configured as an offset to the replica start time.
 /// Used in temporal filters to drop diffs generated at timestamps beyond the expiration time.
 ///
-/// Disabled by default. Once set, cannot be disabled again during the lifetime of a replica.
+/// A zero duration implies no expiration. Changing this value does not affect existing replicas,
+/// even when they are restarted.
 pub const COMPUTE_REPLICA_EXPIRATION_OFFSET: Config<Duration> = Config::new(
     "compute_replica_expiration_offset",
     Duration::ZERO,
@@ -149,5 +159,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&COPY_TO_S3_PARQUET_ROW_GROUP_FILE_RATIO)
         .add(&COPY_TO_S3_ARROW_BUILDER_BUFFER_RATIO)
         .add(&COPY_TO_S3_MULTIPART_PART_SIZE_BYTES)
+        .add(&ENABLE_COMPUTE_REPLICA_EXPIRATION)
         .add(&COMPUTE_REPLICA_EXPIRATION_OFFSET)
 }

--- a/test/testdrive-old-kafka-src-syntax/replica-expiration.td
+++ b/test/testdrive-old-kafka-src-syntax/replica-expiration.td
@@ -30,7 +30,33 @@ ALTER SYSTEM SET compute_replica_expiration_offset = '30d'
 > DROP TABLE events CASCADE;
 > DROP CLUSTER test;
 
-## Does retractions: expiration=20d, temporal filter width=30d
+## Does no retractions: expiration=20d, temporal filter width=30d, master switch off
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_compute_replica_expiration = 'false'
+ALTER SYSTEM SET compute_replica_expiration_offset = '20d'
+
+> CREATE CLUSTER test (SIZE = '1')
+> SET CLUSTER TO test
+> CREATE TABLE events (
+    content TEXT,
+    event_ts TIMESTAMP
+  );
+> CREATE VIEW events_view AS
+  SELECT event_ts, content
+  FROM events
+  WHERE mz_now() <= event_ts + INTERVAL '30 days';
+> CREATE DEFAULT INDEX ON events_view;
+> INSERT INTO events SELECT x::text, now() FROM generate_series(1, 1000) AS x;
+> SELECT records FROM mz_introspection.mz_dataflow_arrangement_sizes
+  WHERE name LIKE '%events_view_primary_idx';
+2000
+> DROP TABLE events CASCADE;
+> DROP CLUSTER test;
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM RESET enable_compute_replica_expiration
+
+## Does no retractions: expiration=20d, temporal filter width=30d
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET compute_replica_expiration_offset = '20d'
 > CREATE CLUSTER test (SIZE = '1')


### PR DESCRIPTION
Implement a main switch to disable replica expiration globally, even without re-creating replicas.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
