### PR TITLE
controller: don't reset the maintenance ticker

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -1092,7 +1092,6 @@ where
         // Perform periodic maintenance work.
         if self.maintenance_scheduled {
             self.maintain(storage);
-            self.maintenance_ticker.reset();
             self.maintenance_scheduled = false;
         }
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1819,7 +1819,6 @@ where
         // Perform periodic maintenance work.
         if self.maintenance_scheduled {
             self.maintain();
-            self.maintenance_ticker.reset();
             self.maintenance_scheduled = false;
         }
 


### PR DESCRIPTION
Previously, the controllers would reset the maintenance ticker after every finished maintenance. So maintenance technically wouldn't be performed once per second, but once per (1s + maintenance duration). The skew caused by this is tiny, but still enough that it produces visible sawtooth patterns in the reported wallclock lag metric when viewed over hours.

This PR removes the ticker reset, so controller maintenance is now performed roughly once per second again, without any inherent skew. The expectation is that this makes the system slightly more predictable and removes skew from metrics that are refreshed during maintenance.

[Slack thread](https://materializeinc.slack.com/archives/C073FCHFWV6/p1731337394420349)

### Motivation

  * This PR fixes a previously unreported bug.

The reported wallclock lag metric sometimes shows variability unrelated to the actual frontier lag.

![Screenshot 2024-11-06 at 14 42 26](https://github.com/user-attachments/assets/ee65a494-7561-4d19-ac2b-74e52fba559c)

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
