### PR TITLE
bazel: Add 'release-local' config to decrease compile times for local release builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -150,22 +150,29 @@ build:release --cxxopt=-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST
 build:release --copt=-O3
 build:release --copt=-DNDEBUG
 build:release --compilation_mode=opt
-build:release --copt=-flto=thin
-build:release --linkopt=-flto=thin
-build:release --@rules_rust//:extra_rustc_flag=-Clto=thin
 # `rules_rust` defaults to stripping debug symbols for release builds, undo that.
 build:release --strip=never
 build:release --@rules_rust//:extra_rustc_flag=-Cstrip=none
+
+# We only enable Link Time Optimization for CI builds and not local release builds.
+build:release-lto --copt=-flto=thin
+build:release-lto --linkopt=-flto=thin
+build:release-lto --@rules_rust//:extra_rustc_flag=-Clto=thin
 
 # Builds from `main` or tagged builds.
 #
 # Note: We don't use a ramdisk for tagged builds because the full debuginfo is
 # too large and we OOD/OOM.
-build:release-tagged --config=release --config=release-stamp --config=debuginfo-full
-# Local builds and from PRs in CI.
+build:release-tagged --config=release --config=release-lto --config=release-stamp --config=debuginfo-full
+# PRs in CI.
 #
 # Not doing a full stamp nor omitting full debug info, greatly speeds up compile times.
-build:release-dev --config=release --config=debuginfo-limited
+build:release-dev --config=release --config=release-lto --config=debuginfo-limited
+# Local Release Builds.
+#
+# Building with LTO can improve performance but it significantly increases compile times. The
+# tradeoff is not worth it when developing locally, but is for builds we ship to production.
+build:release-local --config=release --config=debuginfo-limited
 
 # Build with the Rust Nightly Toolchain
 build:rust-nightly --@rules_rust//rust/toolchain/channel=nightly

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -150,8 +150,11 @@ class RepositoryDetails:
             # approach to update it.
             if ui.env_is_truthy("BUILDKITE_TAG"):
                 flags.extend(["--config=release-tagged"])
-            else:
+            elif ui.env_is_truthy("CI"):
                 flags.extend(["--config=release-dev"])
+                bazel_utils.write_git_hash()
+            else:
+                flags.extend(["--config=release-local"])
                 bazel_utils.write_git_hash()
 
         if self.bazel_remote_cache:


### PR DESCRIPTION
This PR adds a new Bazel build config called `release-local` which does not enable LTO. This offers a significant compile time improvement which is nice for local release builds which generally never need LTO.

### Motivation

Improve iteration speed of local release builds

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
