### PR TITLE
ct: fix dataflow hang for constant MV input

### DIFF
--- a/test/sqllogictest/ct_various.slt
+++ b/test/sqllogictest/ct_various.slt
@@ -127,3 +127,16 @@ SELECT * FROM ct_c2
 # Confirm that the catalog knows the ct is in the right cluster.
 statement error cannot drop cluster "c2" because other objects depend on it
 DROP CLUSTER c2;
+
+# Regression test for constant MV (upper of empty antichain). The dataflow
+# previously hung at runtime.
+statement ok
+CREATE MATERIALIZED VIEW mv_const AS SELECT 1 AS value
+
+statement ok
+CREATE CONTINUAL TASK ct_const_mv FROM TRANSFORM mv_const USING (SELECT MIN(value) FROM mv_const)
+
+query T
+SELECT * FROM ct_const_mv
+----
+1


### PR DESCRIPTION
The CT sink would end up in a state where it had enough information to finalize the output (advance the upper to empty), but it would get stuck waiting for operator input. Fix by repeatedly calling `process()` until there's no work to do before looping back to wait on inputs.

Test and bug find courtesy of Dennis.

Touches https://github.com/MaterializeInc/database-issues/issues/8427

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
