### PR TITLE
builds: Switch to line-tables-only, even for tagged builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -159,12 +159,12 @@ build:release-lto --copt=-flto=thin
 build:release-lto --linkopt=-flto=thin
 build:release-lto --@rules_rust//:extra_rustc_flag=-Clto=thin
 
-# Builds from `main` or tagged builds.
+# Tagged builds, will be used as releases.
 #
-# Note: We don't use a ramdisk for tagged builds because the full debuginfo is
-# too large and we OOD/OOM.
-build:release-tagged --config=release --config=release-lto --config=release-stamp --config=debuginfo-full
-# PRs in CI.
+# Note: Not adding full debuginfo, even in release builds, to keep binary sizes
+# more reasonable.
+build:release-tagged --config=release --config=release-lto --config=release-stamp --config=debuginfo-limited
+# Builds in CI, both in PRs and on main, but without tags.
 #
 # Not doing a full stamp nor omitting full debug info, greatly speeds up compile times.
 build:release-dev --config=release --config=release-lto --config=debuginfo-limited

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,14 +254,8 @@ rustc-demangle = { opt-level = 3 }
 # Compile time seems similar to "lto = false", runtime ~10% faster
 lto = "thin"
 
-# Emit full debug info, allowing us to easily analyze core dumps from
-# staging (and, in an emergency, also prod).
-#
-# This does not negatively impact the sizes of the main binaries
-# (clusterd and environmentd), since we split the debuginfo from those
-# and ship it separately to an s3 bucket before building their
-# docker containers.
-debug = 2
+# Emit limited debug info for smaller binaries
+debug = "line-tables-only"
 
 # IMPORTANT: when patching a dependency, you should only depend on "main",
 # "master", or an upstream release branch (e.g., "v7.x"). Do *not* depend on a


### PR DESCRIPTION
About halfs our binary sizes. For example environmentd: 713 MB -> 347 MB

I'm still seeing working symbols in panics:
```
thread 'main' panicked at src/environmentd/src/bin/environmentd/main.rs:635:9:
environmentd: fatal: creating kubernetes orchestrator: failed to infer config: in-cluster: (failed to read an incluster environment variable: environment variable not found), kubeconfig: (failed to load current context: minikube)
   5: rust_begin_unwind
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/panicking.rs:652:5
   6: core::panicking::panic_fmt
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/panicking.rs:72:14
   7: main
             at src/environmentd/src/bin/environmentd/main.rs:635:9
   8: call_once<fn(), ()>
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/ops/function.rs:250:5
   9: __rust_begin_short_backtrace<fn(), ()>
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/sys_common/backtrace.rs:155:18
  10: std::rt::lang_start::<()>::{closure#0}
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/rt.rs:159:18
  11: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/ops/function.rs:284:13
  12: std::panicking::try::do_call
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/panicking.rs:559:40
  13: std::panicking::try
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/panicking.rs:523:19
  14: std::panic::catch_unwind
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/panic.rs:149:14
  15: std::rt::lang_start_internal::{{closure}}
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/rt.rs:141:48
  16: std::panicking::try::do_call
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/panicking.rs:559:40
  17: std::panicking::try
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/panicking.rs:523:19
  18: std::panic::catch_unwind
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/panic.rs:149:14
  19: std::rt::lang_start_internal
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/rt.rs:141:20
  20: main
  21: __libc_start_call_main
             at ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
  22: __libc_start_main_impl
             at ./csu/../csu/libc-start.c:360:3
  23: _start
             at /build/glibc/csu/../sysdeps/x86_64/start.S:115
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
I'm not sure what impact this has for PolarSignals. gdb is probably affected.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
