### PR TITLE
[adapter] Allow Persist fast-path peeks when ordering matches

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -138,6 +138,7 @@ def get_default_system_parameters(
         "persist_catalog_force_compaction_wait": "1s",
         "persist_encoding_enable_dictionary": "true",
         "persist_fast_path_limit": "1000",
+        "persist_fast_path_order": "true",
         "persist_inline_writes_single_max_bytes": "4096",
         "persist_inline_writes_total_max_bytes": "1048576",
         "persist_pubsub_client_enabled": "true",

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -124,6 +124,12 @@ pub const CONSTRAINT_BASED_TIMESTAMP_SELECTION: Config<&'static str> = Config::n
     "Whether to use the constraint-based timestamp selection, one of: enabled, disabled, verify",
 );
 
+pub const PERSIST_FAST_PATH_ORDER: Config<bool> = Config::new(
+    "persist_fast_path_order",
+    false,
+    "If set, send queries with a compatible literal constraint or ordering clause down the Persist fast path.",
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -143,4 +149,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_EXPRESSION_CACHE)
         .add(&ENABLE_MULTI_REPLICA_SOURCES)
         .add(&CONSTRAINT_BASED_TIMESTAMP_SELECTION)
+        .add(&PERSIST_FAST_PATH_ORDER)
 }

--- a/src/adapter/src/explain/insights.rs
+++ b/src/adapter/src/explain/insights.rs
@@ -213,7 +213,7 @@ fn fast_path_insights(humanizer: &dyn ExprHumanizer, plan: FastPathPlan) -> Plan
         FastPathPlan::PeekExisting(_, id, _, _) => {
             add_import_insights(&mut insights, humanizer, id, ImportType::Compute)
         }
-        FastPathPlan::PeekPersist(id, _) => {
+        FastPathPlan::PeekPersist(id, _, _) => {
             add_import_insights(&mut insights, humanizer, id, ImportType::Storage)
         }
     }

--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -64,6 +64,7 @@ use std::fmt::Debug;
 use std::panic::AssertUnwindSafe;
 
 use mz_adapter_types::connection::ConnectionId;
+use mz_adapter_types::dyncfgs::PERSIST_FAST_PATH_ORDER;
 use mz_catalog::memory::objects::{CatalogCollectionEntry, CatalogEntry, Index};
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::plan::Plan;
@@ -190,6 +191,9 @@ pub struct OptimizerConfig {
     /// Show the slow path plan even if a fast path plan was created. Useful for debugging.
     /// Enforced if `timing` is set.
     pub no_fast_path: bool,
+    // If set, allow some additional queries down the Persist fast path when we believe
+    // the orderings are compatible.
+    persist_fast_path_order: bool,
     /// Optimizer feature flags.
     pub features: OptimizerFeatures,
 }
@@ -208,6 +212,7 @@ impl From<&SystemVars> for OptimizerConfig {
             mode: OptimizeMode::Execute,
             replan: None,
             no_fast_path: false,
+            persist_fast_path_order: PERSIST_FAST_PATH_ORDER.get(vars.dyncfgs()),
             features: OptimizerFeatures::from(vars),
         }
     }

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -329,6 +329,7 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
             self.select_id,
             Some(&self.finishing),
             self.config.features.persist_fast_path_limit,
