### PR TITLE
build(deps): Allow Python 3.13

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -23,12 +23,12 @@ jupyter-black==0.3.4
 kubernetes==25.3.0
 kubernetes-stubs==22.6.0.post1
 launchdarkly-api==11.0.0
-matplotlib==3.9.0
+matplotlib==3.9.2
 matplotlib-stubs==0.2.0
 networkx==3.4.2
 networkx-stubs==0.0.1
-numpy==1.26.1
-pandas==2.1.2
+numpy==1.26.4
+pandas==2.2.3
 pandas-stubs==2.2.3.241009
 parameterized==0.8.1
 paramiko==3.4.1
@@ -48,14 +48,13 @@ pytest-split==0.9.0
 pyyaml==6.0.1
 requests==2.32.3
 ruff==0.0.292
-scipy==1.11.2
+scipy==1.14.1
 semver==3.0.0
 shtab==1.5.8
 sqlparse==0.5.0
 toml==0.10.2
 twine==5.1.1
 types-Markdown==3.6.0.20240316
-types-pkg-resources==0.1.3
 types-prettytable==3.4.2.3
 types-psutil==5.9.5.10
 types-PyMYSQL==1.1.0.20241103
@@ -63,7 +62,7 @@ types-PyYAML==6.0.12.20240917
 types-requests==2.32.0.20241016
 types-setuptools==75.3.0.20241107
 types-toml==0.10.8.20240310
-typing-extensions==4.11.0
+typing-extensions==4.12.2
 xxhash==3.4.1
 yamllint==1.35.1
 confluent-kafka==2.6.0
@@ -72,4 +71,4 @@ websocket-client==1.8.0
 pyarrow-stubs==17.11
 pyarrow==18.0.0
 minio==7.2.5
-zstandard==0.22.0
+zstandard==0.23.0


### PR DESCRIPTION
Verified that Python 3.11 still works too.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
