### PR TITLE
add environmentd_extra_env to the materialize crd

### DIFF
--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -10,7 +10,7 @@
 use std::collections::BTreeMap;
 
 use k8s_openapi::{
-    api::core::v1::ResourceRequirements,
+    api::core::v1::{EnvVar, ResourceRequirements},
     apimachinery::pkg::{
         api::resource::Quantity,
         apis::meta::v1::{Condition, OwnerReference, Time},
@@ -52,6 +52,8 @@ pub mod v1alpha1 {
         pub environmentd_image_ref: String,
         // Extra args to pass to the environmentd binary
         pub environmentd_extra_args: Option<Vec<String>>,
+        // Extra environment variables to pass to the environmentd binary
+        pub environmentd_extra_env: Option<Vec<EnvVar>>,
         // If running in AWS, override the IAM role to use to give
         // environmentd access to the persist S3 bucket
         pub environmentd_iam_role_arn: Option<String>,

--- a/src/orchestratord/src/controller/materialize/resources.rs
+++ b/src/orchestratord/src/controller/materialize/resources.rs
@@ -786,6 +786,8 @@ fn create_environmentd_statefulset_object(
         });
     }
 
+    env.extend(mz.spec.environmentd_extra_env.iter().flatten().cloned());
+
     let mut args = vec![];
 
     if let Some(helm_chart_version) = &config.helm_chart_version {


### PR DESCRIPTION
### Motivation

we'll need this on the cloud side for things like the launchdarkly sdk key

### Tips for reviewer

see https://github.com/MaterializeInc/cloud/pull/10428

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
