### PR TITLE
Attempt to make csv decoding faster

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -1153,7 +1153,7 @@ impl CatalogState {
         let progress_topic = kafka.progress_topic(&self.config.connection_context, id);
         let mut row = Row::default();
         row.packer()
-            .push_array(
+            .try_push_array(
                 &[ArrayDimension {
                     lower_bound: 1,
                     length: kafka.brokers.len(),
@@ -1757,7 +1757,7 @@ impl CatalogState {
 
             let mut row = Row::default();
             row.packer()
-                .push_array(
+                .try_push_array(
                     &[ArrayDimension {
                         lower_bound: 1,
                         length: arg_type_ids.len(),
@@ -1825,7 +1825,7 @@ impl CatalogState {
 
         let mut row = Row::default();
         row.packer()
-            .push_array(
+            .try_push_array(
                 &[ArrayDimension {
                     lower_bound: 1,
                     length: arg_type_ids.len(),
@@ -2136,7 +2136,7 @@ impl CatalogState {
         let mut row = Row::default();
         let flat_privileges: Vec<_> = privileges.all_values_owned().collect();
         row.packer()
-            .push_array(
+            .try_push_array(
                 &[ArrayDimension {
                     lower_bound: 1,
                     length: flat_privileges.len(),
@@ -2254,7 +2254,7 @@ impl CatalogState {
                 ]);
                 if reference.columns.len() > 0 {
                     packer
-                        .push_array(
+                        .try_push_array(
                             &[ArrayDimension {
                                 lower_bound: 1,
                                 length: reference.columns.len(),

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -467,7 +467,7 @@ impl Coordinator {
             },
         ]);
         packer
-            .push_array(
+            .try_push_array(
                 &[ArrayDimension {
                     lower_bound: 1,
                     length: params.len(),

--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -530,7 +530,7 @@ fn eval_unmaterializable_func(
     let pack_1d_array = |datums: Vec<Datum>| {
         let mut row = Row::default();
         row.packer()
-            .push_array(
+            .try_push_array(
                 &[ArrayDimension {
                     lower_bound: 1,
                     length: datums.len(),
@@ -640,7 +640,7 @@ fn eval_unmaterializable_func(
             row.packer().push_dict_with(|row| {
                 for (role_id, role_membership) in &role_memberships {
                     row.push(Datum::from(role_id.as_str()));
-                    row.push_array(
+                    row.try_push_array(
                         &[ArrayDimension {
                             lower_bound: 1,
                             length: role_membership.len(),

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -381,7 +381,7 @@ where
         length: datums.len(),
     };
     temp_storage.make_datum(|packer| {
-        packer.push_array(&[dims], datums).unwrap();
+        packer.try_push_array(&[dims], datums).unwrap();
     })
 }
 

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -272,7 +272,7 @@ impl LazyUnaryFunc for CastArrayToArray {
             .map(|datum| self.cast_expr.eval(&[datum], temp_storage))
             .collect::<Result<Vec<Datum<'a>>, EvalError>>()?;
 
-        Ok(temp_storage.try_make_datum(|packer| packer.push_array(&dims, casted_datums))?)
+        Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, casted_datums))?)
     }
 
     fn output_type(&self, _input_type: ColumnType) -> ColumnType {

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -333,7 +333,7 @@ impl LazyUnaryFunc for CastStringToArray {
             },
         )?;
 
-        Ok(temp_storage.try_make_datum(|packer| packer.push_array(&dims, datums))?)
+        Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, datums))?)
     }
 
     /// The output ColumnType of this function

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -24,7 +24,7 @@ use mz_repr::adt::pg_legacy_name::NAME_MAX_BYTES;
 use mz_repr::adt::range::{Range, RangeInner};
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::strconv::{self, Nestable};
-use mz_repr::{Datum, RelationType, RowArena, RowRef, ScalarType};
+use mz_repr::{Datum, RelationType, RowArena, RowPacker, RowRef, ScalarType};
 use postgres_types::{FromSql, IsNull, ToSql, Type as PgType};
 use uuid::Uuid;
 
@@ -675,6 +675,121 @@ impl Value {
             })?),
             Type::MzAclItem => Value::MzAclItem(strconv::parse_mz_acl_item(s)?),
             Type::AclItem => Value::AclItem(strconv::parse_acl_item(s)?),
+        })
+    }
+
+    /// Deserializes a value of type `ty` from `raw` using the [text encoding
+    /// format](Format::Text).
+    pub fn decode_text_into_row<'a>(
+        ty: &'a Type,
+        s: &'a str,
+        packer: &mut RowPacker,
+    ) -> Result<(), Box<dyn Error + Sync + Send>> {
+        Ok(match ty {
+            Type::Array(elem_type) => {
+                let (elements, dims) =
+                    strconv::parse_array(s, || None, |elem_text| Ok::<_, String>(Some(elem_text)))?;
+                packer
+                    .push_array_with(&dims, |packer| {
+                        let mut nelements = 0;
+                        for element in elements {
+                            match element {
+                                Some(elem_text) => {
+                                    Value::decode_text_into_row(elem_type, &elem_text, packer)
+                                        .unwrap()
+                                } // TODO!
+                                None => packer.push(Datum::Null),
+                            }
+                            nelements += 1;
+                        }
+                        nelements
+                    })
+                    .unwrap()
+            }
+            Type::Int2Vector { .. } => {
+                return Err("input of Int2Vector types is not implemented".into())
+            }
+            Type::Bool => packer.push(Datum::from(strconv::parse_bool(s)?)),
+            Type::Bytea => packer.push(Datum::Bytes(&strconv::parse_bytes(s)?)),
+            Type::Char => packer.push(Datum::UInt8(s.as_bytes().get(0).copied().unwrap_or(0))),
+            Type::Date => packer.push(Datum::Date(strconv::parse_date(s)?)),
+            Type::Float4 => packer.push(Datum::Float32(strconv::parse_float32(s)?.into())),
+            Type::Float8 => packer.push(Datum::Float64(strconv::parse_float64(s)?.into())),
+            Type::Int2 => packer.push(Datum::Int16(strconv::parse_int16(s)?)),
+            Type::Int4 => packer.push(Datum::Int32(strconv::parse_int32(s)?)),
+            Type::Int8 => packer.push(Datum::Int64(strconv::parse_int64(s)?)),
+            Type::UInt2 => packer.push(Datum::UInt16(strconv::parse_uint16(s)?)),
+            Type::UInt4 => packer.push(Datum::UInt32(strconv::parse_uint32(s)?)),
+            Type::UInt8 => packer.push(Datum::UInt64(strconv::parse_uint64(s)?)),
+            Type::Interval { .. } => packer.push(Datum::Interval(strconv::parse_interval(s)?)),
+            Type::Json => return Err("input of json types is not implemented".into()),
+            Type::Jsonb => packer.push(strconv::parse_jsonb(s)?.into_row().unpack_first()),
+            Type::List(elem_type) => {
+                let elems = strconv::parse_list(
+                    s,
+                    matches!(**elem_type, Type::List(..)),
+                    || None,
+                    |elem_text| Ok::<_, String>(Some(elem_text)),
+                )?;
+                packer.push_list_with(|packer| {
+                    for elem in elems {
+                        match elem {
+                            Some(elem) => {
+                                Value::decode_text_into_row(elem_type, &elem, packer).unwrap()
+                            }
+                            None => packer.push(Datum::Null),
+                        }
+                    }
+                });
+            }
+            Type::Map { value_type } => {
+                let map =
+                    strconv::parse_map(s, matches!(**value_type, Type::Map { .. }), |elem_text| {
+                        elem_text.map(|t| Ok::<_, String>(t)).transpose()
+                    })?;
+                packer.push_dict_with(|row| {
+                    for (k, v) in map {
+                        row.push(Datum::String(&k));
+                        match v {
+                            Some(elem) => {
+                                Value::decode_text_into_row(value_type, &elem, row).unwrap()
+                            }
+                            None => row.push(Datum::Null),
+                        }
+                    }
+                });
+            }
+            Type::Name => packer.push(Datum::String(&strconv::parse_pg_legacy_name(s))),
+            Type::Numeric { .. } => packer.push(Datum::Numeric(strconv::parse_numeric(s)?)),
+            Type::Oid | Type::RegClass | Type::RegProc | Type::RegType => {
+                packer.push(Datum::UInt32(strconv::parse_oid(s)?))
+            }
+            Type::Record(_) => {
+                return Err("input of anonymous composite types is not implemented".into())
+            }
+            Type::Text => packer.push(Datum::String(s)),
+            Type::BpChar { .. } => packer.push(Datum::String(s.trim_end())),
+            Type::VarChar { .. } => packer.push(Datum::String(s)),
+            Type::Time { .. } => packer.push(Datum::Time(strconv::parse_time(s)?)),
+            Type::TimeTz { .. } => return Err("input of timetz types is not implemented".into()),
+            Type::Timestamp { .. } => packer.push(Datum::Timestamp(strconv::parse_timestamp(s)?)),
+            Type::TimestampTz { .. } => {
+                packer.push(Datum::TimestampTz(strconv::parse_timestamptz(s)?))
+            }
+            Type::Uuid => packer.push(Datum::Uuid(Uuid::parse_str(s)?)),
+            Type::MzTimestamp => packer.push(Datum::MzTimestamp(strconv::parse_mz_timestamp(s)?)),
+            Type::Range { element_type } => {
+                let range = strconv::parse_range(s, |elem_text| {
+                    Value::decode_text(element_type, elem_text.as_bytes()).map(Box::new)
+                })?;
+                // TODO: bad!
+                let buf = RowArena::new();
+                let range = range.into_bounds(|elem| elem.into_datum(&buf, element_type));
+
+                packer.push_range(range).unwrap()
+            }
+            Type::MzAclItem => packer.push(Datum::MzAclItem(strconv::parse_mz_acl_item(s)?)),
+            Type::AclItem => packer.push(Datum::AclItem(strconv::parse_acl_item(s)?)),
         })
     }
 

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -2166,7 +2166,7 @@ impl RowPacker<'_> {
     /// the cardinality of the array as described by `dims`, or if the
     /// number of dimensions exceeds [`MAX_ARRAY_DIMENSIONS`]. If an error
     /// occurs, the packer's state will be unchanged.
-    pub fn push_array<'a, I, D>(
+    pub fn try_push_array<'a, I, D>(
         &mut self,
         dims: &[ArrayDimension],
         iter: I,
@@ -2175,25 +2175,32 @@ impl RowPacker<'_> {
         I: IntoIterator<Item = D>,
         D: Borrow<Datum<'a>>,
     {
-        self.push_array_with(dims, |packer| {
-            let mut nelements = 0;
-            for datum in iter {
-                packer.push(datum);
-                nelements += 1;
-            }
-            Ok::<_, InvalidArrayError>(nelements)
-        })
+        // SAFETY: The function returns the exact number of elements pushed into the array.
+        unsafe {
+            self.push_array_with_unchecked(dims, |packer| {
+                let mut nelements = 0;
+                for datum in iter {
+                    packer.push(datum);
+                    nelements += 1;
+                }
+                Ok::<_, InvalidArrayError>(nelements)
+            })
+        }
     }
 
     /// Convenience function to construct an array from a function. The function must return the
     /// number of elements it pushed into the array. It is undefined behavior if the function returns
     /// a number different to the number of elements it pushed.
     ///
-    /// Returns an error if the number of elements in `iter` does not match
+    /// Returns an error if the number of elements pushed by `f` does not match
     /// the cardinality of the array as described by `dims`, or if the
-    /// number of dimensions exceeds [`MAX_ARRAY_DIMENSIONS`]. If an error
+    /// number of dimensions exceeds [`MAX_ARRAY_DIMENSIONS`], or if `f` errors. If an error
     /// occurs, the packer's state will be unchanged.
-    pub fn push_array_with<F, E>(&mut self, dims: &[ArrayDimension], f: F) -> Result<(), E>
+    pub unsafe fn push_array_with_unchecked<F, E>(
+        &mut self,
+        dims: &[ArrayDimension],
+        f: F,
+    ) -> Result<(), E>
     where
         F: FnOnce(&mut RowPacker) -> Result<usize, E>,
         E: From<InvalidArrayError>,
@@ -2263,7 +2270,7 @@ impl RowPacker<'_> {
     /// Pushes an [`Array`] that is built from a closure.
     ///
     /// __WARNING__: This is fairly "sharp" tool that is easy to get wrong. You
-    /// should prefer [`RowPacker::push_array`] when possible.
+    /// should prefer [`RowPacker::try_push_array`] when possible.
     ///
     /// Returns an error if the number of elements pushed does not match
     /// the cardinality of the array as described by `dims`, or if the
@@ -3037,7 +3044,7 @@ mod tests {
         let mut row = Row::default();
         let mut packer = row.packer();
         packer
-            .push_array(&[DIM], vec![Datum::Int32(1), Datum::Int32(2)])
+            .try_push_array(&[DIM], vec![Datum::Int32(1), Datum::Int32(2)])
             .unwrap();
         let arr1 = row.unpack_first().unwrap_array();
         assert_eq!(arr1.dims().into_iter().collect::<Vec<_>>(), vec![DIM]);
@@ -3069,7 +3076,7 @@ mod tests {
         let mut row = Row::default();
         let mut packer = row.packer();
         packer
-            .push_array(
+            .try_push_array(
                 &[
                     ArrayDimension {
                         lower_bound: 1,
@@ -3097,7 +3104,7 @@ mod tests {
         let max_dims = usize::from(MAX_ARRAY_DIMENSIONS);
 
         // An array with one too many dimensions should be rejected.
-        let res = row.packer().push_array(
+        let res = row.packer().try_push_array(
             &vec![
                 ArrayDimension {
                     lower_bound: 1,
@@ -3113,7 +3120,7 @@ mod tests {
         // An array with exactly the maximum allowable dimensions should be
         // accepted.
         row.packer()
-            .push_array(
+            .try_push_array(
                 &vec![
                     ArrayDimension {
                         lower_bound: 1,
@@ -3129,7 +3136,7 @@ mod tests {
     #[mz_ore::test]
     fn test_array_wrong_cardinality() {
         let mut row = Row::default();
-        let res = row.packer().push_array(
+        let res = row.packer().try_push_array(
             &[
                 ArrayDimension {
                     lower_bound: 1,

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -2106,12 +2106,12 @@ impl RowPacker<'_> {
                     })
                     .collect::<Vec<_>>();
                 match x.elements.as_ref() {
-                    None => self.push_array(&dims, [].iter()),
+                    None => self.try_push_array(&dims, [].iter()),
                     Some(elements) => {
                         // TODO: Could we avoid this Row alloc if we made a
                         // push_array_with?
                         let elements_row = Row::try_from(elements)?;
-                        self.push_array(&dims, elements_row.iter())
+                        self.try_push_array(&dims, elements_row.iter())
                     }
                 }
                 .map_err(|err| err.to_string())?
@@ -2463,7 +2463,7 @@ mod tests {
         let metrics = ColumnarMetrics::disconnected();
 
         packer
-            .push_array(
+            .try_push_array(
                 &[ArrayDimension {
                     lower_bound: 0,
                     length: 3,
@@ -2682,7 +2682,7 @@ mod tests {
             Datum::Null,
         ]);
         packer
-            .push_array(
+            .try_push_array(
                 &[ArrayDimension {
                     lower_bound: 2,
                     length: 2,

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -2039,7 +2039,7 @@ impl<'a, E> DatumType<'a, E> for ArrayRustType<String> {
     fn into_result(self, temp_storage: &'a RowArena) -> Result<Datum<'a>, E> {
         Ok(temp_storage.make_datum(|packer| {
             packer
-                .push_array(
+                .try_push_array(
                     &[ArrayDimension {
                         lower_bound: 1,
                         length: self.0.len(),
@@ -3298,7 +3298,7 @@ impl ScalarType {
 
                 let mut row = Row::default();
                 row.packer()
-                    .push_array::<_, Datum<'static>>(
+                    .try_push_array::<_, Datum<'static>>(
                         &[ArrayDimension {
                             lower_bound: 1,
                             length: 0,
@@ -3307,7 +3307,7 @@ impl ScalarType {
                     )
                     .expect("failed to push empty array");
                 row.packer()
-                    .push_array(
+                    .try_push_array(
                         &[ArrayDimension {
                             lower_bound: 1,
                             length: datums.len(),
@@ -3328,7 +3328,7 @@ impl ScalarType {
         static EMPTY_ARRAY: LazyLock<Row> = LazyLock::new(|| {
             let mut row = Row::default();
             row.packer()
-                .push_array::<_, Datum<'static>>(
+                .try_push_array::<_, Datum<'static>>(
                     &[ArrayDimension {
                         lower_bound: 1,
                         length: 0,
@@ -3700,7 +3700,7 @@ impl Arbitrary for ScalarType {
 static EMPTY_ARRAY_ROW: LazyLock<Row> = LazyLock::new(|| {
     let mut row = Row::default();
     row.packer()
-        .push_array(&[], iter::empty::<Datum>())
+        .try_push_array(&[], iter::empty::<Datum>())
         .expect("array known to be valid");
     row
 });
@@ -4014,7 +4014,7 @@ fn arb_array(element_strategy: BoxedStrategy<PropDatum>) -> BoxedStrategy<PropAr
         let element_datums: Vec<Datum<'_>> = elements.iter().map(|pd| pd.into()).collect();
         let mut row = Row::default();
         row.packer()
-            .push_array(&dimensions, element_datums)
+            .try_push_array(&dimensions, element_datums)
             .unwrap();
         PropArray(row, elements)
     })

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -2964,7 +2964,7 @@ impl HirScalarExpr {
 
         let mut row = Row::default();
         row.packer()
-            .push_array(
+            .try_push_array(
                 &[ArrayDimension {
                     lower_bound: 1,
                     length: datums.len(),


### PR DESCRIPTION
Attempt to make CSV decoding faster by avoiding ephemeral allocations and copying where possible.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Copying about 760MiB of data into Materialize:

Before:
```
materialize=> \COPY tuple FROM 'data.csv' WITH (FORMAT csv, HEADER true,NULL '\N');
COPY 11010101
Time: 335687.917 ms (05:35.688)
```

After:
```
materialize=> \COPY tuple FROM 'data.csv' WITH (FORMAT csv, HEADER true,NULL '\N');
COPY 11010101
Time: 317502.991 ms (05:17.503)
```

Well, not a substantial improvement!

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
