### PR TITLE
envd: Pass in self-hosted version, print in mz_version() (only)

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -586,6 +586,7 @@ impl Catalog {
                 connection_context: ConnectionContext::for_tests(secrets_reader),
                 active_connection_count,
                 builtin_item_migration_config: BuiltinItemMigrationConfig::Legacy,
+                helm_chart_version: None,
             },
         })
         .await?;

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -204,6 +204,7 @@ impl CatalogState {
                 let session_vars_reference = SessionVars::new_unchecked(
                     &mz_build_info::DUMMY_BUILD_INFO,
                     SYSTEM_USER.clone(),
+                    None,
                 );
 
                 for (name, val) in role.vars() {

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -259,6 +259,7 @@ impl Catalog {
                         &ENABLE_CONTINUAL_TASK_BUILTINS,
                     ),
                 },
+                helm_chart_version: config.helm_chart_version,
             },
             cluster_replica_sizes: config.cluster_replica_sizes,
             availability_zones: config.availability_zones,
@@ -1195,7 +1196,7 @@ fn remove_invalid_config_param_role_defaults_migration(
             //
             // TODO(parkmycar): This is a bit hacky, instead we should have a static list of all
             // session variables.
-            let session_vars = SessionVars::new_unchecked(&BUILD_INFO, SYSTEM_USER.clone());
+            let session_vars = SessionVars::new_unchecked(&BUILD_INFO, SYSTEM_USER.clone(), None);
 
             // Iterate over all of the variable defaults for this role.
             let mut invalid_roles_vars = BTreeMap::new();

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -195,6 +195,7 @@ impl CatalogState {
                 builtins_cfg: BuiltinsConfig {
                     include_continual_tasks: true,
                 },
+                helm_chart_version: None,
             },
             cluster_replica_sizes: Default::default(),
             availability_zones: Default::default(),

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -364,6 +364,7 @@ Issue a SQL query to get started. Need help?
             user: SUPPORT_USER.name.clone(),
             client_ip: None,
             external_metadata_rx: None,
+            helm_chart_version: None,
         });
         let mut session_client = self.startup(session).await?;
 

--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -34,6 +34,7 @@ impl SystemParameterBackend {
             user: SYSTEM_USER.name.clone(),
             client_ip: None,
             external_metadata_rx: None,
+            helm_chart_version: None,
         });
         let session_client = client.startup(session).await?;
         Ok(Self { session_client })

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -994,6 +994,8 @@ pub struct Config {
     /// previous deployment. Only used during 0dt deployment, while in read-only
     /// mode.
     pub caught_up_trigger: Option<Trigger>,
+
+    pub helm_chart_version: Option<String>,
 }
 
 /// Soft-state metadata about a compute replica
@@ -3503,6 +3505,7 @@ pub fn serve(
         read_only_controllers,
         enable_0dt_deployment,
         caught_up_trigger: clusters_caught_up_trigger,
+        helm_chart_version,
     }: Config,
 ) -> BoxFuture<'static, Result<(Handle, Client), AdapterError>> {
     async move {
@@ -3642,6 +3645,7 @@ pub fn serve(
                 active_connection_count,
                 http_host_name,
                 builtin_item_migration_config,
+                helm_chart_version,
             },
         })
         .await?;

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -739,7 +739,12 @@ impl Coordinator {
                 .inner()
                 .expect("Every statement runs in an explicit or implicit transaction")
                 .id,
-            mz_version: self.catalog().state().config().build_info.human_version(),
+            mz_version: self
+                .catalog()
+                .state()
+                .config()
+                .build_info
+                .human_version(None),
             // These are not known yet; we'll fill them in later.
             cluster_id: None,
             cluster_name: None,

--- a/src/adapter/src/coord/validity.rs
+++ b/src/adapter/src/coord/validity.rs
@@ -222,6 +222,7 @@ mod tests {
                     user,
                     client_ip: None,
                     external_metadata_rx: None,
+                    helm_chart_version: None,
                 },
                 metrics.session_metrics(),
             );

--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -659,9 +659,12 @@ fn eval_unmaterializable_func(
             let uptime = chrono::Duration::from_std(uptime).map_or(Datum::Null, Datum::from);
             pack(uptime)
         }
