### PR TITLE
helm-chart: add console deployment example

### DIFF
--- a/misc/helm-charts/operator/Chart.yaml
+++ b/misc/helm-charts/operator/Chart.yaml
@@ -13,6 +13,6 @@ name: materialize-operator
 description: Materialize Kubernetes Operator Helm Chart
 type: application
 version: 0.1.0
-appVersion: "v0.124.0-dev.0--pr.gd5e227d7d07dc4878d2a065c7c10a48c2555385a"
+appVersion: "v0.125.0-dev.0--pr.g38d50d921720caaf15998f30988db1aed720b2fc"
 icon: https://materialize.com/favicon.ico
 home: https://materialize.com

--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -1,6 +1,6 @@
 # Materialize Kubernetes Operator Helm Chart
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.125.0-dev.0--pr.g38d50d921720caaf15998f30988db1aed720b2fc](https://img.shields.io/badge/AppVersion-v0.125.0--dev.0----pr.g38d50d921720caaf15998f30988db1aed720b2fc-informational?style=flat-square)
 
 Materialize Kubernetes Operator Helm Chart
 
@@ -144,7 +144,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.clusters.sizes.probe.workers` |  | ``1`` |
 | `operator.image.pullPolicy` |  | ``"IfNotPresent"`` |
 | `operator.image.repository` |  | ``"materialize/orchestratord"`` |
-| `operator.image.tag` |  | ``"v0.124.0-dev.0--pr.gd5e227d7d07dc4878d2a065c7c10a48c2555385a"`` |
+| `operator.image.tag` |  | ``"v0.125.0-dev.0--pr.g38d50d921720caaf15998f30988db1aed720b2fc"`` |
 | `operator.nodeSelector` |  | ``{}`` |
 | `operator.resources.limits.memory` |  | ``"512Mi"`` |
 | `operator.resources.requests.cpu` |  | ``"100m"`` |
@@ -201,7 +201,7 @@ metadata:
   name: 12345678-1234-1234-1234-123456789012
   namespace: materialize-environment
 spec:
-  environmentdImageRef: materialize/environmentd:v0.124.0-dev.0--pr.gd5e227d7d07dc4878d2a065c7c10a48c2555385a
+  environmentdImageRef: materialize/environmentd:v0.125.0-dev.0--pr.g38d50d921720caaf15998f30988db1aed720b2fc
   environmentdResourceRequirements:
     limits:
       memory: 16Gi

--- a/misc/helm-charts/operator/README.md.gotmpl
+++ b/misc/helm-charts/operator/README.md.gotmpl
@@ -161,7 +161,7 @@ metadata:
   name: 12345678-1234-1234-1234-123456789012
   namespace: materialize-environment
 spec:
-  environmentdImageRef: materialize/environmentd:v0.124.0-dev.0--pr.gd5e227d7d07dc4878d2a065c7c10a48c2555385a
+  environmentdImageRef: materialize/environmentd:v0.125.0-dev.0--pr.g38d50d921720caaf15998f30988db1aed720b2fc
   environmentdResourceRequirements:
     limits:
       memory: 16Gi

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: materialize/orchestratord:v0.124.0-dev.0--pr.gd5e227d7d07dc4878d2a065c7c10a48c2555385a
+          value: materialize/orchestratord:v0.125.0-dev.0--pr.g38d50d921720caaf15998f30988db1aed720b2fc
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -13,7 +13,7 @@ operator:
     # The Docker repository for the operator image
     repository: materialize/orchestratord
     # The tag/version of the operator image to be used
-    tag: v0.124.0-dev.0--pr.gd5e227d7d07dc4878d2a065c7c10a48c2555385a
+    tag: v0.125.0-dev.0--pr.g38d50d921720caaf15998f30988db1aed720b2fc
     # Policy for pulling the image: "IfNotPresent" avoids unnecessary re-pulling of images
     pullPolicy: IfNotPresent
   args:

--- a/misc/helm-charts/testing/console.yaml
+++ b/misc/helm-charts/testing/console.yaml
@@ -1,0 +1,54 @@
+---
+# Source: materialize-environmentd/templates/secret.yaml
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: console
+  namespace: materialize-environment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: console
+  template:
+    metadata:
+      labels:
+        app: console
+    spec:
+      containers:
+        - name: console
+          image: materialize/console:0.1.0
+          env:
+            - name: MZ_ENDPOINT
+              value: "http://mzotkj6fgt6k-environmentd.materialize-environment.svc.cluster.local:6878" # Adjust to the appropriate service name and port
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 30
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: console-service
+  namespace: materialize-environment
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 80
+  selector:
+    app: console

--- a/misc/helm-charts/testing/environmentd.yaml
+++ b/misc/helm-charts/testing/environmentd.yaml
@@ -29,7 +29,7 @@ metadata:
   name: 12345678-1234-1234-1234-123456789012
   namespace: materialize-environment
 spec:
-  environmentdImageRef: materialize/environmentd:v0.124.0-dev.0--pr.gd5e227d7d07dc4878d2a065c7c10a48c2555385a
+  environmentdImageRef: materialize/environmentd:v0.125.0-dev.0--pr.g38d50d921720caaf15998f30988db1aed720b2fc
   requestRollout: 22222222-2222-2222-2222-222222222222
   forceRollout: 33333333-3333-3333-3333-333333333333
   inPlaceRollout: false


### PR DESCRIPTION
Bumping the default envd image to the latest one from main and also adding a simple example for the console deployment.