### PR TITLE
unsafe session var to enable superuser

### DIFF
--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -144,6 +144,10 @@ where
     fn vars(&self) -> &SessionVars {
         &self.vars
     }
+
+    fn is_superuser(&self) -> bool {
+        self.vars.is_superuser()
+    }
 }
 
 /// Data structure suitable for passing to other threads that need access to some common Session

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -392,6 +392,7 @@ impl SessionVars {
             &STATEMENT_LOGGING_SAMPLE_RATE,
             &EMIT_INTROSPECTION_QUERY_NOTICE,
             &UNSAFE_NEW_TRANSACTION_WALL_TIME,
+            &UNSAFE_IS_SUPERUSER,
             &WELCOME_MESSAGE,
         ]
         .into_iter()
@@ -797,7 +798,11 @@ impl SessionVars {
 
     /// Returns the value of `is_superuser` configuration parameter.
     pub fn is_superuser(&self) -> bool {
-        self.user.is_superuser()
+        self.user.is_superuser() || self.unsafe_is_superuser()
+    }
+
+    pub fn unsafe_is_superuser(&self) -> bool {
+        self.expect_value::<bool>(&UNSAFE_IS_SUPERUSER).clone()
     }
 
     /// Returns the user associated with this `SessionVars` instance.

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -669,6 +669,12 @@ pub static PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER: VarDefinition = VarD
     false,
 );
 
+pub static UNSAFE_IS_SUPERUSER: VarDefinition = VarDefinition::new(
+    "unsafe_is_superuser",
+    value!(bool; false),
+    "If true, the user will be treated as a superuser for RBAC checks.",
+    true,
+);
 /// The default for the `DISK` option when creating managed clusters and cluster replicas.
 pub static DISK_CLUSTER_REPLICAS_DEFAULT: VarDefinition = VarDefinition::new(
     "disk_cluster_replicas_default",

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -79,6 +79,7 @@ superuser_reserved_connections      3                       "The number of conne
 TimeZone                            UTC                     "Sets the time zone for displaying and interpreting time stamps (PostgreSQL)."
 transaction_isolation               "strict serializable"   "Sets the current transaction's isolation level (PostgreSQL)."
 unsafe_new_transaction_wall_time    ""                      "Sets the wall time for all new explicit or implicit transactions to control the value of `now()`. If not set, uses the system's clock."
+unsafe_is_superuser                 off                     "If true, the user will be treated as a superuser for RBAC checks."
 welcome_message                     on                      "Whether to send a notice with a welcome message after a successful connection (Materialize)."
 enable_consolidate_after_union_negate on                    "consolidation after Unions that have a Negated input (Materialize)."
 enable_create_table_from_source     on                      "Whether to allow CREATE TABLE .. FROM SOURCE syntax."


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Add an unsafe param that allow the current user to set themselves up as a superuser. This is mean to be used for testing superuser specific behavior and privileges. 


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
