### PR TITLE
catalog: Fix expression cache serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4422,6 +4422,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.13.1",
+ "bincode",
  "bytes",
  "bytesize",
  "chrono",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1.68"
+bincode = { version = "1.3.3" }
 bytes = { version = "1.3.0", features = ["serde"] }
 bytesize = "1.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -1232,8 +1232,6 @@ pub struct DataflowMetainfo<Notice = RawOptimizerNotice> {
     pub optimizer_notices: Vec<Notice>,
     /// What kind of operation (full scan, lookup, ...) will access each index. Computed by
     /// `prune_and_annotate_dataflow_index_imports`.
-    #[serde(serialize_with = "mz_ore::serde::map_key_to_string")]
-    #[serde(deserialize_with = "mz_ore::serde::string_key_to_btree_map")]
     pub index_usage_types: BTreeMap<GlobalId, Vec<IndexUsageType>>,
 }
 


### PR DESCRIPTION
This commit fixes the serialization of optimized expressions in the
expression cache by switching from JSON to `bincode`. JSON
serialization had the following issues:

- All maps needed to serialize their keys through strings.
- Serialization issues tended to manifest as runtime errors instead
  of compile time errors.
- `bincode` and JSON don't get along.

Furthermore, compute is already serializing many of these expressions
using `bincode`, so we know it mostly works properly.

Unfortunately, this makes it more difficult to read and debug the
expression cache. We don't anticipate this being a huge issue, because
we can always disable or clear the expression cache if an issue arises.

Works towards resolving #MaterializeInc/database-issues/8384
Fixes #database-issues/issues/8736

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
