### PR TITLE
Revert "Merge pull request #30284 from teskje/as-of-step-back-migration"

### DIFF
--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -81,7 +81,6 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::rc::Rc;
 
-use differential_dataflow::lattice::Lattice;
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::plan::Plan;
 use mz_ore::collections::CollectionExt;
@@ -465,10 +464,19 @@ impl<'a, T: TimestampManipulation> Context<'a, T> {
                 continue;
             };
 
-            let storage_since = frontiers.read_capabilities;
-            let storage_upper = frontiers.write_frontier;
+            let collection_empty =
+                PartialOrder::less_equal(&frontiers.write_frontier, &frontiers.read_capabilities);
+            let upper = if collection_empty {
+                frontiers.read_capabilities
+            } else {
+                Antichain::from_iter(
+                    frontiers
+                        .write_frontier
+                        .iter()
+                        .map(|t| t.step_back().unwrap_or(T::minimum())),
+                )
+            };
 
-            let upper = storage_since.join(&storage_upper);
             let constraint = Constraint {
                 type_: ConstraintType::Hard,
                 bound_type: BoundType::Upper,
@@ -476,28 +484,6 @@ impl<'a, T: TimestampManipulation> Context<'a, T> {
                 reason: &format!("storage export {id} write frontier"),
             };
             self.apply_constraint(*id, constraint);
-
-            // Apply the stepping-back for non-empty storage outputs as a soft constraint, to allow
-            // upgrading from Mz versions that didn't hold input frontiers back sufficiently (see
-            // database-issues#8718). This technically permits violating correctness for CTs, but
-            // those haven't been publicly released yet.
-
-            // TODO(ct2): revert to a hard constraint in the next/a subsequent release
-            let collection_empty = PartialOrder::less_equal(&storage_upper, &storage_since);
-            if !collection_empty {
-                let upper = Antichain::from_iter(
-                    storage_upper
-                        .iter()
-                        .map(|t| t.step_back().unwrap_or(T::minimum())),
-                );
-                let constraint = Constraint {
-                    type_: ConstraintType::Soft,
-                    bound_type: BoundType::Upper,
-                    frontier: &upper,
-                    reason: &format!("storage export {id} write frontier"),
-                };
-                self.apply_constraint(*id, constraint);
-            }
         }
 
         // Propagate constraints upstream, restoring `AsOfBounds` invariant (2).


### PR DESCRIPTION
This reverts #30284. Now that a release has happened with the updated controller logic that holds back the inputs of MVs/CTs to `upper.step_back()`, as-of selection should always be able to select that frontier as the initial as-of.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8699

### Tips for reviewer

Note that production still could have MVs that didn't have their write frontier advanced during the last release(s), e.g., because they are installed on zero-replica clusters. For these the hard constraint re-introduced here will still fail to apply, but that only results in a logged error because hard constraint application fails with a soft panic. As-of bootstrapping will still proceed to select the correct as-of (i.e. the output shard's `upper`) in this case.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
