### PR TITLE
helm-chart: add openebs

### DIFF
--- a/misc/helm-charts/environmentd/values.yaml
+++ b/misc/helm-charts/environmentd/values.yaml
@@ -21,8 +21,7 @@ environment:
   # Docker image reference for the Materialize `environmentd` service
   environmentdImageRef: "materialize/environmentd:v0.124.0-dev.0--pr.g993af7c1c493f8ca20389c7cc64769208867d3c9"
   # Optional additional arguments to be passed to `environmentd`
-  environmentdExtraArgs:
-    - "--orchestrator-kubernetes-ephemeral-volume-class=hostpath" # Use hostpath for ephemeral storage in testing
+  environmentdExtraArgs: []
   # Resource requirements for the environmentd pod
   environmentdResourceRequirements:
     requests:

--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -13,7 +13,9 @@ This Helm chart deploys the Materialize operator on a Kubernetes cluster. The op
 
 ### Kubernetes Storage Configuration
 
-If you want to use disk-backed clusters, you'll need to configure a storage provider.
+To provide additional disk to clusterd pods, configure a CSI plugin in your kubernetes cluster.
+
+Note that networked storage (such as EBS volumes) may not perform well in this setup; for best results, we recommend targeting local instance store NVMe drives.
 
 We recommend using OpenEBS with LVM for local persistent volumes:
 
@@ -84,7 +86,6 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.args.createBalancers` |  | ``true`` |
 | `operator.args.environmentdConnectionRoleARN` |  | ``""`` |
 | `operator.args.environmentdIAMRoleARN` |  | ``""`` |
-| `operator.args.ephemeralVolumeClass` |  | ``nil`` |
 | `operator.args.localDevelopment` |  | ``true`` |
 | `operator.args.region` |  | ``"kind"`` |
 | `operator.args.startupLogFilter` |  | ``"INFO,mz_orchestratord=TRACE"`` |
@@ -98,15 +99,15 @@ The following table lists the configurable parameters of the Materialize operato
 | `rbac.create` |  | ``true`` |
 | `serviceAccount.create` |  | ``true`` |
 | `serviceAccount.name` |  | ``"orchestratord"`` |
-| `storage.openebs.storageClass.allowVolumeExpansion` |  | ``false`` |
-| `storage.openebs.storageClass.create` |  | ``false`` |
-| `storage.openebs.storageClass.name` |  | ``"openebs-lvm-instance-store-ext4"`` |
-| `storage.openebs.storageClass.parameters.fsType` |  | ``"ext4"`` |
-| `storage.openebs.storageClass.parameters.storage` |  | ``"lvm"`` |
-| `storage.openebs.storageClass.parameters.volgroup` |  | ``"instance-store-vg"`` |
-| `storage.openebs.storageClass.provisioner` |  | ``"local.csi.openebs.io"`` |
-| `storage.openebs.storageClass.reclaimPolicy` |  | ``"Delete"`` |
-| `storage.openebs.storageClass.volumeBindingMode` |  | ``"WaitForFirstConsumer"`` |
+| `storage.storageClass.allowVolumeExpansion` |  | ``false`` |
+| `storage.storageClass.create` |  | ``"fasle"`` |
+| `storage.storageClass.name` |  | ``""`` |
+| `storage.storageClass.parameters.fsType` |  | ``"ext4"`` |
+| `storage.storageClass.parameters.storage` |  | ``"lvm"`` |
+| `storage.storageClass.parameters.volgroup` |  | ``"instance-store-vg"`` |
+| `storage.storageClass.provisioner` |  | ``"local.csi.openebs.io"`` |
+| `storage.storageClass.reclaimPolicy` |  | ``"Delete"`` |
+| `storage.storageClass.volumeBindingMode` |  | ``"WaitForFirstConsumer"`` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -13,50 +13,72 @@ This Helm chart deploys the Materialize operator on a Kubernetes cluster. The op
 
 ### Kubernetes Storage Configuration
 
-To provide additional disk to clusterd pods, configure a CSI plugin in your Kubernetes cluster.
+Materialize requires fast storage for optimal performance. Network-attached storage (like EBS volumes) can significantly impact performance, so we strongly recommend using locally-attached NVMe drives.
 
-**Note:** Networked storage (such as EBS volumes) may not perform well in this setup; for best results, we recommend targeting local instance store NVMe drives.
+We recommend using OpenEBS with LVM Local PV for managing local volumes. While other storage solutions may work, we have tested and recommend OpenEBS for optimal performance.
 
-For local volumes, we recommend using OpenEBS with LVM. The following instructions will guide you through installing OpenEBS. However, **you'll need to set up LVM on your nodes** based on your specific environment:
-
-#### Installing OpenEBS Operator
+#### Installing OpenEBS
 
 ```bash
