### PR TITLE
bazel: disable pipelined compilation for `persist-client`

### DIFF
--- a/src/persist-client/BUILD.bazel
+++ b/src/persist-client/BUILD.bazel
@@ -25,6 +25,7 @@ rust_library(
     compile_data = [],
     crate_features = ["default"],
     data = [],
+    disable_pipelining = True,
     proc_macro_deps = ["//src/persist-proc:mz_persist_proc"] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -87,5 +87,8 @@ default = ["mz-build-tools/default"]
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]
 
+[package.metadata.cargo-gazelle.lib]
+disable_pipelining = true
+
 [package.metadata.cargo-gazelle.test.lib]
 compile_data = ["src/internal/state_serde.json"]


### PR DESCRIPTION
Not totally positive but this might be the cause of the pipelined compilation failures we've been seeing with Bazel. Will disable it here and then daily drive pipelined compilation locally for a while to make sure it's stable before enabling in CI.

### Motivation

Improve Bazel compilation speed

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
