### PR TITLE
proto: unignore breaking changes

### DIFF
--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -49,26 +49,14 @@ breaking:
     - compute-types/src/sinks.proto
     # reason: Ignore because plans are currently not persisted.
     - expr/src/relation.proto
-    # reason: temporarily ignored by ParkMyCar
-    - repr/src/relation_and_scalar.proto
     # reason: does currently not require backward-compatibility
     - storage-client/src/client.proto
     # reason: does currently not require backward-compatibility
     - storage-client/src/statistics.proto
-    # reason: temporarily ignored by ParkMyCar
-    - storage-types/src/connections.proto
     # reason: currently does not require backward-compatibility
     - storage-types/src/connections/aws.proto
     # reason: currently does not require backward-compatibility
     - storage-types/src/connections/string_or_secret.proto
-    # reason: temporarily ignored by ParkMyCar
-    - storage-types/src/sinks.proto
-    # reason: temporarily ignored by ParkMyCar
-    - storage-types/src/sources/kafka.proto
-    # reason: temporarily ignored by ParkMyCar
-    - storage-types/src/sources/mysql.proto
-    # reason: temporarily ignored by ParkMyCar
-    - storage-types/src/sources/postgres.proto
 lint:
   use:
     - DEFAULT

--- a/src/repr/src/relation_and_scalar.proto
+++ b/src/repr/src/relation_and_scalar.proto
@@ -10,8 +10,6 @@
 // Note: protobuf does not support cyclic imports. Thus, this file contains
 // both, definitions from relation.rs and scalar.rs
 
-// buf breaking: ignore (temporarily ignored by ParkMyCar)
-
 syntax = "proto3";
 
 package mz_repr.relation_and_scalar;

--- a/src/storage-types/src/connections.proto
+++ b/src/storage-types/src/connections.proto
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// buf breaking: ignore (temporarily ignored by ParkMyCar)
-
 syntax = "proto3";
 
 package mz_storage_types.connections;

--- a/src/storage-types/src/sinks.proto
+++ b/src/storage-types/src/sinks.proto
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// buf breaking: ignore (temporarily ignored by ParkMyCar)
-
 syntax = "proto3";
 
 package mz_storage_types.sinks;

--- a/src/storage-types/src/sources/kafka.proto
+++ b/src/storage-types/src/sources/kafka.proto
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// buf breaking: ignore (temporarily ignored by ParkMyCar)
-
 syntax = "proto3";
 
 package mz_storage_types.sources.kafka;

--- a/src/storage-types/src/sources/mysql.proto
+++ b/src/storage-types/src/sources/mysql.proto
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// buf breaking: ignore (temporarily ignored by ParkMyCar)
-
 syntax = "proto3";
 
 package mz_storage_types.sources.mysql;

--- a/src/storage-types/src/sources/postgres.proto
+++ b/src/storage-types/src/sources/postgres.proto
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// buf breaking: ignore (temporarily ignored by ParkMyCar)
-
 syntax = "proto3";
 
 package mz_storage_types.sources.postgres;


### PR DESCRIPTION
`buf` is a bit aggressive in what it considers breaking. Some changes I merged in https://github.com/MaterializeInc/materialize/pull/30189 were not wire breaking but `buf` thought they were. To prevent needing a force push to main I marked them as temporarily ignored for breaking changes, this PR unignores them.

### Motivation

Re-enable protobuf linting on temporarily ignored files.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
