### PR TITLE
Annotate timely work threads with labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,12 +1023,15 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "lazycell",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
  "syn 2.0.63",
+ "which",
 ]
 
 [[package]]
@@ -1826,6 +1829,17 @@ checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "custom-labels"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8be3ae20903692f48a3be44e08a202636503829f94c7143bbe94a485d76b35"
+dependencies = [
+ "bindgen",
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -4582,6 +4596,7 @@ dependencies = [
  "bytesize",
  "clap",
  "crossbeam-channel",
+ "custom-labels",
  "dec",
  "differential-dataflow",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4675,6 +4675,7 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
+ "custom-labels",
  "fail",
  "futures",
  "hyper 1.4.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,18 +1020,33 @@ dependencies = [
  "bitflags 2.4.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
- "log",
- "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
  "syn 2.0.63",
- "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.4.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1833,11 +1848,11 @@ dependencies = [
 
 [[package]]
 name = "custom-labels"
-version = "0.1.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8be3ae20903692f48a3be44e08a202636503829f94c7143bbe94a485d76b35"
+checksum = "ddf0e815ae488e15aea399e50ac36aea3078e0fd5ff1d4618230ed58b9713caf"
 dependencies = [
- "bindgen",
+ "bindgen 0.70.1",
  "cc",
  "libc",
 ]
@@ -3737,7 +3752,7 @@ version = "0.16.0+8.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.4",
  "bzip2-sys",
  "cc",
  "glob",
@@ -4064,7 +4079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
 dependencies = [
  "base64 0.21.5",
- "bindgen",
+ "bindgen 0.70.1",
  "bitflags 2.4.1",
  "bitvec",
  "btoi",
@@ -8123,7 +8138,7 @@ checksum = "f8650aabb6c35b860610e9cff5dc1af886c9e25073b7b1712a68972af4281302"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -8143,7 +8158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.63",

--- a/deny.toml
+++ b/deny.toml
@@ -142,6 +142,7 @@ name = "strum-macros"
 [[bans.deny]]
 name = "log"
 wrappers = [
+    "bindgen",
     "deadpool-postgres",
     "eventsource-client",
     "fail",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -299,7 +299,7 @@ version = "1.2.6"
 [[audits.custom-labels]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.1.2"
+version = "0.3.2"
 
 [[audits.datadriven]]
 who = "Ben Kirwin <bkirwi@materialize.com>"

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -296,6 +296,11 @@ who = "Parker Timmerman <parker.timmerman@materialize.com>"
 criteria = "safe-to-deploy"
 version = "1.2.6"
 
+[[audits.custom-labels]]
+who = "Moritz Hoffmann <mh@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.1.2"
+
 [[audits.datadriven]]
 who = "Ben Kirwin <bkirwi@materialize.com>"
 criteria = "safe-to-deploy"

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.68"
 bytesize = "1.1.0"
 clap = { version = "3.2.24", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
-custom-labels = "0.1"
+custom-labels = "0.3"
 dec = { version = "0.4.8", features = ["serde"] }
 differential-dataflow = "0.13.1"
 futures = "0.3.25"

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = "0.1.68"
 bytesize = "1.1.0"
 clap = { version = "3.2.24", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
+custom-labels = "0.1"
 dec = { version = "0.4.8", features = ["serde"] }
 differential-dataflow = "0.13.1"
 futures = "0.3.25"

--- a/src/cluster/src/server.rs
+++ b/src/cluster/src/server.rs
@@ -232,7 +232,7 @@ where
             custom_labels::with_labels(
                 [
                     ("timely_worker", format!("{}", timely_worker.index())),
-                    ("cluster_worker", Worker::name()),
+                    ("server_name", Worker::server_name()),
                 ],
                 || {
                     let timely_worker_index = timely_worker.index();

--- a/src/cluster/src/server.rs
+++ b/src/cluster/src/server.rs
@@ -229,22 +229,31 @@ where
         }
 
         let worker_guards = execute_from(builders, other, worker_config, move |timely_worker| {
-            let timely_worker_index = timely_worker.index();
-            let _tokio_guard = tokio_executor.enter();
-            let client_rx = client_rxs.lock().unwrap()[timely_worker_index % config.workers]
-                .take()
-                .unwrap();
-            let persist_clients = Arc::clone(&persist_clients);
-            let txns_ctx = txns_ctx.clone();
-            let user_worker_config = user_worker_config.clone();
-            let tracing_handle = Arc::clone(&tracing_handle);
-            Worker::build_and_run(
-                user_worker_config,
-                timely_worker,
-                client_rx,
-                persist_clients,
-                txns_ctx,
-                tracing_handle,
+            custom_labels::with_labels(
+                [
+                    ("timely_worker", format!("{}", timely_worker.index())),
+                    ("cluster_worker", Worker::name()),
+                ],
+                || {
+                    let timely_worker_index = timely_worker.index();
+                    let _tokio_guard = tokio_executor.enter();
+                    let client_rx = client_rxs.lock().unwrap()
+                        [timely_worker_index % config.workers]
+                        .take()
+                        .unwrap();
+                    let persist_clients = Arc::clone(&persist_clients);
+                    let txns_ctx = txns_ctx.clone();
+                    let user_worker_config = user_worker_config.clone();
+                    let tracing_handle = Arc::clone(&tracing_handle);
+                    Worker::build_and_run(
+                        user_worker_config,
+                        timely_worker,
+                        client_rx,
+                        persist_clients,
+                        txns_ctx,
+                        tracing_handle,
+                    )
+                },
             )
         })
         .map_err(|e| anyhow!("{e}"))?;

--- a/src/cluster/src/types.rs
+++ b/src/cluster/src/types.rs
@@ -44,5 +44,5 @@ pub trait AsRunnableWorker<C, R> {
     );
 
     /// A debug name for the implementation.
-    fn name() -> String;
+    fn server_name() -> String;
 }

--- a/src/cluster/src/types.rs
+++ b/src/cluster/src/types.rs
@@ -44,5 +44,5 @@ pub trait AsRunnableWorker<C, R> {
     );
 
     /// A debug name for the implementation.
-    fn server_name() -> String;
+    fn server_name() -> &'static str;
 }

--- a/src/cluster/src/types.rs
+++ b/src/cluster/src/types.rs
@@ -42,4 +42,7 @@ pub trait AsRunnableWorker<C, R> {
         txns_ctx: TxnsContext,
         tracing_handle: Arc<TracingHandle>,
     );
+
+    /// A debug name for the implementation.
+    fn name() -> String;
 }

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -43,6 +43,9 @@ tower = "0.4.13"
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
+[build-dependencies]
+custom-labels = "0.3.2"
+
 [features]
 default = ["tokio-console", "mz-alloc-default"]
 jemalloc = ["mz-alloc/jemalloc"]

--- a/src/clusterd/build.rs
+++ b/src/clusterd/build.rs
@@ -1,0 +1,12 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+fn main() {
+    custom_labels::build::emit_build_instructions();
+}

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -230,8 +230,8 @@ impl mz_cluster::types::AsRunnableWorker<ComputeCommand, ComputeResponse> for Co
         .run()
     }
 
-    fn server_name() -> String {
-        "compute".to_string()
+    fn server_name() -> &'static str {
+        "compute"
     }
 }
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -230,7 +230,7 @@ impl mz_cluster::types::AsRunnableWorker<ComputeCommand, ComputeResponse> for Co
         .run()
     }
 
-    fn name() -> String {
+    fn server_name() -> String {
         "compute".to_string()
     }
 }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -229,6 +229,10 @@ impl mz_cluster::types::AsRunnableWorker<ComputeCommand, ComputeResponse> for Co
         }
         .run()
     }
+
+    fn name() -> String {
+        "compute".to_string()
+    }
 }
 
 /// Set the current thread's core affinity, based on the given `worker_id`.

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -121,7 +121,7 @@ impl mz_cluster::types::AsRunnableWorker<StorageCommand, StorageResponse> for Co
         .run();
     }
 
-    fn name() -> String {
+    fn server_name() -> String {
         "storage".to_string()
     }
 }

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -120,4 +120,8 @@ impl mz_cluster::types::AsRunnableWorker<StorageCommand, StorageResponse> for Co
         )
         .run();
     }
+
+    fn name() -> String {
+        "storage".to_string()
+    }
 }

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -121,7 +121,7 @@ impl mz_cluster::types::AsRunnableWorker<StorageCommand, StorageResponse> for Co
         .run();
     }
 
-    fn server_name() -> String {
-        "storage".to_string()
+    fn server_name() -> &'static str {
+        "storage"
     }
 }


### PR DESCRIPTION
Add polar-signals labels to timely worker threads to distinguish worker kind (compute/storage).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
