### PR TITLE
.*: Ignore editor specific settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ test/scalability/results/**/*.png
 misc/wasm/target
 parallel-benchmark.db
 
+# Ignore any editor specific settings for the workspace.
+/.vscode
+
 # This is un-orthodox, but adding it to the repo would "tie" it to each user's
 # local version of nixpkgs. This way, we can all use the flake and have a
 # flake.lock that works well with the rest of the package versions on our


### PR DESCRIPTION
I have a few materialize repos on my machine so I can work on certain changes concurrently. To make it more obvious which repo I'm currently editing I want to change the color theme in VSCode on a per-workspace/repo basis. This requires VSCode to add some editor config in a `.vscode` folder at the root of the repo. I don't want to commit these changes so I added `/.vscode` to our `.gitignore`

### Motivation

Allow workspace specific configs in vscode

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
