### PR TITLE
improve console pod probes

### DIFF
--- a/src/orchestratord/src/controller/materialize/console.rs
+++ b/src/orchestratord/src/controller/materialize/console.rs
@@ -86,8 +86,6 @@ fn create_console_deployment_object(
             port: IntOrString::Int(CONSOLE_IMAGE_HTTP_PORT),
             ..Default::default()
         }),
-        initial_delay_seconds: Some(10),
-        period_seconds: Some(30),
         ..Default::default()
     };
 
@@ -137,7 +135,20 @@ fn create_console_deployment_object(
         image_pull_policy: Some(config.image_pull_policy.to_string()),
         ports: Some(ports),
         env: Some(env),
-        readiness_probe: Some(probe),
+        startup_probe: Some(Probe {
+            period_seconds: Some(1),
+            failure_threshold: Some(10),
+            ..probe.clone()
+        }),
+        readiness_probe: Some(Probe {
+            period_seconds: Some(30),
+            failure_threshold: Some(1),
+            ..probe.clone()
+        }),
+        liveness_probe: Some(Probe {
+            period_seconds: Some(30),
+            ..probe.clone()
+        }),
         resources: mz.spec.console_resource_requirements.clone(),
         security_context,
         ..Default::default()


### PR DESCRIPTION
### Motivation

make the console pod become ready sooner

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
