### PR TITLE
fix network policies installed by orchestratord

### DIFF
--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
         - "--startup-log-filter={{ .Values.operator.args.startupLogFilter }}"
         - "--cloud-provider={{ .Values.operator.args.cloudProvider }}"
         - "--region={{ .Values.operator.args.region }}"
+        {{- range $key, $value := include "materialize-operator.selectorLabels" . | fromYaml }}
+        - "--orchestratord-pod-selector-labels={{ $key }}={{ $value }}"
+        {{- end }}
         {{- if .Values.operator.args.awsAccountID }}
         - "--aws-account-id={{ .Values.operator.args.awsAccountID }}"
         {{- end }}

--- a/misc/helm-charts/operator/templates/networkpolicies.yaml
+++ b/misc/helm-charts/operator/templates/networkpolicies.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.networkPolicies.enabled .Values.networkPolicies.internal.enabled }}
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-to-environmentd
+  namespace: {{ .Values.namespace.name }}
+spec:
+  podSelector:
+    {{- include "materialize-operator.selectorLabels" . | nindent 4 }}
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              materialize.cloud/app: environmentd
+          namespaceSelector: {}
+      ports:
+        # environmentd internal http
+        - port: 6878
+{{- end }}

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -123,6 +123,10 @@ pub mod v1alpha1 {
             self.name_prefixed(&format!("environmentd-{generation}"))
         }
 
+        pub fn environmentd_app_name(&self) -> String {
+            "environmentd".to_owned()
+        }
+
         pub fn environmentd_service_name(&self) -> String {
             self.name_prefixed("environmentd")
         }
@@ -131,12 +135,20 @@ pub mod v1alpha1 {
             self.name_prefixed(&format!("environmentd-{generation}"))
         }
 
