### PR TITLE
ci: Bump Release Qualification timeouts

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -246,7 +246,7 @@ steps:
       - id: mysql-cdc-5_7_44
         label: "MySQL CDC w/ 5.7.44"
         depends_on: build-x86_64
-        timeout_in_minutes: 30
+        timeout_in_minutes: 60
         agents:
           # no matching manifest of MySQL 5.7.x for linux/arm64/v8 in the manifest list entries
           # Increased memory usage following new source syntax
@@ -258,7 +258,7 @@ steps:
       - id: mysql-cdc-8_0_36
         label: "MySQL CDC w/ 8.0.36"
         depends_on: build-aarch64
-        timeout_in_minutes: 30
+        timeout_in_minutes: 60
         agents:
           queue: hetzner-aarch64-4cpu-8gb
         plugins:
@@ -272,7 +272,7 @@ steps:
       - id: pg-cdc-16_4
         label: "Postgres CDC w/ 16.4"
         depends_on: build-aarch64
-        timeout_in_minutes: 30
+        timeout_in_minutes: 60
         inputs: [test/pg-cdc]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -283,7 +283,7 @@ steps:
       - id: pg-cdc-15_6
         label: "Postgres CDC w/ 15.6"
         depends_on: build-aarch64
-        timeout_in_minutes: 30
+        timeout_in_minutes: 60
         inputs: [test/pg-cdc]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -294,7 +294,7 @@ steps:
       - id: pg-cdc-14_11
         label: "Postgres CDC w/ 14.11"
         depends_on: build-aarch64
-        timeout_in_minutes: 30
+        timeout_in_minutes: 60
         inputs: [test/pg-cdc]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -305,7 +305,7 @@ steps:
       - id: pg-cdc-13_14
         label: "Postgres CDC w/ 13.14"
         depends_on: build-aarch64
-        timeout_in_minutes: 30
+        timeout_in_minutes: 60
         inputs: [test/pg-cdc]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -316,7 +316,7 @@ steps:
       - id: pg-cdc-12_18
         label: "Postgres CDC w/ 12.18"
         depends_on: build-aarch64
-        timeout_in_minutes: 30
+        timeout_in_minutes: 60
         inputs: [test/pg-cdc]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -327,7 +327,7 @@ steps:
       - id: pg-cdc-11_22
         label: "Postgres CDC w/ 11.22"
         depends_on: build-aarch64
-        timeout_in_minutes: 30
+        timeout_in_minutes: 60
         inputs: [test/pg-cdc]
         plugins:
           - ./ci/plugins/mzcompose:


### PR DESCRIPTION
Timeout seen in https://buildkite.com/materialize/release-qualification/builds/675#019309c1-7e6b-441d-b436-c2e112cfd044

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
