### PR TITLE
catalog: Implement Arbitrary on expression types

### DIFF
--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -717,13 +717,22 @@ impl Arbitrary for DataflowDescription<FlatPlan, CollectionMetadata, mz_repr::Ti
     type Parameters = ();
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        any_dataflow_description().boxed()
+        any_dataflow_description_flat_plan().boxed()
+    }
+}
+
+impl Arbitrary for DataflowDescription<OptimizedMirRelationExpr, (), mz_repr::Timestamp> {
+    type Strategy = BoxedStrategy<Self>;
+    type Parameters = ();
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        any_dataflow_description_opt_mir().boxed()
     }
 }
 
 proptest::prop_compose! {
-    fn any_dataflow_description()(
-        source_imports in proptest::collection::vec(any_source_import(), 1..3),
+    fn any_dataflow_description_flat_plan()(
+        source_imports in proptest::collection::vec(any_source_import_collection_metadata(), 1..3),
         index_imports in proptest::collection::vec(any_dataflow_index_import(), 1..3),
         objects_to_build in proptest::collection::vec(any::<BuildDesc<FlatPlan>>(), 1..3),
         index_exports in proptest::collection::vec(any_dataflow_index_export(), 1..3),
@@ -770,12 +779,65 @@ proptest::prop_compose! {
     }
 }
 
-fn any_source_import(
+proptest::prop_compose! {
+    fn any_dataflow_description_opt_mir()(
+        source_imports in proptest::collection::vec(any_source_import(), 1..3),
+        index_imports in proptest::collection::vec(any_dataflow_index_import(), 1..3),
+        objects_to_build in proptest::collection::vec(any::<BuildDesc<OptimizedMirRelationExpr>>(), 1..2),
+        index_exports in proptest::collection::vec(any_dataflow_index_export(), 1..3),
+        sink_descs in proptest::collection::vec(
+            any::<(GlobalId, ComputeSinkDesc<(), mz_repr::Timestamp>)>(),
+            1..3,
+        ),
+        as_of_some in any::<bool>(),
+        as_of in proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..5),
+        debug_name in ".*",
+        initial_storage_as_of_some in any::<bool>(),
+        initial_as_of in proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..5),
+        refresh_schedule_some in any::<bool>(),
+        refresh_schedule in any::<RefreshSchedule>(),
+        time_dependence in any::<Option<TimeDependence >>(),
+    ) -> DataflowDescription<OptimizedMirRelationExpr, (), mz_repr::Timestamp> {
+        DataflowDescription {
+            source_imports: BTreeMap::from_iter(source_imports.into_iter()),
+            index_imports: BTreeMap::from_iter(index_imports.into_iter()),
+            objects_to_build,
+            index_exports: BTreeMap::from_iter(index_exports.into_iter()),
+            sink_exports: BTreeMap::from_iter(
+                sink_descs.into_iter(),
+            ),
+            as_of: if as_of_some {
+                Some(Antichain::from(as_of))
+            } else {
+                None
+            },
+            until: Antichain::new(),
+            initial_storage_as_of: if initial_storage_as_of_some {
+                Some(Antichain::from(initial_as_of))
+            } else {
+                None
+            },
+            refresh_schedule: if refresh_schedule_some {
+                Some(refresh_schedule)
+            } else {
+                None
+            },
+            debug_name,
+            time_dependence,
+        }
+    }
+}
+
+fn any_source_import_collection_metadata(
 ) -> impl Strategy<Value = (GlobalId, (SourceInstanceDesc<CollectionMetadata>, bool))> {
     (
         any::<GlobalId>(),
         any::<(SourceInstanceDesc<CollectionMetadata>, bool)>(),
     )
+}
+
+fn any_source_import() -> impl Strategy<Value = (GlobalId, (SourceInstanceDesc<()>, bool))> {
+    (any::<GlobalId>(), any::<(SourceInstanceDesc<()>, bool)>())
 }
 
 proptest::prop_compose! {
@@ -830,7 +892,7 @@ impl RustType<ProtoIndexDesc> for IndexDesc {
 }
 
 /// Information about an imported index, and how it will be used by the dataflow.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Arbitrary)]
 pub struct IndexImport {
     /// Description of index.
     pub desc: IndexDesc,

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -796,7 +796,7 @@ proptest::prop_compose! {
         initial_as_of in proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..5),
         refresh_schedule_some in any::<bool>(),
         refresh_schedule in any::<RefreshSchedule>(),
-        time_dependence in any::<Option<TimeDependence >>(),
+        time_dependence in any::<Option<TimeDependence>>(),
     ) -> DataflowDescription<OptimizedMirRelationExpr, (), mz_repr::Timestamp> {
         DataflowDescription {
             source_imports: BTreeMap::from_iter(source_imports.into_iter()),

--- a/src/compute-types/src/sinks.rs
+++ b/src/compute-types/src/sinks.rs
@@ -80,6 +80,45 @@ impl Arbitrary for ComputeSinkDesc<CollectionMetadata, Timestamp> {
     }
 }
 
+impl Arbitrary for ComputeSinkDesc<(), Timestamp> {
+    type Strategy = BoxedStrategy<Self>;
+    type Parameters = ();
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        (
+            any::<GlobalId>(),
+            any::<RelationDesc>(),
+            any::<ComputeSinkConnection<()>>(),
+            any::<bool>(),
+            proptest::collection::vec(any::<Timestamp>(), 1..4),
+            proptest::collection::vec(any::<usize>(), 0..4),
+            proptest::option::of(any::<RefreshSchedule>()),
+        )
+            .prop_map(
+                |(
+                    from,
+                    from_desc,
+                    connection,
+                    with_snapshot,
+                    up_to_frontier,
+                    non_null_assertions,
+                    refresh_schedule,
+                )| {
+                    ComputeSinkDesc {
+                        from,
+                        from_desc,
+                        connection,
+                        with_snapshot,
+                        up_to: Antichain::from(up_to_frontier),
+                        non_null_assertions,
+                        refresh_schedule,
+                    }
+                },
+            )
+            .boxed()
+    }
+}
+
 impl RustType<ProtoComputeSinkDesc> for ComputeSinkDesc<CollectionMetadata, Timestamp> {
     fn into_proto(&self) -> ProtoComputeSinkDesc {
         ProtoComputeSinkDesc {

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -15,6 +15,7 @@ use std::collections::BTreeSet;
 use std::ops::Deref;
 
 use mz_repr::GlobalId;
+use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 mod id;
@@ -55,7 +56,7 @@ pub use scalar::{
 
 /// A [`MirRelationExpr`] that claims to have been optimized, e.g., by an
 /// `transform::Optimizer`.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct OptimizedMirRelationExpr(pub MirRelationExpr);
 
 impl OptimizedMirRelationExpr {

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -2189,7 +2189,9 @@ impl MirScalarExpr {
 /// The fields are ordered based on heuristic assumptions about their typical selectivity, so that
 /// Ord gives the right ordering for join inputs. Bigger is better, i.e., will tend to come earlier
 /// than other inputs.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(
+    Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Serialize, Deserialize, Hash, MzReflect, Arbitrary,
+)]
 pub struct FilterCharacteristics {
     // `<expr> = <literal>` appears in the filter.
     // Excludes cases where NOT appears anywhere above the literal equality.


### PR DESCRIPTION
This commit adds an Arbitrary implementation on most of the structs
used in the expression cache. The one exception is
`DataflowDescription<mz_compute_types::plan::Plan>`, which is saved for
future work.

This has helped us identify existing issues with the serialization requiring
us to ignore some of the existing tests until it is fixed.

Additionally, if serialization/deserialization fails in production,
then we log an error and move on instead of panic. The cache is purely
an optimization, so we don't want some runtime error to bring down all

Works towards resolving #MaterializeInc/database-issues/8384

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