+        pub fn balancerd_app_name(&self) -> String {
+            "balancerd".to_owned()
+        }
+
         pub fn balancerd_deployment_name(&self) -> String {
             self.name_prefixed("balancerd")
         }
 
         pub fn balancerd_service_name(&self) -> String {
             self.name_prefixed("balancerd")
+        }
+
+        pub fn console_app_name(&self) -> String {
+            "console".to_owned()
         }
 
         pub fn console_deployment_name(&self) -> String {

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -382,13 +382,7 @@ impl k8s_controller::Context for Context {
 
                 trace!("applying environment resources");
                 match resources
-                    .apply(
-                        &client,
-                        &self.config,
-                        increment_generation,
-                        &mz.namespace(),
-                        &self.orchestratord_namespace,
-                    )
+                    .apply(&client, &self.config, increment_generation, &mz.namespace())
                     .await
                 {
                     Ok(Some(action)) => {
@@ -583,23 +577,10 @@ impl k8s_controller::Context for Context {
     #[instrument(fields(organization_name=mz.name_unchecked()))]
     async fn cleanup(
         &self,
-        client: Client,
+        _client: Client,
         mz: &Self::Resource,
     ) -> Result<Option<Action>, Self::Error> {
         self.set_needs_update(mz, false);
-
-        if let Some(status) = &mz.status {
-            let active_resources = resources::Resources::new(
-                &self.config,
-                &self.tracing,
-                &self.orchestratord_namespace,
-                mz,
-                status.active_generation,
-            );
-            active_resources
-                .cleanup(&client, &self.orchestratord_namespace)
-                .await?;
-        }
 
         Ok(None)
     }

--- a/src/orchestratord/src/controller/materialize/console.rs
+++ b/src/orchestratord/src/controller/materialize/console.rs
@@ -15,6 +15,10 @@ use k8s_openapi::{
             PodTemplateSpec, Probe, SeccompProfile, SecurityContext, Service, ServicePort,
             ServiceSpec,
         },
+        networking::v1::{
+            IPBlock, NetworkPolicy, NetworkPolicyIngressRule, NetworkPolicyPeer, NetworkPolicyPort,
+            NetworkPolicySpec,
+        },
     },
     apimachinery::pkg::{apis::meta::v1::LabelSelector, util::intstr::IntOrString},
 };
@@ -28,12 +32,14 @@ use mz_cloud_resources::crd::materialize::v1alpha1::Materialize;
 const CONSOLE_IMAGE_HTTP_PORT: i32 = 8080;
 
 pub struct Resources {
+    network_policies: Vec<NetworkPolicy>,
     console_deployment: Box<Deployment>,
     console_service: Box<Service>,
 }
 
 impl Resources {
     pub fn new(config: &super::Args, mz: &Materialize, console_image_ref: &str) -> Self {
+        let network_policies = create_network_policies(config, mz);
         let console_deployment = Box::new(create_console_deployment_object(
             config,
             mz,
@@ -41,20 +47,74 @@ impl Resources {
         ));
         let console_service = Box::new(create_console_service_object(config, mz));
         Self {
+            network_policies,
             console_deployment,
             console_service,
         }
     }
 
     pub async fn apply(&self, client: &Client, namespace: &str) -> Result<(), anyhow::Error> {
+        let network_policy_api: Api<NetworkPolicy> = Api::namespaced(client.clone(), namespace);
         let deployment_api: Api<Deployment> = Api::namespaced(client.clone(), namespace);
         let service_api: Api<Service> = Api::namespaced(client.clone(), namespace);
 
+        for network_policy in &self.network_policies {
+            apply_resource(&network_policy_api, network_policy).await?;
+        }
         apply_resource(&deployment_api, &self.console_deployment).await?;
         apply_resource(&service_api, &self.console_service).await?;
 
         Ok(())
     }
+}
+
+fn create_network_policies(config: &super::Args, mz: &Materialize) -> Vec<NetworkPolicy> {
+    let mut network_policies = Vec::new();
+    if config.network_policies.ingress_enabled {
+        let console_label_selector = LabelSelector {
+            match_labels: Some(
+                mz.default_labels()
+                    .into_iter()
+                    .chain([(
+                        "materialize.cloud/app".to_owned(),
+                        mz.console_service_name(),
+                    )])
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+        network_policies.extend([NetworkPolicy {
+            metadata: mz.managed_resource_meta(mz.name_prefixed("console-ingress")),
+            spec: Some(NetworkPolicySpec {
+                ingress: Some(vec![NetworkPolicyIngressRule {
+                    from: Some(
+                        config
+                            .network_policies
+                            .ingress_cidrs
+                            .iter()
+                            .map(|cidr| NetworkPolicyPeer {
+                                ip_block: Some(IPBlock {
+                                    cidr: cidr.to_owned(),
+                                    except: None,
+                                }),
+                                ..Default::default()
+                            })
+                            .collect(),
+                    ),
+                    ports: Some(vec![NetworkPolicyPort {
+                        port: Some(IntOrString::Int(CONSOLE_IMAGE_HTTP_PORT)),
+                        protocol: Some("TCP".to_string()),
+                        ..Default::default()
+                    }]),
+                    ..Default::default()
+                }]),
+                pod_selector: console_label_selector,
+                policy_types: Some(vec!["Ingress".to_owned()]),
+                ..Default::default()
+            }),
+        }]);
+    }
+    network_policies
 }
 
 fn create_console_deployment_object(

--- a/src/orchestratord/src/controller/materialize/console.rs
+++ b/src/orchestratord/src/controller/materialize/console.rs
@@ -75,10 +75,7 @@ fn create_network_policies(config: &super::Args, mz: &Materialize) -> Vec<Networ
             match_labels: Some(
                 mz.default_labels()
                     .into_iter()
-                    .chain([(
-                        "materialize.cloud/app".to_owned(),
-                        mz.console_service_name(),
-                    )])
+                    .chain([("materialize.cloud/app".to_owned(), mz.console_app_name())])
                     .collect(),
             ),
             ..Default::default()
@@ -128,10 +125,7 @@ fn create_console_deployment_object(
         mz.console_deployment_name(),
     );
     pod_template_labels.insert("app".to_owned(), "console".to_string());
-    pod_template_labels.insert(
-        "materialize.cloud/app".to_owned(),
-        mz.console_service_name(),
-    );
+    pod_template_labels.insert("materialize.cloud/app".to_owned(), mz.console_app_name());
 
     let ports = vec![ContainerPort {
         container_port: CONSOLE_IMAGE_HTTP_PORT,

--- a/src/orchestratord/src/controller/materialize/resources.rs
+++ b/src/orchestratord/src/controller/materialize/resources.rs
@@ -49,7 +49,6 @@ use mz_ore::instrument;
 pub struct Resources {
     generation: u64,
     environmentd_network_policies: Vec<NetworkPolicy>,
-    orchestratord_network_policies: Vec<NetworkPolicy>,
     service_account: Box<ServiceAccount>,
     role: Box<Role>,
     role_binding: Box<RoleBinding>,
@@ -71,8 +70,6 @@ impl Resources {
     ) -> Self {
         let environmentd_network_policies =
             create_environmentd_network_policies(config, mz, orchestratord_namespace);
-        let orchestratord_network_policies =
-            create_orchestratord_network_policies(config, mz, orchestratord_namespace);
 
         let service_account = Box::new(create_service_account_object(config, mz));
         let role = Box::new(create_role_object(mz));
@@ -94,7 +91,6 @@ impl Resources {
         Self {
             generation,
             environmentd_network_policies,
-            orchestratord_network_policies,
             service_account,
             role,
             role_binding,
@@ -114,12 +110,9 @@ impl Resources {
         args: &super::Args,
         increment_generation: bool,
         namespace: &str,
-        orchestratord_namespace: &str,
     ) -> Result<Option<Action>, anyhow::Error> {
         let environmentd_network_policy_api: Api<NetworkPolicy> =
             Api::namespaced(client.clone(), namespace);
-        let orchestratord_network_policy_api: Api<NetworkPolicy> =
-            Api::namespaced(client.clone(), orchestratord_namespace);
         let service_api: Api<Service> = Api::namespaced(client.clone(), namespace);
         let service_account_api: Api<ServiceAccount> = Api::namespaced(client.clone(), namespace);
         let role_api: Api<Role> = Api::namespaced(client.clone(), namespace);
@@ -130,11 +123,6 @@ impl Resources {
         for policy in &self.environmentd_network_policies {
             trace!("applying network policy {}", policy.name_unchecked());
             apply_resource(&environmentd_network_policy_api, policy).await?;
-        }
-
-        for policy in &self.orchestratord_network_policies {
-            trace!("applying network policy {}", policy.name_unchecked());
-            apply_resource(&orchestratord_network_policy_api, policy).await?;
         }
 
         trace!("applying environmentd service account");
@@ -276,25 +264,6 @@ impl Resources {
         Ok(None)
     }
 
-    // manual cleanup for namespaced resources created in namespaces other
-    // than the one containing the materialize cr, since owner references
-    // can't be used for these
-    pub async fn cleanup(
-        &self,
-        client: &Client,
-        orchestratord_namespace: &str,
-    ) -> Result<(), anyhow::Error> {
-        let orchestratord_network_policy_api: Api<NetworkPolicy> =
-            Api::namespaced(client.clone(), orchestratord_namespace);
-
-        for policy in &self.orchestratord_network_policies {
-            trace!("deleting network policy {}", policy.name_unchecked());
-            delete_resource(&orchestratord_network_policy_api, &policy.name_unchecked()).await?;
-        }
-
-        Ok(())
-    }
-
     #[instrument]
     pub async fn promote_services(
         &self,
@@ -372,7 +341,7 @@ fn create_environmentd_network_policies(
                     .into_iter()
                     .chain([(
                         "materialize.cloud/app".to_owned(),
-                        mz.environmentd_service_name(),
+                        mz.environmentd_app_name(),
                     )])
                     .collect(),
             ),
@@ -454,10 +423,7 @@ fn create_environmentd_network_policies(
     }
     if config.network_policies.ingress_enabled {
         let mut ingress_label_selector = mz.default_labels();
-        ingress_label_selector.insert(
-            "materialize.cloud/app".to_owned(),
-            mz.balancerd_service_name(),
-        );
+        ingress_label_selector.insert("materialize.cloud/app".to_owned(), mz.balancerd_app_name());
         network_policies.extend([NetworkPolicy {
             metadata: mz.managed_resource_meta(mz.name_prefixed("sql-and-http-ingress")),
             spec: Some(NetworkPolicySpec {
@@ -529,76 +495,6 @@ fn create_environmentd_network_policies(
             }),
         }]);
     }
-    network_policies
-}
-
-fn create_orchestratord_network_policies(
-    config: &super::Args,
-    mz: &Materialize,
-    orchestratord_namespace: &str,
-) -> Vec<NetworkPolicy> {
-    let mut network_policies = Vec::new();
-    if config.network_policies.internal_enabled {
-        let environmentd_label_selector = LabelSelector {
-            match_labels: Some(
-                mz.default_labels()
-                    .into_iter()
-                    .chain([(
-                        "materialize.cloud/app".to_owned(),
-                        mz.environmentd_service_name(),
-                    )])
-                    .collect(),
-            ),
-            ..Default::default()
-        };
-        let orchestratord_label_selector = LabelSelector {
-            match_labels: Some(
-                config
-                    .orchestratord_pod_selector_labels
-                    .iter()
-                    .cloned()
-                    .map(|kv| (kv.key, kv.value))
-                    .collect(),
-            ),
-            ..Default::default()
-        };
-        network_policies.extend([NetworkPolicy {
-            // can't use managed_resource_meta here because owner references
-            // don't work cross-namespace - we need to be sure to manually
-            // do the cleanup for this resource
-            metadata: ObjectMeta {
-                namespace: Some(orchestratord_namespace.to_string()),
-                name: Some(mz.name_prefixed("egress-to-environmentd")),
-                labels: Some(mz.default_labels()),
-                ..Default::default()
-            },
-            spec: Some(NetworkPolicySpec {
-                egress: Some(vec![NetworkPolicyEgressRule {
-                    to: Some(vec![NetworkPolicyPeer {
-                        namespace_selector: Some(LabelSelector {
-                            match_labels: Some(btreemap! {
-                                "kubernetes.io/metadata.name".into()
-                                    => mz.namespace(),
-                            }),
-                            ..Default::default()
-                        }),
-                        pod_selector: Some(environmentd_label_selector.clone()),
-                        ..Default::default()
-                    }]),
-                    ports: Some(vec![NetworkPolicyPort {
-                        port: Some(IntOrString::Int(config.environmentd_internal_http_port)),
-                        protocol: Some("TCP".to_string()),
-                        ..Default::default()
-                    }]),
-                    ..Default::default()
-                }]),
-                pod_selector: orchestratord_label_selector.clone(),
-                policy_types: Some(vec!["Egress".to_owned()]),
-                ..Default::default()
-            }),
-        }]);
-    }
-
     network_policies
 }
 
@@ -1263,7 +1159,7 @@ fn create_environmentd_statefulset_object(
     );
     pod_template_labels.insert(
         "materialize.cloud/app".to_owned(),
-        mz.environmentd_service_name(),
+        mz.environmentd_app_name(),
     );
     pod_template_labels.insert("app".to_owned(), "environmentd".to_string());
 
@@ -1411,10 +1307,7 @@ fn create_balancerd_deployment_object(config: &super::Args, mz: &Materialize) ->
         mz.balancerd_deployment_name(),
     );
     pod_template_labels.insert("app".to_owned(), "balancerd".to_string());
-    pod_template_labels.insert(
-        "materialize.cloud/app".to_owned(),
-        mz.balancerd_service_name(),
-    );
+    pod_template_labels.insert("materialize.cloud/app".to_owned(), mz.balancerd_app_name());
 
     let ports = vec![
         ContainerPort {


### PR DESCRIPTION
### Motivation

we were previously testing in kind clusters which had a blanket policy of allowing all network traffic, and this caused a lot of the network policies we were writing to be incorrect. i fixed the setup for cloud's kind cluster in https://github.com/MaterializeInc/cloud/pull/10444 and with these changes i was able to successfully run several environments via orchestratord, both in the same namespace and in multiple different namespaces.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
