### PR TITLE
Correct `promote_let_rec`

### DIFF
--- a/src/compute-types/src/plan/flat_plan.rs
+++ b/src/compute-types/src/plan/flat_plan.rs
@@ -593,13 +593,7 @@ impl<T> FlatPlan<T> {
     ///
     /// The returned value is a list of `value` plans, each with the `LocalId` it is referenced by,
     /// as well as the let-free `body` plan. The `value` plans are in topological order.
-    ///
-    /// # Panics
-    ///
-    /// Panics if this plan is recursive.
     pub fn split_lets(self) -> (Vec<(LocalId, Self)>, Self) {
-        assert!(!self.is_recursive());
-
         let (mut steps, mut root_id, mut topological_order) = self.destruct();
 
         // Descend the chain of `Let` nodes and build for each one the subplan rooted in its


### PR DESCRIPTION
Our implementation of `promote_let_rec` incorrectly fused `LetRec` blocks that it should not have. In fact, it really shouldn't be fusing *any* of these blocks, but due either to a bug or unwarranted optimism, it did. This was an error for blocks under `Let` bindings, where the sequencing is important, and .. to be honest I have no idea how it didn't crash.

An example problematic query was
```sql
create table foo (a int);

create view bar as
with mutually recursive 
    bar(a int) as ( 
        select * from bar union select * from foo 
    )
select * from bar;

create view baz as
with mutually recursive 
    baz(a int) as ( 
        select * from baz except select * from bar 
    )
select * from baz;

explain select * from baz;
```
Here the sequencing means that `baz` should evolve only ever using the final value of `bar`. However, the two loops were fused, and `baz` evolved with the current values of `bar`, which is just wrong, especially in the case where `bar` contributes negatively (the `except`), and just generally when there are not some pleasant monotonicity properties.

The corrected code is I hope improved as well. The structure is very similar, in that we repeatedly hoist bindings out of expressions until we can place pretty much all of them at the root. The old code .. just put them all in a single `LetRec`, even if they came from 37 different `LetRec`s. No clue why; totally wrong. The new code unpacks them into isolated bindings that correctly stage the iteration to ensure the correct values are used for starting subsequent iteration.

At the same time, a few other random glitches have been observed and maybe fixed. For some reason (bugs?) we didn't descend into `LetRec::body` when harvesting bindings. There's no reason not to, as we are going to hoist the letrec bindings, and so we do now. In the outer loop we would descend into `body` presumably because it wasn't really "done", but we don't have to any more (or shouldn't have to).

There are several raised questions about letrec "normalization", and which of the equivalent forms we should choose. I think these are up for discussion, and this is primarily meant to fix a bug rather than usher in a renaissance of letrec understanding. However, I do understand it better now, and might try and tidy other parts up as follow-on work.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
