### PR TITLE
cargo test: Temporarily disable two flaky tests

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -1431,6 +1431,7 @@ fn test_storage_usage_collection_interval_timestamps() {
 }
 
 #[mz_ore::test]
+#[ignore] // TODO: Reenable when database-issues#8743 is fixed
 fn test_old_storage_usage_records_are_reaped_on_restart() {
     let now = Arc::new(Mutex::new(0));
     let now_fn = {

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -2345,6 +2345,7 @@ mod tests {
 
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
+    #[ignore] // TODO: Reenable when database-issues#8744 is fixed
     fn proptest_non_empty_relation_descs() {
         let strat = arb_relation_desc(1..8).prop_flat_map(|desc| {
             proptest::collection::vec(arb_row_for_relation(&desc), 0..12)


### PR DESCRIPTION
See https://github.com/MaterializeInc/database-issues/issues/8744 and https://github.com/MaterializeInc/database-issues/issues/8743

Failures seen in https://buildkite.com/materialize/test/builds/94424 and https://buildkite.com/materialize/test/builds/94431

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
