### PR TITLE
prefix with mz{resource_id} from Materialize CR status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,6 +4568,7 @@ dependencies = [
  "kube",
  "mz-ore",
  "mz-repr",
+ "rand",
  "schemars",
  "semver",
  "serde",

--- a/misc/helm-charts/environmentd/templates/environmentd.yaml
+++ b/misc/helm-charts/environmentd/templates/environmentd.yaml
@@ -33,3 +33,4 @@ spec:
   forceRollout: {{ .Values.environment.forceRollout }}
   {{- end }}
   inPlaceRollout: {{ .Values.environment.inPlaceRollout }}
+  backendSecretName: {{ .Values.environment.backendSecretName }}

--- a/misc/helm-charts/environmentd/templates/secret.yaml
+++ b/misc/helm-charts/environmentd/templates/secret.yaml
@@ -11,7 +11,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: materialize-backend-{{ .Values.environment.name }}
+  name: {{ .Values.environment.backendSecretName }}
   namespace: {{ .Values.namespace.name }}
 stringData:
   metadata_backend_url: {{ .Values.environment.secret.metadataBackendUrl | quote }}

--- a/misc/helm-charts/environmentd/tests/environmentd_test.yaml
+++ b/misc/helm-charts/environmentd/tests/environmentd_test.yaml
@@ -23,7 +23,7 @@ tests:
       - template: secret.yaml
         equal:
           path: metadata.name
-          value: materialize-backend-12345678-1234-1234-1234-123456789012
+          value: materialize-backend
       - template: secret.yaml
         equal:
           path: metadata.namespace
@@ -44,11 +44,23 @@ tests:
       - template: environmentd.yaml
         equal:
           path: spec.environmentdImageRef
-          value: materialize/environmentd:v0.124.0-dev.0--pr.g993af7c1c493f8ca20389c7cc64769208867d3c9
+          value: materialize/environmentd:v0.124.0-dev.0--pr.gd5e227d7d07dc4878d2a065c7c10a48c2555385a
       - template: environmentd.yaml
         equal:
           path: spec.environmentdExtraArgs[0]
           value: "--orchestrator-kubernetes-ephemeral-volume-class=hostpath"
+      - template: environmentd.yaml
+        equal:
+          path: spec.environmentdResourceRequirements.requests.cpu
+          value: "250m"
+      - template: environmentd.yaml
+        equal:
+          path: spec.environmentdResourceRequirements.requests.memory
+          value: "512Mi"
+      - template: environmentd.yaml
+        equal:
+          path: spec.environmentdResourceRequirements.limits.memory
+          value: "512Mi"
 
   - it: should use custom environment name and settings
     set:
@@ -57,11 +69,16 @@ tests:
         environmentdImageRef: materialize/environmentd:custom
         environmentdExtraArgs:
           - "--feature-flag=experimental"
-        environmentdCpuAllocation: "2"
-        environmentdMemoryAllocation: "2Gi"
+        environmentdResourceRequirements:
+          requests:
+            cpu: "2"
+            memory: "2Gi"
+          limits:
+            memory: "2Gi"
         requestRollout: custom-rollout
         forceRollout: custom-force
         inPlaceRollout: true
+        backendSecretName: materialize-backend-custom-env
     asserts:
       # Test secret.yaml with custom values
       - template: secret.yaml
@@ -84,11 +101,15 @@ tests:
           value: "--feature-flag=experimental"
       - template: environmentd.yaml
         equal:
-          path: spec.environmentdCpuAllocation
+          path: spec.environmentdResourceRequirements.requests.cpu
           value: "2"
       - template: environmentd.yaml
         equal:
-          path: spec.environmentdMemoryAllocation
+          path: spec.environmentdResourceRequirements.requests.memory
+          value: "2Gi"
+      - template: environmentd.yaml
+        equal:
+          path: spec.environmentdResourceRequirements.limits.memory
           value: "2Gi"
 
   - it: should create namespace

--- a/misc/helm-charts/environmentd/values.yaml
+++ b/misc/helm-charts/environmentd/values.yaml
@@ -19,7 +19,7 @@ environment:
   # The name of the environment to be deployed, this should be a UUID
   name: "12345678-1234-1234-1234-123456789012"
   # Docker image reference for the Materialize `environmentd` service
-  environmentdImageRef: "materialize/environmentd:v0.124.0-dev.0--pr.g993af7c1c493f8ca20389c7cc64769208867d3c9"
+  environmentdImageRef: "materialize/environmentd:v0.124.0-dev.0--pr.gd5e227d7d07dc4878d2a065c7c10a48c2555385a"
   # Optional additional arguments to be passed to `environmentd`
   environmentdExtraArgs:
     - "--orchestrator-kubernetes-ephemeral-volume-class=hostpath" # Use hostpath for ephemeral storage in testing
@@ -43,6 +43,7 @@ environment:
   forceRollout: 33333333-3333-3333-3333-333333333333
   # Whether rollouts should be done in place or with restarts
   inPlaceRollout: false
+  backendSecretName: materialize-backend
 
   # Secret configuration for database and persistence backends
   secret:

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: materialize/orchestratord:v0.124.0-dev.0--pr.g993af7c1c493f8ca20389c7cc64769208867d3c9
+          value: materialize/orchestratord:v0.124.0-dev.0--pr.gd5e227d7d07dc4878d2a065c7c10a48c2555385a
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -13,7 +13,7 @@ operator:
     # The Docker repository for the operator image
     repository: materialize/orchestratord
     # The tag/version of the operator image to be used
-    tag: v0.124.0-dev.0--pr.g993af7c1c493f8ca20389c7cc64769208867d3c9
+    tag: v0.124.0-dev.0--pr.gd5e227d7d07dc4878d2a065c7c10a48c2555385a
     # Policy for pulling the image: "IfNotPresent" avoids unnecessary re-pulling of images
     pullPolicy: IfNotPresent
   args:

--- a/src/cloud-resources/Cargo.toml
+++ b/src/cloud-resources/Cargo.toml
@@ -18,6 +18,7 @@ chrono = { version = "0.4.35", default-features = false }
 futures = "0.3.25"
 mz-ore = { path = "../ore", features = [] }
 mz-repr = { path = "../repr" }
+rand = "0.8.5"
 schemars = { version = "0.8", features = ["uuid1"] }
 semver = "1.0.16"
 serde = "1.0.152"

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -273,6 +273,9 @@ pub struct Args {
     /// The optional fs group for service's pods' `securityContext`.
     #[clap(long, env = "ORCHESTRATOR_KUBERNETES_SERVICE_FS_GROUP")]
     orchestrator_kubernetes_service_fs_group: Option<i64>,
+    /// The prefix to prepend to all kubernetes object names.
+    #[clap(long, env = "ORCHESTRATOR_KUBERNETES_NAME_PREFIX")]
+    orchestrator_kubernetes_name_prefix: Option<String>,
     #[clap(long, env = "ORCHESTRATOR_PROCESS_WRAPPER")]
     orchestrator_process_wrapper: Option<String>,
     /// Where the process orchestrator should store secrets.
@@ -750,6 +753,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                             .orchestrator_kubernetes_ephemeral_volume_class
                             .clone(),
                         service_fs_group: args.orchestrator_kubernetes_service_fs_group.clone(),
+                        name_prefix: args.orchestrator_kubernetes_name_prefix.clone(),
                     }))
                     .context("creating kubernetes orchestrator")?,
             );

--- a/src/orchestratord/src/controller/materialize/resources.rs
+++ b/src/orchestratord/src/controller/materialize/resources.rs
@@ -924,6 +924,12 @@ fn create_environmentd_statefulset_object(
             "--orchestrator-kubernetes-service-label={key}={val}"
         ));
     }
+    if let Some(status) = &mz.status {
+        args.push(format!(
+            "--orchestrator-kubernetes-name-prefix=mz{}-",
+            status.resource_id
+        ));
+    }
 
     // Add logging and tracing arguments.
     args.extend(["--log-format=json".into()]);


### PR DESCRIPTION
Prefix kubernetes object names with `mz{resource_id}-` based on a randomly generated string stored in the Materialize CR status.

### Motivation

Eventual support for multiple Materialize CRs in a single namespace. We need to avoid name collisions, and we need something short and consistently starting with a letter to avoid DNS-1035 issues.

Originating slack discussion: https://materializeinc.slack.com/archives/CL68GT3AT/p1730717511313559

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
