### PR TITLE
catalog: Fix consistency checks

### DIFF
--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -381,7 +381,7 @@ impl CatalogState {
                     });
                     continue;
                 };
-                if !used_entry.used_by().contains(id) 
+                if !used_entry.used_by().contains(id)
                     // Continual Tasks are self referential.
                     && (used_entry.id() != *id && !used_entry.is_continual_task())
                 {

--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -43,11 +43,18 @@ pub struct CatalogInconsistencies {
 
 impl CatalogInconsistencies {
     pub fn is_empty(&self) -> bool {
-        self.internal_fields.is_empty()
-            && self.roles.is_empty()
-            && self.comments.is_empty()
-            && self.object_dependencies.is_empty()
-            && self.items.is_empty()
+        let CatalogInconsistencies {
+            internal_fields,
+            roles,
+            comments,
+            object_dependencies,
+            items,
+        } = self;
+        internal_fields.is_empty()
+            && roles.is_empty()
+            && comments.is_empty()
+            && object_dependencies.is_empty()
+            && items.is_empty()
     }
 }
 

--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -361,7 +361,10 @@ impl CatalogState {
                     });
                     continue;
                 };
-                if !referenced_entry.referenced_by().contains(id) {
+                if !referenced_entry.referenced_by().contains(id)
+                    // Continual Tasks are self referential.
+                    && (referenced_entry.id() != *id && !referenced_entry.is_continual_task())
+                {
                     dependency_inconsistencies.push(
                         ObjectDependencyInconsistency::InconsistentUsedBy {
                             object_a: *id,
@@ -378,7 +381,10 @@ impl CatalogState {
                     });
                     continue;
                 };
-                if !used_entry.used_by().contains(id) {
+                if !used_entry.used_by().contains(id) 
+                    // Continual Tasks are self referential.
+                    && (used_entry.id() != *id && !used_entry.is_continual_task())
+                {
                     dependency_inconsistencies.push(
                         ObjectDependencyInconsistency::InconsistentUsedBy {
                             object_a: *id,

--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -46,6 +46,7 @@ impl CatalogInconsistencies {
         self.internal_fields.is_empty()
             && self.roles.is_empty()
             && self.comments.is_empty()
+            && self.object_dependencies.is_empty()
             && self.items.is_empty()
     }
 }


### PR DESCRIPTION
Spotted by @ggevay, we were missing the `object_dependencies` field in the `is_empty(...)` check.

### Motivation

* This PR fixes a previously unreported bug.

Catalog consistency checks didn't check everything we thought they did

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
