### PR TITLE
make the secrets manager default to kubernetes in orchestratord

### DIFF
--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -43,6 +43,8 @@ pub struct Args {
     enable_tls: bool,
     #[clap(long)]
     helm_chart_version: Option<String>,
+    #[clap(long, default_value = "kubernetes")]
+    secrets_controller: String,
 
     #[clap(long)]
     console_image_tag_map: Vec<KeyValueArg<String, String>>,

--- a/src/orchestratord/src/controller/materialize/resources.rs
+++ b/src/orchestratord/src/controller/materialize/resources.rs
@@ -880,14 +880,16 @@ fn create_environmentd_statefulset_object(
             .map(|origin| format!("--cors-allowed-origin={}", origin.to_str().unwrap())),
     );
 
+    args.push(format!(
+        "--secrets-controller={}",
+        config.secrets_controller
+    ));
+
     if config.local_development {
         args.extend([
-            "--secrets-controller=kubernetes".into(),
             "--system-parameter-default=cluster_enable_topology_spread=false".into(),
             "--system-parameter-default=log_filter=mz_pgwire[{conn_uuid}]=debug,mz_server_core[{conn_uuid}]=debug,info".into(),
         ]);
-    } else {
-        args.push("--secrets-controller=aws-secrets-manager".into());
     }
 
     if config.enable_tls {


### PR DESCRIPTION
### Motivation

the aws secrets backend is not going to work without a lot of extra configuration

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
