### PR TITLE
Introducing Materialize Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build status](https://badge.buildkite.com/97d6604e015bf633d1c2a12d166bb46f3b43a927d3952c999a.svg?branch=main)](https://buildkite.com/materialize/test)
 [![Doc reference](https://img.shields.io/badge/doc-reference-orange)](https://materialize.com/docs)
 [![Chat on Slack](https://img.shields.io/badge/chat-on%20slack-purple)](https://materialize.com/s/chat)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Materialize%20Guru-006BFF)](https://gurubase.io/g/materialize)
 
 [<img src="https://github.com/MaterializeInc/materialize/assets/23521087/39270ecb-7ac4-4829-b98b-c5b5699a16b8" width=35%>](https://materialize.com)
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Materialize Guru](https://gurubase.io/g/materialize) to Gurubase. Materialize Guru uses the data from this repo and data from the [docs](https://materialize.com/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "Materialize Guru", which highlights that Materialize now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Materialize Guru in Gurubase, just let me know that's totally fine.
