### PR TITLE
Use user-supplied replica sizes during boostrap

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1101,11 +1101,7 @@ fn add_new_builtin_clusters_migration(
     for builtin_cluster in BUILTIN_CLUSTERS {
         if !cluster_names.contains(builtin_cluster.name) {
             let cluster_size = builtin_cluster_sizes.get_size(builtin_cluster.name)?;
-            let cluster_allocation = cluster_sizes.0.get(&cluster_size).ok_or_else(|| {
-                mz_catalog::durable::CatalogError::Catalog(
-                    SqlCatalogError::UnknownClusterReplicaSize(cluster_size.clone()),
-                )
-            })?;
+            let cluster_allocation = cluster_sizes.get_allocation_by_name(&cluster_size)?;
             let id = txn.get_and_increment_id(SYSTEM_CLUSTER_ID_ALLOC_KEY.to_string())?;
             let id = ClusterId::System(id);
             txn.insert_system_cluster(
@@ -1224,11 +1220,7 @@ fn add_new_builtin_cluster_replicas_migration(
                     builtin_cluster_sizes.get_size(builtin_replica.cluster_name)?
                 }
             };
-            let replica_allocation = cluster_sizes.0.get(&replica_size).ok_or_else(|| {
-                mz_catalog::durable::CatalogError::Catalog(
-                    SqlCatalogError::UnknownClusterReplicaSize(replica_size.clone()),
-                )
-            })?;
+            let replica_allocation = cluster_sizes.get_allocation_by_name(&replica_size)?;
 
             let config = builtin_cluster_replica_config(replica_size, replica_allocation);
             txn.insert_cluster_replica(

--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -30,8 +30,8 @@ use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
 use mz_repr::network_policy_id::NetworkPolicyId;
 use mz_repr::role_id::RoleId;
 use mz_sql::catalog::{
-    CatalogError as SqlCatalogError, DefaultPrivilegeAclItem, DefaultPrivilegeObject, ObjectType,
-    RoleAttributes, RoleMembership, RoleVars, SystemObjectType,
+    DefaultPrivilegeAclItem, DefaultPrivilegeObject, ObjectType, RoleAttributes, RoleMembership,
+    RoleVars, SystemObjectType,
 };
 use mz_sql::names::{
     DatabaseId, ObjectId, ResolvedDatabaseSpecifier, SchemaId, SchemaSpecifier, PUBLIC_ROLE_NAME,
@@ -681,13 +681,7 @@ pub(crate) async fn initialize(
                 let cluster_size = options.default_cluster_replica_size.to_string();
                 let cluster_allocation = options
                     .cluster_replica_size_map
-                    .0
-                    .get(&cluster_size)
-                    .ok_or_else(|| {
-                        CatalogError::Catalog(SqlCatalogError::UnknownClusterReplicaSize(
-                            cluster_size,
-                        ))
-                    })?;
+                    .get_allocation_by_name(&cluster_size)?;
                 cluster_allocation.is_cc
             },
             billed_as: None,
@@ -769,13 +763,7 @@ fn default_cluster_config(args: &BootstrapArgs) -> Result<ClusterConfig, Catalog
     let cluster_size = args.default_cluster_replica_size.to_string();
     let cluster_allocation = args
         .cluster_replica_size_map
-        .0
-        .get(&cluster_size)
-        .ok_or_else(|| {
-            CatalogError::Catalog(SqlCatalogError::UnknownClusterReplicaSize(
-                cluster_size.clone(),
-            ))
-        })?;
+        .get_allocation_by_name(&cluster_size)?;
     Ok(ClusterConfig {
         variant: ClusterVariant::Managed(ClusterVariantManaged {
             size: cluster_size,
@@ -798,13 +786,7 @@ fn default_replica_config(args: &BootstrapArgs) -> Result<ReplicaConfig, Catalog
     let cluster_size = args.default_cluster_replica_size.to_string();
     let cluster_allocation = args
         .cluster_replica_size_map
-        .0
-        .get(&cluster_size)
-        .ok_or_else(|| {
-            CatalogError::Catalog(SqlCatalogError::UnknownClusterReplicaSize(
-                cluster_size.clone(),
-            ))
-        })?;
+        .get_allocation_by_name(&cluster_size)?;
     Ok(ReplicaConfig {
         location: ReplicaLocation::Managed {
             size: cluster_size,

--- a/src/environmentd/src/deployment/preflight.rs
+++ b/src/environmentd/src/deployment/preflight.rs
@@ -13,7 +13,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use mz_adapter::ResultExt;
-use mz_catalog::config::ClusterReplicaSizeMap;
 use mz_catalog::durable::{BootstrapArgs, CatalogError, Metrics, OpenableDurableCatalogState};
 use mz_ore::channel::trigger;
 use mz_ore::exit;
@@ -30,14 +29,13 @@ pub struct PreflightInput {
     pub boot_ts: u64,
     pub environment_id: EnvironmentId,
     pub persist_client: PersistClient,
-    pub bootstrap_default_cluster_replica_size: String,
-    pub bootstrap_role: Option<String>,
     pub deploy_generation: u64,
     pub deployment_state: DeploymentState,
     pub openable_adapter_storage: Box<dyn OpenableDurableCatalogState>,
     pub catalog_metrics: Arc<Metrics>,
     pub caught_up_max_wait: Duration,
     pub panic_after_timeout: bool,
+    pub bootstrap_args: BootstrapArgs,
 }
 
 /// Output of preflight checks.
@@ -53,12 +51,11 @@ pub async fn preflight_legacy(
         boot_ts,
         environment_id,
         persist_client,
-        bootstrap_default_cluster_replica_size,
-        bootstrap_role,
         deploy_generation,
         deployment_state,
         mut openable_adapter_storage,
         catalog_metrics,
+        bootstrap_args,
         caught_up_max_wait: _,
         panic_after_timeout: _,
     }: PreflightInput,
@@ -74,14 +71,7 @@ pub async fn preflight_legacy(
     if catalog_generation < deploy_generation {
         tracing::info!("Catalog generation {catalog_generation:?} is less than deploy generation {deploy_generation}. Performing pre-flight checks");
         match openable_adapter_storage
-            .open_savepoint(
-                boot_ts.clone(),
-                &BootstrapArgs {
-                    default_cluster_replica_size: bootstrap_default_cluster_replica_size,
-                    bootstrap_role,
-                    cluster_replica_size_map: ClusterReplicaSizeMap::default(),
-                },
-            )
+            .open_savepoint(boot_ts.clone(), &bootstrap_args)
             .await
         {
             Ok(adapter_storage) => Box::new(adapter_storage).expire().await,
@@ -138,14 +128,13 @@ pub async fn preflight_0dt(
         boot_ts,
         environment_id,
         persist_client,
-        bootstrap_default_cluster_replica_size,
-        bootstrap_role,
         deploy_generation,
         deployment_state,
         mut openable_adapter_storage,
         catalog_metrics,
         caught_up_max_wait,
         panic_after_timeout,
+        bootstrap_args,
     }: PreflightInput,
 ) -> Result<PreflightOutput, CatalogError> {
     info!(%deploy_generation, ?caught_up_max_wait, "performing 0dt preflight checks");
@@ -211,15 +200,7 @@ pub async fn preflight_0dt(
             .expect("incompatible catalog/persist version");
 
             openable_adapter_storage
-                .open(
-                    boot_ts,
-                    &BootstrapArgs {
-                        default_cluster_replica_size: bootstrap_default_cluster_replica_size
-                            .clone(),
-                        bootstrap_role: bootstrap_role.clone(),
-                        cluster_replica_size_map: ClusterReplicaSizeMap::default(),
-                    },
-                )
+                .open(boot_ts, &bootstrap_args)
                 .await
                 .unwrap_or_terminate("unexpected error while fencing out old deployment");
 

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -554,7 +554,7 @@ impl Listeners {
         let bootstrap_args = BootstrapArgs {
             default_cluster_replica_size: config.bootstrap_default_cluster_replica_size.clone(),
             bootstrap_role: config.bootstrap_role,
-            cluster_replica_size_map: ClusterReplicaSizeMap::default(),
+            cluster_replica_size_map: config.cluster_replica_sizes.clone(),
         };
 
         // Load the adapter durable storage.

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -517,20 +517,22 @@ impl Listeners {
         // Preflight checks determine whether to boot in read-only mode or not.
         let mut read_only = false;
         let mut caught_up_trigger = None;
+        let bootstrap_args = BootstrapArgs {
+            default_cluster_replica_size: config.bootstrap_default_cluster_replica_size.clone(),
+            bootstrap_role: config.bootstrap_role.clone(),
+            cluster_replica_size_map: config.cluster_replica_sizes.clone(),
+        };
         let preflight_config = PreflightInput {
             boot_ts,
             environment_id: config.environment_id.clone(),
             persist_client,
-            bootstrap_default_cluster_replica_size: config
-                .bootstrap_default_cluster_replica_size
-                .clone(),
-            bootstrap_role: config.bootstrap_role.clone(),
             deploy_generation: config.controller.deploy_generation,
             deployment_state: deployment_state.clone(),
             openable_adapter_storage,
             catalog_metrics: Arc::clone(&config.catalog_config.metrics),
             caught_up_max_wait: with_0dt_deployment_max_wait,
             panic_after_timeout: enable_0dt_deployment_panic_after_timeout,
+            bootstrap_args,
         };
         if enable_0dt_deployment {
             PreflightOutput {


### PR DESCRIPTION
Fixes a bug where we'd use the default replica sizes during bootstrap instead of the ones supplied by the user.

Cleans up the code around converting replica sizes to allocations.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
