### PR TITLE
make orchestratord also create console pods

### DIFF
--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -121,7 +121,9 @@ The following table lists the configurable parameters of the Materialize operato
 | `observability.prometheus.enabled` |  | ``false`` |
 | `operator.args.awsAccountID` |  | ``""`` |
 | `operator.args.cloudProvider` |  | ``"local"`` |
+| `operator.args.consoleImageTagMapOverride` |  | ``{}`` |
 | `operator.args.createBalancers` |  | ``true`` |
+| `operator.args.createConsole` |  | ``true`` |
 | `operator.args.environmentdConnectionRoleARN` |  | ``""`` |
 | `operator.args.environmentdIAMRoleARN` |  | ``""`` |
 | `operator.args.localDevelopment` |  | ``true`` |

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -35,7 +35,6 @@ spec:
         image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
         imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
         args:
-        - "--helm-chart-version={{ .Chart.Version }}"
         - "--startup-log-filter={{ .Values.operator.args.startupLogFilter }}"
         - "--cloud-provider={{ .Values.operator.args.cloudProvider }}"
         - "--region={{ .Values.operator.args.region }}"
@@ -54,6 +53,13 @@ spec:
         {{- if .Values.operator.args.createBalancers }}
         - "--create-balancers"
         {{- end }}
+        {{- if .Values.operator.args.createConsole }}
+        - "--create-console"
+        {{- end }}
+        {{- range $key, $value := .Values.operator.args.consoleImageTagMapOverride }}
+        - "--console-image-tag-map={{ $key }}={{ $value }}"
+        {{- end }}
+        - "--console-image-tag-map=v0.125.0-dev.0--pr.g38d50d921720caaf15998f30988db1aed720b2fc=0.1.2"
         {{- if .Values.operator.clusters }}
         {{- if .Values.operator.clusters.sizes }}
         - '--environmentd-cluster-replica-sizes={{ toJson .Values.operator.clusters.sizes }}'

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -27,12 +27,16 @@ operator:
     localDevelopment: true
     # Flag to indicate whether to create balancerd pods for the environments
     createBalancers: true
+    # Flag to indicate whether to create console pods for the environments
+    createConsole: true
     # ARN of the IAM role for environmentd
     environmentdIAMRoleARN: ""
     # ARN of the IAM role for the CREATE CONNECTION feature
     environmentdConnectionRoleARN: ""
     # awsAccountID is required when cloudProvider is "aws"
     awsAccountID: ""
