### PR TITLE
Improve key detection logic for Union

### DIFF
--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -1077,48 +1077,81 @@ impl MirRelationExpr {
                 // and who knows what is true (not expected, but again
                 // who knows what the query plan might look like).
 
-                let arity = input_arities.next().unwrap();
-                let (base_projection, base_with_project_stripped) =
-                    if let MirRelationExpr::Project { input, outputs } = &**base {
-                        (outputs.clone(), &**input)
-                    } else {
-                        // A input without a project is equivalent to an input
-                        // with the project being all columns in the input in order.
-                        ((0..arity).collect::<Vec<_>>(), &**base)
-                    };
+                // Accumulate all discovered keys here.
                 let mut result = Vec::new();
-                if let MirRelationExpr::Get {
-                    id: first_id,
-                    typ: _,
-                    ..
-                } = base_with_project_stripped
-                {
-                    if inputs.len() == 1 {
-                        if let MirRelationExpr::Map { input, .. } = &inputs[0] {
-                            if let MirRelationExpr::Union { base, inputs } = &**input {
-                                if inputs.len() == 1 {
-                                    if let Some((input, outputs)) = base.is_negated_project() {
-                                        if let MirRelationExpr::Get {
-                                            id: second_id,
-                                            typ: _,
-                                            ..
-                                        } = input
-                                        {
-                                            if first_id == second_id {
-                                                result.extend(
-                                                    inputs[0].typ().keys.drain(..).filter(|key| {
-                                                        key.iter().all(|c| {
-                                                            outputs.get(*c) == Some(c)
-                                                                && base_projection.get(*c)
-                                                                    == Some(c)
-                                                        })
-                                                    }),
-                                                );
-                                            }
-                                        }
-                                    }
-                                }
+
+                // All inputs laid out in order, so that others can reference them without `base` v `inputs` work.
+                let all_inputs = std::iter::once(&**base).chain(inputs).collect::<Vec<_>>();
+
+                // We are looking for a pattern of `B + (A - A.proj(..).map(..))*`, for key columns of `B`
+                // that comes from `A` rather than from the `map(..)`. When this happens, the sum of diffs
+                // for each key is that from B (0 or 1) plus that from `(A - A..)` which is zero. If we also
+                // confirm that the expression itself is non-negative, then all sums should be 0 or 1.
+
+                // For each input expression, a map-filter-project around some root expression.
+                // Every expression either is or is not a filter-free MFP around a Get, and for these we are
+                // interested in 1. the projection, and 2. the get identifier.
+                //
+                // For each `Get::id`, a pair of list of positive and negative inputs, with associated MFPs.
+                let mut gets_pos_neg = BTreeMap::default();
+                for (index, expr) in all_inputs.iter().enumerate() {
+                    if let MirRelationExpr::Negate { input } = expr {
+                        let (mfp, expr) =
+                            crate::MapFilterProject::extract_from_expression(&**input);
+                        if let MirRelationExpr::Get { id, .. } = expr {
+                            if mfp.predicates.is_empty() {
+                                gets_pos_neg
+                                    .entry(id)
+                                    .or_insert_with(|| (Vec::new(), Vec::new()))
+                                    .1
+                                    .push((index, mfp));
                             }
+                        }
+                    } else {
+                        let (mfp, expr) = crate::MapFilterProject::extract_from_expression(&**expr);
+                        if let MirRelationExpr::Get { id, .. } = expr {
+                            if mfp.predicates.is_empty() {
+                                gets_pos_neg
+                                    .entry(id)
+                                    .or_insert_with(|| (Vec::new(), Vec::new()))
+                                    .0
+                                    .push((index, mfp));
+                            }
+                        }
+                    }
+                }
+
+                for (index, expr) in all_inputs.iter().enumerate() {
+                    // Retain keys for which all remaining inputs can be paired off as pos-neg pairs whose values on key columns are equal.
+                    for key in expr.typ().keys {
+                        // We want to sum across `gets_pos_neg` the pairs that cancel under `key`, not counting `expr` itself.
+                        // If this adds up to `all_inputs.len() - 1`, then everything except `expr` cancels out when projected onto `key`.
+                        let sum: usize = gets_pos_neg
+                            .iter()
+                            .map(|(_id, (pos, neg))| {
+                                // As a first cut, get the number of folks in each of `pos` and `neg` that leave each key column in place.
+                                // More generally, we could try and solve for a matching where columns line up exactly, even if 1. not in
+                                // exactly the same location, and 2. potentially the result of a mapped literal.
+                                let pos_count = pos
+                                    .iter()
+                                    .filter(|(i, mfp)| {
+                                        index != *i
+                                            && key.iter().all(|c| mfp.projection.get(*c) == Some(c))
+                                    })
+                                    .count();
+                                let neg_count = neg
+                                    .iter()
+                                    .filter(|(i, mfp)| {
+                                        index != *i
+                                            && key.iter().all(|c| mfp.projection.get(*c) == Some(c))
+                                    })
+                                    .count();
+                                2 * std::cmp::min(pos_count, neg_count)
+                            })
+                            .sum();
+
+                        if sum + 1 == all_inputs.len() {
+                            result.push(key);
                         }
                     }
                 }

--- a/test/sqllogictest/advent-of-code/2023/aoc_1211.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1211.slt
@@ -203,16 +203,6 @@ Explained Query:
     CrossJoin type=differential
       ArrangeBy keys=[[]]
         Union
-          Get l11
-          Map (null)
-            Union
-              Negate
-                Project ()
-                  Get l11
-              Constant
-                - ()
-      ArrangeBy keys=[[]]
-        Union
           Get l13
           Map (null)
             Union
@@ -221,7 +211,28 @@ Explained Query:
                   Get l13
               Constant
                 - ()
+      ArrangeBy keys=[[]]
+        Union
+          Get l15
+          Map (null)
+            Union
+              Negate
+                Project ()
+                  Get l15
+              Constant
+                - ()
   With
+    cte l15 =
+      Reduce aggregates=[sum((abs((#0 - #2)) + abs((#1 - #3))))]
+        Filter ((#0 < #2) OR ((#0 = #2) AND (#1 < #3)))
+          CrossJoin type=differential
+            Get l14
+            Get l14
+    cte l14 =
+      ArrangeBy keys=[[]]
+        Project (#4, #5)
+          Map (bigint_to_integer((integer_to_bigint(#0) + (999999 * #2))), bigint_to_integer((integer_to_bigint(#1) + (999999 * #3))))
+            Get l11
     cte l13 =
       Reduce aggregates=[sum((abs((#0 - #2)) + abs((#1 - #3))))]
         Filter ((#0 < #2) OR ((#0 = #2) AND (#1 < #3)))
@@ -231,68 +242,77 @@ Explained Query:
     cte l12 =
       ArrangeBy keys=[[]]
         Project (#4, #5)
-          Map (bigint_to_integer((integer_to_bigint(#0) + (999999 * #2))), bigint_to_integer((integer_to_bigint(#1) + (999999 * #3))))
-            Get l9
-    cte l11 =
-      Reduce aggregates=[sum((abs((#0 - #2)) + abs((#1 - #3))))]
-        Filter ((#0 < #2) OR ((#0 = #2) AND (#1 < #3)))
-          CrossJoin type=differential
-            Get l10
-            Get l10
-    cte l10 =
-      ArrangeBy keys=[[]]
-        Project (#4, #5)
           Map (bigint_to_integer((integer_to_bigint(#0) + #2)), bigint_to_integer((integer_to_bigint(#1) + #3)))
-            Get l9
-    cte l9 =
+            Get l11
+    cte l11 =
       Project (#0, #1, #3, #5)
         Join on=(#0 = #2 AND #1 = #4) type=delta
           ArrangeBy keys=[[#0], [#1]]
             Get l1
           ArrangeBy keys=[[#0]]
             Union
-              Get l5
+              Get l6
               Map (null)
                 Union
                   Negate
-                    Project (#0)
-                      Get l5
+                    Distinct project=[#0]
+                      Project (#0)
+                        Get l6
                   Get l3
           ArrangeBy keys=[[#0]]
             Union
-              Get l8
+              Get l10
               Map (null)
                 Union
                   Negate
-                    Project (#0)
-                      Get l8
-                  Get l6
-    cte l8 =
+                    Distinct project=[#0]
+                      Project (#0)
+                        Get l10
+                  Get l7
+    cte l10 =
       Union
-        Get l7
+        Get l9
+        Map (error("more than one record produced in subquery"))
+          Project (#0)
+            Filter (#1 > 1)
+              Reduce group_by=[#0] aggregates=[count(*)]
+                Project (#0)
+                  Get l9
+    cte l9 =
+      Union
+        Get l8
         Map (0)
           Union
             Negate
               Project (#0)
-                Get l7
-            Get l6
-    cte l7 =
+                Get l8
+            Get l7
+    cte l8 =
       Reduce group_by=[#0] aggregates=[count(*)]
         Project (#0)
           Filter (#1 < #0)
             CrossJoin type=differential
               ArrangeBy keys=[[]]
-                Get l6
+                Get l7
               ArrangeBy keys=[[]]
                 Project (#0)
                   Filter (#1 = 0)
                     Reduce group_by=[#0] aggregates=[count((null OR ((#1) IS NOT NULL AND (#1 = "#"))))]
                       Project (#1, #2)
                         Get l0
-    cte l6 =
+    cte l7 =
       Distinct project=[#0]
         Project (#1)
           Get l2
+    cte l6 =
+      Union
+        Get l5
+        Map (error("more than one record produced in subquery"))
+          Project (#0)
+            Filter (#1 > 1)
+              Reduce group_by=[#0] aggregates=[count(*)]
+                Project (#0)
+                  Get l5
     cte l5 =
       Union
         Get l4

--- a/test/sqllogictest/advent-of-code/2023/aoc_1216.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1216.slt
@@ -238,16 +238,16 @@ Explained Query:
                   - ()
         ArrangeBy keys=[[]]
           Union
-            Get l14
+            Get l18
             Map (null)
               Union
                 Negate
                   Project ()
-                    Get l14
+                    Get l18
                 Constant
                   - ()
     With
-      cte l14 =
+      cte l18 =
         Reduce aggregates=[max(#0)]
           Project (#1)
             Reduce group_by=[#0] aggregates=[count(*)]
@@ -257,69 +257,73 @@ Explained Query:
                     Distinct project=[#0..=#2]
                       Project (#0, #1, #3)
                         Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-                          Get l13
+                          Get l17
                   ArrangeBy keys=[[#0, #1]]
                     Distinct project=[#0, #1]
                       Project (#0, #1)
                         Get l0
   With Mutually Recursive
-    cte l13 =
+    cte l17 =
       Distinct project=[#0..=#3]
         Union
           Project (#0, #1, #3, #2)
             Map (("r" || integer_to_text(#0)), "r")
               CrossJoin type=differential
-                Get l11
+                Get l15
                 ArrangeBy keys=[[]]
                   Union
-                    Get l4
+                    Get l5
                     Map (null)
                       Union
                         Negate
-                          Project ()
-                            Get l4
+                          Distinct project=[]
+                            Project ()
+                              Get l5
                         Constant
                           - ()
           Project (#0, #1, #3, #2)
             Map (("l" || integer_to_text(#0)), "l")
               CrossJoin type=differential
-                Get l11
-                ArrangeBy keys=[[]]
-                  Union
-                    Get l6
-                    Map (null)
-                      Union
-                        Negate
-                          Project ()
-                            Get l6
-                        Constant
-                          - ()
-          Project (#1, #0, #3, #2)
-            Map (("d" || integer_to_text(#0)), "d")
-              CrossJoin type=differential
-                Get l12
+                Get l15
                 ArrangeBy keys=[[]]
                   Union
                     Get l8
                     Map (null)
                       Union
                         Negate
-                          Project ()
-                            Get l8
+                          Distinct project=[]
+                            Project ()
+                              Get l8
+                        Constant
+                          - ()
+          Project (#1, #0, #3, #2)
+            Map (("d" || integer_to_text(#0)), "d")
+              CrossJoin type=differential
+                Get l16
+                ArrangeBy keys=[[]]
+                  Union
+                    Get l11
+                    Map (null)
+                      Union
+                        Negate
+                          Distinct project=[]
+                            Project ()
+                              Get l11
                         Constant
                           - ()
           Project (#1, #0, #3, #2)
             Map (("u" || integer_to_text(#0)), "u")
               CrossJoin type=differential
-                Get l12
+                Get l16
                 ArrangeBy keys=[[]]
                   Union
-                    Get l10
+                    Get l14
                     Map (null)
                       Union
                         Negate
-                          Project ()
-                            Get l10
+                          Distinct project=[]
+                            Project ()
+                              Get l14
                         Constant
                           - ()
           Project (#12, #13, #11, #3)
@@ -327,7 +331,7 @@ Explained Query:
               Join on=(#0 = #4 AND #1 = #5 AND #2 = #7 AND #6 = #8) type=differential
                 ArrangeBy keys=[[#0, #1]]
                   Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-                    Get l13
+                    Get l17
                 ArrangeBy keys=[[#0, #1]]
                   Filter (#2) IS NOT NULL
                     Get l0
@@ -355,14 +359,46 @@ Explained Query:
                       - ("l", "|", 1, 0, "d")
                       - ("r", "-", 0, 1, "r")
                       - ("r", ".", 0, 1, "r")
-    cte l12 =
+    cte l16 =
       ArrangeBy keys=[[]]
         Project (#1)
           Get l0
-    cte l11 =
+    cte l15 =
       ArrangeBy keys=[[]]
         Project (#0)
           Get l0
+    cte l14 =
+      Union
+        Get l13
+        Map (error("more than one record produced in subquery"))
+          Project ()
+            Filter (#0 > 1)
+              Reduce aggregates=[count(*)]
+                Project ()
+                  Get l13
+    cte l13 =
+      Union
+        Get l12
+        Map (null)
+          Union
+            Negate
+              Project ()
+                Get l12
+            Constant
+              - ()
+    cte l12 =
+      Reduce aggregates=[max(#0)]
+        Project (#1)
+          Get l0
+    cte l11 =
+      Union
+        Get l10
+        Map (error("more than one record produced in subquery"))
+          Project ()
+            Filter (#0 > 1)
+              Reduce aggregates=[count(*)]
+                Project ()
+                  Get l10
     cte l10 =
       Union
         Get l9
@@ -374,37 +410,41 @@ Explained Query:
             Constant
               - ()
     cte l9 =
-      Reduce aggregates=[max(#0)]
-        Project (#1)
+      Reduce aggregates=[min(#0)]
+        Project (#0)
           Get l0
     cte l8 =
       Union
         Get l7
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l7
-            Constant
-              - ()
+        Map (error("more than one record produced in subquery"))
+          Project ()
+            Filter (#0 > 1)
+              Reduce aggregates=[count(*)]
+                Project ()
+                  Get l7
     cte l7 =
-      Reduce aggregates=[min(#0)]
-        Project (#0)
-          Get l0
-    cte l6 =
       Union
-        Get l5
+        Get l6
         Map (null)
           Union
             Negate
               Project ()
-                Get l5
+                Get l6
             Constant
               - ()
-    cte l5 =
+    cte l6 =
       Reduce aggregates=[max(#0)]
         Project (#1)
           Get l0
+    cte l5 =
+      Union
+        Get l4
+        Map (error("more than one record produced in subquery"))
+          Project ()
+            Filter (#0 > 1)
+              Reduce aggregates=[count(*)]
+                Project ()
+                  Get l4
     cte l4 =
       Union
         Get l3

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -915,18 +915,39 @@ Explained Query:
   Finish order_by=[#1 desc nulls_first] output=[#0, #1]
     Return // { arity: 2 }
       Project (#0, #1) // { arity: 2 }
-        Filter (bigint_to_numeric(#1) > (bigint_to_numeric(#2) * 0.005)) // { arity: 3 }
+        Filter (bigint_to_numeric(#1) > #2) // { arity: 3 }
           CrossJoin type=differential // { arity: 3 }
             implementation
-              %1[×]UA » %0[×]
+              %0[×] » %1[×]
             ArrangeBy keys=[[]] // { arity: 2 }
               Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
                 Get l0 // { arity: 2 }
             ArrangeBy keys=[[]] // { arity: 1 }
-              Reduce aggregates=[sum(#0)] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Get l0 // { arity: 2 }
+              Union // { arity: 1 }
+                Get l2 // { arity: 1 }
+                Map (error("more than one record produced in subquery")) // { arity: 1 }
+                  Project () // { arity: 0 }
+                    Filter (#0 > 1) // { arity: 1 }
+                      Reduce aggregates=[count(*)] // { arity: 1 }
+                        Project () // { arity: 0 }
+                          Get l2 // { arity: 1 }
     With
+      cte l2 =
+        Project (#1) // { arity: 1 }
+          Map ((bigint_to_numeric(#0) * 0.005)) // { arity: 2 }
+            Union // { arity: 1 }
+              Get l1 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l1 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
+      cte l1 =
+        Reduce aggregates=[sum(#0)] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Get l0 // { arity: 2 }
       cte l0 =
         Project (#0, #14) // { arity: 2 }
           Join on=(#17 = #18 AND #19 = #20) type=delta // { arity: 21 }
@@ -1132,8 +1153,8 @@ Explained Query:
       Project (#0..=#3, #5) // { arity: 5 }
         Join on=(#0 = #4 AND #5 = #6) type=delta // { arity: 7 }
           implementation
-            %0:supplier » %1:l0[#0]UKA » %2[#0]UK
-            %1:l0 » %0:supplier[#0]UK » %2[#0]UK
+            %0:supplier » %1:l0[#0]UKA » %2[#0]K
+            %1:l0 » %0:supplier[#0]UK » %2[#0]K
             %2 » %1:l0[#1]K » %0:supplier[#0]UK
           ArrangeBy keys=[[#0]] // { arity: 4 }
             Project (#0..=#2, #4) // { arity: 4 }
@@ -1142,11 +1163,30 @@ Explained Query:
             Filter (#1) IS NOT NULL // { arity: 2 }
               Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
-            Filter (#0) IS NOT NULL // { arity: 1 }
-              Reduce aggregates=[max(#0)] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Get l0 // { arity: 2 }
+            Union // { arity: 1 }
+              Filter (#0) IS NOT NULL // { arity: 1 }
+                Get l2 // { arity: 1 }
+              Map (error("more than one record produced in subquery")) // { arity: 1 }
+                Project () // { arity: 0 }
+                  Filter (#0 > 1) // { arity: 1 }
+                    Reduce aggregates=[count(*)] // { arity: 1 }
+                      Project () // { arity: 0 }
+                        Get l2 // { arity: 1 }
     With
+      cte l2 =
+        Union // { arity: 1 }
+          Get l1 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l1 // { arity: 1 }
+              Constant // { arity: 0 }
+                - ()
+      cte l1 =
+        Reduce aggregates=[max(#0)] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Get l0 // { arity: 2 }
       cte l0 =
         Reduce group_by=[#1] aggregates=[sum(#0)] // { arity: 2 }
           Project (#8, #12) // { arity: 2 }
@@ -1621,43 +1661,65 @@ Explained Query:
         Project (#3, #4) // { arity: 2 }
           Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 8 }
             implementation
-              %0:l1[#0..=#2]UKKK » %1[#0..=#2]KKK
+              %0:l3[#0..=#2]KKK » %1[#0..=#2]KKK
             ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-              Get l1 // { arity: 5 }
+              Get l3 // { arity: 5 }
             ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
               Union // { arity: 3 }
                 Negate // { arity: 3 }
                   Project (#0..=#2) // { arity: 3 }
                     Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                       implementation
-                        %1[#0..=#2]UKKKA » %0:l2[#0..=#2]UKKK
+                        %0:l4[#0..=#2]UKKKA » %1[#0..=#2]UKKKA
                       ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                        Get l2 // { arity: 3 }
+                        Get l4 // { arity: 3 }
                       ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                         Distinct project=[#2, #0, #1] // { arity: 3 }
                           Project (#1..=#3) // { arity: 3 }
                             Filter (#3) IS NOT NULL // { arity: 8 }
                               ReadIndex on=order fk_order_customer=[*** full scan ***] // { arity: 8 }
-                Get l2 // { arity: 3 }
+                Get l4 // { arity: 3 }
     With
-      cte l2 =
-        Project (#0..=#2) // { arity: 3 }
-          Get l1 // { arity: 5 }
-      cte l1 =
+      cte l4 =
+        Distinct project=[#0..=#2] // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            Get l3 // { arity: 5 }
+      cte l3 =
         Project (#0..=#4) // { arity: 5 }
-          Filter (#4 > (#5 / bigint_to_numeric(case when (#6 = 0) then null else #6 end))) // { arity: 7 }
-            CrossJoin type=differential // { arity: 7 }
+          Filter (#4 > #5) // { arity: 6 }
+            CrossJoin type=differential // { arity: 6 }
               implementation
-                %1[×]UA » %0:l0[×]ef
+                %0:l0[×]ef » %1[×]ef
               ArrangeBy keys=[[]] // { arity: 5 }
                 Project (#0..=#2, #9, #16) // { arity: 5 }
                   Filter ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
                     Get l0 // { arity: 23 }
-              ArrangeBy keys=[[]] // { arity: 2 }
-                Reduce aggregates=[sum(#0), count(*)] // { arity: 2 }
-                  Project (#16) // { arity: 1 }
-                    Filter (#16 > 0) AND ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
-                      Get l0 // { arity: 23 }
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Get l2 // { arity: 1 }
+                  Map (error("more than one record produced in subquery")) // { arity: 1 }
+                    Project () // { arity: 0 }
+                      Filter (#0 > 1) // { arity: 1 }
+                        Reduce aggregates=[count(*)] // { arity: 1 }
+                          Project () // { arity: 0 }
+                            Get l2 // { arity: 1 }
+      cte l2 =
+        Project (#2) // { arity: 1 }
+          Map ((#0 / bigint_to_numeric(case when (#1 = 0) then null else #1 end))) // { arity: 3 }
+            Union // { arity: 2 }
+              Get l1 // { arity: 2 }
+              Map (null, 0) // { arity: 2 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l1 // { arity: 2 }
+                  Constant // { arity: 0 }
+                    - ()
+      cte l1 =
+        Reduce aggregates=[sum(#0), count(*)] // { arity: 2 }
+          Project (#16) // { arity: 1 }
+            Filter (#16 > 0) AND ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
+              Get l0 // { arity: 23 }
       cte l0 =
         Map (substr(char_to_text(#11), 1, 1)) // { arity: 23 }
           ReadIndex on=customer fk_customer_district=[*** full scan ***] // { arity: 22 }

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -2734,7 +2734,7 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                             }
                                           ],
                                           {
-                                            "unique_key": true,
+                                            "unique_key": false,
                                             "key_length": 1,
                                             "arranged": false,
                                             "cardinality": null,
@@ -2756,7 +2756,7 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                             }
                                           ],
                                           {
-                                            "unique_key": true,
+                                            "unique_key": false,
                                             "key_length": 1,
                                             "arranged": false,
                                             "cardinality": null,
@@ -2772,28 +2772,6 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                         ]
                                       ],
                                       [
-                                        [
-                                          2,
-                                          [
-                                            {
-                                              "Column": 0
-                                            }
-                                          ],
-                                          {
-                                            "unique_key": true,
-                                            "key_length": 1,
-                                            "arranged": false,
-                                            "cardinality": null,
-                                            "filters": {
-                                              "literal_equality": false,
-                                              "like": false,
-                                              "is_null": false,
-                                              "literal_inequality": 0,
-                                              "any_filter": false
-                                            },
-                                            "input": 2
-                                          }
-                                        ],
                                         [
                                           0,
                                           [
@@ -2815,9 +2793,53 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                             },
                                             "input": 0
                                           }
+                                        ],
+                                        [
+                                          2,
+                                          [
+                                            {
+                                              "Column": 0
+                                            }
+                                          ],
+                                          {
+                                            "unique_key": false,
+                                            "key_length": 1,
+                                            "arranged": false,
+                                            "cardinality": null,
+                                            "filters": {
+                                              "literal_equality": false,
+                                              "like": false,
+                                              "is_null": false,
+                                              "literal_inequality": 0,
+                                              "any_filter": false
+                                            },
+                                            "input": 2
+                                          }
                                         ]
                                       ],
                                       [
+                                        [
+                                          0,
+                                          [
+                                            {
+                                              "Column": 0
+                                            }
+                                          ],
+                                          {
+                                            "unique_key": false,
+                                            "key_length": 1,
+                                            "arranged": false,
+                                            "cardinality": null,
+                                            "filters": {
+                                              "literal_equality": false,
+                                              "like": false,
+                                              "is_null": false,
+                                              "literal_inequality": 0,
+                                              "any_filter": false
+                                            },
+                                            "input": 0
+                                          }
+                                        ],
                                         [
                                           1,
                                           [
@@ -2826,28 +2848,6 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                             }
                                           ],
                                           {
-                                            "unique_key": true,
-                                            "key_length": 1,
-                                            "arranged": false,
-                                            "cardinality": null,
-                                            "filters": {
-                                              "literal_equality": false,
-                                              "like": false,
-                                              "is_null": false,
-                                              "literal_inequality": 0,
-                                              "any_filter": false
-                                            },
-                                            "input": 1
-                                          }
-                                        ],
-                                        [
-                                          0,
-                                          [
-                                            {
-                                              "Column": 0
-                                            }
-                                          ],
-                                          {
                                             "unique_key": false,
                                             "key_length": 1,
                                             "arranged": false,
@@ -2859,7 +2859,7 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                               "literal_inequality": 0,
                                               "any_filter": false
                                             },
-                                            "input": 0
+                                            "input": 1
                                           }
                                         ]
                                       ]

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -271,29 +271,50 @@ materialize.public.q02:
     Project (#5{s_address}, #2{n_name}, #8, #0{s_acctbal}, #1{s_name}, #3{p_partkey}, #4{p_mfgr}, #6{s_phone}) // { arity: 8 }
       Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10{min_ps_supplycost}) type=differential // { arity: 11 }
         implementation
-          %1[#0, #1]UKK » %0:l4[#0, #7]KK
+          %0:l4[#0, #7]KK » %1[#0, #1]KK
         ArrangeBy keys=[[#0{p_partkey}, #7{ps_supplycost}]] // { arity: 9 }
           Get l4 // { arity: 9 }
         ArrangeBy keys=[[#0{p_partkey}, #1{min_ps_supplycost}]] // { arity: 2 }
-          Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
-            Project (#0{p_partkey}, #4) // { arity: 2 }
-              Filter (#18{r_name} = "EUROPE") // { arity: 20 }
-                Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
-                  implementation
-                    %0 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-                    %1:l1 » %0[#0]UKA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-                    %2:l0 » %1:l1[#1]KA » %0[#0]UKA » %3:l2[#0]KA » %4:l3[#0]KAef
-                    %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
-                    %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
-                  ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
-                    Distinct project=[#0{p_partkey}] // { arity: 1 }
-                      Project (#0{p_partkey}) // { arity: 1 }
-                        Get l4 // { arity: 9 }
-                  Get l1 // { arity: 5 }
-                  Get l0 // { arity: 7 }
-                  Get l2 // { arity: 4 }
-                  Get l3 // { arity: 3 }
+          Union // { arity: 2 }
+            Filter (#1{min_ps_supplycost}) IS NOT NULL // { arity: 2 }
+              Get l7 // { arity: 2 }
+            Map (error("more than one record produced in subquery")) // { arity: 2 }
+              Project (#0{p_partkey}) // { arity: 1 }
+                Filter (#1{count} > 1) // { arity: 2 }
+                  Reduce group_by=[#0{p_partkey}] aggregates=[count(*)] // { arity: 2 }
+                    Project (#0{p_partkey}) // { arity: 1 }
+                      Get l7 // { arity: 2 }
   With
+    cte l7 =
+      Union // { arity: 2 }
+        Get l6 // { arity: 2 }
+        Map (null) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0{p_partkey}) // { arity: 1 }
+                Get l6 // { arity: 2 }
+            Get l5 // { arity: 1 }
+    cte l6 =
+      Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
+        Project (#0{p_partkey}, #4) // { arity: 2 }
+          Filter (#18{r_name} = "EUROPE") // { arity: 20 }
+            Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
+              implementation
+                %0:l5 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+                %1:l1 » %0:l5[#0]UKA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+                %2:l0 » %1:l1[#1]KA » %0:l5[#0]UKA » %3:l2[#0]KA » %4:l3[#0]KAef
+                %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0:l5[#0]UKA
+                %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0:l5[#0]UKA
+              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+                Get l5 // { arity: 1 }
+              Get l1 // { arity: 5 }
+              Get l0 // { arity: 7 }
+              Get l2 // { arity: 4 }
+              Get l3 // { arity: 3 }
+    cte l5 =
+      Distinct project=[#0{p_partkey}] // { arity: 1 }
+        Project (#0{p_partkey}) // { arity: 1 }
+          Get l4 // { arity: 9 }
     cte l4 =
       Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
         Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
@@ -999,24 +1020,45 @@ EXPLAIN WITH(humanized expressions, arity, join implementations)
 CREATE DEFAULT INDEX ON Q11;
 ----
 materialize.public.q11_primary_idx:
-  ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 2 }
+  ArrangeBy keys=[[#0{ps_partkey}, #1{value}]] // { arity: 2 }
     ReadGlobalFromSameDataflow materialize.public.q11 // { arity: 2 }
 
 materialize.public.q11:
   Return // { arity: 2 }
     Project (#0{ps_partkey}, #1{sum}) // { arity: 2 }
-      Filter (#1{sum} > (#2{sum} * 0.0001)) // { arity: 3 }
+      Filter (#1{sum} > #2) // { arity: 3 }
         CrossJoin type=differential // { arity: 3 }
           implementation
-            %1[×]UA » %0[×]
+            %0[×] » %1[×]
           ArrangeBy keys=[[]] // { arity: 2 }
             Reduce group_by=[#0{ps_partkey}] aggregates=[sum((#2{ps_supplycost} * integer_to_numeric(#1{ps_availqty})))] // { arity: 2 }
               Get l0 // { arity: 3 }
           ArrangeBy keys=[[]] // { arity: 1 }
-            Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
-              Project (#1{ps_supplycost}, #2) // { arity: 2 }
-                Get l0 // { arity: 3 }
+            Union // { arity: 1 }
+              Get l2 // { arity: 1 }
+              Map (error("more than one record produced in subquery")) // { arity: 1 }
+                Project () // { arity: 0 }
+                  Filter (#0{count} > 1) // { arity: 1 }
+                    Reduce aggregates=[count(*)] // { arity: 1 }
+                      Project () // { arity: 0 }
+                        Get l2 // { arity: 1 }
   With
+    cte l2 =
+      Project (#1) // { arity: 1 }
+        Map ((#0{sum} * 0.0001)) // { arity: 2 }
+          Union // { arity: 1 }
+            Get l1 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l1 // { arity: 1 }
+                Constant // { arity: 0 }
+                  - ()
+    cte l1 =
+      Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
+        Project (#1{ps_supplycost}, #2) // { arity: 2 }
+          Get l0 // { arity: 3 }
     cte l0 =
       Project (#0{ps_partkey}, #2{ps_supplycost}, #3) // { arity: 3 }
         Filter (#13{n_name} = "GERMANY") // { arity: 16 }
@@ -1297,18 +1339,38 @@ materialize.public.q15:
     Project (#0{s_suppkey}..=#2{s_address}, #4{sum}, #8) // { arity: 5 }
       Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
         implementation
-          %0:supplier » %1:l0[#0]UKA » %2[#0]UK
-          %1:l0 » %2[#0]UK » %0:supplier[#0]KA
+          %0:supplier » %1:l0[#0]UKA » %2[#0]K
+          %1:l0 » %0:supplier[#0]KA » %2[#0]K
           %2 » %1:l0[#1]K » %0:supplier[#0]KA
         ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 7 }
           ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] // { arity: 7 }
         ArrangeBy keys=[[#0{l_suppkey}], [#1{sum}]] // { arity: 2 }
           Get l0 // { arity: 2 }
         ArrangeBy keys=[[#0{max_sum}]] // { arity: 1 }
-          Reduce aggregates=[max(#0{sum})] // { arity: 1 }
-            Project (#1) // { arity: 1 }
-              Get l0 // { arity: 2 }
+          Union // { arity: 1 }
+            Filter (#0{max_sum}) IS NOT NULL // { arity: 1 }
+              Get l2 // { arity: 1 }
+            Map (error("more than one record produced in subquery")) // { arity: 1 }
+              Project () // { arity: 0 }
+                Filter (#0{count} > 1) // { arity: 1 }
+                  Reduce aggregates=[count(*)] // { arity: 1 }
+                    Project () // { arity: 0 }
+                      Get l2 // { arity: 1 }
   With
+    cte l2 =
+      Union // { arity: 1 }
+        Get l1 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l1 // { arity: 1 }
+            Constant // { arity: 0 }
+              - ()
+    cte l1 =
+      Reduce aggregates=[max(#0{sum})] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Get l0 // { arity: 2 }
     cte l0 =
       Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
         Project (#2{l_discount}, #5, #6) // { arity: 3 }
@@ -1455,35 +1517,57 @@ materialize.public.q17:
     Project (#1) // { arity: 1 }
       Map ((#0{sum_l_extendedprice} / 7)) // { arity: 2 }
         Union // { arity: 1 }
-          Get l2 // { arity: 1 }
+          Get l5 // { arity: 1 }
           Map (null) // { arity: 1 }
             Union // { arity: 0 }
               Negate // { arity: 0 }
                 Project () // { arity: 0 }
-                  Get l2 // { arity: 1 }
+                  Get l5 // { arity: 1 }
               Constant // { arity: 0 }
                 - ()
   With
-    cte l2 =
+    cte l5 =
       Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
         Project (#2) // { arity: 1 }
-          Filter (#1{l_quantity} < (0.2 * (#4{sum_l_quantity} / bigint_to_numeric(case when (#5{count} = 0) then null else #5{count} end)))) // { arity: 6 }
-            Join on=(#0{l_partkey} = #3{l_partkey}) type=differential // { arity: 6 }
+          Filter (#1{l_quantity} < #4) // { arity: 5 }
+            Join on=(#0{l_partkey} = #3{l_partkey}) type=differential // { arity: 5 }
               implementation
-                %1[#0]UKA » %0:l1[#0]K
+                %0:l1[#0]K » %1[#0]K
               ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
                 Get l1 // { arity: 3 }
-              ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
-                Reduce group_by=[#0{l_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
-                  Project (#0{l_partkey}, #5) // { arity: 2 }
-                    Join on=(#0{l_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
-                      implementation
-                        %0[#0]UKA » %1:l0[#1]KA
-                      ArrangeBy keys=[[#0{l_partkey}]] // { arity: 1 }
-                        Distinct project=[#0{l_partkey}] // { arity: 1 }
+              ArrangeBy keys=[[#0{l_partkey}]] // { arity: 2 }
+                Union // { arity: 2 }
+                  Get l4 // { arity: 2 }
+                  Map (error("more than one record produced in subquery")) // { arity: 2 }
+                    Project (#0{l_partkey}) // { arity: 1 }
+                      Filter (#1{count} > 1) // { arity: 2 }
+                        Reduce group_by=[#0{l_partkey}] aggregates=[count(*)] // { arity: 2 }
                           Project (#0{l_partkey}) // { arity: 1 }
-                            Get l1 // { arity: 3 }
-                      Get l0 // { arity: 16 }
+                            Get l4 // { arity: 2 }
+    cte l4 =
+      Project (#0{l_partkey}, #3) // { arity: 2 }
+        Map ((0.2 * (#1{sum_l_quantity} / bigint_to_numeric(case when (#2{count} = 0) then null else #2{count} end)))) // { arity: 4 }
+          Union // { arity: 3 }
+            Get l3 // { arity: 3 }
+            Map (null, 0) // { arity: 3 }
+              Union // { arity: 1 }
+                Negate // { arity: 1 }
+                  Project (#0{l_partkey}) // { arity: 1 }
+                    Get l3 // { arity: 3 }
+                Get l2 // { arity: 1 }
+    cte l3 =
+      Reduce group_by=[#0{l_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
+        Project (#0{l_partkey}, #5) // { arity: 2 }
+          Join on=(#0{l_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
+            implementation
+              %0:l2[#0]UKA » %1:l0[#1]KA
+            ArrangeBy keys=[[#0{l_partkey}]] // { arity: 1 }
+              Get l2 // { arity: 1 }
+            Get l0 // { arity: 16 }
+    cte l2 =
+      Distinct project=[#0{l_partkey}] // { arity: 1 }
+        Project (#0{l_partkey}) // { arity: 1 }
+          Get l1 // { arity: 3 }
     cte l1 =
       Project (#1{l_quantity}, #4, #5) // { arity: 3 }
         Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") // { arity: 25 }
@@ -1749,27 +1833,47 @@ materialize.public.q20:
               Filter (integer_to_numeric(#2{ps_availqty}) > #5) // { arity: 6 }
                 Join on=(#0{s_suppkey} = #4{ps_suppkey} AND #1{ps_partkey} = #3{ps_partkey}) type=differential // { arity: 6 }
                   implementation
-                    %1[#1, #0]UKK » %0:l1[#0, #1]KKf
-                  ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}]] // { arity: 3 }
+                    %0:l1[#1, #0]KKf » %1[#0, #1]KKf
+                  ArrangeBy keys=[[#1{ps_partkey}, #0{s_suppkey}]] // { arity: 3 }
                     Project (#0{s_suppkey}, #1{ps_partkey}, #3) // { arity: 3 }
                       Filter (#0{s_suppkey} = #2{ps_suppkey}) // { arity: 4 }
                         Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
-                    Project (#0{ps_partkey}, #1{ps_suppkey}, #3) // { arity: 3 }
-                      Map ((0.5 * #2{sum_l_quantity})) // { arity: 4 }
-                        Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
-                          Project (#0{ps_partkey}, #1{ps_suppkey}, #6) // { arity: 3 }
-                            Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
-                              Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
-                                implementation
-                                  %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
-                                ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
-                                  Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
-                                    Project (#1{ps_suppkey}, #2) // { arity: 2 }
-                                      Get l1 // { arity: 4 }
-                                ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
-                                  ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
+                  ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 3 }
+                    Union // { arity: 3 }
+                      Get l4 // { arity: 3 }
+                      Map (error("more than one record produced in subquery")) // { arity: 3 }
+                        Project (#0{ps_partkey}, #1{ps_suppkey}) // { arity: 2 }
+                          Filter (#2{count} > 1) // { arity: 3 }
+                            Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[count(*)] // { arity: 3 }
+                              Project (#0{ps_partkey}, #1{ps_suppkey}) // { arity: 2 }
+                                Get l4 // { arity: 3 }
   With
+    cte l4 =
+      Project (#0{ps_partkey}, #1{ps_suppkey}, #3) // { arity: 3 }
+        Map ((0.5 * #2{sum_l_quantity})) // { arity: 4 }
+          Union // { arity: 3 }
+            Get l3 // { arity: 3 }
+            Map (null) // { arity: 3 }
+              Union // { arity: 2 }
+                Negate // { arity: 2 }
+                  Project (#0{ps_partkey}, #1{ps_suppkey}) // { arity: 2 }
+                    Get l3 // { arity: 3 }
+                Get l2 // { arity: 2 }
+    cte l3 =
+      Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
+        Project (#0{ps_partkey}, #1{ps_suppkey}, #6) // { arity: 3 }
+          Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
+            Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
+              implementation
+                %0:l2[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
+              ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
+                Get l2 // { arity: 2 }
+              ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
+                ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
+    cte l2 =
+      Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
+        Project (#1{ps_suppkey}, #2) // { arity: 2 }
+          Get l1 // { arity: 4 }
     cte l1 =
       Project (#0{s_suppkey}..=#3{ps_availqty}) // { arity: 4 }
         Join on=(#1{ps_partkey} = #4{p_partkey}) type=delta // { arity: 5 }
@@ -2012,43 +2116,64 @@ materialize.public.q22:
       Project (#1{c_acctbal}, #2) // { arity: 2 }
         Join on=(#0{c_custkey} = #3{c_custkey}) type=differential // { arity: 4 }
           implementation
-            %0:l1[#0]K » %1[#0]K
+            %0:l3[#0]K » %1[#0]K
           ArrangeBy keys=[[#0{c_custkey}]] // { arity: 3 }
-            Get l1 // { arity: 3 }
+            Get l3 // { arity: 3 }
           ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Project (#0{c_custkey}) // { arity: 1 }
                   Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
                     implementation
-                      %0:l2[#0]UKA » %1[#0]UKA
+                      %0:l4[#0]UKA » %1[#0]UKA
                     ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-                      Get l2 // { arity: 1 }
+                      Get l4 // { arity: 1 }
                     ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
                       Distinct project=[#0{o_custkey}] // { arity: 1 }
                         Project (#1) // { arity: 1 }
                           ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
-              Get l2 // { arity: 1 }
+              Get l4 // { arity: 1 }
   With
-    cte l2 =
+    cte l4 =
       Distinct project=[#0{c_custkey}] // { arity: 1 }
         Project (#0{c_custkey}) // { arity: 1 }
-          Get l1 // { arity: 3 }
-    cte l1 =
+          Get l3 // { arity: 3 }
+    cte l3 =
       Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
-        Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
-          CrossJoin type=differential // { arity: 5 }
+        Filter (#2{c_acctbal} > #3) // { arity: 4 }
+          CrossJoin type=differential // { arity: 4 }
             implementation
-              %1[×]UA » %0:l0[×]ef
+              %0:l0[×]ef » %1[×]ef
             ArrangeBy keys=[[]] // { arity: 3 }
               Project (#0{c_custkey}, #4, #5) // { arity: 3 }
                 Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                   Get l0 // { arity: 9 }
-            ArrangeBy keys=[[]] // { arity: 2 }
-              Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
-                Project (#5) // { arity: 1 }
-                  Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                    Get l0 // { arity: 9 }
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Union // { arity: 1 }
+                Get l2 // { arity: 1 }
+                Map (error("more than one record produced in subquery")) // { arity: 1 }
+                  Project () // { arity: 0 }
+                    Filter (#0{count} > 1) // { arity: 1 }
+                      Reduce aggregates=[count(*)] // { arity: 1 }
+                        Project () // { arity: 0 }
+                          Get l2 // { arity: 1 }
+    cte l2 =
+      Project (#2) // { arity: 1 }
+        Map ((#0{sum_c_acctbal} / bigint_to_numeric(case when (#1{count} = 0) then null else #1{count} end))) // { arity: 3 }
+          Union // { arity: 2 }
+            Get l1 // { arity: 2 }
+            Map (null, 0) // { arity: 2 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l1 // { arity: 2 }
+                Constant // { arity: 0 }
+                  - ()
+    cte l1 =
+      Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
+        Project (#5) // { arity: 1 }
+          Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
+            Get l0 // { arity: 9 }
     cte l0 =
       Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
         ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -238,7 +238,7 @@ Explained Query:
   Return // { arity: 1 }
     CrossJoin type=differential // { arity: 1 }
       implementation
-        %0:l1[×]Uef » %1[×]Uef
+        %0:l1[×]Uef » %1[×]ef
       Get l1 // { arity: 0 }
       ArrangeBy keys=[[]] // { arity: 1 }
         Union // { arity: 1 }


### PR DESCRIPTION
Key determination for `Union` improvement of https://github.com/MaterializeInc/materialize/pull/28867 without the associated linear operator movement and union consolidation.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
