### PR TITLE
storage: separate kafka consumer for probe task [hack]

### DIFF
--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -1443,7 +1443,7 @@ impl ClientContext for GlueConsumerContext {
 
 impl GlueConsumerContext {
     fn activate(&self) {
-        self.notificator.notify_waiters();
+        self.notificator.notify_one();
     }
 }
 

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -609,6 +609,15 @@ impl SourceRender for KafkaSourceConnection {
                 let mut prev_pid_info: Option<BTreeMap<PartitionId, WatermarkOffsets>> = None;
                 let mut snapshot_total = None;
 
+                reader
+                    .consumer
+                    .client()
+                    .fetch_metadata(
+                        Some(&topic),
+                        config.config.parameters.kafka_timeout_config.fetch_metadata_timeout,
+                    )
+                    .unwrap();
+
                 let max_wait_time =
                     mz_storage_types::dyncfgs::KAFKA_POLL_MAX_WAIT.get(config.config.config_set());
                 loop {


### PR DESCRIPTION
https://github.com/MaterializeInc/materialize/pull/30031, but only the separate kafka consumer commit. cc @teskje @petrosagg