### PR TITLE
catalog: Implement Arbitrary on expression types

### DIFF
--- a/src/catalog/src/expr_cache.rs
+++ b/src/catalog/src/expr_cache.rs
@@ -460,7 +460,6 @@ mod tests {
     use proptest::proptest;
     use proptest::strategy::{Strategy, ValueTree};
     use proptest::test_runner::TestRunner;
-    use timely::progress::Antichain;
     use uuid::Uuid;
 
     use crate::expr_cache::{
@@ -489,29 +488,14 @@ mod tests {
     impl Arbitrary for GlobalExpressions {
         type Parameters = ();
         fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
-            // It would be better to actually implement `Arbitrary` for this type.
-            let physical_plan = DataflowDescription {
-                source_imports: Default::default(),
-                index_imports: Default::default(),
-                objects_to_build: Vec::new(),
-                index_exports: Default::default(),
-                sink_exports: Default::default(),
-                as_of: Default::default(),
-                until: Antichain::new(),
-                initial_storage_as_of: None,
-                refresh_schedule: None,
-                debug_name: "pp".to_string(),
-                time_dependence: None,
-            };
-
             (
                 any::<DataflowDescription<OptimizedMirRelationExpr>>(),
+                any::<DataflowDescription<mz_compute_types::plan::Plan>>(),
                 any::<DataflowMetainfo<Arc<OptimizerNotice>>>(),
                 any::<OptimizerFeatures>(),
             )
                 .prop_map(
-                    move |(global_mir, dataflow_metainfos, optimizer_features)| {
-                        let physical_plan = physical_plan.clone();
+                    |(global_mir, physical_plan, dataflow_metainfos, optimizer_features)| {
                         GlobalExpressions {
                             global_mir,
                             physical_plan,

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -717,7 +717,7 @@ impl Arbitrary for DataflowDescription<FlatPlan, CollectionMetadata, mz_repr::Ti
     type Parameters = ();
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        any_dataflow_description_flat_plan().boxed()
+        any_dataflow_description(any_source_import_collection_metadata()).boxed()
     }
 }
 
@@ -726,106 +726,82 @@ impl Arbitrary for DataflowDescription<OptimizedMirRelationExpr, (), mz_repr::Ti
     type Parameters = ();
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        any_dataflow_description_opt_mir().boxed()
+        any_dataflow_description(any_source_import()).boxed()
     }
 }
 
-proptest::prop_compose! {
-    fn any_dataflow_description_flat_plan()(
-        source_imports in proptest::collection::vec(any_source_import_collection_metadata(), 1..3),
-        index_imports in proptest::collection::vec(any_dataflow_index_import(), 1..3),
-        objects_to_build in proptest::collection::vec(any::<BuildDesc<FlatPlan>>(), 1..3),
-        index_exports in proptest::collection::vec(any_dataflow_index_export(), 1..3),
-        sink_descs in proptest::collection::vec(
-            any::<(GlobalId, ComputeSinkDesc<CollectionMetadata, mz_repr::Timestamp>)>(),
-            1..3,
-        ),
-        as_of_some in any::<bool>(),
-        as_of in proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..5),
-        debug_name in ".*",
-        initial_storage_as_of_some in any::<bool>(),
-        initial_as_of in proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..5),
-        refresh_schedule_some in any::<bool>(),
-        refresh_schedule in any::<RefreshSchedule>(),
-        time_dependence in any::<Option<TimeDependence >>(),
-    ) -> DataflowDescription<FlatPlan, CollectionMetadata, mz_repr::Timestamp> {
-        DataflowDescription {
-            source_imports: BTreeMap::from_iter(source_imports.into_iter()),
-            index_imports: BTreeMap::from_iter(index_imports.into_iter()),
-            objects_to_build,
-            index_exports: BTreeMap::from_iter(index_exports.into_iter()),
-            sink_exports: BTreeMap::from_iter(
-                sink_descs.into_iter(),
-            ),
-            as_of: if as_of_some {
-                Some(Antichain::from(as_of))
-            } else {
-                None
-            },
-            until: Antichain::new(),
-            initial_storage_as_of: if initial_storage_as_of_some {
-                Some(Antichain::from(initial_as_of))
-            } else {
-                None
-            },
-            refresh_schedule: if refresh_schedule_some {
-                Some(refresh_schedule)
-            } else {
-                None
-            },
-            debug_name,
-            time_dependence,
-        }
+impl Arbitrary for DataflowDescription<Plan, (), mz_repr::Timestamp> {
+    type Strategy = BoxedStrategy<Self>;
+    type Parameters = ();
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        any_dataflow_description(any_source_import()).boxed()
     }
 }
 
-proptest::prop_compose! {
-    fn any_dataflow_description_opt_mir()(
-        source_imports in proptest::collection::vec(any_source_import(), 1..3),
-        index_imports in proptest::collection::vec(any_dataflow_index_import(), 1..3),
-        objects_to_build in proptest::collection::vec(any::<BuildDesc<OptimizedMirRelationExpr>>(), 1..2),
-        index_exports in proptest::collection::vec(any_dataflow_index_export(), 1..3),
-        sink_descs in proptest::collection::vec(
-            any::<(GlobalId, ComputeSinkDesc<(), mz_repr::Timestamp>)>(),
-            1..3,
-        ),
-        as_of_some in any::<bool>(),
-        as_of in proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..5),
-        debug_name in ".*",
-        initial_storage_as_of_some in any::<bool>(),
-        initial_as_of in proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..5),
-        refresh_schedule_some in any::<bool>(),
-        refresh_schedule in any::<RefreshSchedule>(),
-        time_dependence in any::<Option<TimeDependence>>(),
-    ) -> DataflowDescription<OptimizedMirRelationExpr, (), mz_repr::Timestamp> {
-        DataflowDescription {
-            source_imports: BTreeMap::from_iter(source_imports.into_iter()),
-            index_imports: BTreeMap::from_iter(index_imports.into_iter()),
-            objects_to_build,
-            index_exports: BTreeMap::from_iter(index_exports.into_iter()),
-            sink_exports: BTreeMap::from_iter(
-                sink_descs.into_iter(),
-            ),
-            as_of: if as_of_some {
-                Some(Antichain::from(as_of))
-            } else {
-                None
+fn any_dataflow_description<P, S, T>(
+    any_source_import: impl Strategy<Value = (GlobalId, (SourceInstanceDesc<S>, bool))>,
+) -> impl Strategy<Value = DataflowDescription<P, S, T>>
+where
+    P: Arbitrary,
+    S: 'static + Arbitrary,
+    T: Arbitrary + timely::PartialOrder,
+    ComputeSinkDesc<S, T>: Arbitrary,
+{
+    (
+        proptest::collection::vec(any_source_import, 1..3),
+        proptest::collection::vec(any_dataflow_index_import(), 1..3),
+        proptest::collection::vec(any::<BuildDesc<P>>(), 1..3),
+        proptest::collection::vec(any_dataflow_index_export(), 1..3),
+        proptest::collection::vec(any::<(GlobalId, ComputeSinkDesc<S, T>)>(), 1..3),
+        any::<bool>(),
+        proptest::collection::vec(any::<T>(), 1..5),
+        any::<bool>(),
+        proptest::collection::vec(any::<T>(), 1..5),
+        any::<bool>(),
+        any::<RefreshSchedule>(),
+        any::<Option<TimeDependence>>(),
+    )
+        .prop_map(
+            |(
+                source_imports,
+                index_imports,
+                objects_to_build,
+                index_exports,
+                sink_descs,
+                as_of_some,
+                as_of,
+                initial_storage_as_of_some,
+                initial_as_of,
+                refresh_schedule_some,
+                refresh_schedule,
+                time_dependence,
+            )| DataflowDescription {
+                source_imports: BTreeMap::from_iter(source_imports),
+                index_imports: BTreeMap::from_iter(index_imports),
+                objects_to_build,
+                index_exports: BTreeMap::from_iter(index_exports),
+                sink_exports: BTreeMap::from_iter(sink_descs),
+                as_of: if as_of_some {
+                    Some(Antichain::from(as_of))
+                } else {
+                    None
+                },
+                until: Antichain::new(),
+                initial_storage_as_of: if initial_storage_as_of_some {
+                    Some(Antichain::from(initial_as_of))
+                } else {
+                    None
+                },
+                refresh_schedule: if refresh_schedule_some {
+                    Some(refresh_schedule)
+                } else {
+                    None
+                },
+                debug_name: "debug_name".to_string(),
+                time_dependence,
             },
-            until: Antichain::new(),
-            initial_storage_as_of: if initial_storage_as_of_some {
-                Some(Antichain::from(initial_as_of))
-            } else {
-                None
-            },
-            refresh_schedule: if refresh_schedule_some {
-                Some(refresh_schedule)
-            } else {
-                None
-            },
-            debug_name,
-            time_dependence,
-        }
-    }
+        )
 }
 
 fn any_source_import_collection_metadata(

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -748,33 +748,41 @@ where
     T: Arbitrary + timely::PartialOrder,
     ComputeSinkDesc<S, T>: Arbitrary,
 {
+    // `prop_map` is only implemented for tuples of 12 elements or less, so we need to use nested
+    // tuples.
     (
-        proptest::collection::vec(any_source_import, 1..3),
-        proptest::collection::vec(any_dataflow_index_import(), 1..3),
-        proptest::collection::vec(any::<BuildDesc<P>>(), 1..3),
-        proptest::collection::vec(any_dataflow_index_export(), 1..3),
-        proptest::collection::vec(any::<(GlobalId, ComputeSinkDesc<S, T>)>(), 1..3),
-        any::<bool>(),
-        proptest::collection::vec(any::<T>(), 1..5),
-        any::<bool>(),
-        proptest::collection::vec(any::<T>(), 1..5),
-        any::<bool>(),
-        any::<RefreshSchedule>(),
+        (
+            proptest::collection::vec(any_source_import, 1..3),
+            proptest::collection::vec(any_dataflow_index_import(), 1..3),
+            proptest::collection::vec(any::<BuildDesc<P>>(), 1..3),
+            proptest::collection::vec(any_dataflow_index_export(), 1..3),
+            proptest::collection::vec(any::<(GlobalId, ComputeSinkDesc<S, T>)>(), 1..3),
+            any::<bool>(),
+            proptest::collection::vec(any::<T>(), 1..5),
+            any::<bool>(),
+            proptest::collection::vec(any::<T>(), 1..5),
+            any::<bool>(),
+            any::<RefreshSchedule>(),
+            proptest::string::string_regex(".*").unwrap(),
+        ),
         any::<Option<TimeDependence>>(),
     )
         .prop_map(
             |(
-                source_imports,
-                index_imports,
-                objects_to_build,
-                index_exports,
-                sink_descs,
-                as_of_some,
-                as_of,
-                initial_storage_as_of_some,
-                initial_as_of,
-                refresh_schedule_some,
-                refresh_schedule,
+                (
+                    source_imports,
+                    index_imports,
+                    objects_to_build,
+                    index_exports,
+                    sink_descs,
+                    as_of_some,
+                    as_of,
+                    initial_storage_as_of_some,
+                    initial_as_of,
+                    refresh_schedule_some,
+                    refresh_schedule,
+                    debug_name,
+                ),
                 time_dependence,
             )| DataflowDescription {
                 source_imports: BTreeMap::from_iter(source_imports),
@@ -798,7 +806,7 @@ where
                 } else {
                     None
                 },
-                debug_name: "debug_name".to_string(),
+                debug_name,
                 time_dependence,
             },
         )


### PR DESCRIPTION
This commit is a follow-up to 5fc12d2ce80892a0e6bd64ae0f1c93e8c8750f78
that implements `Arbitrary` on the remaining expression cache types.

Works towards resolving #MaterializeInc/database-issues/8384

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
