### PR TITLE
persist-pubsub: delegate subscribe in same-process sender

### DIFF
--- a/src/persist-client/src/rpc.rs
+++ b/src/persist-client/src/rpc.rs
@@ -575,14 +575,8 @@ impl PubSubSender for MetricsSameProcessPubSubSender {
     }
 
     fn subscribe(self: Arc<Self>, shard_id: &ShardId) -> Arc<ShardSubscriptionToken> {
-        // Create a no-op token that does not subscribe nor unsubscribe.
-        // For clients running in the same process as the server, this is
-        // safe because the StateCached is shared between them, and the
-        // server necessarily always receives and applies all diffs.
-        Arc::new(ShardSubscriptionToken {
-            shard_id: *shard_id,
-            sender: Arc::new(NoopPubSubSender),
-        })
+        let delegate = Arc::clone(&self.delegate);
+        delegate.subscribe(shard_id)
     }
 }
 


### PR DESCRIPTION
The `MetricsSameProcessPubSubSender` previously would skip delegating subscribe requests, assuming that the pubsub server was already applying diffs to the process persist state. That is not the case (at least not in the current code) so delegate the subscribe request instead.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8721

### Tips for reviewer

No idea if/how that can be tested. Happy to receive suggestions/commits from @MaterializeInc/persist!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
