### PR TITLE
Relation CSE within WMR blocks

### DIFF
--- a/src/transform/src/cse/anf.rs
+++ b/src/transform/src/cse/anf.rs
@@ -67,7 +67,7 @@ impl ANF {
 /// The bindings can be interpreted as an ordered sequence of let bindings,
 /// ordered by their identifier, that should be applied in order before the
 /// use of the expression from which they have been extracted.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct Bindings {
     /// A list of let-bound expressions and their order / identifier.
     bindings: BTreeMap<MirRelationExpr, u64>,
@@ -122,32 +122,155 @@ impl Bindings {
                     ids,
                     values,
                     body,
-                    limits: _,
+                    limits,
                 } => {
-                    // Extend this.rebindings with (id, id) pairs for each
-                    // recursive ID before descending into values and body.
-                    this.rebindings.extend(ids.iter().map(|id| {
-                        let new_id = id_gen.allocate_id();
-                        (id.clone(), LocalId::new(new_id))
-                    }));
+                    // To perform CSE across WMR terms, they need to have the same limits.
+                    // Although we could be more sophisticated and annotate each term with a limit,
+                    // the current form of `Bindings` is not suited for this. If we are able, then
+                    // perform inter-term CSE, otherwise perform only intra-term CSE.
+                    if limits.is_empty() || limits.iter().all(|l| l == &limits[0]) {
+                        // Introduce a new copy of `self`, which will be specific to this scope.
+                        // This makes expressions used in the outer scope available for re-use
+                        // in this new recursive scope. By retaining `self`, we'll be able to see
+                        // the new bindings, and install only them when we reform the expression.
+                        let mut scoped_anf = this.clone();
 
-                    // Descend into each value using a fresh Bindings instance.
-                    for value in values.iter_mut() {
+                        // Used to distinguish new bindings from old bindings.
+                        let id_boundary = id_gen.allocate_id();
+
+                        // Each identifier in `ids` will be given *two* new identifiers,
+                        // one "old" and one "new". This is important to ensure that use
+                        // of the "old" collection does not result in hits for uses of the
+                        // "new" collection. We will need to unify these identifiers before
+                        // returning, but this should just be a matter of rewritting one
+                        // with the other (their distinction comes only from the moment they
+                        // are referenced).
+
+                        // The plan is to walk the bindings `values` in turn, producing a sequence
+                        // of ANF bindings that represent the same computation. As we reach each
+                        // `value`, we'll mint a new identifier and commit that term, but also
+                        // 1. Update the rebindings map to the new identifier, and
+                        // 2. Replace references to the old identifier with the new identifier.
+                        // Once finished, we'll lay out the new sequence of `ids` and `values`.
+
+                        // For each bound identifier from `ids`, a temporary identifier for the "old" version.
+                        let prevs = ids
+                            .iter()
+                            .map(|_id| LocalId::new(id_gen.allocate_id()))
+                            .collect::<Vec<_>>();
+                        let mut nexts = Vec::new();
+
+                        // Install the "old" rebindings to start.
+                        // As we discover uses of `id`, we'll replace them with `old`.
+                        scoped_anf
+                            .rebindings
+                            .extend(ids.iter().zip(prevs.iter()).map(|(x, y)| (*x, *y)));
+
+                        // Intern the sequence of values and then body.
+                        // Care is taken as each value is bound to alter the rebinding
+                        // of the identifier, so that uses of the "old" value do not
+                        // match uses of the "new" value.
+                        for (index, value) in values.iter_mut().enumerate() {
+                            scoped_anf.intern_expression(id_gen, value)?;
+                            // Now replace the rebinding of `id` from `old` to `new`.
+                            // We will ultimately use `new_id` for `value`, and should
+                            // imagine a `let new_id = value` that will appear at this
+                            // point. We cannot use `scoped_anf` for this, because `value`
+                            // may already be bound to something else, and we cannot set
+                            // all references to `value` to now be `new_id`. We can set
+                            // *subsequent* references to `value` to be `new_id`, but we
+                            // oughtn't uninstall `value` if it already exists.
+                            let new_id = id_gen.allocate_id();
+                            nexts.push(new_id);
+                            scoped_anf
+                                .rebindings
+                                .insert(ids[index].clone(), LocalId::new(new_id));
+                        }
+
+                        // We handle `body` separately, as it is an error to rely on arrangements from within the WMR.
+                        // Ideally we wouldn't need that complexity here, but this is called on arrangement-laden MRE
+                        // after join planning where we need to have locked in arrangements. Revisit if we correct that.
+                        let mut body_anf = Bindings::new(this.rebindings.clone());
+                        for id in ids.iter() {
+                            body_anf
+                                .rebindings
+                                .insert(*id, scoped_anf.rebindings[id].clone());
+                        }
+                        body_anf.intern_expression(id_gen, body)?;
+                        body_anf.populate_expression(body);
+
+                        // We now want to rebuild the let bindings that will make `body`
+                        // the correct answer. We have these in `scoped_anf`, but we must
+                        // 1. rewrite occurrences of `Get(old)` into `Get(new)`,
+                        // 2. insert `let new = value` for each existing binding.
+                        // 3. update `ids` and `values` to reflect all of this.
+
+                        // Map from "old" identifiers to "new" identifiers.
+                        // If we have a hit in this map, we should perform the replacement.
+                        let mut remap = BTreeMap::new();
+                        for (p, n) in prevs
+                            .iter()
+                            .zip(nexts.iter())
+                            .map(|(p, n)| (*p, LocalId::new(*n)))
+                        {
+                            remap.insert(p, n);
+                        }
+
+                        // Convert the bindings in to a sequence, by the local identifier.
+                        let mut bindings = scoped_anf
+                            .bindings
+                            .into_iter()
+                            .filter(|(_e, i)| i > &id_boundary)
+                            .map(|(e, i)| (i, e))
+                            .collect::<Vec<_>>();
+                        // Add bindings corresponding to `(ids, values)`
+                        bindings.extend(nexts.into_iter().zip(values.drain(..)));
+                        bindings.sort();
+                        for (_id, expr) in bindings.iter_mut() {
+                            let mut todo = vec![&mut *expr];
+                            while let Some(e) = todo.pop() {
+                                if let MirRelationExpr::Get {
+                                    id: Id::Local(i), ..
+                                } = e
+                                {
+                                    if let Some(next) = remap.get(&i) {
+                                        i.clone_from(next);
+                                    }
+                                }
+                                todo.extend(e.children_mut());
+                            }
+                        }
+
+                        let (new_ids, new_values): (Vec<_>, Vec<_>) = bindings.into_iter().unzip();
+                        *ids = new_ids.into_iter().map(|n| LocalId::new(n)).collect();
+                        *values = new_values;
+                        limits.resize(values.len(), limits.get(0).cloned().unwrap_or(None));
+                    } else {
+                        // Extend this.rebindings with (id, id) pairs for each
+                        // recursive ID before descending into values and body.
+                        this.rebindings.extend(ids.iter().map(|id| {
+                            let new_id = id_gen.allocate_id();
+                            (id.clone(), LocalId::new(new_id))
+                        }));
+
+                        // Descend into each value using a fresh Bindings instance.
+                        for value in values.iter_mut() {
+                            let mut anf = Bindings::new(this.rebindings.clone());
+                            anf.intern_expression(id_gen, value)?;
+                            anf.populate_expression(value);
+                        }
+
+                        // Descend into the body using a fresh Bindings instance.
                         let mut anf = Bindings::new(this.rebindings.clone());
-                        anf.intern_expression(id_gen, value)?;
-                        anf.populate_expression(value);
-                    }
+                        anf.intern_expression(id_gen, body)?;
+                        anf.populate_expression(body);
 
-                    // Descend into the body using a fresh Bindings instance.
-                    let mut anf = Bindings::new(this.rebindings.clone());
-                    anf.intern_expression(id_gen, body)?;
-                    anf.populate_expression(body);
-
-                    // Remove recursive ID extensions from this.rebindings and
-                    // rebind the id in the enclosing LetRec node.
-                    for id in ids.iter_mut() {
-                        let new_id = this.rebindings.remove(id).unwrap();
-                        *id = new_id;
+                        // Remove recursive ID extensions from this.rebindings and
+                        // rebind the id in the enclosing LetRec node.
+                        for id in ids.iter_mut() {
+                            let new_id = this.rebindings.remove(id).unwrap();
+                            *id = new_id;
+                        }
                     }
                 }
                 MirRelationExpr::Let { id, value, body } => {

--- a/src/transform/src/cse/anf.rs
+++ b/src/transform/src/cse/anf.rs
@@ -233,7 +233,7 @@ impl Bindings {
                                     id: Id::Local(i), ..
                                 } = e
                                 {
-                                    if let Some(next) = remap.get(&i) {
+                                    if let Some(next) = remap.get(i) {
                                         i.clone_from(next);
                                     }
                                 }
@@ -242,7 +242,7 @@ impl Bindings {
                         }
 
                         let (new_ids, new_values): (Vec<_>, Vec<_>) = bindings.into_iter().unzip();
-                        *ids = new_ids.into_iter().map(|n| LocalId::new(n)).collect();
+                        *ids = new_ids.into_iter().map(LocalId::new).collect();
                         *values = new_values;
                         limits.resize(values.len(), limits.get(0).cloned().unwrap_or(None));
                     } else {

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -521,7 +521,11 @@ mod let_motion {
                     body,
                 } => {
                     // push bindings into `bindings` as they should not be further processed.
-                    bindings.extend(ids.drain(..).zip(values.drain(..).zip(limits.drain(..))));
+                    use itertools::Itertools;
+                    bindings.extend(
+                        ids.drain(..)
+                            .zip_eq(values.drain(..).zip_eq(limits.drain(..))),
+                    );
                     *expr = body.take_dangerous();
                     // Stop at `LetRec` nodes as we cannot always lift `Let` nodes out of them.
                 }

--- a/src/transform/tests/test_transforms/anf.spec
+++ b/src/transform/tests/test_transforms/anf.spec
@@ -159,76 +159,66 @@ With
         Get t0
 ----
 Return
-  Get l20
+  Get l21
 With
-  cte l20 =
+  cte l21 =
     Return
       Return
-        Get l19
+        Get l20
       With
-        cte l19 =
+        cte l20 =
           Union
-            Get l16
             Get l17
             Get l18
+            Get l19
+        cte l19 =
+          Filter (#1 > 7)
+            Get l11
         cte l18 =
           Filter (#1 > 7)
-            Get l3
+            Get l15
         cte l17 =
           Filter (#1 > 7)
-            Get l4
+            Get l16
         cte l16 =
-          Filter (#1 > 7)
-            Get l15
-        cte l15 =
           Get t0
     With Mutually Recursive
-      cte l4 =
-        Return
-          Get l14
-        With
-          cte l14 =
-            Distinct project=[#0, #1]
-              Get l13
-          cte l13 =
-            Union
-              Get l10
-              Get l11
-              Get l11
-              Get l12
-              Get l12
-          cte l12 =
-            Filter (#1 > 7)
-              Get l4
-          cte l11 =
-            Filter (#1 > 7)
-              Get l3
-          cte l10 =
-            Filter (#1 > 7)
-              Get l2
-      cte l3 =
-        Return
+      cte l15 =
+        Get l14
+      cte l14 =
+        Distinct project=[#0, #1]
+          Get l13
+      cte l13 =
+        Union
+          Get l6
+          Get l12
+          Get l12
+          Get l8
+          Get l8
+      cte l12 =
+        Filter (#1 > 7)
+          Get l11
+      cte l11 =
+        Get l10
+      cte l10 =
+        Distinct project=[#0, #1]
           Get l9
-        With
-          cte l9 =
-            Distinct project=[#0, #1]
-              Get l8
-          cte l8 =
-            Union
-              Get l5
-              Get l6
-              Get l6
-              Get l7
-              Get l7
-          cte l7 =
-            Filter (#1 > 7)
-              Get l4
-          cte l6 =
-            Filter (#1 > 7)
-              Get l3
-          cte l5 =
-            Filter (#1 > 7)
-              Get l2
+      cte l9 =
+        Union
+          Get l6
+          Get l7
+          Get l7
+          Get l8
+          Get l8
+      cte l8 =
+        Filter (#1 > 7)
+          Get l15
+      cte l7 =
+        Filter (#1 > 7)
+          Get l11
+      cte l6 =
+        Filter (#1 > 7)
+          Get l2
   cte l2 =
     Union
       Get l1
@@ -266,51 +256,47 @@ With Mutually Recursive
       Get l1
 ----
 Return
-  Get l12
+  Get l15
 With
-  cte l12 =
+  cte l15 =
     Return
       Return
-        Get l11
+        Get l14
       With
-        cte l11 =
+        cte l14 =
           Project (#1)
-            Get l10
-        cte l10 =
+            Get l13
+        cte l13 =
           Filter (#1 > 7)
-            Get l9
-        cte l9 =
+            Get l12
+        cte l12 =
           Map ((#0 + #0))
-            Get l0
+            Get l6
     With Mutually Recursive
-      cte l1 =
-        Return
+      cte l11 =
+        Get l10
+      cte l10 =
+        Union
+          Get l6
+          Get l9
+          Get l9
+      cte l9 =
+        Project (#1)
           Get l8
-        With
-          cte l8 =
-            Union
-              Get l0
-              Get l7
-              Get l7
-          cte l7 =
-            Project (#1)
-              Get l6
-          cte l6 =
-            Filter (#1 > 7)
-              Get l5
-          cte l5 =
-            Map ((#0 + #0))
-              Get l0
-      cte l0 =
-        Return
+      cte l8 =
+        Filter (#1 > 7)
+          Get l7
+      cte l7 =
+        Map ((#0 + #0))
+          Get l6
+      cte l6 =
+        Get l5
+      cte l5 =
+        Union
           Get l4
-        With
-          cte l4 =
-            Union
-              Get l3
-              Get l1
-          cte l3 =
-            Project (#0)
-              Get l2
-          cte l2 =
-            Get t0
+          Get l11
+      cte l4 =
+        Project (#0)
+          Get l3
+      cte l3 =
+        Get t0

--- a/src/transform/tests/test_transforms/anf.spec
+++ b/src/transform/tests/test_transforms/anf.spec
@@ -107,10 +107,6 @@ With
 
 
 # Recursive queries.
-# Here:
-# (1) l5 and l10 are equivalent.
-# (2) l7 is equivalent to l12.
-# (3) l6 is not equivalent (although structurally equal) to l11.
 apply pipeline=anf
 Return
   Get l3

--- a/src/transform/tests/test_transforms/relation_cse.spec
+++ b/src/transform/tests/test_transforms/relation_cse.spec
@@ -96,44 +96,40 @@ Return
     Filter (#1 > 7)
       Get t0
     Filter (#1 > 7)
-      Get l7
+      Get l6
     Filter (#1 > 7)
       Get l4
 With Mutually Recursive
-  cte l7 =
+  cte l6 =
     Distinct project=[#0, #1]
       Union
-        Filter (#1 > 7)
-          Get l1
+        Get l1
         Get l5
         Get l5
-        Get l6
-        Get l6
-  cte l6 =
-    Filter (#1 > 7)
-      Get l7
+        Get l3
+        Get l3
   cte l5 =
     Filter (#1 > 7)
       Get l4
   cte l4 =
     Distinct project=[#0, #1]
       Union
-        Filter (#1 > 7)
-          Get l1
+        Get l1
         Get l2
         Get l2
         Get l3
         Get l3
   cte l3 =
     Filter (#1 > 7)
-      Get l7
+      Get l6
   cte l2 =
     Filter (#1 > 7)
       Get l4
   cte l1 =
-    Union
-      Get l0
-      Get l0
+    Filter (#1 > 7)
+      Union
+        Get l0
+        Get l0
   cte l0 =
     Project (#0, #1)
       Get t0

--- a/src/transform/tests/test_transforms/relation_cse.spec
+++ b/src/transform/tests/test_transforms/relation_cse.spec
@@ -42,10 +42,6 @@ With
 
 
 # Recursive queries.
-# Here:
-# (1) a Filter (#1 > 7) over l1 appears twice.
-# (2) l3 is equivalent to l6.
-# (3) l2 is not equivalent (although structurally equal) to l5.
 apply pipeline=relation_cse
 Return
   Return

--- a/test/sqllogictest/advent-of-code/2023/aoc_1203.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1203.slt
@@ -233,26 +233,26 @@ Explained Query:
       CrossJoin type=differential
         ArrangeBy keys=[[]]
           Union
-            Get l13
+            Get l15
             Map (null)
               Union
                 Negate
                   Project ()
-                    Get l13
+                    Get l15
                 Constant
                   - ()
         ArrangeBy keys=[[]]
           Union
-            Get l17
+            Get l19
             Map (null)
               Union
                 Negate
                   Project ()
-                    Get l17
+                    Get l19
                 Constant
                   - ()
     With
-      cte l17 =
+      cte l19 =
         Reduce aggregates=[sum(#0)]
           Project (#2)
             Distinct project=[#0, #1, (#2 * #3)]
@@ -262,13 +262,13 @@ Explained Query:
                     ArrangeBy keys=[[#0, #1]]
                       Reduce group_by=[#0, #1] aggregates=[count(*)]
                         Project (#0, #1)
-                          Get l15
-                    Get l16
-                    Get l16
-      cte l16 =
+                          Get l17
+                    Get l18
+                    Get l18
+      cte l18 =
         ArrangeBy keys=[[#0, #1]]
-          Get l15
-      cte l15 =
+          Get l17
+      cte l17 =
         Distinct project=[#0, #1, #4, #2, #3]
           Project (#0, #1, #3, #4, #6)
             Filter (#7 = (#1 + #2))
@@ -278,27 +278,27 @@ Explained Query:
                     ArrangeBy keys=[[]]
                       Project (#0, #1)
                         Filter (#2 = "*")
-                          Get l4
-                    Get l14
-                    Get l14
+                          Get l6
+                    Get l16
+                    Get l16
                     ArrangeBy keys=[[#0]]
-                      Get l12
-      cte l14 =
+                      Get l14
+      cte l16 =
         ArrangeBy keys=[[]]
           Constant
             - (0)
             - (-1)
             - (1)
-      cte l13 =
+      cte l15 =
         Reduce aggregates=[sum(#0)]
           Project (#3)
-            Get l12
-      cte l12 =
+            Get l14
+      cte l14 =
         Project (#1..=#3, #7)
           Map (text_to_integer(#0))
             Join on=(#1 = #4 AND #2 = #5 AND #3 = #6) type=differential
               ArrangeBy keys=[[#1..=#3]]
-                Get l10
+                Get l12
               ArrangeBy keys=[[#0..=#2]]
                 Union
                   Negate
@@ -308,19 +308,19 @@ Explained Query:
                           Map (((#0 = #3) AND (#4 = (#1 + #2))))
                             CrossJoin type=differential
                               ArrangeBy keys=[[]]
-                                Get l11
+                                Get l13
                               ArrangeBy keys=[[]]
-                                Get l9
-                  Get l11
-      cte l11 =
+                                Get l11
+                  Get l13
+      cte l13 =
         Distinct project=[#0..=#2]
           Project (#1..=#3)
-            Get l10
-      cte l10 =
+            Get l12
+      cte l12 =
         Project (#0..=#3)
           Join on=(#1 = #4 AND #2 = #5) type=differential
             ArrangeBy keys=[[#1, #2]]
-              Get l7
+              Get l9
             ArrangeBy keys=[[#0, #1]]
               Union
                 Negate
@@ -328,19 +328,19 @@ Explained Query:
                     Project (#0, #1)
                       Join on=(#0 = #2 AND #3 = (#1 - 1)) type=differential
                         ArrangeBy keys=[[#0, (#1 - 1)]]
-                          Get l8
+                          Get l10
                         ArrangeBy keys=[[#0, #1]]
-                          Get l9
-                Get l8
-      cte l9 =
+                          Get l11
+                Get l10
+      cte l11 =
         Project (#0, #1)
-          Get l2
-      cte l8 =
+          Get l5
+      cte l10 =
         Distinct project=[#0, #1]
           Project (#1, #2)
-            Get l7
+            Get l9
   With Mutually Recursive
-    cte l7 =
+    cte l9 =
       Distinct project=[#0..=#3]
         Union
           Distinct project=[#0..=#3]
@@ -349,65 +349,62 @@ Explained Query:
                 Map (1)
                   Join on=(#0 = (#3 + #5) AND #1 = (#4 + #6)) type=delta
                     ArrangeBy keys=[[]]
-                      Get l2
+                      Get l5
                     ArrangeBy keys=[[]]
                       Project (#0, #1)
-                        Get l4
-                    Get l5
-                    Get l5
+                        Get l6
+                    Get l7
+                    Get l7
               Project (#7, #0, #1, #8)
                 Map ((#2 || #3), (#6 + 1))
                   Join on=(#0 = #4 AND #1 = (#5 - 1)) type=differential
-                    Get l6
+                    Get l8
                     ArrangeBy keys=[[#1, (#2 - 1)]]
-                      Get l7
+                      Get l9
           Project (#7, #0, #5, #8)
             Map ((#3 || #2), (#6 + 1))
               Join on=(#0 = #4 AND #1 = (#5 + #6)) type=differential
-                Get l6
+                Get l8
                 ArrangeBy keys=[[#1, (#2 + #3)]]
                   Filter (#3) IS NOT NULL
-                    Get l7
-    cte l6 =
+                    Get l9
+    cte l8 =
       ArrangeBy keys=[[#0, #1]]
-        Get l2
-    cte l5 =
+        Get l5
+    cte l7 =
       ArrangeBy keys=[[]]
         Constant
           - (0)
           - (-1)
           - (1)
-    cte l4 =
+    cte l6 =
       Project (#0..=#2)
         Join on=(#2 = #3) type=differential
-          ArrangeBy keys=[[#2]]
-            Get l1
+          Get l4
           ArrangeBy keys=[[#0]]
             Union
               Negate
-                Distinct project=[#0]
-                  Project (#0)
-                    Filter (#0 = #1)
-                      FlatMap wrap1("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
-                        Get l3
-              Get l3
+                Get l3
+              Get l2
+    cte l5 =
+      Project (#0..=#2)
+        Join on=(#2 = #3) type=differential
+          Get l4
+          ArrangeBy keys=[[#0]]
+            Get l3
+    cte l4 =
+      ArrangeBy keys=[[#2]]
+        Get l1
     cte l3 =
+      Distinct project=[#0]
+        Project (#0)
+          Filter (#0 = #1)
+            FlatMap wrap1("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
+              Get l2
+    cte l2 =
       Distinct project=[#0]
         Project (#2)
           Get l1
-    cte l2 =
-      Project (#0..=#2)
-        Join on=(#2 = #3) type=differential
-          ArrangeBy keys=[[#2]]
-            Get l1
-          ArrangeBy keys=[[#0]]
-            Distinct project=[#0]
-              Project (#0)
-                Filter (#0 = #1)
-                  FlatMap wrap1("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
-                    Distinct project=[#0]
-                      Project (#2)
-                        Get l1
     cte l1 =
       Project (#0, #2, #3)
         Filter (#3 != ".")

--- a/test/sqllogictest/advent-of-code/2023/aoc_1204.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1204.slt
@@ -283,21 +283,21 @@ Explained Query:
   Return
     Return
       Union
-        Get l6
+        Get l7
         Map (null)
           Union
             Negate
               Project ()
-                Get l6
+                Get l7
             Constant
               - ()
     With
-      cte l6 =
+      cte l7 =
         Reduce aggregates=[sum(#0)]
           Project (#1)
-            Get l5
+            Get l6
   With Mutually Recursive
-    cte l5 =
+    cte l6 =
       Project (#0, #2)
         Map (bigint_to_integer(#1))
           Reduce group_by=[#0] aggregates=[sum(coalesce(#1, 1))]
@@ -306,20 +306,20 @@ Explained Query:
                 Union
                   Negate
                     Project (#0)
-                      Get l4
+                      Get l5
                   Project (#1)
-                    Get l3
-              Get l4
-    cte l4 =
+                    Get l4
+              Get l5
+    cte l5 =
       Project (#1, #3)
         Join on=(#0 = #2) type=differential
           ArrangeBy keys=[[#0]]
             Filter (#0) IS NOT NULL
-              Get l3
+              Get l4
           ArrangeBy keys=[[#0]]
             Filter (#0) IS NOT NULL
-              Get l5
-    cte l3 =
+              Get l6
+    cte l4 =
       Distinct project=[#0, #1]
         Union
           Project (#0, #2)
@@ -333,24 +333,20 @@ Explained Query:
                           Negate
                             Project (#0)
                               Join on=(#0 = #2 AND #1 = #3) type=differential
-                                ArrangeBy keys=[[#0, #1]]
-                                  Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-                                    Get l1
+                                Get l2
                                 ArrangeBy keys=[[#0, #1]]
                                   Distinct project=[#0, #1]
-                                    Get l2
+                                    Get l3
                           Project (#0)
                             Get l1
-                      Get l2
+                      Get l3
           Project (#2, #0)
             Map (0)
               Get l1
-    cte l2 =
+    cte l3 =
       Project (#0, #1)
         Join on=(#0 = #2 AND #1 = #3) type=differential
-          ArrangeBy keys=[[#0, #1]]
-            Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-              Get l1
+          Get l2
           ArrangeBy keys=[[#0, #1]]
             Project (#0, #3)
               Filter (#2) IS NOT NULL
@@ -358,6 +354,10 @@ Explained Query:
                   FlatMap unnest_array(regexp_split_to_array["\s+", case_insensitive=false](btrim(array_index(#1, 1))))
                     Filter (#0) IS NOT NULL
                       Get l0
+    cte l2 =
+      ArrangeBy keys=[[#0, #1]]
+        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+          Get l1
     cte l1 =
       Project (#0, #3)
         Map (text_to_integer(#2))
@@ -513,47 +513,47 @@ Explained Query:
           Project (#1)
             Map (double_to_numeric(#0))
               Union
-                Get l8
+                Get l9
                 Map (null)
                   Union
                     Negate
                       Project ()
-                        Get l8
+                        Get l9
                     Constant
                       - ()
         ArrangeBy keys=[[]]
           Union
-            Get l10
+            Get l11
             Map (0)
               Union
                 Negate
                   Project ()
-                    Get l10
+                    Get l11
                 Constant
                   - ()
     With
-      cte l10 =
+      cte l11 =
         Reduce aggregates=[count(*)]
           Project ()
-            Get l9
+            Get l10
   With Mutually Recursive
-    cte l9 =
+    cte l10 =
       Union
-        Get l7
+        Get l8
         Project (#2, #3)
           Filter (integer_to_bigint(#2) = (integer_to_bigint(#0) + #4))
             FlatMap generate_series(1, #1, 1)
               CrossJoin type=differential
                 ArrangeBy keys=[[]]
-                  Get l9
+                  Get l10
                 ArrangeBy keys=[[]]
-                  Get l7
-    cte l8 =
+                  Get l8
+    cte l9 =
       Reduce aggregates=[sum(power(2, bigint_to_double((#0 - 1))))]
         Project (#1)
           Filter (#1 > 0)
-            Get l7
-    cte l7 =
+            Get l8
+    cte l8 =
       Project (#0, #8)
         Join on=(#0 = #3 AND #1 = #4 = #6 AND #2 = #5 = #7) type=delta
           ArrangeBy keys=[[#0..=#2], [#1, #2]]
@@ -562,7 +562,7 @@ Explained Query:
             Get l1
           ArrangeBy keys=[[#0, #1]]
             Union
-              Get l6
+              Get l7
               Project (#0, #1, #4)
                 Map (null)
                   Join on=(#0 = #2 AND #1 = #3) type=differential
@@ -571,20 +571,19 @@ Explained Query:
                         Negate
                           Distinct project=[#0, #1]
                             Project (#0, #1)
-                              Get l6
+                              Get l7
                         Get l2
-                    ArrangeBy keys=[[#0, #1]]
-                      Get l2
-    cte l6 =
+                    Get l5
+    cte l7 =
       Union
-        Get l5
+        Get l6
         Map (error("more than one record produced in subquery"))
           Project (#0, #1)
             Filter (#2 > 1)
               Reduce group_by=[#0, #1] aggregates=[count(*)]
                 Project (#0, #1)
-                  Get l5
-    cte l5 =
+                  Get l6
+    cte l6 =
       Union
         Get l4
         Project (#0, #1, #4)
@@ -596,8 +595,10 @@ Explained Query:
                     Project (#0, #1)
                       Get l4
                   Get l2
-              ArrangeBy keys=[[#0, #1]]
-                Get l2
+              Get l5
+    cte l5 =
+      ArrangeBy keys=[[#0, #1]]
+        Get l2
     cte l4 =
       Reduce group_by=[#0, #1] aggregates=[count(*)]
         Project (#0, #1)

--- a/test/sqllogictest/advent-of-code/2023/aoc_1205.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1205.slt
@@ -1150,73 +1150,70 @@ Explained Query:
       CrossJoin type=differential
         ArrangeBy keys=[[]]
           Union
-            Get l5
+            Get l8
             Map (null)
               Union
                 Negate
                   Project ()
-                    Get l5
+                    Get l8
                 Constant
                   - ()
         ArrangeBy keys=[[]]
           Union
-            Get l17
+            Get l20
             Map (null)
               Union
                 Negate
                   Project ()
-                    Get l17
+                    Get l20
                 Constant
                   - ()
     With
-      cte l17 =
+      cte l20 =
         Reduce aggregates=[min(#0)]
           Project (#1)
             Filter (#0 = "location")
-              Get l6
+              Get l9
   With Mutually Recursive
-    cte l16 =
+    cte l19 =
       Distinct project=[#0..=#2]
         Union
           Project (#1, #7, #23)
             Join on=(#0 = #9 = #18 AND #1 = #10 = #19 AND #2 = #11 = #20 AND #3 = #12 = #21 AND #4 = #13 AND #5 = #14 AND #6 = #15 AND #7 = #16 = #22 AND #8 = #17) type=delta
               ArrangeBy keys=[[#0..=#8], [#0..=#3, #7]]
-                Get l8
+                Get l11
               ArrangeBy keys=[[#0..=#8]]
-                Get l9
+                Get l12
               ArrangeBy keys=[[#0..=#4]]
                 Union
                   Filter (#4 < #5)
-                    Get l12
+                    Get l15
                   Map (error("more than one record produced in subquery"))
                     Project (#0..=#4)
                       Filter error("more than one record produced in subquery") AND (#5 > 1)
                         Reduce group_by=[#0..=#4] aggregates=[count(*)]
                           Project (#0..=#4)
-                            Get l12
+                            Get l15
           Distinct project=[#1, #0, #2]
             Project (#1, #3, #12)
               Join on=(#0 = #4 = #8 AND #1 = #5 = #10 AND #2 = #6 = #11 AND #3 = #7 = #9) type=delta
-                Get l15
-                Get l15
+                Get l17
+                Get l17
                 ArrangeBy keys=[[#0..=#3]]
                   Union
                     Filter (#2 < #4)
-                      Get l14
+                      Get l18
                     Map (error("more than one record produced in subquery"))
                       Project (#0..=#3)
                         Filter error("more than one record produced in subquery") AND (#4 > 1)
                           Reduce group_by=[#0..=#3] aggregates=[count(*)]
                             Project (#0..=#3)
-                              Get l14
-    cte l15 =
-      ArrangeBy keys=[[#0..=#3]]
-        Get l7
-    cte l14 =
+                              Get l18
+    cte l18 =
       Project (#0..=#3, #5)
         Map (coalesce(#4, #3))
           Union
-            Get l13
+            Get l16
             Project (#0..=#3, #8)
               Map (null)
                 Join on=(#0 = #4 AND #1 = #7 AND #2 = #5 AND #3 = #6) type=differential
@@ -1224,27 +1221,29 @@ Explained Query:
                     Union
                       Negate
                         Project (#0..=#3)
-                          Get l13
+                          Get l16
                       Project (#0, #3, #1, #2)
-                        Get l7
-                  ArrangeBy keys=[[#0..=#3]]
-                    Get l7
-    cte l13 =
+                        Get l10
+                  Get l17
+    cte l17 =
+      ArrangeBy keys=[[#0..=#3]]
+        Get l10
+    cte l16 =
       Reduce group_by=[#0, #3, #1, #2] aggregates=[min(#4)]
         Project (#0..=#3, #8)
           Join on=(#0 = #4 AND #1 = #6 AND #2 = #7 AND #3 = #5) type=differential
             ArrangeBy keys=[[#0..=#3]]
               Filter (#1) IS NOT NULL AND (#2) IS NOT NULL
-                Get l7
+                Get l10
             ArrangeBy keys=[[#0, #2, #3, #1]]
               Project (#0..=#3, #6)
                 Filter (#6 < #3) AND (#6 >= #2)
-                  Get l8
-    cte l12 =
+                  Get l11
+    cte l15 =
       Project (#0..=#4, #6)
         Map (coalesce(#5, #3))
           Union
-            Get l11
+            Get l14
             Project (#0..=#4, #10)
               Map (null)
                 Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8 AND #4 = #9) type=differential
@@ -1252,88 +1251,82 @@ Explained Query:
                     Union
                       Negate
                         Project (#0..=#4)
-                          Get l11
-                      Get l10
+                          Get l14
+                      Get l13
                   ArrangeBy keys=[[#0..=#4]]
-                    Get l10
-    cte l11 =
+                    Get l13
+    cte l14 =
       Reduce group_by=[#0..=#4] aggregates=[min(#5)]
         Project (#0..=#4, #9)
           Filter (#9 >= #4)
             Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8) type=differential
               ArrangeBy keys=[[#0..=#3]]
                 Filter (#2) IS NOT NULL AND (#3) IS NOT NULL
-                  Get l10
+                  Get l13
               ArrangeBy keys=[[#0..=#3]]
                 Project (#0..=#3, #6)
                   Filter (#2) IS NOT NULL AND (#6 < #3)
-                    Get l8
-    cte l10 =
+                    Get l11
+    cte l13 =
       Distinct project=[#0..=#4]
         Project (#0..=#3, #7)
-          Get l9
-    cte l9 =
+          Get l12
+    cte l12 =
       Distinct project=[#0..=#8]
-        Get l8
-    cte l8 =
+        Get l11
+    cte l11 =
       Project (#0, #3, #1, #2, #6, #10, #9, #11, #7)
         Filter (#9 < #11)
           Map (greatest(#1, #6), (#6 + #8), least(#2, #10))
             Join on=(#0 = #4 AND #3 = #5) type=differential
               ArrangeBy keys=[[#0, #3]]
-                Get l7
-              ArrangeBy keys=[[#0, #1]]
-                Get l1
-    cte l7 =
+                Get l10
+              Get l2
+    cte l10 =
       Project (#0..=#2, #4)
         Join on=(#0 = #3) type=differential
           ArrangeBy keys=[[#0]]
-            Get l6
-          ArrangeBy keys=[[#0]]
-            Distinct project=[#0, #1]
-              Project (#0, #1)
-                Get l1
-    cte l6 =
+            Get l9
+          Get l6
+    cte l9 =
       Distinct project=[#0..=#2]
         Union
           Project (#6, #4, #5)
             Map (regexp_split_to_array[" ", case_insensitive=false](btrim(#0)), (2 * #1), text_to_bigint(array_index(#2, integer_to_bigint((#3 - 1)))), (#4 + text_to_bigint(array_index(#2, integer_to_bigint(#3)))), "seed")
               FlatMap generate_series(1, ((regexp_split_to_array[" ", case_insensitive=false](btrim(#0)) array_length 1) / 2), 1)
-                Project (#1)
-                  Filter (#0 = "seeds")
-                    Get l0
+                Get l4
           Project (#1, #10, #11)
             Map ((#8 - #4), (#6 + #9), (#7 + #9))
-              Get l8
-          Get l16
-    cte l5 =
+              Get l11
+          Get l19
+    cte l8 =
       Reduce aggregates=[min(#0)]
         Project (#1)
           Filter (#0 = "location")
-            Get l3
-    cte l4 =
+            Get l5
+    cte l7 =
       Project (#0, #3, #1)
         Join on=(#0 = #2) type=differential
           ArrangeBy keys=[[#0]]
             Distinct project=[#0, #1]
-              Get l3
-          ArrangeBy keys=[[#0]]
-            Distinct project=[#0, #1]
-              Project (#0, #1)
-                Get l1
-    cte l3 =
+              Get l5
+          Get l6
+    cte l6 =
+      ArrangeBy keys=[[#0]]
+        Distinct project=[#0, #1]
+          Project (#0, #1)
+            Get l1
+    cte l5 =
       Union
         Project (#3, #2)
           Map (text_to_bigint(#1), "seed")
             FlatMap unnest_array(regexp_split_to_array[" ", case_insensitive=false](btrim(#0)))
-              Project (#1)
-                Filter (#0 = "seeds")
-                  Get l0
+              Get l4
         Project (#0, #4)
           Map (coalesce((#1 + (#3 - #2)), #1))
             Union
               Project (#1..=#4)
-                Get l2
+                Get l3
               Project (#1, #2, #6, #7)
                 Map (null, null)
                   Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential
@@ -1342,18 +1335,24 @@ Explained Query:
                         Negate
                           Distinct project=[#0..=#2]
                             Project (#0..=#2)
-                              Get l2
-                        Get l4
+                              Get l3
+                        Get l7
                     ArrangeBy keys=[[#0..=#2]]
-                      Get l4
-    cte l2 =
+                      Get l7
+    cte l4 =
+      Project (#1)
+        Filter (#0 = "seeds")
+          Get l0
+    cte l3 =
       Project (#0..=#2, #5, #6)
         Filter (#2 >= #5) AND (#2 <= ((#5 + #7) - 1))
           Join on=(#0 = #3 AND #1 = #4) type=differential
             ArrangeBy keys=[[#0, #1]]
-              Get l4
-            ArrangeBy keys=[[#0, #1]]
-              Get l1
+              Get l7
+            Get l2
+    cte l2 =
+      ArrangeBy keys=[[#0, #1]]
+        Get l1
     cte l1 =
       Project (#5..=#9)
         Filter (#3 != "")

--- a/test/sqllogictest/advent-of-code/2023/aoc_1209.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1209.slt
@@ -123,7 +123,7 @@ Explained Query:
                               Filter (#2 <= 21) AND (#1) IS NOT NULL AND (#2 > #3) AND (0 != (coalesce(#0, 0) - 0))
                                 Get l3
                             ArrangeBy keys=[[#0, #2, #1]]
-                              Get l1
+                              Get l2
                       Filter (#2 <= 21) AND (#2 > #3) AND (0 != (coalesce(#0, 0) - 0))
                         Get l3
                 Map (null, null, null, null)
@@ -134,33 +134,32 @@ Explained Query:
                           ArrangeBy keys=[[#1, #3, (#2 + 1)]]
                             Project (#0..=#3)
                               Filter (#4 <= 21) AND (#1) IS NOT NULL AND (#4 > #3) AND (0 != (0 - coalesce(#0, 0)))
-                                Get l2
+                                Get l0
                           ArrangeBy keys=[[#0..=#2]]
-                            Get l1
+                            Get l2
                     Project (#0..=#3)
                       Filter (#4 <= 21) AND (#4 > #3) AND (0 != (0 - coalesce(#0, 0)))
-                        Get l2
+                        Get l0
                 Project (#0..=#4, #1, #5, #3)
                   Filter (0 != (coalesce(#4, 0) - coalesce(#0, 0)))
-                    Get l0
+                    Get l1
     cte l2 =
-      Map ((#2 + 1))
-        Get l3
-    cte l1 =
       Distinct project=[#0..=#2]
         Project (#1, #3, #5)
-          Get l0
-    cte l0 =
+          Get l1
+    cte l1 =
       Project (#0..=#4, #6)
         Join on=(#1 = #5 AND #3 = #7 AND #6 = (#2 + 1)) type=differential
           ArrangeBy keys=[[#1, (#2 + 1), #3]]
             Project (#0..=#3)
               Filter (#4 <= 21) AND (#1) IS NOT NULL AND (#4 > #3)
-                Map ((#2 + 1))
-                  Get l3
+                Get l0
           ArrangeBy keys=[[#1..=#3]]
             Filter (#2 <= 21) AND (#1) IS NOT NULL AND (#2 > #3)
               Get l3
+    cte l0 =
+      Map ((#2 + 1))
+        Get l3
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1210.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1210.slt
@@ -377,26 +377,26 @@ Explained Query:
           Project (#1)
             Map ((#0 / 2))
               Union
-                Get l5
+                Get l7
                 Map (0)
                   Union
                     Negate
                       Project ()
-                        Get l5
+                        Get l7
                     Constant
                       - ()
         ArrangeBy keys=[[]]
           Union
-            Get l15
+            Get l19
             Map (0)
               Union
                 Negate
                   Project ()
-                    Get l15
+                    Get l19
                 Constant
                   - ()
     With
-      cte l15 =
+      cte l19 =
         Reduce aggregates=[count(*)]
           Project ()
             Union
@@ -404,18 +404,18 @@ Explained Query:
                 Project (#0, #1)
                   Join on=(#0 = #2 AND #1 = #3) type=differential
                     ArrangeBy keys=[[#0, #1]]
-                      Get l14
+                      Get l18
                     ArrangeBy keys=[[#0, #1]]
                       Distinct project=[#0, #1]
                         Project (#0, #1)
-                          Get l6
-              Get l14
-      cte l14 =
+                          Get l8
+              Get l18
+      cte l18 =
         Project (#0, #1)
           Filter (#2 = true)
-            Get l13
+            Get l17
   With Mutually Recursive
-    cte l13 =
+    cte l17 =
       Distinct project=[#0..=#2]
         Union
           Project (#0, #1, #3)
@@ -426,10 +426,10 @@ Explained Query:
             Map (case when #5 then NOT(#0) else #0 end)
               Join on=(#1 = #4) type=differential
                 ArrangeBy keys=[[#1]]
-                  Get l8
+                  Get l11
                 ArrangeBy keys=[[#0]]
                   Union
-                    Get l12
+                    Get l16
                     Project (#0, #2)
                       Map (null)
                         Join on=(#0 = #1) type=differential
@@ -438,22 +438,21 @@ Explained Query:
                               Negate
                                 Distinct project=[#0]
                                   Project (#0)
-                                    Get l12
-                              Get l9
-                          ArrangeBy keys=[[#0]]
-                            Get l9
-    cte l12 =
+                                    Get l16
+                              Get l12
+                          Get l14
+    cte l16 =
       Union
-        Get l11
+        Get l15
         Map (error("more than one record produced in subquery"))
           Project (#0)
             Filter (#1 > 1)
               Reduce group_by=[#0] aggregates=[count(*)]
                 Project (#0)
-                  Get l11
-    cte l11 =
+                  Get l15
+    cte l15 =
       Union
-        Get l10
+        Get l13
         Project (#0, #2)
           Map (false)
             Join on=(#0 = #1) type=differential
@@ -461,19 +460,21 @@ Explained Query:
                 Union
                   Negate
                     Project (#0)
-                      Get l10
-                  Get l9
-              ArrangeBy keys=[[#0]]
-                Get l9
-    cte l10 =
+                      Get l13
+                  Get l12
+              Get l14
+    cte l14 =
+      ArrangeBy keys=[[#0]]
+        Get l12
+    cte l13 =
       Reduce group_by=[#0] aggregates=[any((#0 = #1))]
         FlatMap wrap1("J", "-", "|", "F")
-          Get l9
-    cte l9 =
+          Get l12
+    cte l12 =
       Distinct project=[#0]
         Project (#1)
-          Get l8
-    cte l8 =
+          Get l11
+    cte l11 =
       Project (#2, #3, #6, #7)
         Map ((#0 + 1), (#1 + 1))
           Join on=(#0 = #4 AND #1 = #5) type=differential
@@ -484,32 +485,33 @@ Explained Query:
                     Negate
                       Project (#0..=#2)
                         Join on=(#0 = #3 AND #1 = #4) type=differential
-                          ArrangeBy keys=[[#0, #1]]
-                            Get l13
+                          Get l9
                           ArrangeBy keys=[[#0, #1]]
                             Distinct project=[#0, #1]
                               Project (#0, #1)
-                                Get l7
-                    Get l13
-                Get l7
+                                Get l10
+                    Get l17
+                Get l10
             ArrangeBy keys=[[#0, #1]]
               Project (#0, #1)
                 Get l0
-    cte l7 =
+    cte l10 =
       Project (#0..=#2, #5)
         Join on=(#0 = #3 AND #1 = #4) type=differential
+          Get l9
           ArrangeBy keys=[[#0, #1]]
-            Get l13
-          ArrangeBy keys=[[#0, #1]]
-            Get l6
-    cte l6 =
+            Get l8
+    cte l9 =
+      ArrangeBy keys=[[#0, #1]]
+        Get l17
+    cte l8 =
       Distinct project=[#0..=#2]
         Union
           Project (#0, #1, #4)
             Join on=(#0 = #2 AND #1 = #3) type=differential
               ArrangeBy keys=[[#0, #1]]
                 Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-                  Get l4
+                  Get l6
               ArrangeBy keys=[[#0, #1]]
                 Filter (#2 != "S")
                   Get l0
@@ -517,31 +519,32 @@ Explained Query:
             Map (case when ((#0 = #0) AND (#0 = (#6 + 1)) AND (#1 = #7) AND (#1 = (#1 + 1))) then "J" else case when ((#0 = #0) AND (#0 = #6) AND (#1 = (#1 + 1)) AND (#1 = (#7 - 1))) then "-" else case when ((#0 = #0) AND (#0 = (#6 - 1)) AND (#1 = #7) AND (#1 = (#1 + 1))) then "7" else case when ((#0 = #6) AND (#0 = (#0 + 1)) AND (#1 = #1) AND (#1 = (#7 - 1))) then "L" else case when ((#0 = (#0 + 1)) AND (#0 = (#6 - 1)) AND (#1 = #1) AND (#1 = #7)) then "|" else case when ((#0 = #0) AND (#0 = #6) AND (#1 = (#1 - 1)) AND (#1 = (#7 - 1))) then "F" else "???" end end end end end end)
               Join on=(#0 = #2 = #4 AND #1 = #3 = #5) type=delta
                 ArrangeBy keys=[[#0, #1]]
-                  Project (#0, #1)
-                    Filter (#2 = "S")
-                      Get l0
+                  Get l4
                 ArrangeBy keys=[[#0, #1]]
                   Project (#0, #1)
                     Get l3
-                ArrangeBy keys=[[#0, #1]]
-                  Get l3
-    cte l5 =
+                Get l5
+    cte l7 =
       Reduce aggregates=[count(*)]
         Project ()
-          Get l4
-    cte l4 =
+          Get l6
+    cte l6 =
       Distinct project=[#0, #1]
         Union
-          Project (#0, #1)
-            Filter (#2 = "S")
-              Get l0
+          Get l4
           Project (#4, #5)
             Join on=(#0 = #2 AND #1 = #3) type=differential
               ArrangeBy keys=[[#0, #1]]
                 Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-                  Get l4
-              ArrangeBy keys=[[#0, #1]]
-                Get l3
+                  Get l6
+              Get l5
+    cte l5 =
+      ArrangeBy keys=[[#0, #1]]
+        Get l3
+    cte l4 =
+      Project (#0, #1)
+        Filter (#2 = "S")
+          Get l0
     cte l3 =
       Project (#0..=#3)
         Filter (#4 = 2)

--- a/test/sqllogictest/advent-of-code/2023/aoc_1212.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1212.slt
@@ -94,23 +94,23 @@ Explained Query:
   Return
     Return
       Union
-        Get l5
+        Get l6
         Map (null)
           Union
             Negate
               Project ()
-                Get l5
+                Get l6
             Constant
               - ()
     With
-      cte l5 =
+      cte l6 =
         Reduce aggregates=[sum(#0)]
           Project (#3)
             TopK group_by=[#0] order_by=[#1 desc nulls_first, #2 desc nulls_first] limit=1
               Reduce group_by=[#0..=#2] aggregates=[count(*)]
-                Get l4
+                Get l5
   With Mutually Recursive
-    cte l4 =
+    cte l5 =
       Union
         Project (#0, #3, #4)
           Map (0, 0)
@@ -119,16 +119,13 @@ Explained Query:
           Map ((#1 + 1))
             Join on=(#0 = #3 AND #4 = (#1 + 1)) type=differential
               ArrangeBy keys=[[#0, (#1 + 1)]]
-                Get l4
-              ArrangeBy keys=[[#0, #1]]
-                Project (#0, #1)
-                  Filter (#2 != "#")
-                    Get l1
+                Get l5
+              Get l2
         Project (#0, #7, #8)
           Map (((#1 + #3) + 1), (#2 + 1))
             Join on=(#0 = #4 AND #1 = #5 AND #3 = #6) type=differential
               ArrangeBy keys=[[#0, #1, #3]]
-                Get l2
+                Get l3
               ArrangeBy keys=[[#0..=#2]]
                 Union
                   Negate
@@ -137,32 +134,34 @@ Explained Query:
                         Filter (#4 >= (#1 + 1)) AND (#4 <= (#1 + #2))
                           Join on=(#0 = #3) type=differential
                             ArrangeBy keys=[[#0]]
-                              Get l3
+                              Get l4
                             ArrangeBy keys=[[#0]]
                               Project (#0, #1)
                                 Filter (#2 = ".")
                                   Get l1
-                  Get l3
-    cte l3 =
+                  Get l4
+    cte l4 =
       Distinct project=[#0..=#2]
         Project (#0, #1, #3)
-          Get l2
-    cte l2 =
+          Get l3
+    cte l3 =
       Project (#0..=#2, #5)
         Join on=(#0 = #3 = #6 AND #4 = (#2 + 1) AND #7 = ((#1 + #5) + 1)) type=delta
           ArrangeBy keys=[[#0], [#0, (#2 + 1)]]
             Filter (#2) IS NOT NULL
-              Get l4
+              Get l5
           ArrangeBy keys=[[#0, #1]]
             Project (#0, #2, #3)
               Map (text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2))))
                 FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#1) array_length 1), 1)
                   Project (#0, #2)
                     Get l0
-          ArrangeBy keys=[[#0, #1]]
-            Project (#0, #1)
-              Filter (#2 != "#")
-                Get l1
+          Get l2
+    cte l2 =
+      ArrangeBy keys=[[#0, #1]]
+        Project (#0, #1)
+          Filter (#2 != "#")
+            Get l1
     cte l1 =
       Project (#0, #2, #3)
         Map (substr(#1, #2, 1))

--- a/test/sqllogictest/advent-of-code/2023/aoc_1215.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1215.slt
@@ -216,89 +216,89 @@ Explained Query:
           Project (#1)
             Map (numeric_to_bigint(#0))
               Union
-                Get l19
+                Get l21
                 Map (null)
                   Union
                     Negate
                       Project ()
-                        Get l19
+                        Get l21
                     Constant
                       - ()
     With
-      cte l19 =
+      cte l21 =
         Reduce aggregates=[sum((((1 + #0) * #2) * integer_to_bigint(#1)))]
           Project (#0, #1, #5)
             Join on=(#0 = #3 AND #2 = #4) type=differential
               ArrangeBy keys=[[#0, #2]]
-                Get l15
+                Get l17
               ArrangeBy keys=[[#0, #1]]
                 Union
-                  Get l18
+                  Get l20
                   Map (null)
                     Union
                       Negate
                         Project (#0, #1)
-                          Get l18
-                      Get l16
-      cte l18 =
+                          Get l20
+                      Get l18
+      cte l20 =
         Union
-          Get l17
+          Get l19
           Map (0)
             Union
               Negate
                 Project (#0, #1)
-                  Get l17
-              Get l16
-      cte l17 =
+                  Get l19
+              Get l18
+      cte l19 =
         Reduce group_by=[#0, #1] aggregates=[count(*)]
           Project (#0, #1)
             Filter (#1 >= #3)
               Join on=(#0 = #2) type=differential
                 ArrangeBy keys=[[#0]]
                   Filter (#0) IS NOT NULL
-                    Get l16
+                    Get l18
                 ArrangeBy keys=[[#0]]
                   Project (#0, #2)
                     Filter (#0) IS NOT NULL
-                      Get l15
-      cte l16 =
+                      Get l17
+      cte l18 =
         Distinct project=[#0, #1]
           Project (#0, #2)
-            Get l15
-      cte l15 =
+            Get l17
+      cte l17 =
         Project (#1, #3, #4)
           Join on=(#0 = #2) type=differential
             ArrangeBy keys=[[#0]]
               Project (#0, #2)
                 Filter (#1 = "") AND (#0) IS NOT NULL
-                  Get l14
+                  Get l16
             ArrangeBy keys=[[#0]]
               Project (#0..=#2)
                 Filter NOT(#3)
-                  Get l13
+                  Get l15
   With Mutually Recursive
-    cte [recursion_limit=10, return_at_limit] l14 =
+    cte [recursion_limit=10, return_at_limit] l16 =
       Union
         Project (#0, #0, #4)
           Map (0)
-            Get l13
+            Get l15
         Project (#0, #3, #4)
           Filter (char_length(#1) > 0)
             Map (substr(#1, 2), (((#2 + integer_to_bigint(ascii(substr(#1, 1, 1)))) * 17) % 256))
-              Get l14
-    cte l13 =
+              Get l16
+    cte l15 =
       Project (#1..=#4)
         TopK group_by=[#1] order_by=[#0 desc nulls_first, #2 asc nulls_last] limit=1
           Project (#0..=#2, #7, #8)
             Map ((#1) IS NULL)
               Join on=(#0 = #3 AND #1 = #4 = #6 AND #2 = #5) type=delta
                 ArrangeBy keys=[[#0..=#2], [#1]]
-                  Get l7
-                ArrangeBy keys=[[#0..=#2]]
                   Get l8
+                ArrangeBy keys=[[#0..=#2]]
+                  Get l9
                 ArrangeBy keys=[[#0]]
                   Union
-                    Get l12
+                    Get l14
                     Project (#0, #2)
                       Map (null)
                         Join on=(#0 = #1) type=differential
@@ -307,22 +307,21 @@ Explained Query:
                               Negate
                                 Distinct project=[#0]
                                   Project (#0)
-                                    Get l12
-                              Get l9
-                          ArrangeBy keys=[[#0]]
-                            Get l9
-    cte l12 =
+                                    Get l14
+                              Get l10
+                          Get l12
+    cte l14 =
       Union
-        Get l11
+        Get l13
         Map (error("more than one record produced in subquery"))
           Project (#0)
             Filter (#1 > 1)
               Reduce group_by=[#0] aggregates=[count(*)]
                 Project (#0)
-                  Get l11
-    cte l11 =
+                  Get l13
+    cte l13 =
       Union
-        Get l10
+        Get l11
         Project (#0, #2)
           Map (null)
             Join on=(#0 = #1) type=differential
@@ -330,29 +329,31 @@ Explained Query:
                 Union
                   Negate
                     Project (#0)
-                      Get l10
-                  Get l9
-              ArrangeBy keys=[[#0]]
-                Get l9
-    cte l10 =
+                      Get l11
+                  Get l10
+              Get l12
+    cte l12 =
+      ArrangeBy keys=[[#0]]
+        Get l10
+    cte l11 =
       Reduce group_by=[#0] aggregates=[min(#1)]
         Project (#0, #1)
           Join on=(#0 = #2) type=differential
             ArrangeBy keys=[[#0]]
               Filter (#0) IS NOT NULL
-                Get l9
+                Get l10
             ArrangeBy keys=[[#1]]
               Project (#0, #1)
                 Filter (#1) IS NOT NULL
-                  Get l7
-    cte l9 =
+                  Get l8
+    cte l10 =
       Distinct project=[#0]
         Project (#1)
-          Get l8
-    cte l8 =
+          Get l9
+    cte l9 =
       Distinct project=[#0..=#2]
-        Get l7
-    cte l7 =
+        Get l8
+    cte l8 =
       Project (#0..=#2)
         Filter (#0 > coalesce(#4, 0))
           Join on=(#1 = #3) type=differential
@@ -362,7 +363,7 @@ Explained Query:
                   Get l0
             ArrangeBy keys=[[#0]]
               Union
-                Get l6
+                Get l7
                 Project (#0, #2)
                   Map (null)
                     Join on=(#0 = #1) type=differential
@@ -371,20 +372,19 @@ Explained Query:
                           Negate
                             Distinct project=[#0]
                               Project (#0)
-                                Get l6
+                                Get l7
                           Get l3
-                      ArrangeBy keys=[[#0]]
-                        Get l3
-    cte l6 =
+                      Get l5
+    cte l7 =
       Union
-        Get l5
+        Get l6
         Map (error("more than one record produced in subquery"))
           Project (#0)
             Filter (#1 > 1)
               Reduce group_by=[#0] aggregates=[count(*)]
                 Project (#0)
-                  Get l5
-    cte l5 =
+                  Get l6
+    cte l6 =
       Union
         Get l4
         Project (#0, #2)
@@ -396,8 +396,10 @@ Explained Query:
                     Project (#0)
                       Get l4
                   Get l3
-              ArrangeBy keys=[[#0]]
-                Get l3
+              Get l5
+    cte l5 =
+      ArrangeBy keys=[[#0]]
+        Get l3
     cte l4 =
       Reduce group_by=[#0] aggregates=[max(#1)]
         Project (#0, #1)

--- a/test/sqllogictest/advent-of-code/2023/aoc_1216.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1216.slt
@@ -228,26 +228,26 @@ Explained Query:
       CrossJoin type=differential
         ArrangeBy keys=[[]]
           Union
-            Get l2
+            Get l5
             Map (0)
               Union
                 Negate
                   Project ()
-                    Get l2
+                    Get l5
                 Constant
                   - ()
         ArrangeBy keys=[[]]
           Union
-            Get l14
+            Get l16
             Map (null)
               Union
                 Negate
                   Project ()
-                    Get l14
+                    Get l16
                 Constant
                   - ()
     With
-      cte l14 =
+      cte l16 =
         Reduce aggregates=[max(#0)]
           Project (#1)
             Reduce group_by=[#0] aggregates=[count(*)]
@@ -257,47 +257,20 @@ Explained Query:
                     Distinct project=[#0..=#2]
                       Project (#0, #1, #3)
                         Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-                          Get l13
+                          Get l15
                   ArrangeBy keys=[[#0, #1]]
                     Distinct project=[#0, #1]
                       Project (#0, #1)
                         Get l0
   With Mutually Recursive
-    cte l13 =
+    cte l15 =
       Distinct project=[#0..=#3]
         Union
           Project (#0, #1, #3, #2)
             Map (("r" || integer_to_text(#0)), "r")
               CrossJoin type=differential
-                Get l11
                 ArrangeBy keys=[[]]
-                  Union
-                    Get l4
-                    Map (null)
-                      Union
-                        Negate
-                          Project ()
-                            Get l4
-                        Constant
-                          - ()
-          Project (#0, #1, #3, #2)
-            Map (("l" || integer_to_text(#0)), "l")
-              CrossJoin type=differential
-                Get l11
-                ArrangeBy keys=[[]]
-                  Union
-                    Get l6
-                    Map (null)
-                      Union
-                        Negate
-                          Project ()
-                            Get l6
-                        Constant
-                          - ()
-          Project (#1, #0, #3, #2)
-            Map (("d" || integer_to_text(#0)), "d")
-              CrossJoin type=differential
-                Get l12
+                  Get l11
                 ArrangeBy keys=[[]]
                   Union
                     Get l8
@@ -308,61 +281,65 @@ Explained Query:
                             Get l8
                         Constant
                           - ()
+          Project (#0, #2, #4, #3)
+            Map (("l" || integer_to_text(#0)), "l")
+              Get l14
           Project (#1, #0, #3, #2)
-            Map (("u" || integer_to_text(#0)), "u")
+            Map (("d" || integer_to_text(#0)), "d")
               CrossJoin type=differential
-                Get l12
+                ArrangeBy keys=[[]]
+                  Get l6
                 ArrangeBy keys=[[]]
                   Union
-                    Get l10
+                    Get l13
                     Map (null)
                       Union
                         Negate
                           Project ()
-                            Get l10
+                            Get l13
                         Constant
                           - ()
+          Project (#2, #1, #4, #3)
+            Map (("u" || integer_to_text(#1)), "u")
+              Get l14
           Project (#12, #13, #11, #3)
             Map ((#0 + #9), (#1 + #10))
               Join on=(#0 = #4 AND #1 = #5 AND #2 = #7 AND #6 = #8) type=differential
                 ArrangeBy keys=[[#0, #1]]
                   Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-                    Get l13
-                ArrangeBy keys=[[#0, #1]]
-                  Filter (#2) IS NOT NULL
-                    Get l0
-                ArrangeBy keys=[[#0, #1]]
-                  Constant
-                    total_rows (diffs absed): 24
-                    first_rows:
-                      - ("d", "-", 0, -1, "l")
-                      - ("d", "/", 0, -1, "l")
-                      - ("l", "-", 0, -1, "l")
-                      - ("l", ".", 0, -1, "l")
-                      - ("l", "\", -1, 0, "u")
-                      - ("l", "|", -1, 0, "u")
-                      - ("r", "/", -1, 0, "u")
-                      - ("r", "|", -1, 0, "u")
-                      - ("u", "-", 0, -1, "l")
-                      - ("u", ".", -1, 0, "u")
-                      - ("u", "\", 0, -1, "l")
-                      - ("u", "|", -1, 0, "u")
-                      - ("d", "-", 0, 1, "r")
-                      - ("d", ".", 1, 0, "d")
-                      - ("d", "\", 0, 1, "r")
-                      - ("d", "|", 1, 0, "d")
-                      - ("l", "/", 1, 0, "d")
-                      - ("l", "|", 1, 0, "d")
-                      - ("r", "-", 0, 1, "r")
-                      - ("r", ".", 0, 1, "r")
+                    Get l15
+                Get l1
+                Get l2
+    cte l14 =
+      CrossJoin type=differential
+        ArrangeBy keys=[[]]
+          Get l4
+        ArrangeBy keys=[[]]
+          Union
+            Get l10
+            Map (null)
+              Union
+                Negate
+                  Project ()
+                    Get l10
+                Constant
+                  - ()
+    cte l13 =
+      Union
+        Get l12
+        Map (null)
+          Union
+            Negate
+              Project ()
+                Get l12
+            Constant
+              - ()
     cte l12 =
-      ArrangeBy keys=[[]]
-        Project (#1)
-          Get l0
+      Reduce aggregates=[min(#0)]
+        Get l11
     cte l11 =
-      ArrangeBy keys=[[]]
-        Project (#0)
-          Get l0
+      Project (#0)
+        Get l0
     cte l10 =
       Union
         Get l9
@@ -375,8 +352,7 @@ Explained Query:
               - ()
     cte l9 =
       Reduce aggregates=[max(#0)]
-        Project (#1)
-          Get l0
+        Get l6
     cte l8 =
       Union
         Get l7
@@ -389,85 +365,65 @@ Explained Query:
               - ()
     cte l7 =
       Reduce aggregates=[min(#0)]
-        Project (#0)
-          Get l0
+        Get l6
     cte l6 =
-      Union
-        Get l5
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l5
-            Constant
-              - ()
+      Project (#1)
+        Get l0
     cte l5 =
-      Reduce aggregates=[max(#0)]
-        Project (#1)
-          Get l0
-    cte l4 =
-      Union
-        Get l3
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l3
-            Constant
-              - ()
-    cte l3 =
-      Reduce aggregates=[min(#0)]
-        Project (#1)
-          Get l0
-    cte l2 =
       Reduce aggregates=[count(*)]
         Project ()
           Join on=(#0 = #2 AND #1 = #3) type=differential
             ArrangeBy keys=[[#0, #1]]
               Distinct project=[#0, #1]
                 Project (#0, #1)
-                  Get l1
+                  Get l3
             ArrangeBy keys=[[#0, #1]]
               Distinct project=[#0, #1]
-                Project (#0, #1)
-                  Get l0
-    cte l1 =
+                Get l4
+    cte l4 =
+      Project (#0, #1)
+        Get l0
+    cte l3 =
       Distinct project=[#0..=#2]
         Union
           Project (#11, #12, #10)
             Map ((#0 + #8), (#1 + #9))
               Join on=(#0 = #3 AND #1 = #4 AND #2 = #6 AND #5 = #7) type=differential
                 ArrangeBy keys=[[#0, #1]]
-                  Get l1
-                ArrangeBy keys=[[#0, #1]]
-                  Filter (#2) IS NOT NULL
-                    Get l0
-                ArrangeBy keys=[[#0, #1]]
-                  Constant
-                    total_rows (diffs absed): 24
-                    first_rows:
-                      - ("d", "-", 0, -1, "l")
-                      - ("d", "/", 0, -1, "l")
-                      - ("l", "-", 0, -1, "l")
-                      - ("l", ".", 0, -1, "l")
-                      - ("l", "\", -1, 0, "u")
-                      - ("l", "|", -1, 0, "u")
-                      - ("r", "/", -1, 0, "u")
-                      - ("r", "|", -1, 0, "u")
-                      - ("u", "-", 0, -1, "l")
-                      - ("u", ".", -1, 0, "u")
-                      - ("u", "\", 0, -1, "l")
-                      - ("u", "|", -1, 0, "u")
-                      - ("d", "-", 0, 1, "r")
-                      - ("d", ".", 1, 0, "d")
-                      - ("d", "\", 0, 1, "r")
-                      - ("d", "|", 1, 0, "d")
-                      - ("l", "/", 1, 0, "d")
-                      - ("l", "|", 1, 0, "d")
-                      - ("r", "-", 0, 1, "r")
-                      - ("r", ".", 0, 1, "r")
+                  Get l3
+                Get l1
+                Get l2
           Constant
             - (1, 1, "r")
+    cte l2 =
+      ArrangeBy keys=[[#0, #1]]
+        Constant
+          total_rows (diffs absed): 24
+          first_rows:
+            - ("d", "-", 0, -1, "l")
+            - ("d", "/", 0, -1, "l")
+            - ("l", "-", 0, -1, "l")
+            - ("l", ".", 0, -1, "l")
+            - ("l", "\", -1, 0, "u")
+            - ("l", "|", -1, 0, "u")
+            - ("r", "/", -1, 0, "u")
+            - ("r", "|", -1, 0, "u")
+            - ("u", "-", 0, -1, "l")
+            - ("u", ".", -1, 0, "u")
+            - ("u", "\", 0, -1, "l")
+            - ("u", "|", -1, 0, "u")
+            - ("d", "-", 0, 1, "r")
+            - ("d", ".", 1, 0, "d")
+            - ("d", "\", 0, 1, "r")
+            - ("d", "|", 1, 0, "d")
+            - ("l", "/", 1, 0, "d")
+            - ("l", "|", 1, 0, "d")
+            - ("r", "-", 0, 1, "r")
+            - ("r", ".", 0, 1, "r")
+    cte l1 =
+      ArrangeBy keys=[[#0, #1]]
+        Filter (#2) IS NOT NULL
+          Get l0
     cte l0 =
       Project (#0, #2, #3)
         Map (substr(#1, #2, 1))

--- a/test/sqllogictest/advent-of-code/2023/aoc_1217.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1217.slt
@@ -238,23 +238,23 @@ Explained Query:
                   - ()
         ArrangeBy keys=[[]]
           Union
-            Get l8
+            Get l7
             Map (null)
               Union
                 Negate
                   Project ()
-                    Get l8
+                    Get l7
                 Constant
                   - ()
     With
-      cte l8 =
+      cte l7 =
         Reduce aggregates=[min(#0)]
           Project (#2)
             Join on=(#0 = #3 AND #1 = #4) type=differential
               ArrangeBy keys=[[#0, #1]]
                 Project (#0, #1, #5)
                   Filter (#4 >= 4)
-                    Get l7
+                    Get l6
               ArrangeBy keys=[[]]
                 Reduce aggregates=[max(#0)]
                   Project (#0)
@@ -264,7 +264,7 @@ Explained Query:
                   Project (#1)
                     Get l0
   With Mutually Recursive
-    cte l7 =
+    cte l6 =
       Reduce group_by=[#0..=#4] aggregates=[min(#5)]
         Union
           Project (#6, #7, #2, #3, #9, #10)
@@ -272,30 +272,27 @@ Explained Query:
               Join on=(#6 = (#0 + #2) AND #7 = (#1 + #3)) type=differential
                 ArrangeBy keys=[[(#0 + #2), (#1 + #3)]]
                   Filter (#4 < 10)
-                    Get l7
-                Get l5
+                    Get l6
+                Get l1
           Project (#5, #6, #3, #2, #9, #8)
             Map ((#4 + #7), 1)
               Join on=(#5 = (#0 + #3) AND #6 = (#1 + #2)) type=differential
                 ArrangeBy keys=[[(#0 + #3), (#1 + #2)]]
-                  Get l6
-                Get l5
+                  Get l5
+                Get l1
           Project (#5, #6, #8, #9, #11, #10)
             Map (-(#3), -(#2), (#4 + #7), 1)
               Join on=(#5 = (#0 - #3) AND #6 = (#1 - #2)) type=differential
                 ArrangeBy keys=[[(#0 - #3), (#1 - #2)]]
-                  Get l6
-                Get l5
+                  Get l5
+                Get l1
           Constant
             - (1, 1, 0, 1, 0, 0)
             - (1, 1, 1, 0, 0, 0)
-    cte l6 =
+    cte l5 =
       Project (#0..=#3, #5)
         Filter (#4 >= 4)
-          Get l7
-    cte l5 =
-      ArrangeBy keys=[[#0, #1]]
-        Get l0
+          Get l6
     cte l4 =
       Reduce aggregates=[min(#0)]
         Project (#2)

--- a/test/sqllogictest/advent-of-code/2023/aoc_1220.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1220.slt
@@ -139,9 +139,9 @@ SELECT * FROM signal WHERE target = 'cn' AND pulse = 'hi';
 Explained Query:
   Return
     Filter (#1 = "cn") AND (#4 = "hi")
-      Get l21
+      Get l27
   With Mutually Recursive
-    cte l21 =
+    cte l27 =
       Project (#0, #5, #1..=#3)
         Join on=(#0 = #4) type=differential
           ArrangeBy keys=[[#0]]
@@ -149,15 +149,15 @@ Explained Query:
           ArrangeBy keys=[[#0]]
             Filter (#0) IS NOT NULL
               Get l1
-    cte l20 =
+    cte l26 =
       Project (#1, #2, #4, #11)
         Map (case when (#5 = #10) then "lo" else "hi" end)
           Join on=(#0 = #6 AND #1 = #9 AND #2 = #7 AND #3 = #8) type=differential
             ArrangeBy keys=[[#0, #2, #3, #1]]
-              Get l15
+              Get l20
             ArrangeBy keys=[[#0..=#3]]
               Union
-                Get l19
+                Get l25
                 Project (#0..=#3, #8)
                   Map (null)
                     Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential
@@ -166,22 +166,21 @@ Explained Query:
                           Negate
                             Distinct project=[#0..=#3]
                               Project (#0..=#3)
-                                Get l19
-                          Get l16
-                      ArrangeBy keys=[[#0..=#3]]
-                        Get l16
-    cte l19 =
+                                Get l25
+                          Get l21
+                      Get l23
+    cte l25 =
       Union
-        Get l18
+        Get l24
         Map (error("more than one record produced in subquery"))
           Project (#0..=#3)
             Filter (#4 > 1)
               Reduce group_by=[#0..=#3] aggregates=[count(*)]
                 Project (#0..=#3)
-                  Get l18
-    cte l18 =
+                  Get l24
+    cte l24 =
       Union
-        Get l17
+        Get l22
         Project (#0..=#3, #8)
           Map (0)
             Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential
@@ -189,11 +188,13 @@ Explained Query:
                 Union
                   Negate
                     Project (#0..=#3)
-                      Get l17
-                  Get l16
-              ArrangeBy keys=[[#0..=#3]]
-                Get l16
-    cte l17 =
+                      Get l22
+                  Get l21
+              Get l23
+    cte l23 =
+      ArrangeBy keys=[[#0..=#3]]
+        Get l21
+    cte l22 =
       Reduce group_by=[#0..=#3] aggregates=[count(*)]
         Project (#0..=#3)
           Filter (#7 = "hi")
@@ -202,22 +203,21 @@ Explained Query:
                 Filter ((#6 < #1) OR ((#1 = #6) AND ((#7 < #2) OR ((#2 = #7) AND (#4 <= #0)))))
                   Join on=(#3 = #5) type=differential
                     ArrangeBy keys=[[#3]]
-                      Get l16
+                      Get l21
                     ArrangeBy keys=[[#1]]
-                      Filter (#1) IS NOT NULL
-                        Get l21
-    cte l16 =
+                      Get l13
+    cte l21 =
       Distinct project=[#0, #2, #3, #1]
         Project (#0..=#3)
-          Get l15
-    cte l15 =
+          Get l20
+    cte l20 =
       Project (#0..=#4, #6)
         Join on=(#1 = #5) type=differential
           ArrangeBy keys=[[#1]]
-            Get l10
+            Get l14
           ArrangeBy keys=[[#0]]
             Union
-              Get l14
+              Get l19
               Project (#0, #2)
                 Map (null)
                   Join on=(#0 = #1) type=differential
@@ -226,22 +226,21 @@ Explained Query:
                         Negate
                           Distinct project=[#0]
                             Project (#0)
-                              Get l14
-                        Get l11
-                    ArrangeBy keys=[[#0]]
-                      Get l11
-    cte l14 =
+                              Get l19
+                        Get l15
+                    Get l16
+    cte l19 =
       Union
-        Get l13
+        Get l18
         Map (error("more than one record produced in subquery"))
           Project (#0)
             Filter (#1 > 1)
               Reduce group_by=[#0] aggregates=[count(*)]
                 Project (#0)
-                  Get l13
-    cte l13 =
+                  Get l18
+    cte l18 =
       Union
-        Get l12
+        Get l17
         Project (#0, #2)
           Map (0)
             Join on=(#0 = #1) type=differential
@@ -249,46 +248,48 @@ Explained Query:
                 Union
                   Negate
                     Project (#0)
-                      Get l12
-                  Get l11
-              ArrangeBy keys=[[#0]]
-                Get l11
-    cte l12 =
+                      Get l17
+                  Get l15
+              Get l16
+    cte l17 =
       Reduce group_by=[#0] aggregates=[count(*)]
         Project (#0)
           Join on=(#0 = #1) type=differential
-            ArrangeBy keys=[[#0]]
-              Get l11
+            Get l16
             ArrangeBy keys=[[#0]]
               Project (#1)
                 Filter (#1) IS NOT NULL
                   Get l1
-    cte l11 =
+    cte l16 =
+      ArrangeBy keys=[[#0]]
+        Get l15
+    cte l15 =
       Distinct project=[#0]
         Project (#1)
-          Get l10
-    cte l10 =
+          Get l14
+    cte l14 =
       Project (#0..=#3, #5)
         Map ((#3 + 1))
           Join on=(#1 = #4) type=differential
             ArrangeBy keys=[[#1]]
               Project (#0..=#3)
-                Filter (#1) IS NOT NULL
-                  Get l21
+                Get l13
             ArrangeBy keys=[[#0]]
               Project (#2)
                 Filter ("&" = substr(#1, 1, 1))
-                  Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#0), 1), substr(#1, 2))
-                    Get l0
-    cte l9 =
+                  Get l5
+    cte l13 =
+      Filter (#1) IS NOT NULL
+        Get l27
+    cte l12 =
       Project (#1, #2, #4, #10)
         Map (case when (0 = (#9 % 2)) then "hi" else "lo" end)
           Join on=(#0 = #5 AND #1 = #8 AND #2 = #6 AND #3 = #7) type=differential
             ArrangeBy keys=[[#0, #2, #3, #1]]
-              Get l4
+              Get l6
             ArrangeBy keys=[[#0..=#3]]
               Union
-                Get l8
+                Get l11
                 Project (#0..=#3, #8)
                   Map (null)
                     Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential
@@ -297,22 +298,21 @@ Explained Query:
                           Negate
                             Distinct project=[#0..=#3]
                               Project (#0..=#3)
-                                Get l8
-                          Get l5
-                      ArrangeBy keys=[[#0..=#3]]
-                        Get l5
-    cte l8 =
+                                Get l11
+                          Get l7
+                      Get l9
+    cte l11 =
       Union
-        Get l7
+        Get l10
         Map (error("more than one record produced in subquery"))
           Project (#0..=#3)
             Filter (#4 > 1)
               Reduce group_by=[#0..=#3] aggregates=[count(*)]
                 Project (#0..=#3)
-                  Get l7
-    cte l7 =
+                  Get l10
+    cte l10 =
       Union
-        Get l6
+        Get l8
         Project (#0..=#3, #8)
           Map (0)
             Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential
@@ -320,38 +320,41 @@ Explained Query:
                 Union
                   Negate
                     Project (#0..=#3)
-                      Get l6
-                  Get l5
-              ArrangeBy keys=[[#0..=#3]]
-                Get l5
-    cte l6 =
+                      Get l8
+                  Get l7
+              Get l9
+    cte l9 =
+      ArrangeBy keys=[[#0..=#3]]
+        Get l7
+    cte l8 =
       Reduce group_by=[#0..=#3] aggregates=[count(*)]
         Project (#0..=#3)
           Filter ((#6 < #1) OR ((#1 = #6) AND ((#7 < #2) OR ((#2 = #7) AND (#4 < #0)))))
             Join on=(#3 = #5) type=differential
               ArrangeBy keys=[[#3]]
-                Get l5
-              ArrangeBy keys=[[#1]]
-                Project (#0..=#3)
-                  Filter (#4 = "lo") AND (#1) IS NOT NULL
-                    Get l21
-    cte l5 =
+                Get l7
+              Get l4
+    cte l7 =
       Distinct project=[#0, #2, #3, #1]
         Project (#0..=#3)
-          Get l4
-    cte l4 =
+          Get l6
+    cte l6 =
       Project (#0..=#3, #5)
         Map ((#3 + 1))
           Join on=(#1 = #4) type=differential
-            ArrangeBy keys=[[#1]]
-              Project (#0..=#3)
-                Filter (#4 = "lo") AND (#1) IS NOT NULL
-                  Get l21
+            Get l4
             ArrangeBy keys=[[#0]]
               Project (#2)
                 Filter ("%" = substr(#1, 1, 1))
-                  Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#0), 1), substr(#1, 2))
-                    Get l0
+                  Get l5
+    cte l5 =
+      Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#0), 1), substr(#1, 2))
+        Get l0
+    cte l4 =
+      ArrangeBy keys=[[#1]]
+        Project (#0..=#3)
+          Filter (#4 = "lo") AND (#1) IS NOT NULL
+            Get l27
     cte l3 =
       Union
         Project (#2, #0, #3, #4)
@@ -359,9 +362,9 @@ Explained Query:
             Map ("roadcaster", 1, "lo")
               Get l2
         Filter (#2 > 0)
-          Get l9
+          Get l12
         Filter (#2 > 0)
-          Get l20
+          Get l26
     cte l2 =
       Distinct project=[#0, #1] monotonic
         Union

--- a/test/sqllogictest/advent-of-code/2023/aoc_1222.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1222.slt
@@ -210,58 +210,57 @@ Explained Query:
       CrossJoin type=differential
         ArrangeBy keys=[[]]
           Union
-            Get l12
+            Get l16
             Map (0)
               Union
                 Negate
                   Project ()
-                    Get l12
+                    Get l16
                 Constant
                   - ()
         ArrangeBy keys=[[]]
           Union
-            Get l19
+            Get l24
             Map (0)
               Union
                 Negate
                   Project ()
-                    Get l19
+                    Get l24
                 Constant
                   - ()
     With
-      cte l19 =
+      cte l24 =
         Reduce aggregates=[count(*)]
           Project ()
-            Get l18
+            Get l23
   With Mutually Recursive
-    cte l18 =
+    cte l23 =
       Distinct project=[#0, #1]
         Union
           Project (#0, #1)
             Filter (#3 = 1)
               Join on=(#1 = #2) type=differential
                 ArrangeBy keys=[[#1]]
-                  Get l8
+                  Get l9
                 ArrangeBy keys=[[#0]]
                   Reduce group_by=[#0] aggregates=[count(*)]
-                    Project (#1)
-                      Get l8
+                    Get l10
           Project (#0, #1)
             Join on=(#1 = #3 AND #2 = #4) type=differential
               ArrangeBy keys=[[#1, #2]]
-                Get l14
+                Get l18
               ArrangeBy keys=[[#0, #1]]
                 Union
-                  Get l17
+                  Get l22
                   Map (error("more than one record produced in subquery"))
                     Project (#0)
                       Filter (#1 > 1)
                         Reduce group_by=[#0] aggregates=[count(*)]
                           Project (#0)
-                            Get l17
-    cte l17 =
+                            Get l22
+    cte l22 =
       Union
-        Get l16
+        Get l21
         Project (#0, #2)
           Map (0)
             Join on=(#0 = #1) type=differential
@@ -269,40 +268,38 @@ Explained Query:
                 Union
                   Negate
                     Project (#0)
-                      Get l16
-                  Get l15
-              ArrangeBy keys=[[#0]]
-                Get l15
-    cte l16 =
+                      Get l21
+                  Get l19
+              Get l20
+    cte l21 =
       Reduce group_by=[#0] aggregates=[count(*)]
         Project (#0)
           Join on=(#0 = #1) type=differential
-            ArrangeBy keys=[[#0]]
-              Get l15
-            ArrangeBy keys=[[#0]]
-              Project (#1)
-                Get l8
-    cte l15 =
+            Get l20
+            Get l15
+    cte l20 =
+      ArrangeBy keys=[[#0]]
+        Get l19
+    cte l19 =
       Distinct project=[#0]
         Project (#1)
-          Get l14
-    cte l14 =
+          Get l18
+    cte l18 =
       Reduce group_by=[#0, #1] aggregates=[count(*)]
         Project (#0, #3)
           Join on=(#1 = #2) type=differential
             ArrangeBy keys=[[#1]]
-              Get l18
+              Get l23
             ArrangeBy keys=[[#0]]
-              Get l8
-    cte l13 =
-      Get l1
-    cte l12 =
+              Get l9
+    cte l17 =
+      Get l6
+    cte l16 =
       Reduce aggregates=[count(distinct #0)]
         Project (#0)
           Join on=(#0 = #1 = #2) type=delta
             ArrangeBy keys=[[#0]]
-              Project (#0)
-                Get l0
+              Get l12
             ArrangeBy keys=[[#0]]
               Union
                 Negate
@@ -313,7 +310,7 @@ Explained Query:
                           ArrangeBy keys=[[#1]]
                             Project (#0, #2)
                               Filter (#0 = #1)
-                                Get l11
+                                Get l14
                           ArrangeBy keys=[[#0]]
                             Reduce group_by=[#0] aggregates=[count(*)]
                               Project (#0)
@@ -321,55 +318,60 @@ Explained Query:
                                   ArrangeBy keys=[[#0]]
                                     Distinct project=[#0]
                                       Project (#2)
-                                        Get l11
-                                  ArrangeBy keys=[[#0]]
-                                    Project (#1)
-                                      Get l8
-                Get l10
+                                        Get l14
+                                  Get l15
+                Get l13
             ArrangeBy keys=[[#0]]
-              Get l10
-    cte l11 =
+              Get l13
+    cte l15 =
+      ArrangeBy keys=[[#0]]
+        Get l10
+    cte l14 =
       CrossJoin type=differential
         ArrangeBy keys=[[]]
-          Get l10
+          Get l13
         ArrangeBy keys=[[]]
-          Get l8
-    cte l10 =
+          Get l9
+    cte l13 =
       Distinct project=[#0]
-        Project (#0)
-          Get l0
-    cte l9 =
+        Get l12
+    cte l12 =
+      Project (#0)
+        Get l0
+    cte l11 =
       Distinct project=[#0]
         Union
           Project (#0)
             Filter (#3 = 1)
-              Get l6
-          Project (#1)
-            Get l8
-    cte l8 =
+              Get l7
+          Get l10
+    cte l10 =
+      Project (#1)
+        Get l9
+    cte l9 =
       Distinct project=[#0, #1]
         Project (#0, #4)
           Filter (#0 != #4)
             Join on=(#1 = #5 AND #2 = #6 AND #7 = (#3 + 1)) type=differential
               ArrangeBy keys=[[#1, #2, (#3 + 1)]]
-                Get l7
+                Get l8
               ArrangeBy keys=[[#1..=#3]]
-                Get l7
-    cte l7 =
+                Get l8
+    cte l8 =
       Filter (#3) IS NOT NULL
-        Get l6
-    cte l6 =
+        Get l7
+    cte l7 =
       Union
         Threshold
           Union
-            Get l1
+            Get l6
             Negate
-              Get l13
+              Get l17
         Project (#0..=#2, #6)
           Map (case when #5 then #3 else (#3 - 1) end)
             Join on=(#0 = #4) type=differential
               ArrangeBy keys=[[#0]]
-                Get l6
+                Get l7
               ArrangeBy keys=[[#0]]
                 Union
                   Get l5
@@ -382,44 +384,9 @@ Explained Query:
                               Distinct project=[#0]
                                 Project (#0)
                                   Get l5
-                            Get l2
-                        ArrangeBy keys=[[#0]]
-                          Get l2
-    cte l5 =
-      Union
-        Get l4
-        Map (error("more than one record produced in subquery"))
-          Project (#0)
-            Filter (#1 > 1)
-              Reduce group_by=[#0] aggregates=[count(*)]
-                Project (#0)
-                  Get l4
-    cte l4 =
-      Union
-        Get l3
-        Project (#0, #2)
-          Map (false)
-            Join on=(#0 = #1) type=differential
-              ArrangeBy keys=[[#0]]
-                Union
-                  Negate
-                    Project (#0)
-                      Get l3
-                  Get l2
-              ArrangeBy keys=[[#0]]
-                Get l2
-    cte l3 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l2
-          ArrangeBy keys=[[]]
-            Get l9
-    cte l2 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l6
-    cte l1 =
+                            Get l1
+                        Get l3
+    cte l6 =
       Project (#0, #1, #3, #5)
         Join on=(#0 = #2 = #4) type=delta
           ArrangeBy keys=[[#0]]
@@ -434,6 +401,42 @@ Explained Query:
             Project (#0, #2)
               FlatMap generate_series(text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 1)), 3)), text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 2)), 3)), 1)
                 Get l0
+    cte l5 =
+      Union
+        Get l4
+        Map (error("more than one record produced in subquery"))
+          Project (#0)
+            Filter (#1 > 1)
+              Reduce group_by=[#0] aggregates=[count(*)]
+                Project (#0)
+                  Get l4
+    cte l4 =
+      Union
+        Get l2
+        Project (#0, #2)
+          Map (false)
+            Join on=(#0 = #1) type=differential
+              ArrangeBy keys=[[#0]]
+                Union
+                  Negate
+                    Project (#0)
+                      Get l2
+                  Get l1
+              Get l3
+    cte l3 =
+      ArrangeBy keys=[[#0]]
+        Get l1
+    cte l2 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Get l1
+          ArrangeBy keys=[[]]
+            Get l11
+    cte l1 =
+      Distinct project=[#0]
+        Project (#0)
+          Get l7
     cte l0 =
       Project (#1, #2)
         Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))

--- a/test/sqllogictest/advent-of-code/2023/aoc_1223.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1223.slt
@@ -292,9 +292,9 @@ SELECT * FROM longest ORDER BY d DESC;
 Explained Query:
   Finish order_by=[#2 desc nulls_first] output=[#0..=#3]
     Return
-      Get l15
+      Get l17
     With Mutually Recursive
-      cte l15 =
+      cte l17 =
         Project (#0, #1, #3, #2)
           Reduce group_by=[#0, #1, #3] aggregates=[max(#2)]
             Union
@@ -303,29 +303,27 @@ Explained Query:
                   Map (bigint_to_integer(#17), (#2 + #6), (#3 + (1 << #18)))
                     Join on=(#0 = #4 AND #1 = #5 AND #7 = #9 = #11 = #13 = #15 AND #8 = #10 = #12 = #14 = #16) type=delta
                       ArrangeBy keys=[[#0, #1]]
-                        Get l15
+                        Get l17
                       ArrangeBy keys=[[#0, #1], [#3, #4]]
-                        Get l8
-                      ArrangeBy keys=[[#0, #1]]
-                        Get l4
-                      ArrangeBy keys=[[#0, #1]]
                         Get l9
+                      Get l8
                       ArrangeBy keys=[[#0, #1]]
                         Get l10
+                      Get l15
                       ArrangeBy keys=[[#0, #1]]
                         Union
-                          Get l14
+                          Get l16
                           Map (error("more than one record produced in subquery"))
                             Project (#0, #1)
                               Filter (#2 > 1)
                                 Reduce group_by=[#0, #1] aggregates=[count(*)]
                                   Project (#0, #1)
-                                    Get l14
+                                    Get l16
               Constant
                 - (12, 20, 0, 0)
-      cte l14 =
+      cte l16 =
         Union
-          Get l13
+          Get l14
           Project (#0, #1, #4)
             Map (0)
               Join on=(#0 = #2 AND #1 = #3) type=differential
@@ -333,16 +331,18 @@ Explained Query:
                   Union
                     Negate
                       Project (#0, #1)
-                        Get l13
-                    Get l10
-                ArrangeBy keys=[[#0, #1]]
-                  Get l10
-      cte l13 =
+                        Get l14
+                    Get l11
+                Get l15
+      cte l15 =
+        ArrangeBy keys=[[#0, #1]]
+          Get l11
+      cte l14 =
         Reduce group_by=[#0, #1] aggregates=[count(*)]
           Project (#0, #1)
             Join on=(#2 = #4 AND #3 = #5) type=differential
               ArrangeBy keys=[[#2, #3]]
-                Get l11
+                Get l12
               ArrangeBy keys=[[#0, #1]]
                 Union
                   Negate
@@ -350,23 +350,23 @@ Explained Query:
                       Project (#0, #1)
                         Filter (#0 = #2) AND (#1 = #3)
                           FlatMap wrap2(1, 2, 12, 20, 130, 126, 141, 140)
-                            Get l12
-                  Get l12
-      cte l12 =
+                            Get l13
+                  Get l13
+      cte l13 =
         Distinct project=[#0, #1]
           Project (#2, #3)
-            Get l11
-      cte l11 =
+            Get l12
+      cte l12 =
         Filter ((#2 < #0) OR ((#0 = #2) AND (#3 < #1)))
           CrossJoin type=differential
             ArrangeBy keys=[[]]
-              Get l10
+              Get l11
             ArrangeBy keys=[[]]
               Get l4
-      cte l10 =
+      cte l11 =
         Distinct project=[#0, #1]
-          Get l9
-      cte l9 =
+          Get l10
+      cte l10 =
         Union
           Negate
             Distinct project=[#0, #1]
@@ -375,45 +375,46 @@ Explained Query:
                   FlatMap wrap2(1, 2, 12, 20, 130, 126, 141, 140)
                     Get l4
           Get l4
-      cte l8 =
+      cte l9 =
         Project (#0, #1, #4, #2, #3)
           Reduce group_by=[#0, #1, #3, #4] aggregates=[min(#2)]
             Union
               Project (#0, #1, #6, #2, #3)
                 Map (1)
                   Join on=(#0 = #4 AND #1 = #5) type=differential
-                    ArrangeBy keys=[[#0, #1]]
-                      Get l3
-                    Get l7
+                    Get l5
+                    Get l8
               Project (#0, #1, #9, #5, #6)
                 Map ((#2 + 1))
                   Join on=(#3 = #7 AND #4 = #8) type=differential
                     ArrangeBy keys=[[#3, #4]]
-                      Get l5
+                      Get l6
                     ArrangeBy keys=[[#0, #1]]
                       Union
                         Negate
                           Project (#0, #1)
                             Join on=(#0 = #2 AND #1 = #3) type=differential
                               ArrangeBy keys=[[#0, #1]]
-                                Get l6
-                              Get l7
-                        Get l6
-      cte l7 =
+                                Get l7
+                              Get l8
+                        Get l7
+      cte l8 =
         ArrangeBy keys=[[#0, #1]]
           Get l4
-      cte l6 =
+      cte l7 =
         Distinct project=[#0, #1]
           Project (#3, #4)
-            Get l5
-      cte l5 =
+            Get l6
+      cte l6 =
         Project (#0..=#4, #7, #8)
           Filter ((#0 != #7) OR (#1 != #8))
             Join on=(#3 = #5 AND #4 = #6) type=differential
               ArrangeBy keys=[[#3, #4]]
-                Get l8
-              ArrangeBy keys=[[#0, #1]]
-                Get l3
+                Get l9
+              Get l5
+      cte l5 =
+        ArrangeBy keys=[[#0, #1]]
+          Get l3
       cte l4 =
         Project (#0, #1)
           Filter (#2 != 2)

--- a/test/sqllogictest/advent-of-code/2023/aoc_1225.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1225.slt
@@ -135,65 +135,65 @@ Explained Query:
           CrossJoin type=differential
             ArrangeBy keys=[[]]
               Union
-                Get l9
+                Get l10
                 Map (null)
                   Union
                     Negate
                       Project ()
-                        Get l9
+                        Get l10
                     Constant
                       - ()
             ArrangeBy keys=[[]]
               Union
-                Get l11
+                Get l12
                 Map (null)
                   Union
                     Negate
                       Project ()
-                        Get l11
+                        Get l12
                     Constant
                       - ()
     With
-      cte l11 =
+      cte l12 =
         Union
-          Get l10
+          Get l11
           Map (0)
             Union
               Negate
                 Project ()
-                  Get l10
+                  Get l11
               Constant
                 - ()
-      cte l10 =
+      cte l11 =
         Reduce aggregates=[count(*)]
           Project ()
             Filter (#1 > 0)
-              Get l6
-      cte l9 =
+              Get l7
+      cte l10 =
         Union
-          Get l8
+          Get l9
           Map (0)
             Union
               Negate
                 Project ()
-                  Get l8
+                  Get l9
               Constant
                 - ()
-      cte l8 =
+      cte l9 =
         Reduce aggregates=[count(*)]
           Project ()
             Filter (#1 < 0)
-              Get l6
+              Get l7
   With Mutually Recursive
-    cte [recursion_limit=50, return_at_limit] l7 =
+    cte [recursion_limit=50, return_at_limit] l8 =
       Get l1
-    cte [recursion_limit=50, return_at_limit] l6 =
+    cte [recursion_limit=50, return_at_limit] l7 =
       Union
         Threshold
           Union
             Get l1
             Negate
-              Get l7
+              Get l8
         Reduce group_by=[#0] aggregates=[sum(((#1 - #2) / #3))]
           Project (#0, #3..=#5)
             Join on=(#1 = #2) type=delta
@@ -206,59 +206,60 @@ Explained Query:
                       Get l0
               ArrangeBy keys=[[#0]]
                 Filter (#0) IS NOT NULL
+                  Get l7
+              ArrangeBy keys=[[]]
+                Union
+                  Get l4
+                  Map (null)
+                    Union
+                      Negate
+                        Project ()
+                          Get l4
+                      Constant
+                        - ()
+              ArrangeBy keys=[[]]
+                Union
                   Get l6
-              ArrangeBy keys=[[]]
-                Union
-                  Get l3
                   Map (null)
                     Union
                       Negate
                         Project ()
-                          Get l3
+                          Get l6
                       Constant
                         - ()
-              ArrangeBy keys=[[]]
-                Union
-                  Get l5
-                  Map (null)
-                    Union
-                      Negate
-                        Project ()
-                          Get l5
-                      Constant
-                        - ()
-    cte l5 =
+    cte l6 =
       Project (#3)
         Map (sqrtnumeric(case when ((#0) IS NULL OR (#1) IS NULL OR (case when (#2 = 0) then null else #2 end) IS NULL OR (case when (0 = (#2 - 1)) then null else (#2 - 1) end) IS NULL) then null else greatest(((#0 - ((#1 * #1) / bigint_to_numeric(case when (#2 = 0) then null else #2 end))) / bigint_to_numeric(case when (0 = (#2 - 1)) then null else (#2 - 1) end)), 0) end))
           Union
-            Get l4
+            Get l5
             Map (null, null, 0)
               Union
                 Negate
                   Project ()
-                    Get l4
+                    Get l5
                 Constant
                   - ()
-    cte l4 =
+    cte l5 =
       Reduce aggregates=[sum((#0 * #0)), sum(#0), count(#0)]
-        Project (#1)
-          Get l6
-    cte l3 =
+        Get l2
+    cte l4 =
       Project (#2)
         Map ((#0 / bigint_to_numeric(case when (#1 = 0) then null else #1 end)))
           Union
-            Get l2
+            Get l3
             Map (null, 0)
               Union
                 Negate
                   Project ()
-                    Get l2
+                    Get l3
                 Constant
                   - ()
-    cte l2 =
+    cte l3 =
       Reduce aggregates=[sum(#0), count(#0)]
-        Project (#1)
-          Get l6
+        Get l2
+    cte l2 =
+      Project (#1)
+        Get l7
     cte l1 =
       Map (case when (#0 < "n") then 1 else -1 end)
         Union

--- a/test/sqllogictest/cardinality.slt
+++ b/test/sqllogictest/cardinality.slt
@@ -160,68 +160,52 @@ SELECT * FROM pexists;
 ----
 Explained Query:
   Return
-    Get l5
+    Get l3
   With Mutually Recursive
-    cte l5 =
+    cte l3 =
       Distinct project=[#0, #1]
         Union
           Project (#1, #0)
             CrossJoin type=differential
               ArrangeBy keys=[[]]
-                Get l2
+                Get l0
               ArrangeBy keys=[[]]
                 Union
                   Negate
-                    Get l4
+                    Get l2
                   Constant
                     - ()
           Project (#1, #0)
             Map (true, -1)
-              Get l4
+              Get l2
           Constant
             - (1, true)
             - (2, false)
-    cte l4 =
+    cte l2 =
       Distinct project=[]
         Project ()
           Join on=(#0 = #1) type=differential
             ArrangeBy keys=[[#0]]
               Project (#0)
                 Filter #1
-                  Get l3
+                  Get l1
             ArrangeBy keys=[[#0]]
               Project (#0)
                 Filter NOT(#1)
-                  Get l3
-    cte l3 =
+                  Get l1
+    cte l1 =
       Union
         Project (#1, #0)
-          Get l2
-        Get l5
-    cte l2 =
+          Get l0
+        Get l3
+    cte l0 =
       Project (#1, #3)
         Join on=(#0 = #2) type=differential
           ArrangeBy keys=[[#0]]
-            Get l5
+            Get l3
           ArrangeBy keys=[[#0]]
-            Union
-              Negate
-                CrossJoin type=differential
-                  ArrangeBy keys=[[]]
-                    Get l1
-                  ArrangeBy keys=[[]]
-                    Distinct project=[]
-                      Project ()
-                        Get l0
-              Project (#1, #2)
-                ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
-              Get l1
-    cte l1 =
-      Project (#1, #2)
-        Get l0
-    cte l0 =
-      Filter (3 = least(#1, #2)) AND (4 = greatest(#1, #2))
-        ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
+            Project (#1, #2)
+              ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.person_knows_person_person1id_person2id (*** full scan ***)
@@ -274,68 +258,52 @@ SELECT * FROM pexists;
 ----
 Explained Query:
   Return
-    Get l5
+    Get l3
   With Mutually Recursive
-    cte l5 =
+    cte l3 =
       Distinct project=[#0, #1]
         Union
           Project (#1, #0)
             CrossJoin type=differential
               ArrangeBy keys=[[]]
-                Get l2
+                Get l0
               ArrangeBy keys=[[]]
                 Union
                   Negate
-                    Get l4
+                    Get l2
                   Constant
                     - ()
           Project (#1, #0)
             Map (true, -1)
-              Get l4
+              Get l2
           Constant
             - (1, true)
             - (2, false)
-    cte l4 =
+    cte l2 =
       Distinct project=[]
         Project ()
           Join on=(#0 = #1) type=differential
             ArrangeBy keys=[[#0]]
               Project (#0)
                 Filter #1
-                  Get l3
+                  Get l1
             ArrangeBy keys=[[#0]]
               Project (#0)
                 Filter NOT(#1)
-                  Get l3
-    cte l3 =
+                  Get l1
+    cte l1 =
       Union
         Project (#1, #0)
-          Get l2
-        Get l5
-    cte l2 =
+          Get l0
+        Get l3
+    cte l0 =
       Project (#1, #3)
         Join on=(#0 = #2) type=differential
           ArrangeBy keys=[[#0]]
-            Get l5
+            Get l3
           ArrangeBy keys=[[#0]]
-            Union
-              Negate
-                CrossJoin type=differential
-                  ArrangeBy keys=[[]]
-                    Get l1
-                  ArrangeBy keys=[[]]
-                    Distinct project=[]
-                      Project ()
-                        Get l0
-              Project (#1, #2)
-                ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
-              Get l1
-    cte l1 =
-      Project (#1, #2)
-        Get l0
-    cte l0 =
-      Filter (3 = least(#1, #2)) AND (4 = greatest(#1, #2))
-        ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
+            Project (#1, #2)
+              ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.person_knows_person_person1id_person2id (*** full scan ***)

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -2520,9 +2520,9 @@ Explained Query:
     Return // { arity: 3 }
       Project (#1{min}, #2{min}, #2{min}) // { arity: 3 }
         Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
-          Get l3 // { arity: 3 }
+          Get l4 // { arity: 3 }
     With Mutually Recursive
-      cte l3 =
+      cte l4 =
         Project (#2{min}, #0, #1{person2id}) // { arity: 3 }
           Map (1450) // { arity: 3 }
             Reduce group_by=[#0{person2id}] aggregates=[min(#1)] // { arity: 2 }
@@ -2532,10 +2532,10 @@ Explained Query:
                     Map ((#1 + #4)) // { arity: 6 }
                       Join on=(#0 = #2{person1id}) type=differential // { arity: 5 }
                         implementation
-                          %0:l3[#0]UK » %1[#0]K
+                          %0:l4[#0]UK » %1[#0]K
                         ArrangeBy keys=[[#0]] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
-                            Get l3 // { arity: 3 }
+                            Get l4 // { arity: 3 }
                         ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
                           Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
                             Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
@@ -2546,38 +2546,32 @@ Explained Query:
                                       Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                                         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                                           implementation
-                                            %1[#1, #0]UKK » %0:l2[greatest(#0, #1), least(#0, #1)]KK
-                                          ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                                            Get l2 // { arity: 2 }
+                                            %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+                                          Get l1 // { arity: 2 }
                                           ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                                             Distinct project=[#0, #1] // { arity: 2 }
                                               Project (#2, #3) // { arity: 2 }
-                                                Get l1 // { arity: 5 }
-                                    Get l2 // { arity: 2 }
+                                                Get l3 // { arity: 5 }
+                                    Get l0 // { arity: 2 }
                                 Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
-                                  Get l1 // { arity: 5 }
+                                  Get l3 // { arity: 5 }
                   Constant // { arity: 2 }
                     - (1450, 0)
-      cte l2 =
-        Project (#1{person2id}, #2) // { arity: 2 }
-          ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-      cte l1 =
+      cte l3 =
         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
           implementation
-            %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
-          ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-            Project (#1{person2id}, #2) // { arity: 2 }
-              ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+            %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+          Get l1 // { arity: 2 }
           ArrangeBy keys=[[#1, #0]] // { arity: 3 }
             Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
               Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
                 Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                   implementation
-                    %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
-                    %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                    %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
-                    %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                    %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                    %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                    %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
                   ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
                     ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                   ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
@@ -2588,14 +2582,20 @@ Explained Query:
                     Project (#9, #10, #12) // { arity: 3 }
                       Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                         ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                  Get l0 // { arity: 1 }
-                  Get l0 // { arity: 1 }
-      cte l0 =
+                  Get l2 // { arity: 1 }
+                  Get l2 // { arity: 1 }
+      cte l2 =
         ArrangeBy keys=[[#0{id}]] // { arity: 1 }
           Distinct project=[#0{id}] // { arity: 1 }
             Project (#1) // { arity: 1 }
               Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                 ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+      cte l1 =
+        ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
+          Get l0 // { arity: 2 }
+      cte l0 =
+        Project (#1{person2id}, #2) // { arity: 2 }
+          ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -2719,218 +2719,219 @@ Explained Query:
       Project (#1) // { arity: 1 }
         Map (coalesce(#0{min_min}, -1)) // { arity: 2 }
           Union // { arity: 1 }
-            Get l17 // { arity: 1 }
+            Get l19 // { arity: 1 }
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
                   Project () // { arity: 0 }
-                    Get l17 // { arity: 1 }
+                    Get l19 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
     With
-      cte l17 =
+      cte l19 =
         Reduce aggregates=[min(#0{min})] // { arity: 1 }
           Project (#2) // { arity: 1 }
             Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0, #2, #3, #5) // { arity: 4 }
                 Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
                   implementation
-                    %0:l16[#1]Kef » %1:l16[#1]Kef
+                    %0:l18[#1]Kef » %1:l18[#1]Kef
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
                     Project (#1{person2id}..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
-                        Get l16 // { arity: 4 }
+                        Get l18 // { arity: 4 }
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
                     Project (#1{person2id}..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
-                        Get l16 // { arity: 4 }
-      cte l16 =
+                        Get l18 // { arity: 4 }
+      cte l18 =
         Project (#0..=#3) // { arity: 4 }
           Join on=(#4 = #5{max}) type=differential // { arity: 6 }
             implementation
-              %1[#0]UK » %0:l15[#4]K
+              %1[#0]UK » %0:l17[#4]K
             ArrangeBy keys=[[#4]] // { arity: 5 }
               Project (#0..=#3, #5) // { arity: 5 }
                 Filter (#5) IS NOT NULL // { arity: 6 }
-                  Get l15 // { arity: 6 }
+                  Get l17 // { arity: 6 }
             ArrangeBy keys=[[#0{max}]] // { arity: 1 }
               Filter (#0{max}) IS NOT NULL // { arity: 1 }
                 Reduce aggregates=[max(#0)] // { arity: 1 }
                   Project (#5) // { arity: 1 }
-                    Get l15 // { arity: 6 }
+                    Get l17 // { arity: 6 }
   With Mutually Recursive
-    cte l15 =
+    cte l17 =
       Distinct project=[#0..=#5] // { arity: 6 }
         Union // { arity: 6 }
           Project (#1, #0, #0, #2..=#4) // { arity: 6 }
             Map (0, false, 0) // { arity: 5 }
               Union // { arity: 2 }
                 Map (1450, false) // { arity: 2 }
-                  Get l14 // { arity: 0 }
+                  Get l16 // { arity: 0 }
                 Map (15393162796819, true) // { arity: 2 }
-                  Get l14 // { arity: 0 }
+                  Get l16 // { arity: 0 }
           Project (#0..=#3, #7, #8) // { arity: 6 }
             Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
               CrossJoin type=delta // { arity: 7 }
                 implementation
-                  %0:l11 » %1[×]U » %2[×]U
-                  %1 » %2[×]U » %0:l11[×]
-                  %2 » %1[×]U » %0:l11[×]
+                  %0:l13 » %1[×]U » %2[×]U
+                  %1 » %2[×]U » %0:l13[×]
+                  %2 » %1[×]U » %0:l13[×]
                 ArrangeBy keys=[[]] // { arity: 5 }
-                  Get l11 // { arity: 5 }
+                  Get l13 // { arity: 5 }
                 ArrangeBy keys=[[]] // { arity: 1 }
                   TopK limit=1 // { arity: 1 }
                     Project (#4) // { arity: 1 }
-                      Get l8 // { arity: 5 }
+                      Get l9 // { arity: 5 }
                 ArrangeBy keys=[[]] // { arity: 1 }
                   Union // { arity: 1 }
-                    Get l13 // { arity: 1 }
+                    Get l15 // { arity: 1 }
                     Map (null) // { arity: 1 }
                       Union // { arity: 0 }
                         Negate // { arity: 0 }
                           Project () // { arity: 0 }
-                            Get l13 // { arity: 1 }
+                            Get l15 // { arity: 1 }
                         Constant // { arity: 0 }
                           - ()
-    cte l14 =
+    cte l16 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Filter #1 AND (#0{person2id} = -1) // { arity: 2 }
-            Get l7 // { arity: 2 }
-    cte l13 =
+            Get l8 // { arity: 2 }
+    cte l15 =
       Project (#1) // { arity: 1 }
         Map ((#0{min} / 2)) // { arity: 2 }
           Union // { arity: 1 }
-            Get l12 // { arity: 1 }
+            Get l14 // { arity: 1 }
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
                   Project () // { arity: 0 }
-                    Get l12 // { arity: 1 }
+                    Get l14 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
-    cte l12 =
+    cte l14 =
       Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
         Project (#1, #3) // { arity: 2 }
           Join on=(#0{person2id} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %0:l11[#0]Kef » %1:l11[#0]Kef
+              %0:l13[#0]Kef » %1:l13[#0]Kef
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = false) // { arity: 5 }
-                  Get l11 // { arity: 5 }
+                  Get l13 // { arity: 5 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = true) // { arity: 5 }
-                  Get l11 // { arity: 5 }
-    cte l11 =
+                  Get l13 // { arity: 5 }
+    cte l13 =
       TopK group_by=[#0, #1, #2{person2id}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
         Union // { arity: 5 }
           Project (#3, #4, #1, #7, #8) // { arity: 5 }
             Map ((#6 + #2), false) // { arity: 9 }
               Join on=(#0{person1id} = #5) type=differential // { arity: 7 }
                 implementation
-                  %0:l3[#0]K » %1:l8[#2]K
+                  %0:l4[#0]K » %1:l9[#2]K
                 ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
-                  Get l3 // { arity: 3 }
+                  Get l4 // { arity: 3 }
                 ArrangeBy keys=[[#2]] // { arity: 4 }
                   Project (#0..=#3) // { arity: 4 }
-                    Get l8 // { arity: 5 }
+                    Get l9 // { arity: 5 }
           Project (#0..=#3, #9) // { arity: 5 }
             Map ((#4 OR #8)) // { arity: 10 }
               Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
                 implementation
-                  %0:l15[#0..=#2]KKK » %1[#0..=#2]KKK
+                  %0:l17[#0..=#2]KKK » %1[#0..=#2]KKK
                 ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
                   Project (#0..=#4) // { arity: 5 }
-                    Get l15 // { arity: 6 }
+                    Get l17 // { arity: 6 }
                 ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                   Union // { arity: 4 }
                     Map (true) // { arity: 4 }
-                      Get l10 // { arity: 3 }
+                      Get l12 // { arity: 3 }
                     Project (#0..=#2, #6) // { arity: 4 }
                       Map (false) // { arity: 7 }
                         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                           implementation
-                            %1:l9[#0..=#2]UKKK » %0[#0..=#2]KKK
+                            %1:l11[#0..=#2]UKKK » %0[#0..=#2]KKK
                           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                             Union // { arity: 3 }
                               Negate // { arity: 3 }
-                                Get l10 // { arity: 3 }
-                              Get l9 // { arity: 3 }
-                          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                            Get l9 // { arity: 3 }
-    cte l10 =
+                                Get l12 // { arity: 3 }
+                              Get l10 // { arity: 3 }
+                          Get l11 // { arity: 3 }
+    cte l12 =
       Project (#0..=#2) // { arity: 3 }
         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
           implementation
-            %1[#0..=#2]UKKKA » %0:l9[#0..=#2]UKKK
-          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-            Get l9 // { arity: 3 }
+            %1[#0..=#2]UKKKA » %0:l11[#0..=#2]UKKK
+          Get l11 // { arity: 3 }
           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
             Distinct project=[#0..=#2] // { arity: 3 }
               Project (#0..=#2) // { arity: 3 }
-                Get l8 // { arity: 5 }
-    cte l9 =
+                Get l9 // { arity: 5 }
+    cte l11 =
+      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+        Get l10 // { arity: 3 }
+    cte l10 =
       Distinct project=[#0..=#2] // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
-          Get l15 // { arity: 6 }
-    cte l8 =
+          Get l17 // { arity: 6 }
+    cte l9 =
       TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
         Project (#0..=#3, #5) // { arity: 5 }
           Filter (#4 = false) // { arity: 6 }
-            Get l15 // { arity: 6 }
-    cte l7 =
+            Get l17 // { arity: 6 }
+    cte l8 =
       Distinct project=[#0{person2id}, #1] // { arity: 2 }
         Union // { arity: 2 }
           Project (#1, #0{person2id}) // { arity: 2 }
             CrossJoin type=differential // { arity: 2 }
               implementation
-                %0:l4[×] » %1[×]
+                %0:l5[×] » %1[×]
               ArrangeBy keys=[[]] // { arity: 2 }
-                Get l4 // { arity: 2 }
+                Get l5 // { arity: 2 }
               ArrangeBy keys=[[]] // { arity: 0 }
                 Union // { arity: 0 }
                   Negate // { arity: 0 }
-                    Get l6 // { arity: 0 }
+                    Get l7 // { arity: 0 }
                   Constant // { arity: 0 }
                     - ()
           Project (#1, #0) // { arity: 2 }
             Map (true, -1) // { arity: 2 }
-              Get l6 // { arity: 0 }
+              Get l7 // { arity: 0 }
           Constant // { arity: 2 }
             - (1450, true)
             - (15393162796819, false)
-    cte l6 =
+    cte l7 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Join on=(#0{person2id} = #1{person2id}) type=differential // { arity: 2 }
             implementation
-              %0:l5[#0]Kf » %1:l5[#0]Kf
+              %0:l6[#0]Kf » %1:l6[#0]Kf
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
               Project (#0{person2id}) // { arity: 1 }
                 Filter #1 // { arity: 2 }
-                  Get l5 // { arity: 2 }
+                  Get l6 // { arity: 2 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
               Project (#0{person2id}) // { arity: 1 }
                 Filter NOT(#1) // { arity: 2 }
-                  Get l5 // { arity: 2 }
-    cte l5 =
+                  Get l6 // { arity: 2 }
+    cte l6 =
       Union // { arity: 2 }
         Project (#1, #0{person2id}) // { arity: 2 }
-          Get l4 // { arity: 2 }
-        Get l7 // { arity: 2 }
-    cte l4 =
+          Get l5 // { arity: 2 }
+        Get l8 // { arity: 2 }
+    cte l5 =
       Project (#1{person2id}, #3) // { arity: 2 }
         Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
           implementation
-            %0:l7[#0]K » %1:l3[#0]K
+            %0:l8[#0]K » %1:l4[#0]K
           ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-            Get l7 // { arity: 2 }
+            Get l8 // { arity: 2 }
           ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
             Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-              Get l3 // { arity: 3 }
-    cte l3 =
+              Get l4 // { arity: 3 }
+    cte l4 =
       Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
         Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
           Union // { arity: 3 }
@@ -2940,36 +2941,30 @@ Explained Query:
                   Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                     Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                       implementation
-                        %1[#1, #0]UKK » %0:l2[greatest(#0, #1), least(#0, #1)]KK
-                      ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                        Get l2 // { arity: 2 }
+                        %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+                      Get l1 // { arity: 2 }
                       ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                         Distinct project=[#0, #1] // { arity: 2 }
                           Project (#2, #3) // { arity: 2 }
-                            Get l1 // { arity: 5 }
-                Get l2 // { arity: 2 }
+                            Get l3 // { arity: 5 }
+                Get l0 // { arity: 2 }
             Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
-              Get l1 // { arity: 5 }
-    cte l2 =
-      Project (#1{person2id}, #2) // { arity: 2 }
-        ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-    cte l1 =
+              Get l3 // { arity: 5 }
+    cte l3 =
       Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
         implementation
-          %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
-        ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-          Project (#1{person2id}, #2) // { arity: 2 }
-            ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+          %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+        Get l1 // { arity: 2 }
         ArrangeBy keys=[[#1, #0]] // { arity: 3 }
           Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
             Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
               Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                 implementation
-                  %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
-                  %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                  %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
-                  %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                  %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                  %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
+                  %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                  %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                  %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                  %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
                 ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
                   ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                 ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
@@ -2980,14 +2975,20 @@ Explained Query:
                   Project (#9, #10, #12) // { arity: 3 }
                     Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                Get l0 // { arity: 1 }
-                Get l0 // { arity: 1 }
-    cte l0 =
+                Get l2 // { arity: 1 }
+                Get l2 // { arity: 1 }
+    cte l2 =
       ArrangeBy keys=[[#0{id}]] // { arity: 1 }
         Distinct project=[#0{id}] // { arity: 1 }
           Project (#1) // { arity: 1 }
             Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
               ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+    cte l1 =
+      ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
+        Get l0 // { arity: 2 }
+    cte l0 =
+      Project (#1{person2id}, #2) // { arity: 2 }
+        ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -3680,43 +3681,43 @@ Explained Query:
     Project (#0{id}..=#2{min}) // { arity: 3 }
       Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
         implementation
-          %1[#0]UK » %0:l2[#2]K
+          %1[#0]UK » %0:l5[#2]K
         ArrangeBy keys=[[#2{min}]] // { arity: 3 }
           Filter (#2{min}) IS NOT NULL // { arity: 3 }
-            Get l2 // { arity: 3 }
+            Get l5 // { arity: 3 }
         ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
           Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
             Reduce aggregates=[min(#0{min})] // { arity: 1 }
               Project (#2) // { arity: 1 }
-                Get l2 // { arity: 3 }
+                Get l5 // { arity: 3 }
   With Mutually Recursive
-    cte l4 =
+    cte l7 =
       Union // { arity: 1 }
-        Get l3 // { arity: 1 }
+        Get l6 // { arity: 1 }
         Map (null) // { arity: 1 }
           Union // { arity: 0 }
             Negate // { arity: 0 }
               Project () // { arity: 0 }
-                Get l3 // { arity: 1 }
+                Get l6 // { arity: 1 }
             Constant // { arity: 0 }
               - ()
-    cte l3 =
+    cte l6 =
       Reduce aggregates=[min(#0{min})] // { arity: 1 }
         Project (#2) // { arity: 1 }
-          Get l2 // { arity: 3 }
-    cte l2 =
+          Get l5 // { arity: 3 }
+    cte l5 =
       Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
         Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
           Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
             implementation
-              %0:l0[#1]K » %1:l1[#1]K
+              %0:l3[#1]K » %1:l4[#1]K
             ArrangeBy keys=[[#1{id}]] // { arity: 3 }
               Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                Get l0 // { arity: 3 }
+                Get l3 // { arity: 3 }
             ArrangeBy keys=[[#1{id}]] // { arity: 3 }
               Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                Get l1 // { arity: 3 }
-    cte l1 =
+                Get l4 // { arity: 3 }
+    cte l4 =
       TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
         Union // { arity: 3 }
           Project (#1{id}, #1{id}, #12) // { arity: 3 }
@@ -3727,27 +3728,15 @@ Explained Query:
               Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
                 Join on=(#1 = #4{src}) type=delta // { arity: 7 }
                   implementation
-                    %0:l1 » %2:pathq19[#0]KA » %1[×]
-                    %1 » %0:l1[×] » %2:pathq19[#0]KA
-                    %2:pathq19 » %0:l1[#1]K » %1[×]
+                    %0:l4 » %2:l2[#0]KA » %1:l1[×]
+                    %1:l1 » %0:l4[×] » %2:l2[#0]KA
+                    %2:l2 » %0:l4[#1]K » %1:l1[×]
                   ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
                     Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                      Get l1 // { arity: 3 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    Union // { arity: 1 }
-                      Project (#1) // { arity: 1 }
-                        Map ((#0 / 2)) // { arity: 2 }
-                          Get l4 // { arity: 1 }
-                      Map (null) // { arity: 1 }
-                        Union // { arity: 0 }
-                          Negate // { arity: 0 }
-                            Project () // { arity: 0 }
-                              Get l4 // { arity: 1 }
-                          Constant // { arity: 0 }
-                            - ()
-                  ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-                    ReadIndex on=pathq19 pathq19_src=[delta join lookup] // { arity: 3 }
-    cte l0 =
+                      Get l4 // { arity: 3 }
+                  Get l1 // { arity: 1 }
+                  Get l2 // { arity: 3 }
+    cte l3 =
       TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
         Union // { arity: 3 }
           Project (#1{id}, #1{id}, #12) // { arity: 3 }
@@ -3758,26 +3747,33 @@ Explained Query:
               Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
                 Join on=(#1 = #4{src}) type=delta // { arity: 7 }
                   implementation
-                    %0:l0 » %2:pathq19[#0]KA » %1[×]
-                    %1 » %0:l0[×] » %2:pathq19[#0]KA
-                    %2:pathq19 » %0:l0[#1]K » %1[×]
+                    %0:l3 » %2:l2[#0]KA » %1:l1[×]
+                    %1:l1 » %0:l3[×] » %2:l2[#0]KA
+                    %2:l2 » %0:l3[#1]K » %1:l1[×]
                   ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
                     Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                      Get l0 // { arity: 3 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    Union // { arity: 1 }
-                      Project (#1) // { arity: 1 }
-                        Map ((#0 / 2)) // { arity: 2 }
-                          Get l4 // { arity: 1 }
-                      Map (null) // { arity: 1 }
-                        Union // { arity: 0 }
-                          Negate // { arity: 0 }
-                            Project () // { arity: 0 }
-                              Get l4 // { arity: 1 }
-                          Constant // { arity: 0 }
-                            - ()
-                  ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-                    ReadIndex on=pathq19 pathq19_src=[delta join lookup] // { arity: 3 }
+                      Get l3 // { arity: 3 }
+                  Get l1 // { arity: 1 }
+                  Get l2 // { arity: 3 }
+    cte l2 =
+      ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+        ReadIndex on=pathq19 pathq19_src=[delta join lookup] // { arity: 3 }
+    cte l1 =
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Union // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Map ((#0 / 2)) // { arity: 2 }
+              Get l7 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l7 // { arity: 1 }
+              Constant // { arity: 0 }
+                - ()
+    cte l0 =
+      ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
+        ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -4448,47 +4444,47 @@ Explained Query:
         Project (#0{personid}, #1{min}) // { arity: 2 }
           Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
             implementation
-              %1[#0]UK » %0:l11[#1]K
+              %1[#0]UK » %0:l14[#1]K
             ArrangeBy keys=[[#1{min}]] // { arity: 2 }
               Filter (#1{min}) IS NOT NULL // { arity: 2 }
-                Get l11 // { arity: 2 }
+                Get l14 // { arity: 2 }
             ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
               Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
                 Reduce aggregates=[min(#0{min})] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Get l11 // { arity: 2 }
+                    Get l14 // { arity: 2 }
       With
-        cte l11 =
+        cte l14 =
           Project (#1{min}, #2) // { arity: 2 }
             Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0{personid}, #2{personid}, #3, #5) // { arity: 4 }
                 Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
                   implementation
-                    %0:l10[#1]Kef » %1:l10[#1]Kef
+                    %0:l13[#1]Kef » %1:l13[#1]Kef
                   ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
                     Project (#1{personid}..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
-                        Get l10 // { arity: 4 }
+                        Get l13 // { arity: 4 }
                   ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
                     Project (#1{personid}..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
-                        Get l10 // { arity: 4 }
-        cte l10 =
+                        Get l13 // { arity: 4 }
+        cte l13 =
           Project (#0..=#3) // { arity: 4 }
             Join on=(#4 = #5{max}) type=differential // { arity: 6 }
               implementation
-                %1[#0]UK » %0:l9[#4]K
+                %1[#0]UK » %0:l12[#4]K
               ArrangeBy keys=[[#4]] // { arity: 5 }
                 Project (#0..=#3, #5) // { arity: 5 }
                   Filter (#5) IS NOT NULL // { arity: 6 }
-                    Get l9 // { arity: 6 }
+                    Get l12 // { arity: 6 }
               ArrangeBy keys=[[#0{max}]] // { arity: 1 }
                 Filter (#0{max}) IS NOT NULL // { arity: 1 }
                   Reduce aggregates=[max(#0)] // { arity: 1 }
                     Project (#5) // { arity: 1 }
-                      Get l9 // { arity: 6 }
+                      Get l12 // { arity: 6 }
     With Mutually Recursive
-      cte l9 =
+      cte l12 =
         Distinct project=[#0..=#5] // { arity: 6 }
           Union // { arity: 6 }
             Project (#0..=#2{personid}, #4, #3, #5) // { arity: 6 }
@@ -4497,145 +4493,143 @@ Explained Query:
                   Union // { arity: 3 }
                     Project (#1, #0, #0) // { arity: 3 }
                       Map (10995116285979, false) // { arity: 2 }
-                        Get l8 // { arity: 0 }
+                        Get l11 // { arity: 0 }
                     Project (#1{personid}, #0, #0) // { arity: 3 }
                       Map (true) // { arity: 2 }
                         CrossJoin type=differential // { arity: 1 }
                           implementation
-                            %1:l8[×]U » %0:l0[×]
+                            %1:l11[×]U » %0:l0[×]
                           ArrangeBy keys=[[]] // { arity: 1 }
                             Get l0 // { arity: 1 }
                           ArrangeBy keys=[[]] // { arity: 0 }
-                            Get l8 // { arity: 0 }
+                            Get l11 // { arity: 0 }
             Project (#0..=#3, #7, #8) // { arity: 6 }
               Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
                 CrossJoin type=delta // { arity: 7 }
                   implementation
-                    %0:l5 » %1[×]U » %2[×]U
-                    %1 » %2[×]U » %0:l5[×]
-                    %2 » %1[×]U » %0:l5[×]
+                    %0:l8 » %1[×]U » %2[×]U
+                    %1 » %2[×]U » %0:l8[×]
+                    %2 » %1[×]U » %0:l8[×]
                   ArrangeBy keys=[[]] // { arity: 5 }
-                    Get l5 // { arity: 5 }
+                    Get l8 // { arity: 5 }
                   ArrangeBy keys=[[]] // { arity: 1 }
                     TopK limit=1 // { arity: 1 }
                       Project (#4) // { arity: 1 }
-                        Get l2 // { arity: 5 }
+                        Get l4 // { arity: 5 }
                   ArrangeBy keys=[[]] // { arity: 1 }
                     Union // { arity: 1 }
-                      Get l7 // { arity: 1 }
+                      Get l10 // { arity: 1 }
                       Map (null) // { arity: 1 }
                         Union // { arity: 0 }
                           Negate // { arity: 0 }
                             Project () // { arity: 0 }
-                              Get l7 // { arity: 1 }
+                              Get l10 // { arity: 1 }
                           Constant // { arity: 0 }
                             - ()
-      cte l8 =
+      cte l11 =
         Distinct project=[] // { arity: 0 }
           Project () // { arity: 0 }
             Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
               implementation
-                %0:l1[#0]UK » %1:l0[#0]K
+                %0:l3[#0]UK » %1:l2[#0]K
               ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                Get l1 // { arity: 1 }
-              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
-                Get l0 // { arity: 1 }
-      cte l7 =
+                Get l3 // { arity: 1 }
+              Get l2 // { arity: 1 }
+      cte l10 =
         Project (#1) // { arity: 1 }
           Map ((#0{min} / 2)) // { arity: 2 }
             Union // { arity: 1 }
-              Get l6 // { arity: 1 }
+              Get l9 // { arity: 1 }
               Map (null) // { arity: 1 }
                 Union // { arity: 0 }
                   Negate // { arity: 0 }
                     Project () // { arity: 0 }
-                      Get l6 // { arity: 1 }
+                      Get l9 // { arity: 1 }
                   Constant // { arity: 0 }
                     - ()
-      cte l6 =
+      cte l9 =
         Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
           Project (#1, #3) // { arity: 2 }
             Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
               implementation
-                %0:l5[#0]Kef » %1:l5[#0]Kef
+                %0:l8[#0]Kef » %1:l8[#0]Kef
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
                   Filter (#0 = false) // { arity: 5 }
-                    Get l5 // { arity: 5 }
+                    Get l8 // { arity: 5 }
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
                   Filter (#0 = true) // { arity: 5 }
-                    Get l5 // { arity: 5 }
-      cte l5 =
+                    Get l8 // { arity: 5 }
+      cte l8 =
         TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
           Union // { arity: 5 }
             Project (#3, #4, #1, #7, #8) // { arity: 5 }
               Map ((#6 + integer_to_bigint(#2{w})), false) // { arity: 9 }
                 Join on=(#0{src} = #5) type=differential // { arity: 7 }
                   implementation
-                    %0:pathq20[#0]KA » %1:l2[#2]K
-                  ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-                    ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
+                    %0:l1[#0]KA » %1:l4[#2]K
+                  Get l1 // { arity: 3 }
                   ArrangeBy keys=[[#2]] // { arity: 4 }
                     Project (#0..=#3) // { arity: 4 }
-                      Get l2 // { arity: 5 }
+                      Get l4 // { arity: 5 }
             Project (#0..=#3, #9) // { arity: 5 }
               Map ((#4 OR #8)) // { arity: 10 }
                 Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
                   implementation
-                    %0:l9[#0..=#2]KKK » %1[#0..=#2]KKK
+                    %0:l12[#0..=#2]KKK » %1[#0..=#2]KKK
                   ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
                     Project (#0..=#4) // { arity: 5 }
-                      Get l9 // { arity: 6 }
+                      Get l12 // { arity: 6 }
                   ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                     Union // { arity: 4 }
                       Map (true) // { arity: 4 }
-                        Get l4 // { arity: 3 }
+                        Get l7 // { arity: 3 }
                       Project (#0..=#2, #6) // { arity: 4 }
                         Map (false) // { arity: 7 }
                           Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                             implementation
-                              %1:l3[#0..=#2]UKKK » %0[#0..=#2]KKK
+                              %1:l6[#0..=#2]UKKK » %0[#0..=#2]KKK
                             ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                               Union // { arity: 3 }
                                 Negate // { arity: 3 }
-                                  Get l4 // { arity: 3 }
-                                Get l3 // { arity: 3 }
-                            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                              Get l3 // { arity: 3 }
-      cte l4 =
+                                  Get l7 // { arity: 3 }
+                                Get l5 // { arity: 3 }
+                            Get l6 // { arity: 3 }
+      cte l7 =
         Project (#0..=#2) // { arity: 3 }
           Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
             implementation
-              %1[#0..=#2]UKKKA » %0:l3[#0..=#2]UKKK
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Get l3 // { arity: 3 }
+              %1[#0..=#2]UKKKA » %0:l6[#0..=#2]UKKK
+            Get l6 // { arity: 3 }
             ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
               Distinct project=[#0..=#2] // { arity: 3 }
                 Project (#0..=#2) // { arity: 3 }
-                  Get l2 // { arity: 5 }
-      cte l3 =
+                  Get l4 // { arity: 5 }
+      cte l6 =
+        ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+          Get l5 // { arity: 3 }
+      cte l5 =
         Distinct project=[#0..=#2] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
-            Get l9 // { arity: 6 }
-      cte l2 =
+            Get l12 // { arity: 6 }
+      cte l4 =
         TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
           Project (#0..=#3, #5) // { arity: 5 }
             Filter (#4 = false) // { arity: 6 }
-              Get l9 // { arity: 6 }
-      cte l1 =
+              Get l12 // { arity: 6 }
+      cte l3 =
         Distinct project=[#0{dst}] // { arity: 1 }
           Union // { arity: 1 }
             Project (#2) // { arity: 1 }
               Join on=(#0 = #1{src}) type=delta // { arity: 4 }
                 implementation
-                  %0:l1 » %1:pathq20[#0]KA » %2[×]
-                  %1:pathq20 » %0:l1[#0]UK » %2[×]
-                  %2 » %0:l1[×] » %1:pathq20[#0]KA
+                  %0:l3 » %1:l1[#0]KA » %2[×]
+                  %1:l1 » %0:l3[#0]UK » %2[×]
+                  %2 » %0:l3[×] » %1:l1[#0]KA
                 ArrangeBy keys=[[], [#0{dst}]] // { arity: 1 }
-                  Get l1 // { arity: 1 }
-                ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-                  ReadIndex on=pathq20 pathq20_src=[delta join lookup] // { arity: 3 }
+                  Get l3 // { arity: 1 }
+                Get l1 // { arity: 3 }
                 ArrangeBy keys=[[]] // { arity: 0 }
                   Union // { arity: 0 }
                     Negate // { arity: 0 }
@@ -4643,15 +4637,20 @@ Explained Query:
                         Project () // { arity: 0 }
                           Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
                             implementation
-                              %0:l1[#0]UK » %1:l0[#0]K
+                              %0:l3[#0]UK » %1:l2[#0]K
                             ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                              Get l1 // { arity: 1 }
-                            ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
-                              Get l0 // { arity: 1 }
+                              Get l3 // { arity: 1 }
+                            Get l2 // { arity: 1 }
                     Constant // { arity: 0 }
                       - ()
             Constant // { arity: 1 }
               - (10995116285979)
+      cte l2 =
+        ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+          Get l0 // { arity: 1 }
+      cte l1 =
+        ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+          ReadIndex on=pathq20 pathq20_src=[differential join, delta join lookup] // { arity: 3 }
       cte l0 =
         Project (#1) // { arity: 1 }
           Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -2527,9 +2527,9 @@ Explained Query:
     Return // { arity: 3 }
       Project (#1{min}, #2{min}, #2{min}) // { arity: 3 }
         Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
-          Get l3 // { arity: 3 }
+          Get l4 // { arity: 3 }
     With Mutually Recursive
-      cte l3 =
+      cte l4 =
         Project (#2{min}, #0, #1{person2id}) // { arity: 3 }
           Map (1450) // { arity: 3 }
             Reduce group_by=[#0{person2id}] aggregates=[min(#1)] // { arity: 2 }
@@ -2539,10 +2539,10 @@ Explained Query:
                     Map ((#1 + #4)) // { arity: 6 }
                       Join on=(#0 = #2{person1id}) type=differential // { arity: 5 }
                         implementation
-                          %0:l3[#0]UK » %1[#0]K
+                          %0:l4[#0]UK » %1[#0]K
                         ArrangeBy keys=[[#0]] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
-                            Get l3 // { arity: 3 }
+                            Get l4 // { arity: 3 }
                         ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
                           Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
                             Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
@@ -2553,38 +2553,32 @@ Explained Query:
                                       Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                                         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                                           implementation
-                                            %1[#1, #0]UKK » %0:l2[greatest(#0, #1), least(#0, #1)]KK
-                                          ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                                            Get l2 // { arity: 2 }
+                                            %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+                                          Get l1 // { arity: 2 }
                                           ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                                             Distinct project=[#0, #1] // { arity: 2 }
                                               Project (#2, #3) // { arity: 2 }
-                                                Get l1 // { arity: 5 }
-                                    Get l2 // { arity: 2 }
+                                                Get l3 // { arity: 5 }
+                                    Get l0 // { arity: 2 }
                                 Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
-                                  Get l1 // { arity: 5 }
+                                  Get l3 // { arity: 5 }
                   Constant // { arity: 2 }
                     - (1450, 0)
-      cte l2 =
-        Project (#1{person2id}, #2) // { arity: 2 }
-          ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-      cte l1 =
+      cte l3 =
         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
           implementation
-            %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
-          ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-            Project (#1{person2id}, #2) // { arity: 2 }
-              ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+            %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+          Get l1 // { arity: 2 }
           ArrangeBy keys=[[#1, #0]] // { arity: 3 }
             Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
               Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
                 Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                   implementation
-                    %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
-                    %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                    %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
-                    %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                    %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                    %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                    %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
                   ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
                     ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                   ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
@@ -2595,14 +2589,20 @@ Explained Query:
                     Project (#9, #10, #12) // { arity: 3 }
                       Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                         ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                  Get l0 // { arity: 1 }
-                  Get l0 // { arity: 1 }
-      cte l0 =
+                  Get l2 // { arity: 1 }
+                  Get l2 // { arity: 1 }
+      cte l2 =
         ArrangeBy keys=[[#0{id}]] // { arity: 1 }
           Distinct project=[#0{id}] // { arity: 1 }
             Project (#1) // { arity: 1 }
               Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                 ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+      cte l1 =
+        ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
+          Get l0 // { arity: 2 }
+      cte l0 =
+        Project (#1{person2id}, #2) // { arity: 2 }
+          ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -2726,218 +2726,219 @@ Explained Query:
       Project (#1) // { arity: 1 }
         Map (coalesce(#0{min_min}, -1)) // { arity: 2 }
           Union // { arity: 1 }
-            Get l17 // { arity: 1 }
+            Get l19 // { arity: 1 }
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
                   Project () // { arity: 0 }
-                    Get l17 // { arity: 1 }
+                    Get l19 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
     With
-      cte l17 =
+      cte l19 =
         Reduce aggregates=[min(#0{min})] // { arity: 1 }
           Project (#2) // { arity: 1 }
             Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0, #2, #3, #5) // { arity: 4 }
                 Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
                   implementation
-                    %0:l16[#1]Kef » %1:l16[#1]Kef
+                    %0:l18[#1]Kef » %1:l18[#1]Kef
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
                     Project (#1{person2id}..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
-                        Get l16 // { arity: 4 }
+                        Get l18 // { arity: 4 }
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
                     Project (#1{person2id}..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
-                        Get l16 // { arity: 4 }
-      cte l16 =
+                        Get l18 // { arity: 4 }
+      cte l18 =
         Project (#0..=#3) // { arity: 4 }
           Join on=(#4 = #5{max}) type=differential // { arity: 6 }
             implementation
-              %1[#0]UK » %0:l15[#4]K
+              %1[#0]UK » %0:l17[#4]K
             ArrangeBy keys=[[#4]] // { arity: 5 }
               Project (#0..=#3, #5) // { arity: 5 }
                 Filter (#5) IS NOT NULL // { arity: 6 }
-                  Get l15 // { arity: 6 }
+                  Get l17 // { arity: 6 }
             ArrangeBy keys=[[#0{max}]] // { arity: 1 }
               Filter (#0{max}) IS NOT NULL // { arity: 1 }
                 Reduce aggregates=[max(#0)] // { arity: 1 }
                   Project (#5) // { arity: 1 }
-                    Get l15 // { arity: 6 }
+                    Get l17 // { arity: 6 }
   With Mutually Recursive
-    cte l15 =
+    cte l17 =
       Distinct project=[#0..=#5] // { arity: 6 }
         Union // { arity: 6 }
           Project (#1, #0, #0, #2..=#4) // { arity: 6 }
             Map (0, false, 0) // { arity: 5 }
               Union // { arity: 2 }
                 Map (1450, false) // { arity: 2 }
-                  Get l14 // { arity: 0 }
+                  Get l16 // { arity: 0 }
                 Map (15393162796819, true) // { arity: 2 }
-                  Get l14 // { arity: 0 }
+                  Get l16 // { arity: 0 }
           Project (#0..=#3, #7, #8) // { arity: 6 }
             Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
               CrossJoin type=delta // { arity: 7 }
                 implementation
-                  %0:l11 » %1[×]U » %2[×]U
-                  %1 » %2[×]U » %0:l11[×]
-                  %2 » %1[×]U » %0:l11[×]
+                  %0:l13 » %1[×]U » %2[×]U
+                  %1 » %2[×]U » %0:l13[×]
+                  %2 » %1[×]U » %0:l13[×]
                 ArrangeBy keys=[[]] // { arity: 5 }
-                  Get l11 // { arity: 5 }
+                  Get l13 // { arity: 5 }
                 ArrangeBy keys=[[]] // { arity: 1 }
                   TopK limit=1 // { arity: 1 }
                     Project (#4) // { arity: 1 }
-                      Get l8 // { arity: 5 }
+                      Get l9 // { arity: 5 }
                 ArrangeBy keys=[[]] // { arity: 1 }
                   Union // { arity: 1 }
-                    Get l13 // { arity: 1 }
+                    Get l15 // { arity: 1 }
                     Map (null) // { arity: 1 }
                       Union // { arity: 0 }
                         Negate // { arity: 0 }
                           Project () // { arity: 0 }
-                            Get l13 // { arity: 1 }
+                            Get l15 // { arity: 1 }
                         Constant // { arity: 0 }
                           - ()
-    cte l14 =
+    cte l16 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Filter #1 AND (#0{person2id} = -1) // { arity: 2 }
-            Get l7 // { arity: 2 }
-    cte l13 =
+            Get l8 // { arity: 2 }
+    cte l15 =
       Project (#1) // { arity: 1 }
         Map ((#0{min} / 2)) // { arity: 2 }
           Union // { arity: 1 }
-            Get l12 // { arity: 1 }
+            Get l14 // { arity: 1 }
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
                   Project () // { arity: 0 }
-                    Get l12 // { arity: 1 }
+                    Get l14 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
-    cte l12 =
+    cte l14 =
       Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
         Project (#1, #3) // { arity: 2 }
           Join on=(#0{person2id} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %0:l11[#0]Kef » %1:l11[#0]Kef
+              %0:l13[#0]Kef » %1:l13[#0]Kef
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = false) // { arity: 5 }
-                  Get l11 // { arity: 5 }
+                  Get l13 // { arity: 5 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = true) // { arity: 5 }
-                  Get l11 // { arity: 5 }
-    cte l11 =
+                  Get l13 // { arity: 5 }
+    cte l13 =
       TopK group_by=[#0, #1, #2{person2id}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
         Union // { arity: 5 }
           Project (#3, #4, #1, #7, #8) // { arity: 5 }
             Map ((#6 + #2), false) // { arity: 9 }
               Join on=(#0{person1id} = #5) type=differential // { arity: 7 }
                 implementation
-                  %0:l3[#0]K » %1:l8[#2]K
+                  %0:l4[#0]K » %1:l9[#2]K
                 ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
-                  Get l3 // { arity: 3 }
+                  Get l4 // { arity: 3 }
                 ArrangeBy keys=[[#2]] // { arity: 4 }
                   Project (#0..=#3) // { arity: 4 }
-                    Get l8 // { arity: 5 }
+                    Get l9 // { arity: 5 }
           Project (#0..=#3, #9) // { arity: 5 }
             Map ((#4 OR #8)) // { arity: 10 }
               Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
                 implementation
-                  %0:l15[#0..=#2]KKK » %1[#0..=#2]KKK
+                  %0:l17[#0..=#2]KKK » %1[#0..=#2]KKK
                 ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
                   Project (#0..=#4) // { arity: 5 }
-                    Get l15 // { arity: 6 }
+                    Get l17 // { arity: 6 }
                 ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                   Union // { arity: 4 }
                     Map (true) // { arity: 4 }
-                      Get l10 // { arity: 3 }
+                      Get l12 // { arity: 3 }
                     Project (#0..=#2, #6) // { arity: 4 }
                       Map (false) // { arity: 7 }
                         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                           implementation
-                            %1:l9[#0..=#2]UKKK » %0[#0..=#2]KKK
+                            %1:l11[#0..=#2]UKKK » %0[#0..=#2]KKK
                           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                             Union // { arity: 3 }
                               Negate // { arity: 3 }
-                                Get l10 // { arity: 3 }
-                              Get l9 // { arity: 3 }
-                          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                            Get l9 // { arity: 3 }
-    cte l10 =
+                                Get l12 // { arity: 3 }
+                              Get l10 // { arity: 3 }
+                          Get l11 // { arity: 3 }
+    cte l12 =
       Project (#0..=#2) // { arity: 3 }
         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
           implementation
-            %1[#0..=#2]UKKKA » %0:l9[#0..=#2]UKKK
-          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-            Get l9 // { arity: 3 }
+            %1[#0..=#2]UKKKA » %0:l11[#0..=#2]UKKK
+          Get l11 // { arity: 3 }
           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
             Distinct project=[#0..=#2] // { arity: 3 }
               Project (#0..=#2) // { arity: 3 }
-                Get l8 // { arity: 5 }
-    cte l9 =
+                Get l9 // { arity: 5 }
+    cte l11 =
+      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+        Get l10 // { arity: 3 }
+    cte l10 =
       Distinct project=[#0..=#2] // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
-          Get l15 // { arity: 6 }
-    cte l8 =
+          Get l17 // { arity: 6 }
+    cte l9 =
       TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
         Project (#0..=#3, #5) // { arity: 5 }
           Filter (#4 = false) // { arity: 6 }
-            Get l15 // { arity: 6 }
-    cte l7 =
+            Get l17 // { arity: 6 }
+    cte l8 =
       Distinct project=[#0{person2id}, #1] // { arity: 2 }
         Union // { arity: 2 }
           Project (#1, #0{person2id}) // { arity: 2 }
             CrossJoin type=differential // { arity: 2 }
               implementation
-                %0:l4[×] » %1[×]
+                %0:l5[×] » %1[×]
               ArrangeBy keys=[[]] // { arity: 2 }
-                Get l4 // { arity: 2 }
+                Get l5 // { arity: 2 }
               ArrangeBy keys=[[]] // { arity: 0 }
                 Union // { arity: 0 }
                   Negate // { arity: 0 }
-                    Get l6 // { arity: 0 }
+                    Get l7 // { arity: 0 }
                   Constant // { arity: 0 }
                     - ()
           Project (#1, #0) // { arity: 2 }
             Map (true, -1) // { arity: 2 }
-              Get l6 // { arity: 0 }
+              Get l7 // { arity: 0 }
           Constant // { arity: 2 }
             - (1450, true)
             - (15393162796819, false)
-    cte l6 =
+    cte l7 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Join on=(#0{person2id} = #1{person2id}) type=differential // { arity: 2 }
             implementation
-              %0:l5[#0]Kf » %1:l5[#0]Kf
+              %0:l6[#0]Kf » %1:l6[#0]Kf
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
               Project (#0{person2id}) // { arity: 1 }
                 Filter #1 // { arity: 2 }
-                  Get l5 // { arity: 2 }
+                  Get l6 // { arity: 2 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
               Project (#0{person2id}) // { arity: 1 }
                 Filter NOT(#1) // { arity: 2 }
-                  Get l5 // { arity: 2 }
-    cte l5 =
+                  Get l6 // { arity: 2 }
+    cte l6 =
       Union // { arity: 2 }
         Project (#1, #0{person2id}) // { arity: 2 }
-          Get l4 // { arity: 2 }
-        Get l7 // { arity: 2 }
-    cte l4 =
+          Get l5 // { arity: 2 }
+        Get l8 // { arity: 2 }
+    cte l5 =
       Project (#1{person2id}, #3) // { arity: 2 }
         Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
           implementation
-            %0:l7[#0]K » %1:l3[#0]K
+            %0:l8[#0]K » %1:l4[#0]K
           ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-            Get l7 // { arity: 2 }
+            Get l8 // { arity: 2 }
           ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
             Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-              Get l3 // { arity: 3 }
-    cte l3 =
+              Get l4 // { arity: 3 }
+    cte l4 =
       Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
         Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
           Union // { arity: 3 }
@@ -2947,36 +2948,30 @@ Explained Query:
                   Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                     Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                       implementation
-                        %1[#1, #0]UKK » %0:l2[greatest(#0, #1), least(#0, #1)]KK
-                      ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                        Get l2 // { arity: 2 }
+                        %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+                      Get l1 // { arity: 2 }
                       ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                         Distinct project=[#0, #1] // { arity: 2 }
                           Project (#2, #3) // { arity: 2 }
-                            Get l1 // { arity: 5 }
-                Get l2 // { arity: 2 }
+                            Get l3 // { arity: 5 }
+                Get l0 // { arity: 2 }
             Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
-              Get l1 // { arity: 5 }
-    cte l2 =
-      Project (#1{person2id}, #2) // { arity: 2 }
-        ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-    cte l1 =
+              Get l3 // { arity: 5 }
+    cte l3 =
       Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
         implementation
-          %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
-        ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-          Project (#1{person2id}, #2) // { arity: 2 }
-            ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+          %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+        Get l1 // { arity: 2 }
         ArrangeBy keys=[[#1, #0]] // { arity: 3 }
           Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
             Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
               Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                 implementation
-                  %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
-                  %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                  %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
-                  %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                  %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                  %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
+                  %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                  %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                  %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                  %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
                 ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
                   ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                 ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
@@ -2987,14 +2982,20 @@ Explained Query:
                   Project (#9, #10, #12) // { arity: 3 }
                     Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                Get l0 // { arity: 1 }
-                Get l0 // { arity: 1 }
-    cte l0 =
+                Get l2 // { arity: 1 }
+                Get l2 // { arity: 1 }
+    cte l2 =
       ArrangeBy keys=[[#0{id}]] // { arity: 1 }
         Distinct project=[#0{id}] // { arity: 1 }
           Project (#1) // { arity: 1 }
             Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
               ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+    cte l1 =
+      ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
+        Get l0 // { arity: 2 }
+    cte l0 =
+      Project (#1{person2id}, #2) // { arity: 2 }
+        ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -3687,43 +3688,43 @@ Explained Query:
     Project (#0{id}..=#2{min}) // { arity: 3 }
       Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
         implementation
-          %1[#0]UK » %0:l2[#2]K
+          %1[#0]UK » %0:l5[#2]K
         ArrangeBy keys=[[#2{min}]] // { arity: 3 }
           Filter (#2{min}) IS NOT NULL // { arity: 3 }
-            Get l2 // { arity: 3 }
+            Get l5 // { arity: 3 }
         ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
           Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
             Reduce aggregates=[min(#0{min})] // { arity: 1 }
               Project (#2) // { arity: 1 }
-                Get l2 // { arity: 3 }
+                Get l5 // { arity: 3 }
   With Mutually Recursive
-    cte l4 =
+    cte l7 =
       Union // { arity: 1 }
-        Get l3 // { arity: 1 }
+        Get l6 // { arity: 1 }
         Map (null) // { arity: 1 }
           Union // { arity: 0 }
             Negate // { arity: 0 }
               Project () // { arity: 0 }
-                Get l3 // { arity: 1 }
+                Get l6 // { arity: 1 }
             Constant // { arity: 0 }
               - ()
-    cte l3 =
+    cte l6 =
       Reduce aggregates=[min(#0{min})] // { arity: 1 }
         Project (#2) // { arity: 1 }
-          Get l2 // { arity: 3 }
-    cte l2 =
+          Get l5 // { arity: 3 }
+    cte l5 =
       Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
         Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
           Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
             implementation
-              %0:l0[#1]K » %1:l1[#1]K
+              %0:l3[#1]K » %1:l4[#1]K
             ArrangeBy keys=[[#1{id}]] // { arity: 3 }
               Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                Get l0 // { arity: 3 }
+                Get l3 // { arity: 3 }
             ArrangeBy keys=[[#1{id}]] // { arity: 3 }
               Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                Get l1 // { arity: 3 }
-    cte l1 =
+                Get l4 // { arity: 3 }
+    cte l4 =
       TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
         Union // { arity: 3 }
           Project (#1{id}, #1{id}, #12) // { arity: 3 }
@@ -3734,27 +3735,15 @@ Explained Query:
               Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
                 Join on=(#1 = #4{src}) type=delta // { arity: 7 }
                   implementation
-                    %0:l1 » %2:pathq19[#0]KA » %1[×]
-                    %1 » %0:l1[×] » %2:pathq19[#0]KA
-                    %2:pathq19 » %0:l1[#1]K » %1[×]
+                    %0:l4 » %2:l2[#0]KA » %1:l1[×]
+                    %1:l1 » %0:l4[×] » %2:l2[#0]KA
+                    %2:l2 » %0:l4[#1]K » %1:l1[×]
                   ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
                     Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                      Get l1 // { arity: 3 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    Union // { arity: 1 }
-                      Project (#1) // { arity: 1 }
-                        Map ((#0 / 2)) // { arity: 2 }
-                          Get l4 // { arity: 1 }
-                      Map (null) // { arity: 1 }
-                        Union // { arity: 0 }
-                          Negate // { arity: 0 }
-                            Project () // { arity: 0 }
-                              Get l4 // { arity: 1 }
-                          Constant // { arity: 0 }
-                            - ()
-                  ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-                    ReadIndex on=pathq19 pathq19_src=[delta join lookup] // { arity: 3 }
-    cte l0 =
+                      Get l4 // { arity: 3 }
+                  Get l1 // { arity: 1 }
+                  Get l2 // { arity: 3 }
+    cte l3 =
       TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
         Union // { arity: 3 }
           Project (#1{id}, #1{id}, #12) // { arity: 3 }
@@ -3765,26 +3754,33 @@ Explained Query:
               Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
                 Join on=(#1 = #4{src}) type=delta // { arity: 7 }
                   implementation
-                    %0:l0 » %2:pathq19[#0]KA » %1[×]
-                    %1 » %0:l0[×] » %2:pathq19[#0]KA
-                    %2:pathq19 » %0:l0[#1]K » %1[×]
+                    %0:l3 » %2:l2[#0]KA » %1:l1[×]
+                    %1:l1 » %0:l3[×] » %2:l2[#0]KA
+                    %2:l2 » %0:l3[#1]K » %1:l1[×]
                   ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
                     Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                      Get l0 // { arity: 3 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    Union // { arity: 1 }
-                      Project (#1) // { arity: 1 }
-                        Map ((#0 / 2)) // { arity: 2 }
-                          Get l4 // { arity: 1 }
-                      Map (null) // { arity: 1 }
-                        Union // { arity: 0 }
-                          Negate // { arity: 0 }
-                            Project () // { arity: 0 }
-                              Get l4 // { arity: 1 }
-                          Constant // { arity: 0 }
-                            - ()
-                  ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-                    ReadIndex on=pathq19 pathq19_src=[delta join lookup] // { arity: 3 }
+                      Get l3 // { arity: 3 }
+                  Get l1 // { arity: 1 }
+                  Get l2 // { arity: 3 }
+    cte l2 =
+      ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+        ReadIndex on=pathq19 pathq19_src=[delta join lookup] // { arity: 3 }
+    cte l1 =
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Union // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Map ((#0 / 2)) // { arity: 2 }
+              Get l7 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l7 // { arity: 1 }
+              Constant // { arity: 0 }
+                - ()
+    cte l0 =
+      ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
+        ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -4455,47 +4451,47 @@ Explained Query:
         Project (#0{personid}, #1{min}) // { arity: 2 }
           Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
             implementation
-              %1[#0]UK » %0:l11[#1]K
+              %1[#0]UK » %0:l14[#1]K
             ArrangeBy keys=[[#1{min}]] // { arity: 2 }
               Filter (#1{min}) IS NOT NULL // { arity: 2 }
-                Get l11 // { arity: 2 }
+                Get l14 // { arity: 2 }
             ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
               Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
                 Reduce aggregates=[min(#0{min})] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Get l11 // { arity: 2 }
+                    Get l14 // { arity: 2 }
       With
-        cte l11 =
+        cte l14 =
           Project (#1{min}, #2) // { arity: 2 }
             Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0{personid}, #2{personid}, #3, #5) // { arity: 4 }
                 Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
                   implementation
-                    %0:l10[#1]Kef » %1:l10[#1]Kef
+                    %0:l13[#1]Kef » %1:l13[#1]Kef
                   ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
                     Project (#1{personid}..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
-                        Get l10 // { arity: 4 }
+                        Get l13 // { arity: 4 }
                   ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
                     Project (#1{personid}..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
-                        Get l10 // { arity: 4 }
-        cte l10 =
+                        Get l13 // { arity: 4 }
+        cte l13 =
           Project (#0..=#3) // { arity: 4 }
             Join on=(#4 = #5{max}) type=differential // { arity: 6 }
               implementation
-                %1[#0]UK » %0:l9[#4]K
+                %1[#0]UK » %0:l12[#4]K
               ArrangeBy keys=[[#4]] // { arity: 5 }
                 Project (#0..=#3, #5) // { arity: 5 }
                   Filter (#5) IS NOT NULL // { arity: 6 }
-                    Get l9 // { arity: 6 }
+                    Get l12 // { arity: 6 }
               ArrangeBy keys=[[#0{max}]] // { arity: 1 }
                 Filter (#0{max}) IS NOT NULL // { arity: 1 }
                   Reduce aggregates=[max(#0)] // { arity: 1 }
                     Project (#5) // { arity: 1 }
-                      Get l9 // { arity: 6 }
+                      Get l12 // { arity: 6 }
     With Mutually Recursive
-      cte l9 =
+      cte l12 =
         Distinct project=[#0..=#5] // { arity: 6 }
           Union // { arity: 6 }
             Project (#0..=#2{personid}, #4, #3, #5) // { arity: 6 }
@@ -4504,145 +4500,143 @@ Explained Query:
                   Union // { arity: 3 }
                     Project (#1, #0, #0) // { arity: 3 }
                       Map (10995116285979, false) // { arity: 2 }
-                        Get l8 // { arity: 0 }
+                        Get l11 // { arity: 0 }
                     Project (#1{personid}, #0, #0) // { arity: 3 }
                       Map (true) // { arity: 2 }
                         CrossJoin type=differential // { arity: 1 }
                           implementation
-                            %1:l8[×]U » %0:l0[×]
+                            %1:l11[×]U » %0:l0[×]
                           ArrangeBy keys=[[]] // { arity: 1 }
                             Get l0 // { arity: 1 }
                           ArrangeBy keys=[[]] // { arity: 0 }
-                            Get l8 // { arity: 0 }
+                            Get l11 // { arity: 0 }
             Project (#0..=#3, #7, #8) // { arity: 6 }
               Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
                 CrossJoin type=delta // { arity: 7 }
                   implementation
-                    %0:l5 » %1[×]U » %2[×]U
-                    %1 » %2[×]U » %0:l5[×]
-                    %2 » %1[×]U » %0:l5[×]
+                    %0:l8 » %1[×]U » %2[×]U
+                    %1 » %2[×]U » %0:l8[×]
+                    %2 » %1[×]U » %0:l8[×]
                   ArrangeBy keys=[[]] // { arity: 5 }
-                    Get l5 // { arity: 5 }
+                    Get l8 // { arity: 5 }
                   ArrangeBy keys=[[]] // { arity: 1 }
                     TopK limit=1 // { arity: 1 }
                       Project (#4) // { arity: 1 }
-                        Get l2 // { arity: 5 }
+                        Get l4 // { arity: 5 }
                   ArrangeBy keys=[[]] // { arity: 1 }
                     Union // { arity: 1 }
-                      Get l7 // { arity: 1 }
+                      Get l10 // { arity: 1 }
                       Map (null) // { arity: 1 }
                         Union // { arity: 0 }
                           Negate // { arity: 0 }
                             Project () // { arity: 0 }
-                              Get l7 // { arity: 1 }
+                              Get l10 // { arity: 1 }
                           Constant // { arity: 0 }
                             - ()
-      cte l8 =
+      cte l11 =
         Distinct project=[] // { arity: 0 }
           Project () // { arity: 0 }
             Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
               implementation
-                %0:l1[#0]UK » %1:l0[#0]K
+                %0:l3[#0]UK » %1:l2[#0]K
               ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                Get l1 // { arity: 1 }
-              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
-                Get l0 // { arity: 1 }
-      cte l7 =
+                Get l3 // { arity: 1 }
+              Get l2 // { arity: 1 }
+      cte l10 =
         Project (#1) // { arity: 1 }
           Map ((#0{min} / 2)) // { arity: 2 }
             Union // { arity: 1 }
-              Get l6 // { arity: 1 }
+              Get l9 // { arity: 1 }
               Map (null) // { arity: 1 }
                 Union // { arity: 0 }
                   Negate // { arity: 0 }
                     Project () // { arity: 0 }
-                      Get l6 // { arity: 1 }
+                      Get l9 // { arity: 1 }
                   Constant // { arity: 0 }
                     - ()
-      cte l6 =
+      cte l9 =
         Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
           Project (#1, #3) // { arity: 2 }
             Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
               implementation
-                %0:l5[#0]Kef » %1:l5[#0]Kef
+                %0:l8[#0]Kef » %1:l8[#0]Kef
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
                   Filter (#0 = false) // { arity: 5 }
-                    Get l5 // { arity: 5 }
+                    Get l8 // { arity: 5 }
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
                   Filter (#0 = true) // { arity: 5 }
-                    Get l5 // { arity: 5 }
-      cte l5 =
+                    Get l8 // { arity: 5 }
+      cte l8 =
         TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
           Union // { arity: 5 }
             Project (#3, #4, #1, #7, #8) // { arity: 5 }
               Map ((#6 + integer_to_bigint(#2{w})), false) // { arity: 9 }
                 Join on=(#0{src} = #5) type=differential // { arity: 7 }
                   implementation
-                    %0:pathq20[#0]KA » %1:l2[#2]K
-                  ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-                    ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
+                    %0:l1[#0]KA » %1:l4[#2]K
+                  Get l1 // { arity: 3 }
                   ArrangeBy keys=[[#2]] // { arity: 4 }
                     Project (#0..=#3) // { arity: 4 }
-                      Get l2 // { arity: 5 }
+                      Get l4 // { arity: 5 }
             Project (#0..=#3, #9) // { arity: 5 }
               Map ((#4 OR #8)) // { arity: 10 }
                 Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
                   implementation
-                    %0:l9[#0..=#2]KKK » %1[#0..=#2]KKK
+                    %0:l12[#0..=#2]KKK » %1[#0..=#2]KKK
                   ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
                     Project (#0..=#4) // { arity: 5 }
-                      Get l9 // { arity: 6 }
+                      Get l12 // { arity: 6 }
                   ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                     Union // { arity: 4 }
                       Map (true) // { arity: 4 }
-                        Get l4 // { arity: 3 }
+                        Get l7 // { arity: 3 }
                       Project (#0..=#2, #6) // { arity: 4 }
                         Map (false) // { arity: 7 }
                           Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                             implementation
-                              %1:l3[#0..=#2]UKKK » %0[#0..=#2]KKK
+                              %1:l6[#0..=#2]UKKK » %0[#0..=#2]KKK
                             ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                               Union // { arity: 3 }
                                 Negate // { arity: 3 }
-                                  Get l4 // { arity: 3 }
-                                Get l3 // { arity: 3 }
-                            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                              Get l3 // { arity: 3 }
-      cte l4 =
+                                  Get l7 // { arity: 3 }
+                                Get l5 // { arity: 3 }
+                            Get l6 // { arity: 3 }
+      cte l7 =
         Project (#0..=#2) // { arity: 3 }
           Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
             implementation
-              %1[#0..=#2]UKKKA » %0:l3[#0..=#2]UKKK
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Get l3 // { arity: 3 }
+              %1[#0..=#2]UKKKA » %0:l6[#0..=#2]UKKK
+            Get l6 // { arity: 3 }
             ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
               Distinct project=[#0..=#2] // { arity: 3 }
                 Project (#0..=#2) // { arity: 3 }
-                  Get l2 // { arity: 5 }
-      cte l3 =
+                  Get l4 // { arity: 5 }
+      cte l6 =
+        ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+          Get l5 // { arity: 3 }
+      cte l5 =
         Distinct project=[#0..=#2] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
-            Get l9 // { arity: 6 }
-      cte l2 =
+            Get l12 // { arity: 6 }
+      cte l4 =
         TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
           Project (#0..=#3, #5) // { arity: 5 }
             Filter (#4 = false) // { arity: 6 }
-              Get l9 // { arity: 6 }
-      cte l1 =
+              Get l12 // { arity: 6 }
+      cte l3 =
         Distinct project=[#0{dst}] // { arity: 1 }
           Union // { arity: 1 }
             Project (#2) // { arity: 1 }
               Join on=(#0 = #1{src}) type=delta // { arity: 4 }
                 implementation
-                  %0:l1 » %1:pathq20[#0]KA » %2[×]
-                  %1:pathq20 » %0:l1[#0]UK » %2[×]
-                  %2 » %0:l1[×] » %1:pathq20[#0]KA
+                  %0:l3 » %1:l1[#0]KA » %2[×]
+                  %1:l1 » %0:l3[#0]UK » %2[×]
+                  %2 » %0:l3[×] » %1:l1[#0]KA
                 ArrangeBy keys=[[], [#0{dst}]] // { arity: 1 }
-                  Get l1 // { arity: 1 }
-                ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-                  ReadIndex on=pathq20 pathq20_src=[delta join lookup] // { arity: 3 }
+                  Get l3 // { arity: 1 }
+                Get l1 // { arity: 3 }
                 ArrangeBy keys=[[]] // { arity: 0 }
                   Union // { arity: 0 }
                     Negate // { arity: 0 }
@@ -4650,15 +4644,20 @@ Explained Query:
                         Project () // { arity: 0 }
                           Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
                             implementation
-                              %0:l1[#0]UK » %1:l0[#0]K
+                              %0:l3[#0]UK » %1:l2[#0]K
                             ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                              Get l1 // { arity: 1 }
-                            ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
-                              Get l0 // { arity: 1 }
+                              Get l3 // { arity: 1 }
+                            Get l2 // { arity: 1 }
                     Constant // { arity: 0 }
                       - ()
             Constant // { arity: 1 }
               - (10995116285979)
+      cte l2 =
+        ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+          Get l0 // { arity: 1 }
+      cte l1 =
+        ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+          ReadIndex on=pathq20 pathq20_src=[differential join, delta join lookup] // { arity: 3 }
       cte l0 =
         Project (#1) // { arity: 1 }
           Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -1590,26 +1590,27 @@ Explained Query:
       Filter (#0 > 7) // { arity: 2 }
         Get l0 // { arity: 2 }
       Filter (#0 > 7) // { arity: 2 }
-        Get l1 // { arity: 2 }
-      Filter (#0 > 7) // { arity: 2 }
         Get l2 // { arity: 2 }
+      Filter (#0 > 7) // { arity: 2 }
+        Get l3 // { arity: 2 }
   With Mutually Recursive
+    cte l3 =
+      Union // { arity: 2 }
+        Get l1 // { arity: 2 }
+        Get l2 // { arity: 2 }
+        Get l2 // { arity: 2 }
+        Get l3 // { arity: 2 }
+        Get l3 // { arity: 2 }
     cte l2 =
       Union // { arity: 2 }
-        Filter (#1 > 7) // { arity: 2 }
-          Get l0 // { arity: 2 }
-        Get l1 // { arity: 2 }
         Get l1 // { arity: 2 }
         Get l2 // { arity: 2 }
         Get l2 // { arity: 2 }
+        Get l3 // { arity: 2 }
+        Get l3 // { arity: 2 }
     cte l1 =
-      Union // { arity: 2 }
-        Filter (#1 > 7) // { arity: 2 }
-          Get l0 // { arity: 2 }
-        Get l1 // { arity: 2 }
-        Get l1 // { arity: 2 }
-        Get l2 // { arity: 2 }
-        Get l2 // { arity: 2 }
+      Filter (#1 > 7) // { arity: 2 }
+        Get l0 // { arity: 2 }
     cte l0 =
       Union // { arity: 2 }
         ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -1542,11 +1542,6 @@ EOF
 # -------------------------------
 
 # Basic support for recursive queries.
-# Note that some opportunities arising from the appearance of the same
-# sub-expression under different WMR bindings are not exploited at the moment:
-# (1) a Filter (#1 > 7) over l0 appears twice.
-# (2) l2 is equivalent to l5.
-# (3) l1 is not equivalent (although structurally equal) to l4.
 # With materialize#27389 this stopped testing what it says it tests; see issue database-issues#8294.
 query T multiline
 EXPLAIN WITH(arity, join implementations)


### PR DESCRIPTION
Currently, within `LetRec` blocks we only perform relation CSE within each binding. We do not optimize across bindings, nor do we take advantage of bindings outside the `LetRec` region. This PR addresses this with extended code for the `LetRec` case that both references `LetRec`-external bindings, and shares across `LetRec`-internal bindings.

There are some potential gotchas, documented in the code:
1. References to `LetRec` bindings should not be equated across the moment the binding is refreshed. Each binding has a "before" identifier and an "after" identifier, and this is sufficient to avoid unintentionally equating the two.
2. The `body` should not borrow much from within the scope. Although all terms are available for use, the current suffix of the optimizer pipeline goes sideways if this happens. Concretely, `JoinImplementation` ends up surprised about the location of arrangements it thought would certainly exist, but do not. There are some unspecified requirements of `RelationCSE`, and the careful treatment of `body` seems to be necessary (unknown if sufficient).
3. There was some initial concern that various iteration limits would complicate the applicability of CSE, but it seems that all new terms can be treated as if having no iteration limits, and things "just work out" because two terms are equated only if they are exact syntactic matches, which happens only when they depend on the same terms, in which case those terms will have the same limits.

As a demonstration of what can change, these two WMR blocks are merged, and the necessary arrangement of `t` by `b` is shared between the two terms. On `main` that sharing cannot happen, and two identical copies are made.
```sql
create table t(a int, b int);

create view foo as with mutually recursive
foo0 (a int, b int) as (
    select t.a, foo0.b from t, foo0 where t.b = foo0.a 
    union 
    select * from t where t.a > 3
)
select * from foo0;

create view bar as with mutually recursive
bar0 (a int, b int) as (
    select t.a, bar0.b from t, bar0 where t.b = bar0.a 
    union 
    select * from t where t.a > 2
)
select * from bar0;

-- demonstrates re-use of `t` arranged by `b`.
explain select * from foo union select * from bar;
```
this results in a shared term `l0` seen below
```
materialize=> explain select * from foo union select * from bar;
                 Optimized Plan                  
-------------------------------------------------
 Explained Query:                               +
   Return                                       +
     Distinct project=[#0, #1]                  +
       Union                                    +
         Get l1                                 +
         Get l2                                 +
   With Mutually Recursive                      +
     cte l2 =                                   +
       Distinct project=[#0, #1]                +
         Union                                  +
           Project (#0, #3)                     +
             Join on=(#1 = #2) type=differential+
               Get l0                           +
               ArrangeBy keys=[[#0]]            +
                 Filter (#0) IS NOT NULL        +
                   Get l2                       +
           Filter (#0 > 2)                      +
             ReadStorage materialize.public.t   +
     cte l1 =                                   +
       Distinct project=[#0, #1]                +
         Union                                  +
           Project (#0, #3)                     +
             Join on=(#1 = #2) type=differential+
               Get l0                           +
               ArrangeBy keys=[[#0]]            +
                 Filter (#0) IS NOT NULL        +
                   Get l1                       +
           Filter (#0 > 3)                      +
             ReadStorage materialize.public.t   +
     cte l0 =                                   +
       ArrangeBy keys=[[#1]]                    +
         Filter (#1) IS NOT NULL                +
           ReadStorage materialize.public.t     +
                                                +
 Source materialize.public.t                    +
                                                +
 Target cluster: quickstart                     +
 
(1 row)

materialize=> 
```

There is a missed opportunity for further sharing, where loop-invariant structure is common to both `values` and `body`. We could perform more work to hoist all bindings that do not depend on `values` out of `body`, and install those bindings before considering `values`. In some sense, the CSE must be done "outside the scope" in order to avoid the peril of `body` depending on terms that will later be made unavailable.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
