### PR TITLE
ci: Try zstd compression for debug sections

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -93,12 +93,11 @@ build:debug --@rules_rust//:extra_rustc_flag="-Csplit-debuginfo=unpacked"
 
 # TODO(parkmycar): Enable this for macOS. `toolchains_llvm` defaults to ld64 which
 # doesn't support zlib compression.
-build:linux --linkopt="-Wl,--compress-debug-sections=zlib"
-build:linux --@rules_rust//:extra_rustc_flag="-Clink-arg=-Wl,--compress-debug-sections=zlib"
-# Specifying "-O2" uses level 6 zlib compression.
-build:linux --linkopt="-Wl,-O2"
+build:linux --linkopt="-Wl,--compress-debug-sections=zstd"
+build:linux --@rules_rust//:extra_rustc_flag="-Clink-arg=-Wl,--compress-debug-sections=zstd"
+build:linux --linkopt="-Wl,-O3"
 build:linux --@rules_rust//:extra_rustc_flag="-Clink-arg=-Wl,-O2"
-build:linux --copt="-gz=zlib"
+build:linux --copt="-gz=zstd"
 
 # Match the DWARF version used by Rust
 #

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,8 +13,8 @@
 # Sync: This target-cpu and list of features should be kept in sync with the ones in ci-builder and
 # xcompile.
 rustflags = [
-    "-Clink-arg=-Wl,--compress-debug-sections=zlib",
-    "-Clink-arg=-Wl,-O2",
+    "-Clink-arg=-Wl,--compress-debug-sections=zstd",
+    "-Clink-arg=-Wl,-O3",
     "-Clink-arg=-fuse-ld=lld",
     "-Csymbol-mangling-version=v0",
     "--cfg=tokio_unstable",
@@ -30,8 +30,8 @@ rustflags = [
 # xcompile.
 [target."aarch64-unknown-linux-gnu"]
 rustflags = [
-    "-Clink-arg=-Wl,--compress-debug-sections=zlib",
-    "-Clink-arg=-Wl,-O2",
+    "-Clink-arg=-Wl,--compress-debug-sections=zstd",
+    "-Clink-arg=-Wl,-O3",
     "-Clink-arg=-fuse-ld=lld",
     "-Csymbol-mangling-version=v0",
     "--cfg=tokio_unstable",

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -303,7 +303,7 @@ ENV CC=$ARCH_GCC-unknown-linux-gnu-cc
 ENV CXX=$ARCH_GCC-unknown-linux-gnu-c++
 ENV CXXSTDLIB=static=stdc++
 ENV LDFLAGS="-fuse-ld=lld -static-libstdc++"
-ENV RUSTFLAGS="-Clink-arg=-Wl,--compress-debug-sections=zlib -Clink-arg=-fuse-ld=lld -L/opt/x-tools/$ARCH_GCC-unknown-linux-gnu/$ARCH_GCC-unknown-linux-gnu/sysroot/lib/ -Csymbol-mangling-version=v0 --cfg=tokio_unstable"
+ENV RUSTFLAGS="-Clink-arg=-Wl,--compress-debug-sections=zstd -Clink-arg=-Wl,-O3 -Clink-arg=-fuse-ld=lld -L/opt/x-tools/$ARCH_GCC-unknown-linux-gnu/$ARCH_GCC-unknown-linux-gnu/sysroot/lib/ -Csymbol-mangling-version=v0 --cfg=tokio_unstable"
 ENV TARGET_AR=$AR
 ENV TARGET_CC=$CC
 ENV TARGET_CXX=$CXX

--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -150,7 +150,8 @@ def cargo(
     }
 
     rustflags += [
-        "-Clink-arg=-Wl,--compress-debug-sections=zlib",
+        "-Clink-arg=-Wl,--compress-debug-sections=zstd",
+        "-Clink-arg=-Wl,-O3",
         "-Csymbol-mangling-version=v0",
         "--cfg=tokio_unstable",
     ]


### PR DESCRIPTION
While we are trying things I thought I'd also give this a go. It only has a relatively small effect. environmentd: 347 MB -> 331 MB
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
