### PR TITLE
make it more straightforward to configure environmentd's iam roles via orchestratord

### DIFF
--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -47,6 +47,9 @@ pub mod v1alpha1 {
         pub environmentd_image_ref: String,
         // Extra args to pass to the environmentd binary
         pub environmentd_extra_args: Option<Vec<String>>,
+        // If running in AWS, override the IAM role to use to give
+        // environmentd access to the persist S3 bucket
+        pub environmentd_iam_role_arn: Option<String>,
         // Resource requirements for the environmentd pod
         pub environmentd_resource_requirements: Option<ResourceRequirements>,
         // Resource requirements for the balancerd pod

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -50,6 +50,9 @@ pub mod v1alpha1 {
         // If running in AWS, override the IAM role to use to give
         // environmentd access to the persist S3 bucket
         pub environmentd_iam_role_arn: Option<String>,
+        // If running in AWS, override the IAM role to use to support
+        // the CREATE CONNECTION feature
+        pub environmentd_connection_role_arn: Option<String>,
         // Resource requirements for the environmentd pod
         pub environmentd_resource_requirements: Option<ResourceRequirements>,
         // Resource requirements for the balancerd pod

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -143,6 +143,8 @@ pub struct AwsInfo {
     #[clap(long)]
     environmentd_iam_role_arn: Option<String>,
     #[clap(long)]
+    environmentd_connection_role_arn: Option<String>,
+    #[clap(long)]
     aws_secrets_controller_tags: Vec<String>,
     #[clap(long)]
     environmentd_availability_zones: Option<Vec<String>>,

--- a/src/orchestratord/src/controller/materialize/resources.rs
+++ b/src/orchestratord/src/controller/materialize/resources.rs
@@ -874,8 +874,11 @@ fn create_environmentd_statefulset_object(
             }
         }
 
-        if let Some(environmentd_connection_role_arn) =
-            &config.aws_info.environmentd_connection_role_arn
+        if let Some(environmentd_connection_role_arn) = mz
+            .spec
+            .environmentd_connection_role_arn
+            .as_deref()
+            .or(config.aws_info.environmentd_connection_role_arn.as_deref())
         {
             args.push(format!(
                 "--aws-connection-role-arn={}",

--- a/src/orchestratord/src/controller/materialize/resources.rs
+++ b/src/orchestratord/src/controller/materialize/resources.rs
@@ -868,7 +868,9 @@ fn create_environmentd_statefulset_object(
             }
         }
 
-        if let Some(environmentd_connection_role_arn) = &config.aws_info.environmentd_iam_role_arn {
+        if let Some(environmentd_connection_role_arn) =
+            &config.aws_info.environmentd_connection_role_arn
+        {
             args.push(format!(
                 "--aws-connection-role-arn={}",
                 environmentd_connection_role_arn

--- a/src/orchestratord/src/controller/materialize/resources.rs
+++ b/src/orchestratord/src/controller/materialize/resources.rs
@@ -486,9 +486,15 @@ fn create_network_policies(
 
 fn create_service_account_object(config: &super::Args, mz: &Materialize) -> ServiceAccount {
     let annotations = if config.cloud_provider == CloudProvider::Aws {
+        let role_arn = mz
+            .spec
+            .environmentd_iam_role_arn
+            .as_deref()
+            .or(config.aws_info.environmentd_iam_role_arn.as_deref())
+            .unwrap()
+            .to_string();
         Some(btreemap! {
-            "eks.amazonaws.com/role-arn".to_string()
-                => config.aws_info.environmentd_iam_role_arn.as_ref().unwrap().to_string()
+            "eks.amazonaws.com/role-arn".to_string() => role_arn
         })
     } else {
         None


### PR DESCRIPTION
### Motivation

using the environmentd iam role as the connection role was actually just wrong, and in a setup where a user is running their own orchestratord, it will probably be a lot easier to get started if they create a separate iam role per environment (because using a single iam role requires wiring up a lot of oidc stuff in order to restrict things via iam policy variables)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