-        UnmaterializableFunc::MzVersion => {
-            pack(Datum::from(&*state.config().build_info.human_version()))
-        }
+        UnmaterializableFunc::MzVersion => pack(Datum::from(
+            &*state
+                .config()
+                .build_info
+                .human_version(state.config().helm_chart_version.clone()),
+        )),
         UnmaterializableFunc::MzVersionNum => {
             pack(Datum::Int32(state.config().build_info.version_num()))
         }

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -198,6 +198,8 @@ pub struct SessionConfig {
     /// An optional receiver that the session will periodically check for
     /// updates to a user's external metadata.
     pub external_metadata_rx: Option<watch::Receiver<ExternalUserMetadata>>,
+    /// Helm chart version
+    pub helm_chart_version: Option<String>,
 }
 
 impl<T: TimestampManipulation> Session<T> {
@@ -279,6 +281,7 @@ impl<T: TimestampManipulation> Session<T> {
                 user: SYSTEM_USER.name.clone(),
                 client_ip: None,
                 external_metadata_rx: None,
+                helm_chart_version: None,
             },
             metrics,
         );
@@ -294,6 +297,7 @@ impl<T: TimestampManipulation> Session<T> {
             user,
             client_ip,
             mut external_metadata_rx,
+            helm_chart_version,
         }: SessionConfig,
         metrics: SessionMetrics,
     ) -> Session<T> {
@@ -305,7 +309,7 @@ impl<T: TimestampManipulation> Session<T> {
                 .as_mut()
                 .map(|rx| rx.borrow_and_update().clone()),
         };
-        let mut vars = SessionVars::new_unchecked(build_info, user);
+        let mut vars = SessionVars::new_unchecked(build_info, user, helm_chart_version);
         if let Some(default_cluster) = default_cluster {
             vars.set_cluster(default_cluster.clone());
         }

--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -383,7 +383,7 @@ impl BalancerService {
             });
         }
 
-        println!("balancerd {} listening...", BUILD_INFO.human_version());
+        println!("balancerd {} listening...", BUILD_INFO.human_version(None));
         println!(" TLS enabled: {}", self.cfg.tls.is_some());
         println!(" pgwire address: {}", pgwire_addr);
         println!(" HTTPS address: {}", https_addr);

--- a/src/build-info/src/lib.rs
+++ b/src/build-info/src/lib.rs
@@ -38,8 +38,17 @@ pub const TARGET_TRIPLE: &str = env!("TARGET_TRIPLE");
 
 impl BuildInfo {
     /// Constructs a human-readable version string.
-    pub fn human_version(&self) -> String {
-        format!("v{} ({})", self.version, &self.sha[..9])
+    pub fn human_version(&self, helm_chart_version: Option<String>) -> String {
+        if let Some(ref helm_chart_version) = helm_chart_version {
+            format!(
+                "v{} ({}, helm chart: {})",
+                self.version,
+                &self.sha[..9],
+                helm_chart_version
+            )
+        } else {
+            format!("v{} ({})", self.version, &self.sha[..9])
+        }
     }
 
     /// Returns the version as a rich [semantic version][semver].

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -59,7 +59,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{error, Instrument};
 
 pub const BUILD_INFO: BuildInfo = build_info!();
-pub static VERSION: LazyLock<String> = LazyLock::new(|| BUILD_INFO.human_version());
+pub static VERSION: LazyLock<String> = LazyLock::new(|| BUILD_INFO.human_version(None));
 
 #[derive(Parser, Debug)]
 #[clap(name = "catalog", next_line_help = true, version = VERSION.as_str())]
@@ -598,6 +598,7 @@ async fn upgrade_check(
             ),
             active_connection_count: Arc::new(Mutex::new(ConnectionCounter::new(0, 0))),
             builtin_item_migration_config: BuiltinItemMigrationConfig::Legacy,
+            helm_chart_version: None,
         },
         &mut storage,
     )
