### PR TITLE
compute: Fix Threshold lowering's ArrangeBy

### DIFF
--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -773,13 +773,6 @@ This is not expected to cause incorrect results, but could indicate a performanc
             MirRelationExpr::Threshold { input } => {
                 let arity = input.arity();
                 let (plan, keys) = self.lower_mir_expr(input)?;
-                // We don't have an MFP here -- install an operator to permute the
-                // input, if necessary.
-                let plan = if !keys.raw {
-                    self.arrange_by(plan, AvailableCollections::new_raw(), &keys, arity)
-                } else {
-                    plan
-                };
                 let (threshold_plan, required_arrangement) = ThresholdPlan::create_from(arity);
                 let mut types = keys.types.clone();
                 let plan = if !keys


### PR DESCRIPTION
`Threshold`'s MIR-to-LIR lowering had some copy-pasted lines that don't fit there. This PR deletes these lines. They were probably copied from lowerings of other operators, which need an unarranged (i.e., raw) input. However, `Threshold` needs an arranged input, so these lines are unnecessary.

Actually, the deleted lines could have caused a panic if we had an input that was already arranged, and not available in raw form: This is because the subsequent lines, which aim to create an arrangement if necessary, were not actually testing the latest form of the input (i.e., the form that the deleted lines were producing), because `keys` was valid only before the deleted lines. Therefore, if we had an input that was already arranged the right way for the `Threshold`, the deleted lines would have dropped this arranged form, and then the subsequent check wouldn't have realized that it needs to re-create this arranged form. Then, the rendering would panic [here](https://github.com/MaterializeInc/materialize/blob/cbaed5e677317feabd97048595e529bf3770547e/src/compute/src/render/threshold.rs#L122), expecting this arrangement to exist. Fortunately, this didn't happen, because apparently we currently never have the right arrangement before a Threshold. (This also means I can't add a test to the PR.)

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer



### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
