### PR TITLE
Properly disable lgalloc

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -299,7 +299,7 @@ impl ComputeState {
             }
         } else {
             info!("disabling lgalloc");
-            lgalloc::lgalloc_set_config(&lgalloc::LgAlloc::new())
+            lgalloc::lgalloc_set_config(lgalloc::LgAlloc::new().disable());
         }
 
         let chunked_stack = ENABLE_CHUNKED_STACK.get(config);


### PR DESCRIPTION
Fixes a bug where we could not disable lgalloc if it was previously enabled.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