@@ -609,7 +610,7 @@ async fn upgrade_check(
     let msg = format!(
         "catalog upgrade from {} to {} would succeed in about {} ms",
         last_seen_version,
-        &BUILD_INFO.human_version(),
+        &BUILD_INFO.human_version(None),
         dur.as_millis(),
     );
     println!("{msg}");

--- a/src/catalog/src/config.rs
+++ b/src/catalog/src/config.rs
@@ -84,6 +84,8 @@ pub struct StateConfig {
     /// Global connection limit and count
     pub active_connection_count: Arc<std::sync::Mutex<ConnectionCounter>>,
     pub builtin_item_migration_config: BuiltinItemMigrationConfig,
+    /// Helm chart version
+    pub helm_chart_version: Option<String>,
 }
 
 #[derive(Debug)]

--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -43,7 +43,7 @@ use tracing::{error, info};
 
 const BUILD_INFO: BuildInfo = build_info!();
 
-pub static VERSION: LazyLock<String> = LazyLock::new(|| BUILD_INFO.human_version());
+pub static VERSION: LazyLock<String> = LazyLock::new(|| BUILD_INFO.human_version(None));
 
 /// Independent cluster server for Materialize.
 #[derive(clap::Parser)]

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -93,6 +93,7 @@ pub struct HttpConfig {
     pub adapter_client: mz_adapter::Client,
     pub allowed_origin: AllowOrigin,
     pub active_connection_count: Arc<Mutex<ConnectionCounter>>,
+    pub helm_chart_version: Option<String>,
     pub concurrent_webhook_req: Arc<tokio::sync::Semaphore>,
     pub metrics: Metrics,
 }
@@ -114,6 +115,7 @@ pub struct WsState {
     frontegg: Arc<Option<FronteggAuthentication>>,
     adapter_client_rx: Delayed<mz_adapter::Client>,
     active_connection_count: SharedConnectionCounter,
+    helm_chart_version: Option<String>,
 }
 
 #[derive(Clone)]
@@ -137,6 +139,7 @@ impl HttpServer {
             adapter_client,
             allowed_origin,
             active_connection_count,
+            helm_chart_version,
             concurrent_webhook_req,
             metrics,
         }: HttpConfig,
@@ -177,6 +180,7 @@ impl HttpServer {
                 frontegg,
                 adapter_client_rx,
                 active_connection_count,
+                helm_chart_version,
             });
 
         let webhook_router = Router::new()
@@ -259,6 +263,7 @@ pub struct InternalHttpConfig {
     pub metrics_registry: MetricsRegistry,
     pub adapter_client_rx: oneshot::Receiver<mz_adapter::Client>,
     pub active_connection_count: Arc<Mutex<ConnectionCounter>>,
+    pub helm_chart_version: Option<String>,
     pub deployment_state_handle: DeploymentStateHandle,
     pub internal_console_redirect_url: Option<String>,
 }
@@ -320,6 +325,7 @@ impl InternalHttpServer {
             metrics_registry,
             adapter_client_rx,
             active_connection_count,
+            helm_chart_version,
             deployment_state_handle,
             internal_console_redirect_url,
         }: InternalHttpConfig,
@@ -414,6 +420,7 @@ impl InternalHttpServer {
                 frontegg: Arc::new(None),
                 adapter_client_rx,
                 active_connection_count,
+                helm_chart_version: helm_chart_version.clone(),
             });
 
         let leader_router = Router::new()
@@ -508,6 +515,7 @@ impl AuthedClient {
         user: AuthedUser,
         peer_addr: IpAddr,
         active_connection_count: SharedConnectionCounter,
+        helm_chart_version: Option<String>,
         session_config: F,
         options: BTreeMap<String, String>,
     ) -> Result<Self, AdapterError>
@@ -521,6 +529,7 @@ impl AuthedClient {
             user: user.name,
             client_ip: Some(peer_addr),
             external_metadata_rx: user.external_metadata_rx,
+            helm_chart_version,
         });
         let drop_connection =
             DropConnection::new_connection(session.user(), active_connection_count)?;
@@ -582,6 +591,7 @@ where
             (StatusCode::INTERNAL_SERVER_ERROR, "adapter client missing").into_response()
         })?;
         let active_connection_count = req.extensions.get::<SharedConnectionCounter>().unwrap();
