### PR TITLE
Extend `RelationType` analysis to optimistic `LetRec`

### DIFF
--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -545,11 +545,20 @@ mod arity {
 /// Expression types
 mod types {
 
-    use super::{Analysis, Derived};
+    use super::{Analysis, Derived, Lattice};
     use mz_expr::MirRelationExpr;
     use mz_repr::ColumnType;
 
     /// Analysis that determines the type of relation expressions.
+    ///
+    /// The value is `Some` when it discovers column types, and `None` in the case that
+    /// it has discovered no constraining information on the column types. The `None`
+    /// variant should only occur in the course of iteration, and should not be revealed
+    /// as an output of the analysis. One can `unwrap()` the result, and if it errors then
+    /// either the expression is malformed or the analysis has a bug.
+    ///
+    /// The analysis will panic if an expression is not well typed (i.e. if `try_col_with_input_cols`
+    /// returns an error).
     #[derive(Debug)]
     pub struct RelationType;
 
@@ -568,12 +577,81 @@ mod types {
                 .map(|child| &results[child])
                 .collect::<Vec<_>>();
 
-            if offsets.iter().all(|o| o.is_some()) {
-                let input_cols = offsets.into_iter().rev().map(|o| o.as_ref().unwrap());
-                let subtree_column_types = expr.try_col_with_input_cols(input_cols);
-                subtree_column_types.ok()
-            } else {
-                None
+            // For most expressions we'll apply `try_col_with_input_cols`, but for `Get` expressions
+            // we'll want to combine what we know (iteratively) with the stated `Get::typ`.
+            match expr {
+                MirRelationExpr::Get {
+                    id: mz_expr::Id::Local(i),
+                    typ,
+                    ..
+                } => {
+                    let mut result = typ.column_types.clone();
+                    if let Some(o) = depends.bindings().get(i) {
+                        if let Some(t) = results.get(*o) {
+                            if let Some(rec_typ) = t {
+                                // Reconcile nullability statements.
+                                // Unclear if we should trust `typ`.
+                                assert_eq!(result.len(), rec_typ.len());
+                                result.clone_from(rec_typ);
+                                for (res, col) in result.iter_mut().zip(typ.column_types.iter()) {
+                                    if !col.nullable {
+                                        res.nullable = false;
+                                    }
+                                }
+                            } else {
+                                // Our `None` information indicates that we are optimistically
+                                // assuming the best, including that all columns are non-null.
+                                // This should only happen in the first visit to a `Get` expr.
+                                // Use `typ`, but flatten nullability.
+                                for col in result.iter_mut() {
+                                    col.nullable = false;
+                                }
+                            }
+                        }
+                    }
+                    Some(result)
+                }
+                _ => {
+                    // Every expression with inputs should have non-`None` inputs at this point.
+                    let input_cols = offsets.into_iter().rev().map(|o| {
+                        o.as_ref()
+                            .expect("RelationType analysis discovered type-less expression")
+                    });
+                    Some(expr.try_col_with_input_cols(input_cols).unwrap())
+                }
+            }
+        }
+
+        fn lattice() -> Option<Box<dyn Lattice<Self::Value>>> {
+            Some(Box::new(RTLattice))
+        }
+    }
+
+    struct RTLattice;
+
+    impl Lattice<Option<Vec<ColumnType>>> for RTLattice {
+        fn top(&self) -> Option<Vec<ColumnType>> {
+            None
+        }
+        fn meet_assign(&self, a: &mut Option<Vec<ColumnType>>, b: Option<Vec<ColumnType>>) -> bool {
+            match (a, b) {
+                (_, None) => false,
+                (Some(a), Some(b)) => {
+                    let mut changed = false;
+                    assert_eq!(a.len(), b.len());
+                    for (at, bt) in a.iter_mut().zip(b.iter()) {
+                        assert_eq!(at.scalar_type, bt.scalar_type);
+                        if !at.nullable && bt.nullable {
+                            at.nullable = true;
+                            changed = true;
+                        }
+                    }
+                    changed
+                }
+                (a, b) => {
+                    *a = b;
+                    true
+                }
             }
         }
     }

--- a/src/transform/tests/test_transforms/types.spec
+++ b/src/transform/tests/test_transforms/types.spec
@@ -53,11 +53,11 @@ explain with=types
 Return
   Get l0
 With Mutually Recursive
-  cte l0 = // { types: "(bigint, bigint)" }
+  cte l0 = // { types: "(bigint, smallint)" }
     Get t0
 ----
-Return // { types: "(Int64, Int64)" }
-  Get l0 // { types: "(Int64, Int64)" }
+Return // { types: "(Int64, Int16)" }
+  Get l0 // { types: "(Int64, Int16)" }
 With Mutually Recursive
   cte l0 =
     Get t0 // { types: "(Int64, Int16)" }

--- a/test/sqllogictest/advent-of-code/2023/aoc_1203.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1203.slt
@@ -304,13 +304,10 @@ Explained Query:
                   Negate
                     Distinct project=[#0..=#2]
                       Project (#0..=#2)
-                        Filter (#5 OR (#5) IS NULL)
-                          Map (((#0 = #3) AND (#4 = (#1 + #2))))
-                            CrossJoin type=differential
-                              ArrangeBy keys=[[]]
-                                Get l13
-                              ArrangeBy keys=[[]]
-                                Get l11
+                        Join on=(#0 = #3 AND #4 = (#1 + #2)) type=differential
+                          ArrangeBy keys=[[#0, (#1 + #2)]]
+                            Get l13
+                          Get l11
                   Get l13
       cte l13 =
         Distinct project=[#0..=#2]
@@ -329,12 +326,12 @@ Explained Query:
                       Join on=(#0 = #2 AND #3 = (#1 - 1)) type=differential
                         ArrangeBy keys=[[#0, (#1 - 1)]]
                           Get l10
-                        ArrangeBy keys=[[#0, #1]]
-                          Get l11
+                        Get l11
                 Get l10
       cte l11 =
-        Project (#0, #1)
-          Get l5
+        ArrangeBy keys=[[#0, #1]]
+          Project (#0, #1)
+            Get l5
       cte l10 =
         Distinct project=[#0, #1]
           Project (#1, #2)
@@ -366,8 +363,7 @@ Explained Query:
               Join on=(#0 = #4 AND #1 = (#5 + #6)) type=differential
                 Get l8
                 ArrangeBy keys=[[#1, (#2 + #3)]]
-                  Filter (#3) IS NOT NULL
-                    Get l9
+                  Get l9
     cte l8 =
       ArrangeBy keys=[[#0, #1]]
         Get l5

--- a/test/sqllogictest/advent-of-code/2023/aoc_1212.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1212.slt
@@ -148,8 +148,7 @@ Explained Query:
       Project (#0..=#2, #5)
         Join on=(#0 = #3 = #6 AND #4 = (#2 + 1) AND #7 = ((#1 + #5) + 1)) type=delta
           ArrangeBy keys=[[#0], [#0, (#2 + 1)]]
-            Filter (#2) IS NOT NULL
-              Get l5
+            Get l5
           ArrangeBy keys=[[#0, #1]]
             Project (#0, #2, #3)
               Map (text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2))))

--- a/test/sqllogictest/advent-of-code/2023/aoc_1214.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1214.slt
@@ -129,59 +129,60 @@ SELECT * FROM part1;
 Explained Query:
   Return
     Union
-      Get l6
+      Get l7
       Map (null)
         Union
           Negate
             Project ()
-              Get l6
+              Get l7
           Constant
             - ()
   With Mutually Recursive
-    cte l7 =
+    cte l8 =
       Get l1
-    cte l6 =
+    cte l7 =
       Reduce aggregates=[sum(((1 + #1) - #0))]
         CrossJoin type=differential
           ArrangeBy keys=[[]]
             Project (#0)
-              Filter (#2 = "O")
-                Get l2
+              Get l3
           ArrangeBy keys=[[]]
             Union
-              Get l5
+              Get l6
               Map (null)
                 Union
                   Negate
                     Project ()
-                      Get l5
+                      Get l6
                   Constant
                     - ()
-    cte l5 =
+    cte l6 =
       Union
-        Get l4
+        Get l5
         Map (null)
           Union
             Negate
               Project ()
-                Get l4
+                Get l5
             Constant
               - ()
-    cte l4 =
+    cte l5 =
       Reduce aggregates=[max(#0)]
         Project (#0)
           Get l0
-    cte l3 =
+    cte l4 =
       Project (#0, #1)
         Join on=(#0 = (#2 + 1) AND #1 = #3) type=differential
           ArrangeBy keys=[[#1, #0]]
             Project (#0, #1)
-              Filter (#2 = "O") AND (#0) IS NOT NULL
-                Get l2
+              Get l3
           ArrangeBy keys=[[#1, (#0 + 1)]]
             Project (#0, #1)
-              Filter (#2 = ".") AND (#0) IS NOT NULL
+              Filter (#2 = ".")
                 Get l2
+    cte l3 =
+      Filter (#2 = "O")
+        Get l2
     cte l2 =
       Threshold
         Union
@@ -192,19 +193,19 @@ Explained Query:
                   Get l2
                   Project (#2, #1, #3)
                     Map ((#0 - 1), "O")
-                      Get l3
+                      Get l4
                   Negate
                     Project (#2, #1, #3)
                       Map ((#0 - 1), ".")
-                        Get l3
+                        Get l4
               Map (".")
-                Get l3
+                Get l4
               Negate
                 Map ("O")
-                  Get l3
+                  Get l4
           Get l1
           Negate
-            Get l7
+            Get l8
     cte l1 =
       Project (#0, #2, #3)
         Map (substr(#1, #2, 1))
@@ -622,11 +623,11 @@ Explained Query:
             Join on=(#0 = #2 AND #1 = (#3 - 1)) type=differential
               ArrangeBy keys=[[#0, #1]]
                 Project (#0, #1)
-                  Filter (#2 = "O") AND (#0) IS NOT NULL AND (#1) IS NOT NULL
+                  Filter (#2 = "O")
                     Get l15
               ArrangeBy keys=[[#0, (#1 - 1)]]
                 Project (#0, #1)
-                  Filter (#2 = ".") AND (#0) IS NOT NULL AND (#1) IS NOT NULL
+                  Filter (#2 = ".")
                     Get l15
         cte l15 =
           Threshold
@@ -662,11 +663,11 @@ Explained Query:
             Join on=(#0 = (#2 - 1) AND #1 = #3) type=differential
               ArrangeBy keys=[[#1, #0]]
                 Project (#0, #1)
-                  Filter (#2 = "O") AND (#0) IS NOT NULL AND (#1) IS NOT NULL
+                  Filter (#2 = "O")
                     Get l11
               ArrangeBy keys=[[#1, (#0 - 1)]]
                 Project (#0, #1)
-                  Filter (#2 = ".") AND (#0) IS NOT NULL AND (#1) IS NOT NULL
+                  Filter (#2 = ".")
                     Get l11
         cte l11 =
           Threshold
@@ -702,11 +703,11 @@ Explained Query:
             Join on=(#0 = #2 AND #1 = (#3 + 1)) type=differential
               ArrangeBy keys=[[#0, #1]]
                 Project (#0, #1)
-                  Filter (#2 = "O") AND (#0) IS NOT NULL AND (#1) IS NOT NULL
+                  Filter (#2 = "O")
                     Get l7
               ArrangeBy keys=[[#0, (#1 + 1)]]
                 Project (#0, #1)
-                  Filter (#2 = ".") AND (#0) IS NOT NULL AND (#1) IS NOT NULL
+                  Filter (#2 = ".")
                     Get l7
         cte l7 =
           Threshold
@@ -742,11 +743,11 @@ Explained Query:
             Join on=(#0 = (#2 + 1) AND #1 = #3) type=differential
               ArrangeBy keys=[[#1, #0]]
                 Project (#0, #1)
-                  Filter (#2 = "O") AND (#0) IS NOT NULL AND (#1) IS NOT NULL
+                  Filter (#2 = "O")
                     Get l3
               ArrangeBy keys=[[#1, (#0 + 1)]]
                 Project (#0, #1)
-                  Filter (#2 = ".") AND (#0) IS NOT NULL AND (#1) IS NOT NULL
+                  Filter (#2 = ".")
                     Get l3
         cte l3 =
           Threshold

--- a/test/sqllogictest/advent-of-code/2023/aoc_1215.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1215.slt
@@ -216,16 +216,16 @@ Explained Query:
           Project (#1)
             Map (numeric_to_bigint(#0))
               Union
-                Get l21
+                Get l22
                 Map (null)
                   Union
                     Negate
                       Project ()
-                        Get l21
+                        Get l22
                     Constant
                       - ()
     With
-      cte l21 =
+      cte l22 =
         Reduce aggregates=[sum((((1 + #0) * #2) * integer_to_bigint(#1)))]
           Project (#0, #1, #5)
             Join on=(#0 = #3 AND #2 = #4) type=differential
@@ -233,38 +233,37 @@ Explained Query:
                 Get l17
               ArrangeBy keys=[[#0, #1]]
                 Union
-                  Get l20
+                  Get l21
                   Map (null)
                     Union
                       Negate
                         Project (#0, #1)
-                          Get l20
-                      Get l18
-      cte l20 =
+                          Get l21
+                      Get l19
+      cte l21 =
         Union
-          Get l19
+          Get l20
           Map (0)
             Union
               Negate
                 Project (#0, #1)
-                  Get l19
-              Get l18
-      cte l19 =
+                  Get l20
+              Get l19
+      cte l20 =
         Reduce group_by=[#0, #1] aggregates=[count(*)]
           Project (#0, #1)
             Filter (#1 >= #3)
               Join on=(#0 = #2) type=differential
                 ArrangeBy keys=[[#0]]
-                  Filter (#0) IS NOT NULL
-                    Get l18
+                  Get l19
                 ArrangeBy keys=[[#0]]
-                  Project (#0, #2)
-                    Filter (#0) IS NOT NULL
-                      Get l17
-      cte l18 =
+                  Get l18
+      cte l19 =
         Distinct project=[#0, #1]
-          Project (#0, #2)
-            Get l17
+          Get l18
+      cte l18 =
+        Project (#0, #2)
+          Get l17
       cte l17 =
         Project (#1, #3, #4)
           Join on=(#0 = #2) type=differential

--- a/test/sqllogictest/advent-of-code/2023/aoc_1222.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1222.slt
@@ -210,57 +210,57 @@ Explained Query:
       CrossJoin type=differential
         ArrangeBy keys=[[]]
           Union
-            Get l16
+            Get l15
             Map (0)
               Union
                 Negate
                   Project ()
-                    Get l16
+                    Get l15
                 Constant
                   - ()
         ArrangeBy keys=[[]]
           Union
-            Get l24
+            Get l23
             Map (0)
               Union
                 Negate
                   Project ()
-                    Get l24
+                    Get l23
                 Constant
                   - ()
     With
-      cte l24 =
+      cte l23 =
         Reduce aggregates=[count(*)]
           Project ()
-            Get l23
+            Get l22
   With Mutually Recursive
-    cte l23 =
+    cte l22 =
       Distinct project=[#0, #1]
         Union
           Project (#0, #1)
             Filter (#3 = 1)
               Join on=(#1 = #2) type=differential
                 ArrangeBy keys=[[#1]]
-                  Get l9
+                  Get l8
                 ArrangeBy keys=[[#0]]
                   Reduce group_by=[#0] aggregates=[count(*)]
-                    Get l10
+                    Get l9
           Project (#0, #1)
             Join on=(#1 = #3 AND #2 = #4) type=differential
               ArrangeBy keys=[[#1, #2]]
-                Get l18
+                Get l17
               ArrangeBy keys=[[#0, #1]]
                 Union
-                  Get l22
+                  Get l21
                   Map (error("more than one record produced in subquery"))
                     Project (#0)
                       Filter (#1 > 1)
                         Reduce group_by=[#0] aggregates=[count(*)]
                           Project (#0)
-                            Get l22
-    cte l22 =
+                            Get l21
+    cte l21 =
       Union
-        Get l21
+        Get l20
         Project (#0, #2)
           Map (0)
             Join on=(#0 = #1) type=differential
@@ -268,38 +268,38 @@ Explained Query:
                 Union
                   Negate
                     Project (#0)
-                      Get l21
-                  Get l19
-              Get l20
-    cte l21 =
+                      Get l20
+                  Get l18
+              Get l19
+    cte l20 =
       Reduce group_by=[#0] aggregates=[count(*)]
         Project (#0)
           Join on=(#0 = #1) type=differential
-            Get l20
-            Get l15
-    cte l20 =
-      ArrangeBy keys=[[#0]]
-        Get l19
+            Get l19
+            Get l14
     cte l19 =
+      ArrangeBy keys=[[#0]]
+        Get l18
+    cte l18 =
       Distinct project=[#0]
         Project (#1)
-          Get l18
-    cte l18 =
+          Get l17
+    cte l17 =
       Reduce group_by=[#0, #1] aggregates=[count(*)]
         Project (#0, #3)
           Join on=(#1 = #2) type=differential
             ArrangeBy keys=[[#1]]
-              Get l23
+              Get l22
             ArrangeBy keys=[[#0]]
-              Get l9
-    cte l17 =
-      Get l6
+              Get l8
     cte l16 =
+      Get l6
+    cte l15 =
       Reduce aggregates=[count(distinct #0)]
         Project (#0)
           Join on=(#0 = #1 = #2) type=delta
             ArrangeBy keys=[[#0]]
-              Get l12
+              Get l11
             ArrangeBy keys=[[#0]]
               Union
                 Negate
@@ -310,7 +310,7 @@ Explained Query:
                           ArrangeBy keys=[[#1]]
                             Project (#0, #2)
                               Filter (#0 = #1)
-                                Get l14
+                                Get l13
                           ArrangeBy keys=[[#0]]
                             Reduce group_by=[#0] aggregates=[count(*)]
                               Project (#0)
@@ -318,55 +318,52 @@ Explained Query:
                                   ArrangeBy keys=[[#0]]
                                     Distinct project=[#0]
                                       Project (#2)
-                                        Get l14
-                                  Get l15
-                Get l13
+                                        Get l13
+                                  Get l14
+                Get l12
             ArrangeBy keys=[[#0]]
-              Get l13
-    cte l15 =
-      ArrangeBy keys=[[#0]]
-        Get l10
+              Get l12
     cte l14 =
+      ArrangeBy keys=[[#0]]
+        Get l9
+    cte l13 =
       CrossJoin type=differential
         ArrangeBy keys=[[]]
-          Get l13
+          Get l12
         ArrangeBy keys=[[]]
-          Get l9
-    cte l13 =
-      Distinct project=[#0]
-        Get l12
+          Get l8
     cte l12 =
+      Distinct project=[#0]
+        Get l11
+    cte l11 =
       Project (#0)
         Get l0
-    cte l11 =
+    cte l10 =
       Distinct project=[#0]
         Union
           Project (#0)
             Filter (#3 = 1)
               Get l7
-          Get l10
-    cte l10 =
-      Project (#1)
-        Get l9
+          Get l9
     cte l9 =
+      Project (#1)
+        Get l8
+    cte l8 =
       Distinct project=[#0, #1]
         Project (#0, #4)
           Filter (#0 != #4)
             Join on=(#1 = #5 AND #2 = #6 AND #7 = (#3 + 1)) type=differential
               ArrangeBy keys=[[#1, #2, (#3 + 1)]]
-                Get l8
+                Get l7
               ArrangeBy keys=[[#1..=#3]]
-                Get l8
-    cte l8 =
-      Filter (#3) IS NOT NULL
-        Get l7
+                Get l7
     cte l7 =
       Union
         Threshold
           Union
             Get l6
             Negate
-              Get l17
+              Get l16
         Project (#0..=#2, #6)
           Map (case when #5 then #3 else (#3 - 1) end)
             Join on=(#0 = #4) type=differential
@@ -432,7 +429,7 @@ Explained Query:
           ArrangeBy keys=[[]]
             Get l1
           ArrangeBy keys=[[]]
-            Get l11
+            Get l10
     cte l1 =
       Distinct project=[#0]
         Project (#0)

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -617,7 +617,7 @@ Explained Query:
   Finish order_by=[#4{count} desc nulls_first, #0{containerforumid} asc nulls_last] limit=20 output=[#0..=#4]
     Reduce group_by=[#0{containerforumid}, #2{title}, #1{creationdate}, #3{moderatorpersonid}] aggregates=[count(*)] // { arity: 5 }
       Project (#10, #13, #15, #16) // { arity: 4 }
-        Filter (#33{name} = "China") AND (#10{containerforumid}) IS NOT NULL AND (#16{moderatorpersonid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
+        Filter (#33{name} = "China") AND (#16{moderatorpersonid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
           Join on=(#1{messageid} = #36{messageid} AND #10{containerforumid} = #14{id} AND #16{moderatorpersonid} = #18{id} AND #25{locationcityid} = #28{id} AND #31{partofcountryid} = #32{id}) type=delta // { arity: 37 }
             implementation
               %0:message » %5[#0]UKA » %1:forum[#1]KA » %2:person[#1]KA » %3:city[#0]KA » %4:country[#0]KAef
@@ -1596,7 +1596,7 @@ Explained Query:
             ArrangeBy keys=[[#0{rootpostid}]] // { arity: 2 }
               Reduce group_by=[#0{rootpostid}] aggregates=[count(*)] // { arity: 2 }
                 Project (#2) // { arity: 1 }
-                  Filter (#0{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#0{creationdate} >= 2012-08-29 00:00:00 UTC) AND (#2{rootpostid}) IS NOT NULL // { arity: 13 }
+                  Filter (#0{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#0{creationdate} >= 2012-08-29 00:00:00 UTC) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
@@ -2576,11 +2576,10 @@ Explained Query:
                     ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                   ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
                     Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                      Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
-                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                   ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
                     Project (#9, #10, #12) // { arity: 3 }
-                      Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                      Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                         ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                   Get l2 // { arity: 1 }
                   Get l2 // { arity: 1 }
@@ -2751,13 +2750,11 @@ Explained Query:
               %1[#0]UK » %0:l17[#4]K
             ArrangeBy keys=[[#4]] // { arity: 5 }
               Project (#0..=#3, #5) // { arity: 5 }
-                Filter (#5) IS NOT NULL // { arity: 6 }
-                  Get l17 // { arity: 6 }
+                Get l17 // { arity: 6 }
             ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-              Filter (#0{max}) IS NOT NULL // { arity: 1 }
-                Reduce aggregates=[max(#0)] // { arity: 1 }
-                  Project (#5) // { arity: 1 }
-                    Get l17 // { arity: 6 }
+              Reduce aggregates=[max(#0)] // { arity: 1 }
+                Project (#5) // { arity: 1 }
+                  Get l17 // { arity: 6 }
   With Mutually Recursive
     cte l17 =
       Distinct project=[#0..=#5] // { arity: 6 }
@@ -2969,11 +2966,10 @@ Explained Query:
                   ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                 ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
                   Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                    Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
-                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                 ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
                   Project (#9, #10, #12) // { arity: 3 }
-                    Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                    Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                 Get l2 // { arity: 1 }
                 Get l2 // { arity: 1 }
@@ -3290,8 +3286,7 @@ Explained Query:
                 %4:l1 » %3:l1[#1]KA » %0:l0[#2]K » %1:l0[#2]K » %2:l0[#0, #1]KK
               ArrangeBy keys=[[#2{containerforumid}]] // { arity: 3 }
                 Project (#0{creationdate}, #2{containerforumid}, #3) // { arity: 3 }
-                  Filter (#3{containerforumid}) IS NOT NULL // { arity: 5 }
-                    Get l0 // { arity: 5 }
+                  Get l0 // { arity: 5 }
               ArrangeBy keys=[[#1{messageid}, #2{creatorpersonid}], [#2{creatorpersonid}]] // { arity: 4 }
                 Project (#0{creationdate}..=#3{containerforumid}) // { arity: 4 }
                   Get l0 // { arity: 5 }
@@ -3573,13 +3568,11 @@ Explained Query:
           implementation
             %1[#0]UK » %0:l1[#2]K
           ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-            Filter (#2{min}) IS NOT NULL // { arity: 3 }
-              Get l1 // { arity: 3 }
+            Get l1 // { arity: 3 }
           ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-            Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
-              Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                Project (#2) // { arity: 1 }
-                  Get l1 // { arity: 3 }
+            Reduce aggregates=[min(#0{min})] // { arity: 1 }
+              Project (#2) // { arity: 1 }
+                Get l1 // { arity: 3 }
     With
       cte l1 =
         Project (#0{id}..=#2{min}) // { arity: 3 }
@@ -3683,13 +3676,11 @@ Explained Query:
         implementation
           %1[#0]UK » %0:l5[#2]K
         ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-          Filter (#2{min}) IS NOT NULL // { arity: 3 }
-            Get l5 // { arity: 3 }
+          Get l5 // { arity: 3 }
         ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-          Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
-            Reduce aggregates=[min(#0{min})] // { arity: 1 }
-              Project (#2) // { arity: 1 }
-                Get l5 // { arity: 3 }
+          Reduce aggregates=[min(#0{min})] // { arity: 1 }
+            Project (#2) // { arity: 1 }
+              Get l5 // { arity: 3 }
   With Mutually Recursive
     cte l7 =
       Union // { arity: 1 }
@@ -3845,13 +3836,11 @@ Explained Query:
             implementation
               %1[#0]UK » %0:l9[#2]K
             ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-              Filter (#2{min}) IS NOT NULL // { arity: 3 }
-                Get l9 // { arity: 3 }
+              Get l9 // { arity: 3 }
             ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-              Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
-                Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                  Project (#2) // { arity: 1 }
-                    Get l9 // { arity: 3 }
+              Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                Project (#2) // { arity: 1 }
+                  Get l9 // { arity: 3 }
       With
         cte l9 =
           Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
@@ -3874,13 +3863,12 @@ Explained Query:
                 %1[#0]UK » %0:l7[#4]K
               ArrangeBy keys=[[#4]] // { arity: 5 }
                 Project (#0..=#3, #5) // { arity: 5 }
-                  Filter (#2{id}) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
+                  Filter (#2{id}) IS NOT NULL // { arity: 6 }
                     Get l7 // { arity: 6 }
               ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-                Filter (#0{max}) IS NOT NULL // { arity: 1 }
-                  Reduce aggregates=[max(#0)] // { arity: 1 }
-                    Project (#5) // { arity: 1 }
-                      Get l7 // { arity: 6 }
+                Reduce aggregates=[max(#0)] // { arity: 1 }
+                  Project (#5) // { arity: 1 }
+                    Get l7 // { arity: 6 }
     With Mutually Recursive
       cte l7 =
         Distinct project=[#0..=#5] // { arity: 6 }
@@ -4446,13 +4434,11 @@ Explained Query:
             implementation
               %1[#0]UK » %0:l14[#1]K
             ArrangeBy keys=[[#1{min}]] // { arity: 2 }
-              Filter (#1{min}) IS NOT NULL // { arity: 2 }
-                Get l14 // { arity: 2 }
+              Get l14 // { arity: 2 }
             ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-              Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
-                Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
-                    Get l14 // { arity: 2 }
+              Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Get l14 // { arity: 2 }
       With
         cte l14 =
           Project (#1{min}, #2) // { arity: 2 }
@@ -4476,13 +4462,11 @@ Explained Query:
                 %1[#0]UK » %0:l12[#4]K
               ArrangeBy keys=[[#4]] // { arity: 5 }
                 Project (#0..=#3, #5) // { arity: 5 }
-                  Filter (#5) IS NOT NULL // { arity: 6 }
-                    Get l12 // { arity: 6 }
+                  Get l12 // { arity: 6 }
               ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-                Filter (#0{max}) IS NOT NULL // { arity: 1 }
-                  Reduce aggregates=[max(#0)] // { arity: 1 }
-                    Project (#5) // { arity: 1 }
-                      Get l12 // { arity: 6 }
+                Reduce aggregates=[max(#0)] // { arity: 1 }
+                  Project (#5) // { arity: 1 }
+                    Get l12 // { arity: 6 }
     With Mutually Recursive
       cte l12 =
         Distinct project=[#0..=#5] // { arity: 6 }

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -624,7 +624,7 @@ Explained Query:
   Finish order_by=[#4{count} desc nulls_first, #0{containerforumid} asc nulls_last] limit=20 output=[#0..=#4]
     Reduce group_by=[#0{containerforumid}, #2{title}, #1{creationdate}, #3{moderatorpersonid}] aggregates=[count(*)] // { arity: 5 }
       Project (#10, #13, #15, #16) // { arity: 4 }
-        Filter (#33{name} = "China") AND (#10{containerforumid}) IS NOT NULL AND (#16{moderatorpersonid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
+        Filter (#33{name} = "China") AND (#16{moderatorpersonid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
           Join on=(#1{messageid} = #36{messageid} AND #10{containerforumid} = #14{id} AND #16{moderatorpersonid} = #18{id} AND #25{locationcityid} = #28{id} AND #31{partofcountryid} = #32{id}) type=delta // { arity: 37 }
             implementation
               %0:message » %5[#0]UKA » %1:forum[#1]KA » %2:person[#1]KA » %3:city[#0]KA » %4:country[#0]KAef
@@ -1603,7 +1603,7 @@ Explained Query:
             ArrangeBy keys=[[#0{rootpostid}]] // { arity: 2 }
               Reduce group_by=[#0{rootpostid}] aggregates=[count(*)] // { arity: 2 }
                 Project (#2) // { arity: 1 }
-                  Filter (#0{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#0{creationdate} >= 2012-08-29 00:00:00 UTC) AND (#2{rootpostid}) IS NOT NULL // { arity: 13 }
+                  Filter (#0{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#0{creationdate} >= 2012-08-29 00:00:00 UTC) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
@@ -2583,11 +2583,10 @@ Explained Query:
                     ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                   ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
                     Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                      Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
-                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                   ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
                     Project (#9, #10, #12) // { arity: 3 }
-                      Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                      Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                         ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                   Get l2 // { arity: 1 }
                   Get l2 // { arity: 1 }
@@ -2758,13 +2757,11 @@ Explained Query:
               %1[#0]UK » %0:l17[#4]K
             ArrangeBy keys=[[#4]] // { arity: 5 }
               Project (#0..=#3, #5) // { arity: 5 }
-                Filter (#5) IS NOT NULL // { arity: 6 }
-                  Get l17 // { arity: 6 }
+                Get l17 // { arity: 6 }
             ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-              Filter (#0{max}) IS NOT NULL // { arity: 1 }
-                Reduce aggregates=[max(#0)] // { arity: 1 }
-                  Project (#5) // { arity: 1 }
-                    Get l17 // { arity: 6 }
+              Reduce aggregates=[max(#0)] // { arity: 1 }
+                Project (#5) // { arity: 1 }
+                  Get l17 // { arity: 6 }
   With Mutually Recursive
     cte l17 =
       Distinct project=[#0..=#5] // { arity: 6 }
@@ -2976,11 +2973,10 @@ Explained Query:
                   ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                 ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
                   Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                    Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
-                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                 ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
                   Project (#9, #10, #12) // { arity: 3 }
-                    Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                    Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                 Get l2 // { arity: 1 }
                 Get l2 // { arity: 1 }
@@ -3297,8 +3293,7 @@ Explained Query:
                 %4:l1 » %3:l1[#1]KA » %0:l0[#2]K » %1:l0[#2]K » %2:l0[#0, #1]KK
               ArrangeBy keys=[[#2{containerforumid}]] // { arity: 3 }
                 Project (#0{creationdate}, #2{containerforumid}, #3) // { arity: 3 }
-                  Filter (#3{containerforumid}) IS NOT NULL // { arity: 5 }
-                    Get l0 // { arity: 5 }
+                  Get l0 // { arity: 5 }
               ArrangeBy keys=[[#1{messageid}, #2{creatorpersonid}], [#2{creatorpersonid}]] // { arity: 4 }
                 Project (#0{creationdate}..=#3{containerforumid}) // { arity: 4 }
                   Get l0 // { arity: 5 }
@@ -3580,13 +3575,11 @@ Explained Query:
           implementation
             %1[#0]UK » %0:l1[#2]K
           ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-            Filter (#2{min}) IS NOT NULL // { arity: 3 }
-              Get l1 // { arity: 3 }
+            Get l1 // { arity: 3 }
           ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-            Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
-              Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                Project (#2) // { arity: 1 }
-                  Get l1 // { arity: 3 }
+            Reduce aggregates=[min(#0{min})] // { arity: 1 }
+              Project (#2) // { arity: 1 }
+                Get l1 // { arity: 3 }
     With
       cte l1 =
         Project (#0{id}..=#2{min}) // { arity: 3 }
@@ -3690,13 +3683,11 @@ Explained Query:
         implementation
           %1[#0]UK » %0:l5[#2]K
         ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-          Filter (#2{min}) IS NOT NULL // { arity: 3 }
-            Get l5 // { arity: 3 }
+          Get l5 // { arity: 3 }
         ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-          Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
-            Reduce aggregates=[min(#0{min})] // { arity: 1 }
-              Project (#2) // { arity: 1 }
-                Get l5 // { arity: 3 }
+          Reduce aggregates=[min(#0{min})] // { arity: 1 }
+            Project (#2) // { arity: 1 }
+              Get l5 // { arity: 3 }
   With Mutually Recursive
     cte l7 =
       Union // { arity: 1 }
@@ -3852,13 +3843,11 @@ Explained Query:
             implementation
               %1[#0]UK » %0:l9[#2]K
             ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-              Filter (#2{min}) IS NOT NULL // { arity: 3 }
-                Get l9 // { arity: 3 }
+              Get l9 // { arity: 3 }
             ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-              Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
-                Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                  Project (#2) // { arity: 1 }
-                    Get l9 // { arity: 3 }
+              Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                Project (#2) // { arity: 1 }
+                  Get l9 // { arity: 3 }
       With
         cte l9 =
           Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
@@ -3881,13 +3870,12 @@ Explained Query:
                 %1[#0]UK » %0:l7[#4]K
               ArrangeBy keys=[[#4]] // { arity: 5 }
                 Project (#0..=#3, #5) // { arity: 5 }
-                  Filter (#2{id}) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
+                  Filter (#2{id}) IS NOT NULL // { arity: 6 }
                     Get l7 // { arity: 6 }
               ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-                Filter (#0{max}) IS NOT NULL // { arity: 1 }
-                  Reduce aggregates=[max(#0)] // { arity: 1 }
-                    Project (#5) // { arity: 1 }
-                      Get l7 // { arity: 6 }
+                Reduce aggregates=[max(#0)] // { arity: 1 }
+                  Project (#5) // { arity: 1 }
+                    Get l7 // { arity: 6 }
     With Mutually Recursive
       cte l7 =
         Distinct project=[#0..=#5] // { arity: 6 }
@@ -4453,13 +4441,11 @@ Explained Query:
             implementation
               %1[#0]UK » %0:l14[#1]K
             ArrangeBy keys=[[#1{min}]] // { arity: 2 }
-              Filter (#1{min}) IS NOT NULL // { arity: 2 }
-                Get l14 // { arity: 2 }
+              Get l14 // { arity: 2 }
             ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-              Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
-                Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
-                    Get l14 // { arity: 2 }
+              Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Get l14 // { arity: 2 }
       With
         cte l14 =
           Project (#1{min}, #2) // { arity: 2 }
@@ -4483,13 +4469,11 @@ Explained Query:
                 %1[#0]UK » %0:l12[#4]K
               ArrangeBy keys=[[#4]] // { arity: 5 }
                 Project (#0..=#3, #5) // { arity: 5 }
-                  Filter (#5) IS NOT NULL // { arity: 6 }
-                    Get l12 // { arity: 6 }
+                  Get l12 // { arity: 6 }
               ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-                Filter (#0{max}) IS NOT NULL // { arity: 1 }
-                  Reduce aggregates=[max(#0)] // { arity: 1 }
-                    Project (#5) // { arity: 1 }
-                      Get l12 // { arity: 6 }
+                Reduce aggregates=[max(#0)] // { arity: 1 }
+                  Project (#5) // { arity: 1 }
+                    Get l12 // { arity: 6 }
     With Mutually Recursive
       cte l12 =
         Distinct project=[#0..=#5] // { arity: 6 }

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -774,22 +774,22 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0;
 ----
 Explained Query:
-  Return // { arity: 3, types: "(integer, integer?, integer?)" }
-    Get l1 // { arity: 3, types: "(integer, integer?, integer?)" }
+  Return // { arity: 3, types: "(integer, integer, integer?)" }
+    Get l1 // { arity: 3, types: "(integer, integer, integer?)" }
   With Mutually Recursive
     cte l1 =
-      Project (#2, #0, #1) // { arity: 3, types: "(integer, integer?, integer?)" }
-        Map (2) // { arity: 3, types: "(integer?, integer?, integer)" }
-          Distinct project=[#0, #1] // { arity: 2, types: "(integer?, integer?)" }
-            Union // { arity: 2, types: "(integer?, integer?)" }
+      Project (#2, #0, #1) // { arity: 3, types: "(integer, integer, integer?)" }
+        Map (2) // { arity: 3, types: "(integer, integer?, integer)" }
+          Distinct project=[#0, #1] // { arity: 2, types: "(integer, integer?)" }
+            Union // { arity: 2, types: "(integer, integer?)" }
               CrossJoin type=differential // { arity: 2, types: "(integer, integer?)" }
                 ArrangeBy keys=[[]] // { arity: 0, types: "()" }
                   Project () // { arity: 0, types: "()" }
                     Get l0 // { arity: 1, types: "(integer)" }
                 ArrangeBy keys=[[]] // { arity: 2, types: "(integer, integer?)" }
                   ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
-              Project (#1, #2) // { arity: 2, types: "(integer?, integer?)" }
-                Get l1 // { arity: 3, types: "(integer, integer?, integer?)" }
+              Project (#1, #2) // { arity: 2, types: "(integer, integer?)" }
+                Get l1 // { arity: 3, types: "(integer, integer, integer?)" }
     cte l0 =
       Map (1) // { arity: 1, types: "(integer)" }
         Distinct project=[] monotonic // { arity: 0, types: "()" }
@@ -827,22 +827,22 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0;
 ----
 Explained Query:
-  Return // { arity: 3, types: "(boolean, integer?, integer?)" }
-    Get l1 // { arity: 3, types: "(boolean, integer?, integer?)" }
+  Return // { arity: 3, types: "(boolean, integer, integer?)" }
+    Get l1 // { arity: 3, types: "(boolean, integer, integer?)" }
   With Mutually Recursive
     cte l1 =
-      Project (#2, #0, #1) // { arity: 3, types: "(boolean, integer?, integer?)" }
-        Map (false) // { arity: 3, types: "(integer?, integer?, boolean)" }
-          Distinct project=[#0, #1] // { arity: 2, types: "(integer?, integer?)" }
-            Union // { arity: 2, types: "(integer?, integer?)" }
+      Project (#2, #0, #1) // { arity: 3, types: "(boolean, integer, integer?)" }
+        Map (false) // { arity: 3, types: "(integer, integer?, boolean)" }
+          Distinct project=[#0, #1] // { arity: 2, types: "(integer, integer?)" }
+            Union // { arity: 2, types: "(integer, integer?)" }
               CrossJoin type=differential // { arity: 2, types: "(integer, integer?)" }
                 ArrangeBy keys=[[]] // { arity: 0, types: "()" }
                   Project () // { arity: 0, types: "()" }
                     Get l0 // { arity: 1, types: "(integer)" }
                 ArrangeBy keys=[[]] // { arity: 2, types: "(integer, integer?)" }
                   ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
-              Project (#1, #2) // { arity: 2, types: "(integer?, integer?)" }
-                Get l1 // { arity: 3, types: "(boolean, integer?, integer?)" }
+              Project (#1, #2) // { arity: 2, types: "(integer, integer?)" }
+                Get l1 // { arity: 3, types: "(boolean, integer, integer?)" }
     cte l0 =
       Map (1) // { arity: 1, types: "(integer)" }
         Distinct project=[] monotonic // { arity: 0, types: "()" }


### PR DESCRIPTION
Our `RelationType` analysis was pessimistic, and wouldn't produce great nullability information going around `LetRec`s. This fixes that, in order to unblock #30429.

As it turns out, this unlocks more plan improvements than realized. Many instanced of column nullability were not being discovered, I suppose because our transforms trusted `Get` and didn't reconsider the possibility non-nullability? I'm not entirely sure, and perhaps we should carefully double check to make sure that we believe the changes (all "good", if correct).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
