### PR TITLE
storage-client: fix frontier watching

### DIFF
--- a/src/persist-client/src/rpc.rs
+++ b/src/persist-client/src/rpc.rs
@@ -75,7 +75,7 @@ pub(crate) const PUBSUB_PUSH_DIFF_ENABLED: Config<bool> = Config::new(
 /// subscribed clients.
 pub(crate) const PUBSUB_SAME_PROCESS_DELEGATE_ENABLED: Config<bool> = Config::new(
     "persist_pubsub_same_process_delegate_enabled",
-    false, // TODO(database-issues#8725)
+    true,
     "Whether to push state diffs to Persist PubSub on the same process.",
 );
 


### PR DESCRIPTION
The previous implementation of the shard frontier watcher task in `StorageCollections` could skip over frontier advancements. This is particularly problematic if the skipped advancement was to the empty frontier because the storage controller would never learn about the fact that the collection had reached the empty frontier in this case.

This PR fixes the watcher issue and also re-enables the persist pubsub same-process delegation, which was previously disabled because it surfaced this issue.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8725
Fixes https://github.com/MaterializeInc/database-issues/issues/8721

### Tips for reviewer

Not sure if this is the best fix. I'm pretty sure it works, but having to add a large explanatory comment feels a bit bad. I was considering passing the current upper to `gen_upper_future` as an argument, but wasn't sure what to do in the `BackgroundCmd::Register` case where we don't have a previous upper. We could use either of `write_handle.upper()`, `write_handle.shared_upper()`, or `[0]`, but it's not clear to me which is correct.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