+        let helm_chart_version = None;
 
         let options = if params.options.is_empty() {
             // It's possible 'options' simply wasn't provided, we don't want that to
@@ -604,6 +614,7 @@ where
             user.clone(),
             peer_addr,
             Arc::clone(active_connection_count),
+            helm_chart_version,
             |session| {
                 session
                     .vars_mut()
@@ -710,6 +721,7 @@ async fn init_ws(
         frontegg,
         adapter_client_rx,
         active_connection_count,
+        helm_chart_version,
     }: &WsState,
     existing_user: Option<AuthedUser>,
     peer_addr: IpAddr,
@@ -790,6 +802,7 @@ async fn init_ws(
         user,
         peer_addr,
         Arc::clone(active_connection_count),
+        helm_chart_version.clone(),
         |_session| (),
         options,
     )

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -164,6 +164,8 @@ pub struct Config {
     /// Values to set for system parameters, if those system parameters have not
     /// already been set by the system user.
     pub system_parameter_defaults: BTreeMap<String, String>,
+    /// Helm chart version
+    pub helm_chart_version: Option<String>,
 
     // === AWS options. ===
     /// The AWS account ID, which will be used to generate ARNs for
@@ -324,6 +326,7 @@ impl Listeners {
                 metrics_registry: config.metrics_registry.clone(),
                 adapter_client_rx: internal_http_adapter_client_rx,
                 active_connection_count: Arc::clone(&active_connection_count),
+                helm_chart_version: config.helm_chart_version.clone(),
                 deployment_state_handle,
                 internal_console_redirect_url: config.internal_console_redirect_url,
             });
@@ -655,6 +658,7 @@ impl Listeners {
             read_only_controllers: read_only,
             enable_0dt_deployment,
             caught_up_trigger,
+            helm_chart_version: config.helm_chart_version.clone(),
         })
         .instrument(info_span!("adapter::serve"))
         .await?;
@@ -683,6 +687,7 @@ impl Listeners {
                 metrics: metrics.clone(),
                 internal: false,
                 active_connection_count: Arc::clone(&active_connection_count),
+                helm_chart_version: config.helm_chart_version.clone(),
             });
             mz_server_core::serve(ServeConfig {
                 conns: sql_conns,
@@ -712,6 +717,7 @@ impl Listeners {
                 metrics: metrics.clone(),
                 internal: true,
                 active_connection_count: Arc::clone(&active_connection_count),
+                helm_chart_version: config.helm_chart_version.clone(),
             });
             mz_server_core::serve(ServeConfig {
                 conns: internal_sql_conns,
@@ -732,6 +738,7 @@ impl Listeners {
                 adapter_client: adapter_client.clone(),
                 allowed_origin: config.cors_allowed_origin.clone(),
                 active_connection_count: Arc::clone(&active_connection_count),
+                helm_chart_version: config.helm_chart_version.clone(),
                 concurrent_webhook_req: webhook_concurrency_limit.semaphore(),
                 metrics: http_metrics.clone(),
             });
@@ -754,6 +761,7 @@ impl Listeners {
                 adapter_client: adapter_client.clone(),
                 allowed_origin: config.cors_allowed_origin,
                 active_connection_count: Arc::clone(&active_connection_count),
+                helm_chart_version: config.helm_chart_version.clone(),
                 concurrent_webhook_req: webhook_concurrency_limit.semaphore(),
                 metrics: http_metrics,
             });
@@ -776,6 +784,7 @@ impl Listeners {
                 metrics,
                 internal: false,
                 active_connection_count: Arc::clone(&active_connection_count),
+                helm_chart_version: config.helm_chart_version.clone(),
             });
             mz_server_core::serve(ServeConfig {
                 conns: balancer_sql_conns,

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -538,6 +538,7 @@ impl Listeners {
                 http_host_name: Some(host_name),
                 internal_console_redirect_url: config.internal_console_redirect_url,
                 tls_reload_certs,
+                helm_chart_version: None,
             })
             .await?;
 

--- a/src/orchestratord/src/bin/orchestratord.rs
+++ b/src/orchestratord/src/bin/orchestratord.rs
@@ -31,7 +31,7 @@ use mz_ore::{
 };
 
 const BUILD_INFO: BuildInfo = build_info!();
-static VERSION: LazyLock<String> = LazyLock::new(|| BUILD_INFO.human_version());
+static VERSION: LazyLock<String> = LazyLock::new(|| BUILD_INFO.human_version(None));
 
 #[derive(clap::Parser)]
 #[clap(name = "orchestratord", version = VERSION.as_str())]

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -97,6 +97,8 @@ pub struct RunParams<'a, A> {
     pub internal: bool,
     /// Global connection limit and count
     pub active_connection_count: Arc<Mutex<ConnectionCounter>>,
+    /// Helm chart version
+    pub helm_chart_version: Option<String>,
 }
 
 /// Runs a pgwire connection to completion.
