### PR TITLE
bazel: Alias library targets

### DIFF
--- a/misc/bazel/cargo-gazelle/BUILD.bazel
+++ b/misc/bazel/cargo-gazelle/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = [] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "cargo-gazelle",
+    actual = "cargo_gazelle",
+)
+
 rust_test(
     name = "cargo_gazelle_lib_tests",
     size = "medium",

--- a/misc/bazel/cargo-gazelle/src/lib.rs
+++ b/misc/bazel/cargo-gazelle/src/lib.rs
@@ -429,6 +429,38 @@ impl ToBazelDefinition for FileGroup {
     }
 }
 
+/// A Bazel [`alias`](https://bazel.build/reference/be/general#alias)
+#[derive(Debug)]
+pub struct Alias {
+    name: Field<QuotedString>,
+    actual: Field<QuotedString>,
+}
+
+impl Alias {
+    pub fn new<N: Into<String>, A: Into<String>>(name: N, actual: A) -> Self {
+        let name = Field::new("name", QuotedString::new(name.into()));
+        let actual = Field::new("actual", QuotedString::new(actual.into()));
+
+        Alias { name, actual }
+    }
+}
+
+impl ToBazelDefinition for Alias {
+    fn format(&self, writer: &mut dyn fmt::Write) -> Result<(), fmt::Error> {
+        let mut w = AutoIndentingWriter::new(writer);
+
+        writeln!(w, "alias(")?;
+        {
+            let mut w = w.indent();
+            self.name.format(&mut w)?;
+            self.actual.format(&mut w)?;
+        }
+        writeln!(w, ")")?;
+
+        Ok(())
+    }
+}
+
 /// A Bazel [`glob`](https://bazel.build/reference/be/functions#glob)
 ///
 /// TODO(parkmcar): Support `excludes`.

