### PR TITLE
ct: fix bug where CT name was not escaped in `create_sql`

### DIFF
--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -495,7 +495,17 @@ impl AstDisplay for ResolvedItemName {
             }
             ResolvedItemName::Cte { name, .. } => f.write_node(&Ident::new_unchecked(name)),
             ResolvedItemName::ContinualTask { name, .. } => {
-                f.write_str(&name);
+                // TODO: Remove this once PartialItemName uses Ident instead of
+                // String.
+                if let Some(database) = name.database.as_ref() {
+                    f.write_node(&Ident::new_unchecked(database));
+                    f.write_str(".");
+                }
+                if let Some(schema) = name.schema.as_ref() {
+                    f.write_node(&Ident::new_unchecked(schema));
+                    f.write_str(".");
+                }
+                f.write_node(&Ident::new_unchecked(&name.item));
             }
             ResolvedItemName::Error => {}
         }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -812,7 +812,7 @@ impl<'a> Runner<'a> {
             let name: &str = row.get("name");
             inner
                 .system_client
-                .batch_execute(&format!("DROP DATABASE {name}"))
+                .batch_execute(&format!("DROP DATABASE \"{name}\""))
                 .await?;
         }
         inner

--- a/test/sqllogictest/ct_various.slt
+++ b/test/sqllogictest/ct_various.slt
@@ -64,6 +64,29 @@ SELECT * FROM y.z.ct;
 ----
 1
 
+# Crazy names
+statement ok
+CREATE DATABASE "--";
+
+statement ok
+CREATE SCHEMA "--"."</script><script>alert(123)</script>";
+
+statement ok
+CREATE TABLE "--"."</script><script>alert(123)</script>"."1;DROP TABLE users" (count int);
+
+statement ok
+INSERT INTO "--"."</script><script>alert(123)</script>"."1;DROP TABLE users" VALUES (1);
+
+statement ok
+CREATE CONTINUAL TASK "--"."</script><script>alert(123)</script>"."┬─┬ノ( º _ ºノ)"
+FROM TRANSFORM "--"."</script><script>alert(123)</script>"."1;DROP TABLE users"
+USING (SELECT MAX(COUNT) FROM "--"."</script><script>alert(123)</script>"."1;DROP TABLE users");
+
+query T
+SELECT * FROM "--"."</script><script>alert(123)</script>"."┬─┬ノ( º _ ºノ)";
+----
+1
+
 # Regression test for a bug where we'd panic if no CT inputs were referenced.
 statement ok
 CREATE CONTINUAL TASK no_input_refs (key INT) ON INPUT input AS (


### PR DESCRIPTION
This happens because, unlike other things, the CT name is represented on the statement as a `T::ItemName` instead of `UnresolvedItemName` (so that we can sniff out the assigned LocalId). There are probably other ways to fix this, but I don't have enough context to have an opinion on which is the best.

Test and bug find courtesy of Dennis.

Touches https://github.com/MaterializeInc/database-issues/issues/8427

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
