### PR TITLE
helm version improvements

### DIFF
--- a/misc/helm-charts/operator/Chart.yaml
+++ b/misc/helm-charts/operator/Chart.yaml
@@ -13,6 +13,6 @@ name: materialize-operator
 description: Materialize Kubernetes Operator Helm Chart
 type: application
 version: 0.1.0
-appVersion: "0.1.0"
+appVersion: "v0.124.0-dev.0--pr.gd5e227d7d07dc4878d2a065c7c10a48c2555385a"
 icon: https://materialize.com/favicon.ico
 home: https://materialize.com

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
         image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
         imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
         args:
+        - "--helm-chart-version={{ .Chart.Version }}"
         - "--startup-log-filter={{ .Values.operator.args.startupLogFilter }}"
         - "--cloud-provider={{ .Values.operator.args.cloudProvider }}"
         - "--region={{ .Values.operator.args.region }}"

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -38,6 +38,8 @@ pub struct Args {
     create_balancers: bool,
     #[clap(long)]
     enable_tls: bool,
+    #[clap(long)]
+    helm_chart_version: Option<String>,
 
     #[clap(flatten)]
     aws_info: AwsInfo,

--- a/src/orchestratord/src/controller/materialize/resources.rs
+++ b/src/orchestratord/src/controller/materialize/resources.rs
@@ -788,6 +788,10 @@ fn create_environmentd_statefulset_object(
 
     let mut args = vec![];
 
+    if let Some(helm_chart_version) = &config.helm_chart_version {
+        args.push(format!("--helm-chart-version={helm_chart_version}"));
+    }
+
     // Add environment ID argument.
     args.push(format!(
         "--environment-id={}",


### PR DESCRIPTION
### Motivation

pass the helm chart version through to environmentd, and keep appVersion in sync with the orchestratord version we're running

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