--- a/src/adapter-types/BUILD.bazel
+++ b/src/adapter-types/BUILD.bazel
@@ -36,6 +36,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "adapter-types",
+    actual = "mz_adapter_types",
+)
+
 rust_test(
     name = "mz_adapter_types_lib_tests",
     size = "medium",

--- a/src/adapter/BUILD.bazel
+++ b/src/adapter/BUILD.bazel
@@ -71,6 +71,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "adapter",
+    actual = "mz_adapter",
+)
+
 rust_test(
     name = "mz_adapter_lib_tests",
     size = "medium",

--- a/src/alloc-default/BUILD.bazel
+++ b/src/alloc-default/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = ["//src/alloc:mz_alloc"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "alloc-default",
+    actual = "mz_alloc_default",
+)
+
 rust_test(
     name = "mz_alloc_default_lib_tests",
     size = "medium",

--- a/src/alloc/BUILD.bazel
+++ b/src/alloc/BUILD.bazel
@@ -47,6 +47,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "alloc",
+    actual = "mz_alloc",
+)
+
 rust_test(
     name = "mz_alloc_lib_tests",
     size = "medium",

--- a/src/arrow-util/BUILD.bazel
+++ b/src/arrow-util/BUILD.bazel
@@ -34,6 +34,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "arrow-util",
+    actual = "mz_arrow_util",
+)
+
 rust_test(
     name = "mz_arrow_util_lib_tests",
     size = "medium",

--- a/src/audit-log/BUILD.bazel
+++ b/src/audit-log/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = ["//src/ore:mz_ore"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "audit-log",
+    actual = "mz_audit_log",
+)
+
 rust_test(
     name = "mz_audit_log_lib_tests",
     size = "medium",

--- a/src/avro/BUILD.bazel
+++ b/src/avro/BUILD.bazel
@@ -36,6 +36,11 @@ rust_library(
     deps = ["//src/ore:mz_ore"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "avro",
+    actual = "mz_avro",
+)
+
 rust_test(
     name = "mz_avro_lib_tests",
     size = "medium",

--- a/src/aws-secrets-controller/BUILD.bazel
+++ b/src/aws-secrets-controller/BUILD.bazel
@@ -35,6 +35,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "aws-secrets-controller",
+    actual = "mz_aws_secrets_controller",
+)
+
 rust_test(
     name = "mz_aws_secrets_controller_lib_tests",
     size = "medium",

--- a/src/aws-util/BUILD.bazel
+++ b/src/aws-util/BUILD.bazel
@@ -35,6 +35,11 @@ rust_library(
     deps = ["//src/ore:mz_ore"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "aws-util",
+    actual = "mz_aws_util",
+)
+
 rust_test(
     name = "mz_aws_util_lib_tests",
     size = "medium",

--- a/src/build-tools/BUILD.bazel
+++ b/src/build-tools/BUILD.bazel
@@ -37,6 +37,11 @@ rust_library(
     deps = ["@rules_rust//tools/runfiles"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "build-tools",
+    actual = "mz_build_tools",
+)
+
 rust_test(
     name = "mz_build_tools_lib_tests",
     size = "medium",

--- a/src/catalog/BUILD.bazel
+++ b/src/catalog/BUILD.bazel
@@ -60,6 +60,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "catalog",
+    actual = "mz_catalog",
+)
+
 rust_test(
     name = "mz_catalog_lib_tests",
     size = "medium",

--- a/src/ccsr/BUILD.bazel
+++ b/src/ccsr/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = ["//src/tls-util:mz_tls_util"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "ccsr",
+    actual = "mz_ccsr",
+)
+
 rust_test(
     name = "mz_ccsr_lib_tests",
     size = "medium",

--- a/src/cloud-api/BUILD.bazel
+++ b/src/cloud-api/BUILD.bazel
@@ -34,6 +34,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "cloud-api",
+    actual = "mz_cloud_api",
+)
+
 rust_test(
     name = "mz_cloud_api_lib_tests",
     size = "medium",

--- a/src/cloud-resources/BUILD.bazel
+++ b/src/cloud-resources/BUILD.bazel
@@ -34,6 +34,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "cloud-resources",
+    actual = "mz_cloud_resources",
+)
+
 rust_test(
     name = "mz_cloud_resources_lib_tests",
     size = "medium",

--- a/src/cluster-client/BUILD.bazel
+++ b/src/cluster-client/BUILD.bazel
@@ -36,6 +36,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "cluster-client",
+    actual = "mz_cluster_client",
+)
+
 rust_test(
     name = "mz_cluster_client_lib_tests",
     size = "medium",

--- a/src/cluster/BUILD.bazel
+++ b/src/cluster/BUILD.bazel
@@ -41,6 +41,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "cluster",
+    actual = "mz_cluster",
+)
+
 rust_test(
     name = "mz_cluster_lib_tests",
     size = "medium",

--- a/src/compute-client/BUILD.bazel
+++ b/src/compute-client/BUILD.bazel
@@ -53,6 +53,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "compute-client",
+    actual = "mz_compute_client",
+)
+
 rust_test(
     name = "mz_compute_client_lib_tests",
     size = "medium",

--- a/src/compute-types/BUILD.bazel
+++ b/src/compute-types/BUILD.bazel
@@ -40,6 +40,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "compute-types",
+    actual = "mz_compute_types",
+)
+
 rust_test(
     name = "mz_compute_types_lib_tests",
     size = "medium",

--- a/src/compute/BUILD.bazel
+++ b/src/compute/BUILD.bazel
@@ -49,6 +49,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "compute",
+    actual = "mz_compute",
+)
+
 rust_test(
     name = "mz_compute_lib_tests",
     size = "medium",

--- a/src/controller-types/BUILD.bazel
+++ b/src/controller-types/BUILD.bazel
@@ -35,6 +35,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "controller-types",
+    actual = "mz_controller_types",
+)
+
 rust_test(
     name = "mz_controller_types_lib_tests",
     size = "medium",

--- a/src/controller/BUILD.bazel
+++ b/src/controller/BUILD.bazel
@@ -48,6 +48,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "controller",
+    actual = "mz_controller",
+)
+
 rust_test(
     name = "mz_controller_lib_tests",
     size = "medium",

--- a/src/durable-cache/BUILD.bazel
+++ b/src/durable-cache/BUILD.bazel
@@ -37,6 +37,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "durable-cache",
+    actual = "mz_durable_cache",
+)
+
 rust_test(
     name = "mz_durable_cache_lib_tests",
     size = "medium",

--- a/src/dyncfg-launchdarkly/BUILD.bazel
+++ b/src/dyncfg-launchdarkly/BUILD.bazel
@@ -35,6 +35,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "dyncfg-launchdarkly",
+    actual = "mz_dyncfg_launchdarkly",
+)
+
 rust_test(
     name = "mz_dyncfg_launchdarkly_lib_tests",
     size = "medium",

--- a/src/dyncfg/BUILD.bazel
+++ b/src/dyncfg/BUILD.bazel
@@ -36,6 +36,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "dyncfg",
+    actual = "mz_dyncfg",
+)
+
 rust_test(
     name = "mz_dyncfg_lib_tests",
     size = "medium",

--- a/src/dyncfgs/BUILD.bazel
+++ b/src/dyncfgs/BUILD.bazel
@@ -39,6 +39,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "dyncfgs",
+    actual = "mz_dyncfgs",
+)
+
 rust_test(
     name = "mz_dyncfgs_lib_tests",
     size = "medium",

--- a/src/expr-parser/BUILD.bazel
+++ b/src/expr-parser/BUILD.bazel
@@ -35,6 +35,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "expr-parser",
+    actual = "mz_expr_parser",
+)
+
 rust_test(
     name = "mz_expr_parser_lib_tests",
     size = "medium",

--- a/src/expr-test-util/BUILD.bazel
+++ b/src/expr-test-util/BUILD.bazel
@@ -37,6 +37,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "expr-test-util",
+    actual = "mz_expr_test_util",
+)
+
 rust_test(
     name = "mz_expr_test_util_lib_tests",
     size = "medium",

--- a/src/expr/BUILD.bazel
+++ b/src/expr/BUILD.bazel
@@ -45,6 +45,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "expr",
+    actual = "mz_expr",
+)
+
 rust_test(
     name = "mz_expr_lib_tests",
     size = "medium",

--- a/src/fivetran-destination/BUILD.bazel
+++ b/src/fivetran-destination/BUILD.bazel
@@ -38,6 +38,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "fivetran-destination",
+    actual = "mz_fivetran_destination",
+)
+
 rust_test(
     name = "mz_fivetran_destination_lib_tests",
     size = "medium",

--- a/src/frontegg-auth/BUILD.bazel
+++ b/src/frontegg-auth/BUILD.bazel
@@ -34,6 +34,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "frontegg-auth",
+    actual = "mz_frontegg_auth",
+)
+
 rust_test(
     name = "mz_frontegg_auth_lib_tests",
     size = "medium",

--- a/src/frontegg-client/BUILD.bazel
+++ b/src/frontegg-client/BUILD.bazel
@@ -34,6 +34,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "frontegg-client",
+    actual = "mz_frontegg_client",
+)
+
 rust_test(
     name = "mz_frontegg_client_lib_tests",
     size = "medium",

--- a/src/frontegg-mock/BUILD.bazel
+++ b/src/frontegg-mock/BUILD.bazel
@@ -34,6 +34,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "frontegg-mock",
+    actual = "mz_frontegg_mock",
+)
+
 rust_test(
     name = "mz_frontegg_mock_lib_tests",
     size = "medium",

--- a/src/http-util/BUILD.bazel
+++ b/src/http-util/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = ["//src/ore:mz_ore"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "http-util",
+    actual = "mz_http_util",
+)
+
 rust_test(
     name = "mz_http_util_lib_tests",
     size = "medium",

--- a/src/interchange/BUILD.bazel
+++ b/src/interchange/BUILD.bazel
@@ -39,6 +39,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "interchange",
+    actual = "mz_interchange",
+)
+
 rust_test(
     name = "mz_interchange_lib_tests",
     size = "medium",

--- a/src/kafka-util/BUILD.bazel
+++ b/src/kafka-util/BUILD.bazel
@@ -36,6 +36,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "kafka-util",
+    actual = "mz_kafka_util",
+)
+
 rust_test(
     name = "mz_kafka_util_lib_tests",
     size = "medium",

--- a/src/lowertest-derive/BUILD.bazel
+++ b/src/lowertest-derive/BUILD.bazel
@@ -31,6 +31,11 @@ rust_proc_macro(
     deps = [] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "lowertest-derive",
+    actual = "mz_lowertest_derive",
+)
+
 rust_test(
     name = "mz_lowertest_derive_lib_tests",
     size = "medium",

--- a/src/lowertest/BUILD.bazel
+++ b/src/lowertest/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = ["//src/ore:mz_ore"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "lowertest",
+    actual = "mz_lowertest",
+)
+
 rust_test(
     name = "mz_lowertest_lib_tests",
     size = "medium",

--- a/src/lsp-server/BUILD.bazel
+++ b/src/lsp-server/BUILD.bazel
@@ -37,6 +37,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "lsp-server",
+    actual = "mz_lsp_server",
+)
+
 rust_test(
     name = "mz_lsp_server_lib_tests",
     size = "medium",

--- a/src/metabase/BUILD.bazel
+++ b/src/metabase/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = [] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "metabase",
+    actual = "mz_metabase",
+)
+
 rust_test(
     name = "mz_metabase_lib_tests",
     size = "medium",

--- a/src/metrics/BUILD.bazel
+++ b/src/metrics/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = ["//src/ore:mz_ore"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "metrics",
+    actual = "mz_metrics",
+)
+
 rust_test(
     name = "mz_metrics_lib_tests",
     size = "medium",

--- a/src/mysql-util/BUILD.bazel
+++ b/src/mysql-util/BUILD.bazel
@@ -39,6 +39,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "mysql-util",
+    actual = "mz_mysql_util",
+)
+
 rust_test(
     name = "mz_mysql_util_lib_tests",
     size = "medium",

--- a/src/npm/BUILD.bazel
+++ b/src/npm/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = [] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "npm",
+    actual = "mz_npm",
+)
+
 rust_test(
     name = "mz_npm_lib_tests",
     size = "medium",

--- a/src/orchestrator-kubernetes/BUILD.bazel
+++ b/src/orchestrator-kubernetes/BUILD.bazel
@@ -37,6 +37,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "orchestrator-kubernetes",
+    actual = "mz_orchestrator_kubernetes",
+)
+
 rust_test(
     name = "mz_orchestrator_kubernetes_lib_tests",
     size = "medium",

--- a/src/orchestrator-process/BUILD.bazel
+++ b/src/orchestrator-process/BUILD.bazel
@@ -36,6 +36,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "orchestrator-process",
+    actual = "mz_orchestrator_process",
+)
+
 rust_test(
     name = "mz_orchestrator_process_lib_tests",
     size = "medium",

--- a/src/orchestrator-tracing/BUILD.bazel
+++ b/src/orchestrator-tracing/BUILD.bazel
@@ -45,6 +45,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "orchestrator-tracing",
+    actual = "mz_orchestrator_tracing",
+)
+
 rust_test(
     name = "mz_orchestrator_tracing_lib_tests",
     size = "medium",

--- a/src/orchestrator/BUILD.bazel
+++ b/src/orchestrator/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = ["//src/ore:mz_ore"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "orchestrator",
+    actual = "mz_orchestrator",
+)
+
 rust_test(
     name = "mz_orchestrator_lib_tests",
     size = "medium",

--- a/src/ore-proc/BUILD.bazel
+++ b/src/ore-proc/BUILD.bazel
@@ -31,6 +31,11 @@ rust_proc_macro(
     deps = [] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "ore-proc",
+    actual = "mz_ore_proc",
+)
+
 rust_test(
     name = "mz_ore_proc_lib_tests",
     size = "medium",

--- a/src/ore/BUILD.bazel
+++ b/src/ore/BUILD.bazel
@@ -86,6 +86,11 @@ rust_library(
     deps = [] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "ore",
+    actual = "mz_ore",
+)
+
 rust_test(
     name = "mz_ore_lib_tests",
     size = "medium",

--- a/src/persist-client/BUILD.bazel
+++ b/src/persist-client/BUILD.bazel
@@ -42,6 +42,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "persist-client",
+    actual = "mz_persist_client",
+)
+
 rust_test(
     name = "mz_persist_client_lib_tests",
     size = "medium",

--- a/src/persist-proc/BUILD.bazel
+++ b/src/persist-proc/BUILD.bazel
@@ -31,6 +31,11 @@ rust_proc_macro(
     deps = [] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "persist-proc",
+    actual = "mz_persist_proc",
+)
+
 rust_test(
     name = "mz_persist_proc_lib_tests",
     size = "medium",

--- a/src/persist-types/BUILD.bazel
+++ b/src/persist-types/BUILD.bazel
@@ -36,6 +36,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "persist-types",
+    actual = "mz_persist_types",
+)
+
 rust_test(
     name = "mz_persist_types_lib_tests",
     size = "medium",

--- a/src/persist/BUILD.bazel
+++ b/src/persist/BUILD.bazel
@@ -40,6 +40,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "persist",
+    actual = "mz_persist",
+)
+
 rust_test(
     name = "mz_persist_lib_tests",
     size = "medium",

--- a/src/pgcopy/BUILD.bazel
+++ b/src/pgcopy/BUILD.bazel
@@ -38,6 +38,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "pgcopy",
+    actual = "mz_pgcopy",
+)
+
 rust_test(
     name = "mz_pgcopy_lib_tests",
     size = "medium",

--- a/src/pgrepr-consts/BUILD.bazel
+++ b/src/pgrepr-consts/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = [] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "pgrepr-consts",
+    actual = "mz_pgrepr_consts",
+)
+
 rust_test(
     name = "mz_pgrepr_consts_lib_tests",
     size = "medium",

--- a/src/pgrepr/BUILD.bazel
+++ b/src/pgrepr/BUILD.bazel
@@ -36,6 +36,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "pgrepr",
+    actual = "mz_pgrepr",
+)
+
 rust_test(
     name = "mz_pgrepr_lib_tests",
     size = "medium",

--- a/src/pgtest/BUILD.bazel
+++ b/src/pgtest/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = ["//src/ore:mz_ore"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "pgtest",
+    actual = "mz_pgtest",
+)
+
 rust_test(
     name = "mz_pgtest_lib_tests",
     size = "medium",

--- a/src/pgtz/BUILD.bazel
+++ b/src/pgtz/BUILD.bazel
@@ -37,6 +37,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "pgtz",
+    actual = "mz_pgtz",
+)
+
 rust_test(
     name = "mz_pgtz_lib_tests",
     size = "medium",

--- a/src/pgwire-common/BUILD.bazel
+++ b/src/pgwire-common/BUILD.bazel
@@ -34,6 +34,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "pgwire-common",
+    actual = "mz_pgwire_common",
+)
+
 rust_test(
     name = "mz_pgwire_common_lib_tests",
     size = "medium",

--- a/src/pgwire/BUILD.bazel
+++ b/src/pgwire/BUILD.bazel
@@ -43,6 +43,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "pgwire",
+    actual = "mz_pgwire",
+)
+
 rust_test(
     name = "mz_pgwire_lib_tests",
     size = "medium",

--- a/src/postgres-client/BUILD.bazel
+++ b/src/postgres-client/BUILD.bazel
@@ -34,6 +34,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "postgres-client",
+    actual = "mz_postgres_client",
+)
+
 rust_test(
     name = "mz_postgres_client_lib_tests",
     size = "medium",

--- a/src/postgres-util/BUILD.bazel
+++ b/src/postgres-util/BUILD.bazel
@@ -54,6 +54,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "postgres-util",
+    actual = "mz_postgres_util",
+)
+
 rust_test(
     name = "mz_postgres_util_lib_tests",
     size = "medium",

--- a/src/prof-http/BUILD.bazel
+++ b/src/prof-http/BUILD.bazel
@@ -52,6 +52,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "prof-http",
+    actual = "mz_prof_http",
+)
+
 rust_test(
     name = "mz_prof_http_lib_tests",
     size = "medium",

--- a/src/prof/BUILD.bazel
+++ b/src/prof/BUILD.bazel
@@ -47,6 +47,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "prof",
+    actual = "mz_prof",
+)
+
 rust_test(
     name = "mz_prof_lib_tests",
     size = "medium",

--- a/src/proto/BUILD.bazel
+++ b/src/proto/BUILD.bazel
@@ -40,6 +40,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "proto",
+    actual = "mz_proto",
+)
+
 rust_test(
     name = "mz_proto_lib_tests",
     size = "medium",

--- a/src/regexp/BUILD.bazel
+++ b/src/regexp/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = ["//src/repr:mz_repr"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "regexp",
+    actual = "mz_regexp",
+)
+
 rust_test(
     name = "mz_regexp_lib_tests",
     size = "medium",

--- a/src/repr-test-util/BUILD.bazel
+++ b/src/repr-test-util/BUILD.bazel
@@ -35,6 +35,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "repr-test-util",
+    actual = "mz_repr_test_util",
+)
+
 rust_test(
     name = "mz_repr_test_util_lib_tests",
     size = "medium",

--- a/src/repr/BUILD.bazel
+++ b/src/repr/BUILD.bazel
@@ -45,6 +45,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "repr",
+    actual = "mz_repr",
+)
+
 rust_test(
     name = "mz_repr_lib_tests",
     size = "medium",

--- a/src/rocksdb-types/BUILD.bazel
+++ b/src/rocksdb-types/BUILD.bazel
@@ -36,6 +36,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "rocksdb-types",
+    actual = "mz_rocksdb_types",
+)
+
 rust_test(
     name = "mz_rocksdb_types_lib_tests",
     size = "medium",

--- a/src/rocksdb/BUILD.bazel
+++ b/src/rocksdb/BUILD.bazel
@@ -35,6 +35,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "rocksdb",
+    actual = "mz_rocksdb",
+)
+
 rust_test(
     name = "mz_rocksdb_lib_tests",
     size = "medium",

--- a/src/secrets/BUILD.bazel
+++ b/src/secrets/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = ["//src/repr:mz_repr"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "secrets",
+    actual = "mz_secrets",
+)
+
 rust_test(
     name = "mz_secrets_lib_tests",
     size = "medium",

--- a/src/segment/BUILD.bazel
+++ b/src/segment/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = ["//src/ore:mz_ore"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "segment",
+    actual = "mz_segment",
+)
+
 rust_test(
     name = "mz_segment_lib_tests",
     size = "medium",

--- a/src/server-core/BUILD.bazel
+++ b/src/server-core/BUILD.bazel
@@ -34,6 +34,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "server-core",
+    actual = "mz_server_core",
+)
+
 rust_test(
     name = "mz_server_core_lib_tests",
     size = "medium",

--- a/src/service/BUILD.bazel
+++ b/src/service/BUILD.bazel
@@ -42,6 +42,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "service",
+    actual = "mz_service",
+)
+
 rust_test(
     name = "mz_service_lib_tests",
     size = "medium",

--- a/src/sql-lexer/BUILD.bazel
+++ b/src/sql-lexer/BUILD.bazel
@@ -35,6 +35,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "sql-lexer",
+    actual = "mz_sql_lexer",
+)
+
 rust_test(
     name = "mz_sql_lexer_lib_tests",
     size = "medium",

--- a/src/sql-parser/BUILD.bazel
+++ b/src/sql-parser/BUILD.bazel
@@ -41,6 +41,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "sql-parser",
+    actual = "mz_sql_parser",
+)
+
 rust_test(
     name = "mz_sql_parser_lib_tests",
     size = "medium",

--- a/src/sql-pretty/BUILD.bazel
+++ b/src/sql-pretty/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = ["//src/sql-parser:mz_sql_parser"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "sql-pretty",
+    actual = "mz_sql_pretty",
+)
+
 rust_test(
     name = "mz_sql_pretty_lib_tests",
     size = "medium",

--- a/src/sql/BUILD.bazel
+++ b/src/sql/BUILD.bazel
@@ -62,6 +62,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "sql",
+    actual = "mz_sql",
+)
+
 rust_test(
     name = "mz_sql_lib_tests",
     size = "medium",

--- a/src/ssh-util/BUILD.bazel
+++ b/src/ssh-util/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = ["//src/ore:mz_ore"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "ssh-util",
+    actual = "mz_ssh_util",
+)
+
 rust_test(
     name = "mz_ssh_util_lib_tests",
     size = "medium",

--- a/src/storage-client/BUILD.bazel
+++ b/src/storage-client/BUILD.bazel
@@ -48,6 +48,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "storage-client",
+    actual = "mz_storage_client",
+)
+
 rust_test(
     name = "mz_storage_client_lib_tests",
     size = "medium",

--- a/src/storage-controller/BUILD.bazel
+++ b/src/storage-controller/BUILD.bazel
@@ -48,6 +48,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "storage-controller",
+    actual = "mz_storage_controller",
+)
+
 rust_test(
     name = "mz_storage_controller_lib_tests",
     size = "medium",

--- a/src/storage-operators/BUILD.bazel
+++ b/src/storage-operators/BUILD.bazel
@@ -44,6 +44,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "storage-operators",
+    actual = "mz_storage_operators",
+)
+
 rust_test(
     name = "mz_storage_operators_lib_tests",
     size = "medium",

--- a/src/storage-types/BUILD.bazel
+++ b/src/storage-types/BUILD.bazel
@@ -56,6 +56,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "storage-types",
+    actual = "mz_storage_types",
+)
+
 rust_test(
     name = "mz_storage_types_lib_tests",
     size = "medium",

--- a/src/storage/BUILD.bazel
+++ b/src/storage/BUILD.bazel
@@ -61,6 +61,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "storage",
+    actual = "mz_storage",
+)
+
 rust_test(
     name = "mz_storage_lib_tests",
     size = "medium",

--- a/src/timely-util/BUILD.bazel
+++ b/src/timely-util/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = ["//src/ore:mz_ore"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "timely-util",
+    actual = "mz_timely_util",
+)
+
 rust_test(
     name = "mz_timely_util_lib_tests",
     size = "medium",

--- a/src/timestamp-oracle/BUILD.bazel
+++ b/src/timestamp-oracle/BUILD.bazel
@@ -37,6 +37,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "timestamp-oracle",
+    actual = "mz_timestamp_oracle",
+)
+
 rust_test(
     name = "mz_timestamp_oracle_lib_tests",
     size = "medium",

--- a/src/tls-util/BUILD.bazel
+++ b/src/tls-util/BUILD.bazel
@@ -31,6 +31,11 @@ rust_library(
     deps = [] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "tls-util",
+    actual = "mz_tls_util",
+)
+
 rust_test(
     name = "mz_tls_util_lib_tests",
     size = "medium",

--- a/src/tracing/BUILD.bazel
+++ b/src/tracing/BUILD.bazel
@@ -36,6 +36,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "tracing",
+    actual = "mz_tracing",
+)
+
 rust_test(
     name = "mz_tracing_lib_tests",
     size = "medium",

--- a/src/transform/BUILD.bazel
+++ b/src/transform/BUILD.bazel
@@ -36,6 +36,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "transform",
+    actual = "mz_transform",
+)
+
 rust_test(
     name = "mz_transform_lib_tests",
     size = "medium",

--- a/src/txn-wal/BUILD.bazel
+++ b/src/txn-wal/BUILD.bazel
@@ -39,6 +39,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "txn-wal",
+    actual = "mz_txn_wal",
+)
+
 rust_test(
     name = "mz_txn_wal_lib_tests",
     size = "medium",

--- a/src/workspace-hack/BUILD.bazel
+++ b/src/workspace-hack/BUILD.bazel
@@ -32,6 +32,11 @@ rust_library(
     deps = [":workspace_hack_build_script"] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "workspace-hack",
+    actual = "workspace_hack",
+)
+
 rust_test(
     name = "workspace_hack_lib_tests",
     size = "medium",

--- a/test/test-util/BUILD.bazel
+++ b/test/test-util/BUILD.bazel
@@ -34,6 +34,11 @@ rust_library(
     ] + all_crate_deps(normal = True),
 )
 
+alias(
+    name = "test-util",
+    actual = "mz_test_util",
+)
+
 rust_test(
     name = "mz_test_util_lib_tests",
     size = "medium",


### PR DESCRIPTION
This PR aliases library targets so you can reference them with a short-hand syntax instead of having to fully type out their names. Not a huge change but a small nicety I ran into while using Bazel

Before
```
bin/bazel build //src/compute-types:mz_compute_types
```
After
```
bin/bazel build //src/compute-types
```

### Motivation

Make building with Bazel a little more pleasant

### Tips for reviewer

First commit are the actual changes, second commit is just running `bin/bazel gen`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
