### PR TITLE
Remove orchestratord name injections

### DIFF
--- a/misc/helm-charts/environmentd/README.md
+++ b/misc/helm-charts/environmentd/README.md
@@ -52,7 +52,7 @@ The following table lists the configurable parameters of the Materialize environ
 | `environment.balancerdResourceRequirements.requests.cpu` |  | ``"100m"`` |
 | `environment.balancerdResourceRequirements.requests.memory` |  | ``"256Mi"`` |
 | `environment.environmentdExtraArgs[0]` |  | ``"--orchestrator-kubernetes-ephemeral-volume-class=hostpath"`` |
-| `environment.environmentdImageRef` |  | ``"materialize/environmentd:v0.122.0-dev.0--pr.g47923ddb1bb4f3fb38d152b8aa86a77514599b29"`` |
+| `environment.environmentdImageRef` |  | ``"materialize/environmentd:v0.124.0-dev.0--pr.g88ffd14ea8c194bc76d53f22ef10d08bf36b0a08"`` |
 | `environment.environmentdResourceRequirements.limits.memory` |  | ``"512Mi"`` |
 | `environment.environmentdResourceRequirements.requests.cpu` |  | ``"250m"`` |
 | `environment.environmentdResourceRequirements.requests.memory` |  | ``"512Mi"`` |
@@ -108,7 +108,7 @@ Control environment updates using the rollout parameters:
 
 ### Secret Configuration
 
-The chart automatically creates a secret named `materialize-backend-{environment.name}` containing:
+The chart automatically creates a secret named `materialize-backend` containing:
 - `metadata_backend_url`: Database connection URL
 - `persist_backend_url`: Storage backend URL
 

--- a/misc/helm-charts/environmentd/README.md.gotmpl
+++ b/misc/helm-charts/environmentd/README.md.gotmpl
@@ -106,7 +106,7 @@ Control environment updates using the rollout parameters:
 
 ### Secret Configuration
 
-The chart automatically creates a secret named `materialize-backend-{environment.name}` containing:
+The chart automatically creates a secret named `materialize-backend` containing:
 - `metadata_backend_url`: Database connection URL
 - `persist_backend_url`: Storage backend URL
 

--- a/misc/helm-charts/environmentd/templates/secret.yaml
+++ b/misc/helm-charts/environmentd/templates/secret.yaml
@@ -11,7 +11,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: materialize-backend-{{ .Values.environment.name }}
+  name: materialize-backend
   namespace: {{ .Values.namespace.name }}
 stringData:
   metadata_backend_url: {{ .Values.environment.secret.metadataBackendUrl | quote }}

--- a/misc/helm-charts/environmentd/tests/environmentd_test.yaml
+++ b/misc/helm-charts/environmentd/tests/environmentd_test.yaml
@@ -23,7 +23,7 @@ tests:
       - template: secret.yaml
         equal:
           path: metadata.name
-          value: materialize-backend-12345678-1234-1234-1234-123456789012
+          value: materialize-backend
       - template: secret.yaml
         equal:
           path: metadata.namespace
@@ -44,11 +44,23 @@ tests:
       - template: environmentd.yaml
         equal:
           path: spec.environmentdImageRef
-          value: materialize/environmentd:v0.122.0-dev.0--pr.g47923ddb1bb4f3fb38d152b8aa86a77514599b29
+          value: materialize/environmentd:v0.124.0-dev.0--pr.g88ffd14ea8c194bc76d53f22ef10d08bf36b0a08
       - template: environmentd.yaml
         equal:
           path: spec.environmentdExtraArgs[0]
           value: "--orchestrator-kubernetes-ephemeral-volume-class=hostpath"
+      - template: environmentd.yaml
+        equal:
+          path: spec.environmentdResourceRequirements.requests.cpu
+          value: "250m"
+      - template: environmentd.yaml
+        equal:
+          path: spec.environmentdResourceRequirements.requests.memory
+          value: "512Mi"
+      - template: environmentd.yaml
+        equal:
+          path: spec.environmentdResourceRequirements.limits.memory
+          value: "512Mi"
 
   - it: should use custom environment name and settings
     set:
@@ -57,8 +69,12 @@ tests:
         environmentdImageRef: materialize/environmentd:custom
         environmentdExtraArgs:
           - "--feature-flag=experimental"
-        environmentdCpuAllocation: "2"
-        environmentdMemoryAllocation: "2Gi"
+        environmentdResourceRequirements:
+          requests:
+            cpu: "2"
+            memory: "2Gi"
+          limits:
+            memory: "2Gi"
         requestRollout: custom-rollout
         forceRollout: custom-force
         inPlaceRollout: true
@@ -67,7 +83,7 @@ tests:
       - template: secret.yaml
         equal:
           path: metadata.name
-          value: materialize-backend-custom-env
+          value: materialize-backend
 
       # Test environmentd.yaml with custom values
       - template: environmentd.yaml
@@ -84,11 +100,15 @@ tests:
           value: "--feature-flag=experimental"
       - template: environmentd.yaml
         equal:
-          path: spec.environmentdCpuAllocation
+          path: spec.environmentdResourceRequirements.requests.cpu
           value: "2"
       - template: environmentd.yaml
         equal:
-          path: spec.environmentdMemoryAllocation
+          path: spec.environmentdResourceRequirements.requests.memory
+          value: "2Gi"
+      - template: environmentd.yaml
+        equal:
+          path: spec.environmentdResourceRequirements.limits.memory
           value: "2Gi"
 
   - it: should create namespace

