### PR TITLE
docs: Indexes store both keys and associated rows

### DIFF
--- a/doc/user/content/concepts/indexes.md
+++ b/doc/user/content/concepts/indexes.md
@@ -28,7 +28,7 @@ or a table without performing some transformation using a view, etc.
 {{</ note>}}
 
 In Materialize, you can create indexes on a [source](/concepts/sources/) or a
-[table](/sql/create-table) to maintain in-memory up-to-date source or table data
+[table](/sql/create-table) to maintain in-memory, up-to-date source or table data
 in the cluster you create the index. This can help improve [query
 performance](#indexes-and-query-optimizations) when [using
 joins](/transform-data/optimization/#join) or when serving results directly
@@ -54,7 +54,7 @@ CREATE INDEX idx_on_my_view ON my_view_name(...) ;
 
 During the index creation on a [view](/concepts/views/#views "query saved under
 a name"), the view is executed. The index stores both the key and the associated
-the view results (i.e., the associated rows) in memory within the cluster. **As
+results (i.e., the associated rows) in memory within the cluster. **As
 new data arrives**, the index **incrementally updates** the view results.
 
 Within the cluster, querying an indexed view is:
@@ -98,10 +98,11 @@ vs. materialized views, see [Usage patterns](#usage-patterns).
 
 ## Indexes and clusters
 
-Indexes are local to a cluster. Queries from a different cluster cannot use the
+Indexes are local to a cluster. Queries executed against a cluster where the
+desired indexes do not exist **will not** use the
 indexes in another cluster.
 
-For example, the following operation creates an index in the current cluster:
+For example, the following statement creates an index in the current cluster:
 
 ```mzsql
 CREATE INDEX idx_on_my_view ON my_view_name(...) ;
@@ -109,7 +110,7 @@ CREATE INDEX idx_on_my_view ON my_view_name(...) ;
 
 Only queries in the current cluster can use the index.
 
-Similarly, the following operation creates an index in the specified cluster
+Similarly, the following statement creates an index in the specified cluster
 named `active_cluster`:
 
 ```mzsql

--- a/doc/user/content/concepts/views.md
+++ b/doc/user/content/concepts/views.md
@@ -44,7 +44,7 @@ view results in memory.
 CREATE INDEX idx_on_my_view ON my_view_name(...) ;
 ```
 
-See [Indexes and views](#indexes-on-views) for more information.
+See [Indexes on views](#indexes-on-views) for more information.
 
 See also:
 
@@ -54,25 +54,31 @@ See also:
 ### Indexes on views
 
 In Materialize, views can be [indexed](/concepts/indexes/). Indexes represent
-query results stored in memory. Creating an index on a view executes the
-underlying view query and stores the view results in memory within that
-[cluster](/concepts/clusters/).
+query results stored in memory. Indexes in Materialize store **both** the key
+and any associated rows.
 
-For example, to create an index in the current cluster:
+Creating an index on a view executes the underlying view query and the index
+stores both the key and the associated the view results (i.e., the associated
+rows) in memory within the [cluster](/concepts/clusters/) where the index is
+created.
 
-```mzsql
-CREATE INDEX idx_on_my_view ON my_view_name(...) ;
-```
+For example,
 
-You can also explicitly specify the cluster:
+- To create an index in the current cluster:
 
-```mzsql
-CREATE INDEX idx_on_my_view IN CLUSTER active_cluster ON my_view (...);
-```
+  ```mzsql
+  CREATE INDEX idx_on_my_view ON my_view_name(...) ;
+  ```
+
+- To explicitly specify the cluster when creating the index:
+
+  ```mzsql
+  CREATE INDEX idx_on_my_view IN CLUSTER active_cluster ON my_view (...);
+  ```
 
 **As new data arrives**, the index **incrementally updates** view results in
 memory within that [cluster](/concepts/clusters/). Within the cluster, the
-**in-memory up-to-date** results are immediately available and computationally
+**in-memory, up-to-date** results are immediately available and computationally
 free to query.
 
 See also:
@@ -98,7 +104,6 @@ You can also index a materialized view to maintain the results in memory within
 the cluster. This enables queries within the cluster to use the index to access
 view results from memory.
 
-
 See also:
 
 - [`CREATE MATERIALIZED VIEW`](/sql/create-materialized-view) for complete
@@ -112,10 +117,12 @@ In Materalize, materialized views can be indexed.
 CREATE INDEX idx_on_my_view ON my_mat_view_name(...) ;
 ```
 
-Because materialized views maintain the up-to-date results in durable storage,
-indexes on materialized views serve up-to-date results without themselves
-performing the incremental computation. However, unlike materialized views that
-are accessible across clusters, indexes are accessible only within the cluster.
+The index stores both the key and the associated view results in memory within
+the cluster. Because materialized views maintain the up-to-date results in
+durable storage, indexes on materialized views serve up-to-date results without
+themselves performing the incremental computation. However, unlike materialized
+views that are accessible across clusters, indexes are accessible only within
+the cluster. .
 
 {{< note >}}
 
@@ -146,6 +153,8 @@ See also:
 - Materialized views can be referenced across [clusters](/concepts/clusters/).
 
 - [Indexes](/concepts/indexes) are local to a cluster.
+
+- Indexes in Materialize store **both** the key and any associated rows.
 
 - Views can be monotonic; that is, views can be recognized as append-only.
 

--- a/doc/user/content/concepts/views.md
+++ b/doc/user/content/concepts/views.md
@@ -58,7 +58,7 @@ query results stored in memory. Indexes in Materialize store **both** the key
 and any associated rows.
 
 Creating an index on a view executes the underlying view query and the index
-stores both the key and the associated the view results (i.e., the associated
+stores both the key and the associated results (i.e., the associated
 rows) in memory within the [cluster](/concepts/clusters/) where the index is
 created.
 
@@ -78,7 +78,7 @@ For example,
 
 **As new data arrives**, the index **incrementally updates** view results in
 memory within that [cluster](/concepts/clusters/). Within the cluster, the
-**in-memory, up-to-date** results are immediately available and computationally
+**in-memory**, **up-to-date** results are immediately available and computationally
 free to query.
 
 See also:
@@ -122,7 +122,7 @@ the cluster. Because materialized views maintain the up-to-date results in
 durable storage, indexes on materialized views serve up-to-date results without
 themselves performing the incremental computation. However, unlike materialized
 views that are accessible across clusters, indexes are accessible only within
-the cluster. .
+the cluster.
 
 {{< note >}}
 

--- a/doc/user/content/sql/create-index.md
+++ b/doc/user/content/sql/create-index.md
@@ -8,14 +8,15 @@ menu:
     parent: 'commands'
 ---
 
-`CREATE INDEX` creates an in-memory [index](/concepts/indexes/) on a source, view, or materialized
-view.
+`CREATE INDEX` creates an in-memory [index](/concepts/indexes/) on a source,
+table,view, or materialized view.
 
-In Materialize, indexes store query results in memory within a [cluster](https://materialize.com/docs/concepts/clusters/),
-and keep these results incrementally updated as new data arrives. By making
-up-to-date results available in memory, indexes can help [optimize query
-performance](https://materialize.com/docs/transform-data/optimization/),
-both when serving results and maintaining resource-heavy operations like joins.
+In Materialize, indexes store  **both** the key and the query results in memory
+within a [cluster](https://materialize.com/docs/concepts/clusters/), and keep
+these results incrementally updated as new data arrives. By making up-to-date
+results available in memory, indexes can help [optimize query
+performance](https://materialize.com/docs/transform-data/optimization/), both
+when serving results and maintaining resource-heavy operations like joins.
 
 ### Usage patterns
 

--- a/doc/user/content/sql/create-index.md
+++ b/doc/user/content/sql/create-index.md
@@ -100,15 +100,7 @@ When creating your own indexes, you can choose the indexed expressions.
 
 ### Memory footprint
 
-The in-memory sizes of indexes are proportional to the current size of the source
-or view they represent. The actual amount of memory required depends on several
-details related to the rate of compaction and the representation of the types of
-data in the source or view.
-
-Creating an index may also force the first materialization of a view, which may
-cause Materialize to install a dataflow to determine and maintain the results of
-the view. This dataflow may have a memory footprint itself, in addition to that
-of the index.
+{{% views-indexes/indexes-memory-footprint %}}
 
 ## Examples
 

--- a/doc/user/layouts/shortcodes/views-indexes/indexes-memory-footprint.html
+++ b/doc/user/layouts/shortcodes/views-indexes/indexes-memory-footprint.html
@@ -1,0 +1,9 @@
+The in-memory sizes of indexes are proportional to the current size of the
+source or view they represent. The actual amount of memory required depends on
+several details related to the rate of compaction and the representation of the
+types of data in the source or view.
+
+Creating an index may also force the first materialization of a view, which may
+cause Materialize to install a dataflow to determine and maintain the results of
+the view. This dataflow may have a memory footprint itself, in addition to that
+of the index.

--- a/doc/user/layouts/shortcodes/views-indexes/table-usage-pattern-intro.html
+++ b/doc/user/layouts/shortcodes/views-indexes/table-usage-pattern-intro.html
@@ -1,9 +1,8 @@
-In Materialize, both [indexes](/concepts/indexes) (specifically on views) and
-[materialized views](/concepts/views/#materialized-views) incrementally update
-the view results when Materialize ingests new data. Whereas materialized views
-persist the view results in durable storage and can be accessed across clusters,
-indexes on views compute and store view results in memory within a **single**
-cluster.
+In Materialize, both [indexes](/concepts/indexes) and [materialized views](/concepts/views/#materialized-views)
+store the latest, incrementally updated results as Materialize ingests
+new data. Whereas materialized views persist the view results in durable
+storage and can be accessed across clusters, indexes store view results in
+memory within a **single** cluster.
 
 Maintaining a materialized view in durable storage has resource and latency
 costs that should be carefully considered depending on the main usage of the

--- a/doc/user/layouts/shortcodes/views-indexes/table-usage-pattern-intro.html
+++ b/doc/user/layouts/shortcodes/views-indexes/table-usage-pattern-intro.html
@@ -1,8 +1,9 @@
-In Materialize, both [indexes](/concepts/indexes) on views and [materialized
-views](/concepts/views/#materialized-views) incrementally update the view
-results when Materialize ingests new data. Whereas materialized views persist
-the view results in durable storage and can be accessed across clusters, indexes
-on views compute and store view results in memory within a **single** cluster.
+In Materialize, both [indexes](/concepts/indexes) (specifically on views) and
+[materialized views](/concepts/views/#materialized-views) incrementally update
+the view results when Materialize ingests new data. Whereas materialized views
+persist the view results in durable storage and can be accessed across clusters,
+indexes on views compute and store view results in memory within a **single**
+cluster.
 
 Maintaining a materialized view in durable storage has resource and latency
 costs that should be carefully considered depending on the main usage of the


### PR DESCRIPTION
Per index 101 meeting, updating to explicitly state "Indexes in materialize store both the key and any associated rows."
