### PR TITLE
Nightly fixes (November 8)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,6 +17,10 @@ filter = "package(mz-environmentd) and test(test_storage_usage_collection_interv
 slow-timeout = { period = "300s", terminate-after = 2 }
 
 [[profile.default.overrides]]
+filter = "package(mz-catalog) and test(global_expr_cache_roundtrip)"
+slow-timeout = { period = "300s", terminate-after = 2 }
+
+[[profile.default.overrides]]
 filter = "package(mz-environmentd)"
 threads-required = 8
 slow-timeout = { period = "120s", terminate-after = 2 }

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -227,6 +227,11 @@ class PgPreExecutionInconsistencyIgnoreFilter(
         expression: ExpressionWithArgs,
         all_involved_characteristics: set[ExpressionCharacteristics],
     ) -> IgnoreVerdict:
+        if db_function.function_name_in_lower_case == "generate_subscripts":
+            return YesIgnore(
+                "database-issues#8410: table functions: combination with operations with NULL"
+            )
+
         if db_function.function_name_in_lower_case == "jsonb_pretty":
             return YesIgnore("Accepted")
 

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1675,6 +1675,7 @@ SERVICES = [
             "--https-resolver-template=materialized:6876",
             "--tls-key=/secrets/balancerd.key",
             "--tls-cert=/secrets/balancerd.crt",
+            "--internal-tls",
         ],
         depends_on=["test-certs"],
         volumes=[


### PR DESCRIPTION
See individual commits

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
