### PR TITLE
Sort peek results in the replica instead of the coordinator

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -37,7 +37,7 @@ use mz_ore::str::{separated, StrExt};
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::explain::text::DisplayText;
 use mz_repr::explain::{CompactScalars, IndexUsageType, PlanRenderingContext, UsedIndexes};
-use mz_repr::{Diff, GlobalId, IntoRowIterator, RelationType, Row, RowCollection, RowIterator};
+use mz_repr::{Diff, GlobalId, IntoRowIterator, RelationType, Row, RowCollections, RowIterator};
 use serde::{Deserialize, Serialize};
 use timely::progress::Timestamp;
 use uuid::Uuid;
@@ -481,11 +481,11 @@ impl crate::coord::Coordinator {
                     ));
                 }
             }
-            let row_collection = RowCollection::new(&results);
+            let row_collections = RowCollections::from_rows(&results);
             let duration_histogram = self.metrics.row_set_finishing_seconds();
 
             let (ret, reason) = match finishing.finish(
-                vec![row_collection],
+                row_collections,
                 max_result_size,
                 max_returned_query_size,
                 &duration_histogram,
@@ -645,7 +645,7 @@ impl crate::coord::Coordinator {
             move |resp| match resp {
                 PeekResponse::Rows(rows) => {
                     match finishing.finish(
-                        vec![rows],
+                        rows,
                         max_result_size,
                         max_returned_query_size,
                         &duration_histogram,

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -481,7 +481,7 @@ impl crate::coord::Coordinator {
                     ));
                 }
             }
-            let row_collections = RowCollections::from_rows(&results);
+            let row_collections = RowCollections::from_rows(&results, false);
             let duration_histogram = self.metrics.row_set_finishing_seconds();
 
             let (ret, reason) = match finishing.finish(

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -485,7 +485,7 @@ impl crate::coord::Coordinator {
             let duration_histogram = self.metrics.row_set_finishing_seconds();
 
             let (ret, reason) = match finishing.finish(
-                row_collection,
+                vec![row_collection],
                 max_result_size,
                 max_returned_query_size,
                 &duration_histogram,
@@ -645,7 +645,7 @@ impl crate::coord::Coordinator {
             move |resp| match resp {
                 PeekResponse::Rows(rows) => {
                     match finishing.finish(
-                        rows,
+                        vec![rows],
                         max_result_size,
                         max_returned_query_size,
                         &duration_histogram,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -17,7 +17,7 @@ use futures::FutureExt;
 use inner::return_if_err;
 use mz_expr::{MirRelationExpr, RowSetFinishing};
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_repr::{CatalogItemId, Diff, GlobalId, RowCollection};
+use mz_repr::{CatalogItemId, Diff, GlobalId, RowCollections};
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan::{
@@ -838,7 +838,7 @@ impl Coordinator {
             let duration_histogram = session.metrics().row_set_finishing_seconds();
 
             return match finishing.finish(
-                vec![RowCollection::new(&plan.returning)],
+                RowCollections::from_rows(&plan.returning),
                 plan.max_result_size,
                 Some(max_returned_query_size),
                 duration_histogram,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -838,7 +838,7 @@ impl Coordinator {
             let duration_histogram = session.metrics().row_set_finishing_seconds();
 
             return match finishing.finish(
-                RowCollection::new(&plan.returning),
+                vec![RowCollection::new(&plan.returning)],
                 plan.max_result_size,
                 Some(max_returned_query_size),
                 duration_histogram,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -838,7 +838,7 @@ impl Coordinator {
             let duration_histogram = session.metrics().row_set_finishing_seconds();
 
             return match finishing.finish(
-                RowCollections::from_rows(&plan.returning),
+                RowCollections::from_rows(&plan.returning, false),
                 plan.max_result_size,
                 Some(max_returned_query_size),
                 duration_histogram,

--- a/src/compute-client/src/protocol/response.proto
+++ b/src/compute-client/src/protocol/response.proto
@@ -59,7 +59,7 @@ message ProtoFrontiersResponse {
 
 message ProtoPeekResponse {
   oneof kind {
-    mz_repr.row.collection.ProtoRowCollection rows = 1;
+    mz_repr.row.collection.ProtoRowCollections row_collections = 4;
     string error = 2;
     google.protobuf.Empty canceled = 3;
   }

--- a/src/compute-client/src/protocol/response.proto
+++ b/src/compute-client/src/protocol/response.proto
@@ -59,7 +59,7 @@ message ProtoFrontiersResponse {
 
 message ProtoPeekResponse {
   oneof kind {
-    mz_repr.row.collection.ProtoRowCollections row_collections = 4;
+    mz_repr.row.collection.ProtoRowCollections row_collections = 1;
     string error = 2;
     google.protobuf.Empty canceled = 3;
   }

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -367,7 +367,7 @@ impl Arbitrary for PeekResponse {
                 ),
                 1..11,
             )
-            .prop_map(|rows| PeekResponse::Rows(RowCollections::from_rows(&rows)))
+            .prop_map(|rows| PeekResponse::Rows(RowCollections::from_rows(&rows, false)))
             .boxed(),
             ".*".prop_map(PeekResponse::Error).boxed(),
             Just(PeekResponse::Canceled).boxed(),

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -21,7 +21,7 @@ use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::lattice::Lattice;
 use mz_ore::assert_none;
 use mz_ore::cast::CastFrom;
-use mz_repr::{Diff, GlobalId, Row, RowCollection};
+use mz_repr::{Diff, GlobalId, Row, RowCollections};
 use mz_service::client::{GenericClient, Partitionable, PartitionedState};
 use mz_service::grpc::{GrpcClient, GrpcServer, ProtoServiceTypes, ResponseStream};
 use timely::progress::frontier::{Antichain, MutableAntichain};
@@ -319,7 +319,7 @@ where
                 assert_none!(novel, "Duplicate peek response");
                 // We may be ready to respond.
                 if entry.len() == self.parts {
-                    let mut response = PeekResponse::Rows(RowCollection::default());
+                    let mut response = PeekResponse::Rows(RowCollections::new());
                     for (_part, r) in std::mem::take(entry).into_iter() {
                         response = match (response, r) {
                             (_, PeekResponse::Canceled) => PeekResponse::Canceled,
@@ -340,7 +340,7 @@ where
                                     );
                                     PeekResponse::Error(err)
                                 } else {
-                                    rows.merge(&other);
+                                    rows.extend(other);
                                     PeekResponse::Rows(rows)
                                 }
                             }

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -319,7 +319,7 @@ where
                 assert_none!(novel, "Duplicate peek response");
                 // We may be ready to respond.
                 if entry.len() == self.parts {
-                    let mut response = PeekResponse::Rows(RowCollections::new());
+                    let mut response = PeekResponse::Rows(RowCollections::default());
                     for (_part, r) in std::mem::take(entry).into_iter() {
                         response = match (response, r) {
                             (_, PeekResponse::Canceled) => PeekResponse::Canceled,

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -44,7 +44,7 @@ use mz_persist_client::read::ReadHandle;
 use mz_persist_client::Diagnostics;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::fixed_length::ToDatumIter;
-use mz_repr::{DatumVec, Diff, GlobalId, Row, RowArena, RowCollection, Timestamp};
+use mz_repr::{DatumVec, Diff, GlobalId, Row, RowArena, RowCollections, Timestamp};
 use mz_storage_operators::stats::StatsCursor;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::sources::SourceData;
@@ -1095,7 +1095,7 @@ impl PendingPeek {
                 Ok(vec![])
             };
             let result = match result {
-                Ok(rows) => PeekResponse::Rows(RowCollection::new(&rows)),
+                Ok(rows) => PeekResponse::Rows(RowCollections::from_rows(&rows)),
                 Err(e) => PeekResponse::Error(e.to_string()),
             };
             match result_tx.send((result, start.elapsed())) {
@@ -1297,7 +1297,7 @@ impl IndexPeek {
         }
 
         let response = match self.collect_finished_data(max_result_size) {
-            Ok(rows) => PeekResponse::Rows(RowCollection::new(&rows)),
+            Ok(rows) => PeekResponse::Rows(RowCollections::from_rows(&rows)),
             Err(text) => PeekResponse::Error(text),
         };
         Some(response)

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -35,7 +35,7 @@ use mz_repr::explain::{
 };
 use mz_repr::{
     ColumnName, ColumnType, Datum, Diff, GlobalId, IntoRowIterator, RelationType, Row,
-    RowCollection, RowIterator, ScalarType, SortedRowCollections, SortedRowCollectionsIter,
+    RowCollections, RowIterator, ScalarType, SortedRowCollections, SortedRowCollectionsIter,
 };
 use proptest::prelude::{any, Arbitrary, BoxedStrategy};
 use proptest::strategy::{Strategy, Union};
@@ -3521,11 +3521,11 @@ impl<L> RowSetFinishing<L> {
 }
 
 impl RowSetFinishing {
-    /// Applies finishing actions to a [`RowCollection`], and reports the total
+    /// Applies finishing actions to a [`RowCollections`], and reports the total
     /// time it took to run.
     pub fn finish(
         &self,
-        rows: Vec<RowCollection>,
+        rows: RowCollections,
         max_result_size: u64,
         max_returned_query_size: Option<u64>,
         duration_histogram: &Histogram,
@@ -3541,11 +3541,11 @@ impl RowSetFinishing {
     /// Implementation for [`RowSetFinishing::finish`].
     fn finish_inner(
         &self,
-        rows: Vec<RowCollection>,
+        rows: RowCollections,
         _max_result_size: u64,
         max_returned_query_size: Option<u64>,
     ) -> Result<SortedRowCollectionsIter, String> {
-        let sorted_view = SortedRowCollections::new(rows);
+        let sorted_view = SortedRowCollections::new(rows.inner());
         let mut iter = sorted_view
             .into_row_iter()
             .apply_offset(self.offset)

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -3548,16 +3548,14 @@ impl RowSetFinishing {
         max_returned_query_size: Option<u64>,
     ) -> Result<SortedRowCollectionsIter, String> {
         let order_by = self.order_by.clone();
-        let left_datum_vec = Mutex::new(mz_repr::DatumVec::new());
-        let right_datum_vec = Mutex::new(mz_repr::DatumVec::new());
+        let mut left_datum_vec = mz_repr::DatumVec::new();
+        let mut right_datum_vec = mz_repr::DatumVec::new();
         let sort_by = move |left: &RowRef, right: &RowRef| {
-            let mut left_vec = left_datum_vec.lock().unwrap();
-            let left_datums = left_vec.borrow_with(left);
-            let mut right_vec = right_datum_vec.lock().unwrap();
-            let right_datums = right_vec.borrow_with(right);
+            let left_datums = left_datum_vec.borrow_with(left);
+            let right_datums = right_datum_vec.borrow_with(right);
             compare_columns(&order_by, &left_datums, &right_datums, || left.cmp(right))
         };
-        let sorted_view = SortedRowCollections::new(rows.inner(), Arc::new(sort_by));
+        let sorted_view = SortedRowCollections::new(rows.inner(), Arc::new(Mutex::new(sort_by)));
         let mut iter = sorted_view
             .into_row_iter()
             .apply_offset(self.offset)

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -58,7 +58,7 @@ pub use crate::relation::{
     RelationDesc, RelationDescBuilder, RelationType, RelationVersion, RelationVersionSelector,
     VersionedRelationDesc,
 };
-pub use crate::row::collection::{ProtoRowCollection, RowCollection, SortedRowCollections, SortedRowCollectionIter};
+pub use crate::row::collection::{ProtoRowCollection, ProtoRowCollections, RowCollection, RowCollections, SortedRowCollections, SortedRowCollectionIter};
 pub use crate::row::encode::{preserves_order, RowColumnarDecoder, RowColumnarEncoder};
 pub use crate::row::iter::{IntoRowIterator, RowIterator};
 pub use crate::row::{

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -58,7 +58,7 @@ pub use crate::relation::{
     RelationDesc, RelationDescBuilder, RelationType, RelationVersion, RelationVersionSelector,
     VersionedRelationDesc,
 };
-pub use crate::row::collection::{ProtoRowCollection, RowCollection, SortedRowCollectionIter};
+pub use crate::row::collection::{ProtoRowCollection, RowCollection, SortedRowCollections, SortedRowCollectionIter};
 pub use crate::row::encode::{preserves_order, RowColumnarDecoder, RowColumnarEncoder};
 pub use crate::row::iter::{IntoRowIterator, RowIterator};
 pub use crate::row::{

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -58,7 +58,7 @@ pub use crate::relation::{
     RelationDesc, RelationDescBuilder, RelationType, RelationVersion, RelationVersionSelector,
     VersionedRelationDesc,
 };
-pub use crate::row::collection::{ProtoRowCollection, ProtoRowCollections, RowCollection, RowCollections, SortedRowCollections, SortedRowCollectionIter};
+pub use crate::row::collection::{ProtoRowCollection, ProtoRowCollections, RowCollection, RowCollections, RowDiffs, SortedRowCollections, SortedRowCollectionIter};
 pub use crate::row::encode::{preserves_order, RowColumnarDecoder, RowColumnarEncoder};
 pub use crate::row::iter::{IntoRowIterator, RowIterator};
 pub use crate::row::{

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -58,7 +58,10 @@ pub use crate::relation::{
     RelationDesc, RelationDescBuilder, RelationType, RelationVersion, RelationVersionSelector,
     VersionedRelationDesc,
 };
-pub use crate::row::collection::{ProtoRowCollection, ProtoRowCollections, RowCollection, RowCollections, RowDiffs, SortedRowCollections, SortedRowCollectionIter};
+pub use crate::row::collection::{
+    ProtoRowCollection, ProtoRowCollections, RowCollection, RowCollections, RowDiffs,
+    SortedRowCollections, SortedRowCollectionsIter,
+};
 pub use crate::row::encode::{preserves_order, RowColumnarDecoder, RowColumnarEncoder};
 pub use crate::row::iter::{IntoRowIterator, RowIterator};
 pub use crate::row::{

--- a/src/repr/src/row/collection.proto
+++ b/src/repr/src/row/collection.proto
@@ -14,6 +14,7 @@ package mz_repr.row.collection;
 message ProtoRowCollection {
   bytes encoded = 1;
   repeated ProtoEncodedRowMetadata metadata = 2;
+  bool is_sorted = 3;
 }
 
 message ProtoEncodedRowMetadata {

--- a/src/repr/src/row/collection.proto
+++ b/src/repr/src/row/collection.proto
@@ -20,3 +20,7 @@ message ProtoEncodedRowMetadata {
   uint64 offset = 1;
   uint64 diff = 2;
 }
+
+message ProtoRowCollections {
+  repeated ProtoRowCollection data = 1;
+}

--- a/src/repr/src/row/collection.rs
+++ b/src/repr/src/row/collection.rs
@@ -418,10 +418,11 @@ impl SortedRowCollections {
         let mut total_count = 0;
         for row_collection in data {
             total_count += row_collection.count(0, None);
+            let row_collection = row_collection.sorted_view(Arc::clone(&sort_by));
             if let Some((_, meta)) = row_collection.get(0) {
                 let diffs_left = meta.diff.get();
                 heap.push(HeapRowCollection {
-                    row_collection: row_collection.sorted_view(Arc::clone(&sort_by)),
+                    row_collection,
                     row_index: 0,
                     diffs_left,
                     sort_by: Arc::clone(&sort_by),


### PR DESCRIPTION
Skunkworks while planning a wedding. Continued thinking about the project and came up with this solution. The tricky part was to get the merge logic represented in a way that satisfies the existing constraints, e.g., should be `Sync+Send`, hence no references (?).

### Motivation

Currently, peek results are sorted in the coordinator. For `k` workers each producing `N` results, the sorting cost is `(N*k)*log(N*k)` in the single coordinator thread.

This PR shifts the sorting to the replicas when possible, leaving just a `k`-way merge in the coordinator. The new cost is `(N*k)*(log(N)+log(k))`, for sorting `N` results at each of the `k` workers and a final merge of `N*k` results at the coordinator using a binary heap. Moreover, the bulk of the computation occurs across multiple workers instead of a single coordinator thread.

**Note that fast peeks and other results that are not computed in the replica will still be sorted in the coordinator.**

### Tips for reviewer

* I haven't had a chance to run benchmarks yet. Will take a stab at it after CI passes.

cc @teskje 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
