### PR TITLE
[introspection] schema fix: operator spans are never null

### DIFF
--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -541,8 +541,8 @@ impl LogVariant {
                 .with_column("operator", ScalarType::String.nullable(false))
                 .with_column("parent_lir_id", ScalarType::UInt64.nullable(true))
                 .with_column("nesting", ScalarType::UInt16.nullable(false))
-                .with_column("operator_id_start", ScalarType::UInt64.nullable(true))
-                .with_column("operator_id_end", ScalarType::UInt64.nullable(true))
+                .with_column("operator_id_start", ScalarType::UInt64.nullable(false))
+                .with_column("operator_id_end", ScalarType::UInt64.nullable(false))
                 .with_key(vec![0, 1, 2])
                 .finish(),
 


### PR DESCRIPTION
While writing up some documentation in Notion, I realized that the operator span columns are listed as nullable but will in fact never be null ([see `compute.rs`](https://github.com/mgree/materialize/blob/lir-mapping-non-nullable-span/src/compute/src/logging/compute.rs#L460)).

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