-# Install OpenEBS operator (required only for disk-backed clusters)
+# Install OpenEBS operator
 helm repo add openebs https://openebs.github.io/openebs
 helm repo update
 
-# To install just the OpenEBS Local PV Storage Engines, use the following command:
-helm install openebs --namespace openebs openebs/openebs --set engines.replicated.mayastor.enabled=false --create-namespace
+# Install only the Local PV Storage Engines
+helm install openebs --namespace openebs openebs/openebs \
+  --set engines.replicated.mayastor.enabled=false \
+  --create-namespace
 ```
 
-Verify that the OpenEBS operator is running:
-
+Verify the installation:
 ```bash
 kubectl get pods -n openebs -l role=openebs-lvm
 ```
 
-#### Setting Up LVM on AWS EC2 Bottlerocket Instances
+#### LVM Configuration
 
-In environments such as AWS, where instance types with instance store volumes are available (e.g., `i3.xlarge`, `i4i.xlarge`, `r5d.xlarge`), you can configure LVM. We recommend setting up LVM specifically on AWS EC2 instances running **Bottlerocket AMI on instance types like `m6g` or `m7g`**.
+LVM setup varies by environment. Below is our tested and recommended configuration:
 
-> **Note:** Paths and device names for instance store volumes can vary significantly across cloud providers, hardware configurations, and kernel versions. Setting up LVM on other configurations may work but has not been tested by us.
+##### AWS EC2 with Bottlerocket AMI
+Tested configurations:
+- Instance types: m6g, m7g families
+- AMI: AWS Bottlerocket
+- Instance store volumes required
 
-If you're using a different environment or instance type, refer to specific documentation or use a custom setup. Here's an example configuration you might need to adjust for Bottlerocket:
+Setup process:
+1. Use Bottlerocket bootstrap container for LVM configuration
+2. Configure volume group name as `instance-store-vg`
 
-- Use a Bottlerocket bootstrap container to set up LVM.
-- Ensure device paths and volume groups align with your instance configuration.
+**Note:** While LVM setup may work on other instance types with local storage (like i3.xlarge, i4i.xlarge, r5d.xlarge), we have not extensively tested these configurations.
 
-#### Example Configuration for `values.yaml`
+#### Storage Configuration
 
-Once you have OpenEBS installed and LVM set up on your nodes, create a storage class by adding the following configuration to your `values.yaml`:
+Once LVM is configured, set up the storage class:
 
 ```yaml
 storage:
   storageClass:
     create: true
-    name: openebs-lvm-instance-store-ext4
-    provisioner: local.csi.openebs.io
+    name: "openebs-lvm-instance-store-ext4"
+    provisioner: "local.csi.openebs.io"
+    parameters:
+      storage: "lvm"
+      fsType: "ext4"
+      volgroup: "instance-store-vg"
+```
+
+While OpenEBS is our recommended solution, you can use any storage provisioner that meets your performance requirements by overriding the provisioner and parameters values.
+
+For example, to use a different storage provider:
+
+```yaml
+storage:
+  storageClass:
+    create: true
+    name: "your-storage-class"
+    provisioner: "your.storage.provisioner"
+    parameters:
+      # Parameters specific to your chosen storage provisioner
 ```
 
 ## Installing the Chart

--- a/misc/helm-charts/operator/README.md.gotmpl
+++ b/misc/helm-charts/operator/README.md.gotmpl
@@ -24,50 +24,72 @@ This Helm chart deploys the Materialize operator on a Kubernetes cluster. The op
 
 ### Kubernetes Storage Configuration
 
-To provide additional disk to clusterd pods, configure a CSI plugin in your Kubernetes cluster.
+Materialize requires fast storage for optimal performance. Network-attached storage (like EBS volumes) can significantly impact performance, so we strongly recommend using locally-attached NVMe drives.
 
-**Note:** Networked storage (such as EBS volumes) may not perform well in this setup; for best results, we recommend targeting local instance store NVMe drives.
+We recommend using OpenEBS with LVM Local PV for managing local volumes. While other storage solutions may work, we have tested and recommend OpenEBS for optimal performance.
 
-For local volumes, we recommend using OpenEBS with LVM. The following instructions will guide you through installing OpenEBS. However, **you'll need to set up LVM on your nodes** based on your specific environment:
-
-#### Installing OpenEBS Operator
+#### Installing OpenEBS
 
 ```bash
