### PR TITLE
Add arg to toggle internal TLS in balancers

### DIFF
--- a/src/balancerd/src/bin/balancerd.rs
+++ b/src/balancerd/src/bin/balancerd.rs
@@ -58,6 +58,9 @@ pub struct ServiceArgs {
     #[clap(long, value_name = "HOST:PORT")]
     internal_http_listen_addr: SocketAddr,
 
+    /// Whether to initiate internal connections over TLS
+    #[clap(long)]
+    internal_tls: bool,
     /// Static pgwire resolver address to use for local testing.
     #[clap(long, value_name = "HOST:PORT")]
     static_resolver_addr: Option<String>,
@@ -237,6 +240,7 @@ pub async fn run(args: ServiceArgs, tracing_handle: TracingHandle) -> Result<(),
         resolver,
         args.https_resolver_template,
         args.tls.into_config()?,
+        args.internal_tls,
         metrics_registry,
         mz_server_core::default_cert_reload_ticker(),
         args.launchdarkly_sdk_key,

--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -168,6 +168,7 @@ async fn test_balancer() {
             resolver,
             envd_server.inner.http_local_addr().to_string(),
             cert_config.clone(),
+            true,
             MetricsRegistry::new(),
             ticker,
             None,

--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -99,6 +99,7 @@ SERVICES = [
             "--tls-key=/secrets/balancerd.key",
             "--tls-cert=/secrets/balancerd.crt",
             "--default-config=balancerd_inject_proxy_protocol_header_http=true",
+            "--internal-tls",
         ],
         depends_on=["test-certs"],
         volumes=[
@@ -182,11 +183,44 @@ def pg8000_sql_cursor(
 def workflow_default(c: Composition) -> None:
     c.down(destroy_volumes=True)
 
-    for i, name in enumerate(c.workflows):
-        if name == "default":
+    for name in c.workflows:
+        if name in ["default", "plaintext"]:
             continue
         with c.test_case(name):
             c.workflow(name)
+    with c.test_case("plaintext"):
+        c.workflow("plaintext")
+
+
+def workflow_plaintext(c: Composition) -> None:
+    """Test plaintext internal connections"""
+    c.down(destroy_volumes=True)
+    with c.override(
+        Balancerd(
+            command=[
+                "service",
+                "--pgwire-listen-addr=0.0.0.0:6875",
+                "--https-listen-addr=0.0.0.0:6876",
+                "--internal-http-listen-addr=0.0.0.0:6878",
+                "--frontegg-resolver-template=materialized:6880",
+                "--frontegg-jwk-file=/secrets/frontegg-mock.crt",
+                f"--frontegg-api-token-url={FRONTEGG_URL}/identity/resources/auth/v1/api-token",
+                f"--frontegg-admin-role={ADMIN_ROLE}",
+                "--https-resolver-template=materialized:6881",
+                "--tls-key=/secrets/balancerd.key",
+                "--tls-cert=/secrets/balancerd.crt",
+                "--default-config=balancerd_inject_proxy_protocol_header_http=true",
+            ],
+            depends_on=["test-certs"],
+            volumes=[
+                "secrets:/secrets",
+            ],
+        ),
+    ):
+        with c.test_case("plaintext_http"):
+            c.workflow("http")
+        with c.test_case("plaintext_wide_result"):
+            c.workflow("wide-result")
 
 
 def workflow_http(c: Composition) -> None:


### PR DESCRIPTION
Adds an arg to toggle internal TLS in balancers.

### Motivation

We had to revert the TLS support in the cloud repo, so this allows us to run newer balancerds there.

It may also be useful for self-hosted, as it allows them to run without certs for environmentd.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
