### PR TITLE
sink/kafka: actually use the configured tx timeout

### DIFF
--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -206,6 +206,7 @@ impl FromStr for MzKafkaError {
             Ok(Self::UnsupportedBrokerVersion)
         } else if s.contains("Disconnected while requesting ApiVersion")
             || s.contains("Broker transport failure")
+            || s.contains("Connection refused")
         {
             Ok(Self::BrokerTransportFailure)
         } else if Regex::new(r"(\d+)/\1 brokers are down")

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -230,6 +230,8 @@ struct TransactionalProducer {
     staged_bytes: u64,
     /// The timeout to use for network operations.
     socket_timeout: Duration,
+    /// The timeout to use for committing transactions.
+    transaction_timeout: Duration,
 }
 
 impl TransactionalProducer {
@@ -341,6 +343,7 @@ impl TransactionalProducer {
             staged_messages: 0,
             staged_bytes: 0,
             socket_timeout: timeout_config.socket_timeout,
+            transaction_timeout: timeout_config.transaction_timeout,
         };
 
         let timeout = timeout_config.socket_timeout;
@@ -499,7 +502,7 @@ impl TransactionalProducer {
 
         fail::fail_point!("kafka_sink_commit_transaction");
 
-        let timeout = self.socket_timeout;
+        let timeout = self.transaction_timeout;
         match self
             .spawn_blocking(move |p| p.commit_transaction(timeout))
             .await

--- a/test/ssh-connection/kafka-sink.td
+++ b/test/ssh-connection/kafka-sink.td
@@ -9,6 +9,7 @@
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_create_source_denylist_with_options = true
+ALTER SYSTEM SET kafka_transaction_timeout = '60s'
 
 # Test creating a Kafka sink using ssh.
 


### PR DESCRIPTION
The code correctly set the desired transaction timeout value when instantiating the producer but then incorrectl used the socket timeout as the limit for the commit call. This led the `librdkafka` client to stop trying after 60 seconds, which is the default value of the socket timeout.

This PR instead sets the timeout to `Timeout::Never` which according to the `librdkafka` documentation automatically sets the timeout to the remaining transaction time based on the transaction_timeout_ms setting.


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