-# Install OpenEBS operator (required only for disk-backed clusters)
+# Install OpenEBS operator
 helm repo add openebs https://openebs.github.io/openebs
 helm repo update
 
-# To install just the OpenEBS Local PV Storage Engines, use the following command:
-helm install openebs --namespace openebs openebs/openebs --set engines.replicated.mayastor.enabled=false --create-namespace
+# Install only the Local PV Storage Engines
+helm install openebs --namespace openebs openebs/openebs \
+  --set engines.replicated.mayastor.enabled=false \
+  --create-namespace
 ```
 
-Verify that the OpenEBS operator is running:
-
+Verify the installation:
 ```bash
 kubectl get pods -n openebs -l role=openebs-lvm
 ```
 
-#### Setting Up LVM on AWS EC2 Bottlerocket Instances
+#### LVM Configuration
 
-In environments such as AWS, where instance types with instance store volumes are available (e.g., `i3.xlarge`, `i4i.xlarge`, `r5d.xlarge`), you can configure LVM. We recommend setting up LVM specifically on AWS EC2 instances running **Bottlerocket AMI on instance types like `m6g` or `m7g`**.
+LVM setup varies by environment. Below is our tested and recommended configuration:
 
-> **Note:** Paths and device names for instance store volumes can vary significantly across cloud providers, hardware configurations, and kernel versions. Setting up LVM on other configurations may work but has not been tested by us.
+##### AWS EC2 with Bottlerocket AMI
+Tested configurations:
+- Instance types: m6g, m7g families
+- AMI: AWS Bottlerocket
+- Instance store volumes required
 
-If you're using a different environment or instance type, refer to specific documentation or use a custom setup. Here's an example configuration you might need to adjust for Bottlerocket:
+Setup process:
+1. Use Bottlerocket bootstrap container for LVM configuration
+2. Configure volume group name as `instance-store-vg`
 
-- Use a Bottlerocket bootstrap container to set up LVM.
-- Ensure device paths and volume groups align with your instance configuration.
+**Note:** While LVM setup may work on other instance types with local storage (like i3.xlarge, i4i.xlarge, r5d.xlarge), we have not extensively tested these configurations.
 
-#### Example Configuration for `values.yaml`
+#### Storage Configuration
 
-Once you have OpenEBS installed and LVM set up on your nodes, create a storage class by adding the following configuration to your `values.yaml`:
+Once LVM is configured, set up the storage class:
 
 ```yaml
 storage:
   storageClass:
     create: true
