### PR TITLE
testdrive: Disable flaky check temporarily

### DIFF
--- a/test/testdrive-old-kafka-src-syntax/controller-frontiers.td
+++ b/test/testdrive-old-kafka-src-syntax/controller-frontiers.td
@@ -302,6 +302,10 @@ mv1  r3
 r2 <null>
 r3 <null>
 
+# TODO: Reenable when database-issues#8725 is fixed
+$ skip-if
+SELECT true
+
 > SELECT
     frontiers.read_frontier,
     frontiers.write_frontier
@@ -311,6 +315,8 @@ r3 <null>
   WHERE
     mvs.name = 'mv2'
 0 <null>
+
+$ skip-end
 
 # Test that frontiers are removed when objects are dropped.
 

--- a/test/testdrive/controller-frontiers.td
+++ b/test/testdrive/controller-frontiers.td
@@ -339,6 +339,10 @@ mv1  r3
 r2 <null>
 r3 <null>
 
+# TODO: Reenable when database-issues#8725 is fixed
+$ skip-if
+SELECT true
+
 > SELECT
     frontiers.read_frontier,
     frontiers.write_frontier
@@ -348,6 +352,8 @@ r3 <null>
   WHERE
     mvs.name = 'mv2'
 0 <null>
+
+$ skip-end
 
 # Test that frontiers are removed when objects are dropped.
 


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
