### PR TITLE
make the ephemeral storage class to use configurable

### DIFF
--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -53,6 +53,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.args.cloudProvider` |  | ``"local"`` |
 | `operator.args.createBalancers` |  | ``true`` |
 | `operator.args.environmentdIAMRoleARN` |  | ``""`` |
+| `operator.args.ephemeralVolumeClass` |  | ``nil`` |
 | `operator.args.localDevelopment` |  | ``true`` |
 | `operator.args.region` |  | ``"kind"`` |
 | `operator.args.startupLogFilter` |  | ``"INFO,mz_orchestratord=TRACE"`` |

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
         {{- range $key, $value := .Values.clusterd.nodeSelector }}
         - "--clusterd-node-selector={{ $key }}={{ $value }}"
         {{- end }}
+        {{- if .Values.operator.args.ephemeralVolumeClass }}
+        - "--ephemeral-volume-class={{ .Values.operator.args.ephemeralVolumeClass }}"
+        {{- end }}
         {{- if .Values.networkPolicies.enabled }}
         {{- if .Values.networkPolicies.internal.enabled }}
         - "--network-policies-internal-enabled=true"

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -31,6 +31,13 @@ operator:
     environmentdIAMRoleARN: ""
     # awsAccountID is required when cloudProvider is "aws"
     awsAccountID: ""
+    # To provide additional disk to clusterd pods, configure a CSI plugin in
+    # your kubernetes cluster, and put its storage class here. Note that
+    # networked storage (EBS volumes, for instance) is unlikely to work well
+    # here - we recommend using something like
+    # https://github.com/openebs/lvm-localpv targeting local instance store
+    # NVME drives.
+    ephemeralVolumeClass: null
   # Node selector to use for the operator pod
   nodeSelector: {}
   resources:

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -44,6 +44,8 @@ pub struct Args {
     aws_info: AwsInfo,
 
     #[clap(long)]
+    ephemeral_volume_class: Option<String>,
+    #[clap(long)]
     scheduler_name: Option<String>,
     #[clap(long)]
     enable_security_context: bool,


### PR DESCRIPTION
### Motivation

removing one more bit of hardcoded configuration

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
