### PR TITLE
Increment the compactions-requested metric in exert

### DIFF
--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -744,6 +744,7 @@ pub async fn dangerous_force_compaction_and_break_pushdown<K, V, T, D>(
                 req.desc.upper().elements(),
                 req.desc.since().elements(),
             );
+            machine.applier.metrics.compaction.requested.inc();
             let start = Instant::now();
             let res = Compactor::<K, V, T, D>::compact_and_apply(
                 &machine,


### PR DESCRIPTION
Previously the only way to request a compaction was by throwing the `CompactReq` in a queue... but now there is a second way, and our requested and performed metrics see some drift.

### Motivation

Previously-unreported bug - came up in some internal conversation.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
