### PR TITLE
Feature/network policies lockout prevention

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -135,8 +135,8 @@ use mz_sql::catalog::{CatalogCluster, EnvironmentId};
 use mz_sql::names::{QualifiedItemName, ResolvedIds, SchemaSpecifier};
 use mz_sql::optimizer_metrics::OptimizerMetrics;
 use mz_sql::plan::{
-    self, AlterSinkPlan, ConnectionDetails, CreateConnectionPlan, OnTimeoutAction, Params,
-    QueryWhen,
+    self, AlterSinkPlan, ConnectionDetails, CreateConnectionPlan, NetworkPolicyRule,
+    OnTimeoutAction, Params, QueryWhen,
 };
 use mz_sql::session::user::User;
 use mz_sql::session::vars::{ConnectionCounter, SystemVars};
@@ -4203,13 +4203,13 @@ pub enum NetworkPolicyError {
     MissingIp,
 }
 
-pub(crate) fn validate_network_with_policy(
+pub(crate) fn validate_ip_with_policy_rules(
     ip: &IpAddr,
-    policy: &NetworkPolicy,
+    rules: &Vec<NetworkPolicyRule>,
 ) -> Result<(), NetworkPolicyError> {
     // At the moment we're not handling action or direction
     // as those are only able to be "allow" and "ingress" respectively
-    if policy.rules.iter().any(|r| r.address.0.contains(ip)) {
+    if rules.iter().any(|r| r.address.0.contains(ip)) {
         Ok(())
     } else {
         Err(NetworkPolicyError::AddressDenied(ip.clone()))

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -97,7 +97,7 @@ use mz_catalog::config::{AwsPrincipalContext, BuiltinItemMigrationConfig, Cluste
 use mz_catalog::durable::OpenableDurableCatalogState;
 use mz_catalog::memory::objects::{
     CatalogEntry, CatalogItem, ClusterReplicaProcessStatus, ClusterVariantManaged, Connection,
-    DataSourceDesc, NetworkPolicy, Table, TableDataSource,
+    DataSourceDesc, Table, TableDataSource,
 };
 use mz_cloud_resources::{CloudResourceController, VpcEndpointConfig, VpcEndpointEvent};
 use mz_compute_client::as_of_selection;

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -62,7 +62,7 @@ use crate::command::{
 };
 use crate::coord::appends::PendingWriteTxn;
 use crate::coord::{
-    validate_network_with_policy, ConnMeta, Coordinator, DeferredPlanStatement, Message,
+    validate_ip_with_policy_rules, ConnMeta, Coordinator, DeferredPlanStatement, Message,
     PendingTxn, PlanStatement, PlanValidity, PurifiedStatementReady,
 };
 use crate::error::AdapterError;
@@ -406,7 +406,7 @@ impl Coordinator {
             };
 
             if let Some(ip) = client_ip {
-                match validate_network_with_policy(ip, network_policy) {
+                match validate_ip_with_policy_rules(ip, &network_policy.rules) {
                     Ok(_) => {}
                     Err(e) => return Err(AdapterError::NetworkPolicyDenied(e)),
                 }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4277,7 +4277,7 @@ impl Coordinator {
         };
         let maybe_network_policy = policy_name
             .as_ref()
-            .and_then(|name| self.catalog.get_network_policy_by_name(&name));
+            .and_then(|name| self.catalog.get_network_policy_by_name(name));
         let Some(network_policy) = maybe_network_policy else {
             return Err(AdapterError::PlanError(plan::PlanError::VarError(
                 VarError::InvalidParameterValue {

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -271,6 +271,7 @@ pub enum PlanError {
     SubsourceResolutionError(ExternalReferenceResolutionError),
     Replan(String),
     NetworkPolicyLockoutError,
+    NetworkPolicyInUse,
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -454,6 +455,9 @@ impl PlanError {
             }
             Self::RetainHistoryLow { .. } | Self::RetainHistoryRequired => {
                 Some("Use ALTER ... RESET (RETAIN HISTORY) to set the retain history to its default and lowest value.".into())
+            }
+            Self::NetworkPolicyInUse => {
+                Some("Use ALTER SYSTEM SET 'network_policy' to change the default network policy.".into())
             }
             _ => None,
         }
@@ -767,6 +771,7 @@ impl fmt::Display for PlanError {
             Self::SubsourceResolutionError(e) => write!(f, "{}", e),
             Self::Replan(msg) => write!(f, "internal error while replanning, please contact support: {msg}"),
             Self::NetworkPolicyLockoutError => write!(f, "policy would block current session IP"),
+            Self::NetworkPolicyInUse => write!(f, "network policy is currently in use"),
             Self::UntilReadyTimeoutRequired => {
                 write!(f, "TIMEOUT=<duration> option is required for ALTER CLUSTER ... WITH (WAIT UNTIL READY ( ... ))")
             },

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -270,6 +270,7 @@ pub enum PlanError {
     UntilReadyTimeoutRequired,
     SubsourceResolutionError(ExternalReferenceResolutionError),
     Replan(String),
+    NetworkPolicyLockoutError,
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -765,6 +766,7 @@ impl fmt::Display for PlanError {
             },
             Self::SubsourceResolutionError(e) => write!(f, "{}", e),
             Self::Replan(msg) => write!(f, "internal error while replanning, please contact support: {msg}"),
+            Self::NetworkPolicyLockoutError => write!(f, "policy would block current session IP"),
             Self::UntilReadyTimeoutRequired => {
                 write!(f, "TIMEOUT=<duration> option is required for ALTER CLUSTER ... WITH (WAIT UNTIL READY ( ... ))")
             },

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -5309,12 +5309,14 @@ fn plan_drop_network_policy(
 ) -> Result<Option<NetworkPolicyId>, PlanError> {
     match scx.catalog.resolve_network_policy(name.as_str()) {
         Ok(policy) => {
-            // TODO @jubrad don't let this be dropped if it's the default policy or
-            // is being used by other objects.
-            // if scx.catalog.system_vars().default_network_policy().id() == policy.id() {
-            //     return Err(PlanError::Unstructured("Cannot drop default network policy.")
-            // }
-            Ok(Some(policy.id()))
+            if scx.catalog.system_vars().default_network_policy_name() == policy.name() {
+                Err(PlanError::Unstructured(
+                    "Cannot drop the network polic referenced by system variable network_policy."
+                        .into(),
+                ))
+            } else {
+                Ok(Some(policy.id()))
+            }
         }
         Err(_) if if_exists => Ok(None),
         Err(e) => Err(e.into()),

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -5309,11 +5309,10 @@ fn plan_drop_network_policy(
 ) -> Result<Option<NetworkPolicyId>, PlanError> {
     match scx.catalog.resolve_network_policy(name.as_str()) {
         Ok(policy) => {
+            // TODO(network_policy): When we support role based network policies, check if any role
+            // currently has the specified policy set.
             if scx.catalog.system_vars().default_network_policy_name() == policy.name() {
-                Err(PlanError::Unstructured(
-                    "Cannot drop the network polic referenced by system variable network_policy."
-                        .into(),
-                ))
+                Err(PlanError::NetworkPolicyInUse)
             } else {
                 Ok(Some(policy.id()))
             }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Attempt to prevent user lockout when modifying network
policies or the default `network_policy` system var by validating
the users IP against the policy changes they request.


stacked on 
- https://github.com/MaterializeInc/materialize/pull/30261
part of https://github.com/MaterializeInc/database-issues/issues/4637

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Only superusers can modify the `network_policy` system var and alter the default network policy and there's currently no way to make a superuser outside of frontegg mock making this very difficult to test.

It might be viable to add a flag or systemvar that specifies the name of a superuser, or this will have to be run in tests that use frontegg mock. 

We could use this pr as well to turn the current user into a super user then modify the system var https://github.com/MaterializeInc/materialize/pull/30316


<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
