### PR TITLE
catalog: Make v70 to v71 migration hermetic

### DIFF
--- a/src/catalog/src/durable/upgrade/v70_to_v71.rs
+++ b/src/catalog/src/durable/upgrade/v70_to_v71.rs
@@ -7,14 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use mz_pgrepr::oid::NETWORK_POLICIES_DEFAULT_POLICY_OID;
-
 use crate::durable::upgrade::objects_v71::Empty;
 
 use crate::durable::upgrade::MigrationAction;
 use crate::durable::upgrade::{objects_v70 as v70, objects_v71 as v71};
 
 const DEFAULT_USER_NETWORK_POLICY_NAME: &str = "default";
+const NETWORK_POLICIES_DEFAULT_POLICY_OID: u32 = 17048;
 
 const MZ_SYSTEM_ROLE_ID: u64 = 1;
 const MZ_SUPPORT_ROLE_ID: u64 = 2;


### PR DESCRIPTION
Very small tweak, OIDs should never change but ideally this migration is fully hermetic.

### Motivation

Make catalog migration totally hermetic

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
