### PR TITLE
Tests define custom cluster replica sizes

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -12,6 +12,7 @@
 import argparse
 import atexit
 import getpass
+import json
 import os
 import pathlib
 import shlex
@@ -30,7 +31,10 @@ import pg8000.native
 import psutil
 
 from materialize import MZ_ROOT, rustc_flags, spawn, ui
-from materialize.mzcompose import get_default_system_parameters
+from materialize.mzcompose import (
+    cluster_replica_size_map,
+    get_default_system_parameters,
+)
 from materialize.ui import UIError
 from materialize.xcompile import Arch
 
@@ -270,6 +274,7 @@ def main() -> int:
                 f"--timestamp-oracle-url={args.postgres}?options=--search_path=tsoracle",
                 f"--environment-id={environment_id}",
                 "--bootstrap-role=materialize",
+                f"--cluster-replica-sizes={json.dumps(cluster_replica_size_map())}",
                 *args.args,
             ]
             if args.monitoring:

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import json
 import operator
 import urllib.parse
 from collections.abc import Callable
@@ -37,7 +38,10 @@ from materialize.cloudtest import DEFAULT_K8S_NAMESPACE
 from materialize.cloudtest.k8s.api.k8s_service import K8sService
 from materialize.cloudtest.k8s.api.k8s_stateful_set import K8sStatefulSet
 from materialize.mz_version import MzVersion
-from materialize.mzcompose import get_default_system_parameters
+from materialize.mzcompose import (
+    cluster_replica_size_map,
+    get_default_system_parameters,
+)
 
 
 class EnvironmentdService(K8sService):
@@ -308,6 +312,10 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             V1EnvVar(
                 name="MZ_ADAPTER_STASH_URL",
                 value=f"postgres://root@cockroach.{self.cockroach_namespace}:26257?options=--search_path=adapter",
+            ),
+            V1EnvVar(
+                name="MZ_CLUSTER_REPLICA_SIZES",
+                value=f"{json.dumps(cluster_replica_size_map())}",
             ),
         ]
 

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -322,6 +322,26 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
                 name="MZ_BOOTSTRAP_DEFAULT_CLUSTER_REPLICA_SIZE",
                 value=bootstrap_cluster_replica_size(),
             ),
+            V1EnvVar(
+                name="MZ_BOOTSTRAP_BUILTIN_SYSTEM_CLUSTER_REPLICA_SIZE",
+                value=bootstrap_cluster_replica_size(),
+            ),
+            V1EnvVar(
+                name="MZ_BOOTSTRAP_BUILTIN_PROBE_CLUSTER_REPLICA_SIZE",
+                value=bootstrap_cluster_replica_size(),
+            ),
+            V1EnvVar(
+                name="MZ_BOOTSTRAP_BUILTIN_SUPPORT_CLUSTER_REPLICA_SIZE",
+                value=bootstrap_cluster_replica_size(),
+            ),
+            V1EnvVar(
+                name="MZ_BOOTSTRAP_BUILTIN_CATALOG_SERVER_CLUSTER_REPLICA_SIZE",
+                value=bootstrap_cluster_replica_size(),
+            ),
+            V1EnvVar(
+                name="MZ_BOOTSTRAP_BUILTIN_ANALYTICS_CLUSTER_REPLICA_SIZE",
+                value=bootstrap_cluster_replica_size(),
+            ),
         ]
 
         if self._meets_minimum_version("0.118.0-dev"):

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -39,6 +39,7 @@ from materialize.cloudtest.k8s.api.k8s_service import K8sService
 from materialize.cloudtest.k8s.api.k8s_stateful_set import K8sStatefulSet
 from materialize.mz_version import MzVersion
 from materialize.mzcompose import (
+    bootstrap_cluster_replica_size,
     cluster_replica_size_map,
     get_default_system_parameters,
 )
