### PR TITLE
testdrive: Unflake source-statistics.td

### DIFF
--- a/test/testdrive-old-kafka-src-syntax/source-statistics.td
+++ b/test/testdrive-old-kafka-src-syntax/source-statistics.td
@@ -103,13 +103,13 @@ $ set-sql-timeout duration=2minutes
 # interval is 30 seconds.
 > SELECT s.name,
   bool_and(u.snapshot_committed),
-  SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
+  SUM(u.messages_received) BETWEEN 2 AND 6, SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('metrics_test_source')
   GROUP BY s.name
   ORDER BY s.name
-metrics_test_source true 2 2 2 true true
+metrics_test_source true true 2 2 true true
 
 > DROP SOURCE metrics_test_source CASCADE
 
@@ -153,10 +153,12 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 # There could also be up to 11 updates, as updates cause inserts and deletes
 # (5 initial inserts, 2 deletes, and 2 updates). In total 3 records should be present in upsert state.
 # We can't control this, so have to accept the range.
+
+# testdrive with SIZE 8 saw messages received go up to 27
 > SELECT
     s.name,
     bool_and(u.snapshot_committed),
-    SUM(u.messages_received),
+    SUM(u.messages_received) BETWEEN 9 AND 27,
     SUM(u.updates_staged) BETWEEN 3 AND 11,
     SUM(u.updates_committed) BETWEEN 3 AND 11,
     SUM(u.bytes_received) > 0,
@@ -168,7 +170,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
-upsert true 9 true true true true 3 true
+upsert true true true true true true 3 true
 
 # While we can't control how batching works above, we can ensure that this new, later update
 # causes 1 more messages to be received, which is 1 update, a delete.

--- a/test/testdrive/source-statistics.td
+++ b/test/testdrive/source-statistics.td
@@ -107,13 +107,13 @@ $ set-sql-timeout duration=2minutes
 # interval is 30 seconds.
 > SELECT s.name,
   bool_and(u.snapshot_committed),
-  SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
+  SUM(u.messages_received) BETWEEN 2 AND 6, SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('metrics_test_source')
   GROUP BY s.name
   ORDER BY s.name
-metrics_test_source true 4 2 2 true true
+metrics_test_source true true 2 2 true true
 
 > DROP SOURCE metrics_test_source CASCADE
 
@@ -157,10 +157,12 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 # There could also be up to 11 updates, as updates cause inserts and deletes
 # (5 initial inserts, 2 deletes, and 2 updates). In total 3 records should be present in upsert state.
 # We can't control this, so have to accept the range.
+
+# testdrive with SIZE 8 saw messages received go up to 27
 > SELECT
     s.name,
     bool_and(u.snapshot_committed),
-    SUM(u.messages_received),
+    SUM(u.messages_received) BETWEEN 9 AND 27,
     SUM(u.updates_staged) BETWEEN 3 AND 11,
     SUM(u.updates_committed) BETWEEN 3 AND 11,
     SUM(u.bytes_received) > 0,
@@ -172,7 +174,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
-upsert true 18 true true true true 3 true
+upsert true true true true true true 3 true
 
 # While we can't control how batching works above, we can ensure that this new, later update
 # causes 1 more messages to be received, which is 1 update, a delete.


### PR DESCRIPTION
This occurred in the Nightly for v0.125.0 release: https://buildkite.com/materialize/nightly/builds/10410#01932dcd-a68f-4c00-bb5b-4d05ef5c76ba

@petrosagg @teskje Can you confirm that it's ok to just allow this?
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
