### PR TITLE
0dt tests: handle another error

### DIFF
--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -749,10 +749,10 @@ def workflow_basic(c: Composition) -> None:
             try:
                 c.sql("SELECT 1", service="mz_old")
             except OperationalError as e:
-                assert "server closed the connection unexpectedly" in str(
-                    e
-                ) or "Can't create a connection to host" in str(
-                    e
+                assert (
+                    "server closed the connection unexpectedly" in str(e)
+                    or "Can't create a connection to host" in str(e)
+                    or "Connection refused" in str(e)
                 ), f"Unexpected error: {e}"
             except CommandFailureCausedUIError as e:
                 # service "mz_old" is not running


### PR DESCRIPTION
Noticed in https://buildkite.com/materialize/test/builds/94685#01932ba5-dae3-4588-bb6e-bbc812308133

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
