### PR TITLE
ct: move WITH options to a consistent location in the syntax

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1455,14 +1455,14 @@ impl<T: AstInfo> AstDisplay for CreateContinualTaskStatement<T> {
             f.write_node(cluster);
         }
 
+        if !self.with_options.is_empty() {
+            f.write_str(" WITH (");
+            f.write_node(&display::comma_separated(&self.with_options));
+            f.write_str(")");
+        }
+
         match &self.sugar {
             Some(CreateContinualTaskSugar::Transform { transform }) => {
-                if !self.with_options.is_empty() {
-                    f.write_str(" WITH (");
-                    f.write_node(&display::comma_separated(&self.with_options));
-                    f.write_str(")");
-                }
-
                 f.write_str(" FROM TRANSFORM ");
                 f.write_node(&self.input);
                 f.write_str(" USING ");
@@ -1471,11 +1471,6 @@ impl<T: AstInfo> AstDisplay for CreateContinualTaskStatement<T> {
                 f.write_str(")");
             }
             Some(CreateContinualTaskSugar::Retain { retain }) => {
-                if !self.with_options.is_empty() {
-                    f.write_str(" WITH (");
-                    f.write_node(&display::comma_separated(&self.with_options));
-                    f.write_str(")");
-                }
                 f.write_str(" FROM RETAIN ");
                 f.write_node(&self.input);
                 f.write_str(" WHILE ");
@@ -1486,15 +1481,6 @@ impl<T: AstInfo> AstDisplay for CreateContinualTaskStatement<T> {
             None => {
                 f.write_str(" ON INPUT ");
                 f.write_node(&self.input);
-
-                // TODO(ct3): Move these WITH options to be after the IN CLUSTER
-                // clause, so we can pull it out into common code.
-                if !self.with_options.is_empty() {
-                    f.write_str(" WITH (");
-                    f.write_node(&display::comma_separated(&self.with_options));
-                    f.write_str(")");
-                }
-
                 f.write_str(" AS (");
                 for (idx, stmt) in self.stmts.iter().enumerate() {
                     if idx > 0 {

--- a/src/sql-parser/tests/testdata/continual-task
+++ b/src/sql-parser/tests/testdata/continual-task
@@ -38,18 +38,26 @@ CreateContinualTask(CreateContinualTaskStatement { name: Name(UnresolvedItemName
 
 # With snapshot
 parse-statement
-CREATE CONTINUAL TASK foo ON INPUT bar WITH (SNAPSHOT = false) AS ();
+CREATE CONTINUAL TASK foo WITH (SNAPSHOT = false) ON INPUT bar AS ();
 ----
-CREATE CONTINUAL TASK foo ON INPUT bar WITH (SNAPSHOT = false) AS ()
+CREATE CONTINUAL TASK foo WITH (SNAPSHOT = false) ON INPUT bar AS ()
 =>
 CreateContinualTask(CreateContinualTaskStatement { name: Name(UnresolvedItemName([Ident("foo")])), columns: None, in_cluster: None, as_of: None, with_options: [ContinualTaskOption { name: Snapshot, value: Some(Value(Boolean(false))) }], input: Name(UnresolvedItemName([Ident("bar")])), stmts: [], sugar: None })
 
 parse-statement
-CREATE CONTINUAL TASK foo ON INPUT bar WITH (SNAPSHOT) AS ();
+CREATE CONTINUAL TASK foo WITH (SNAPSHOT) ON INPUT bar AS ();
 ----
-CREATE CONTINUAL TASK foo ON INPUT bar WITH (SNAPSHOT) AS ()
+CREATE CONTINUAL TASK foo WITH (SNAPSHOT) ON INPUT bar AS ()
 =>
 CreateContinualTask(CreateContinualTaskStatement { name: Name(UnresolvedItemName([Ident("foo")])), columns: None, in_cluster: None, as_of: None, with_options: [ContinualTaskOption { name: Snapshot, value: None }], input: Name(UnresolvedItemName([Ident("bar")])), stmts: [], sugar: None })
+
+# Legacy with location (for CI upgrade tests)
+parse-statement
+CREATE CONTINUAL TASK foo ON INPUT bar WITH (SNAPSHOT = false) AS ();
+----
+CREATE CONTINUAL TASK foo WITH (SNAPSHOT = false) ON INPUT bar AS ()
+=>
+CreateContinualTask(CreateContinualTaskStatement { name: Name(UnresolvedItemName([Ident("foo")])), columns: None, in_cluster: None, as_of: None, with_options: [ContinualTaskOption { name: Snapshot, value: Some(Value(Boolean(false))) }], input: Name(UnresolvedItemName([Ident("bar")])), stmts: [], sugar: None })
 
 parse-statement
 CREATE CONTINUAL TASK "materialize"."public"."upsert" ("key" [s20 AS "pg_catalog"."int4"], "val" [s20 AS "pg_catalog"."int4"]) IN CLUSTER [u1] ON INPUT [u1 AS "materialize"."public"."append_only"] AS (

--- a/test/sqllogictest/ct_liveness.slt
+++ b/test/sqllogictest/ct_liveness.slt
@@ -26,13 +26,13 @@ statement ok
 CREATE TABLE append_only (key INT, val STRING)
 
 statement ok
-CREATE CONTINUAL TASK upsert_snap ON INPUT append_only WITH (SNAPSHOT = true) AS (
+CREATE CONTINUAL TASK upsert_snap WITH (SNAPSHOT = true) ON INPUT append_only AS (
     DELETE FROM upsert_snap WHERE key IN (SELECT key FROM append_only);
     INSERT INTO upsert_snap SELECT key, max(val) FROM append_only GROUP BY key;
 )
 
 statement ok
-CREATE CONTINUAL TASK upsert_no_snap ON INPUT append_only WITH (SNAPSHOT = false) AS (
+CREATE CONTINUAL TASK upsert_no_snap WITH (SNAPSHOT = false) ON INPUT append_only AS (
     DELETE FROM upsert_no_snap WHERE key IN (SELECT key FROM append_only);
     INSERT INTO upsert_no_snap SELECT key, max(val) FROM append_only GROUP BY key;
 )


### PR DESCRIPTION
This allows us to pull more common code out in `AstDisplay`, which will hopefully help prevent bugs like MaterializeInc/database-issues#8719.

Touches https://github.com/MaterializeInc/database-issues/issues/8427

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