--- a/misc/helm-charts/environmentd/values.yaml
+++ b/misc/helm-charts/environmentd/values.yaml
@@ -19,7 +19,7 @@ environment:
   # The name of the environment to be deployed, this should be a UUID
   name: "12345678-1234-1234-1234-123456789012"
   # Docker image reference for the Materialize `environmentd` service
-  environmentdImageRef: "materialize/environmentd:v0.122.0-dev.0--pr.g47923ddb1bb4f3fb38d152b8aa86a77514599b29"
+  environmentdImageRef: "materialize/environmentd:v0.124.0-dev.0--pr.g88ffd14ea8c194bc76d53f22ef10d08bf36b0a08"
   # Optional additional arguments to be passed to `environmentd`
   environmentdExtraArgs:
     - "--orchestrator-kubernetes-ephemeral-volume-class=hostpath" # Use hostpath for ephemeral storage in testing

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -13,7 +13,7 @@ operator:
     # The Docker repository for the operator image
     repository: materialize/orchestratord
     # The tag/version of the operator image to be used
-    tag: v0.122.0-dev.0--pr.g47923ddb1bb4f3fb38d152b8aa86a77514599b29
+    tag: v0.124.0-dev.0--pr.g88ffd14ea8c194bc76d53f22ef10d08bf36b0a08
     # Policy for pulling the image: "IfNotPresent" avoids unnecessary re-pulling of images
     pullPolicy: IfNotPresent
   args:

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -81,7 +81,7 @@ pub mod v1alpha1 {
 
     impl Materialize {
         pub fn backend_secret_name(&self) -> String {
-            format!("materialize-backend-{}", self.name_unchecked())
+            "materialize-backend".to_owned()
         }
 
         pub fn namespace(&self) -> String {
@@ -101,31 +101,27 @@ pub mod v1alpha1 {
         }
 
         pub fn environmentd_statefulset_name(&self, generation: u64) -> String {
-            format!("environmentd-{}-{generation}", self.name_unchecked())
+            format!("environmentd-{generation}")
         }
 
         pub fn environmentd_service_name(&self) -> String {
-            format!("environmentd-{}", self.name_unchecked())
+            "environmentd".to_owned()
         }
 
         pub fn environmentd_generation_service_name(&self, generation: u64) -> String {
-            format!("environmentd-{}-{generation}", self.name_unchecked())
+            format!("environmentd-{generation}")
         }
 
         pub fn balancerd_deployment_name(&self) -> String {
-            format!("balancerd-{}", self.name_unchecked())
+            "balancerd".to_owned()
         }
 
         pub fn balancerd_service_name(&self) -> String {
-            format!("balancerd-{}", self.name_unchecked())
+            "balancerd".to_owned()
         }
 
         pub fn persist_pubsub_service_name(&self, generation: u64) -> String {
-            format!("persist-pubsub-{}-{generation}", self.name_unchecked())
-        }
-
-        pub fn name_prefixed(&self, suffix: &str) -> String {
-            format!("{}-{}", self.name_unchecked(), suffix)
+            format!("persist-pubsub-{generation}")
         }
 
         pub fn default_labels(&self) -> BTreeMap<String, String> {

--- a/src/orchestratord/src/controller/materialize/resources.rs
+++ b/src/orchestratord/src/controller/materialize/resources.rs
@@ -340,7 +340,7 @@ fn create_network_policies(
         network_policies.extend([
             // Allow all clusterd/environmentd traffic (within the namespace)
             NetworkPolicy {
-                metadata: mz.managed_resource_meta(mz.name_prefixed("allow-all-within-namespace")),
+                metadata: mz.managed_resource_meta("allow-all-within-namespace".to_owned()),
                 spec: Some(NetworkPolicySpec {
                     egress: Some(vec![NetworkPolicyEgressRule {
                         to: Some(vec![NetworkPolicyPeer {
@@ -369,7 +369,7 @@ fn create_network_policies(
             // Allow traffic from orchestratord to environmentd in order to hit
             // the promotion endpoints during upgrades
             NetworkPolicy {
-                metadata: mz.managed_resource_meta(mz.name_prefixed("allow-orchestratord")),
+                metadata: mz.managed_resource_meta("allow-orchestratord".to_owned()),
                 spec: Some(NetworkPolicySpec {
                     ingress: Some(vec![NetworkPolicyIngressRule {
                         from: Some(vec![NetworkPolicyPeer {
@@ -411,7 +411,7 @@ fn create_network_policies(
             mz.balancerd_service_name(),
         );
         network_policies.extend([NetworkPolicy {
-            metadata: mz.managed_resource_meta(mz.name_prefixed("sql-and-http-ingress")),
+            metadata: mz.managed_resource_meta("sql-and-http-ingress".to_owned()),
             spec: Some(NetworkPolicySpec {
                 ingress: Some(vec![NetworkPolicyIngressRule {
                     from: Some(
@@ -453,7 +453,7 @@ fn create_network_policies(
     }
     if config.network_policies.egress_enabled {
         network_policies.extend([NetworkPolicy {
-            metadata: mz.managed_resource_meta(mz.name_prefixed("sources-and-sinks-egress")),
+            metadata: mz.managed_resource_meta("sources-and-sinks-egress".to_owned()),
             spec: Some(NetworkPolicySpec {
                 egress: Some(vec![NetworkPolicyEgressRule {
                     to: Some(


### PR DESCRIPTION
Remove orchestratord name injections.

### Motivation


  * This PR fixes a previously unreported bug.
 They were inconsistent and based on a user-defined name of the Materialize CR, which could break things if they cause us to violate DNS-1035 rules.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
