### PR TITLE
ci: Fix junit report in testdrive

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -700,9 +700,7 @@ def annotate_logged_errors(
 def get_errors(log_file_names: list[str]) -> list[ErrorLog | JunitError]:
     error_logs = []
     for log_file_name in log_file_names:
-        # junit_testdrive_* is excluded by this, but currently
-        # not more useful than junit_mzcompose anyway
-        if "junit_" in log_file_name and "junit_testdrive_" not in log_file_name:
+        if "junit_" in log_file_name:
             error_logs.extend(_get_errors_from_junit_file(log_file_name))
         else:
             error_logs.extend(_get_errors_from_log_file(log_file_name))
@@ -729,7 +727,7 @@ def _get_errors_from_junit_file(log_file_name: str) -> list[JunitError]:
                     JunitError(
                         testcase.classname,
                         testcase.name,
-                        result.message or "",
+                        result.message.replace("&#10;", "\n") or "",
                         result.text or "",
                     )
                 )

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -708,6 +708,8 @@ To see the available workflows, run:
         return composition not in {
             # sqllogictest already generates a proper junit.xml file
             "sqllogictest",
+            # testdrive already generates a proper junit.xml file
+            "testdrive",
             # not a test, run as post-command, and should not overwrite an existing junit.xml from a previous test
             "get-cloud-hostname",
         }

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -502,7 +502,8 @@ async fn main() {
                     &file.to_string_lossy(),
                     start_time.elapsed(),
                     "failure",
-                    &error.to_string(),
+                    // Encode newlines so they get preserved when being parsed by python-junit-xml
+                    &error.to_string().replace("\n", "&#10;"),
                 ),
             };
             test_case.set_classname("testdrive");

--- a/src/testdrive/src/error.rs
+++ b/src/testdrive/src/error.rs
@@ -83,7 +83,27 @@ impl Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.source.display_with_causes())
+        match &self.location {
+            Some(location) => {
+                if let Some(filename) = &location.filename {
+                    write!(
+                        f,
+                        "{}:{}:{}: ",
+                        filename.display(),
+                        location.line,
+                        location.col
+                    )?;
+                } else {
+                    write!(f, "{}:{}: ", location.line, location.col)?;
+                }
+                writeln!(f, "{}", self.source.display_with_causes())?;
+                write!(f, "{}", location.snippet)?;
+                writeln!(f, "{}^", " ".repeat(location.col - 1))
+            }
+            None => {
+                write!(f, "{}", self.source.display_with_causes())
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Noticed in https://materializeinc.slack.com/archives/C01LKF361MZ/p1731536333820569

Broke in https://github.com/MaterializeInc/materialize/pull/30176

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
