### PR TITLE
Add release information when running a dbt deploy_promote

### DIFF
--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import subprocess
 import time
 from collections import namedtuple
 from dataclasses import dataclass
@@ -255,6 +256,20 @@ class MaterializeAdapter(PostgresAdapter, SQLAdapter):
     @classmethod
     def sleep(cls, seconds):
         time.sleep(seconds)
+
+    @available
+    @classmethod
+    def get_git_commit_sha(cls):
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                capture_output=True,
+                check=True,
+                text=True,
+            )
+            return result.stdout.strip()
+        except subprocess.CalledProcessError:
+            return None
 
     def get_column_schema_from_query(self, sql: str) -> List[PostgresColumn]:
         # The idea is that this function returns the names and types of the

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -461,6 +461,21 @@ class TestTargetDeploy:
         assert before_schemas["prod"] == after_schemas["prod_dbt_deploy"]
         assert before_schemas["prod"] == after_schemas["prod_dbt_deploy"]
 
+        # Verify that the 'prod' schema is tagged correctly
+        tagged_schema_comment = project.run_sql(
+            """
+            SELECT c.comment
+            FROM mz_internal.mz_comments c
+            JOIN mz_schemas s USING (id)
+            WHERE s.name = 'prod';
+            """,
+            fetch="one",
+        )
+
+        assert tagged_schema_comment is not None
+        assert "Deployment by" in tagged_schema_comment[0]
+        assert "on" in tagged_schema_comment[0]
+
     def test_dbt_deploy_with_force(self, project):
         project.run_sql("CREATE CLUSTER prod SIZE = '1'")
         project.run_sql("CREATE CLUSTER prod_dbt_deploy SIZE = '1'")


### PR DESCRIPTION
### Motivation

When working with users, it is often useful to understand which version of their code is deployed, when it was deployed, and who deployed it. 

This commit adds comments to each schema managed by a deploy_promote with the user and time of deployment, and optionally adds the commit sha if part a git repo. 

Example Comment: 

```
Deployment by seth@materialize.com on 2024-11-06 20:40:00.798+00 | Commit Sha d0527093d6a0c754e9c9d11feb22f2ed761633b2
```

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
