### PR TITLE
storage: optional probe streams from source operators

### DIFF
--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -184,7 +184,7 @@ impl SourceRender for KafkaSourceConnection {
         Option<Stream<G, Infallible>>,
         Stream<G, HealthStatusMessage>,
         Stream<G, ProgressStatisticsUpdate>,
-        Stream<G, Probe<KafkaTimestamp>>,
+        Option<Stream<G, Probe<KafkaTimestamp>>>,
         Vec<PressOnDropButton>,
     ) {
         let mut builder = AsyncOperatorBuilder::new(config.name.clone(), scope.clone());
@@ -1020,7 +1020,7 @@ impl SourceRender for KafkaSourceConnection {
             Some(progress_stream),
             health_stream,
             stats_stream,
-            probe_stream,
+            Some(probe_stream),
             vec![button.press_on_drop()],
         )
     }

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -107,7 +107,7 @@ impl SourceRender for MySqlSourceConnection {
         Option<Stream<G, Infallible>>,
         Stream<G, HealthStatusMessage>,
         Stream<G, ProgressStatisticsUpdate>,
-        Stream<G, Probe<GtidPartition>>,
+        Option<Stream<G, Probe<GtidPartition>>>,
         Vec<PressOnDropButton>,
     ) {
         // Collect the source outputs that we will be exporting.
@@ -218,7 +218,7 @@ impl SourceRender for MySqlSourceConnection {
             Some(uppers),
             health,
             stats_stream,
-            probe_stream,
+            Some(probe_stream),
             vec![snapshot_token, repl_token, stats_token],
         )
     }

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -245,7 +245,7 @@ impl SourceRender for PostgresSourceConnection {
             Some(uppers),
             health,
             stats_stream,
-            Some(probe_stream),
+            probe_stream,
             vec![snapshot_token, repl_token],
         )
     }

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -131,7 +131,7 @@ impl SourceRender for PostgresSourceConnection {
         Option<Stream<G, Infallible>>,
         Stream<G, HealthStatusMessage>,
         Stream<G, ProgressStatisticsUpdate>,
-        Stream<G, Probe<MzOffset>>,
+        Option<Stream<G, Probe<MzOffset>>>,
         Vec<PressOnDropButton>,
     ) {
         // Collect the source outputs that we will be exporting into a per-table map.
@@ -245,7 +245,7 @@ impl SourceRender for PostgresSourceConnection {
             Some(uppers),
             health,
             stats_stream,
-            probe_stream,
+            Some(probe_stream),
             vec![snapshot_token, repl_token],
         )
     }

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -97,7 +97,7 @@ pub trait SourceRender {
         Option<Stream<G, Infallible>>,
         Stream<G, HealthStatusMessage>,
         Stream<G, ProgressStatisticsUpdate>,
-        Stream<G, Probe<Self::Time>>,
+        Option<Stream<G, Probe<Self::Time>>>,
         Vec<PressOnDropButton>,
     );
 }


### PR DESCRIPTION
This PR introduces the ability for source operators to omit returning a probe stream. This is appropriate for sources that don't support probing the upstream system. This ability is then made use of for load generators and Yugabyte sources. 

The "latest" reclocking mode still expects to receive probes, so the reader pipeline synthesizes a probe stream from source progress events and uses that in cases where the source doesn't support probing. This is the same approach previously used by the load generators, just centralized in a single place.

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/database-issues/issues/7020

### Tips for reviewes

@petrosagg This is different from what we discussed last week where you suggested synthesizing the probes in the existing `SourceGenericStats` operator. I realized that we need a timer to ensure new probes get produced even when no upstream progress is reported, and introducing a timer into the existing operator felt unwieldy, so I decided to introduce a separate operator instead.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
