### PR TITLE
catalog: Improve serializability of expressions

### DIFF
--- a/src/catalog/src/expr_cache.rs
+++ b/src/catalog/src/expr_cache.rs
@@ -460,7 +460,6 @@ mod tests {
     use proptest::proptest;
     use proptest::strategy::{Strategy, ValueTree};
     use proptest::test_runner::TestRunner;
-    use timely::progress::Antichain;
     use uuid::Uuid;
 
     use crate::expr_cache::{
@@ -489,29 +488,14 @@ mod tests {
     impl Arbitrary for GlobalExpressions {
         type Parameters = ();
         fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
-            // It would be better to actually implement `Arbitrary` for this type.
-            let physical_plan = DataflowDescription {
-                source_imports: Default::default(),
-                index_imports: Default::default(),
-                objects_to_build: Vec::new(),
-                index_exports: Default::default(),
-                sink_exports: Default::default(),
-                as_of: Default::default(),
-                until: Antichain::new(),
-                initial_storage_as_of: None,
-                refresh_schedule: None,
-                debug_name: "pp".to_string(),
-                time_dependence: None,
-            };
-
             (
                 any::<DataflowDescription<OptimizedMirRelationExpr>>(),
+                any::<DataflowDescription<mz_compute_types::plan::Plan>>(),
                 any::<DataflowMetainfo<Arc<OptimizerNotice>>>(),
                 any::<OptimizerFeatures>(),
             )
                 .prop_map(
-                    move |(global_mir, dataflow_metainfos, optimizer_features)| {
-                        let physical_plan = physical_plan.clone();
+                    |(global_mir, physical_plan, dataflow_metainfos, optimizer_features)| {
                         GlobalExpressions {
                             global_mir,
                             physical_plan,

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -717,7 +717,7 @@ impl Arbitrary for DataflowDescription<FlatPlan, CollectionMetadata, mz_repr::Ti
     type Parameters = ();
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        any_dataflow_description_flat_plan().boxed()
+        any_dataflow_description(any_source_import_collection_metadata()).boxed()
     }
 }
 
@@ -726,106 +726,82 @@ impl Arbitrary for DataflowDescription<OptimizedMirRelationExpr, (), mz_repr::Ti
     type Parameters = ();
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        any_dataflow_description_opt_mir().boxed()
+        any_dataflow_description(any_source_import()).boxed()
     }
 }
 
-proptest::prop_compose! {
-    fn any_dataflow_description_flat_plan()(
-        source_imports in proptest::collection::vec(any_source_import_collection_metadata(), 1..3),
-        index_imports in proptest::collection::vec(any_dataflow_index_import(), 1..3),
-        objects_to_build in proptest::collection::vec(any::<BuildDesc<FlatPlan>>(), 1..3),
-        index_exports in proptest::collection::vec(any_dataflow_index_export(), 1..3),
-        sink_descs in proptest::collection::vec(
-            any::<(GlobalId, ComputeSinkDesc<CollectionMetadata, mz_repr::Timestamp>)>(),
-            1..3,
-        ),
-        as_of_some in any::<bool>(),
-        as_of in proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..5),
-        debug_name in ".*",
-        initial_storage_as_of_some in any::<bool>(),
-        initial_as_of in proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..5),
-        refresh_schedule_some in any::<bool>(),
-        refresh_schedule in any::<RefreshSchedule>(),
-        time_dependence in any::<Option<TimeDependence >>(),
-    ) -> DataflowDescription<FlatPlan, CollectionMetadata, mz_repr::Timestamp> {
-        DataflowDescription {
-            source_imports: BTreeMap::from_iter(source_imports.into_iter()),
-            index_imports: BTreeMap::from_iter(index_imports.into_iter()),
-            objects_to_build,
-            index_exports: BTreeMap::from_iter(index_exports.into_iter()),
-            sink_exports: BTreeMap::from_iter(
-                sink_descs.into_iter(),
-            ),
-            as_of: if as_of_some {
-                Some(Antichain::from(as_of))
-            } else {
-                None
-            },
-            until: Antichain::new(),
-            initial_storage_as_of: if initial_storage_as_of_some {
-                Some(Antichain::from(initial_as_of))
-            } else {
-                None
-            },
-            refresh_schedule: if refresh_schedule_some {
-                Some(refresh_schedule)
-            } else {
-                None
-            },
-            debug_name,
-            time_dependence,
-        }
+impl Arbitrary for DataflowDescription<Plan, (), mz_repr::Timestamp> {
+    type Strategy = BoxedStrategy<Self>;
+    type Parameters = ();
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        any_dataflow_description(any_source_import()).boxed()
     }
 }
 
-proptest::prop_compose! {
-    fn any_dataflow_description_opt_mir()(
-        source_imports in proptest::collection::vec(any_source_import(), 1..3),
-        index_imports in proptest::collection::vec(any_dataflow_index_import(), 1..3),
-        objects_to_build in proptest::collection::vec(any::<BuildDesc<OptimizedMirRelationExpr>>(), 1..2),
-        index_exports in proptest::collection::vec(any_dataflow_index_export(), 1..3),
-        sink_descs in proptest::collection::vec(
-            any::<(GlobalId, ComputeSinkDesc<(), mz_repr::Timestamp>)>(),
-            1..3,
-        ),
-        as_of_some in any::<bool>(),
-        as_of in proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..5),
-        debug_name in ".*",
-        initial_storage_as_of_some in any::<bool>(),
-        initial_as_of in proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..5),
-        refresh_schedule_some in any::<bool>(),
-        refresh_schedule in any::<RefreshSchedule>(),
-        time_dependence in any::<Option<TimeDependence>>(),
-    ) -> DataflowDescription<OptimizedMirRelationExpr, (), mz_repr::Timestamp> {
-        DataflowDescription {
-            source_imports: BTreeMap::from_iter(source_imports.into_iter()),
-            index_imports: BTreeMap::from_iter(index_imports.into_iter()),
-            objects_to_build,
-            index_exports: BTreeMap::from_iter(index_exports.into_iter()),
-            sink_exports: BTreeMap::from_iter(
-                sink_descs.into_iter(),
-            ),
-            as_of: if as_of_some {
-                Some(Antichain::from(as_of))
-            } else {
-                None
+fn any_dataflow_description<P, S, T>(
+    any_source_import: impl Strategy<Value = (GlobalId, (SourceInstanceDesc<S>, bool))>,
+) -> impl Strategy<Value = DataflowDescription<P, S, T>>
+where
+    P: Arbitrary,
+    S: 'static + Arbitrary,
+    T: Arbitrary + timely::PartialOrder,
+    ComputeSinkDesc<S, T>: Arbitrary,
+{
+    (
+        proptest::collection::vec(any_source_import, 1..3),
+        proptest::collection::vec(any_dataflow_index_import(), 1..3),
+        proptest::collection::vec(any::<BuildDesc<P>>(), 1..3),
+        proptest::collection::vec(any_dataflow_index_export(), 1..3),
+        proptest::collection::vec(any::<(GlobalId, ComputeSinkDesc<S, T>)>(), 1..3),
+        any::<bool>(),
+        proptest::collection::vec(any::<T>(), 1..5),
+        any::<bool>(),
+        proptest::collection::vec(any::<T>(), 1..5),
+        any::<bool>(),
+        any::<RefreshSchedule>(),
+        any::<Option<TimeDependence>>(),
+    )
+        .prop_map(
+            |(
+                source_imports,
+                index_imports,
+                objects_to_build,
+                index_exports,
+                sink_descs,
+                as_of_some,
+                as_of,
+                initial_storage_as_of_some,
+                initial_as_of,
+                refresh_schedule_some,
+                refresh_schedule,
+                time_dependence,
+            )| DataflowDescription {
+                source_imports: BTreeMap::from_iter(source_imports),
+                index_imports: BTreeMap::from_iter(index_imports),
+                objects_to_build,
+                index_exports: BTreeMap::from_iter(index_exports),
+                sink_exports: BTreeMap::from_iter(sink_descs),
+                as_of: if as_of_some {
+                    Some(Antichain::from(as_of))
+                } else {
+                    None
+                },
+                until: Antichain::new(),
+                initial_storage_as_of: if initial_storage_as_of_some {
+                    Some(Antichain::from(initial_as_of))
+                } else {
+                    None
+                },
+                refresh_schedule: if refresh_schedule_some {
+                    Some(refresh_schedule)
+                } else {
+                    None
+                },
+                debug_name: "debug_name".to_string(),
+                time_dependence,
             },
-            until: Antichain::new(),
-            initial_storage_as_of: if initial_storage_as_of_some {
-                Some(Antichain::from(initial_as_of))
-            } else {
-                None
-            },
-            refresh_schedule: if refresh_schedule_some {
-                Some(refresh_schedule)
-            } else {
-                None
-            },
-            debug_name,
-            time_dependence,
-        }
-    }
+        )
 }
 
 fn any_source_import_collection_metadata(

--- a/src/compute-types/src/explain.rs
+++ b/src/compute-types/src/explain.rs
@@ -17,6 +17,8 @@ use mz_expr::explain::{enforce_linear_chains, ExplainContext, ExplainMultiPlan, 
 use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
 use mz_repr::explain::{AnnotatedPlan, Explain, ExplainError, UnsupportedFormat};
 use mz_repr::GlobalId;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 use crate::dataflows::DataflowDescription;
 use crate::plan::Plan;
@@ -152,7 +154,9 @@ impl<'a> DataflowDescription<OptimizedMirRelationExpr> {
 }
 
 /// TODO(database-issues#7533): Add documentation.
-pub fn export_ids_for<P, S, T>(dd: &DataflowDescription<P, S, T>) -> BTreeMap<GlobalId, GlobalId> {
+pub fn export_ids_for<P, S: Serialize + DeserializeOwned, T>(
+    dd: &DataflowDescription<P, S, T>,
+) -> BTreeMap<GlobalId, GlobalId> {
     let mut map = BTreeMap::<GlobalId, GlobalId>::default();
 
     // Dataflows created from a `CREATE MATERIALIZED VIEW` have:

--- a/src/compute-types/src/sinks.rs
+++ b/src/compute-types/src/sinks.rs
@@ -24,7 +24,7 @@ include!(concat!(env!("OUT_DIR"), "/mz_compute_types.sinks.rs"));
 
 /// A sink for updates to a relational collection.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct ComputeSinkDesc<S: 'static = (), T = Timestamp> {
+pub struct ComputeSinkDesc<S: 'static + Serialize = (), T = Timestamp> {
     /// TODO(database-issues#7533): Add documentation.
     pub from: GlobalId,
     /// TODO(database-issues#7533): Add documentation.

--- a/src/compute/src/render/continual_task.rs
+++ b/src/compute/src/render/continual_task.rs
@@ -171,6 +171,8 @@ use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::SourceData;
 use mz_timely_util::builder_async::{Button, Event, OperatorBuilder as AsyncOperatorBuilder};
 use mz_timely_util::operator::CollectionExt;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::{Filter, FrontierNotificator, Map, Operator};
@@ -311,7 +313,9 @@ impl ContinualTaskSourceTransformer {
 }
 
 impl<G: Scope<Timestamp = Timestamp>> ContinualTaskCtx<G> {
-    pub fn new<P, S>(dataflow: &DataflowDescription<P, S, Timestamp>) -> Self {
+    pub fn new<P, S: Serialize + DeserializeOwned>(
+        dataflow: &DataflowDescription<P, S, Timestamp>,
+    ) -> Self {
         let mut name = None;
         let mut ct_inputs = BTreeSet::new();
         let mut ct_outputs = BTreeSet::new();

--- a/src/repr/src/adt/regex.rs
+++ b/src/repr/src/adt/regex.rs
@@ -247,7 +247,7 @@ impl<'de> Deserialize<'de> for Regex {
             where
                 V: de::MapAccess<'de>,
             {
-                let mut pattern: Option<&str> = None;
+                let mut pattern: Option<String> = None;
                 let mut case_insensitive: Option<bool> = None;
                 let mut dot_matches_new_line: Option<bool> = None;
                 while let Some(key) = map.next_key()? {
@@ -277,7 +277,7 @@ impl<'de> Deserialize<'de> for Regex {
                     case_insensitive.ok_or_else(|| de::Error::missing_field("case_insensitive"))?;
                 let dot_matches_new_line = dot_matches_new_line
                     .ok_or_else(|| de::Error::missing_field("dot_matches_new_line"))?;
-                Regex::new_dot_matches_new_line(pattern, case_insensitive, dot_matches_new_line)
+                Regex::new_dot_matches_new_line(&pattern, case_insensitive, dot_matches_new_line)
                     .map_err(|err| {
                         V::Error::custom(format!(
                             "Unable to recreate regex during deserialization: {}",

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -8,7 +8,9 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::{Display, Formatter};
 use std::rc::Rc;
+use std::str::FromStr;
 use std::{fmt, vec};
 
 use anyhow::bail;
@@ -367,6 +369,20 @@ pub struct ColumnIndex(usize);
 
 static_assertions::assert_not_impl_all!(ColumnIndex: Arbitrary);
 
+impl Display for ColumnIndex {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for ColumnIndex {
+    type Err = <u64 as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(ColumnIndex(s.parse()?))
+    }
+}
+
 /// The version a given column was added at.
 #[derive(
     Clone,
@@ -485,6 +501,8 @@ struct ColumnMetadata {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct RelationDesc {
     typ: RelationType,
+    #[serde(serialize_with = "mz_ore::serde::map_key_to_string")]
+    #[serde(deserialize_with = "mz_ore::serde::string_key_to_btree_map")]
     metadata: BTreeMap<ColumnIndex, ColumnMetadata>,
 }
 


### PR DESCRIPTION
This commit adds the necessary logic so that all cached expressions can be serialized by serde. That includes:

- Serializing/deserializing map keys through a String.
- Adding `Serialize` and `DeserializeOwned` trait bounds to various structs.
- Adding the ability for regexes to deserialize owned strings.

Many of the serailization errors that existed before this commit would only manifest as runtime errors, not compile time errors. To help catch more errors, this commit also implements `Arbitrary` on most of the cached expressions. The one exception is
`DataflowDescription<mz_compute_types::plan::Plan>`, which is saved for future work. The `Arbitrary` implementations are fairly slow, which causes all expression cache tests to be slow.

Additionally, if serialization/deserialization fails, then we log an error and move on instead of panic. The cache is purely an optimization, so we don't want some runtime error to bring down all of environmentd.

Works towards resolving #MaterializeInc/database-issues/8384

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
