### PR TITLE
test: Fix non-deterministic debug catalog test

### DIFF
--- a/src/catalog/src/durable/debug.rs
+++ b/src/catalog/src/durable/debug.rs
@@ -304,6 +304,18 @@ impl<T: Collection> CollectionTrace<T> {
     }
 }
 
+impl<T: Collection> CollectionTrace<T>
+where
+    T: Collection,
+    T::Key: Ord,
+    T::Value: Ord,
+{
+    fn sort(&mut self) {
+        self.values
+            .sort_by(|(x1, ts1, d1), (x2, ts2, d2)| ts1.cmp(ts2).then(d1.cmp(d2)).then(x1.cmp(x2)));
+    }
+}
+
 /// Catalog data structured as timestamped diffs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Trace {
@@ -355,6 +367,53 @@ impl Trace {
             unfinalized_shards: CollectionTrace::new(),
             txn_wal_shard: CollectionTrace::new(),
         }
+    }
+
+    pub fn sort(&mut self) {
+        let Trace {
+            audit_log,
+            clusters,
+            introspection_sources,
+            cluster_replicas,
+            comments,
+            configs,
+            databases,
+            default_privileges,
+            id_allocator,
+            items,
+            network_policies,
+            roles,
+            schemas,
+            settings,
+            source_references,
+            system_object_mappings,
+            system_configurations,
+            system_privileges,
+            storage_collection_metadata,
+            unfinalized_shards,
+            txn_wal_shard,
+        } = self;
+        audit_log.sort();
+        clusters.sort();
+        introspection_sources.sort();
+        cluster_replicas.sort();
+        comments.sort();
+        configs.sort();
+        databases.sort();
+        default_privileges.sort();
+        id_allocator.sort();
+        items.sort();
+        network_policies.sort();
+        roles.sort();
+        schemas.sort();
+        settings.sort();
+        source_references.sort();
+        system_object_mappings.sort();
+        system_configurations.sort();
+        system_privileges.sort();
+        storage_collection_metadata.sort();
+        unfinalized_shards.sort();
+        txn_wal_shard.sort();
     }
 }
 

--- a/src/catalog/tests/debug.rs
+++ b/src/catalog/tests/debug.rs
@@ -139,7 +139,8 @@ async fn test_debug<'a>(state_builder: TestCatalogStateBuilder) {
     assert_eq!(Epoch::new(2).unwrap(), epoch);
 
     // Check opened trace.
-    let unconsolidated_trace = openable_state2.trace_unconsolidated().await.unwrap();
+    let mut unconsolidated_trace = openable_state2.trace_unconsolidated().await.unwrap();
+    unconsolidated_trace.sort();
     {
         let test_trace = HiddenUserVersionTrace(&unconsolidated_trace);
         let ((user_version_key, user_version_value), user_version_ts, user_version_diff) =
@@ -155,9 +156,10 @@ async fn test_debug<'a>(state_builder: TestCatalogStateBuilder) {
     let mut debug_state = openable_state2.open_debug().await.unwrap();
 
     let mut openable_state_reader = state_builder.clone().unwrap_build().await;
+    let mut unconsolidated_trace2 = openable_state_reader.trace_unconsolidated().await.unwrap();
+    unconsolidated_trace2.sort();
     assert_eq!(
-        openable_state_reader.trace_unconsolidated().await.unwrap(),
-        unconsolidated_trace,
+        unconsolidated_trace2, unconsolidated_trace,
         "opening a debug catalog should not modify the contents"
     );
 

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -671,7 +671,7 @@ async fn force_gc(
 /// Exposed for `mz-catalog`.
 pub const CATALOG_FORCE_COMPACTION_FUEL: Config<usize> = Config::new(
     "persist_catalog_force_compaction_fuel",
-    0,
+    1024,
     "fuel to use in catalog dangerous_force_compaction task",
 );
 


### PR DESCRIPTION
Previously, `test_persist_debug` was comparing two unsorted catalog traces. Catalog traces do not provide any guarantee about sort order and the two traces just happened to be in the same order. This commit fixes the issue by sorting the two traces before comparing.

Fixes #MaterializeInc/database-issues/8742

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
