### PR TITLE
cargo test: Also ignore proptest_datums for now

### DIFF
--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -2331,6 +2331,7 @@ mod tests {
 
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
+    #[ignore] // TODO: Reenable when database-issues#8744 is fixed
     fn proptest_datums() {
         let strat = any::<ColumnType>().prop_flat_map(|ty| {
             proptest::collection::vec(arb_datum_for_column(&ty), 0..16)


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/test/builds/94474#01932143-9b50-4072-b27d-6e25ea1ac36b

See https://github.com/MaterializeInc/database-issues/issues/8744 for the issue

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
