### PR TITLE
blue-green-deployment test: Another strictness reduction

### DIFF
--- a/test/cluster/blue-green-deployment/deploy.td
+++ b/test/cluster/blue-green-deployment/deploy.td
@@ -52,7 +52,7 @@
     ),
     -- Collect ready dataflows.
     -- For a dataflow to be ready it must be hydrated and caught up.
-    -- We define a dataflow to be caught up if its local lag is less than 1 second.
+    -- We define a dataflow to be caught up if its local lag is less than 2 seconds.
     ready_dataflows AS (
         SELECT id
         FROM dataflows d
@@ -62,7 +62,7 @@
         LEFT JOIN mz_internal.mz_materialization_lag l ON (l.object_id = d.id)
         WHERE
             h.hydrated AND
-            (l.local_lag <= '1s' OR l.local_lag IS NULL)
+            (l.local_lag <= '2s' OR l.local_lag IS NULL)
     ),
     -- Collect dataflows that are not yet ready.
     pending_dataflows AS (

--- a/test/cluster/blue-green-deployment/setup.td
+++ b/test/cluster/blue-green-deployment/setup.td
@@ -88,7 +88,7 @@ ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;
     ),
     -- Collect ready dataflows.
     -- For a dataflow to be ready it must be hydrated and caught up.
-    -- We define a dataflow to be caught up if its local lag is less than 1 second.
+    -- We define a dataflow to be caught up if its local lag is less than 2 seconds.
     ready_dataflows AS (
         SELECT id
         FROM dataflows d


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/30368

Seen failing in https://buildkite.com/materialize/test/builds/94332#0193186c-c516-4075-bdaf-586e7455b554

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
