### PR TITLE
catalog: Optimize loading audit logs on startup

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -1160,7 +1160,7 @@ impl CatalogState {
     /// Generate a list of `BuiltinTableUpdate`s that correspond to a single update made to the
     /// durable catalog.
     #[instrument(level = "debug")]
-    fn generate_builtin_table_update(
+    pub(crate) fn generate_builtin_table_update(
         &self,
         kind: StateUpdateKind,
         diff: StateDiff,


### PR DESCRIPTION
The apply step of the catalog takes in a list of durable catalog updates and does two things with them. It inserts/removes the updates into/from the in-memory catalog, and it generates builtin table updates. At the start of the apply step, updates must be sorted so that they're added in memory in the correct order.

Audit logs are not stored in memory, so the first part of the apply step is a no-op. Audit logs are also append only, so for many environments they are extremely large. Sorting all the audit logs can be extremely expensive and is not actually required.

This commit separates the loading of audit logs during startup, so that they bypass the apply step and instead directly generate builtin table updates.

Works towards resolving #MaterializeInc/database-issues/8384

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
