### PR TITLE
Use provided methods to construct literals

### DIFF
--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -725,8 +725,8 @@ impl MirScalarExpr {
     /// use mz_repr::{ColumnType, Datum, ScalarType};
     ///
     /// let expr_0 = MirScalarExpr::Column(0);
-    /// let expr_t = MirScalarExpr::literal_ok(Datum::True, ScalarType::Bool);
-    /// let expr_f = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool);
+    /// let expr_t = MirScalarExpr::literal_true();
+    /// let expr_f = MirScalarExpr::literal_false();
     ///
     /// let mut test =
     /// expr_t

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -1894,7 +1894,7 @@ fn apply_scalar_subquery(
                     (0..inner_arity).collect::<Vec<_>>(),
                     vec![mz_expr::AggregateExpr {
                         func: mz_expr::AggregateFunc::Count,
-                        expr: MirScalarExpr::literal_ok(Datum::True, ScalarType::Bool),
+                        expr: MirScalarExpr::literal_true(),
                         distinct: false,
                     }],
                     None,

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -805,7 +805,7 @@ fn optimize(
                     if matches!(&knowledge, DatumKnowledge::Lit { .. }) {
                         e.reduce(column_types);
                     } else if func == &UnaryFunc::IsNull(func::IsNull) && !knowledge.nullable() {
-                        *e = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool);
+                        *e = MirScalarExpr::literal_false();
                     };
                     DatumKnowledge::from(&*e)
                 }

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -15,7 +15,7 @@
 // TODO(frank): evaluate for redundancy with `column_knowledge`, or vice-versa.
 
 use mz_expr::{func, AggregateExpr, AggregateFunc, MirRelationExpr, MirScalarExpr, UnaryFunc};
-use mz_repr::{Datum, RelationType, ScalarType};
+use mz_repr::RelationType;
 
 use crate::{TransformCtx, TransformError};
 
@@ -124,7 +124,7 @@ fn scalar_nonnullable(expr: &mut MirScalarExpr, metadata: &RelationType) {
         {
             if let MirScalarExpr::Column(c) = &**expr {
                 if !metadata.column_types[*c].nullable {
-                    *e = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool);
+                    *e = MirScalarExpr::literal_false();
                 }
             }
         }
@@ -137,7 +137,7 @@ fn aggregate_nonnullable(expr: &mut AggregateExpr, metadata: &RelationType) {
     // count(true).
     if let (AggregateFunc::Count, MirScalarExpr::Column(c)) = (&expr.func, &expr.expr) {
         if !metadata.column_types[*c].nullable && !expr.distinct {
-            expr.expr = MirScalarExpr::literal_ok(Datum::True, ScalarType::Bool);
+            expr.expr = MirScalarExpr::literal_true();
         }
     }
 }

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -53,7 +53,7 @@
 //! let predicate0 = MirScalarExpr::column(0);
 //! let predicate1 = MirScalarExpr::column(1);
 //! let predicate01 = MirScalarExpr::column(0).call_binary(MirScalarExpr::column(2), BinaryFunc::AddInt64);
-//! let predicate012 = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool);
+//! let predicate012 = MirScalarExpr::literal_false();
 //!
 //! let mut expr = join.filter(
 //!    vec![


### PR DESCRIPTION
Instances of explicit construction of `Datum::True` and `Datum::False` literals are replaced with the existing `literal_true` and `literal_false` methods.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
