### PR TITLE
CODEOWNERS: update for current org structure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,9 +8,9 @@
 #
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-/.cargo                             @benesch
-/.config                            @benesch
-/.github                            @benesch
+/.cargo                             @MaterializeInc/testing @parkmycar
+/.config                            @MaterializeInc/testing
+/.github                            @MaterializeInc/testing
 /bin
 /bin/lint-versions                  @MaterializeInc/testing
 /ci                                 @MaterializeInc/testing
@@ -51,10 +51,10 @@
 /src/avro                           @MaterializeInc/cluster
 /src/avro-derive                    @MaterializeInc/cluster
 /src/build-id                       @teskje
-/src/build-info                     @benesch
+/src/build-info                     @MaterializeInc/testing @parkmycar
 /src/catalog                        @MaterializeInc/adapter
 /src/catalog-debug                  @MaterializeInc/adapter
-/src/ccsr                           @benesch
+/src/ccsr                           @MaterializeInc/adapter @MaterializeInc/cluster
 /src/cloud-resources                @MaterializeInc/cloud
 /src/cluster                        @MaterializeInc/cluster
 /src/cluster-client                 @MaterializeInc/cluster
@@ -82,10 +82,10 @@
 /src/mysql-util                     @MaterializeInc/cluster
 /src/mz                             @MaterializeInc/integrations
 /src/npm                            @benesch
-/src/orchestrator                   @benesch
-/src/orchestrator-kubernetes        @benesch
-/src/orchestrator-process           @benesch
-/src/orchestrator-tracing           @benesch
+/src/orchestrator                   @MaterializeInc/cloud
+/src/orchestrator-kubernetes        @MaterializeInc/cloud
+/src/orchestrator-process           @MaterializeInc/cloud
+/src/orchestrator-tracing           @MaterializeInc/cloud
 /src/ore                            @benesch
 /src/persist                        @MaterializeInc/persist
 /src/persist-cli                    @MaterializeInc/persist
@@ -133,8 +133,8 @@
 /src/timely-util                    @MaterializeInc/cluster
 /src/transform                      @MaterializeInc/cluster
 /src/txn-wal                        @aljoscha @danhhz @jkosh44
-/src/walkabout                      @benesch
-/src/workspace-hack                 @benesch
+/src/walkabout                      @MaterializeInc/adapter
+/src/workspace-hack                 @MaterializeInc/testing
 /test
 /MODULE.bazel                       @parkmycar
 /WORKSPACE                          @parkmycar


### PR DESCRIPTION
Notable changes:

  * Add @ParkMyCar/testing as the owner of various CI related crates.
  * Migrate the orchestrator crates to the cloud team.
  * Migrate the ccsr crate to joint ownership of the cluster and adapter teams.
  * Migrate the walkabout crate to the adapter team (as it's essentially just part of the SQL parser).

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

@MaterializeInc/cloud any concerns about taking ownership of the orchestrator crates? I'm trying to divest myself of individual crate ownership, and y'all have been getting closer to the orchestrator crates with the latest self-hosted push.

@def- added @MaterializeInc/testing to a few CI related crates, but @ParkMyCar has volunteered to help with ownership on these crates too. Let me know if any concerns!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
