### PR TITLE
compute: properly initialize uppers of storage sinks

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1234,6 +1234,12 @@ where
                 dataflow.initial_storage_as_of.clone(),
                 dataflow.refresh_schedule.clone(),
             );
+
+            // If the export is a storage sink, we can advance its write frontier to the write
+            // frontier of the target storage collection.
+            if let Ok(frontiers) = self.storage_collections.collection_frontiers(export_id) {
+                self.maybe_update_global_write_frontier(export_id, frontiers.write_frontier);
+            }
         }
 
         // Initialize tracking of subscribes.


### PR DESCRIPTION
This PR makes the compute controller advance the write frontier of new storage sink collections (MVs, CTs) to the write frontier of the target storage collection.

Previously it didn't do that, which is normally fine because once a replica has installed the dataflow it will send a `Frontiers` response to bump the write frontier in the controller. However, if the cluster has no replicas (e.g. because it is paused between MV refreshes) this doesn't happen. In this case, the write frontier would get stuck at dataflow creation time, which made the implied capability get stuck at the same time too, which in turn held back compaction of the dataflow inputs to the same time. If the write frontier of the target storage collection is significantly in the future, this holding back is undesired, as it prevents compaction of the inputs more than necessary.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8734

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
