### PR TITLE
adapter: Acquire locks earlier for read-then-write plans

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -230,6 +230,16 @@ pub enum Message {
     TryDeferred {
         /// The connection that created this op.
         conn_id: ConnectionId,
+        /// The write lock that notified us our deferred op might be able to run.
+        ///
+        /// Note: While we never want to hold a partial set of locks, it can be important to hold
+        /// onto the _one_ that notified us our op might be ready. If there are multiple operations
+        /// waiting on a single collection, and we don't hold this lock through retyring the op,
+        /// then everything waiting on this collection will get retried causing traffic in the
+        /// Coordinator's message queue.
+        ///
+        /// See [`DeferredWriteOp::can_be_optimistically_retried`] for more detail.
+        acquired_lock: Option<(GlobalId, tokio::sync::OwnedMutexGuard<()>)>,
     },
     /// Initiates a group commit.
     GroupCommitInitiate(Span, Option<GroupCommitPermit>),

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -34,7 +34,7 @@ use crate::catalog::BuiltinTableUpdate;
 use crate::coord::{Coordinator, Message, PendingTxn, PlanValidity};
 use crate::session::{GroupCommitWriteLocks, WriteLocks};
 use crate::util::{CompletedClientTransmitter, ResultExt};
-use crate::ExecuteContext;
+use crate::{AdapterError, ExecuteContext};
 
 /// An operation that was deferred waiting for [`WriteLocks`].
 #[derive(Debug)]
@@ -46,6 +46,38 @@ pub enum DeferredWriteOp {
 }
 
 impl DeferredWriteOp {
+    /// Certain operations, e.g. "blind writes"/`INSERT` statements, can be optimistically retried
+    /// because we can share a write lock between multiple operations. In this case we wait to
+    /// acquire the locks until [`group_commit`], where writes are groupped by collection and
+    /// comitted at a single timestamp.
+    ///
+    /// Other operations, e.g. read-then-write plans/`UPDATE` statements, must uniquely hold their
+    /// write locks and thus we should acquire the locks in [`try_deferred`] to prevent multiple
+    /// queued plans attempting to get retried at the same time, when we know only one can proceed.
+    ///
+    /// [`try_deferred`]: crate::coord::Coordinator::try_deferred
+    /// [`group_commit`]: crate::coord::Coordinator::group_commit
+    pub(crate) fn can_be_optimistically_retried(&self) -> bool {
+        match self {
+            DeferredWriteOp::Plan(_) => false,
+            DeferredWriteOp::Write(_) => true,
+        }
+    }
+
+    /// Returns an Iterator of all the required locks for current operation.
+    pub fn required_locks(&self) -> impl Iterator<Item = GlobalId> + use<'_> {
+        match self {
+            DeferredWriteOp::Plan(plan) => {
+                let iter = plan.requires_locks.iter().copied();
+                itertools::Either::Left(iter)
+            }
+            DeferredWriteOp::Write(write) => {
+                let iter = write.writes.keys().copied();
+                itertools::Either::Right(iter)
+            }
+        }
+    }
+
     /// Returns the [`ConnectionId`] associated with this deferred op.
     pub fn conn_id(&self) -> &ConnectionId {
         match self {
@@ -136,11 +168,45 @@ impl Coordinator {
     ///
     /// If we can't acquire all of the write locks then we'll defer the plan again and wait for
     /// the necessary locks to become available.
-    pub(crate) async fn try_deferred(&mut self, conn_id: ConnectionId) {
+    pub(crate) async fn try_deferred(
+        &mut self,
+        conn_id: ConnectionId,
+        acquired_lock: Option<(GlobalId, tokio::sync::OwnedMutexGuard<()>)>,
+    ) {
         // Try getting the deferred op, it may have already been canceled.
         let Some(op) = self.deferred_write_ops.remove(&conn_id) else {
             tracing::warn!(%conn_id, "no deferred op found, it must have been canceled?");
             return;
+        };
+
+        // If we pre-acquired a lock, try to acquire the rest.
+        let write_locks = match acquired_lock {
+            Some((acquired_gid, acquired_lock)) => {
+                let mut write_locks = WriteLocks::builder(op.required_locks());
+
+                // Insert the one lock we already acquired into the our builder.
+                write_locks.insert_lock(acquired_gid, acquired_lock);
+
+                // Acquire the rest of our locks, filtering out the one we already have.
+                for gid in op.required_locks().filter(|gid| *gid != acquired_gid) {
+                    if let Some(lock) = self.try_grant_object_write_lock(gid) {
+                        write_locks.insert_lock(gid, lock);
+                    }
+                }
+
+                // If we failed to acquire any locks, spawn a task that waits for them to become available.
+                let locks = match write_locks.all_or_nothing(op.conn_id()) {
+                    Ok(locks) => locks,
+                    Err(failed_to_acquire) => {
+                        let acquire_future = self.grant_object_write_lock(failed_to_acquire);
+                        self.defer_op(acquire_future, op);
+                        return;
+                    }
+                };
+
+                Some(locks)
+            }
+            None => None,
         };
 
         match op {
@@ -151,6 +217,22 @@ impl Coordinator {
                     // Write statements never need to track resolved IDs (NOTE: This is not the
                     // same thing as plan dependencies, which we do need to re-validate).
                     let resolved_ids = ResolvedIds(BTreeSet::new());
+
+                    // If we pre-acquired our locks, grant them to the session.
+                    if let Some(locks) = write_locks {
+                        let conn_id = deferred.ctx.session().conn_id().clone();
+                        if let Err(existing) =
+                            deferred.ctx.session_mut().try_grant_write_locks(locks)
+                        {
+                            tracing::error!(
+                                %conn_id,
+                                ?existing,
+                                "session already write locks granted?",
+                            );
+                            return deferred.ctx.retire(Err(AdapterError::WrongSetOfLocks));
+                        }
+                    };
+
                     // Note: This plan is not guaranteed to run, it may get deferred again.
                     self.sequence_plan(deferred.ctx, deferred.plan, resolved_ids)
                         .await;
@@ -164,7 +246,7 @@ impl Coordinator {
                 self.submit_write(PendingWriteTxn::User {
                     span,
                     writes,
-                    write_locks: None,
+                    write_locks,
                     pending_txn,
                 });
             }
@@ -523,6 +605,7 @@ impl Coordinator {
         let conn_id = op.conn_id().clone();
 
         // Track all of our deferred ops.
+        let is_optimistic = op.can_be_optimistically_retried();
         self.deferred_write_ops.insert(conn_id.clone(), op);
 
         let internal_cmd_tx = self.internal_cmd_tx.clone();
@@ -533,9 +616,21 @@ impl Coordinator {
             //
             // Note: This does not guarantee the plan will be able to run, there might be
             // other locks that we later fail to get.
-            let _ = acquire_future.await;
+            let acquired_lock = acquire_future.await;
+
+            // If the op can be optimistically retried, don't hold onto the lock so other similar
+            // ops might be queued at the same time.
+            let acquired_lock = if is_optimistic {
+                None
+            } else {
+                Some(acquired_lock)
+            };
+
             // If this send fails then the Coordinator is shutting down.
-            let _ = internal_cmd_tx.send(Message::TryDeferred { conn_id });
+            let _ = internal_cmd_tx.send(Message::TryDeferred {
+                conn_id,
+                acquired_lock,
+            });
         });
     }
 

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -91,7 +91,10 @@ impl Coordinator {
                     .boxed_local()
                     .await
             }
-            Message::TryDeferred { conn_id } => self.try_deferred(conn_id).await,
+            Message::TryDeferred {
+                conn_id,
+                acquired_lock,
+            } => self.try_deferred(conn_id, acquired_lock).await,
             Message::GroupCommitInitiate(span, permit) => {
                 // Add an OpenTelemetry link to our current span.
                 tracing::Span::current().add_link(span.context().span().span_context().clone());


### PR DESCRIPTION
This PR acquires locks earlier for deferred read then write plans which I believe should improve performance in high contention scenarios. Previously when a write lock for a dependency became available we would retry _all_ plans waiting on that dependency. This is an optimistic approach and works well for blind writes e.g. `INSERT` statements, because we can share a write lock between `INSERT`s committed at the same time. This doesn't work well for read-then-write plans, e.g. UPDATE statements, though because they must uniquely hold the write lock.

So currently if there are a bunch of read-then-write plans deferred when a lock becomes available they all get retried, only for one to succeed and the rest to get deferred. This causes a lot of traffic in the Coordinator, which I believe is causing the perf regression.

What this PR does is when the lock for a dependency of a read-then-write plan becomes available, we hold onto that lock through the execution of the plan, which prevents other deferred plans waiting on this lock from getting retried. Theres no point in retrying them since we know they won't succeed.

### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/8727

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