@@ -316,6 +317,10 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             V1EnvVar(
                 name="MZ_CLUSTER_REPLICA_SIZES",
                 value=f"{json.dumps(cluster_replica_size_map())}",
+            ),
+            V1EnvVar(
+                name="MZ_BOOTSTRAP_DEFAULT_CLUSTER_REPLICA_SIZE",
+                value=bootstrap_cluster_replica_size(),
             ),
         ]
 

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -18,7 +18,6 @@ from kubernetes.client import V1Container, V1EnvVar, V1ObjectMeta, V1Pod, V1PodS
 from materialize.cloudtest import DEFAULT_K8S_NAMESPACE
 from materialize.cloudtest.k8s.api.k8s_pod import K8sPod
 from materialize.mzcompose import (
-    bootstrap_cluster_replica_size,
     cluster_replica_size_map,
     get_default_system_parameters,
 )
@@ -83,7 +82,6 @@ class TestdriveBase:
             "--var=default-storage-size=1",
             "--var=default-replica-size=1",
             f"--cluster-replica-sizes={json.dumps(cluster_replica_size_map())}",
-            f"--bootstrap-default-cluster-replica-size={bootstrap_cluster_replica_size()}",
             *([f"--aws-region={self.aws_region}"] if self.aws_region else []),
             *(
                 [

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import json
 import os
 import subprocess
 import sys
@@ -16,7 +17,11 @@ from kubernetes.client import V1Container, V1EnvVar, V1ObjectMeta, V1Pod, V1PodS
 
 from materialize.cloudtest import DEFAULT_K8S_NAMESPACE
 from materialize.cloudtest.k8s.api.k8s_pod import K8sPod
-from materialize.mzcompose import get_default_system_parameters
+from materialize.mzcompose import (
+    bootstrap_cluster_replica_size,
+    cluster_replica_size_map,
+    get_default_system_parameters,
+)
 from materialize.mzcompose.test_result import (
     extract_error_chunks_from_output,
 )
@@ -77,6 +82,8 @@ class TestdriveBase:
             "--var=single-replica-cluster=quickstart",
             "--var=default-storage-size=1",
             "--var=default-replica-size=1",
+            f"--cluster-replica-sizes={json.dumps(cluster_replica_size_map())}",
+            f"--bootstrap-default-cluster-replica-size={bootstrap_cluster_replica_size()}",
             *([f"--aws-region={self.aws_region}"] if self.aws_region else []),
             *(
                 [

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -184,12 +184,6 @@ class Materialized(Service):
                 else default_size
             )
         )
-        command += [
-            # Issue database-issues#4562 prevents the habitual use of large introspection
-            # clusters, so we leave the builtin cluster replica size as is.
-            # f"--bootstrap-builtin-cluster-replica-size={self.default_replica_size}",
-            f"--bootstrap-default-cluster-replica-size={self.default_replica_size}",
-        ]
 
         if external_metadata_store:
             address = (

--- a/misc/python/materialize/mzcompose/services/testdrive.py
+++ b/misc/python/materialize/mzcompose/services/testdrive.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import json
 import random
 
 from materialize import buildkite
@@ -15,6 +16,7 @@ from materialize.mzcompose.service import (
     Service,
     ServiceDependency,
 )
+from materialize.mzcompose.services.materialized import cluster_replica_sizes
 from materialize.mzcompose.services.postgres import METADATA_STORE
 
 
@@ -56,8 +58,12 @@ class Testdrive(Service):
         mz_service: str = "materialized",
         metadata_store: str = METADATA_STORE,
         stop_grace_period: str = "120s",
+        cluster_replica_size: dict[str, str] | None = None,
     ) -> None:
         depends_graph: dict[str, ServiceDependency] = {}
+
+        if cluster_replica_size is None:
+            cluster_replica_size = cluster_replica_sizes()
 
         if environment is None:
             environment = [
@@ -74,6 +80,10 @@ class Testdrive(Service):
                 "AWS_SECRET_ACCESS_KEY",
                 "AWS_SESSION_TOKEN",
             ]
+
+        environment += [
+            f"CLUSTER_REPLICA_SIZES={json.dumps(cluster_replica_size)}",
+        ]
 
         volumes = [
             volume_workdir,

--- a/misc/python/materialize/mzcompose/services/testdrive.py
+++ b/misc/python/materialize/mzcompose/services/testdrive.py
@@ -9,14 +9,14 @@
 
 import json
 import random
+from typing import Any
 
 from materialize import buildkite
-from materialize.mzcompose import DEFAULT_MZ_VOLUMES
+from materialize.mzcompose import DEFAULT_MZ_VOLUMES, cluster_replica_size_map
 from materialize.mzcompose.service import (
     Service,
     ServiceDependency,
 )
-from materialize.mzcompose.services.materialized import cluster_replica_sizes
 from materialize.mzcompose.services.postgres import METADATA_STORE
 
 
@@ -58,12 +58,12 @@ class Testdrive(Service):
         mz_service: str = "materialized",
         metadata_store: str = METADATA_STORE,
         stop_grace_period: str = "120s",
-        cluster_replica_size: dict[str, str] | None = None,
+        cluster_replica_size: dict[str, dict[str, Any]] | None = None,
     ) -> None:
         depends_graph: dict[str, ServiceDependency] = {}
 
         if cluster_replica_size is None:
-            cluster_replica_size = cluster_replica_sizes()
+            cluster_replica_size = cluster_replica_size_map()
 
         if environment is None:
             environment = [

--- a/src/adapter/benches/catalog.rs
+++ b/src/adapter/benches/catalog.rs
@@ -9,6 +9,7 @@
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use mz_adapter::catalog::{Catalog, Op};
+use mz_catalog::durable::test_bootstrap_args;
 use mz_persist_client::PersistClient;
 use mz_sql::session::user::MZ_SYSTEM_ROLE_ID;
 use tokio::runtime::Runtime;
@@ -18,10 +19,15 @@ fn bench_transact(c: &mut Criterion) {
     c.bench_function("transact", |b| {
         let runtime = Runtime::new().unwrap();
 
+        let bootstrap_args = test_bootstrap_args();
         let mut catalog = runtime.block_on(async {
-            Catalog::open_debug_catalog(PersistClient::new_for_tests().await, Uuid::new_v4())
-                .await
-                .unwrap()
+            Catalog::open_debug_catalog(
+                PersistClient::new_for_tests().await,
+                Uuid::new_v4(),
+                &bootstrap_args,
+            )
+            .await
+            .unwrap()
         });
         let mut id = 0;
         b.iter(|| {

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -29,7 +29,9 @@ use mz_catalog::builtin::{
 use mz_catalog::config::{BuiltinItemMigrationConfig, ClusterReplicaSizeMap, Config, StateConfig};
 #[cfg(test)]
 use mz_catalog::durable::CatalogError;
-use mz_catalog::durable::{test_bootstrap_args, DurableCatalogState, TestCatalogStateBuilder};
+use mz_catalog::durable::{
+    test_bootstrap_args, BootstrapArgs, DurableCatalogState, TestCatalogStateBuilder,
+};
 use mz_catalog::expr_cache::{ExpressionCacheHandle, GlobalExpressions, LocalExpressions};
 use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
@@ -590,15 +592,14 @@ impl Catalog {
         environment_id: EnvironmentId,
         system_parameter_defaults: BTreeMap<String, String>,
         version: semver::Version,
+        bootstrap_args: &BootstrapArgs,
     ) -> Result<Catalog, anyhow::Error> {
         let openable_storage = TestCatalogStateBuilder::new(persist_client.clone())
             .with_organization_id(environment_id.organization_id())
             .with_version(version)
             .build()
             .await?;
-        let storage = openable_storage
-            .open_read_only(&test_bootstrap_args())
-            .await?;
+        let storage = openable_storage.open_read_only(bootstrap_args).await?;
         Self::open_debug_catalog_inner(
             persist_client,
             storage,

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -150,7 +150,7 @@ enum Action {
         #[clap(flatten)]
         secrets: SecretsReaderCliArgs,
         /// Map of cluster name to resource specification. Check the README for latest values.
-        cluster_replica_sizes: Option<String>,
+        cluster_replica_sizes: String,
     },
 }
 
@@ -250,10 +250,8 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             secrets,
             cluster_replica_sizes,
         } => {
-            let cluster_replica_sizes: ClusterReplicaSizeMap = match cluster_replica_sizes {
-                None => Default::default(),
-                Some(json) => serde_json::from_str(&json).context("parsing replica size map")?,
-            };
+            let cluster_replica_sizes: ClusterReplicaSizeMap =
+                serde_json::from_str(&cluster_replica_sizes).context("parsing replica size map")?;
             upgrade_check(
                 args,
                 openable_state,
@@ -551,7 +549,7 @@ async fn upgrade_check(
                 default_cluster_replica_size:
                     "DEFAULT CLUSTER REPLICA SIZE IS ONLY USED FOR NEW ENVIRONMENTS".into(),
                 bootstrap_role: None,
-                cluster_replica_size_map: ClusterReplicaSizeMap::default(),
+                cluster_replica_size_map: cluster_replica_sizes.clone(),
             },
         )
         .await?;

--- a/src/catalog/src/config.rs
+++ b/src/catalog/src/config.rs
@@ -118,14 +118,12 @@ impl ClusterReplicaSizeMap {
             CatalogError::Catalog(SqlCatalogError::UnknownClusterReplicaSize(name.into()))
         })
     }
-}
 
-impl Default for ClusterReplicaSizeMap {
-    // Used for testing and local purposes. This default value should not be used in production.
-    //
-    // Credits per hour are calculated as being equal to scale. This is not necessarily how the
-    // value is computed in production.
-    fn default() -> Self {
+    /// Used for testing and local purposes. This default value should not be used in production.
+    ///
+    /// Credits per hour are calculated as being equal to scale. This is not necessarily how the
+    /// value is computed in production.
+    pub fn for_tests() -> Self {
         // {
         //     "1": {"scale": 1, "workers": 1},
         //     "2": {"scale": 1, "workers": 2},

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -414,6 +414,6 @@ pub fn test_bootstrap_args() -> BootstrapArgs {
     BootstrapArgs {
         default_cluster_replica_size: "1".into(),
         bootstrap_role: None,
-        cluster_replica_size_map: ClusterReplicaSizeMap::default(),
+        cluster_replica_size_map: ClusterReplicaSizeMap::for_tests(),
     }
 }

--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -437,7 +437,7 @@ pub struct Args {
         env = "CLUSTER_REPLICA_SIZES",
         requires = "bootstrap-default-cluster-replica-size"
     )]
-    cluster_replica_sizes: Option<String>,
+    cluster_replica_sizes: String,
     /// An API key for Segment. Enables export of audit events to Segment.
     #[clap(long, env = "SEGMENT_API_KEY")]
     segment_api_key: Option<String>,
@@ -980,10 +980,8 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         },
     };
 
-    let cluster_replica_sizes: ClusterReplicaSizeMap = match args.cluster_replica_sizes {
-        None => Default::default(),
-        Some(json) => serde_json::from_str(&json).context("parsing replica size map")?,
-    };
+    let cluster_replica_sizes: ClusterReplicaSizeMap =
+        serde_json::from_str(&args.cluster_replica_sizes).context("parsing replica size map")?;
 
     emit_boot_diagnostics!(&BUILD_INFO);
     sys::adjust_rlimits();

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -25,6 +25,7 @@ use futures::Future;
 use headers::{Header, HeaderMapExt};
 use hyper::http::header::HeaderMap;
 use mz_adapter::TimestampExplanation;
+use mz_catalog::config::ClusterReplicaSizeMap;
 use mz_controller::ControllerConfig;
 use mz_orchestrator_process::{ProcessOrchestrator, ProcessOrchestratorConfig};
 use mz_orchestrator_tracing::{TracingCliArgs, TracingOrchestrator};
@@ -509,7 +510,7 @@ impl Listeners {
                 now: config.now,
                 environment_id: config.environment_id,
                 cors_allowed_origin: AllowOrigin::list([]),
-                cluster_replica_sizes: Default::default(),
+                cluster_replica_sizes: ClusterReplicaSizeMap::for_tests(),
                 bootstrap_default_cluster_replica_size: config.default_cluster_replica_size,
                 bootstrap_builtin_system_cluster_replica_size: config
                     .builtin_system_cluster_replica_size,

--- a/src/materialized/ci/entrypoint.sh
+++ b/src/materialized/ci/entrypoint.sh
@@ -73,6 +73,86 @@ export MZ_ORCHESTRATOR_PROCESS_SECRETS_DIRECTORY=${MZ_ORCHESTRATOR_PROCESS_SECRE
 export MZ_ORCHESTRATOR_PROCESS_SCRATCH_DIRECTORY=${MZ_ORCHESTRATOR_PROCESS_SCRATCH_DIRECTORY:-/scratch}
 export MZ_BOOTSTRAP_ROLE=${MZ_BOOTSTRAP_ROLE:-materialize}
 
+# Supported replica sizes.
+export MZ_CLUSTER_REPLICA_SIZES=${MZ_CLUSTER_REPLICA_SIZES:-$(cat <<EOF
+{
+  "25cc": {
+    "cpu_limit": 0.5,
+    "credits_per_hour": "0.25",
+    "scale": 1,
+    "workers": 1
+  },
+  "50cc": {
+    "cpu_limit": 1,
+    "credits_per_hour": "0.5",
+    "scale": 1,
+    "workers": 1
+  },
+  "100cc": {
+    "cpu_limit": 2,
+    "credits_per_hour": "1",
+    "scale": 1,
+    "workers": 2
+  },
+  "200cc": {
+    "cpu_limit": 4,
+    "credits_per_hour": "2",
+    "scale": 1,
+    "workers": 4
+  },
+  "300cc": {
+    "cpu_limit": 6,
+    "credits_per_hour": "3",
+    "scale": 1,
+    "workers": 6
+  },
+  "400cc": {
+    "cpu_limit": 8,
+    "credits_per_hour": "4",
+    "scale": 1,
+    "workers": 8
+  },
+  "600cc": {
+    "cpu_limit": 12,
+    "credits_per_hour": "6",
+    "scale": 1,
+    "workers": 12
+  },
+  "800cc": {
+    "cpu_limit": 16,
+    "credits_per_hour": "8",
+    "scale": 1,
+    "workers": 16
+  },
+  "1200cc": {
+    "cpu_limit": 24,
+    "credits_per_hour": "12",
+    "scale": 1,
+    "workers": 24
+  },
+  "1600cc": {
+    "cpu_limit": 31,
+    "credits_per_hour": "16",
+    "scale": 1,
+    "workers": 31
+  },
+  "3200cc": {
+    "cpu_limit": 62,
+    "credits_per_hour": "32",
+    "scale": 1,
+    "workers": 62
+  }
+}
+EOF
+)}
+
+export MZ_BOOTSTRAP_DEFAULT_CLUSTER_REPLICA_SIZE="${MZ_BOOTSTRAP_DEFAULT_CLUSTER_REPLICA_SIZE:-25cc}"
+export MZ_BOOTSTRAP_BUILTIN_SYSTEM_CLUSTER_REPLICA_SIZE="${MZ_BOOTSTRAP_BUILTIN_SYSTEM_CLUSTER_REPLICA_SIZE:-${MZ_BOOTSTRAP_DEFAULT_CLUSTER_REPLICA_SIZE}}"
+export MZ_BOOTSTRAP_BUILTIN_PROBE_CLUSTER_REPLICA_SIZE="${MZ_BOOTSTRAP_BUILTIN_PROBE_CLUSTER_REPLICA_SIZE:-${MZ_BOOTSTRAP_DEFAULT_CLUSTER_REPLICA_SIZE}}"
+export MZ_BOOTSTRAP_BUILTIN_SUPPORT_CLUSTER_REPLICA_SIZE="${MZ_BOOTSTRAP_BUILTIN_SUPPORT_CLUSTER_REPLICA_SIZE:-${MZ_BOOTSTRAP_DEFAULT_CLUSTER_REPLICA_SIZE}}"
+export MZ_BOOTSTRAP_BUILTIN_CATALOG_SERVER_CLUSTER_REPLICA_SIZE="${MZ_BOOTSTRAP_BUILTIN_CATALOG_SERVER_CLUSTER_REPLICA_SIZE:-${MZ_BOOTSTRAP_DEFAULT_CLUSTER_REPLICA_SIZE}}"
+export MZ_BOOTSTRAP_BUILTIN_ANALYTICS_CLUSTER_REPLICA_SIZE="${MZ_BOOTSTRAP_BUILTIN_ANALYTICS_CLUSTER_REPLICA_SIZE:-${MZ_BOOTSTRAP_DEFAULT_CLUSTER_REPLICA_SIZE}}"
+
 if [ -z "${MZ_NO_TELEMETRY:-}" ]; then
     export MZ_SEGMENT_API_KEY=${MZ_SEGMENT_API_KEY:-hMWi3sZ17KFMjn2sPWo9UJGpOQqiba4A}
     export MZ_SEGMENT_CLIENT_SIDE=${MZ_SEGMENT_API_KEY:-true}

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -43,6 +43,7 @@ use fallible_iterator::FallibleIterator;
 use futures::sink::SinkExt;
 use itertools::Itertools;
 use md5::{Digest, Md5};
+use mz_catalog::config::ClusterReplicaSizeMap;
 use mz_controller::ControllerConfig;
 use mz_environmentd::CatalogConfig;
 use mz_orchestrator_process::{ProcessOrchestrator, ProcessOrchestratorConfig};
@@ -1071,7 +1072,7 @@ impl<'a> RunnerInner<'a> {
             metrics_registry,
             now,
             environment_id,
-            cluster_replica_sizes: Default::default(),
+            cluster_replica_sizes: ClusterReplicaSizeMap::for_tests(),
             bootstrap_default_cluster_replica_size: config.replicas.to_string(),
             bootstrap_builtin_system_cluster_replica_size: config.replicas.to_string(),
             bootstrap_builtin_catalog_server_cluster_replica_size: config.replicas.to_string(),

--- a/src/testdrive/src/action/consistency.rs
+++ b/src/testdrive/src/action/consistency.rs
@@ -187,9 +187,12 @@ async fn check_catalog_state(state: &State) -> Result<(), anyhow::Error> {
     // Load the on-disk catalog and dump its state.
     let version: semver::Version = state.build_info.version.parse().expect("invalid version");
     let maybe_disk_catalog = state
-        .with_catalog_copy(system_parameter_defaults, version, |catalog| {
-            catalog.state().clone()
-        })
+        .with_catalog_copy(
+            system_parameter_defaults,
+            version,
+            &state.materialize.bootstrap_args,
+            |catalog| catalog.state().clone(),
+        )
         .await
         .map_err(|e| anyhow!("failed to read on-disk catalog state: {e}"))?
         .map(|catalog| {

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -266,7 +266,7 @@ struct Args {
     fivetran_destination_files_path: String,
     /// A map from size name to resource allocations for cluster replicas.
     #[clap(long, env = "CLUSTER_REPLICA_SIZES")]
-    cluster_replica_sizes: Option<String>,
+    cluster_replica_sizes: String,
 }
 
 #[tokio::main]
@@ -356,11 +356,9 @@ async fn main() {
         arg_vars.insert(name.to_string(), val.to_string());
     }
 
-    let cluster_replica_sizes: ClusterReplicaSizeMap = match args.cluster_replica_sizes {
-        None => Default::default(),
-        Some(json) => serde_json::from_str(&json)
-            .unwrap_or_else(|e| die!("testdrive: failed to parse replica size map: {}", e)),
-    };
+    let cluster_replica_sizes: ClusterReplicaSizeMap =
+        serde_json::from_str(&args.cluster_replica_sizes)
+            .unwrap_or_else(|e| die!("testdrive: failed to parse replica size map: {}", e));
 
     let materialize_catalog_config = if args.validate_catalog_store {
         Some(CatalogConfig {

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -19,6 +19,7 @@ use aws_types::region::Region;
 use globset::GlobBuilder;
 use itertools::Itertools;
 use mz_build_info::{build_info, BuildInfo};
+use mz_catalog::config::ClusterReplicaSizeMap;
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::path::PathExt;
 use mz_ore::url::SensitiveUrl;
@@ -263,6 +264,9 @@ struct Args {
         default_value = "/tmp"
     )]
     fivetran_destination_files_path: String,
+    /// A map from size name to resource allocations for cluster replicas.
+    #[clap(long, env = "CLUSTER_REPLICA_SIZES")]
+    cluster_replica_sizes: Option<String>,
 }
 
 #[tokio::main]
@@ -352,6 +356,12 @@ async fn main() {
         arg_vars.insert(name.to_string(), val.to_string());
     }
 
+    let cluster_replica_sizes: ClusterReplicaSizeMap = match args.cluster_replica_sizes {
+        None => Default::default(),
+        Some(json) => serde_json::from_str(&json)
+            .unwrap_or_else(|e| die!("testdrive: failed to parse replica size map: {}", e)),
+    };
+
     let materialize_catalog_config = if args.validate_catalog_store {
         Some(CatalogConfig {
             persist_consensus_url: args
@@ -382,6 +392,7 @@ async fn main() {
 
         // === Materialize options. ===
         materialize_pgconfig: args.materialize_url,
+        materialize_cluster_replica_sizes: cluster_replica_sizes,
         materialize_internal_pgconfig: args.materialize_internal_url,
         materialize_http_port: args.materialize_http_port,
         materialize_internal_http_port: args.materialize_internal_http_port,

--- a/test/testdrive/github-3955.td
+++ b/test/testdrive/github-3955.td
@@ -7,13 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-arg-default default-replica-size=1
-
 # Regression test for https://github.com/MaterializeInc/database-issues/issues/3955
 
 # The contents of the introspection tables depend on the replica size
-$ skip-if
-SELECT '${arg.default-replica-size}' != '4-4'
+> CREATE CLUSTER test (SIZE '4-4');
+
+> SET cluster = test;
 
 # In case the environment has other replicas
 > SET cluster_replica = r1
@@ -36,3 +35,5 @@ SELECT '${arg.default-replica-size}' != '4-4'
     compute_exports.export_id = frontiers.export_id AND
     time > 0
 16
+
+> DROP CLUSTER test CASCADE;

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -105,7 +105,7 @@ INSERT INTO temp SELECT * FROM temp
 $ set-regex match=true|false replacement=<TRUE_OR_FALSE>
 
 > SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
-mz_system r1 1 <TRUE_OR_FALSE> ""
+mz_system r1 bootstrap <TRUE_OR_FALSE> ""
 
 > SELECT COUNT(*) FROM mz_catalog.mz_cluster_replicas as r, mz_catalog.mz_clusters as c WHERE r.cluster_id = c.id and c.name = 'mz_support';
 0


### PR DESCRIPTION
Tests define their cluster replica sizes without relying on the builtin defaults.

### Motivation

This allows us to decouple the builtin sizes in the materialize binary to differ from what tests require. It's a step towards a better emulator experience.

This PR turned out bigger than expected because we'd use the builtin defaults in places where we shouldn't. Tracing the places is hard, often because the place where the defaults are used is separated from where we encounter potential inconsistencies. To avoid the issues going forward, this PR changes the way we handle default cluster replica sizes: It's not an optional parameter anymore but all callers need to provide it to environmentd and testdrive. Only sqllogictest still uses the default.

The PR adjusts all entrypoints within the materialize repo to supply a cluster replica size map, and all uses outside the repo should do so already.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