+    # override the mapping of environmentd versions to console versions
+    consoleImageTagMapOverride: {}
   clusters:
     sizes:
       3xsmall:

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -66,6 +66,8 @@ pub mod v1alpha1 {
         pub environmentd_scratch_volume_storage_requirement: Option<Quantity>,
         // Resource requirements for the balancerd pod
         pub balancerd_resource_requirements: Option<ResourceRequirements>,
+        // Resource requirements for the console pod
+        pub console_resource_requirements: Option<ResourceRequirements>,
 
         // When changes are made to the environmentd resources (either via
         // modifying fields in the spec here or by deploying a new
@@ -135,6 +137,14 @@ pub mod v1alpha1 {
 
         pub fn balancerd_service_name(&self) -> String {
             self.name_prefixed("balancerd")
+        }
+
+        pub fn console_deployment_name(&self) -> String {
+            self.name_prefixed("console")
+        }
+
+        pub fn console_service_name(&self) -> String {
+            self.name_prefixed("console")
         }
 
         pub fn persist_pubsub_service_name(&self, generation: u64) -> String {

--- a/src/orchestratord/src/controller/materialize/console.rs
+++ b/src/orchestratord/src/controller/materialize/console.rs
@@ -1,0 +1,219 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use k8s_openapi::{
+    api::{
+        apps::v1::{Deployment, DeploymentSpec},
+        core::v1::{
+            Capabilities, Container, ContainerPort, EnvVar, HTTPGetAction, PodSpec,
+            PodTemplateSpec, Probe, SeccompProfile, SecurityContext, Service, ServicePort,
+            ServiceSpec,
+        },
+    },
+    apimachinery::pkg::{apis::meta::v1::LabelSelector, util::intstr::IntOrString},
+};
+use kube::{api::ObjectMeta, Api, Client};
+use maplit::btreemap;
+
+use crate::k8s::apply_resource;
+use mz_cloud_resources::crd::materialize::v1alpha1::Materialize;
+
+// corresponds to the `EXPOSE` line in the console dockerfile
+const CONSOLE_IMAGE_HTTP_PORT: i32 = 8080;
+
+pub struct Resources {
+    console_deployment: Box<Deployment>,
+    console_service: Box<Service>,
+}
+
+impl Resources {
+    pub fn new(config: &super::Args, mz: &Materialize, console_image_ref: &str) -> Self {
+        let console_deployment = Box::new(create_console_deployment_object(
+            config,
+            mz,
+            console_image_ref,
+        ));
+        let console_service = Box::new(create_console_service_object(config, mz));
+        Self {
+            console_deployment,
+            console_service,
+        }
+    }
+
+    pub async fn apply(&self, client: &Client, namespace: &str) -> Result<(), anyhow::Error> {
+        let deployment_api: Api<Deployment> = Api::namespaced(client.clone(), namespace);
+        let service_api: Api<Service> = Api::namespaced(client.clone(), namespace);
+
+        apply_resource(&deployment_api, &self.console_deployment).await?;
+        apply_resource(&service_api, &self.console_service).await?;
+
+        Ok(())
+    }
+}
+
+fn create_console_deployment_object(
+    config: &super::Args,
+    mz: &Materialize,
+    console_image_ref: &str,
+) -> Deployment {
+    let mut pod_template_labels = mz.default_labels();
+    pod_template_labels.insert(
+        "materialize.cloud/name".to_owned(),
+        mz.console_deployment_name(),
+    );
+    pod_template_labels.insert("app".to_owned(), "console".to_string());
+    pod_template_labels.insert(
+        "materialize.cloud/app".to_owned(),
+        mz.console_service_name(),
+    );
+
+    let ports = vec![ContainerPort {
+        container_port: CONSOLE_IMAGE_HTTP_PORT,
+        name: Some("http".into()),
+        protocol: Some("TCP".into()),
+        ..Default::default()
+    }];
+
+    let probe = Probe {
+        http_get: Some(HTTPGetAction {
+            path: Some("/".to_string()),
+            port: IntOrString::Int(CONSOLE_IMAGE_HTTP_PORT),
+            ..Default::default()
+        }),
+        initial_delay_seconds: Some(10),
+        period_seconds: Some(30),
+        ..Default::default()
+    };
+
+    let env = vec![EnvVar {
+        name: "MZ_ENDPOINT".to_string(),
+        value: Some(format!(
+            "http://{}.{}.svc.cluster.local:{}",
+            // TODO: this should talk to balancerd eventually, but for now we
+            // need to bypass auth which requires using the internal port
+            mz.environmentd_service_name(),
+            mz.namespace(),
+            config.environmentd_internal_http_port,
+        )),
+        ..Default::default()
+    }];
+
+    if config.enable_tls {
+        unimplemented!();
+    } else {
+        // currently the docker image just doesn't implement tls
+    }
+
+    let security_context = if config.enable_security_context {
+        // Since we want to adhere to the most restrictive security context, all
+        // of these fields have to be set how they are.
+        // See https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
+        Some(SecurityContext {
+            run_as_non_root: Some(true),
+            capabilities: Some(Capabilities {
+                drop: Some(vec!["ALL".to_string()]),
+                ..Default::default()
+            }),
+            seccomp_profile: Some(SeccompProfile {
+                type_: "RuntimeDefault".to_string(),
+                ..Default::default()
+            }),
+            allow_privilege_escalation: Some(false),
+            ..Default::default()
+        })
+    } else {
+        None
+    };
+
+    let container = Container {
+        name: "console".to_owned(),
+        image: Some(console_image_ref.to_string()),
+        image_pull_policy: Some(config.image_pull_policy.to_string()),
+        ports: Some(ports),
+        env: Some(env),
+        readiness_probe: Some(probe),
+        resources: mz.spec.console_resource_requirements.clone(),
+        security_context,
+        ..Default::default()
+    };
+
+    let deployment_spec = DeploymentSpec {
+        replicas: Some(2),
+        selector: LabelSelector {
+            match_labels: Some(pod_template_labels.clone()),
+            ..Default::default()
+        },
+        template: PodTemplateSpec {
+            // not using managed_resource_meta because the pod should be
+            // owned by the deployment, not the materialize instance
+            metadata: Some(ObjectMeta {
+                labels: Some(pod_template_labels),
+                ..Default::default()
+            }),
+            spec: Some(PodSpec {
+                containers: vec![container],
+                node_selector: Some(
+                    config
+                        .console_node_selector
+                        .iter()
+                        .map(|selector| (selector.key.clone(), selector.value.clone()))
+                        .collect(),
+                ),
+                scheduler_name: config.scheduler_name.clone(),
+                service_account_name: Some(mz.service_account_name()),
+                ..Default::default()
+            }),
+        },
+        ..Default::default()
+    };
+
+    Deployment {
+        metadata: ObjectMeta {
+            ..mz.managed_resource_meta(mz.console_deployment_name())
+        },
+        spec: Some(deployment_spec),
+        status: None,
+    }
+}
+
+fn create_console_service_object(config: &super::Args, mz: &Materialize) -> Service {
+    let selector = btreemap! {"materialize.cloud/name".to_string() => mz.console_deployment_name()};
+
+    let ports = vec![ServicePort {
+        name: Some("http".to_string()),
+        protocol: Some("TCP".to_string()),
+        port: config.console_http_port,
+        target_port: Some(IntOrString::Int(CONSOLE_IMAGE_HTTP_PORT)),
+        ..Default::default()
+    }];
+
+    let spec = if config.local_development {
+        ServiceSpec {
+            type_: Some("NodePort".to_string()),
+            selector: Some(selector),
+            ports: Some(ports),
+            external_traffic_policy: Some("Local".to_string()),
+            ..Default::default()
+        }
+    } else {
+        ServiceSpec {
+            type_: Some("ClusterIP".to_string()),
+            cluster_ip: Some("None".to_string()),
+            selector: Some(selector),
+            ports: Some(ports),
+            ..Default::default()
+        }
+    };
+
+    Service {
+        metadata: mz.managed_resource_meta(mz.console_service_name()),
+        spec: Some(spec),
+        status: None,
+    }
+}


### PR DESCRIPTION
### Motivation

console support for orchestratord

i can access the console on localhost when i run this, but it doesn't appear to work very well - i think @SangJunBak mentioned that this is currently expected, though?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
