### PR TITLE
kafka auth test: Handle different error

### DIFF
--- a/test/kafka-auth/test-schema-registry-mssl.td
+++ b/test/kafka-auth/test-schema-registry-mssl.td
@@ -42,7 +42,7 @@ $ kafka-ingest topic=avro-data format=avro schema=${schema}
     URL 'https://mssl.schema-registry.local:8082',
     SSL CERTIFICATE AUTHORITY = '${ca-crt}'
   )
-contains:alert bad certificate
+contains:error sending request for url
 
 # This is a bad error message to indicate "disallowed client certificate" but
 # it's not under our control.


### PR DESCRIPTION
Failed 16 times in CI: https://ci-failures.dev.materialize.com/?key=test-failures&tfFilters=%5B%7B%22id%22%3A%22build_date%22%2C%22value%22%3A%5Bnull%2Cnull%5D%7D%2C%7B%22id%22%3A%22content%22%2C%22value%22%3A%22files%20involved%3A%20test-schema-registry-mssl.td%22%7D%5D

I'm not sure if this indicates something worse or is just an inconsistent error message.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
