### PR TITLE
helm charts: Minor documentation updates

### DIFF
--- a/misc/helm-charts/operator/README.md.gotmpl
+++ b/misc/helm-charts/operator/README.md.gotmpl
@@ -64,7 +64,7 @@ Setup process:
 
 #### Storage Configuration
 
-Once LVM is configured, set up the storage class:
+Once LVM is configured, set up the storage class (for example in misc/helm-charts/operator/values.yaml):
 
 ```yaml
 storage:
@@ -97,7 +97,8 @@ storage:
 To install the chart with the release name `my-materialize-operator`:
 
 ```shell
-helm install my-materialize-operator materialize/misc/helm-charts/operator
+kubectl create namespace materialize
+helm install my-materialize-operator misc/helm-charts/operator
 ```
 
 This command deploys the Materialize operator on the Kubernetes cluster with default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.

--- a/misc/helm-charts/testing/README.md
+++ b/misc/helm-charts/testing/README.md
@@ -16,29 +16,27 @@ This directory contains simple examples for deploying MinIO, PostgreSQL, and Red
 0. Create a namespace:
 
     ```bash
+    kind create cluster
     kubectl create namespace materialize # or use an existing namespace
     ```
 
 1. Deploy the services to your Kubernetes cluster:
 
     ```bash
-    kubectl apply -f minio.yaml
-    kubectl apply -f postgres.yaml
+    kubectl apply -f misc/helm-charts/testing/minio.yaml
+    kubectl apply -f misc/helm-charts/testing/postgres.yaml
     ```
 
 2. Monitor the deployments to ensure the pods are running:
 
     ```bash
-    kubectl get pods -w
+    kubectl get pods -w -n materialize
     ```
 
 3. Create a bucket in MinIO (replace `minio-123456-abcdef` with the actual pod name):
 
     ```bash
-    kubectl exec -it minio-123456-abcdef -n materialize -- /bin/sh
-    mc alias set local http://localhost:9000 minio minio123
-    mc mb local/bucket
-    exit
+    kubectl exec -it minio-69c8d67494-clvwk -n materialize -- /bin/sh -c "mc alias set local http://localhost:9000 minio minio123; mc mb local/bucket"
     ```
 
 ## Node labels for ephemeral storage


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
