### PR TITLE
catalog: Optimize catalog opens

### DIFF
--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -897,12 +897,8 @@ impl ApplyUpdate<StateUpdateKindJson> for UnopenedCatalogStateInner {
         current_fence_token: &mut FenceableToken,
         _metrics: &Arc<Metrics>,
     ) -> Result<Option<StateUpdate<StateUpdateKindJson>>, FenceError> {
-        // TODO(jkosh44) It's a bit unfortunate that we have to clone all updates to attempt to
-        // convert them into a `StateUpdateKind` and cache a very small subset of them. It would
-        // be better if we could figure out a way not to clone everything.
-        if let Ok(kind) =
-            <StateUpdateKindJson as TryIntoStateUpdateKind>::try_into(update.kind.clone())
-        {
+        if update.kind.is_always_deserializable() {
+            let kind = TryInto::try_into(&update.kind).expect("kind is known to be deserializable");
             match (kind, update.diff) {
                 (StateUpdateKind::Config(key, value), 1) => {
                     let prev = self.configs.insert(key.key, value.value);

--- a/src/catalog/src/durable/upgrade.rs
+++ b/src/catalog/src/durable/upgrade.rs
@@ -19,7 +19,6 @@
 //!
 //!   - Config
 //!   - Setting
-//!   - Epoch
 //!   - FenceToken
 //!
 //! When you want to make a change to the `Catalog` you need to follow these steps:

--- a/src/repr/src/adt/jsonb.rs
+++ b/src/repr/src/adt/jsonb.rs
@@ -139,6 +139,11 @@ impl Jsonb {
     pub fn into_row(self) -> Row {
         self.row
     }
+
+    /// Returns a reference to the underlying [`Row`].
+    pub fn row(&self) -> &Row {
+        &self.row
+    }
 }
 
 impl FromStr for Jsonb {


### PR DESCRIPTION
An unopened catalog caches the fence token, configs collection, and
settings collection. Previously, in order to do this it would clone all
catalog updates, attempt to deserialize them, and then check if it was
one of those three cached update kinds. This was hugely wasteful
because the cached updates makes up a tiny portion of all updates.

This commit fixes the issue, by first peeking into the JSON of the
serialized updates, and only deserializing the updates that are one of
the cached updates. The process of peeking into the JSONB is a bit
scary and may break some abstraction boundaries, but is hopefully worth
it for the performance improvements.

Works towards resolving #MaterializeInc/database-issues/8384

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
