### PR TITLE
build: Fix PolarSignals upload when build tag is set

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -53,7 +53,7 @@ steps:
         depends_on: [build-x86_64]
         timeout_in_minutes: 10
         priority: 50
-        if: build.tag != "" && build.branch =~ /^v.*\..*\$/
+        if: build.tag != null
         agents:
           queue: builder-linux-x86_64
         coverage: skip
@@ -81,7 +81,7 @@ steps:
         depends_on: [build-aarch64]
         priority: 50
         timeout_in_minutes: 10
-        if: build.tag != "" && build.branch =~ /^v.*\..*\$/
+        if: build.tag != null
         agents:
           queue: builder-linux-aarch64-mem
         coverage: skip


### PR DESCRIPTION
Broken in https://github.com/MaterializeInc/materialize/pull/29961 (and correctly identified there by @antiguru)

Test run with a tag: https://buildkite.com/materialize/test/builds/93866

Test run without a tag: https://buildkite.com/materialize/test/builds/93868

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
