### PR TITLE
adapter: Don't create new builtins in read-only

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -557,7 +557,6 @@ impl Catalog {
             catalog,
             storage_collections_to_drop: _,
             migrated_storage_collections_0dt: _,
-            new_builtins: _,
             builtin_table_updates: _,
         } = Catalog::open(Config {
             storage,
@@ -570,6 +569,7 @@ impl Catalog {
                 now,
                 boot_ts: previous_ts,
                 skip_migrations: true,
+                read_only: false,
                 cluster_replica_sizes: Default::default(),
                 builtin_system_cluster_replica_size: "1".into(),
                 builtin_catalog_server_cluster_replica_size: "1".into(),
@@ -2616,6 +2616,7 @@ mod tests {
 
             let builtins_cfg = BuiltinsConfig {
                 include_continual_tasks: true,
+                include_new_items: true,
             };
             for builtin in BUILTINS::iter(&builtins_cfg) {
                 match builtin {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3626,7 +3626,6 @@ pub fn serve(
             mut catalog,
             storage_collections_to_drop,
             migrated_storage_collections_0dt,
-            new_builtins,
             builtin_table_updates,
         } = Catalog::open(mz_catalog::config::Config {
             storage,
@@ -3639,6 +3638,7 @@ pub fn serve(
                 now: now.clone(),
                 boot_ts: boot_ts.clone(),
                 skip_migrations: false,
+                read_only: read_only_controllers,
                 cluster_replica_sizes,
                 builtin_system_cluster_replica_size,
                 builtin_catalog_server_cluster_replica_size,
@@ -3715,10 +3715,7 @@ pub fn serve(
         };
 
         let clusters_caught_up_check =
-            clusters_caught_up_trigger.map(|trigger| CaughtUpCheckContext {
-                trigger,
-                exclude_collections: new_builtins,
-            });
+            clusters_caught_up_trigger.map(|trigger| CaughtUpCheckContext { trigger });
 
         if let Some(config) = pg_timestamp_oracle_config.as_ref() {
             // Apply settings from system vars as early as possible because some

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -549,7 +549,7 @@ impl Coordinator {
         let hydrated_fut = self
             .controller
             .compute
-            .collections_hydrated_for_replicas(cluster.id, pending_replicas, [].into())
+            .collections_hydrated_for_replicas(cluster.id, pending_replicas)
             .map_err(|e| AdapterError::internal("Failed to check hydration", e))?;
 
         let span = Span::current();

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -563,7 +563,6 @@ async fn upgrade_check(
         state: _state,
         storage_collections_to_drop: _,
         migrated_storage_collections_0dt: _,
-        new_builtins: _,
         builtin_table_updates: _,
         last_seen_version,
     } = Catalog::initialize_state(
@@ -575,6 +574,7 @@ async fn upgrade_check(
             now,
             boot_ts,
             skip_migrations: false,
+            read_only: false,
             cluster_replica_sizes,
             builtin_system_cluster_replica_size: builtin_clusters_replica_size.clone(),
             builtin_catalog_server_cluster_replica_size: builtin_clusters_replica_size.clone(),

--- a/src/catalog/src/config.rs
+++ b/src/catalog/src/config.rs
@@ -52,6 +52,8 @@ pub struct StateConfig {
     pub boot_ts: mz_repr::Timestamp,
     /// Whether or not to skip catalog migrations.
     pub skip_migrations: bool,
+    /// Whether the system is starting in read-only mode or not.
+    pub read_only: bool,
     /// Map of strings to corresponding compute replica sizes.
     pub cluster_replica_sizes: ClusterReplicaSizeMap,
     /// Builtin system cluster replica size.

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -694,6 +694,10 @@ impl<'a> Transaction<'a> {
         key: String,
         amount: u64,
     ) -> Result<Vec<u64>, CatalogError> {
+        if amount == 0 {
+            return Ok(Vec::new());
+        }
+
         let current_id = self
             .id_allocator
             .items()

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -662,7 +662,6 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
     pub fn collections_hydrated_on_replicas(
         &self,
         target_replica_ids: Option<Vec<ReplicaId>>,
-        exclude_collections: &BTreeSet<GlobalId>,
     ) -> Result<bool, HydrationCheckBadTarget> {
         if self.replicas.is_empty() {
             return Ok(true);
@@ -684,7 +683,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
         }
 
         for (id, _collection) in self.collections_iter() {
-            if id.is_transient() || exclude_collections.contains(&id) {
+            if id.is_transient() {
                 continue;
             }
 
@@ -721,8 +720,8 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
     /// This also returns `true` in case this cluster does not have any
     /// replicas.
     #[mz_ore::instrument(level = "debug")]
-    pub fn collections_hydrated(&self, exclude_collections: &BTreeSet<GlobalId>) -> bool {
-        self.collections_hydrated_on_replicas(None, exclude_collections)
+    pub fn collections_hydrated(&self) -> bool {
+        self.collections_hydrated_on_replicas(None)
             .expect("Cannot error if target_replica_ids is None")
     }
 

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -3739,6 +3739,7 @@ async fn test_builtin_schemas() {
 
     let builtins_cfg = BuiltinsConfig {
         include_continual_tasks: true,
+        include_new_items: true,
     };
     let mut builtins = BTreeMap::new();
     for builtin in BUILTINS::iter(&builtins_cfg) {

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -828,7 +828,7 @@ pub struct CatalogTypePgMetadata {
 }
 
 /// Represents a reference to type in the catalog
-pub trait TypeReference {
+pub trait TypeReference: Debug {
     /// The actual type used to reference a `CatalogType`
     type Reference: Clone + Debug + Eq + PartialEq;
 }
@@ -1709,6 +1709,8 @@ impl DefaultPrivilegeAclItem {
 pub struct BuiltinsConfig {
     /// If true, include system builtin continual tasks.
     pub include_continual_tasks: bool,
+    /// If true, include new system builtin items.
+    pub include_new_items: bool,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This commit skips creating new builtin objects in read-only mode. While in read-only mode, we cannot allocate new `GlobalId`s durably. So there's no way to create a new builtin object with a `GlobalId` and guarantee that we'll use the same `GlobalId` when rebooting in read-write mode.

Fixes #MaterializeInc/database-issues/8731

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
