### PR TITLE
releases: Bump orchestratord version too

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "mz-orchestratord"
-version = "0.120.0-dev.0"
+version = "0.125.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -38,7 +38,7 @@ version=${1#v}
 
 sed -i.bak \
     "s/^version = .*/version = \"$version\"/" \
-    src/{clusterd,environmentd,persist-client,testdrive,catalog-debug,balancerd}/Cargo.toml
+    src/{clusterd,environmentd,persist-client,testdrive,catalog-debug,balancerd,orchestratord}/Cargo.toml
 
 if ! [[ "$version" = *-dev* ]]; then
     sed -i.bak \
@@ -58,7 +58,7 @@ else
     done
 fi
 
-rm -f src/{clusterd,environmentd,persist-client,testdrive,catalog-debug,balancerd}/Cargo.toml.bak LICENSE.bak
+rm -f src/{clusterd,environmentd,persist-client,testdrive,catalog-debug,balancerd,orchestratord}/Cargo.toml.bak LICENSE.bak
 
 cargo update --workspace
 

--- a/src/orchestratord/BUILD.bazel
+++ b/src/orchestratord/BUILD.bazel
@@ -30,7 +30,7 @@ rust_library(
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.120.0-dev.0",
+    version = "0.125.0-dev.0",
     deps = [
         "//src/alloc:mz_alloc",
         "//src/alloc-default:mz_alloc_default",
@@ -68,7 +68,7 @@ rust_test(
     ),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.120.0-dev.0",
+    version = "0.125.0-dev.0",
     deps = [
         "//src/alloc:mz_alloc",
         "//src/alloc-default:mz_alloc_default",
@@ -121,7 +121,7 @@ rust_binary(
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],
-    version = "0.120.0-dev.0",
+    version = "0.125.0-dev.0",
     deps = [
         ":mz_orchestratord",
         "//src/alloc:mz_alloc",

--- a/src/orchestratord/Cargo.toml
+++ b/src/orchestratord/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-orchestratord"
 description = "Kubernetes operator for Materialize regions"
-version = "0.120.0-dev.0"
+version = "0.125.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
