### PR TITLE
bazel: Improve the documentation

### DIFF
--- a/misc/bazel/README.md
+++ b/misc/bazel/README.md
@@ -148,7 +148,7 @@ resulting [`rust_library`](http://bazelbuild.github.io/rules_rust/defs.html#rust
 # Configuration for the crate as a whole.
 [package.metadata.cargo-gazelle]
 # Will skip generating a BUILD.bazel entirely.
-skip_generating = [True | False]
+skip_generating = (true | false)
 # Concatenate the specified string at the end of the generated BUILD.bazel file.
 #
 # This is largely an escape hatch and should be avoided if possible.
@@ -158,44 +158,44 @@ additive_content = "String"
 # Configuration for the library target of the crate.
 [package.metadata.cargo-gazelle.lib]
 # Skip generating the library target.
-skip = [True | False]
+skip = (true | false)
 # Extra data that will be provided to the Bazel target at compile time.
-compile_data = ["String"]
+compile_data = ["String Array"]
 # Extra data that will be provided to the Bazel target at compile and run time.
-data = ["String"]
+data = ["String Array"]
 # Extra flags for rustc.
-rustc_flags = ["String"]
+rustc_flags = ["String Array"]
 # Environment variables to set for rustc.
 [package.metadata.cargo-gazelle.lib.rustc_env]
 var1 = "my_value"
 
 # By default Bazel enables all features of a crate, if provided we will
 # _override_ that set with this list.
-features_override = ["String"]
+features_override = ["String Array"]
 # Extra dependencies to include for the target.
-extra_deps = ["String"]
+extra_deps = ["String Array"]
 # Extra proc-macro dependencies to include for the target.
-extra_proc_macro_deps = ["String"]
+extra_proc_macro_deps = ["String Array"]
 
 
 # Configuration for the crate's build script.
 [package.metadata.cargo-gazelle.build]
 # Skip generating the library target.
-skip = [True | False]
+skip = (true | false)
 # Extra data that will be provided to the Bazel target at compile time.
-compile_data = ["String"]
+compile_data = ["String Array"]
 # Extra data that will be provided to the Bazel target at compile and run time.
-data = ["String"]
+data = ["String Array"]
 # Extra flags for rustc.
-rustc_flags = ["String"]
+rustc_flags = ["String Array"]
 # Environment variables to set for rustc.
 [package.metadata.cargo-gazelle.build.rustc_env]
 var1 = "my_value"
 
 # Environment variables to set for the build script.
-build_script_env = ["String"]
+build_script_env = ["String Array"]
 # Skip the automatic search for protobuf dependencies.
-skip_proto_search = [True | False]
+skip_proto_search = (true | false)
 
 
 # Configuration for test targets in the crate.
@@ -205,13 +205,13 @@ skip_proto_search = [True | False]
 #
 [package.metadata.cargo-gazelle.test.<name>]
 # Skip generating the library target.
-skip = [True | False]
+skip = (true | false)
 # Extra data that will be provided to the Bazel target at compile time.
-compile_data = ["String"]
+compile_data = ["String Array"]
 # Extra data that will be provided to the Bazel target at compile and run time.
-data = ["String"]
+data = ["String Array"]
 # Extra flags for rustc.
-rustc_flags = ["String"]
+rustc_flags = ["String Array"]
 # Environment variables to set for rustc.
 [package.metadata.cargo-gazelle.test.<name>.rustc_env]
 var1 = "my_value"
@@ -228,13 +228,13 @@ var1 = "my_value"
 # Configuration for binary targets of the crate.
 [package.metadata.cargo-gazelle.binary.<name>]
 # Skip generating the library target.
-skip = [True | False]
+skip = (true | false)
 # Extra data that will be provided to the Bazel target at compile time.
-compile_data = ["String"]
+compile_data = ["String Array"]
 # Extra data that will be provided to the Bazel target at compile and run time.
-data = ["String"]
+data = ["String Array"]
 # Extra flags for rustc.
-rustc_flags = ["String"]
+rustc_flags = ["String Array"]
 # Environment variables to set for rustc.
 [[package.metadata.cargo-gazelle.binary.<name>.rustc_env]]
 var1 = "my_value"

--- a/misc/bazel/README.md
+++ b/misc/bazel/README.md
@@ -102,7 +102,7 @@ A good default to start with is:
 # Bazel will use all but one CPU core, so your machine is still responsive.
 common --local_resources=cpu="HOST_CPUS-1"
 
-# Define a shared disk cache so builds from different directories can share artifacts.
+# Define a shared disk cache so builds from different Materialize repos can share artifacts.
 build --disk_cache=~/.cache/bazel
 ```
 


### PR DESCRIPTION
While waiting for tests to run I took a pass at the existing Bazel docs.

## [Rendered](https://github.com/ParkMyCar/materialize/blob/bazel/readme-improvements/misc/bazel/README.md)

### Motivation

Improve docs so more folks can use Bazel.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
