### PR TITLE
Update to Timely 0.14.1 and Differential 0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "differential-dataflow"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5ad19c6ddddedba008bf9626348810ff5171de9cad62406cd4e9ea291fa8d1"
+checksum = "c437c8688c813b36da4823af3562607dca0bface950206afccec6bb8ef7f762b"
 dependencies = [
  "fnv",
  "serde",
@@ -2050,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "differential-dogs3"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd672f3f2167a08496c0ba47206e1c857b75abd14a7c560d1a7da2e07ee08cb1"
+checksum = "5a4c2c8d32c7fc5ac4f0412d45ec8b019478a69e82e570f8f892156ae542d95e"
 dependencies = [
  "differential-dataflow",
  "serde",
@@ -9784,9 +9784,9 @@ dependencies = [
 
 [[package]]
 name = "timely"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b6f390cec7160992fd8502fe02064a0f52dcfd2978544f4999f18664b709aa"
+checksum = "7a4794ec27c59ae109928ce1273a16633d324268bca4538c7e40e6c4608b40a3"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -9807,11 +9807,10 @@ checksum = "1f8a545b35b019b8b63afb913214695f542cbbf39032c7b7349e1a15b7f2a2cf"
 
 [[package]]
 name = "timely_communication"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22d602b340fd8d5d4128660a577f7886070098b860dc9a9aa46512a2e0d683b4"
+checksum = "0dad90c2eb029d4ed8d8c7f26c326b1ec86a5104d38e3ec94fdefdd995a944a5"
 dependencies = [
- "bincode",
  "byteorder",
  "crossbeam-channel",
  "getopts",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -1737,13 +1737,13 @@ end = "2024-11-16"
 criteria = "safe-to-deploy"
 user-id = 704 # Frank McSherry (frankmcsherry)
 start = "2019-03-31"
-end = "2024-11-21"
+end = "2025-12-31"
 
 [[trusted.differential-dogs3]]
 criteria = "safe-to-deploy"
 user-id = 704 # Frank McSherry (frankmcsherry)
 start = "2019-03-31"
-end = "2024-11-21"
+end = "2025-12-31"
 
 [[trusted.dyn-clone]]
 criteria = "safe-to-deploy"
@@ -2157,31 +2157,31 @@ end = "2024-11-16"
 criteria = "safe-to-deploy"
 user-id = 704 # Frank McSherry (frankmcsherry)
 start = "2019-03-31"
-end = "2024-11-21"
+end = "2025-12-31"
 
 [[trusted.timely_bytes]]
 criteria = "safe-to-deploy"
 user-id = 704 # Frank McSherry (frankmcsherry)
 start = "2019-03-31"
-end = "2024-11-21"
+end = "2025-12-31"
 
 [[trusted.timely_communication]]
 criteria = "safe-to-deploy"
 user-id = 704 # Frank McSherry (frankmcsherry)
 start = "2019-03-31"
-end = "2024-11-21"
+end = "2025-12-31"
 
 [[trusted.timely_container]]
 criteria = "safe-to-deploy"
 user-id = 704 # Frank McSherry (frankmcsherry)
 start = "2024-10-29"
-end = "2029-10-28"
+end = "2025-12-31"
 
 [[trusted.timely_logging]]
 criteria = "safe-to-deploy"
 user-id = 704 # Frank McSherry (frankmcsherry)
 start = "2019-03-31"
-end = "2024-11-21"
+end = "2025-12-31"
 
 [[trusted.tokio-macros]]
 criteria = "safe-to-deploy"

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -17,9 +17,6 @@ url = "https://raw.githubusercontent.com/google/supply-chain/main/audits.toml"
 [imports.mozilla]
 url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 
-[policy.differential-dataflow]
-audit-as-crates-io = true
-
 [policy.eventsource-client]
 audit-as-crates-io = true
 
@@ -76,18 +73,6 @@ audit-as-crates-io = true
 audit-as-crates-io = true
 
 [policy.serde-value]
-audit-as-crates-io = true
-
-[policy.timely]
-audit-as-crates-io = true
-
-[policy.timely_bytes]
-audit-as-crates-io = true
-
-[policy.timely_communication]
-audit-as-crates-io = true
-
-[policy.timely_logging]
 audit-as-crates-io = true
 
 [policy.tokio-postgres]

--- a/misc/cargo-vet/imports.lock
+++ b/misc/cargo-vet/imports.lock
@@ -280,9 +280,23 @@ user-id = 704
 user-login = "frankmcsherry"
 user-name = "Frank McSherry"
 
+[[publisher.differential-dataflow]]
+version = "0.13.1"
+when = "2024-11-11"
+user-id = 704
+user-login = "frankmcsherry"
+user-name = "Frank McSherry"
+
 [[publisher.differential-dogs3]]
 version = "0.1.0"
 when = "2024-10-29"
+user-id = 704
+user-login = "frankmcsherry"
+user-name = "Frank McSherry"
+
+[[publisher.differential-dogs3]]
+version = "0.1.1"
+when = "2024-11-11"
 user-id = 704
 user-login = "frankmcsherry"
 user-name = "Frank McSherry"
@@ -693,8 +707,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.timely]]
-version = "0.13.0"
-when = "2024-10-29"
+version = "0.14.1"
+when = "2024-11-12"
 user-id = 704
 user-login = "frankmcsherry"
 user-name = "Frank McSherry"
@@ -707,8 +721,8 @@ user-login = "frankmcsherry"
 user-name = "Frank McSherry"
 
 [[publisher.timely_communication]]
-version = "0.13.0"
-when = "2024-10-29"
+version = "0.14.0"
+when = "2024-11-11"
 user-id = 704
 user-login = "frankmcsherry"
 user-name = "Frank McSherry"

--- a/src/adapter-types/Cargo.toml
+++ b/src/adapter-types/Cargo.toml
@@ -15,7 +15,7 @@ mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }
 mz-storage-types = { path = "../storage-types" }
 serde = "1.0.152"
-timely = "0.13.0"
+timely = "0.14.1"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 dec = "0.4.8"
 deadpool-postgres = "0.10.3"
 derivative = "2.2.0"
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 enum-kinds = "0.5.1"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
@@ -94,7 +94,7 @@ serde_plain = "1.0.1"
 sha2 = "0.10.6"
 smallvec = { version = "1.10.0", features = ["union"] }
 static_assertions = "1.1"
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = { version = "1.38.0", features = ["rt", "time"] }
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = "0.1.11"

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -18,7 +18,7 @@ bytesize = "1.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 clap = { version = "3.2.24", features = ["derive"] }
 derivative = "2.2.0"
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
 ipnet = "2.5.0"
@@ -64,7 +64,7 @@ smallvec = { version = "1.10.0", features = ["union"] }
 static_assertions = "1.1"
 sha2 = "0.10.6"
 thiserror = "1.0.37"
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = { version = "1.38.0" }
 tracing = "0.1.37"
 uuid = "1.2.2"

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -16,7 +16,7 @@ bytesize = "1.1.0"
 clap = { version = "3.2.24", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
 dec = { version = "0.4.8", features = ["serde"] }
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 futures = "0.3.25"
 mz-build-info = { path = "../build-info" }
 mz-cluster-client = { path = "../cluster-client" }
@@ -33,7 +33,7 @@ rocksdb = { version = "0.22.0", default-features = false, features = ["snappy", 
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -37,7 +37,7 @@ mz-storage-client = { path = "../storage-client" }
 mz-storage-types = { path = "../storage-types" }
 mz-timely-util = { path = "../timely-util" }
 mz-txn-wal = { path = "../txn-wal" }
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util"] }
 tower = "0.4.13"
 tracing = "0.1.37"

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -17,7 +17,7 @@ bytes = "1.3.0"
 bytesize = "1.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.8"
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 futures = "0.3.25"
 http = "1.1.0"
 mz-build-info = { path = "../build-info" }
@@ -47,7 +47,7 @@ regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.125"
 thiserror = "1.0.37"
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tonic = "0.12.1"

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -89,7 +89,7 @@ type StorageCollections<T> = Arc<
 
 /// A composite trait for types that serve as timestamps in the Compute Controller.
 /// `Into<Datum<'a>>` is needed for writing timestamps to introspection collections.
-pub trait ComputeControllerTimestamp: TimestampManipulation + Into<Datum<'static>> {}
+pub trait ComputeControllerTimestamp: TimestampManipulation + Into<Datum<'static>> + Sync {}
 
 impl ComputeControllerTimestamp for mz_repr::Timestamp {}
 

--- a/src/compute-types/Cargo.toml
+++ b/src/compute-types/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 columnation = "0.1.0"
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 itertools = "0.10.5"
 mz-dyncfg = { path = "../dyncfg" }
 mz-expr = { path = "../expr" }
@@ -23,7 +23,7 @@ proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
-timely = "0.13.0"
+timely = "0.14.1"
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -17,8 +17,8 @@ bytesize = "1.1.0"
 clap = { version = "3.2.24", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
 dec = { version = "0.4.8", features = ["serde"] }
-differential-dataflow = "0.13.0"
-differential-dogs3 = "0.1.0"
+differential-dataflow = "0.13.1"
+differential-dogs3 = "0.1.1"
 futures = "0.3.25"
 itertools = "0.10.5"
 lgalloc = "0.3"
@@ -43,7 +43,7 @@ prometheus = { version = "0.13.3", default-features = false }
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -221,13 +221,11 @@ where
     let stream = arranged
         .stream
         .unary(Pipeline, "ArrangementSize", |_cap, info| {
-            let mut buffer = Default::default();
             let address = info.address;
             logger.log(ComputeEvent::ArrangementHeapSizeOperator { operator, address });
             move |input, output| {
                 while let Some((time, data)) = input.next() {
-                    data.swap(&mut buffer);
-                    output.session(&time).give_container(&mut buffer);
+                    output.session(&time).give_container(data);
                 }
                 let Some(trace) = trace.upgrade() else {
                     return;

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -83,7 +83,6 @@ pub(super) fn construct<A: Allocate>(
         let (mut batcher_capacity_out, batcher_capacity) = demux.new_output();
         let (mut batcher_allocations_out, batcher_allocations) = demux.new_output();
 
-        let mut demux_buffer = Vec::new();
         let mut demux_state = Default::default();
         demux.build(move |_capability| {
             move |_frontiers| {
@@ -106,9 +105,7 @@ pub(super) fn construct<A: Allocate>(
                         batcher_allocations: batcher_allocations.session_with_builder(&cap),
                     };
 
-                    data.swap(&mut demux_buffer);
-
-                    for (time, logger_id, event) in demux_buffer.drain(..) {
+                    for (time, logger_id, event) in data.drain(..) {
                         // We expect the logging infrastructure to not shuffle events between
                         // workers and this code relies on the assumption that each worker handles
                         // its own events.

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -89,7 +89,6 @@ pub(super) fn construct<A: Allocate>(
         let (mut batches_received_out, batches_received) = demux.new_output();
 
         let mut demux_state = DemuxState::default();
-        let mut demux_buffer = Vec::new();
         demux.build(move |_capability| {
             move |_frontiers| {
                 let mut operates = operates_out.activate();
@@ -117,9 +116,7 @@ pub(super) fn construct<A: Allocate>(
                         batches_received: batches_received.session_with_builder(&cap),
                     };
 
-                    data.swap(&mut demux_buffer);
-
-                    for (time, logger_id, event) in demux_buffer.drain(..) {
+                    for (time, logger_id, event) in data.drain(..) {
                         // We expect the logging infrastructure to not shuffle events between
                         // workers and this code relies on the assumption that each worker handles
                         // its own events.

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -39,7 +39,6 @@ where
         let until = self.until.clone();
         let mfp_plan = mfp.into_plan().expect("MapFilterProject planning failed");
         let (ok_collection, err_collection) = input.as_specific_collection(input_key.as_deref());
-        let mut storage = Vec::new();
         let stream = ok_collection.inner;
         let (oks, errs) = stream.unary_fallible(Pipeline, "FlatMapStage", move |_, _| {
             Box::new(move |input, ok_output, err_output| {
@@ -50,12 +49,10 @@ where
                 let mut table_func_output = Vec::new();
 
                 input.for_each(|cap, data| {
-                    data.swap(&mut storage);
-
                     let mut ok_session = ok_output.session_with_builder(&cap);
                     let mut err_session = err_output.session_with_builder(&cap);
 
-                    'input: for (input_row, time, diff) in storage.drain(..) {
+                    'input: for (input_row, time, diff) in data.drain(..) {
                         let temp_storage = RowArena::new();
 
                         // Unpack datums for expression evaluation.

--- a/src/compute/src/render/join/mz_join_core.rs
+++ b/src/compute/src/render/join/mz_join_core.rs
@@ -213,10 +213,6 @@ where
             let mut trace1_option = Some(trace1);
             let mut trace2_option = Some(trace2);
 
-            // Swappable buffers for input extraction.
-            let mut input1_buffer = Vec::new();
-            let mut input2_buffer = Vec::new();
-
             move |input1, input2, output| {
                 // If the dataflow is shutting down, discard all existing and future work.
                 if shutdown_token.in_shutdown() {
@@ -256,8 +252,7 @@ where
                         .as_mut()
                         .expect("we only drop a trace in response to the other input emptying");
                     let capability = capability.retain();
-                    data.swap(&mut input1_buffer);
-                    for batch1 in input1_buffer.drain(..) {
+                    for batch1 in data.drain(..) {
                         // Ignore any pre-loaded data.
                         if PartialOrder::less_equal(&acknowledged1, batch1.lower()) {
                             trace!(
@@ -313,8 +308,7 @@ where
                         .as_mut()
                         .expect("we only drop a trace in response to the other input emptying");
                     let capability = capability.retain();
-                    data.swap(&mut input2_buffer);
-                    for batch2 in input2_buffer.drain(..) {
+                    for batch2 in data.drain(..) {
                         // Ignore any pre-loaded data.
                         if PartialOrder::less_equal(&acknowledged2, batch2.lower()) {
                             trace!(

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -657,7 +657,6 @@ where
     let mut datum_vec = mz_repr::DatumVec::new();
 
     let mut aggregates = BTreeMap::new();
-    let mut vector = Vec::new();
     let shared = Rc::new(RefCell::new(monoids::Top1MonoidShared {
         order_key,
         left: DatumVec::new(),
@@ -671,11 +670,10 @@ where
             [],
             move |input, output, notificator| {
                 while let Some((time, data)) = input.next() {
-                    data.swap(&mut vector);
                     let agg_time = aggregates
                         .entry(time.time().clone())
                         .or_insert_with(BTreeMap::new);
-                    for ((grp_row, row), record_time, diff) in vector.drain(..) {
+                    for ((grp_row, row), record_time, diff) in data.drain(..) {
                         let monoid = monoids::Top1MonoidLocal {
                             row,
                             shared: Rc::clone(&shared),

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -352,7 +352,6 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
             let cmd_queue = Rc::clone(&cmd_queue);
 
             move |scope| {
-                let mut container = Default::default();
                 source(scope, "CmdSource", |capability, info| {
                     // Send activator for this operator back.
                     let activator = scope.sync_activator_for(info.address.to_vec());
@@ -418,8 +417,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                             queue.push_back(Err(TryRecvError::Disconnected))
                         }
                         while let Some((_, data)) = input.next() {
-                            data.swap(&mut container);
-                            for (_, cmd) in container.drain(..) {
+                            for (_, cmd) in data.drain(..) {
                                 queue.push_back(Ok(cmd));
                             }
                         }

--- a/src/compute/src/sink/copy_to_s3_oneshot.rs
+++ b/src/compute/src/sink/copy_to_s3_oneshot.rs
@@ -100,14 +100,12 @@ where
                 .inner
                 .unary_frontier(Pipeline, "COPY TO S3 error filtering", |_cap, _info| {
                     let up_to = sink.up_to.clone();
-                    let mut vector = Vec::new();
                     let mut received_one = false;
                     move |input, output| {
                         while let Some((time, data)) = input.next() {
                             if !up_to.less_equal(time.time()) && !received_one {
                                 received_one = true;
-                                data.swap(&mut vector);
-                                output.session(&time).give_iterator(vector.drain(..1));
+                                output.session(&time).give_iterator(data.drain(..1));
                             }
                         }
                     }

--- a/src/compute/src/sink/refresh.rs
+++ b/src/compute/src/sink/refresh.rs
@@ -43,7 +43,6 @@ where
         // the empty output frontier when the last refresh is done. (We must be careful that we only
         // ever emit output updates at times that are at or beyond this capability.)
         let mut capability = capabilities.into_iter().next(); // (We have 1 one input.)
-        let mut buffer = Vec::new();
         move |frontiers| {
             let mut output_handle_core = output_buf.activate();
             input.for_each(|input_cap, data| {
@@ -63,10 +62,9 @@ where
                 };
                 let mut output_buf = output_handle_core.session_with_builder(&capability);
 
-                data.swap(&mut buffer);
                 let mut cached_ts: Option<Timestamp> = None;
                 let mut cached_rounded_up_data_ts = None;
-                for (d, ts, r) in buffer.drain(..) {
+                for (d, ts, r) in data.drain(..) {
                     let rounded_up_data_ts = {
                         // We cache the rounded up timestamp for the last seen timestamp,
                         // because the rounding up has a non-negligible cost. Caching for

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -97,8 +97,6 @@ fn subscribe<G>(
         let mut rows_to_emit = Vec::new();
         let mut errors_to_emit = Vec::new();
         let mut finished = false;
-        let mut ok_buf = Default::default();
-        let mut err_buf = Default::default();
 
         move |frontiers| {
             if finished {
@@ -124,16 +122,14 @@ fn subscribe<G>(
             };
 
             ok_input.for_each(|_, data| {
-                data.swap(&mut ok_buf);
-                for (row, time, diff) in ok_buf.drain(..) {
+                for (row, time, diff) in data.drain(..) {
                     if should_emit(&time) {
                         rows_to_emit.push((time, row, diff));
                     }
                 }
             });
             err_input.for_each(|_, data| {
-                data.swap(&mut err_buf);
-                for (error, time, diff) in err_buf.drain(..) {
+                for (error, time, diff) in data.drain(..) {
                     if should_emit(&time) {
                         errors_to_emit.push((time, error, diff));
                     }

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.66"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 futures = "0.3.25"
 mz-build-info = { path = "../build-info" }
 mz-cluster-client = { path = "../cluster-client" }
@@ -33,7 +33,7 @@ mz-txn-wal = { path = "../txn-wal" }
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.125"
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tracing = "0.1.37"

--- a/src/durable-cache/Cargo.toml
+++ b/src/durable-cache/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1.68"
 bytes = { version = "1.3.0" }
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 futures = "0.3.25"
 itertools = { version = "0.10.5" }
 mz-ore = { path = "../ore", features = ["process"] }
@@ -23,7 +23,7 @@ mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = { version = "1.38.0", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -149,7 +149,7 @@ reqwest = { version = "0.11.13", features = ["blocking"] }
 serde_json = "1.0.125"
 serde_urlencoded = "0.7.1"
 similar-asserts = "1.4"
-timely = "0.13.0"
+timely = "0.14.1"
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4"] }
 
 [build-dependencies]

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -59,7 +59,7 @@ serde_json = "1.0.125"
 sha1 = "0.10.5"
 sha2 = "0.10.6"
 subtle = "2.4.1"
-timely = "0.13.0"
+timely = "0.14.1"
 tracing = "0.1.37"
 uncased = "0.9.7"
 uuid = { version = "1.7.0", features = ["v5"] }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -20,7 +20,7 @@ byteorder = "1.4.3"
 bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 clap = { version = "3.2.24", features = ["derive"] }
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 itertools = "0.10.5"
 maplit = "1.0.2"
 mz-avro = { path = "../avro", features = ["snappy"] }
@@ -33,7 +33,7 @@ prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 prost-reflect = "0.14.2"
 seahash = "4"
 serde_json = "1.0.125"
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = { version = "1.38.0", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde"] }

--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -47,15 +47,13 @@ where
     Tr::Batch: Batch,
     for<'a> Tr::TimeGat<'a>: Ord,
 {
-    let mut rows_buf = vec![];
     let x: Stream<G, ((Option<Row>, Vec<DiffPair<Row>>), G::Timestamp, Diff)> = arranged
         .stream
         .unary(Pipeline, "combine_at_timestamp", move |_, _| {
             move |input, output| {
                 while let Some((cap, batches)) = input.next() {
                     let mut session = output.session(&cap);
-                    batches.swap(&mut rows_buf);
-                    for batch in rows_buf.drain(..) {
+                    for batch in batches.drain(..) {
                         let mut befores = vec![];
                         let mut afters = vec![];
 

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -23,7 +23,7 @@ async-trait = "0.1.68"
 axum = "0.7.5"
 bytes = { version = "1.3.0", features = ["serde"] }
 clap = { version = "3.2.24", features = ["derive", "env"] }
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 futures = "0.3.25"
 humantime = "2.1.0"
 mz-http-util = { path = "../http-util" }
@@ -40,7 +40,7 @@ num_enum = "0.5.7"
 prometheus = { version = "0.13.3", default-features = false }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.125"
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 url = "2.3.1"

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -35,7 +35,7 @@ async-stream = "0.3.3"
 async-trait = "0.1.68"
 bytes = { version = "1.3.0", features = ["serde"] }
 clap = { version = "3.2.24", features = ["derive"] }
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 futures = "0.3.25"
 futures-util = "0.3"
 h2 = "0.3.13"
@@ -59,7 +59,7 @@ sentry-tracing = "0.29.1"
 semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.125"
-timely = "0.13.0"
+timely = "0.14.1"
 thiserror = "1.0.37"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tokio-metrics = "0.3.0"

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -327,7 +327,7 @@ impl<K, V, T, D> DynState for LockingTypedState<K, V, T, D>
 where
     K: Codec,
     V: Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Codec64,
 {
     fn codecs(&self) -> (String, String, String, String, Option<CodecConcreteType>) {
@@ -434,7 +434,7 @@ impl StateCache {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Codec64,
         F: Future<Output = Result<TypedState<K, V, T, D>, Box<CodecMismatch>>>,
         InitFn: FnMut() -> F,

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -425,7 +425,7 @@ pub async fn force_compaction<K, V, T, D>(
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Ord + Codec64 + Send + Sync,
 {
     let metrics = Arc::new(Metrics::new(&cfg, metrics_registry));
@@ -564,7 +564,7 @@ async fn make_typed_machine<K, V, T, D>(
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64,
 {
     let state_versions = Arc::new(StateVersions::new(
@@ -721,7 +721,7 @@ pub async fn dangerous_force_compaction_and_break_pushdown<K, V, T, D>(
 ) where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Ord + Codec64 + Send + Sync,
 {
     let machine = write.machine.clone();

--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -113,7 +113,7 @@ impl<K, V, T, D, O> SinceHandle<K, V, T, D, O>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64 + Send + Sync,
     O: Opaque + Codec64,
 {

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -129,7 +129,7 @@ impl<K, V, T, D> BatchFetcher<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64 + Send + Sync,
 {
     /// Takes a [`SerdeLeasedBatchPart`] into a [`LeasedBatchPart`].
@@ -339,7 +339,7 @@ pub(crate) async fn fetch_leased_part<K, V, T, D>(
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64 + Send + Sync,
 {
     let encoded_part = EncodedPart::fetch(

--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -87,7 +87,7 @@ impl<K, V, T, D> Applier<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64,
 {
     pub async fn new(

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -148,7 +148,7 @@ impl<K, V, T, D> Compactor<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Ord + Codec64 + Send + Sync,
 {
     pub fn new(

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -113,7 +113,7 @@ impl<K, V, T, D> GarbageCollector<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64,
 {
     pub fn new(machine: Machine<K, V, T, D>, isolated_runtime: Arc<IsolatedRuntime>) -> Self {

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -109,7 +109,7 @@ impl<K, V, T, D> Machine<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64,
 {
     pub async fn new(
@@ -1177,7 +1177,7 @@ impl<K, V, T, D> Machine<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64 + Send + Sync,
 {
     #[allow(clippy::unused_async)]

--- a/src/persist-client/src/internal/maintenance.rs
+++ b/src/persist-client/src/internal/maintenance.rs
@@ -57,7 +57,7 @@ impl RoutineMaintenance {
     ) where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Codec64 + Send + Sync,
     {
         let _ = self.perform_in_background(machine, gc);
@@ -75,7 +75,7 @@ impl RoutineMaintenance {
     ) where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Codec64 + Send + Sync,
     {
         let mut more_maintenance = RoutineMaintenance::default();
@@ -103,7 +103,7 @@ impl RoutineMaintenance {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Codec64 + Send + Sync,
     {
         let mut futures = vec![];
@@ -184,7 +184,7 @@ impl<T> Default for WriterMaintenance<T> {
 
 impl<T> WriterMaintenance<T>
 where
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
 {
     /// Initiates any writer maintenance necessary in background tasks
     pub(crate) fn start_performing<K, V, D>(

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -563,7 +563,7 @@ impl std::fmt::Display for MissingBlob {
 
 impl std::error::Error for MissingBlob {}
 
-impl<T: Timestamp + Codec64> RunPart<T> {
+impl<T: Timestamp + Codec64 + Sync> RunPart<T> {
     pub fn part_stream<'a>(
         &'a self,
         shard_id: ShardId,
@@ -806,7 +806,7 @@ impl<T: Ord> Ord for HollowBatch<T> {
     }
 }
 
-impl<T: Timestamp + Codec64> HollowBatch<T> {
+impl<T: Timestamp + Codec64 + Sync> HollowBatch<T> {
     pub fn part_stream<'a>(
         &'a self,
         shard_id: ShardId,

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -492,7 +492,7 @@ where
 
 impl<T, D, Sort> Consolidator<T, D, Sort>
 where
-    T: Timestamp + Codec64 + Lattice,
+    T: Timestamp + Codec64 + Lattice + Sync,
     D: Codec64 + Semigroup + Ord,
     Sort: RowSort<T, D>,
 {

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -240,7 +240,7 @@ impl PersistClient {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Codec64 + Send + Sync,
     {
         let state_versions = StateVersions::new(
@@ -292,7 +292,7 @@ impl PersistClient {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Ord + Codec64 + Send + Sync,
     {
         Ok((
@@ -334,7 +334,7 @@ impl PersistClient {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Codec64 + Send + Sync,
     {
         let machine = self.make_machine(shard_id, diagnostics.clone()).await?;
@@ -386,7 +386,7 @@ impl PersistClient {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Codec64 + Send + Sync,
     {
         let machine = self.make_machine(shard_id, diagnostics.clone()).await?;
@@ -465,7 +465,7 @@ impl PersistClient {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Codec64 + Send + Sync,
         O: Opaque + Codec64,
     {
@@ -506,7 +506,7 @@ impl PersistClient {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Ord + Codec64 + Send + Sync,
     {
         let machine = self.make_machine(shard_id, diagnostics.clone()).await?;
@@ -559,7 +559,7 @@ impl PersistClient {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Codec64 + Send + Sync,
     {
         let machine = self
@@ -577,7 +577,7 @@ impl PersistClient {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Codec64 + Send + Sync,
     {
         let machine = self
@@ -607,7 +607,7 @@ impl PersistClient {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Codec64 + Send + Sync,
     {
         if !DANGEROUS_ENABLE_SCHEMA_EVOLUTION.get(&self.cfg.configs) {
@@ -636,7 +636,7 @@ impl PersistClient {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Codec64 + Send + Sync,
     {
         let machine = self
@@ -664,7 +664,7 @@ impl PersistClient {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Codec64 + Send + Sync,
     {
         let machine = self
@@ -718,7 +718,7 @@ impl PersistClient {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Ord + Codec64 + Send + Sync,
         K::Schema: Default,
         V::Schema: Default,

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -92,7 +92,7 @@ where
     F: FnMut(&PartStats, AntichainRef<G::Timestamp>) -> bool + 'static,
     G: Scope,
     // TODO: Figure out how to get rid of the TotalOrder bound :(.
-    G::Timestamp: Timestamp + Lattice + Codec64 + TotalOrder,
+    G::Timestamp: Timestamp + Lattice + Codec64 + TotalOrder + Sync,
     T: Refines<G::Timestamp>,
     DT: FnOnce(
         Child<'g, G, T>,
@@ -245,7 +245,7 @@ where
     F: FnMut(&PartStats, AntichainRef<G::Timestamp>) -> bool + 'static,
     G: Scope,
     // TODO: Figure out how to get rid of the TotalOrder bound :(.
-    G::Timestamp: Timestamp + Lattice + Codec64 + TotalOrder,
+    G::Timestamp: Timestamp + Lattice + Codec64 + TotalOrder + Sync,
 {
     let worker_index = scope.index();
     let num_workers = scope.peers();
@@ -541,7 +541,7 @@ pub(crate) fn shard_source_fetch<K, V, T, D, G>(
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64 + Send + Sync,
     G: Scope,
     G::Timestamp: Refines<T>,

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -114,7 +114,7 @@ impl<K, V, T, D> Subscribe<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64 + Send + Sync,
 {
     fn new(snapshot_parts: Vec<LeasedBatchPart<T>>, listen: Listen<K, V, T, D>) -> Self {
@@ -151,7 +151,7 @@ impl<K, V, T, D> Subscribe<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64 + Send + Sync,
 {
     /// Equivalent to `next`, but rather than returning a [`LeasedBatchPart`],
@@ -196,7 +196,7 @@ impl<K, V, T, D> Subscribe<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64 + Send + Sync,
 {
     /// Politely expires this subscribe, releasing its lease.
@@ -239,7 +239,7 @@ impl<K, V, T, D> Listen<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64 + Send + Sync,
 {
     async fn new(mut handle: ReadHandle<K, V, T, D>, as_of: Antichain<T>) -> Self {
@@ -366,7 +366,7 @@ impl<K, V, T, D> Listen<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64 + Send + Sync,
 {
     /// Attempt to pull out the next values of this subscription.
@@ -441,7 +441,7 @@ impl<K, V, T, D> Listen<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64 + Send + Sync,
 {
     /// Fetches the contents of `part` and returns its lease.
@@ -526,7 +526,7 @@ impl<K, V, T, D> ReadHandle<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64 + Send + Sync,
 {
     pub(crate) async fn new(
@@ -938,7 +938,7 @@ impl<K, V, T, D> Cursor<K, V, T, D>
 where
     K: Debug + Codec + Ord,
     V: Debug + Codec + Ord,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Ord + Codec64 + Send + Sync,
 {
     /// Grab the next batch of consolidated data.
@@ -1002,7 +1002,7 @@ impl<K, V, T, D> ReadHandle<K, V, T, D>
 where
     K: Debug + Codec + Ord,
     V: Debug + Codec + Ord,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Ord + Codec64 + Send + Sync,
 {
     /// Generates a [Self::snapshot], and fetches all of the batches it
@@ -1197,7 +1197,7 @@ impl<K, V, T, D> ReadHandle<K, V, T, D>
 where
     K: Debug + Codec + Ord,
     V: Debug + Codec + Ord,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64 + Send + Sync,
 {
     /// Generates a [Self::snapshot], and streams out all of the updates
@@ -1247,7 +1247,7 @@ impl<K, V, T, D> ReadHandle<K, V, T, D>
 where
     K: Debug + Codec + Ord,
     V: Debug + Codec + Ord,
-    T: Timestamp + Lattice + Codec64 + Ord,
+    T: Timestamp + Lattice + Codec64 + Ord + Sync,
     D: Semigroup + Ord + Codec64 + Send + Sync,
 {
     /// Test helper to generate a [Self::snapshot] call that is expected to

--- a/src/persist-client/src/schema.rs
+++ b/src/persist-client/src/schema.rs
@@ -93,7 +93,7 @@ impl<K, V, T, D> SchemaCache<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Codec64,
 {
     pub fn new(maps: Arc<SchemaCacheMaps<K, V>>, applier: Applier<K, V, T, D>) -> Self {
@@ -342,7 +342,7 @@ where
         schema_cache: &mut SchemaCache<K, V, T, D>,
     ) -> Result<Self, Schemas<K, V>>
     where
-        T: Timestamp + Lattice + Codec64,
+        T: Timestamp + Lattice + Codec64 + Sync,
         D: Semigroup + Codec64,
     {
         match (write, read.id) {

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -127,7 +127,7 @@ impl<K, V, T, D> WriteHandle<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
+    T: Timestamp + Lattice + Codec64 + Sync,
     D: Semigroup + Ord + Codec64 + Send + Sync,
 {
     pub(crate) fn new(

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -26,7 +26,7 @@ proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
-timely = "0.13.0"
+timely = "0.14.1"
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -33,7 +33,7 @@ aws-types = "1.1.1"
 base64 = "0.13.1"
 bytes = "1.3.0"
 deadpool-postgres = "0.10.3"
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures-util = "0.3.25"
 md-5 = "0.10.5"
@@ -54,7 +54,7 @@ proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.152", features = ["derive"] }
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = { version = "1.38.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -36,7 +36,7 @@ chrono = { version = "0.4.35", default-features = false, features = ["serde", "s
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
 compact_bytes = "0.1.2"
 dec = "0.4.8"
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 enum-kinds = "0.5.1"
 flatcontainer = "0.5.0"
 hex = "0.4.3"
@@ -68,7 +68,7 @@ serde_json = { version = "1.0.125", features = ["arbitrary_precision", "preserve
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
 static_assertions = "1.1"
 strsim = "0.10"
-timely = "0.13.0"
+timely = "0.14.1"
 tokio-postgres = { version = "0.7.8" }
 tracing-core = "0.1.30"
 url = { version = "2.3.1", features = ["serde"] }

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -70,6 +70,7 @@ pub trait TimestampManipulation:
     + differential_dataflow::lattice::Lattice
     + std::fmt::Debug
     + mz_persist_types::StepForward
+    + Sync
 {
     /// Advance a timestamp by the least amount possible such that
     /// `ts.less_than(ts.step_forward())` is true. Panic if unable to do so.

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -35,7 +35,7 @@ prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 semver = "1.0.16"
 serde = { version = "1.0.152", features = ["derive"] }
 sysinfo = "0.27.2"
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tonic = "0.12.1"

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 anyhow = "1.0.66"
 async-trait = "0.1.68"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 futures = "0.3.25"
 http = "1.1.0"
 itertools = { version = "0.10.5" }
@@ -45,7 +45,7 @@ rdkafka = { version = "0.29.0", features = [
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
 static_assertions = "1.1"
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = { version = "1.38.0", features = [
     "fs",
     "rt",

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -168,7 +168,7 @@ pub struct SnapshotCursor<T: Codec64 + Timestamp + Lattice> {
     pub cursor: Cursor<SourceData, (), T, Diff>,
 }
 
-impl<T: Codec64 + Timestamp + Lattice> SnapshotCursor<T> {
+impl<T: Codec64 + Timestamp + Lattice + Sync> SnapshotCursor<T> {
     pub async fn next(
         &mut self,
     ) -> Option<

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -412,7 +412,8 @@ where
         + Codec64
         + From<EpochMillis>
         + TimestampManipulation
-        + Into<mz_repr::Timestamp>,
+        + Into<mz_repr::Timestamp>
+        + Sync,
 {
     /// Creates and returns a new [StorageCollections].
     ///
@@ -1112,7 +1113,8 @@ where
         + Codec64
         + From<EpochMillis>
         + TimestampManipulation
-        + Into<mz_repr::Timestamp>,
+        + Into<mz_repr::Timestamp>
+        + Sync,
 {
     type Timestamp = T;
 
@@ -2055,7 +2057,7 @@ where
 
 impl<T> SinceHandleWrapper<T>
 where
-    T: TimelyTimestamp + Lattice + Codec64 + TotalOrder,
+    T: TimelyTimestamp + Lattice + Codec64 + TotalOrder + Sync,
 {
     pub fn since(&self) -> &Antichain<T> {
         match self {
@@ -2272,7 +2274,8 @@ where
         + Codec64
         + From<EpochMillis>
         + TimestampManipulation
-        + Into<mz_repr::Timestamp>,
+        + Into<mz_repr::Timestamp>
+        + Sync,
 {
     async fn run(&mut self) {
         // Futures that fetch the recent upper from all other shards.
@@ -2594,7 +2597,7 @@ async fn finalize_shards_task<T>(
         read_only,
     }: FinalizeShardsTaskConfig,
 ) where
-    T: TimelyTimestamp + Lattice + Codec64,
+    T: TimelyTimestamp + Lattice + Codec64 + Sync,
 {
     if read_only {
         info!("disabling shard finalization in read only mode");

--- a/src/storage-controller/Cargo.toml
+++ b/src/storage-controller/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.68"
 bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 derivative = "2.2.0"
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 futures = "0.3.25"
 itertools = { version = "0.10.5" }
 mz-build-info = { path = "../build-info" }
@@ -38,7 +38,7 @@ proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"

--- a/src/storage-controller/src/persist_handles.rs
+++ b/src/storage-controller/src/persist_handles.rs
@@ -92,7 +92,7 @@ impl<T: Timestamp + Lattice + Codec64> PersistTableWriteCmd<T> {
     }
 }
 
-async fn append_work<T2: Timestamp + Lattice + Codec64>(
+async fn append_work<T2: Timestamp + Lattice + Codec64 + Sync>(
     write_handles: &mut BTreeMap<GlobalId, WriteHandle<SourceData, (), T2, Diff>>,
     mut commands: BTreeMap<
         GlobalId,

--- a/src/storage-controller/src/rtr.rs
+++ b/src/storage-controller/src/rtr.rs
@@ -44,7 +44,7 @@ use crate::Timestamp;
 ///   recency. You can avoid this panic by choosing to not call this
 ///   function on load generator sources.
 pub(super) async fn real_time_recency_ts<
-    T: Timestamp + Lattice + TotalOrder + Codec64 + From<EpochMillis>,
+    T: Timestamp + Lattice + TotalOrder + Codec64 + From<EpochMillis> + Sync,
 >(
     connection: GenericSourceConnection,
     id: GlobalId,
@@ -106,7 +106,7 @@ pub(super) async fn real_time_recency_ts<
 
 async fn decode_remap_data_until_geq_external_frontier<
     FromTime: SourceTimestamp,
-    T: Timestamp + Lattice + TotalOrder + Codec64 + From<EpochMillis>,
+    T: Timestamp + Lattice + TotalOrder + Codec64 + From<EpochMillis> + Sync,
 >(
     id: GlobalId,
     external_frontier: timely::progress::Antichain<FromTime>,

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -15,7 +15,7 @@ arrow = { version = "51.0.0", default-features = false }
 async-stream = "0.3.3"
 aws-types = "1.1.1"
 bytesize = "1.1.0"
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 futures = "0.3.25"
 http = "1.1.0"
 mz-aws-util = { path = "../aws-util" }
@@ -35,7 +35,7 @@ prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 sentry = { version = "0.29.1" }
 serde = { version = "1.0.152", features = ["derive"] }
-timely = "0.13.0"
+timely = "0.14.1"
 thiserror = "1.0.37"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tracing = "0.1.37"

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -442,13 +442,11 @@ where
         let activator = Activator::new(operator_info.address, activations);
         // Maintain a list of work to do
         let mut pending_work = std::collections::VecDeque::new();
-        let mut buffer = Default::default();
 
         move |_frontier| {
             fetched_input.for_each(|time, data| {
-                data.swap(&mut buffer);
                 let capability = time.retain();
-                for fetched_blob in buffer.drain(..) {
+                for fetched_blob in data.drain(..) {
                     pending_work.push_back(PendingWork {
                         capability: capability.clone(),
                         part: PendingPart::Unparsed(fetched_blob),

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -25,7 +25,7 @@ bytes = "1.3.0"
 columnation = "0.1.0"
 dec = "0.4.8"
 derivative = "2.2.0"
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 hex = "0.4.3"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
@@ -64,7 +64,7 @@ regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125", features = ["preserve_order"] }
 thiserror = "1.0.37"
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tracing = "0.1.37"

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -373,7 +373,9 @@ impl ProtoMapEntry<GlobalId, SourceExport<CollectionMetadata>> for ProtoSourceEx
     }
 }
 
-pub trait SourceTimestamp: Timestamp + Columnation + Refines<()> + std::fmt::Display {
+pub trait SourceTimestamp:
+    Timestamp + Columnation + Refines<()> + std::fmt::Display + Sync
+{
     fn encode_row(&self) -> Row;
     fn decode_row(row: &Row) -> Self;
 }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -26,7 +26,7 @@ columnation = "0.1.0"
 crossbeam-channel = "0.5.8"
 csv-core = { version = "0.1.10" }
 dec = "0.4.8"
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 either = { version = "1.8.0", features = ["serde"] }
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
@@ -85,7 +85,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
 serde_bytes = { version = "0.11.14" }
 sha2 = "0.10.6"
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"

--- a/src/storage/examples/upsert_open_loop.rs
+++ b/src/storage/examples/upsert_open_loop.rs
@@ -589,7 +589,6 @@ async fn run_benchmark(
                 let rocks_options = Arc::clone(rocks_options);
                 let mut num_additions = 0;
                 let mut num_retractions = 0;
-                let mut buffer = Vec::new();
 
                 let mut frontier = Antichain::from_elem(0);
                 let mut max_lag = 0;
@@ -601,8 +600,7 @@ async fn run_benchmark(
                             return;
                         }
                         input.for_each(|_time, data| {
-                            data.swap(&mut buffer);
-                            for (_k, _v, diff) in buffer.drain(..) {
+                            for (_k, _v, diff) in data.drain(..) {
                                 if diff == 1 {
                                     num_additions += 1;
                                 } else if diff == -1 {

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -158,7 +158,7 @@ fn render_source_stream<G, FromTime>(
 )
 where
     G: Scope<Timestamp = mz_repr::Timestamp>,
-    FromTime: Timestamp,
+    FromTime: Timestamp + Sync,
 {
     let mut needed_tokens = vec![];
 

--- a/src/storage/src/source/reclock/compat.rs
+++ b/src/storage/src/source/reclock/compat.rs
@@ -54,7 +54,7 @@ pub struct PersistHandle<FromTime: SourceTimestamp, IntoTime: Timestamp + Lattic
     shared_write_frontier: Rc<RefCell<Antichain<IntoTime>>>,
 }
 
-impl<FromTime: Timestamp, IntoTime: Timestamp> PersistHandle<FromTime, IntoTime>
+impl<FromTime: Timestamp, IntoTime: Timestamp + Sync> PersistHandle<FromTime, IntoTime>
 where
     FromTime: SourceTimestamp,
     IntoTime: Timestamp + Lattice + Codec64,
@@ -208,7 +208,7 @@ where
 impl<FromTime, IntoTime> RemapHandle for PersistHandle<FromTime, IntoTime>
 where
     FromTime: SourceTimestamp,
-    IntoTime: Timestamp + Lattice + Codec64,
+    IntoTime: Timestamp + Lattice + Codec64 + Sync,
 {
     async fn compare_and_append(
         &mut self,

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -1071,12 +1071,10 @@ where
         let mut ready_times = VecDeque::new();
         let mut source_upper = MutableAntichain::new();
 
-        let mut vector = Vec::new();
         move |frontiers| {
             // Accept new bindings
             while let Some((_, data)) = bindings.next() {
-                data.swap(&mut vector);
-                accepted_times.extend(vector.drain(..).map(|(from, mut into, diff)| {
+                accepted_times.extend(data.drain(..).map(|(from, mut into, diff)| {
                     into.advance_by(as_of.borrow());
                     (from, into, diff)
                 }));

--- a/src/storage/src/storage_state/async_storage_worker.rs
+++ b/src/storage/src/storage_state/async_storage_worker.rs
@@ -88,7 +88,7 @@ async fn reclock_resume_uppers<C, IntoTime>(
 ) -> BTreeMap<GlobalId, Antichain<C::Time>>
 where
     C: SourceConnection + SourceRender,
-    IntoTime: Timestamp + Lattice + Codec64 + Display,
+    IntoTime: Timestamp + Lattice + Codec64 + Display + Sync,
 {
     let metadata = &ingestion_description.ingestion_metadata;
 
@@ -199,7 +199,7 @@ where
     source_resume_uppers
 }
 
-impl<T: Timestamp + Lattice + Codec64 + Display> AsyncStorageWorker<T> {
+impl<T: Timestamp + Lattice + Codec64 + Display + Sync> AsyncStorageWorker<T> {
     /// Creates a new [`AsyncStorageWorker`].
     ///
     /// IMPORTANT: The passed in `activatable` is activated when new responses

--- a/src/storage/src/upsert_continual_feedback.rs
+++ b/src/storage/src/upsert_continual_feedback.rs
@@ -135,11 +135,11 @@ pub fn upsert_inner<G: Scope, FromTime, F, Fut, US>(
     PressOnDropButton,
 )
 where
-    G::Timestamp: TotalOrder,
+    G::Timestamp: TotalOrder + Sync,
     F: FnOnce() -> Fut + 'static,
     Fut: std::future::Future<Output = US>,
     US: UpsertStateBackend<Option<FromTime>>,
-    FromTime: Debug + timely::ExchangeData + Ord,
+    FromTime: Debug + timely::ExchangeData + Ord + Sync,
 {
     let mut builder = AsyncOperatorBuilder::new("Upsert".to_string(), input.scope());
 
@@ -633,8 +633,8 @@ async fn drain_staged_input<S, G, T, FromTime, E>(
 where
     S: UpsertStateBackend<Option<FromTime>>,
     G: Scope,
-    T: TotalOrder + Ord + Clone + Debug + timely::progress::Timestamp,
-    FromTime: timely::ExchangeData + Ord,
+    T: TotalOrder + Ord + Clone + Debug + timely::progress::Timestamp + Sync,
+    FromTime: timely::ExchangeData + Ord + Sync,
     E: UpsertErrorEmitter<G>,
 {
     let mut min_remaining_time = Antichain::new();
@@ -790,7 +790,7 @@ async fn ingest_state_updates<S, G, T, FromTime, E>(
     S: UpsertStateBackend<Option<FromTime>>,
     G: Scope,
     T: PartialOrder + Ord + Clone + Debug + timely::progress::Timestamp,
-    FromTime: timely::ExchangeData + Ord,
+    FromTime: timely::ExchangeData + Ord + Sync,
     E: UpsertErrorEmitter<G>,
 {
     // Sort by (key, diff) and make sure additions sort before retractions,

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 ahash = { version = "0.8.11", default-features = false }
 columnation = "0.1.0"
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 either = "1"
 futures-util = "0.3.25"
 lgalloc = "0.3"
@@ -20,7 +20,7 @@ mz-ore = { path = "../ore", features = ["async", "process", "tracing_", "test"] 
 num-traits = "0.2"
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 serde = { version = "1.0.152", features = ["derive"] }
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -20,7 +20,7 @@ use std::task::{ready, Context, Poll, Waker};
 
 use futures_util::task::ArcWake;
 use futures_util::Stream;
-use timely::communication::{Message, Pull, Push};
+use timely::communication::{Pull, Push};
 use timely::container::columnation::Columnation;
 use timely::container::{CapacityContainerBuilder, ContainerBuilder, PushInto};
 use timely::dataflow::channels::pact::ParallelizationContract;
@@ -34,6 +34,7 @@ use timely::dataflow::operators::{Capability, CapabilitySet, InputCapability};
 use timely::dataflow::{Scope, StreamCore};
 use timely::progress::{Antichain, Timestamp};
 use timely::scheduling::{Activator, SyncActivator};
+use timely::Message;
 use timely::{Container, PartialOrder};
 
 use crate::containers::stack::{AccountedStackBuilder, StackWrapper};
@@ -84,7 +85,7 @@ where
         while let Some((cap, data)) = self.handle.next() {
             new_data = true;
             let cap = self.connection.accept(cap);
-            queue.push_back(Event::Data(cap, data.take()));
+            queue.push_back(Event::Data(cap, std::mem::take(data)));
         }
         if new_data {
             if let Some(waker) = self.waker.take() {

--- a/src/timely-util/src/capture.rs
+++ b/src/timely-util/src/capture.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use mz_ore::channel::{InstrumentedChannelMetric, InstrumentedUnboundedSender};
-use timely::communication::{Message, Push};
+use timely::communication::Push;
 use timely::dataflow::operators::capture::{Event, EventPusher};
 
 pub struct UnboundedTokioCapture<T, C, M>(pub InstrumentedUnboundedSender<Event<T, C>, M>);
@@ -33,9 +33,9 @@ where
 /// A helper type to allow capturing timely streams into timely pushers
 pub struct PusherCapture<P>(pub P);
 
-impl<P: Push<Message<Event<T, D>>>, T, D> EventPusher<T, D> for PusherCapture<P> {
+impl<P: Push<Event<T, D>>, T, D> EventPusher<T, D> for PusherCapture<P> {
     fn push(&mut self, event: Event<T, D>) {
-        self.0.send(Message::from_typed(event));
+        self.0.send(event);
         self.0.done();
     }
 }

--- a/src/timely-util/src/order.rs
+++ b/src/timely-util/src/order.rs
@@ -20,12 +20,11 @@ use std::fmt::{self, Debug};
 use std::hash::Hash;
 
 use serde::{Deserialize, Serialize};
-use timely::communication::Data;
 use timely::container::columnation::CopyRegion;
 use timely::order::Product;
 use timely::progress::timestamp::{PathSummary, Refines, Timestamp};
 use timely::progress::Antichain;
-use timely::PartialOrder;
+use timely::{ExchangeData, PartialOrder};
 use uuid::Uuid;
 
 use mz_ore::cast::CastFrom;
@@ -104,7 +103,7 @@ impl<P: fmt::Display, T: fmt::Display> fmt::Display for Partitioned<P, T> {
 
 impl<P, T: Timestamp> Timestamp for Partitioned<P, T>
 where
-    P: Extrema + Clone + Debug + Data + Hash + Ord,
+    P: Extrema + Clone + Debug + ExchangeData + Hash + Ord,
 {
     type Summary = ();
     fn minimum() -> Self {
@@ -113,7 +112,7 @@ where
 }
 impl<P, T: Timestamp> Refines<()> for Partitioned<P, T>
 where
-    P: Extrema + Clone + Debug + Data + Hash + Ord,
+    P: Extrema + Clone + Debug + ExchangeData + Hash + Ord,
 {
     fn to_inner(_other: ()) -> Self {
         Self::minimum()
@@ -272,7 +271,7 @@ impl<P: Clone> PathSummary<Interval<P>> for () {
 
 impl<P> Timestamp for Interval<P>
 where
-    P: Extrema + Clone + Debug + Data + Hash + Ord,
+    P: Extrema + Clone + Debug + ExchangeData + Hash + Ord,
 {
     type Summary = ();
 

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 enum-kinds = "0.5.1"
 itertools = "0.10.5"
 mz-compute-types = { path = "../compute-types" }

--- a/src/txn-wal/Cargo.toml
+++ b/src/txn-wal/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1.68"
 bytes = { version = "1.3.0" }
-differential-dataflow = "0.13.0"
+differential-dataflow = "0.13.1"
 futures = "0.3.25"
 itertools = { version = "0.10.5" }
 mz-ore = { path = "../ore", features = ["process"] }
@@ -23,7 +23,7 @@ mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
-timely = "0.13.0"
+timely = "0.14.1"
 tokio = { version = "1.38.0", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }

--- a/src/txn-wal/src/lib.rs
+++ b/src/txn-wal/src/lib.rs
@@ -332,7 +332,7 @@ where
     F: Fn() -> S,
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + TotalOrder + Codec64,
+    T: Timestamp + Lattice + TotalOrder + Codec64 + Sync,
     D: Debug + Semigroup + Ord + Codec64 + Send + Sync,
 {
     fn debug_sep<'a, T: Debug + 'a>(sep: &str, xs: impl IntoIterator<Item = &'a T>) -> String {
@@ -396,7 +396,7 @@ pub(crate) async fn empty_caa<S, F, K, V, T, D>(
     F: Fn() -> S,
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync,
     D: Debug + Semigroup + Ord + Codec64 + Send + Sync,
 {
     let name = name();
@@ -442,7 +442,7 @@ async fn apply_caa<K, V, T, D>(
 ) where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync,
     D: Semigroup + Ord + Codec64 + Send + Sync,
 {
     let mut batches = batch_raws
@@ -529,7 +529,7 @@ pub(crate) async fn cads<T, O, C>(
     txns_since: &mut SinceHandle<C::Key, C::Val, T, i64, O>,
     new_since_ts: T,
 ) where
-    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync,
     O: Opaque + Debug + Codec64,
     C: TxnsCodec,
 {
@@ -574,7 +574,7 @@ pub mod tests {
     where
         K: Debug + Codec + Clone,
         V: Debug + Codec + Clone,
-        T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+        T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync,
         D: Debug + Semigroup + Ord + Codec64 + Send + Sync + Clone,
         O: Opaque + Debug + Codec64,
         C: TxnsCodec,
@@ -598,7 +598,7 @@ pub mod tests {
     where
         K: Debug + Codec + Clone,
         V: Debug + Codec + Clone,
-        T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+        T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync,
         D: Debug + Semigroup + Ord + Codec64 + Send + Sync + Clone,
     {
         pub(crate) fn new() -> Self {

--- a/src/txn-wal/src/operator.rs
+++ b/src/txn-wal/src/operator.rs
@@ -107,7 +107,7 @@ pub fn txns_progress<K, V, T, D, P, C, F, G>(
 where
     K: Debug + Codec + Send + Sync,
     V: Debug + Codec + Send + Sync,
-    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync,
     D: Debug + Data + Semigroup + Ord + Codec64 + Send + Sync,
     P: Debug + Data,
     C: TxnsCodec + 'static,
@@ -171,7 +171,7 @@ fn txns_progress_source_local<K, V, T, D, P, C, G>(
 where
     K: Debug + Codec + Send + Sync,
     V: Debug + Codec + Send + Sync,
-    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync,
     D: Debug + Data + Semigroup + Ord + Codec64 + Send + Sync,
     P: Debug + Data,
     C: TxnsCodec + 'static,
@@ -287,7 +287,7 @@ fn txns_progress_source_global<K, V, T, D, P, C, G>(
 where
     K: Debug + Codec + Send + Sync,
     V: Debug + Codec + Send + Sync,
-    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync,
     D: Debug + Data + Semigroup + Ord + Codec64 + Send + Sync,
     P: Debug + Data,
     C: TxnsCodec + 'static,
@@ -536,7 +536,7 @@ pub struct TxnsContext {
 impl TxnsContext {
     async fn get_or_init<T, C>(&self, client: &PersistClient, txns_id: ShardId) -> TxnsRead<T>
     where
-        T: Timestamp + Lattice + Codec64 + TotalOrder + StepForward,
+        T: Timestamp + Lattice + Codec64 + TotalOrder + StepForward + Sync,
         C: TxnsCodec + 'static,
     {
         let read = self
@@ -887,7 +887,7 @@ mod tests {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+        T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync,
         D: Debug + Semigroup + Ord + Codec64 + Send + Sync,
         O: Opaque + Debug + Codec64,
         C: TxnsCodec,

--- a/src/txn-wal/src/txn_cache.rs
+++ b/src/txn-wal/src/txn_cache.rs
@@ -127,7 +127,7 @@ pub struct TxnsCache<T, C: TxnsCodec = TxnsCodecDefault> {
     state: TxnsCacheState<T>,
 }
 
-impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64> TxnsCacheState<T> {
+impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync> TxnsCacheState<T> {
     /// Creates a new empty [`TxnsCacheState`].
     ///
     /// `init_ts` must be == the critical handle's since of the txn shard.
@@ -786,7 +786,11 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64> TxnsCacheState
     }
 }
 
-impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> TxnsCache<T, C> {
+impl<T, C> TxnsCache<T, C>
+where
+    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync,
+    C: TxnsCodec,
+{
     /// Initialize the txn shard at `init_ts` and returns a [TxnsCache] reading
     /// from that shard.
     pub(crate) async fn init(

--- a/src/txn-wal/src/txn_write.rs
+++ b/src/txn-wal/src/txn_write.rs
@@ -67,7 +67,7 @@ impl<K, V, T, D> Txn<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync,
     D: Debug + Semigroup + Ord + Codec64 + Send + Sync,
 {
     pub(crate) fn new() -> Self {
@@ -353,7 +353,7 @@ impl<T> TxnApply<T> {
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+        T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync,
         D: Debug + Semigroup + Ord + Codec64 + Send + Sync,
         O: Opaque + Debug + Codec64,
         C: TxnsCodec,

--- a/src/txn-wal/src/txns.rs
+++ b/src/txn-wal/src/txns.rs
@@ -116,7 +116,7 @@ impl<K, V, T, D, O, C> TxnsHandle<K, V, T, D, O, C>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync,
     D: Debug + Semigroup + Ord + Codec64 + Send + Sync,
     O: Opaque + Debug + Codec64,
     C: TxnsCodec,
@@ -706,7 +706,7 @@ impl<K, V, T, D> DataHandles<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + TotalOrder + Codec64,
+    T: Timestamp + Lattice + TotalOrder + Codec64 + Sync,
     D: Semigroup + Ord + Codec64 + Send + Sync,
 {
     async fn open_data_write_for_apply(&self, data_id: ShardId) -> DataWriteApply<K, V, T, D> {
@@ -847,7 +847,7 @@ impl<K, V, T, D> DataWriteApply<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + TotalOrder + Codec64,
+    T: Timestamp + Lattice + TotalOrder + Codec64 + Sync,
     D: Semigroup + Ord + Codec64 + Send + Sync,
 {
     pub(crate) async fn maybe_replace_with_batch_schema(&mut self, batches: &[Batch<K, V, T, D>]) {


### PR DESCRIPTION
As it says on the box, update both Timely and Differential to their latest versions.

The main source of changes are that `Timestamp` doesn't imply `Sync`, and that input handles provide `&mut data` instead of the now-removed `RefOrMut` wrapper.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
