### PR TITLE
ct: fix `EXPLAIN TIMESTAMP` for `SELECT FROM continual_task`

### DIFF
--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -60,11 +60,19 @@ impl DataflowBuilder<'_> {
                         // Record that we are missing at least one index.
                         id_bundle.storage_ids.insert(id);
                     }
+                    CatalogItem::ContinualTask(_) => {
+                        id_bundle.storage_ids.insert(id);
+                    }
                     CatalogItem::Log(_) => {
                         // Log sources should always have an index.
                         panic!("log source {id} is missing index");
                     }
-                    _ => {
+                    CatalogItem::Sink(_)
+                    | CatalogItem::Index(_)
+                    | CatalogItem::Type(_)
+                    | CatalogItem::Func(_)
+                    | CatalogItem::Secret(_)
+                    | CatalogItem::Connection(_) => {
                         // Non-indexable thing; no work to do.
                     }
                 }


### PR DESCRIPTION
While I'm in here, fix this match to list the enum variants, so this sort of bug wouldn't happen again.

Not particularly sure how to add a regression test for this, though. :(

Touches https://github.com/MaterializeInc/database-issues/issues/8427

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
