### PR TITLE
docs: Add hydrations page

### DIFF
--- a/doc/user/content/concepts/_index.md
+++ b/doc/user/content/concepts/_index.md
@@ -23,5 +23,6 @@ Component                                | Use
 [Views](/concepts/views/)    | Views represent a named query that you want to save for repeated execution. You can use **indexed views** and **materialized views** to incrementally maintain the results of views.
 [Indexes](/concepts/indexes/)            | Indexes represent query results stored in memory.
 [Sinks](/concepts/sinks/)                | Sinks describe an external system you want Materialize to write data to.
+[Hydration](/concepts/hydration/)        | Hydration refers to the process of populating materialized views and indexes with a snapshot of the data from the upstream source.
 
 Refer to the individual pages for more information.

--- a/doc/user/content/concepts/_index.md
+++ b/doc/user/content/concepts/_index.md
@@ -23,6 +23,6 @@ Component                                | Use
 [Views](/concepts/views/)    | Views represent a named query that you want to save for repeated execution. You can use **indexed views** and **materialized views** to incrementally maintain the results of views.
 [Indexes](/concepts/indexes/)            | Indexes represent query results stored in memory.
 [Sinks](/concepts/sinks/)                | Sinks describe an external system you want Materialize to write data to.
-[Hydration](/concepts/hydration/)        | Hydration refers to the process of populating materialized views and indexes with a snapshot of the data from the upstream source.
+[Hydration](/concepts/hydration/)        | Hydration is an overarching term that refers to populating [sources](/concepts/sources/), [materialized views](/concepts/views/#materialized-views), and [indexes](/concepts/indexes/) in Materialize. Hydration in Materialize occurs via two specific processes, the snapshotting process and the hydration process.
 
 Refer to the individual pages for more information.

--- a/doc/user/content/concepts/hydration.md
+++ b/doc/user/content/concepts/hydration.md
@@ -1,0 +1,62 @@
+---
+title: "Hydration"
+description: "Learn about hydration in Materialize."
+menu:
+  main:
+    parent: 'concepts'
+    weight: 50
+    identifier: 'concepts-hydration'
+---
+
+Hydration refers to the process of populating sources, materialized views, and
+indexes using a snapshot of the data from the upstream source. 
+
+## Hydration occurences
+
+Hydration occurs:
+
+- **When you create a source**.
+
+  - During this hydration, queries that use the hydrating objects will block
+    until the objects are hydrated.
+
+- **When a cluster restarts** (such as during [cluster
+  resizing](/sql/alter-cluster/#resizing) or Materialize's [weekly
+  upgrades](/releases/#schedule)).
+
+  - During this hydration (also referred to as rehydration),
+  
+    - If using the default *strict serializable* isolation, queries that use the
+      hydrating objects will block until the objects are hydrated.
+
+    - If using *serializable* isolation, queries can use the hydrating objects
+      but with stale data.
+
+Generally, the hydration time for an object is proportional to data volume and
+query complexity. For sources with upsert envelope, the initial hydration may
+take longer while the upsert envelope effectively dedupes your records.
+
+## Hydration status
+
+You can view the hydration status of an object in the [Materialize
+console](/console/). For an object, go to its **Workflow** page in the
+[Database object explorer](/console/data/).
+
+
+Alternatively, you can query the following system catalog views:
+
+- [`mz_hydration_statuses`](/sql/system-catalog/mz_internal/#mz_hydration_statuses)
+
+- [`mz_compute_hydration_statuses`](/sql/system-catalog/#mz_compute_hydration_statuses/)
+
+## Memory considerations for hydration
+
+- Materialized views require memory proportional to ~2x size of the output
+  during hydration (to recalculate the output from scratch and compare with
+  existing output to ensure correctness).
+
+- Sinks need to load an entire snapshot of the data in memory when they start
+  up.
+
+For example, for clusters that contain the materialized views and the sinks from
+those materialized views, the memory requirements is ~3x size of the output.

--- a/doc/user/content/concepts/hydration.md
+++ b/doc/user/content/concepts/hydration.md
@@ -9,7 +9,7 @@ menu:
 ---
 
 Hydration refers to the process of populating sources, materialized views, and
-indexes using a snapshot of the data from the upstream source. 
+indexes using a snapshot of the data from the upstream source.
 
 ## Hydration occurences
 
@@ -25,7 +25,7 @@ Hydration occurs:
   upgrades](/releases/#schedule)).
 
   - During this hydration (also referred to as rehydration),
-  
+
     - If using the default *strict serializable* isolation, queries that use the
       hydrating objects will block until the objects are hydrated.
 
@@ -47,7 +47,7 @@ Alternatively, you can query the following system catalog views:
 
 - [`mz_hydration_statuses`](/sql/system-catalog/mz_internal/#mz_hydration_statuses)
 
-- [`mz_compute_hydration_statuses`](/sql/system-catalog/#mz_compute_hydration_statuses/)
+- [`mz_compute_hydration_statuses`](/sql/system-catalog/mz_internal/#mz_compute_hydration_statuses)
 
 ## Memory considerations for hydration
 

--- a/doc/user/content/concepts/hydration.md
+++ b/doc/user/content/concepts/hydration.md
@@ -1,6 +1,6 @@
 ---
 title: "Hydration"
-description: "Learn about hydration in Materialize."
+description: "Learn about snapshotting and hydration) in Materialize."
 menu:
   main:
     parent: 'concepts'
@@ -8,55 +8,139 @@ menu:
     identifier: 'concepts-hydration'
 ---
 
-Hydration refers to the process of populating sources, materialized views, and
-indexes using a snapshot of the data from the upstream source.
+## Overview
 
-## Hydration occurences
+Hydration is an overarching term that refers to populating
+[sources](/concepts/sources/), [materialized
+views](/concepts/views/#materialized-views), and [indexes](/concepts/indexes/)
+in Materialize. Hydration in Materialize occurs via two specific processes, the
+snapshotting process and the hydration process.
 
-Hydration occurs:
+Snapshotting and hydration processes refers to the process of populating
+[sources](/concepts/sources/), [materialized
+views](/concepts/views/#materialized-views), and [indexes](/concepts/indexes/)
+in Materialize:
 
-- **When you create a source**.
+- **Snapshotting**: Occurs when you create or recreate a source, and refers
+  to the process of populating a source in Materialize by reading the [upstream
+  (i.e., external) source's](/concepts/sources/) history and catching up to a
+  chosen offset.
 
-  - During this hydration, queries that use the hydrating objects will block
-    until the objects are hydrated.
-
-- **When a cluster restarts** (such as during [cluster
+- **Hydration**: Occurs during cluster restarts (such as during [cluster
   resizing](/sql/alter-cluster/#resizing) or Materialize's [weekly
-  upgrades](/releases/#schedule)).
+  upgrades](/releases/#schedule)), and refers to the process of populating
+  [sources](/concepts/sources/), [materialized
+  views](/concepts/views/#materialized-views), and [indexes](/concepts/indexes/)
+  from persisted data in Materialize.
 
-  - During this hydration (also referred to as rehydration),
+{{< annotation type="Disambiguation" >}}
 
-    - If using the default *strict serializable* isolation, queries that use the
-      hydrating objects will block until the objects are hydrated.
+Hydration can refer to either the overarching term or the specific process of
+populating objects in Materialize. For the remainder of this page, hydration
+refers to the specific process.
 
-    - If using *serializable* isolation, queries can use the hydrating objects
-      but with stale data.
+{{</ annotation>}}
 
-Generally, the hydration time for an object is proportional to data volume and
-query complexity. For sources with upsert envelope, the initial hydration may
-take longer while the upsert envelope effectively dedupes your records.
+## Snapshotting
 
-## Hydration status
+Snapshotting occurs when you create or recreate a source. Snapshotting refers to
+initial population of a source in Materialize by reading the [upstream (i.e.,
+external) source](/concepts/sources/).
+
+### Process
+
+Materialize chooses the latest available offset upstream. For the latest
+available offset, Materialize uses:
+
+- Log Sequence Number (LSN) for [PostgreSQL](/ingest-data/postgres/) sources
+
+- Global Transaction Identifier (GTID) for [MySQL](/ingest-data/mysql/) sources
+
+- Kafka offset for Kafka sources
+
+Materialize then captures/commits a complete snapshot of all historical data up
+to that point. All records in this initial load have the same timestamp.
+
+Once Materialize has committed the snapshot, the source transitions from a
+**Snapshotting** status to a **Running** status, and Materialize resumes
+real-time ingestion from that offset.
+
+### Snapshotting duration and status
+
+Generally, the snapshotting duration is proportional to data volume. However,
+for sources with upsert envelope, the snapshotting may take longer while the
+upsert envelope effectively dedupes your records.
+
+You can view the snapshotting status of an object in the [Materialize
+console](/console/). For an object, go to its **Overview** page in the [Database
+object explorer](/console/data/).
+
+Alternatively, you can query the following system catalog views,
+[`mz_hydration_statuses`](/sql/system-catalog/mz_internal/#mz_hydration_statuses)
+and
+[`mz_compute_hydration_statuses`](/sql/system-catalog/mz_internal/#mz_compute_hydration_statuses).
+
+### Reads during snapshotting
+
+While a source is in a **Snapshotting** status, the source cannot serve queries,
+and queries to a  **Snapshotting** status will hang. You can, however, create
+views, materialized views, and indexes on the source, but these objects also
+cannot serve queries until the underlying source finishes snapshotting and the
+objects hydrate.
+
+## Hydration
+
+Hydration occurs when a cluster restarts (such as during [cluster
+resizing](/sql/alter-cluster/#resizing) or Materialize's [weekly
+upgrades](/releases/#schedule)).
+
+- For sources, hydration refers to the process of reconstructing state in-memory
+  (or on-disk), from the existing persisted source data.
+
+- For materialized views and indexes, hydration refers to reconstructing
+  in-memory state from persisted data.
+
+### Process
+
+To reconstruct the object's state, during hydration:
+
+- Internal data structures are re-created.
+
+- Necessary processes are initiated. These may also require re-reading of their
+  required in-memory state.
+
+### Hydration duration and status
+
+Generally, the hydration time for an object is proportional to data volume
+and query complexity.
 
 You can view the hydration status of an object in the [Materialize
 console](/console/). For an object, go to its **Workflow** page in the
 [Database object explorer](/console/data/).
 
+Alternatively, you can query the following system catalog views,
+[`mz_hydration_statuses`](/sql/system-catalog/mz_internal/#mz_hydration_statuses)
+and
+[`mz_compute_hydration_statuses`](/sql/system-catalog/mz_internal/#mz_compute_hydration_statuses).
 
-Alternatively, you can query the following system catalog views:
+### Reads during hydration
 
-- [`mz_hydration_statuses`](/sql/system-catalog/mz_internal/#mz_hydration_statuses)
+While an object is hydrating:
 
-- [`mz_compute_hydration_statuses`](/sql/system-catalog/mz_internal/#mz_compute_hydration_statuses)
+- With default *strict serializable* isolation, a hydrating object cannot serve
+  queries, and queries that use the hydrating objects will hang until the
+  objects finish hydrating.
 
-## Memory considerations for hydration
+- With *serializable* isolation, a hydrating object can serve queries but with
+  **stale** data.
 
-- Materialized views require memory proportional to ~2x size of the output
-  during hydration (to recalculate the output from scratch and compare with
-  existing output to ensure correctness).
+### Memory considerations for hydration
 
-- Sinks need to load an entire snapshot of the data in memory when they start
-  up.
+During hydration:
 
-For example, for clusters that contain the materialized views and the sinks from
-those materialized views, the memory requirements is ~3x size of the output.
+- Materialized views require memory proportional to ~2x the output size (to
+  recalculate the output from scratch and compare with existing output to ensure
+  correctness).
+
+- Sinks require memory proportional to ~1x the output size to load an entire
+  snapshot of the data in memory when they start up.

--- a/doc/user/content/concepts/hydration.md
+++ b/doc/user/content/concepts/hydration.md
@@ -54,9 +54,10 @@ available offset, Materialize uses:
 
 - Log Sequence Number (LSN) for [PostgreSQL](/ingest-data/postgres/) sources
 
-- Global Transaction Identifier (GTID) for [MySQL](/ingest-data/mysql/) sources
+- The number of transactions committed across all servers in the cluster.for
+  [MySQL](/ingest-data/mysql/) sources.
 
-- Kafka offset for Kafka sources
+- Kafka message offset for Kafka sources
 
 Materialize then captures/commits a complete snapshot of all historical data up
 to that point. All records in this initial load have the same timestamp.
@@ -71,14 +72,15 @@ Generally, the snapshotting duration is proportional to data volume. However,
 for sources with upsert envelope, the snapshotting may take longer while the
 upsert envelope effectively dedupes your records.
 
-You can view the snapshotting status of an object in the [Materialize
-console](/console/). For an object, go to its **Overview** page in the [Database
+You can view the snapshotting status of a source in the [Materialize
+console](/console/). For a source, go to its **Overview** page in the [Database
 object explorer](/console/data/).
 
 Alternatively, you can query the following system catalog views,
-[`mz_hydration_statuses`](/sql/system-catalog/mz_internal/#mz_hydration_statuses)
-and
-[`mz_compute_hydration_statuses`](/sql/system-catalog/mz_internal/#mz_compute_hydration_statuses).
+[`mz_source_statistics`](/sql/system-catalog/mz_internal/#mz_source_statistics).
+However, note that objects in the `mz_internal` schema are not part of
+Materialize's stable interface, and backwards-incompatible changes to these
+objects may be made at any time.
 
 ### Reads during snapshotting
 
@@ -122,6 +124,9 @@ Alternatively, you can query the following system catalog views,
 [`mz_hydration_statuses`](/sql/system-catalog/mz_internal/#mz_hydration_statuses)
 and
 [`mz_compute_hydration_statuses`](/sql/system-catalog/mz_internal/#mz_compute_hydration_statuses).
+However, note that objects in the `mz_internal` schema are not part of
+Materialize's stable interface, and backwards-incompatible changes to these
+objects may be made at any time.
 
 ### Reads during hydration
 

--- a/doc/user/content/concepts/hydration.md
+++ b/doc/user/content/concepts/hydration.md
@@ -69,8 +69,9 @@ real-time ingestion from that offset.
 ### Snapshotting duration and status
 
 Generally, the snapshotting duration is proportional to data volume. However,
-for sources with upsert envelope, the snapshotting may take longer while the
-upsert envelope effectively dedupes your records.
+for [sources with upsert envelope](/concepts/sources/#envelopes), the
+snapshotting may take longer while the upsert envelope effectively dedupes your
+records.
 
 You can view the snapshotting status of a source in the [Materialize
 console](/console/). For a source, go to its **Overview** page in the [Database
@@ -139,9 +140,9 @@ While an object is hydrating:
 - With *serializable* isolation, a hydrating object can serve queries but with
   **stale** data.
 
-### Memory considerations for hydration
+## Memory considerations:
 
-During hydration:
+During snapshotting and hydration:
 
 - Materialized views require memory proportional to ~2x the output size (to
   recalculate the output from scratch and compare with existing output to ensure
@@ -149,3 +150,8 @@ During hydration:
 
 - Sinks require memory proportional to ~1x the output size to load an entire
   snapshot of the data in memory when they start up.
+
+- When using upsert envelope, a larger cluster size may be needed for the source
+  cluster since in addition to writing data to S3, a copy of each key consumed
+  and the latest value is maintained in memory. Materialize will automatically
+  spill the workload to disk if key spaces are larger than memory.

--- a/doc/user/content/concepts/sources.md
+++ b/doc/user/content/concepts/sources.md
@@ -72,7 +72,7 @@ Envelope | Action
 ---------|-------
 **Append-only** | Inserts all received data; does not support updates or deletes.
 **Debezium** | Treats data as wrapped in a "diff envelope" that indicates whether the record is an insertion, deletion, or update. The Debezium envelope is only supported by sources published to Kafka by [Debezium].<br/><br/>For more information, see [`CREATE SOURCE`: Kafka&mdash;Using Debezium](/sql/create-source/kafka/#using-debezium).
-**Upsert** | Treats data as having a key and a value. New records with non-null value that have the same key as a preexisting record in the dataflow will replace the preexisting record. New records with null value that have the same key as preexisting record will cause the preexisting record to be deleted. <br/><br/>For more information, see [`CREATE SOURCE`: &mdash;Handling upserts](/sql/create-source/kafka/#handling-upserts).
+**Upsert** | Treats data as having a key and a value. New records with non-null value that have the same key as a preexisting record in the dataflow will replace the preexisting record. New records with null value that have the same key as preexisting record will cause the preexisting record to be deleted. <br /><br/>For sources with upsert envelopes, Materialize both writes data to disk and maintains a copy of each key consumed and the latest value in memory. Materialize will automatically spill the workload to disk if the key space is larger than memory. <br><br>For more information, see [`CREATE SOURCE`: &mdash;Handling upserts](/sql/create-source/kafka/#handling-upserts).
 
 ## Related pages
 


### PR DESCRIPTION
Adding an initial content to a hydration page.  While refashioning the [considerations draft](https://github.com/MaterializeInc/materialize/pull/30088) into actual docs content, found that it might be better if I at least added a separate page for hydration (but didn't want to make the next patch to that PR both ne'er ending and gigantic).