### PR TITLE
ore: Add new `ore::panic::catch_unwind_str` function

### DIFF
--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -123,7 +123,7 @@ where
     /// [`OptimizerError::Internal`] error.
     #[mz_ore::instrument(target = "optimizer", level = "debug", name = "optimize")]
     fn catch_unwind_optimize(&mut self, plan: From) -> Result<Self::To, OptimizerError> {
-        match mz_ore::panic::catch_unwind(AssertUnwindSafe(|| self.optimize(plan))) {
+        match mz_ore::panic::catch_unwind_str(AssertUnwindSafe(|| self.optimize(plan))) {
             Ok(result) => {
                 match result.map_err(Into::into) {
                     Err(OptimizerError::TransformError(TransformError::CallerShouldPanic(msg))) => {
@@ -136,8 +136,8 @@ where
                     result => result,
                 }
             }
-            Err(_) => {
-                let msg = "unexpected panic during query optimization".to_string();
+            Err(panic) => {
+                let msg = format!("unexpected panic during query optimization: {panic}");
                 Err(OptimizerError::Internal(msg))
             }
         }

--- a/src/ore/src/panic.rs
+++ b/src/ore/src/panic.rs
@@ -17,6 +17,7 @@
 
 use std::any::Any;
 use std::backtrace::Backtrace;
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fs::File;
 use std::io::{self, Write as _};
@@ -195,4 +196,24 @@ where
         *catching_unwind.borrow_mut() = false;
         res
     })
+}
+
+/// Like [`crate::panic::crate_unwind`], but downcasts the returned `Box<dyn Any>` error to a
+/// string which is almost always is.
+///
+/// See: <https://doc.rust-lang.org/stable/std/panic/struct.PanicHookInfo.html#method.payload>
+pub fn catch_unwind_str<F, R>(f: F) -> Result<R, Cow<'static, str>>
+where
+    F: FnOnce() -> R + UnwindSafe,
+{
+    match crate::panic::catch_unwind(f) {
+        Ok(res) => Ok(res),
+        Err(opaque) => match opaque.downcast_ref::<&'static str>() {
+            Some(s) => Err(Cow::Borrowed(*s)),
+            None => match opaque.downcast_ref::<String>() {
+                Some(s) => Err(Cow::Owned(s.to_owned())),
+                None => Err(Cow::Borrowed("Box<Any>")),
+            },
+        },
+    }
 }

--- a/src/ore/src/panic.rs
+++ b/src/ore/src/panic.rs
@@ -198,7 +198,7 @@ where
     })
 }
 
-/// Like [`crate::panic::crate_unwind`], but downcasts the returned `Box<dyn Any>` error to a
+/// Like [`crate::panic::catch_unwind`], but downcasts the returned `Box<dyn Any>` error to a
 /// string which is almost always is.
 ///
 /// See: <https://doc.rust-lang.org/stable/std/panic/struct.PanicHookInfo.html#method.payload>

--- a/src/ore/tests/panic.rs
+++ b/src/ore/tests/panic.rs
@@ -15,7 +15,7 @@
 
 use std::panic;
 
-use mz_ore::panic::{catch_unwind, install_enhanced_handler};
+use mz_ore::panic::{catch_unwind_str, install_enhanced_handler};
 use scopeguard::defer;
 
 // IMPORTANT!!! Do not add any additional tests to this file. This test sets and
@@ -31,12 +31,10 @@ fn catch_panic() {
 
     install_enhanced_handler();
 
-    let result = catch_unwind(|| {
+    let result = catch_unwind_str(|| {
         panic!("panicked");
     })
-    .unwrap_err()
-    .downcast::<&str>()
-    .unwrap();
+    .unwrap_err();
 
-    assert_eq!(*result, "panicked");
+    assert_eq!(result, "panicked");
 }


### PR DESCRIPTION
Today `ore::panic::catch_unwind` returns a `Box<dyn Any>` which isn't useful to callers since the `Debug` format when printing is just `Any`. This PR adds a new methond `catch_unwind_str` that tries downcasting to a `&'static str` or `String` which is the type of the returning object should be, and is the panic message.

### Motivation

Happened upon this while talking to @frankmcsherry 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