@@ -120,6 +122,7 @@ pub async fn run<'a, A>(
         frontegg,
         internal,
         active_connection_count,
+        helm_chart_version,
     }: RunParams<'a, A>,
 ) -> Result<(), io::Error>
 where
@@ -190,6 +193,7 @@ where
                     user: auth_session.user().into(),
                     client_ip: conn.peer_addr().clone(),
                     external_metadata_rx: Some(auth_session.external_metadata_rx()),
+                    helm_chart_version,
                 });
                 let expired = async move { auth_session.expired().await };
                 (session, expired.left_future())
@@ -211,6 +215,7 @@ where
             user,
             client_ip: conn.peer_addr().clone(),
             external_metadata_rx: None,
+            helm_chart_version,
         });
         // No frontegg check, so auth session lasts indefinitely.
         let auth_session = pending().right_future();

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -57,6 +57,8 @@ pub struct Config {
     pub internal: bool,
     /// Global connection limit and count
     pub active_connection_count: Arc<Mutex<ConnectionCounter>>,
+    /// Helm chart version
+    pub helm_chart_version: Option<String>,
 }
 
 /// A server that communicates with clients via the pgwire protocol.
@@ -67,6 +69,7 @@ pub struct Server {
     metrics: Metrics,
     internal: bool,
     active_connection_count: Arc<Mutex<ConnectionCounter>>,
+    helm_chart_version: Option<String>,
 }
 
 #[async_trait]
@@ -91,6 +94,7 @@ impl Server {
             metrics: Metrics::new(config.metrics, config.label),
             internal: config.internal,
             active_connection_count: config.active_connection_count,
+            helm_chart_version: config.helm_chart_version,
         }
     }
 
@@ -105,6 +109,7 @@ impl Server {
         let internal = self.internal;
         let metrics = self.metrics.clone();
         let active_connection_count = Arc::clone(&self.active_connection_count);
+        let helm_chart_version = self.helm_chart_version.clone();
         // TODO(guswynn): remove this redundant_closure_call
         #[allow(clippy::redundant_closure_call)]
         async move {
@@ -174,6 +179,7 @@ impl Server {
                                     frontegg: frontegg.as_ref(),
                                     internal,
                                     active_connection_count,
+                                    helm_chart_version,
                                 })
                                 .await?;
                                 conn.flush().await?;

--- a/src/prof-http/src/bin/fgviz.rs
+++ b/src/prof-http/src/bin/fgviz.rs
@@ -21,7 +21,7 @@ fn main() {
         })
         .unwrap_or_else(|| "".into());
     let rendered = FlamegraphTemplate {
-        version: &bi.human_version(),
+        version: &bi.human_version(None),
         title: "Flamegraph Visualizer",
         mzfg: &mzfg,
     }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -394,6 +394,8 @@ pub struct CatalogConfig {
     pub connection_context: ConnectionContext,
     /// Which system builtins to include. Not allowed to change dynamically.
     pub builtins_cfg: BuiltinsConfig,
+    /// Helm chart version
+    pub helm_chart_version: Option<String>,
 }
 
 /// A database in a [`SessionCatalog`].

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1103,6 +1103,7 @@ impl<'a> RunnerInner<'a> {
             http_host_name: Some(host_name),
             internal_console_redirect_url: None,
             tls_reload_certs: mz_server_core::cert_reload_never_reload(),
+            helm_chart_version: None,
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned


### PR DESCRIPTION
See https://materializeinc.slack.com/archives/CQM08AP9V/p1729875799567639 for context
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