-    name: openebs-lvm-instance-store-ext4
-    provisioner: local.csi.openebs.io
+    name: "openebs-lvm-instance-store-ext4"
+    provisioner: "local.csi.openebs.io"
+    parameters:
+      storage: "lvm"
+      fsType: "ext4"
+      volgroup: "instance-store-vg"
+```
+
+While OpenEBS is our recommended solution, you can use any storage provisioner that meets your performance requirements by overriding the provisioner and parameters values.
+
+For example, to use a different storage provider:
+
+```yaml
+storage:
+  storageClass:
+    create: true
+    name: "your-storage-class"
+    provisioner: "your.storage.provisioner"
+    parameters:
+      # Parameters specific to your chosen storage provisioner
 ```
 
 ## Installing the Chart

--- a/misc/helm-charts/operator/README.md.gotmpl
+++ b/misc/helm-charts/operator/README.md.gotmpl
@@ -22,6 +22,36 @@ This Helm chart deploys the Materialize operator on a Kubernetes cluster. The op
 - Kubernetes 1.19+
 - Helm 3.2.0+
 
+### Kubernetes Storage Configuration
+
+If you want to use disk-backed clusters, you'll need to configure a storage provider.
+
+We recommend using OpenEBS with LVM for local persistent volumes:
+
+```bash
+# Install OpenEBS operator (required only for disk-backed clusters)
+helm repo add openebs https://openebs.github.io/openebs
+helm repo update
+helm install openebs --namespace openebs openebs/openebs --create-namespace
+```
+
+Then verify that the OpenEBS operator is running:
+
+```bash
+kubectl get pods -n openebs -l role=openebs-lvm
+```
+
+Your nodes must have available disks for LVM to use. For AWS EC2, this means using instance types with instance store volumes (e.g., i3.xlarge, i4i.xlarge, r5d.xlarge).
+
+To create the storage class for OpenEBS, add the following configuration to your `values.yaml`:
+
+```yaml
+storage:
+  openebs:
+    storageClass:
+      create: true
+```
+
 ## Installing the Chart
 
 To install the chart with the release name `my-materialize-operator`:

--- a/misc/helm-charts/operator/README.md.gotmpl
+++ b/misc/helm-charts/operator/README.md.gotmpl
@@ -24,34 +24,50 @@ This Helm chart deploys the Materialize operator on a Kubernetes cluster. The op
 
 ### Kubernetes Storage Configuration
 
-To provide additional disk to clusterd pods, configure a CSI plugin in your kubernetes cluster.
+To provide additional disk to clusterd pods, configure a CSI plugin in your Kubernetes cluster.
 
-Note that networked storage (such as EBS volumes) may not perform well in this setup; for best results, we recommend targeting local instance store NVMe drives.
+**Note:** Networked storage (such as EBS volumes) may not perform well in this setup; for best results, we recommend targeting local instance store NVMe drives.
 
-We recommend using OpenEBS with LVM for local persistent volumes:
+For local volumes, we recommend using OpenEBS with LVM. The following instructions will guide you through installing OpenEBS. However, **you'll need to set up LVM on your nodes** based on your specific environment:
+
+#### Installing OpenEBS Operator
 
 ```bash
 # Install OpenEBS operator (required only for disk-backed clusters)
 helm repo add openebs https://openebs.github.io/openebs
 helm repo update
-helm install openebs --namespace openebs openebs/openebs --create-namespace
+
+# To install just the OpenEBS Local PV Storage Engines, use the following command:
+helm install openebs --namespace openebs openebs/openebs --set engines.replicated.mayastor.enabled=false --create-namespace
 ```
 
-Then verify that the OpenEBS operator is running:
+Verify that the OpenEBS operator is running:
 
 ```bash
 kubectl get pods -n openebs -l role=openebs-lvm
 ```
 
-Your nodes must have available disks for LVM to use. For AWS EC2, this means using instance types with instance store volumes (e.g., i3.xlarge, i4i.xlarge, r5d.xlarge).
+#### Setting Up LVM on AWS EC2 Bottlerocket Instances
 
-To create the storage class for OpenEBS, add the following configuration to your `values.yaml`:
+In environments such as AWS, where instance types with instance store volumes are available (e.g., `i3.xlarge`, `i4i.xlarge`, `r5d.xlarge`), you can configure LVM. We recommend setting up LVM specifically on AWS EC2 instances running **Bottlerocket AMI on instance types like `m6g` or `m7g`**.
+
+> **Note:** Paths and device names for instance store volumes can vary significantly across cloud providers, hardware configurations, and kernel versions. Setting up LVM on other configurations may work but has not been tested by us.
+
+If you're using a different environment or instance type, refer to specific documentation or use a custom setup. Here's an example configuration you might need to adjust for Bottlerocket:
+
+- Use a Bottlerocket bootstrap container to set up LVM.
+- Ensure device paths and volume groups align with your instance configuration.
+
+#### Example Configuration for `values.yaml`
+
+Once you have OpenEBS installed and LVM set up on your nodes, create a storage class by adding the following configuration to your `values.yaml`:
 
 ```yaml
 storage:
