### PR TITLE
storage: in persist_sink, obey read-only flag

### DIFF
--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -93,6 +93,7 @@ use std::fmt::Debug;
 use std::ops::AddAssign;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::Duration;
 
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
@@ -1186,48 +1187,116 @@ where
                 }
 
                 let result = {
-                    let _permit = busy_signal.acquire().await;
+                    let maybe_err = if *read_only_rx.borrow() {
 
-                    if *read_only_rx.borrow() {
-                        // We synthesize an `UpperMismatch` so that we can go
-                        // through the same logic below for trimming down our
-                        // batches.
+                        // We have to wait for either us coming out of read-only
+                        // mode or someone else applying a write that covers our
+                        // batch.
                         //
-                        // Notably, we are not trying to be smart, and teach the
-                        // write operator about read-only mode. Writing down
-                        // those batches does not append anything to the persist
-                        // shard, and it would be a hassle to figure out in the
-                        // write workers how to trim down batches in read-only
-                        // mode, when the shard upper advances.
-                        //
-                        // Right here, in the logic below, we have all we need
-                        // for figuring out how to trim our batches.
-                        let current_upper = write.fetch_recent_upper().await.clone();
+                        // If we didn't wait for the latter here, and just go
+                        // around the loop again, we might miss a moment where
+                        // _we_ have to write down a batch. For example when our
+                        // input frontier advances to a state where we can
+                        // write, and the read-write instance sees the same
+                        // update but then crashes before it can append a batch.
 
-                        if collection_id.is_user() {
-                            tracing::debug!(
-                                %worker_id,
-                                %collection_id,
-                                %shard_id,
-                                ?batch_lower,
-                                ?batch_upper,
-                                ?current_upper,
-                                "persist_sink not appending in read-only mode"
-                            );
-                        }
+                        let maybe_err = loop {
+                            if collection_id.is_user() {
+                                tracing::debug!(
+                                    %worker_id,
+                                    %collection_id,
+                                    %shard_id,
+                                    ?batch_lower,
+                                    ?batch_upper,
+                                    ?current_upper,
+                                    "persist_sink is in read-only mode, waiting until we come out of it or the shard upper advances"
+                                );
+                            }
 
-                        Err(UpperMismatch {
-                            current: current_upper,
-                            expected: batch_lower.clone()}
-                        )
+                            // We don't try to be smart here, and for example
+                            // use `wait_for_upper_past()` and awaiting the
+                            // read-only flag. We'd have to use a select!, which
+                            // would require cancel safety of
+                            // `wait_for_upper_past()`, which it doesn't
+                            // advertise.
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+
+                            if !*read_only_rx.borrow() {
+                                if collection_id.is_user() {
+                                    tracing::debug!(
+                                        %worker_id,
+                                        %collection_id,
+                                        %shard_id,
+                                        ?batch_lower,
+                                        ?batch_upper,
+                                        ?current_upper,
+                                        "persist_sink has come out of read-only mode"
+                                    );
+                                }
+
+                                // It's okay to write now.
+                                break Ok(());
+                            }
+
+                            let current_upper = write.fetch_recent_upper().await;
+
+                            if PartialOrder::less_than(&batch_upper, current_upper) {
+                                // We synthesize an `UpperMismatch` so that we can go
+                                // through the same logic below for trimming down our
+                                // batches.
+                                //
+                                // Notably, we are not trying to be smart, and teach the
+                                // write operator about read-only mode. Writing down
+                                // those batches does not append anything to the persist
+                                // shard, and it would be a hassle to figure out in the
+                                // write workers how to trim down batches in read-only
+                                // mode, when the shard upper advances.
+                                //
+                                // Right here, in the logic below, we have all we need
+                                // for figuring out how to trim our batches.
+
+                                if collection_id.is_user() {
+                                    tracing::debug!(
+                                        %worker_id,
+                                        %collection_id,
+                                        %shard_id,
+                                        ?batch_lower,
+                                        ?batch_upper,
+                                        ?current_upper,
+                                        "persist_sink not appending in read-only mode"
+                                    );
+                                }
+
+                                break Err(UpperMismatch {
+                                    current: current_upper.clone(),
+                                    expected: batch_lower.clone()}
+                                );
+                            }
+                        };
+
+                        maybe_err
                     } else {
-                        write.compare_and_append_batch(
-                            &mut to_append[..],
-                            batch_lower.clone(),
-                            batch_upper.clone(),
-                        )
-                        .await
-                        .expect("Invalid usage")
+                        // It's okay to proceed with the write.
+                        Ok(())
+                    };
+
+                    match maybe_err {
+                        Ok(()) => {
+                            let _permit = busy_signal.acquire().await;
+
+                            write.compare_and_append_batch(
+                                &mut to_append[..],
+                                batch_lower.clone(),
+                                batch_upper.clone(),
+                            )
+                            .await
+                            .expect("Invalid usage")
+                        },
+                        Err(e) => {
+                            // We forward the synthesize error message, so that
+                            // we go though the batch cleanup logic below.
+                            Err(e)
+                        }
                     }
                 };
 


### PR DESCRIPTION
Closes MaterializeInc/database-issues#8583

The second commit is not strictly related to this, but it felt incorrect how we updated those metrics before.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