+            self.config.persist_fast_path_order,
         ) {
             Ok(maybe_fast_path_plan) => maybe_fast_path_plan.is_some(),
             Err(OptimizerError::UnsafeMfpPlan) => {
@@ -382,6 +383,7 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
             self.select_id,
             Some(&self.finishing),
             self.config.features.persist_fast_path_limit,
+            self.config.persist_fast_path_order,
         )? {
             Some(plan) if !self.config.no_fast_path => {
                 if self.config.mode == OptimizeMode::Explain {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1213,6 +1213,7 @@ impl PersistPeek {
             &mut reader,
             txns_read.as_mut(),
             metrics,
+            &mfp_plan,
             &metadata.relation_desc,
             Antichain::from_elem(as_of),
         )

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -95,7 +95,6 @@ pub fn preserves_order(scalar_type: &ScalarType) -> bool {
         | ScalarType::UInt16
         | ScalarType::UInt32
         | ScalarType::UInt64
-        | ScalarType::Numeric { .. }
         | ScalarType::Date
         | ScalarType::Time
         | ScalarType::Timestamp { .. }
@@ -114,6 +113,9 @@ pub fn preserves_order(scalar_type: &ScalarType) -> bool {
         // Our floating-point encoding preserves order generally, but differs when comparing
         // -0 and 0. Opt these out for now.
         ScalarType::Float32 | ScalarType::Float64 => false,
+        // Numeric is sensitive to similar ordering issues as floating point numbers, and requires
+        // some special handling we don't have yet.
+        ScalarType::Numeric { .. } => false,
         // For all other types: either the encoding is known to not preserve ordering, or we
         // don't yet care to make strong guarantees one way or the other.
         ScalarType::PgLegacyChar

--- a/src/storage-operators/src/stats.rs
+++ b/src/storage-operators/src/stats.rs
@@ -9,6 +9,7 @@
 
 //! Types and traits that connect up our mz-repr types with the stats that persist maintains.
 
+use mz_expr::{ResultSpec, SafeMfpPlan};
 use mz_persist_client::metrics::Metrics;
 use mz_persist_client::read::{Cursor, LazyPartStats, ReadHandle, Since};
 use mz_repr::{Diff, RelationDesc, Row, Timestamp};
@@ -39,25 +40,30 @@ impl StatsCursor {
         // and we have to go through txn-wal for reads.
         txns_read: Option<&mut TxnsCache<Timestamp, TxnsCodecRow>>,
         metrics: &Metrics,
+        mfp_plan: &SafeMfpPlan,
         desc: &RelationDesc,
         as_of: Antichain<Timestamp>,
     ) -> Result<StatsCursor, Since<Timestamp>> {
-        let should_fetch = |name: &'static str, count: fn(&RelationPartStats) -> Option<usize>| {
+        let should_fetch = |name: &'static str, errors: bool| {
             move |stats: Option<&LazyPartStats>| {
                 let Some(stats) = stats else { return true };
                 let stats = stats.decode();
                 let metrics = &metrics.pushdown.part_stats;
                 let relation_stats = RelationPartStats::new(name, metrics, desc, &stats);
-                count(&relation_stats).map_or(true, |n| n > 0)
+                if errors {
+                    relation_stats.err_count().map_or(true, |e| e > 0)
+                } else {
+                    relation_stats.may_match_mfp(ResultSpec::value_all(), mfp_plan)
+                }
             }
         };
         let (errors, data) = match txns_read {
             None => {
                 let errors = handle
-                    .snapshot_cursor(as_of.clone(), should_fetch("errors", |s| s.err_count()))
+                    .snapshot_cursor(as_of.clone(), should_fetch("errors", true))
                     .await?;
                 let data = handle
-                    .snapshot_cursor(as_of.clone(), should_fetch("data", |s| s.ok_count()))
+                    .snapshot_cursor(as_of.clone(), should_fetch("data", false))
                     .await?;
                 (errors, data)
             }
@@ -69,10 +75,10 @@ impl StatsCursor {
                 let _ = txns_read.update_gt(&as_of).await;
                 let data_snapshot = txns_read.data_snapshot(handle.shard_id(), as_of);
                 let errors: Cursor<SourceData, (), Timestamp, i64> = data_snapshot
-                    .snapshot_cursor(handle, should_fetch("errors", |s| s.err_count()))
+                    .snapshot_cursor(handle, should_fetch("errors", true))
                     .await?;
                 let data = data_snapshot
-                    .snapshot_cursor(handle, should_fetch("data", |s| s.ok_count()))
+                    .snapshot_cursor(handle, should_fetch("data", false))
                     .await?;
                 (errors, data)
             }

--- a/test/sqllogictest/persist-fast-path.slt
+++ b/test/sqllogictest/persist-fast-path.slt
@@ -150,11 +150,24 @@ Target cluster: quickstart
 
 EOF
 
+# ORDER BY is only okay when the ordering matches the shard ordering exactly
+
 query T multiline
-EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT * from numbers ORDER BY value LIMIT 10;
+EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT * from numbers ORDER BY value ASC LIMIT 10;
+----
+Explained Query (fast path):
+  Finish order_by=[#0 asc nulls_last] limit=10 output=[#0]
+    PeekPersist materialize.public.numbers
+
+Target cluster: quickstart
+
+EOF
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT * from numbers ORDER BY value DESC LIMIT 10;
 ----
 Explained Query:
-  Finish order_by=[#0{value} asc nulls_last] limit=10 output=[#0]
+  Finish order_by=[#0{value} desc nulls_first] limit=10 output=[#0]
     ReadStorage materialize.public.numbers
 
 Source materialize.public.numbers
@@ -162,6 +175,37 @@ Source materialize.public.numbers
 Target cluster: quickstart
 
 EOF
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT value % 2 from numbers ORDER BY value % 2 LIMIT 10;
+----
+Explained Query:
+  Finish order_by=[#0 asc nulls_last] limit=10 output=[#0]
+    Project (#1)
+      Map ((#0{value} % 2))
+        ReadStorage materialize.public.numbers
+
+Source materialize.public.numbers
+
+Target cluster: quickstart
+
+EOF
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT * from numbers ORDER BY value NULLS FIRST LIMIT 10;
+----
+Explained Query:
+  Finish order_by=[#0{value} asc nulls_first] limit=10 output=[#0]
+    ReadStorage materialize.public.numbers
+
+Source materialize.public.numbers
+
+Target cluster: quickstart
+
+EOF
+
+# Arbitrary filters can't be pushed down... we may need to scan
+# an arbitrary number of records to find one that matches.
 
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT * from numbers WHERE value > mz_now() LIMIT 10;

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -32,12 +32,9 @@ CREATE TABLE t3 (f1 INTEGER PRIMARY KEY, f2 INTEGER);
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR SELECT * FROM t1 WHERE t1.f1 = 123 AND t1.f1 = t1.f2
 ----
-Explained Query:
-  Filter (#0{f1} = 123) AND (#0{f1} = #1{f2}) // { arity: 2 }
-    ReadStorage materialize.public.t1 // { arity: 2 }
-
-Source materialize.public.t1
-  filter=((#0{f1} = 123) AND (#0{f1} = #1{f2}))
+Explained Query (fast path):
+  Filter (#0{f1} = 123) AND (#0{f1} = #1{f2})
+    PeekPersist materialize.public.t1 [value=(123)]
 
 Target cluster: quickstart
 
@@ -469,13 +466,10 @@ CREATE TABLE t4 (f1 INTEGER, f2 INTEGER, PRIMARY KEY (f1, f2));
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR SELECT * FROM t4 AS a1, t4 AS a2 WHERE a1.f1 = 123 AND a1.f2 = 234 AND a1.f1 = a2.f1 AND a1.f2 = a2.f2;
 ----
-Explained Query:
-  Project (#0{f1}, #1{f2}, #0{f1}, #1{f2}) // { arity: 4 }
-    Filter (#0{f1} = 123) AND (#1{f2} = 234) // { arity: 2 }
-      ReadStorage materialize.public.t4 // { arity: 2 }
-
-Source materialize.public.t4
-  filter=((#0{f1} = 123) AND (#1{f2} = 234))
+Explained Query (fast path):
+  Project (#0{f1}, #1{f2}, #0{f1}, #1{f2})
+    Filter (#0{f1} = 123) AND (#1{f2} = 234)
+      PeekPersist materialize.public.t4 [value=(123, 234)]
 
 Target cluster: quickstart
 
@@ -484,12 +478,9 @@ EOF
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR SELECT * FROM t4 AS a1 LEFT JOIN t4 AS a2 USING (f1, f2) WHERE a1.f1 = 123 AND a1.f2 = 234;
 ----
-Explained Query:
-  Filter (#0{f1} = 123) AND (#1{f2} = 234) // { arity: 2 }
-    ReadStorage materialize.public.t4 // { arity: 2 }
-
-Source materialize.public.t4
-  filter=((#0{f1} = 123) AND (#1{f2} = 234))
+Explained Query (fast path):
+  Filter (#0{f1} = 123) AND (#1{f2} = 234)
+    PeekPersist materialize.public.t4 [value=(123, 234)]
 
 Target cluster: quickstart
 
@@ -502,12 +493,9 @@ EOF
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR SELECT * FROM t4 AS a1 LEFT JOIN t4 AS a2 USING (f1, f2) WHERE a1.f1 = 123 AND a2.f2 = 234;
 ----
-Explained Query:
-  Filter (#0{f1} = 123) AND (#1{f2} = 234) // { arity: 2 }
-    ReadStorage materialize.public.t4 // { arity: 2 }
-
-Source materialize.public.t4
-  filter=((#0{f1} = 123) AND (#1{f2} = 234))
+Explained Query (fast path):
+  Filter (#0{f1} = 123) AND (#1{f2} = 234)
+    PeekPersist materialize.public.t4 [value=(123, 234)]
 
 Target cluster: quickstart
 


### PR DESCRIPTION
### Motivation

Now that we've finished switching all users over to write data using the new ordering, we can rely on that ordering to optimize some queries. In particular:
- If we're fetching data for a specific key, and that key is a prefix of the Persist columns, we can push down that filter to get just the relevant part from each run.
- We used to ignore any `LIMIT` query with an ordering clause, since the Persist data wasn't in any user-meaningful order... but now we can allow ordering clauses where the order matches.

### Tips for reviewer

Aside from any possibility of bugs, this might not give a speedup on poorly-compacted datasets. Hopefully should be pretty rare... but in any case I've added a dyncfg so we can opt out environments as needed.

This is related to #30485, but not dependent on it. (The PARTITION BY syntax gives a way to express their intent, but this optimization is valid even if the columns in the query are only "coincidentally" defined in the useful way.)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