-  openebs:
-    storageClass:
-      create: true
+  storageClass:
+    create: true
+    name: openebs-lvm-instance-store-ext4
+    provisioner: local.csi.openebs.io
 ```
 
 ## Installing the Chart

--- a/misc/helm-charts/operator/README.md.gotmpl
+++ b/misc/helm-charts/operator/README.md.gotmpl
@@ -24,7 +24,9 @@ This Helm chart deploys the Materialize operator on a Kubernetes cluster. The op
 
 ### Kubernetes Storage Configuration
 
-If you want to use disk-backed clusters, you'll need to configure a storage provider.
+To provide additional disk to clusterd pods, configure a CSI plugin in your kubernetes cluster.
+
+Note that networked storage (such as EBS volumes) may not perform well in this setup; for best results, we recommend targeting local instance store NVMe drives.
 
 We recommend using OpenEBS with LVM for local persistent volumes:
 

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -60,8 +60,8 @@ spec:
         {{- range $key, $value := .Values.clusterd.nodeSelector }}
         - "--clusterd-node-selector={{ $key }}={{ $value }}"
         {{- end }}
-        {{- if .Values.operator.args.ephemeralVolumeClass }}
-        - "--ephemeral-volume-class={{ .Values.operator.args.ephemeralVolumeClass }}"
+        {{- if .Values.storage.storageClass.name }}
+        - "--ephemeral-volume-class={{ .Values.storage.storageClass.name }}"
         {{- end }}
         {{- if .Values.networkPolicies.enabled }}
         {{- if .Values.networkPolicies.internal.enabled }}

--- a/misc/helm-charts/operator/templates/storageclass.yaml
+++ b/misc/helm-charts/operator/templates/storageclass.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.storage.openebs.storageClass.create }}
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.storage.openebs.storageClass.name }}
+allowVolumeExpansion: {{ .Values.storage.openebs.storageClass.allowVolumeExpansion }}
+provisioner: {{ .Values.storage.openebs.storageClass.provisioner }}
+parameters:
+  {{- toYaml .Values.storage.openebs.storageClass.parameters | nindent 2 }}
+reclaimPolicy: {{ .Values.storage.openebs.storageClass.reclaimPolicy }}
+volumeBindingMode: {{ .Values.storage.openebs.storageClass.volumeBindingMode }}
+
+{{- end }}

--- a/misc/helm-charts/operator/templates/storageclass.yaml
+++ b/misc/helm-charts/operator/templates/storageclass.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.storage.openebs.storageClass.create }}
+{{- if and .Values.storage.storageClass.create .Values.storage.storageClass.name }}
 # Copyright Materialize, Inc. and contributors. All rights reserved.
 #
 # Use of this software is governed by the Business Source License
@@ -11,12 +11,12 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ .Values.storage.openebs.storageClass.name }}
-allowVolumeExpansion: {{ .Values.storage.openebs.storageClass.allowVolumeExpansion }}
-provisioner: {{ .Values.storage.openebs.storageClass.provisioner }}
+  name: {{ .Values.storage.storageClass.name }}
+allowVolumeExpansion: {{ .Values.storage.storageClass.allowVolumeExpansion }}
+provisioner: {{ .Values.storage.storageClass.provisioner }}
 parameters:
-  {{- toYaml .Values.storage.openebs.storageClass.parameters | nindent 2 }}
-reclaimPolicy: {{ .Values.storage.openebs.storageClass.reclaimPolicy }}
-volumeBindingMode: {{ .Values.storage.openebs.storageClass.volumeBindingMode }}
+  {{- toYaml .Values.storage.storageClass.parameters | nindent 2 }}
+reclaimPolicy: {{ .Values.storage.storageClass.reclaimPolicy }}
+volumeBindingMode: {{ .Values.storage.storageClass.volumeBindingMode }}
 
 {{- end }}

--- a/misc/helm-charts/operator/tests/storageclass_test.yaml
+++ b/misc/helm-charts/operator/tests/storageclass_test.yaml
@@ -13,15 +13,15 @@ templates:
 tests:
   - it: should render storage class with correct values
     set:
-      storage.openebs.storageClass.create: true
-      storage.openebs.storageClass.name: openebs-lvm-instance-store-ext4
-      storage.openebs.storageClass.allowVolumeExpansion: false
-      storage.openebs.storageClass.provisioner: local.csi.openebs.io
-      storage.openebs.storageClass.parameters.storage: lvm
-      storage.openebs.storageClass.parameters.fsType: ext4
-      storage.openebs.storageClass.parameters.volgroup: instance-store-vg
-      storage.openebs.storageClass.reclaimPolicy: Delete
-      storage.openebs.storageClass.volumeBindingMode: WaitForFirstConsumer
+      storage.storageClass.create: true
+      storage.storageClass.name: openebs-lvm-instance-store-ext4
+      storage.storageClass.allowVolumeExpansion: false
+      storage.storageClass.provisioner: local.csi.openebs.io
+      storage.storageClass.parameters.storage: lvm
+      storage.storageClass.parameters.fsType: ext4
+      storage.storageClass.parameters.volgroup: instance-store-vg
+      storage.storageClass.reclaimPolicy: Delete
+      storage.storageClass.volumeBindingMode: WaitForFirstConsumer
     asserts:
       - hasDocuments:
           count: 1
@@ -54,14 +54,14 @@ tests:
 
   - it: should not render when storage class creation is disabled
     set:
-      storage.openebs.storageClass.create: false
+      storage.storageClass.create: false
     asserts:
       - hasDocuments:
           count: 0
 
   - it: should render if storage class creation is enabled
     set:
-      storage.openebs.storageClass.create: true
+      storage.storageClass.create: true
     asserts:
       - hasDocuments:
           count: 1

--- a/misc/helm-charts/operator/tests/storageclass_test.yaml
+++ b/misc/helm-charts/operator/tests/storageclass_test.yaml
@@ -1,0 +1,67 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+suite: test storageclass
+templates:
+  - storageclass.yaml
+tests:
+  - it: should render storage class with correct values
+    set:
+      storage.openebs.storageClass.create: true
+      storage.openebs.storageClass.name: openebs-lvm-instance-store-ext4
+      storage.openebs.storageClass.allowVolumeExpansion: false
+      storage.openebs.storageClass.provisioner: local.csi.openebs.io
+      storage.openebs.storageClass.parameters.storage: lvm
+      storage.openebs.storageClass.parameters.fsType: ext4
+      storage.openebs.storageClass.parameters.volgroup: instance-store-vg
+      storage.openebs.storageClass.reclaimPolicy: Delete
+      storage.openebs.storageClass.volumeBindingMode: WaitForFirstConsumer
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: StorageClass
+      - equal:
+          path: metadata.name
+          value: openebs-lvm-instance-store-ext4
+      - equal:
+          path: allowVolumeExpansion
+          value: false
+      - equal:
+          path: provisioner
+          value: local.csi.openebs.io
+      - equal:
+          path: parameters.storage
+          value: lvm
+      - equal:
+          path: parameters.fsType
+          value: ext4
+      - equal:
+          path: parameters.volgroup
+          value: instance-store-vg
+      - equal:
+          path: reclaimPolicy
+          value: Delete
+      - equal:
+          path: volumeBindingMode
+          value: WaitForFirstConsumer
+
+  - it: should not render when storage class creation is disabled
+    set:
+      storage.openebs.storageClass.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render if storage class creation is enabled
+    set:
+      storage.openebs.storageClass.create: true
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/misc/helm-charts/operator/tests/storageclass_test.yaml
+++ b/misc/helm-charts/operator/tests/storageclass_test.yaml
@@ -59,9 +59,10 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should render if storage class creation is enabled
+  - it: should render if storage class creation is enabled and name is set
     set:
       storage.storageClass.create: true
+      storage.storageClass.name: openebs-lvm-instance-store-ext4
     asserts:
       - hasDocuments:
           count: 1

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -101,14 +101,13 @@ namespace:
 storage:
   storageClass:
     # Set to false to use an existing StorageClass instead
-    create: fasle
+    create: false
 
     # Name of the StorageClass to create/use: eg "openebs-lvm-instance-store-ext4"
     name: ""
 
-    # CSI driver to use
-    # Default is OpenEBS, but can be changed (e.g., ebs.csi.aws.com, pd.csi.storage.gke.io)
-    provisioner: "local.csi.openebs.io"
+    # CSI driver to use, eg "local.csi.openebs.io"
+    provisioner: ""
 
     # Parameters for the CSI driver
     parameters:

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -103,3 +103,27 @@ namespace:
   create: false
   # Name of the namespace where the operator and environment will be deployed
   name: "materialize"
+
+# Storage configuration
+storage:
+  # Storage class configuration for OpenEBS
+  # Requires the OpenEBS operator to be installed in the cluster
+  # https://github.com/openebs/lvm-localpv?tab=readme-ov-file#installation
+  # To install OpenEBS, you can use Helm:
+  # helm repo add openebs https://openebs.github.io/openebs
+  # helm repo update
+  # helm install openebs --namespace openebs openebs/openebs --create-namespace
+  openebs:
+    # Storage class configuration for OpenEBS
+    storageClass:
+      # Whether to create the storage class
+      create: false
+      name: "openebs-lvm-instance-store-ext4"
+      allowVolumeExpansion: false
+      provisioner: "local.csi.openebs.io"
+      parameters:
+        storage: "lvm"
+        fsType: "ext4"
+        volgroup: "instance-store-vg"
+      reclaimPolicy: Delete
+      volumeBindingMode: WaitForFirstConsumer

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -33,13 +33,6 @@ operator:
     environmentdConnectionRoleARN: ""
     # awsAccountID is required when cloudProvider is "aws"
     awsAccountID: ""
-    # To provide additional disk to clusterd pods, configure a CSI plugin in
-    # your kubernetes cluster, and put its storage class here. Note that
-    # networked storage (EBS volumes, for instance) is unlikely to work well
-    # here - we recommend using something like
-    # https://github.com/openebs/lvm-localpv targeting local instance store
-    # NVME drives.
-    ephemeralVolumeClass: null
   # Node selector to use for the operator pod
   nodeSelector: {}
   resources:
@@ -106,24 +99,23 @@ namespace:
 
 # Storage configuration
 storage:
-  # Storage class configuration for OpenEBS
-  # Requires the OpenEBS operator to be installed in the cluster
-  # https://github.com/openebs/lvm-localpv?tab=readme-ov-file#installation
-  # To install OpenEBS, you can use Helm:
-  # helm repo add openebs https://openebs.github.io/openebs
-  # helm repo update
-  # helm install openebs --namespace openebs openebs/openebs --create-namespace
-  openebs:
-    # Storage class configuration for OpenEBS
-    storageClass:
-      # Whether to create the storage class
-      create: false
-      name: "openebs-lvm-instance-store-ext4"
-      allowVolumeExpansion: false
-      provisioner: "local.csi.openebs.io"
-      parameters:
-        storage: "lvm"
-        fsType: "ext4"
-        volgroup: "instance-store-vg"
-      reclaimPolicy: Delete
-      volumeBindingMode: WaitForFirstConsumer
+  storageClass:
+    # Set to false to use an existing StorageClass instead
+    create: fasle
+
+    # Name of the StorageClass to create/use: eg "openebs-lvm-instance-store-ext4"
+    name: ""
+
+    # CSI driver to use
+    # Default is OpenEBS, but can be changed (e.g., ebs.csi.aws.com, pd.csi.storage.gke.io)
+    provisioner: "local.csi.openebs.io"
+
+    # Parameters for the CSI driver
+    parameters:
+      storage: "lvm"
+      fsType: "ext4"
+      volgroup: "instance-store-vg"
+
+    allowVolumeExpansion: false
+    reclaimPolicy: Delete
+    volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
One thing that this PR is missing is to actually bootstrap and set up LVM on all nodes. I've got this working with the following Daemon Set, but will need to come up with a more robust solution:

```yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: lvm-setup
  namespace: openebs
spec:
  selector:
    matchLabels:
      app: lvm-setup
  template:
    metadata:
      labels:
        app: lvm-setup
    spec:
      initContainers:
      - name: lvm-setup
        image: ubuntu:latest
        securityContext:
          privileged: true
        command:
        - /bin/bash
        - -c
        - |
          apt-get update
          apt-get install -y lvm2
          nvme_dev="/dev/nvme0n1"
          if [ -e "$nvme_dev" ]; then
            # Check if device is already a PV
            if ! pvs | grep -q "$nvme_dev"; then
              pvcreate "$nvme_dev"
            fi
            # Check if volume group exists
            if ! vgs | grep -q "instance-store-vg"; then
              vgcreate instance-store-vg "$nvme_dev"
            fi
          fi
      containers:
      - name: pause
        image: k8s.gcr.io/pause:3.7
      volumes:
      - name: host-dev
        hostPath:
          path: /dev
      - name: host-sys
        hostPath:
          path: /sys
```