### PR TITLE
rust: downgrade back to `v1.80.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,7 +233,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.82.0"
+rust-version = "1.80.1"
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -334,9 +334,9 @@ rules_rust_dependencies()
 # Fetch and register the relevant Rust toolchains. We use a custom macro that
 # depends on `rules_rust` but cuts down on bloat from their defaults.
 
-RUST_VERSION = "1.82.0"
+RUST_VERSION = "1.80.1"
 
-RUST_NIGHTLY_VERSION = "nightly/2024-10-27"
+RUST_NIGHTLY_VERSION = "nightly/2024-08-01"
 
 load("//misc/bazel/toolchains:rust.bzl", "rust_toolchains")
 
@@ -348,66 +348,66 @@ rust_toolchains(
     {
         "aarch64-apple-darwin": {
             "stable": {
-                "rustc": "5eca44b4a6f8bcd9ba5c29661fabdfbdf9c3ba5a49b4d3427a8d27ca5040c67b",
-                "clippy": "3e213bcfe1260e19876b9c78889613d1c6a5a079d9a614d4138d3cabb2649c94",
-                "cargo": "6b04e0d825fbcd92d066b0d6ced229d164b2648dc92bc1318d27b84685b51a8e",
-                "llvm-tools": "46fd0fb00d47d78059490a1d1f97132ee656513f1acc0d808f89604d244f833b",
-                "rust-std": "b329d0c9e54eb55ec4e19d0f14099096c5e3fdc772cc22c272125a02f30fdcdd",
+                "rustc": "ada84b7c4521b10f54ab73d34916cb45fb68cc928b16c9e1be39f89406b84c86",
+                "clippy": "f1f6772c917008d170e4cdc7ae10e370cfbe11da6105bf5913a1b43ea126b0f1",
+                "cargo": "4649742a7bfc4a46036e47ea057d60bf8301c0299054c9785ee37947b2d1294c",
+                "llvm-tools": "725bb2381dd287fb070a05eb6092fc5b4000ba69eb2cb27790c0f40fd248a56a",
+                "rust-std": "ddd123723fe4576a155ce0190da5f16a2c067cbd5b1a2c23b301592568e5752d",
             },
             "nightly": {
-                "rustc": "f8df936737d5a7e89385665b6c8360366ce2d448d892e07a6d3567cfecfe6971",
-                "clippy": "dc6946d4839d6ef92d3b175b5d6b9ffe83eba07108ad0c8e21bd91ed5395975b",
-                "cargo": "06c477e81b84e497d72503e78d2a90cd73e75220b8597ff3db810f640c92624b",
-                "llvm-tools": "906046d9349af8a1a5179a10b12377713b6fb52c9ed55ec7c6bfea1a08bba994",
-                "rust-std": "a9a93c9cfcbb39963573f85e202a79a969b72ceefd1981b2114458121d8f9a1c",
+                "rustc": "16a8eefc8121633bc1d80342975cc5299a3da4c11d28e3a134ce376eafea4784",
+                "clippy": "341b35b68ab14d0de0b6cece0042ae91b640a66b6fbc71ff6a4e021c2a1cea18",
+                "cargo": "e633472e33eb97d2886d3149968b27956b91efa8da5cded10399c7a1f0ede481",
+                "llvm-tools": "2cf35c331fff0034301fb0cbef221c3203f23ab4c6780e20a70c92d76b1bf7f5",
+                "rust-std": "f0742c7371383c1ea2849440b8d5f631be2aa7211b3e150a41cca552dcd92ddd",
             },
         },
         "aarch64-unknown-linux-gnu": {
             "stable": {
-                "rustc": "d09e5441dd699d69c90c4a71b1d0664bb05b1a2f485f853fadc0d4e59787261c",
-                "clippy": "e6867dc89cc642e0f2ef0d9f88eb3845542412273f9d1b79750090ad2d38c92e",
-                "cargo": "467309c7767c6ff758d8094908773deeda0a69538bd61343bd4cd76ca4b573f2",
-                "llvm-tools": "61d139395186b81870a05a786e2c8c907fd8cb34f02603b65be4011f9a131016",
-                "rust-std": "e88eac6bbb73d1d2a3040ebaf0e43c99360d8db716682de8c3471ac7435c85bd",
+                "rustc": "4ca87875f8a23ef1f23d60a958a0dc798e2b8e97bf6782b2ec534026181fa72c",
+                "clippy": "fcda253a6704f612310696f25f161c880f16ec8be6b640ccf5fe26245c822efc",
+                "cargo": "6973b542f54ade0215becd34a06d011e4c35a8091a27ac667d0438ebc45a935e",
+                "llvm-tools": "2574807dcf8a1d68adc57c42c4caa812ac3d54f376b16b536c8073c60877c680",
+                "rust-std": "07238d367cfba20bf80150f725234b877b11bc3ab82d04ed0ccc95375e9cedd8",
             },
             "nightly": {
-                "rustc": "95b02cd12417df24895e6d90ae29a458cc2a986dd090b55769a67d48c7ce1e97",
-                "clippy": "f65a14e34d2212d516c6d39654277007e9eed1b78a621b306ad5945e1c72b0b2",
-                "cargo": "496dd7471f538084c27a5979da51c44bb70b838b639b5f8826413a076eb5ee9b",
-                "llvm-tools": "07aad3b7aa2869f2f1ea9ce17e380ec05fcdd1271d5a5782572a80b88babfdd8",
-                "rust-std": "532983ade819108388b9bc2ec374f5caef794d857e6b64bcbc59987e158bc9ee",
+                "rustc": "d21d28f3b81637070004f486c5267989381ad763e7d4c9084d2d226aa46cd308",
+                "clippy": "58a022177e2cb99f40ddd4e4dacd4b5580af9920829a873bbbd92d91cb934979",
+                "cargo": "4b56caba8ccd3101cbae3b2093b0858ae9045534c7378fc16150285d0f3c082f",
+                "llvm-tools": "52cf02c11e64b320d05ca1df8d1104a757080a3088e397bd1f752f5bd0b6b258",
+                "rust-std": "6ad1dc3b4aa3f78a7ead87ecc475299b35e884778ecc99a057a3178fa1c332b5",
             },
         },
         "x86_64-unknown-linux-gnu": {
             "stable": {
-                "rustc": "14e1256aa8dc41df658de6a38b89678d0993839ca7c522e22cdd25bce38e1722",
-                "clippy": "24f736f62357cc00c691b4fc5078026fd7c8c5cfb7ec159fae76e13a6702238b",
-                "cargo": "94f8db0d7f389a6fa06f6af48dc38df3e4594a98175f08729999c7cc7c240c3f",
-                "llvm-tools": "a98adb0acc575807ad5f9befd7e241ab8809a1045c0dd48267ad70a37f84baa7",
-                "rust-std": "09794abfb07cf49ddf722107d40b8aa823febccc13f5a50c1a2252fa1be3fe00",
+                "rustc": "5c7fce7a0323b8669b4e17ec370b38a5f207fcdcd5c66b83c877b72e252d561e",
+                "clippy": "39253ce4ecb036977686f5a8cc183de295cf280766678201f919c5655e3dd063",
+                "cargo": "863c016fc458b1fa8809d7b66dcccd272f8b6b2e8a42c89b7dff4b619f3d3940",
+                "llvm-tools": "86e441024b0e538ed69fa0098be48592caae6fc28097f7630b906be276c79622",
+                "rust-std": "e7b766fce1cd89c02bde33f8cc3a81f341c52677258a546df2bee1c7090e9fc5",
             },
             "nightly": {
-                "rustc": "cfee96fda96a49dfd9a3e9e8895a50a14fc8e2852da3905e7368676e842ab102",
-                "clippy": "f682d44e8da98da2d50488088e126ea3096c70d7d1c66e7ed45d53413f681cab",
-                "cargo": "33f1ff0f57e0a07c2a9e72e2dd4d3218b7c550aa8d02c4a4960c42832f66bf7f",
-                "llvm-tools": "763f2ac63b955aaf07e41757055c06477af203d5e41ace4204d1055cf68fd1fb",
-                "rust-std": "adba52f3259e6c3486fdd5436f7c05529def5ddcdbe63bf876f904b166d15b0f",
+                "rustc": "10bf2f8f95cf934bf1f3e0f7d507b615c6a329bedb78adaa1d3bdf75532d7d36",
+                "clippy": "692f4550bf4e2f3a783f97a3706ed0c557258b885a6c166830e4b4e40bc8ba06",
+                "cargo": "10cc2e832b8ac2386eb0fbd2f1eb3583ff6f9468332619f6bb1324b27fe6451f",
+                "llvm-tools": "45b11ccde9ec167c4d741ade55fdab958db01a938a6e2b437f93733aa2bfa036",
+                "rust-std": "8a8bf9b1d4f93ca2a162a28d0f478ac7bc73aab241befecdf9a1dbf27d86f68f",
             },
         },
         "x86_64-apple-darwin": {
             "stable": {
-                "rustc": "5f9618e419b73b3ed5ee4b872e87278b327867a064d9d38732bd9463378c0dc6",
-                "clippy": "e22d19e9cc33223996d3798a687c3d9743dcee243fb0a9b4053612849dbd0dbb",
-                "cargo": "125840ecf29a0e8b917fac1641fc4be269057bb427e238537a93d03d57dd8b1f",
-                "llvm-tools": "019ffae54f83c848c0e567466306b4efc03218931bdadb41b497e9d692f8ef3c",
-                "rust-std": "2906332ec97ede5f0815ba5d39b9c613cc90569c08120977c8e3d2a897ee1e10",
+                "rustc": "f0adfff86a9d5055f537dab26f6d0b7a81efe087f90b7e16c42698d58af0ffca",
+                "clippy": "5b6e393a7784839a1554188df2d87481696a0e0be242d1d2982e442b43199c08",
+                "cargo": "e3d03157061987be0c7cddf1e708f376929273779a65459a9b3a7ebc6ccadaae",
+                "llvm-tools": "3c443d068464c95a0a02072082bff6661cee5568dbbedbb82dcb6737147f3d6c",
+                "rust-std": "c9e366e76ee470d11afadbd70b200976ef4b34e626b568f19e429d4d23dead86",
             },
             "nightly": {
-                "rustc": "7e6c5a56cf56af15e418b9b21630cd4e78e84531377c0546921608f479ed70d4",
-                "clippy": "6b0054d4e878a19a3090cfe9598a2c2e6d7eeaf1aa596092bcc728a313542fa5",
-                "cargo": "a6996bed7843fd626ff28460c28699f77eea8673de174f76e3e91858f70f7cc4",
-                "llvm-tools": "092d87ee26b3e47eac61d6f049bb54fdd16d82fa708266895befc248f9934a73",
-                "rust-std": "3594ec946bb6d7e61a316f3b93da5227649cbafb31772a7229c9573a3025859f",
+                "rustc": "9ea43d51a690240f2c505ba62f1705de3c1329d7b3399ce462f4ecd242dbd87a",
+                "clippy": "058e05278fe37789a54ad603691e06b35c7ff345b1dbad82d13552c2409f0ff0",
+                "cargo": "fe5c735fec5c8d05de922ad4ec1296f2115cf3e2cc0617420104586d020efe6d",
+                "llvm-tools": "8a3f90b01ec1ae47dbe33fbb5329a8457da1252a07c2bbfac0d297cb4f031b88",
+                "rust-std": "a2d70b9f21a69639b61c87273495de579a32d197015e4a76dabf6cd417a6a12f",
             },
         },
     },

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-NIGHTLY_RUST_DATE=2024-10-27
+NIGHTLY_RUST_DATE=2024-08-01
 
 cd "$(dirname "$0")/.."
 

--- a/bin/lint-versions
+++ b/bin/lint-versions
@@ -11,5 +11,5 @@
 #
 # lint-versions - Check rust version
 
-grep "rust-version = " Cargo.toml | grep -q "1\.82\.0" || \
+grep "rust-version = " Cargo.toml | grep -q "1\.80\.1" || \
 (echo "Please validate new Rust versions for compilation time performance regressions or ask Team Testing to do so. Afterwards change the tested version in bin/lint-versions" && exit 1)

--- a/misc/bazel/rust_deps/cxxbridge-cmd/Cargo.cxxbridge-cmd.lock
+++ b/misc/bazel/rust_deps/cxxbridge-cmd/Cargo.cxxbridge-cmd.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "f995964271aa021b1d7a7538be6286c219c38b56f20331e21f1d82a18e47262a",
+  "checksum": "1b88de7d7f3ec7292f59a809812300eeed87d6453d1f6b712059b88cd3f31140",
   "crates": {
     "anstyle 1.0.4": {
       "name": "anstyle",

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -65,7 +65,7 @@ impl DeferredWriteOp {
     }
 
     /// Returns an Iterator of all the required locks for current operation.
-    pub fn required_locks(&self) -> impl Iterator<Item = CatalogItemId> + use<'_> {
+    pub fn required_locks(&self) -> impl Iterator<Item = CatalogItemId> + '_ {
         match self {
             DeferredWriteOp::Plan(plan) => {
                 let iter = plan.requires_locks.iter().copied();


### PR DESCRIPTION
We saw serious compile time regressions with `v1.82.0`, while we try to determine the root cause and file an issue upstream with the Rust project, we'll revert back to `v1.80.1` which we were using before the upgrade.

### Motivation

Improve compile times.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
