### PR TITLE
storage: make feedback UPSERT robust against ingestion spikes

### DIFF
--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -289,16 +289,21 @@ where
 
         // A closure that will initialize and return a configured RocksDB instance
         let rocksdb_init_fn = move || async move {
-            let merge_operator = if rocksdb_use_native_merge_operator {
-                Some((
-                    "upsert_state_snapshot_merge_v1".to_string(),
-                    |a: &[u8], b: ValueIterator<BincodeOpts, StateValue<Option<FromTime>>>| {
-                        snapshot_merge_function::<Option<FromTime>>(a.into(), b)
-                    },
-                ))
-            } else {
-                None
-            };
+            let merge_operator =
+                if rocksdb_use_native_merge_operator {
+                    Some((
+                        "upsert_state_snapshot_merge_v1".to_string(),
+                        |a: &[u8],
+                         b: ValueIterator<
+                            BincodeOpts,
+                            StateValue<G::Timestamp, Option<FromTime>>,
+                        >| {
+                            snapshot_merge_function::<G::Timestamp, Option<FromTime>>(a.into(), b)
+                        },
+                    ))
+                } else {
+                    None
+                };
             rocksdb::RocksDB::new(
                 mz_rocksdb::RocksDBInstance::new(
                     &rocksdb_dir,
@@ -403,7 +408,7 @@ where
     G::Timestamp: TotalOrder + Sync,
     F: FnOnce() -> Fut + 'static,
     Fut: std::future::Future<Output = US>,
-    US: UpsertStateBackend<Option<FromTime>>,
+    US: UpsertStateBackend<G::Timestamp, Option<FromTime>>,
     FromTime: Debug + timely::ExchangeData + Ord + Sync,
 {
     let use_continual_feedback_upsert =
@@ -543,16 +548,19 @@ enum DrainStyle<'a, T> {
 /// from the input timely edge.
 async fn drain_staged_input<S, G, T, FromTime, E>(
     stash: &mut Vec<(T, UpsertKey, Reverse<FromTime>, Option<UpsertValue>)>,
-    commands_state: &mut indexmap::IndexMap<UpsertKey, types::UpsertValueAndSize<Option<FromTime>>>,
+    commands_state: &mut indexmap::IndexMap<
+        UpsertKey,
+        types::UpsertValueAndSize<T, Option<FromTime>>,
+    >,
     output_updates: &mut Vec<(Result<Row, UpsertError>, T, Diff)>,
     multi_get_scratch: &mut Vec<UpsertKey>,
     drain_style: DrainStyle<'_, T>,
     error_emitter: &mut E,
-    state: &mut UpsertState<'_, S, Option<FromTime>>,
+    state: &mut UpsertState<'_, S, T, Option<FromTime>>,
 ) where
-    S: UpsertStateBackend<Option<FromTime>>,
+    S: UpsertStateBackend<T, Option<FromTime>>,
     G: Scope,
-    T: PartialOrder + Ord + Clone + Debug,
+    T: PartialOrder + Ord + Clone + Send + Sync + Serialize + Debug + 'static,
     FromTime: timely::ExchangeData + Ord + Sync,
     E: UpsertErrorEmitter<G>,
 {
@@ -637,10 +645,11 @@ async fn drain_staged_input<S, G, T, FromTime, E>(
 
         match value {
             Some(value) => {
-                if let Some(old_value) = existing_value
-                    .replace(StateValue::value(value.clone(), Some(from_time.0.clone())))
-                {
-                    if let Value::Value(old_value, _) = old_value.into_decoded() {
+                if let Some(old_value) = existing_value.replace(StateValue::finalized_value(
+                    value.clone(),
+                    Some(from_time.0.clone()),
+                )) {
+                    if let Value::FinalizedValue(old_value, _) = old_value.into_decoded() {
                         output_updates.push((old_value, ts.clone(), -1));
                     }
                 }
@@ -648,7 +657,7 @@ async fn drain_staged_input<S, G, T, FromTime, E>(
             }
             None => {
                 if let Some(old_value) = existing_value.take() {
-                    if let Value::Value(old_value, _) = old_value.into_decoded() {
+                    if let Value::FinalizedValue(old_value, _) = old_value.into_decoded() {
                         output_updates.push((old_value, ts, -1));
                     }
                 }
@@ -711,7 +720,7 @@ where
     G::Timestamp: TotalOrder + Sync,
     F: FnOnce() -> Fut + 'static,
     Fut: std::future::Future<Output = US>,
-    US: UpsertStateBackend<Option<FromTime>>,
+    US: UpsertStateBackend<G::Timestamp, Option<FromTime>>,
     FromTime: timely::ExchangeData + Ord + Sync,
 {
     let mut builder = AsyncOperatorBuilder::new("Upsert".to_string(), input.scope());
@@ -755,7 +764,7 @@ where
         // The order key of the `UpsertState` is `Option<FromTime>`, which implements `Default`
         // (as required for `consolidate_snapshot_chunk`), with slightly more efficient serialization
         // than a default `Partitioned`.
-        let mut state = UpsertState::<_, Option<FromTime>>::new(
+        let mut state = UpsertState::<_, _, Option<FromTime>>::new(
             state().await,
             upsert_shared_metrics,
             &upsert_metrics,
@@ -892,8 +901,10 @@ where
 
         // A re-usable buffer of changes, per key. This is an `IndexMap` because it has to be `drain`-able
         // and have a consistent iteration order.
-        let mut commands_state: indexmap::IndexMap<_, types::UpsertValueAndSize<Option<FromTime>>> =
-            indexmap::IndexMap::new();
+        let mut commands_state: indexmap::IndexMap<
+            _,
+            types::UpsertValueAndSize<G::Timestamp, Option<FromTime>>,
+        > = indexmap::IndexMap::new();
         let mut multi_get_scratch = Vec::new();
 
         // Now can can resume consuming the collection

--- a/src/storage/src/upsert/autospill.rs
+++ b/src/storage/src/upsert/autospill.rs
@@ -24,23 +24,23 @@ use super::types::{
 };
 use super::UpsertKey;
 
-pub enum BackendType<O> {
-    InMemory(InMemoryHashMap<O>),
-    RocksDb(RocksDB<O>),
+pub enum BackendType<T, O> {
+    InMemory(InMemoryHashMap<T, O>),
+    RocksDb(RocksDB<T, O>),
 }
 
-pub struct AutoSpillBackend<O, F> {
-    backend_type: BackendType<O>,
+pub struct AutoSpillBackend<T, O, F> {
+    backend_type: BackendType<T, O>,
     auto_spill_threshold_bytes: usize,
     rocksdb_autospill_in_use: Arc<DeleteOnDropGauge<'static, AtomicU64, Vec<String>>>,
     rocksdb_init_fn: Option<F>,
 }
 
-impl<O, F, Fut> AutoSpillBackend<O, F>
+impl<T, O, F, Fut> AutoSpillBackend<T, O, F>
 where
     O: Clone + Send + Sync + Serialize + DeserializeOwned + 'static,
     F: FnOnce() -> Fut + 'static,
-    Fut: std::future::Future<Output = RocksDB<O>>,
+    Fut: std::future::Future<Output = RocksDB<T, O>>,
 {
     pub(crate) fn new(
         rocksdb_init_fn: F,
@@ -59,11 +59,12 @@ where
 }
 
 #[async_trait::async_trait(?Send)]
-impl<O, F, Fut> UpsertStateBackend<O> for AutoSpillBackend<O, F>
+impl<T, O, F, Fut> UpsertStateBackend<T, O> for AutoSpillBackend<T, O, F>
 where
     O: Clone + Send + Sync + Serialize + DeserializeOwned + 'static,
+    T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static,
     F: FnOnce() -> Fut + 'static,
-    Fut: std::future::Future<Output = RocksDB<O>>,
+    Fut: std::future::Future<Output = RocksDB<T, O>>,
 {
     fn supports_merge(&self) -> bool {
         // We only support merge if the backend supports it; the in-memory backend does not
@@ -76,7 +77,7 @@ where
 
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
-        P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<O>>)>,
+        P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<T, O>>)>,
     {
         // Note that we never revert back to memory if the size shrinks below the threshold.
         // That case is considered rare and not worth the complexity.
@@ -123,7 +124,7 @@ where
 
     async fn multi_merge<M>(&mut self, merges: M) -> Result<MergeStats, anyhow::Error>
     where
-        M: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<O>>)>,
+        M: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<T, O>>)>,
     {
         match &mut self.backend_type {
             BackendType::InMemory(_) => {
@@ -140,7 +141,7 @@ where
     ) -> Result<GetStats, anyhow::Error>
     where
         G: IntoIterator<Item = UpsertKey>,
-        R: IntoIterator<Item = &'r mut UpsertValueAndSize<O>>,
+        R: IntoIterator<Item = &'r mut UpsertValueAndSize<T, O>>,
         O: 'r,
     {
         match &mut self.backend_type {

--- a/src/storage/src/upsert/autospill.rs
+++ b/src/storage/src/upsert/autospill.rs
@@ -88,7 +88,7 @@ where
                     .try_into()
                     .expect("unexpected error while casting");
                 if in_memory_size > self.auto_spill_threshold_bytes {
-                    tracing::info!("spilling to disk for upsert");
+                    tracing::info!(%in_memory_size, %self.auto_spill_threshold_bytes, "spilling to disk for upsert");
                     let mut rocksdb_backend =
                         self.rocksdb_init_fn
                             .take()

--- a/src/storage/src/upsert/types.rs
+++ b/src/storage/src/upsert/types.rs
@@ -16,7 +16,7 @@
 //! into a differential collection, by indexing the data based on the key.
 //!
 //! _This module does not implement this transformation, instead exposing APIs designed
-//! for use within an UPSERT operator. There is one exception to this: `consolidate_snapshot_chunk`
+//! for use within an UPSERT operator. There is one exception to this: `consolidate_chunk`
 //! implements an efficient upsert-like transformation to re-index a collection using the
 //! _output collection_ of an upsert transformation. More on this below.
 //!
@@ -44,13 +44,13 @@
 //!
 //! `multi_put` is implemented directly with `UpsertStateBackend::multi_put`.
 //!
-//! ### `consolidate_snapshot_chunk`
+//! ### `consolidate_chunk`
 //!
-//! `consolidate_snapshot_chunk` re-indexes an UPSERT collection based on its _output collection_ (as
-//! opposed to its _input `Stream`_. Please see the docs on `consolidate_snapshot_chunk` and `StateValue`
+//! `consolidate_chunk` re-indexes an UPSERT collection based on its _output collection_ (as
+//! opposed to its _input `Stream`_. Please see the docs on `consolidate_chunk` and `StateValue`
 //! for more information.
 //!
-//! `consolidate_snapshot_chunk` is implemented with both `UpsertStateBackend::multi_put` and
+//! `consolidate_chunk` is implemented with both `UpsertStateBackend::multi_put` and
 //! `UpsertStateBackend::multi_get`
 //!
 //! ## Order Keys
@@ -64,7 +64,7 @@
 //! There is currently no support for cleaning these tombstones up, as they are considered rare and
 //! small enough.
 //!
-//! Because `consolidate_snapshot_chunk` handles data that consolidates correctly, it does not handle
+//! Because `consolidate_chunk` handles data that consolidates correctly, it does not handle
 //! order keys.
 //!
 //!
@@ -79,7 +79,7 @@
 //! `InMemoryHashMap`, they may be rough estimates of actual memory usage. See
 //! `StateValue::memory_size` for more information.
 //!
-//! Note also that after snapshot consolidation, additional space may be used if `StateValue` is
+//! Note also that after consolidation, additional space may be used if `StateValue` is
 //! used.
 //!
 
@@ -99,7 +99,7 @@ use crate::metrics::upsert::{UpsertMetrics, UpsertSharedMetrics};
 use crate::statistics::SourceStatistics;
 
 /// The default set of `bincode` options used for consolidating
-/// upsert snapshots (and writing values to RocksDB).
+/// upsert updates (and writing values to RocksDB).
 pub type BincodeOpts = bincode::config::DefaultOptions;
 
 /// Build the default `BincodeOpts`.
@@ -172,34 +172,32 @@ pub struct MergeValue<V> {
 
 /// `UpsertState` has 2 modes:
 /// - Normal operation
-/// - Consolidation of snapshots (during rehydration).
+/// - Consolidation.
 ///
 /// This struct and its substructs are helpers to simplify the logic that
 /// individual `UpsertState` implementations need to do to manage these 2 modes.
 ///
 /// Normal operation is simple, we just store an ordinary `UpsertValue`, and allow the implementer
-/// to store it any way they want. During consolidation of snapshots, the logic is more complex.
+/// to store it any way they want. During consolidation, the logic is more complex.
 /// See the docs on `StateValue::merge_update` for more information.
-///
 ///
 /// Note also that this type is designed to support _partial updates_. All values are
 /// associated with an _order key_ `O` that can be used to determine if a value existing in the
 /// `UpsertStateBackend` occurred before or after a value being considered for insertion.
 ///
 /// `O` typically required to be `: Default`, with the default value sorting below all others.
-/// Values consolidated during snapshotting consolidate correctly (as they are actual
+/// During consolidation, values consolidate correctly (as they are actual
 /// differential updates with diffs), so order keys are not required.
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub enum StateValue<T, O> {
-    // TODO(aljoscha): This should really be called Consolidating, or Ingesting.
-    Snapshotting(Snapshotting),
+    Consolidating(Consolidating),
     Value(Value<T, O>),
 }
 
 impl<T, O> std::fmt::Debug for StateValue<T, O> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            StateValue::Snapshotting(_) => write!(f, "Snapshotting"),
+            StateValue::Consolidating(_) => write!(f, "Consolidating"),
             StateValue::Value(_) => write!(f, "Value"),
         }
     }
@@ -237,9 +235,9 @@ pub enum Value<T, O> {
     },
 }
 
-/// A value as produced during consolidation of a snapshot.
+/// A value as produced during consolidation.
 #[derive(Clone, Default, serde::Serialize, serde::Deserialize, Debug)]
-pub struct Snapshotting {
+pub struct Consolidating {
     #[serde(with = "serde_bytes")]
     value_xor: Vec<u8>,
     len_sum: Wrapping<i64>,
@@ -247,9 +245,9 @@ pub struct Snapshotting {
     diff_sum: Wrapping<i64>,
 }
 
-impl fmt::Display for Snapshotting {
+impl fmt::Display for Consolidating {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Snapshotting")
+        f.debug_struct("Consolidating")
             .field("len_sum", &self.len_sum)
             .field("checksum_sum", &self.checksum_sum)
             .field("diff_sum", &self.checksum_sum)
@@ -306,7 +304,7 @@ impl<T, O> StateValue<T, O> {
     pub fn memory_size(&self) -> u64 {
         match self {
             // Similar to `Row::byte_len`, we add the heap size and the size of the value itself.
-            Self::Snapshotting(Snapshotting { value_xor, .. }) => {
+            Self::Consolidating(Consolidating { value_xor, .. }) => {
                 u64::cast_from(value_xor.len()) + u64::cast_from(std::mem::size_of::<Self>())
             }
             Self::Value(Value::FinalizedValue(Ok(row), ..)) => {
@@ -410,7 +408,7 @@ impl<T: Eq, O> StateValue<T, O> {
                 finalized_value,
                 provisional_value: (Some(provisional_value), provisional_ts, provisional_order),
             }),
-            StateValue::Snapshotting(_) => {
+            StateValue::Consolidating(_) => {
                 panic!("called `into_provisional_value` without calling `ensure_decoded`")
             }
         }
@@ -452,7 +450,7 @@ impl<T: Eq, O> StateValue<T, O> {
                 finalized_value,
                 provisional_value: (None, provisional_ts, provisional_order),
             }),
-            StateValue::Snapshotting(_) => {
+            StateValue::Consolidating(_) => {
                 panic!("called `into_provisional_tombstone` without calling `ensure_decoded`")
             }
         }
@@ -474,7 +472,7 @@ impl<T: Eq, O> StateValue<T, O> {
                 finalized_value,
                 provisional_value: _,
             }) => finalized_value.as_ref().map(|v| &v.1),
-            Self::Snapshotting(_) => {
+            Self::Consolidating(_) => {
                 panic!("called `provisional_order` without calling `ensure_decoded`")
             }
         }
@@ -490,7 +488,7 @@ impl<T: Eq, O> StateValue<T, O> {
     //            finalized_value,
     //            provisional_value: _,
     //        }) => finalized_value.as_ref().map(|v| &v.1),
-    //        Self::Snapshotting(_) => {
+    //        Self::Consolidating(_) => {
     //            panic!("called `finalized_order` without calling `ensure_decoded`")
     //        }
     //    }
@@ -510,7 +508,7 @@ impl<T: Eq, O> StateValue<T, O> {
     //            finalized_value,
     //            provisional_value: _,
     //        }) => finalized_value.map(|boxed| *boxed),
-    //        Self::Snapshotting(_) => {
+    //        Self::Consolidating(_) => {
     //            panic!("called `into_provisional_value` without calling `ensure_decoded`")
     //        }
     //    }
@@ -530,7 +528,7 @@ impl<T: Eq, O> StateValue<T, O> {
                 finalized_value,
                 provisional_value: _,
             }) => finalized_value.as_ref().map(|boxed| &boxed.0),
-            Self::Snapshotting(_) => {
+            Self::Consolidating(_) => {
                 panic!("called `provisional_value_ref` without calling `ensure_decoded`")
             }
         }
@@ -551,7 +549,7 @@ impl<T: Eq, O> StateValue<T, O> {
 }
 
 impl<T: Eq, O: Default> StateValue<T, O> {
-    /// We use a XOR trick in order to accumulate the snapshot without having to store the full
+    /// We use a XOR trick in order to accumulate the values without having to store the full
     /// unconsolidated history in memory. For all (value, diff) updates of a key we track:
     /// - diff_sum = SUM(diff)
     /// - checksum_sum = SUM(checksum(bincode(value)) * diff)
@@ -563,7 +561,8 @@ impl<T: Eq, O: Default> StateValue<T, O> {
     ///
     /// ## Correctness
     ///
-    /// The method is correct because a well formed upsert snapshot will have for each key:
+    /// The method is correct because a well formed upsert collection at a given
+    /// timestamp will have for each key:
     /// - Zero or one updates of the form (cur_value, +1)
     /// - Zero or more pairs of updates of the form (prev_value, +1), (prev_value, -1)
     ///
@@ -581,7 +580,7 @@ impl<T: Eq, O: Default> StateValue<T, O> {
     /// ## Robustness
     ///
     /// In the absense of bugs, accumulating the diff and checksum is not required since we know
-    /// that a well formed snapshot always satisfies XOR(bincode(values)) == bincode(cur_value).
+    /// that a well formed collection always satisfies XOR(bincode(values)) == bincode(cur_value).
     /// However bugs may happen and so storing 16 more bytes per key to have a very high
     /// guarantee that we're not decoding garbage is more than worth it.
     /// The main key->value used to store previous values.
@@ -594,7 +593,7 @@ impl<T: Eq, O: Default> StateValue<T, O> {
         bincode_buffer: &mut Vec<u8>,
     ) -> bool {
         match self {
-            Self::Snapshotting(Snapshotting {
+            Self::Consolidating(Consolidating {
                 value_xor,
                 len_sum,
                 checksum_sum,
@@ -624,21 +623,21 @@ impl<T: Eq, O: Default> StateValue<T, O> {
                     }
                 }
 
-                // Returns whether or not the value can be deleted. This allows us to delete values in
-                // `UpsertState::consolidate_snapshot_chunk` (even if they come back later) during snapshotting,
-                // to minimize space usage.
+                // Returns whether or not the value can be deleted. This allows
+                // us to delete values in `UpsertState::consolidate_chunk` (even
+                // if they come back later), to minimize space usage.
                 diff_sum.0 == 0 && checksum_sum.0 == 0 && value_xor.iter().all(|&x| x == 0)
             }
             StateValue::Value(_value) => {
-                // We can turn a Value back into a Snapshotting state:
+                // We can turn a Value back into a Consolidating state:
                 // `std::mem::take` will leave behind a default value, which
-                // happens to be a default `Snapshotting` `StateValue`.
+                // happens to be a default `Consolidating` `StateValue`.
                 let this = std::mem::take(self);
 
                 let finalized_value = this.into_finalized_value();
                 if let Some((finalized_value, _order)) = finalized_value {
-                    // If we had a value before, merge it into the now-snapshotting
-                    // state first.
+                    // If we had a value before, merge it into the
+                    // now-consolidating state first.
                     let _ = self.merge_update(finalized_value, 1, bincode_opts, bincode_buffer);
 
                     // Then merge the new value in.
@@ -657,68 +656,68 @@ impl<T: Eq, O: Default> StateValue<T, O> {
     pub fn merge_update_state(&mut self, other: &Self) {
         match (self, other) {
             (
-                Self::Snapshotting(Snapshotting {
+                Self::Consolidating(Consolidating {
                     value_xor,
                     len_sum,
                     checksum_sum,
                     diff_sum,
                 }),
-                Self::Snapshotting(other_snapshotting),
+                Self::Consolidating(other_consolidating),
             ) => {
-                *diff_sum += other_snapshotting.diff_sum;
-                *len_sum += other_snapshotting.len_sum;
-                *checksum_sum += other_snapshotting.checksum_sum;
-                if other_snapshotting.value_xor.len() > value_xor.len() {
-                    value_xor.resize(other_snapshotting.value_xor.len(), 0);
+                *diff_sum += other_consolidating.diff_sum;
+                *len_sum += other_consolidating.len_sum;
+                *checksum_sum += other_consolidating.checksum_sum;
+                if other_consolidating.value_xor.len() > value_xor.len() {
+                    value_xor.resize(other_consolidating.value_xor.len(), 0);
                 }
                 for (acc, val) in value_xor
                     .iter_mut()
-                    .zip(other_snapshotting.value_xor.iter())
+                    .zip(other_consolidating.value_xor.iter())
                 {
                     *acc ^= val;
                 }
             }
-            _ => panic!("`merge_update_state` called with non-snapshotting state"),
+            _ => panic!("`merge_update_state` called with non-consolidating state"),
         }
     }
 
-    /// After consolidation of a snapshot, we assume that all values in the `UpsertStateBackend` implementation
-    /// are `Self::Snapshotting`, with a `diff_sum` of 1 (or 0, if they have been deleted).
+    /// During and after consolidation, we assume that values in the `UpsertStateBackend` implementation
+    /// can be `Self::Consolidating`, with a `diff_sum` of 1 (or 0, if they have been deleted).
     /// Afterwards, if we need to retract one of these values, we need to assert that its in this correct state,
     /// then mutate it to its `Value` state, so the `upsert` operator can use it.
     #[allow(clippy::as_conversions)]
     pub fn ensure_decoded(&mut self, bincode_opts: BincodeOpts) {
         match self {
-            StateValue::Snapshotting(snapshotting) => {
-                match snapshotting.diff_sum.0 {
+            StateValue::Consolidating(consolidating) => {
+                match consolidating.diff_sum.0 {
                     1 => {
-                        let len = usize::try_from(snapshotting.len_sum.0)
+                        let len = usize::try_from(consolidating.len_sum.0)
                             .map_err(|_| {
                                 format!(
                                     "len_sum can't be made into a usize, state: {}",
-                                    snapshotting
+                                    consolidating
                                 )
                             })
                             .expect("invalid upsert state");
-                        let value = &snapshotting
+                        let value = &consolidating
                             .value_xor
                             .get(..len)
                             .ok_or_else(|| {
                                 format!(
                                     "value_xor is not the same length ({}) as len ({}), state: {}",
-                                    snapshotting.value_xor.len(),
+                                    consolidating.value_xor.len(),
                                     len,
-                                    snapshotting
+                                    consolidating
                                 )
                             })
                             .expect("invalid upsert state");
                         // Truncation is fine (using `as`) as this is just a checksum
                         assert_eq!(
-                            snapshotting.checksum_sum.0,
+                            consolidating.checksum_sum.0,
                             // Hash the value, not the full buffer, which may have extra 0's
                             seahash::hash(value) as i64,
                             "invalid upsert state: checksum_sum does not match, state: {}",
-                            snapshotting
+                            consolidating
                         );
                         *self = Self::Value(Value::FinalizedValue(
                             bincode_opts.deserialize(value).unwrap(),
@@ -727,31 +726,31 @@ impl<T: Eq, O: Default> StateValue<T, O> {
                     }
                     0 => {
                         assert_eq!(
-                            snapshotting.len_sum.0, 0,
+                            consolidating.len_sum.0, 0,
                             "invalid upsert state: len_sum is non-0, state: {}",
-                            snapshotting
+                            consolidating
                         );
                         assert_eq!(
-                            snapshotting.checksum_sum.0, 0,
+                            consolidating.checksum_sum.0, 0,
                             "invalid upsert state: checksum_sum is non-0, state: {}",
-                            snapshotting
+                            consolidating
                         );
                         assert!(
-                            snapshotting.value_xor.iter().all(|&x| x == 0),
+                            consolidating.value_xor.iter().all(|&x| x == 0),
                             "invalid upsert state: value_xor not all 0s with 0 diff. \
                             Non-zero positions: {:?}, state: {}",
-                            snapshotting
+                            consolidating
                                 .value_xor
                                 .iter()
                                 .positions(|&x| x != 0)
                                 .collect::<Vec<_>>(),
-                            snapshotting
+                            consolidating
                         );
                         *self = Self::Value(Value::Tombstone(Default::default()));
                     }
                     other => panic!(
                         "invalid upsert state: non 0/1 diff_sum: {}, state: {}",
-                        other, snapshotting
+                        other, consolidating
                     ),
                 }
             }
@@ -762,11 +761,11 @@ impl<T: Eq, O: Default> StateValue<T, O> {
 
 impl<T, O> Default for StateValue<T, O> {
     fn default() -> Self {
-        Self::Snapshotting(Snapshotting::default())
+        Self::Consolidating(Consolidating::default())
     }
 }
 
-/// Statistics for a single call to `consolidate_snapshot_chunk`.
+/// Statistics for a single call to `consolidate_chunk`.
 #[derive(Clone, Default, Debug)]
 pub struct SnapshotStats {
     /// The number of updates processed.
@@ -774,7 +773,7 @@ pub struct SnapshotStats {
     /// The aggregated number of values inserted or deleted into `state`.
     pub values_diff: i64,
     /// The total aggregated size of values inserted, deleted, or updated in `state`.
-    /// If the current call to `consolidate_snapshot_chunk` deletes a lot of values,
+    /// If the current call to `consolidate_chunk` deletes a lot of values,
     /// or updates values to smaller ones, this can be negative!
     pub size_diff: i64,
     /// The number of inserts i.e. +1 diff
@@ -797,11 +796,11 @@ impl std::ops::AddAssign for SnapshotStats {
 #[derive(Clone, Default, Debug)]
 pub struct MergeStats {
     /// The number of updates written as merge operands to the backend, for the backend
-    /// to process async in the `snapshot_merge_function`.
+    /// to process async in the `consolidating_merge_function`.
     /// Should be equal to number of inserts + deletes
     pub written_merge_operands: u64,
     /// The total size of values provided to `multi_merge`. The backend will write these
-    /// down and then later merge them in the `snapshot_merge_function`.
+    /// down and then later merge them in the `consolidating_merge_function`.
     pub size_written: u64,
     /// The estimated diff of the total size of the working set after the merge operands
     /// are merged by the backend. This is an estimate since it can't account for the
@@ -976,7 +975,7 @@ where
         R: IntoIterator<Item = &'r mut UpsertValueAndSize<T, O>>;
 
     /// For each key in `merges` writes a 'merge operand' to the backend. The backend stores these
-    /// merge operands and periodically calls the `snapshot_merge_function` to merge them into
+    /// merge operands and periodically calls the `consolidating_merge_function` to merge them into
     /// any existing value for each key. The backend will merge the merge operands in the order
     /// they are provided, and the merge function will always be run for a given key when a `get`
     /// operation is performed on that key, or when the backend decides to run the merge based
@@ -1000,16 +999,17 @@ where
         P: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<T, O>>)>;
 }
 
-/// A function that merges a set of updates for a key into the existing value for the key, expected
-/// to only be used during the snapshotting-phase of an upsert operator. This is called by the
-/// backend implementation when it has accumulated a set of updates for a key, and needs to merge
-/// them into the existing value for the key.
+/// A function that merges a set of updates for a key into the existing value
+/// for the key. This is called by the backend implementation when it has
+/// accumulated a set of updates for a key, and needs to merge them into the
+/// existing value for the key.
 ///
 /// The function is called with the following arguments:
 /// - The key for which the merge is being performed.
 /// - An iterator over any current value and merge operands queued for the key.
+///
 /// The function should return the new value for the key after merging all the updates.
-pub(crate) fn snapshot_merge_function<T, O>(
+pub(crate) fn consolidating_merge_function<T, O>(
     _key: UpsertKey,
     updates: impl Iterator<Item = StateValue<T, O>>,
 ) -> StateValue<T, O>
@@ -1022,7 +1022,7 @@ where
     let mut bincode_buf = Vec::new();
     for update in updates {
         match update {
-            StateValue::Snapshotting(_) => {
+            StateValue::Consolidating(_) => {
                 current.merge_update_state(&update);
             }
             StateValue::Value(_) => {
@@ -1045,12 +1045,12 @@ where
     current
 }
 
-/// An `UpsertStateBackend` wrapper that supports
-/// snapshot merging, and reports basic metrics about the usage of the `UpsertStateBackend`.
+/// An `UpsertStateBackend` wrapper that supports consolidating merging, and
+/// reports basic metrics about the usage of the `UpsertStateBackend`.
 pub struct UpsertState<'metrics, S, T, O> {
     inner: S,
 
-    // The status, start time, and stats about calls to `consolidate_snapshot_chunk`.
+    // The status, start time, and stats about calls to `consolidate_chunk`.
     pub snapshot_start: Instant,
     snapshot_stats: SnapshotStats,
     snapshot_completed: bool,
@@ -1062,15 +1062,14 @@ pub struct UpsertState<'metrics, S, T, O> {
     // User-facing statistics.
     stats: SourceStatistics,
 
-    // Bincode options and buffer used
-    // in `consolidate_snapshot_chunk`.
+    // Bincode options and buffer used in `consolidate_chunk`.
     bincode_opts: BincodeOpts,
     bincode_buffer: Vec<u8>,
 
-    // We need to iterate over `updates` in `consolidate_snapshot_chunk`
-    // twice, so we have a scratch vector for this.
+    // We need to iterate over `updates` in `consolidate_chunk` twice, so we
+    // have a scratch vector for this.
     consolidate_scratch: Vec<(UpsertKey, UpsertValue, mz_repr::Diff)>,
-    // "mini-upsert" map used in `consolidate_snapshot_chunk`
+    // "mini-upsert" map used in `consolidate_chunk`
     consolidate_upsert_scratch: indexmap::IndexMap<UpsertKey, UpsertValueAndSize<T, O>>,
     // a scratch vector for calling `multi_get`
     multi_get_scratch: Vec<UpsertKey>,
@@ -1109,26 +1108,26 @@ where
     T: Eq + Clone + Send + Sync + Serialize + 'static,
     O: Default + Clone + Send + Sync + Serialize + DeserializeOwned + 'static,
 {
-    // TODO: Update docs.
-    /// Consolidate the following differential updates into the state, during snapshotting.
-    /// Updates provided to this method can be assumed to consolidate into a single value
-    /// per-key, after all chunks have been processed.
+    /// Consolidate the following differential updates into the state. Updates
+    /// provided to this method can be assumed to consolidate into a single
+    /// value per-key, after all chunks of updates for a given timestamp have
+    /// been processed,
     ///
-    /// Therefore, after an entire snapshot has been `consolidated`, all values must be in the correct state
-    /// (as determined by `StateValue::ensure_decoded`), and `consolidate_snapshot_chunk` must NOT
-    /// be called again.
+    /// Therefore, after all updates of a given timestamp have been
+    /// `consolidated`, all values must be in the correct state (as determined
+    /// by `StateValue::ensure_decoded`).
     ///
-    /// The `completed` boolean communicates whether or not this is the final chunk of updates
-    /// to be consolidated, to assert correct usage.
+    /// The `completed` boolean communicates whether or not this is the final
+    /// chunk of updates for the initial "snapshot" from persist.
     ///
-    /// If the backend supports it, this method will use `multi_merge` to consolidate the updates
-    /// to avoid having to read the existing value for each key first.
-    /// On some backends (like RocksDB), this can be significantly faster than the read-then-write
-    /// consolidation strategy.
+    /// If the backend supports it, this method will use `multi_merge` to
+    /// consolidate the updates to avoid having to read the existing value for
+    /// each key first. On some backends (like RocksDB), this can be
+    /// significantly faster than the read-then-write consolidation strategy.
     ///
-    /// Also note that we use `self.inner.multi_*`, not `self.multi_*`. This is to avoid
-    /// erroneously changing metric and stats values.
-    pub async fn consolidate_snapshot_chunk<U>(
+    /// Also note that we use `self.inner.multi_*`, not `self.multi_*`. This is
+    /// to avoid erroneously changing metric and stats values.
+    pub async fn consolidate_chunk<U>(
         &mut self,
         updates: U,
         completed: bool,
@@ -1136,8 +1135,8 @@ where
     where
         U: IntoIterator<Item = (UpsertKey, UpsertValue, mz_repr::Diff)> + ExactSizeIterator,
     {
-        fail::fail_point!("fail_consolidate_snapshot_chunk", |_| {
-            Err(anyhow::anyhow!("Error consolidating snapshot values"))
+        fail::fail_point!("fail_consolidate_chunk", |_| {
+            Err(anyhow::anyhow!("Error consolidating values"))
         });
 
         if completed && self.snapshot_completed {
@@ -1168,15 +1167,13 @@ where
         // the Autospill backend will switch from in-memory to rocksdb after a certain
         // number of updates have been processed and begin supporting multi_merge).
         let stats = if self.inner.supports_merge() {
-            self.consolidate_snapshot_merge_inner(updates).await?
+            self.consolidate_merge_inner(updates).await?
         } else {
-            self.consolidate_snapshot_read_write_inner(updates).await?
+            self.consolidate_read_write_inner(updates).await?
         };
 
-        // NOTE: These metrics use the term `merge` to refer to the consolidation of snapshot values.
-        // This is because they were introduced before we the `multi_merge` operation was added, and
-        // to differentiate the two separate `merge` notions we renamed `merge_snapshot_chunk` to
-        // `consolidate_snapshot_chunk`.
+        // NOTE: These metrics use the term `merge` to refer to the consolidation of values.
+        // This is because they were introduced before we the `multi_merge` operation was added.
         self.metrics
             .merge_snapshot_latency
             .observe(now.elapsed().as_secs_f64());
@@ -1233,16 +1230,16 @@ where
         Ok(())
     }
 
-    /// Consolidate the updates into the state during snapshotting. This method requires the
-    /// backend has support for the `multi_merge` operation, and will panic if
-    /// `self.inner.supports_merge()` was not checked before calling this method.
-    /// `multi_merge` will write the updates as 'merge operands' to the backend, and then the
-    /// backend will consolidate those updates with any existing state using the
-    /// `snapshot_merge_function`.
+    /// Consolidate the updates into the state. This method requires the backend
+    /// has support for the `multi_merge` operation, and will panic if
+    /// `self.inner.supports_merge()` was not checked before calling this
+    /// method. `multi_merge` will write the updates as 'merge operands' to the
+    /// backend, and then the backend will consolidate those updates with any
+    /// existing state using the `consolidating_merge_function`.
     ///
     /// This method can have significant performance benefits over the
-    /// read-then-write method of `consolidate_snapshot_read_write_inner`.
-    async fn consolidate_snapshot_merge_inner<U>(
+    /// read-then-write method of `consolidate_read_write_inner`.
+    async fn consolidate_merge_inner<U>(
         &mut self,
         updates: U,
     ) -> Result<SnapshotStats, anyhow::Error>
@@ -1257,8 +1254,9 @@ where
             let m_stats = self
                 .inner
                 .multi_merge(updates.map(|(k, v, diff)| {
-                    // Transform into a `StateValue<O>` that can be used by the `snapshot_merge_function`
-                    // to merge with any existing value for the key.
+                    // Transform into a `StateValue<O>` that can be used by the
+                    // `consolidating_merge_function` to merge with any existing
+                    // value for the key.
                     let mut val: StateValue<T, O> = Default::default();
                     val.merge_update(v, diff, self.bincode_opts, &mut self.bincode_buffer);
 
@@ -1272,7 +1270,7 @@ where
                     // To keep track of the overall `values_diff` we can use the sum of diffs which
                     // should be equal to the number of non-tombstoned values in the backend.
                     // This is a bit misleading as this represents the eventual state after the
-                    // `snapshot_merge_function` has been called to merge all the updates,
+                    // `consolidating_merge_function` has been called to merge all the updates,
                     // and not the state after this `multi_merge` call.
                     //
                     // This does not accurately report values that have been consolidated to diff == 0, as tracking that
@@ -1289,9 +1287,10 @@ where
         Ok(stats)
     }
 
-    /// Consolidates the updates into the state during snapshotting. This method reads the existing
-    /// values for each key, consolidates the updates, and writes the new values back to the state.
-    async fn consolidate_snapshot_read_write_inner<U>(
+    /// Consolidates the updates into the state. This method reads the existing
+    /// values for each key, consolidates the updates, and writes the new values
+    /// back to the state.
+    async fn consolidate_read_write_inner<U>(
         &mut self,
         updates: U,
     ) -> Result<SnapshotStats, anyhow::Error>
@@ -1328,7 +1327,7 @@ where
 
                 // We rely on the diffs in our input instead of the result of
                 // multi_put below. This makes sure we report the same stats as
-                // `consolidate_snapshot_merge_inner`, regardless of what values
+                // `consolidate_merge_inner`, regardless of what values
                 // there were in state before.
                 stats.values_diff += diff;
 
@@ -1459,7 +1458,7 @@ mod tests {
         let mut buf = Vec::new();
         let opts = upsert_bincode_opts();
 
-        let mut s = StateValue::<(), ()>::Snapshotting(Snapshotting::default());
+        let mut s = StateValue::<(), ()>::Consolidating(Consolidating::default());
 
         let small_row = Ok(mz_repr::Row::default());
         let longer_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Null]));
@@ -1470,7 +1469,7 @@ mod tests {
         // that we are tracking checksums correctly.
         s.merge_update(longer_row, 1, opts, &mut buf);
 
-        // Assert that the `Snapshotting` value is fully merged.
+        // Assert that the `Consolidating` value is fully merged.
         s.ensure_decoded(opts);
     }
 
@@ -1502,29 +1501,29 @@ mod tests {
             provisional_value_without_finalized_value.memory_size(),
         );
 
-        let mut snapshotting_value: StateValue<(), ()> = StateValue::default();
-        snapshotting_value.merge_update(
+        let mut consolidating_value: StateValue<(), ()> = StateValue::default();
+        consolidating_value.merge_update(
             Ok(Row::default()),
             1,
             upsert_bincode_opts(),
             &mut Vec::new(),
         );
         assert!(
-            snapshotting_value.memory_size() <= 90,
+            consolidating_value.memory_size() <= 90,
             "memory size is {}",
-            snapshotting_value.memory_size(),
+            consolidating_value.memory_size(),
         );
     }
 
     #[mz_ore::test]
     #[should_panic(
-        expected = "invalid upsert state: len_sum is non-0, state: Snapshotting { len_sum: 1"
+        expected = "invalid upsert state: len_sum is non-0, state: Consolidating { len_sum: 1"
     )]
     fn test_merge_update_len_0_assert() {
         let mut buf = Vec::new();
         let opts = upsert_bincode_opts();
 
-        let mut s = StateValue::<(), ()>::Snapshotting(Snapshotting::default());
+        let mut s = StateValue::<(), ()>::Consolidating(Consolidating::default());
 
         let small_row = Ok(mz_repr::Row::default());
         let longer_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Null]));
@@ -1536,13 +1535,13 @@ mod tests {
 
     #[mz_ore::test]
     #[should_panic(
-        expected = "invalid upsert state: \"value_xor is not the same length (3) as len (4), state: Snapshotting { len_sum: 4"
+        expected = "invalid upsert state: \"value_xor is not the same length (3) as len (4), state: Consolidating { len_sum: 4"
     )]
     fn test_merge_update_len_to_long_assert() {
         let mut buf = Vec::new();
         let opts = upsert_bincode_opts();
 
-        let mut s = StateValue::<(), ()>::Snapshotting(Snapshotting::default());
+        let mut s = StateValue::<(), ()>::Consolidating(Consolidating::default());
 
         let small_row = Ok(mz_repr::Row::default());
         let longer_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Null]));
@@ -1559,7 +1558,7 @@ mod tests {
         let mut buf = Vec::new();
         let opts = upsert_bincode_opts();
 
-        let mut s = StateValue::<(), ()>::Snapshotting(Snapshotting::default());
+        let mut s = StateValue::<(), ()>::Consolidating(Consolidating::default());
 
         let small_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Int64(2)]));
         let longer_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Int64(1)]));

--- a/src/storage/src/upsert/types.rs
+++ b/src/storage/src/upsert/types.rs
@@ -114,13 +114,31 @@ pub fn upsert_bincode_opts() -> BincodeOpts {
 /// can reuse this value as they overwrite this value, keeping
 /// track of the previous metadata. Additionally, values
 /// may be `None` for tombstones.
-#[derive(Debug, Default, Clone)]
-pub struct UpsertValueAndSize<O> {
+#[derive(Clone)]
+pub struct UpsertValueAndSize<T, O> {
     /// The value, if there was one.
-    pub value: Option<StateValue<O>>,
+    pub value: Option<StateValue<T, O>>,
     /// The size of original`value` as persisted,
     /// Useful for users keeping track of statistics.
     pub metadata: Option<ValueMetadata<u64>>,
+}
+
+impl<T, O> std::fmt::Debug for UpsertValueAndSize<T, O> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UpsertValueAndSize")
+            .field("value", &self.value)
+            .field("metadata", &self.metadata)
+            .finish()
+    }
+}
+
+impl<T, O> Default for UpsertValueAndSize<T, O> {
+    fn default() -> Self {
+        Self {
+            value: None,
+            metadata: None,
+        }
+    }
 }
 
 /// Metadata about an existing value in the upsert state backend, as returned
@@ -171,19 +189,51 @@ pub struct MergeValue<V> {
 /// `O` typically required to be `: Default`, with the default value sorting below all others.
 /// Values consolidated during snapshotting consolidate correctly (as they are actual
 /// differential updates with diffs), so order keys are not required.
-#[derive(Clone, serde::Serialize, serde::Deserialize, Debug)]
-pub enum StateValue<O> {
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub enum StateValue<T, O> {
     Snapshotting(Snapshotting),
-    Value(Value<O>),
+    Value(Value<T, O>),
+}
+
+impl<T, O> std::fmt::Debug for StateValue<T, O> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StateValue::Snapshotting(_) => write!(f, "Snapshotting"),
+            StateValue::Value(_) => write!(f, "Value"),
+        }
+    }
 }
 
 /// A totally consolidated value stored within the `UpsertStateBackend`.
 ///
-/// This type contains support for _tombstones_, that contain an _order key_.
+/// This type contains support for _tombstones_, that contain an _order key_,
+/// and provisional values.
+///
+/// What is considered finalized and provisional depends on the implementation
+/// of the UPSERT operator: it might consider everything that it writes to its
+/// state finalized, and assume that what it emits will be written down in the
+/// output exactly as presented. Or it might consider everything it writes down
+/// provisional, and only consider updates that it _knows_ to be persisted as
+/// finalized.
+///
+/// Provisional values should only be considered while still "working off"
+/// updates with the same timestamp at which the provisional update was
+/// recorded.
 #[derive(Clone, serde::Serialize, serde::Deserialize, Debug)]
-pub enum Value<O> {
-    Value(UpsertValue, O),
+pub enum Value<T, O> {
+    FinalizedValue(UpsertValue, O),
     Tombstone(O),
+    ProvisionalValue {
+        // We keep the finalized value around, because the provisional value is
+        // only valid when processing updates at the same timestamp. And at any
+        // point we might still require access to the finalized value.
+        finalized_value: Option<Box<(UpsertValue, O)>>,
+        // A provisional value of `None` is a provisional tombstone.
+        //
+        // WIP: We can also box this, to keep the size of StateValue as it was
+        // previously.
+        provisional_value: (Option<UpsertValue>, T, O),
+    },
 }
 
 /// A value as produced during consolidation of a snapshot.
@@ -206,10 +256,11 @@ impl fmt::Display for Snapshotting {
     }
 }
 
-impl<O> StateValue<O> {
-    /// A normal value occurring at some order key.
-    pub fn value(value: UpsertValue, order: O) -> Self {
-        Self::Value(Value::Value(value, order))
+impl<T, O> StateValue<T, O> {
+    /// A finalized, that is (assumed) persistent, value occurring at some order
+    /// key.
+    pub fn finalized_value(value: UpsertValue, order: O) -> Self {
+        Self::Value(Value::FinalizedValue(value, order))
     }
 
     #[allow(unused)]
@@ -229,14 +280,17 @@ impl<O> StateValue<O> {
     /// Pull out the order for the given `Value`, assuming `ensure_decoded` has been called.
     pub fn order(&self) -> &O {
         match self {
-            Self::Value(Value::Value(_, order)) => order,
+            Self::Value(Value::FinalizedValue(_, order)) => order,
+            Self::Value(Value::ProvisionalValue { .. }) => {
+                panic!("order() called on provisional value")
+            }
             Self::Value(Value::Tombstone(order)) => order,
             _ => panic!("called `order` without calling `ensure_decoded`"),
         }
     }
 
     /// Pull out the `Value` value for a `StateValue`, after `ensure_decoded` has been called.
-    pub fn into_decoded(self) -> Value<O> {
+    pub fn into_decoded(self) -> Value<T, O> {
         match self {
             Self::Value(value) => value,
             _ => panic!("called `into_decoded without calling `ensure_decoded`"),
@@ -254,21 +308,51 @@ impl<O> StateValue<O> {
             Self::Snapshotting(Snapshotting { value_xor, .. }) => {
                 u64::cast_from(value_xor.len()) + u64::cast_from(std::mem::size_of::<Self>())
             }
-            Self::Value(Value::Value(Ok(row), ..)) => {
+            Self::Value(Value::FinalizedValue(Ok(row), ..)) => {
                 // `Row::byte_len` includes the size of `Row`, which is also in `Self`, so we
                 // subtract it.
-                u64::cast_from(row.byte_len())
+                u64::cast_from(row.byte_len()) - u64::cast_from(std::mem::size_of::<mz_repr::Row>())
                 // This assumes the size of any `O` instantiation is meaningful (i.e. not a heap
                 // object).
                 + u64::cast_from(std::mem::size_of::<Self>())
-                    - u64::cast_from(std::mem::size_of::<mz_repr::Row>())
+            }
+            Self::Value(Value::ProvisionalValue {
+                finalized_value,
+                provisional_value,
+            }) => {
+                finalized_value.as_ref().map(|v| match v.as_ref() {
+                    (Ok(row), _order) =>
+                        // The finalized value is boxed, so the size of Row is
+                        // not included in the outer size of Self. We therefore
+                        // don't subtract it here like for the other branches.
+                        u64::cast_from(row.byte_len())
+                        // Add the size of the order, because it's also behind
+                        // the box.
+                        + u64::cast_from(std::mem::size_of::<O>()),
+                    // Assume errors are rare enough to not move the needle.
+                    (Err(_), _order) => 0,
+                }).unwrap_or(0)
+                +
+                provisional_value.0.as_ref().map(|v| match v{
+                    Ok(row) =>
+                        // `Row::byte_len` includes the size of `Row`, which is
+                        // also in `Self`, so we subtract it.
+                        u64::cast_from(row.byte_len()) - u64::cast_from(std::mem::size_of::<mz_repr::Row>()),
+                        // The size of order is already included in the outer
+                        // size of self.
+                    // Assume errors are rare enough to not move the needle.
+                    Err(_) => 0,
+                }).unwrap_or(0)
+                // This assumes the size of any `O` instantiation is meaningful (i.e. not a heap
+                // object).
+                + u64::cast_from(std::mem::size_of::<Self>())
             }
             Self::Value(Value::Tombstone(_)) => {
                 // This assumes the size of any `O` instantiation is meaningful (i.e. not a heap
                 // object).
                 u64::cast_from(std::mem::size_of::<Self>())
             }
-            Self::Value(Value::Value(Err(_), ..)) => {
+            Self::Value(Value::FinalizedValue(Err(_), ..)) => {
                 // Assume errors are rare enough to not move the needle.
                 0
             }
@@ -276,7 +360,196 @@ impl<O> StateValue<O> {
     }
 }
 
-impl<O: Default> StateValue<O> {
+impl<T: Eq, O> StateValue<T, O> {
+    /// Creates a new provisional value, occurring at some order key, observed
+    /// at the given timestamp.
+    pub fn new_provisional_value(
+        provisional_value: UpsertValue,
+        provisional_ts: T,
+        order: O,
+    ) -> Self {
+        Self::Value(Value::ProvisionalValue {
+            finalized_value: None,
+            provisional_value: (Some(provisional_value), provisional_ts, order),
+        })
+    }
+
+    /// Creates a provisional value, that retains the finalized value along with
+    /// its order in this `StateValue`, if any.
+    ///
+    /// We record the finalized value, so that we can present it when needed or
+    /// when trying to read a provisional value at a different timestamp.
+    pub fn into_provisional_value(
+        self,
+        provisional_value: UpsertValue,
+        provisional_ts: T,
+        provisional_order: O,
+    ) -> Self {
+        match self {
+            StateValue::Value(Value::FinalizedValue(value, order)) => {
+                StateValue::Value(Value::ProvisionalValue {
+                    finalized_value: Some(Box::new((value, order))),
+                    provisional_value: (Some(provisional_value), provisional_ts, provisional_order),
+                })
+            }
+            StateValue::Value(Value::Tombstone(_)) => {
+                // This cannot happen with how the new feedback UPSERT uses
+                // state. There are only ever provisional tombstones, and all
+                // updates that are merged/consolidated into upsert state come
+                // from the persist input, which doesn't need tombstones.
+                //
+                // Regular, finalized tombstones are only used by the classic
+                // UPSERT operator when doing partial processing.
+                panic!("cannot turn a finalized tombstone into a provisional value")
+            }
+            StateValue::Value(Value::ProvisionalValue {
+                finalized_value,
+                provisional_value: _,
+            }) => StateValue::Value(Value::ProvisionalValue {
+                finalized_value,
+                provisional_value: (Some(provisional_value), provisional_ts, provisional_order),
+            }),
+            StateValue::Snapshotting(_) => {
+                panic!("called `into_provisional_value` without calling `ensure_decoded`")
+            }
+        }
+    }
+
+    /// Creates a new provisional tombstone occurring at some order key,
+    /// observed at the given timestamp.
+    pub fn new_provisional_tombstone(provisional_ts: T, order: O) -> Self {
+        Self::Value(Value::ProvisionalValue {
+            finalized_value: None,
+            provisional_value: (None, provisional_ts, order),
+        })
+    }
+
+    /// Creates a provisional tombstone, that retains the finalized value along
+    /// with its order in this `StateValue`, if any.
+    ///
+    /// We record the current finalized value, so that we can present it when
+    /// needed or when trying to read a provisional value at a different
+    /// timestamp.
+    pub fn into_provisional_tombstone(self, provisional_ts: T, provisional_order: O) -> Self {
+        match self {
+            StateValue::Value(Value::FinalizedValue(value, order)) => {
+                StateValue::Value(Value::ProvisionalValue {
+                    finalized_value: Some(Box::new((value, order))),
+                    provisional_value: (None, provisional_ts, provisional_order),
+                })
+            }
+            StateValue::Value(Value::Tombstone(order)) => {
+                StateValue::Value(Value::ProvisionalValue {
+                    finalized_value: None,
+                    provisional_value: (None, provisional_ts, order),
+                })
+            }
+            StateValue::Value(Value::ProvisionalValue {
+                finalized_value,
+                provisional_value: _,
+            }) => StateValue::Value(Value::ProvisionalValue {
+                finalized_value,
+                provisional_value: (None, provisional_ts, provisional_order),
+            }),
+            StateValue::Snapshotting(_) => {
+                panic!("called `into_provisional_tombstone` without calling `ensure_decoded`")
+            }
+        }
+    }
+
+    /// Returns the order of a provisional value at the given timestamp. If that
+    /// doesn't exist, the order of the finalized value.
+    ///
+    /// Returns `None` if none of the above exist.
+    pub fn provisional_order(&self, ts: &T) -> Option<&O> {
+        match self {
+            Self::Value(Value::FinalizedValue(_, order)) => Some(order),
+            Self::Value(Value::Tombstone(order)) => Some(order),
+            Self::Value(Value::ProvisionalValue {
+                finalized_value: _,
+                provisional_value: (_, provisional_ts, provisional_order),
+            }) if provisional_ts == ts => Some(provisional_order),
+            Self::Value(Value::ProvisionalValue {
+                finalized_value,
+                provisional_value: _,
+            }) => finalized_value.as_ref().map(|v| &v.1),
+            Self::Snapshotting(_) => {
+                panic!("called `provisional_order` without calling `ensure_decoded`")
+            }
+        }
+    }
+
+    // WIP: We don't need these after all, but leave in for review.
+    ///// Returns the order of this value, if a finalized value is present.
+    //pub fn finalized_order(&self) -> Option<&O> {
+    //    match self {
+    //        Self::Value(Value::FinalizedValue(_, order)) => Some(order),
+    //        Self::Value(Value::Tombstone(order)) => Some(order),
+    //        Self::Value(Value::ProvisionalValue {
+    //            finalized_value,
+    //            provisional_value: _,
+    //        }) => finalized_value.as_ref().map(|v| &v.1),
+    //        Self::Snapshotting(_) => {
+    //            panic!("called `finalized_order` without calling `ensure_decoded`")
+    //        }
+    //    }
+    //}
+
+    ///// Returns the provisional value, if one is present at the given timestamp.
+    ///// Falls back to the finalized value, or `None` if there is neither.
+    //pub fn into_provisional_value(self, ts: &T) -> Option<(UpsertValue, O)> {
+    //    match self {
+    //        Self::Value(Value::FinalizedValue(value, order)) => Some((value, order)),
+    //        Self::Value(Value::Tombstone(_)) => None,
+    //        Self::Value(Value::ProvisionalValue {
+    //            finalized_value: _,
+    //            provisional_value: (provisional_value, provisional_ts, provisional_order),
+    //        }) if provisional_ts == *ts => provisional_value.map(|v| (v, provisional_order)),
+    //        Self::Value(Value::ProvisionalValue {
+    //            finalized_value,
+    //            provisional_value: _,
+    //        }) => finalized_value.map(|boxed| *boxed),
+    //        Self::Snapshotting(_) => {
+    //            panic!("called `into_provisional_value` without calling `ensure_decoded`")
+    //        }
+    //    }
+    //}
+
+    /// Returns the provisional value, if one is present at the given timestamp.
+    /// Falls back to the finalized value, or `None` if there is neither.
+    pub fn provisional_value_ref(&self, ts: &T) -> Option<&UpsertValue> {
+        match self {
+            Self::Value(Value::FinalizedValue(value, _order)) => Some(value),
+            Self::Value(Value::Tombstone(_)) => None,
+            Self::Value(Value::ProvisionalValue {
+                finalized_value: _,
+                provisional_value: (provisional_value, provisional_ts, _provisional_order),
+            }) if provisional_ts == ts => provisional_value.as_ref(),
+            Self::Value(Value::ProvisionalValue {
+                finalized_value,
+                provisional_value: _,
+            }) => finalized_value.as_ref().map(|boxed| &boxed.0),
+            Self::Snapshotting(_) => {
+                panic!("called `provisional_value_ref` without calling `ensure_decoded`")
+            }
+        }
+    }
+
+    /// Returns the the finalized value, if one is present.
+    pub fn into_finalized_value(self) -> Option<(UpsertValue, O)> {
+        match self {
+            Self::Value(Value::FinalizedValue(value, order)) => Some((value, order)),
+            Self::Value(Value::Tombstone(_order)) => None,
+            Self::Value(Value::ProvisionalValue {
+                finalized_value,
+                provisional_value: _,
+            }) => finalized_value.map(|boxed| *boxed),
+            _ => panic!("called `order` without calling `ensure_decoded`"),
+        }
+    }
+}
+
+impl<T: Eq, O: Default> StateValue<T, O> {
     /// We use a XOR trick in order to accumulate the snapshot without having to store the full
     /// unconsolidated history in memory. For all (value, diff) updates of a key we track:
     /// - diff_sum = SUM(diff)
@@ -427,7 +700,7 @@ impl<O: Default> StateValue<O> {
                             "invalid upsert state: checksum_sum does not match, state: {}",
                             snapshotting
                         );
-                        *self = Self::Value(Value::Value(
+                        *self = Self::Value(Value::FinalizedValue(
                             bincode_opts.deserialize(value).unwrap(),
                             Default::default(),
                         ));
@@ -467,7 +740,7 @@ impl<O: Default> StateValue<O> {
     }
 }
 
-impl<O> Default for StateValue<O> {
+impl<T, O> Default for StateValue<T, O> {
     fn default() -> Self {
         Self::Snapshotting(Snapshotting::default())
     }
@@ -545,9 +818,9 @@ impl PutStats {
     /// as some backends increase the total size after an entire batch is processed.
     ///
     /// This method is provided for implementors of `UpsertStateBackend::multi_put`.
-    pub fn adjust<O>(
+    pub fn adjust<T, O>(
         &mut self,
-        new_value: Option<&StateValue<O>>,
+        new_value: Option<&StateValue<T, O>>,
         new_size: Option<i64>,
         previous_metdata: &Option<ValueMetadata<i64>>,
     ) {
@@ -556,9 +829,9 @@ impl PutStats {
         self.adjust_tombstone(new_value, previous_metdata);
     }
 
-    fn adjust_size<O>(
+    fn adjust_size<T, O>(
         &mut self,
-        new_value: Option<&StateValue<O>>,
+        new_value: Option<&StateValue<T, O>>,
         new_size: Option<i64>,
         previous_metdata: &Option<ValueMetadata<i64>>,
     ) {
@@ -581,9 +854,9 @@ impl PutStats {
         }
     }
 
-    fn adjust_values<O>(
+    fn adjust_values<T, O>(
         &mut self,
-        new_value: Option<&StateValue<O>>,
+        new_value: Option<&StateValue<T, O>>,
         previous_metdata: &Option<ValueMetadata<i64>>,
     ) {
         let truly_new_value = new_value.map_or(false, |v| !v.is_tombstone());
@@ -600,9 +873,9 @@ impl PutStats {
         }
     }
 
-    fn adjust_tombstone<O>(
+    fn adjust_tombstone<T, O>(
         &mut self,
-        new_value: Option<&StateValue<O>>,
+        new_value: Option<&StateValue<T, O>>,
         previous_metdata: &Option<ValueMetadata<i64>>,
     ) {
         let new_tombstone = new_value.map_or(false, |v| v.is_tombstone());
@@ -644,8 +917,9 @@ pub struct GetStats {
 /// This **must** is not a correctness requirement (we won't panic when emitting statistics), but
 /// rather a requirement to ensure the upsert operator is introspectable.
 #[async_trait::async_trait(?Send)]
-pub trait UpsertStateBackend<O>
+pub trait UpsertStateBackend<T, O>
 where
+    T: 'static,
     O: 'static,
 {
     /// Whether this backend supports the `multi_merge` operation.
@@ -667,7 +941,7 @@ where
     /// in the backend, regardless of whether the values are tombstones or not.
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
-        P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<O>>)>;
+        P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<T, O>>)>;
 
     /// Get the `gets` keys, which must be unique, placing the results in `results_out`.
     ///
@@ -679,7 +953,7 @@ where
     ) -> Result<GetStats, anyhow::Error>
     where
         G: IntoIterator<Item = UpsertKey>,
-        R: IntoIterator<Item = &'r mut UpsertValueAndSize<O>>;
+        R: IntoIterator<Item = &'r mut UpsertValueAndSize<T, O>>;
 
     /// For each key in `merges` writes a 'merge operand' to the backend. The backend stores these
     /// merge operands and periodically calls the `snapshot_merge_function` to merge them into
@@ -703,7 +977,7 @@ where
     ///    merge operands are merged by the backend.
     async fn multi_merge<P>(&mut self, merges: P) -> Result<MergeStats, anyhow::Error>
     where
-        P: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<O>>)>;
+        P: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<T, O>>)>;
 }
 
 /// A function that merges a set of updates for a key into the existing value for the key, expected
@@ -715,12 +989,13 @@ where
 /// - The key for which the merge is being performed.
 /// - An iterator over any current value and merge operands queued for the key.
 /// The function should return the new value for the key after merging all the updates.
-pub(crate) fn snapshot_merge_function<O>(
+pub(crate) fn snapshot_merge_function<T, O>(
     _key: UpsertKey,
-    updates: impl Iterator<Item = StateValue<O>>,
-) -> StateValue<O>
+    updates: impl Iterator<Item = StateValue<T, O>>,
+) -> StateValue<T, O>
 where
     O: Default,
+    T: std::cmp::Eq,
 {
     let mut current = Default::default();
     assert!(
@@ -740,7 +1015,7 @@ where
 
 /// An `UpsertStateBackend` wrapper that supports
 /// snapshot merging, and reports basic metrics about the usage of the `UpsertStateBackend`.
-pub struct UpsertState<'metrics, S, O> {
+pub struct UpsertState<'metrics, S, T, O> {
     inner: S,
 
     // The status, start time, and stats about calls to `consolidate_snapshot_chunk`.
@@ -764,13 +1039,13 @@ pub struct UpsertState<'metrics, S, O> {
     // twice, so we have a scratch vector for this.
     consolidate_scratch: Vec<(UpsertKey, UpsertValue, mz_repr::Diff)>,
     // "mini-upsert" map used in `consolidate_snapshot_chunk`
-    consolidate_upsert_scratch: indexmap::IndexMap<UpsertKey, UpsertValueAndSize<O>>,
+    consolidate_upsert_scratch: indexmap::IndexMap<UpsertKey, UpsertValueAndSize<T, O>>,
     // a scratch vector for calling `multi_get`
     multi_get_scratch: Vec<UpsertKey>,
     shrink_upsert_unused_buffers_by_ratio: usize,
 }
 
-impl<'metrics, S, O> UpsertState<'metrics, S, O> {
+impl<'metrics, S, T, O> UpsertState<'metrics, S, T, O> {
     pub(crate) fn new(
         inner: S,
         metrics: Arc<UpsertSharedMetrics>,
@@ -796,9 +1071,10 @@ impl<'metrics, S, O> UpsertState<'metrics, S, O> {
     }
 }
 
-impl<S, O> UpsertState<'_, S, O>
+impl<S, T, O> UpsertState<'_, S, T, O>
 where
-    S: UpsertStateBackend<O>,
+    S: UpsertStateBackend<T, O>,
+    T: Eq + Clone + Send + Sync + Serialize + 'static,
     O: Default + Clone + Send + Sync + Serialize + DeserializeOwned + 'static,
 {
     /// Consolidate the following differential updates into the state, during snapshotting.
@@ -948,7 +1224,7 @@ where
                 .multi_merge(updates.map(|(k, v, diff)| {
                     // Transform into a `StateValue<O>` that can be used by the `snapshot_merge_function`
                     // to merge with any existing value for the key.
-                    let mut val: StateValue<O> = Default::default();
+                    let mut val: StateValue<T, O> = Default::default();
                     val.merge_update(v, diff, self.bincode_opts, &mut self.bincode_buffer);
 
                     stats.updates += 1;
@@ -1052,7 +1328,7 @@ where
     /// repeated keys.
     pub async fn multi_put<P>(&mut self, puts: P) -> Result<(), anyhow::Error>
     where
-        P: IntoIterator<Item = (UpsertKey, PutValue<Value<O>>)>,
+        P: IntoIterator<Item = (UpsertKey, PutValue<Value<T, O>>)>,
     {
         fail::fail_point!("fail_state_multi_put", |_| {
             Err(anyhow::anyhow!("Error putting values into state"))
@@ -1104,7 +1380,7 @@ where
         precomputed_stats: PutStats,
     ) -> Result<(), anyhow::Error>
     where
-        P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<O>>)>,
+        P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<T, O>>)>,
     {
         fail::fail_point!("fail_state_multi_put", |_| {
             Err(anyhow::anyhow!("Error putting values into state"))
@@ -1155,7 +1431,7 @@ where
     ) -> Result<(), anyhow::Error>
     where
         G: IntoIterator<Item = UpsertKey>,
-        R: IntoIterator<Item = &'r mut UpsertValueAndSize<O>>,
+        R: IntoIterator<Item = &'r mut UpsertValueAndSize<T, O>>,
         O: 'r,
     {
         fail::fail_point!("fail_state_multi_get", |_| {
@@ -1183,13 +1459,15 @@ where
 
 #[cfg(test)]
 mod tests {
+    use mz_repr::Row;
+
     use super::*;
     #[mz_ore::test]
     fn test_merge_update() {
         let mut buf = Vec::new();
         let opts = upsert_bincode_opts();
 
-        let mut s = StateValue::<()>::Snapshotting(Snapshotting::default());
+        let mut s = StateValue::<(), ()>::Snapshotting(Snapshotting::default());
 
         let small_row = Ok(mz_repr::Row::default());
         let longer_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Null]));
@@ -1204,6 +1482,48 @@ mod tests {
         s.ensure_decoded(opts);
     }
 
+    // We guard some of our assumptions. Increasing in-memory size of StateValue
+    // has a direct impact on memory usage of in-memory UPSERT sources.
+    #[mz_ore::test]
+    fn test_memory_size() {
+        let finalized_value: StateValue<(), ()> =
+            StateValue::finalized_value(Ok(Row::default()), ());
+        assert!(
+            finalized_value.memory_size() <= 88,
+            "memory size is {}",
+            finalized_value.memory_size(),
+        );
+
+        let provisional_value_with_finalized_value: StateValue<(), ()> =
+            finalized_value.into_provisional_value(Ok(Row::default()), (), ());
+        assert!(
+            provisional_value_with_finalized_value.memory_size() <= 112,
+            "memory size is {}",
+            provisional_value_with_finalized_value.memory_size(),
+        );
+
+        let provisional_value_without_finalized_value: StateValue<(), ()> =
+            StateValue::new_provisional_value(Ok(Row::default()), (), ());
+        assert!(
+            provisional_value_without_finalized_value.memory_size() <= 88,
+            "memory size is {}",
+            provisional_value_without_finalized_value.memory_size(),
+        );
+
+        let mut snapshotting_value: StateValue<(), ()> = StateValue::default();
+        snapshotting_value.merge_update(
+            Ok(Row::default()),
+            1,
+            upsert_bincode_opts(),
+            &mut Vec::new(),
+        );
+        assert!(
+            snapshotting_value.memory_size() <= 90,
+            "memory size is {}",
+            snapshotting_value.memory_size(),
+        );
+    }
+
     #[mz_ore::test]
     #[should_panic(
         expected = "invalid upsert state: len_sum is non-0, state: Snapshotting { len_sum: 1"
@@ -1212,7 +1532,7 @@ mod tests {
         let mut buf = Vec::new();
         let opts = upsert_bincode_opts();
 
-        let mut s = StateValue::<()>::Snapshotting(Snapshotting::default());
+        let mut s = StateValue::<(), ()>::Snapshotting(Snapshotting::default());
 
         let small_row = Ok(mz_repr::Row::default());
         let longer_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Null]));
@@ -1230,7 +1550,7 @@ mod tests {
         let mut buf = Vec::new();
         let opts = upsert_bincode_opts();
 
-        let mut s = StateValue::<()>::Snapshotting(Snapshotting::default());
+        let mut s = StateValue::<(), ()>::Snapshotting(Snapshotting::default());
 
         let small_row = Ok(mz_repr::Row::default());
         let longer_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Null]));
@@ -1247,7 +1567,7 @@ mod tests {
         let mut buf = Vec::new();
         let opts = upsert_bincode_opts();
 
-        let mut s = StateValue::<()>::Snapshotting(Snapshotting::default());
+        let mut s = StateValue::<(), ()>::Snapshotting(Snapshotting::default());
 
         let small_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Int64(2)]));
         let longer_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Int64(1)]));

--- a/src/storage/src/upsert_continual_feedback.rs
+++ b/src/storage/src/upsert_continual_feedback.rs
@@ -170,7 +170,7 @@ where
         let mut snapshot_cap = CapabilitySet::from_elem(snapshot_cap);
 
         // The order key of the `UpsertState` is `Option<FromTime>`, which implements `Default`
-        // (as required for `consolidate_snapshot_chunk`), with slightly more efficient serialization
+        // (as required for `consolidate_chunk`), with slightly more efficient serialization
         // than a default `Partitioned`.
 
         let mut state = UpsertState::<_, G::Timestamp, Option<FromTime>>::new(
@@ -297,7 +297,7 @@ where
                     });
 
                     match state
-                        .consolidate_snapshot_chunk(
+                        .consolidate_chunk(
                             persist_stash_iter,
                             last_rehydration_chunk,
                         )

--- a/src/storage/src/upsert_continual_feedback.rs
+++ b/src/storage/src/upsert_continual_feedback.rs
@@ -449,8 +449,8 @@ where
                     worker_id = %source_config.worker_id,
                     source_id = %source_config.id,
                     ?cap,
-                    ?stash,
-                    "input stash");
+                    ?updates,
+                    "stashed updates");
 
                 let mut min_remaining_time = drain_staged_input::<_, G, _, _, _>(
                     &mut updates,
@@ -513,8 +513,8 @@ where
                         worker_id = %source_config.worker_id,
                         source_id = %source_config.id,
                         ?cap,
-                        ?stash,
-                        "input stash");
+                        ?updates,
+                        "stashed updates");
 
                     let mut min_remaining_time = drain_staged_input::<_, G, _, _, _>(
                         &mut updates,

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -170,6 +170,8 @@ def workflow_rehydration(c: Composition) -> None:
                     "--orchestrator-process-scratch-directory=/scratch",
                 ],
                 additional_system_parameter_defaults={
+                    "storage_statistics_collection_interval": "1000",
+                    "storage_statistics_interval": "2000",
                     "enable_unorchestrated_cluster_replicas": "true",
                     "disk_cluster_replicas_default": "true",
                     "enable_disk_cluster_replicas": "true",
@@ -199,6 +201,8 @@ def workflow_rehydration(c: Composition) -> None:
                     "--orchestrator-process-scratch-directory=/scratch",
                 ],
                 additional_system_parameter_defaults={
+                    "storage_statistics_collection_interval": "1000",
+                    "storage_statistics_interval": "2000",
                     "enable_unorchestrated_cluster_replicas": "true",
                     "disk_cluster_replicas_default": "true",
                     "enable_disk_cluster_replicas": "true",
@@ -230,6 +234,8 @@ def workflow_rehydration(c: Composition) -> None:
                     "--orchestrator-process-scratch-directory=/scratch",
                 ],
                 additional_system_parameter_defaults={
+                    "storage_statistics_collection_interval": "1000",
+                    "storage_statistics_interval": "2000",
                     "enable_unorchestrated_cluster_replicas": "true",
                     # Force backpressure to be enabled.
                     "storage_dataflow_max_inflight_bytes": "1",

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -277,8 +277,8 @@ def workflow_failpoint(c: Composition) -> None:
 
     for failpoint in [
         (
-            "fail_consolidate_snapshot_chunk",
-            "upsert: Failed to rehydrate state: Error consolidating snapshot values",
+            "fail_consolidate_chunk",
+            "upsert: Failed to rehydrate state: Error consolidating values",
         ),
         (
             "fail_state_multi_put",

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -487,7 +487,7 @@ def workflow_autospill(c: Composition) -> None:
                 additional_system_parameter_defaults={
                     "disk_cluster_replicas_default": "true",
                     "upsert_rocksdb_auto_spill_to_disk": "true",
-                    "upsert_rocksdb_auto_spill_threshold_bytes": "250",
+                    "upsert_rocksdb_auto_spill_threshold_bytes": "290",
                     "enable_unorchestrated_cluster_replicas": "true",
                     "storage_dataflow_delay_sources_past_rehydration": "true",
                 },
@@ -502,7 +502,7 @@ def workflow_autospill(c: Composition) -> None:
                 additional_system_parameter_defaults={
                     "disk_cluster_replicas_default": "true",
                     "upsert_rocksdb_auto_spill_to_disk": "true",
-                    "upsert_rocksdb_auto_spill_threshold_bytes": "250",
+                    "upsert_rocksdb_auto_spill_threshold_bytes": "290",
                     "enable_unorchestrated_cluster_replicas": "true",
                     "storage_dataflow_delay_sources_past_rehydration": "true",
                     # Enable the RocksDB merge operator


### PR DESCRIPTION
For our purposes, an ingestion spike is a large batch of updates (from
the external source) at the same timestamp that we need to ingest. And
specifically we want to make the feedback UPSERT operator robust in
terms of memory/storage usage. Below, I'll first explain the behavior of
the classic UPSERT operator and the feedback UPSERT operator as they are
before this change, and later describe the behavior of the feedback
UPSERT operator after this here change.

We differentiate between costs in terms of memory, which is strictly
talking about RAM, and storage, which is talking about upsert state
being stored in the upsert state backend. The upsert state backend can
(currently) either be storing state in memory or on disk (rocksdb).

As an side, ingestion spikes occur a) when ingesting an initial large
snapshot from the source, or b) when after a period of downtime a large
batch of updates have accumulated in the external source, all of which
will be ingested at the same timestamp.

Memory/Storage usage before this change
---------------------------------------

The root of the differences is whether or not the operator supports
emitting partial updates. If we didn't care about memory costs, we would
always wait for a timestamp to be complete (not beyond the frontier
anymore) and then process its updates. This would make it so we emit at
most one pair of updates per key (a retraction of the old value, if any,
and the addition of the new value). However, this means we have to
buffer all updates of a given timestamp, with potentially unbounded
memory requirements. The solution the classic UPSERT operator uses is to
emit _partial updates_: when ingesting updates right at the input
frontier, we go into a mode where we ingest updates at that frontier as
they come in, and keep emitting pairs of retractions/updates. The
trade-off is that additional memory costs stay low (basically at
`O(0)`), but we emit more updates to persist, which will have to be
consolidated by someone at some point. Another slight downside is that
management of upsert state becomes more complicated because we have to
keep around tombstones for deleted values: the updates can be processed
in an order that is different from the order implied by their _FromTime_
(kafka partition/offset, for kafka)

With all of the above, we can see that the classic UPSERT operator has
NO additional memory costs from an ingestion spike, and storage costs
are `O(num_keys)`.

The feedback UPSERT operator cannot "just" use this optimization: it
cannot update its state in reaction to inputs, so it cannot keep track
of state for correctly emitting those partial updates. We will see below
that the solution is the same, in the end, though we have to finesse
things a bit for it to work.

Without partial emission, the feedback UPSERT operator has to buffer a
batch of updates at the same timestamp until the timestamp is complete.
Its memory costs are therefore `O(size_batch)`. Its storage costs are
the same at `O(num_keys)`. It is _not_ robust against ingestion spikes.

Making partial emission work with feedback UPSERT
-------------------------------------------------

We have to address two things: a) partial emission of updates on the
source-ingest side, and b) re-ingesting those updates on the persist
feedback input.

For the former, we do the same as the classic UPSERT operator, with the
change that we introduce _provisional values_ in upsert state. These
values are stored for a given timestamp and it's only valid to read and
use them when processing updates at that timestamp. Along with a
provisional value we have to store the _finalized value_ for that key.
It's the value that we have ingested from the persist input and is known
globally (across concurrent ingestions) to be the current value for that
key.

The bigger change is how we ingest updates on the persist side. With
partial updates, there can be multiple pairs of retractions/additions
for a key, within a timestamp, and we have to be careful to consolidate
these. Before this change, the feedback UPSERT operator had been using
two different mechanisms for ingesting updates into upsert state: a)
`consolidate_snapshot_chunk`, and b) `multi_put`. The former is used
when ingesting a "snapshot" from persist, when starting up. It's also
what's used by the classic UPSERT operator when ingesting its previous
state on startup. After the initial snapshot, the feedback UPSERT
operator would use `multi_put`, which is what the classic operator
always uses to put values into state. In order to keep using it with
partial updates, though, we would have to (when reading from the persist
input) wait until the timestamp is complete, then consolidate the batch,
and then insert. We can't do that because it would again need
`O(size_batch)` memory.

Here, the solution is to just always use `consolidate_snapshot_chunk`,
both for ingesting the initial snapshot _and_ for ingesting updates as
we go. This is trading off a slight increase in CPU usage (because we
have to bincode encode/decode values when using the "consolidation" mode
of state), against robustness. In practise, we rarely have problems with
CPU usage for sources, but we do care a lot about memory/storage, so it
seems a good tradeoff to make. One additional benefit is that we might
have slightly lower memory/storage costs, because bincode will at least
to var-length encoding of integers.

Please see comments in the code about what is required for using this
"snapshotting" mode of upsert state at steady state, after ingesting the
snapshot. As you can see in the code, we're also renaming this from
"Snapshotting" to "Consolidating", to reflect this new usage pattern.

With these changes, the feedback UPSERT operator has `O(num_keys +
num_new_keys)` storage costs, with NO additional memory costs. When
ingesting the initial source snapshot, this reduces to
`O(num_new_keys)`, which is the same as classic UPSERT.

A note on stats
---------------

When reading the code, you will find that the way we track stats about
upsert state is complicated. I see why it is that way and therefore
wanted to give some helpful notes here, also because I lightly touch
some of these parts. It might be hard to refactor while still providing
the same stats, but that might be a worthwhile endeavour.

Most of the hard-to-maintain stats are concerned with numbers of records
kept in state and total size of the records in state.

The root of the problem is that we are doing blind writes to rocksdb and
that we are using the rocksdb merge function for consolidating multiple
updates to the same key. Both make it so that we cannot, when inserting
a value for a key into state, know whether there was a previous value
and what the size of that previous value was (if any).

If we only had the in-memory state backend, which uses a `HashMap`,
things would be easy: we'd do a `let prev = insert(key, new)` and then
update both our count and size stats based on that.

Instead, what we do is that `multi_put` requires the caller to provide
metadata about previous values existing under a key. And the caller must
guarantee that this metadata is correct and up to date. Most usage of
the upsert state APIs then looks like this:

```rust
let prev_value = state.get(key);
let prev_value_metadata = derive_metadata(prev_value);
// fiddle with prev_value and prepare a new_value
let new_value = [...]

state.put(key, Put { new_value, prev_value_metadata })
```

Plus, these APIs are always `multi_get` and `multi_put`, but one hopes
one gets the point.


### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
