### PR TITLE
build: Keep non-bazel builds on zlib for now

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,7 +13,7 @@
 # Sync: This target-cpu and list of features should be kept in sync with the ones in ci-builder and
 # xcompile.
 rustflags = [
-    "-Clink-arg=-Wl,--compress-debug-sections=zstd",
+    "-Clink-arg=-Wl,--compress-debug-sections=zlib",
     "-Clink-arg=-Wl,-O3",
     "-Clink-arg=-fuse-ld=lld",
     "-Csymbol-mangling-version=v0",
@@ -30,7 +30,7 @@ rustflags = [
 # xcompile.
 [target."aarch64-unknown-linux-gnu"]
 rustflags = [
-    "-Clink-arg=-Wl,--compress-debug-sections=zstd",
+    "-Clink-arg=-Wl,--compress-debug-sections=zlib",
     "-Clink-arg=-Wl,-O3",
     "-Clink-arg=-fuse-ld=lld",
     "-Csymbol-mangling-version=v0",

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -303,7 +303,7 @@ ENV CC=$ARCH_GCC-unknown-linux-gnu-cc
 ENV CXX=$ARCH_GCC-unknown-linux-gnu-c++
 ENV CXXSTDLIB=static=stdc++
 ENV LDFLAGS="-fuse-ld=lld -static-libstdc++"
-ENV RUSTFLAGS="-Clink-arg=-Wl,--compress-debug-sections=zstd -Clink-arg=-Wl,-O3 -Clink-arg=-fuse-ld=lld -L/opt/x-tools/$ARCH_GCC-unknown-linux-gnu/$ARCH_GCC-unknown-linux-gnu/sysroot/lib/ -Csymbol-mangling-version=v0 --cfg=tokio_unstable"
+ENV RUSTFLAGS="-Clink-arg=-Wl,--compress-debug-sections=zlib -Clink-arg=-Wl,-O3 -Clink-arg=-fuse-ld=lld -L/opt/x-tools/$ARCH_GCC-unknown-linux-gnu/$ARCH_GCC-unknown-linux-gnu/sysroot/lib/ -Csymbol-mangling-version=v0 --cfg=tokio_unstable"
 ENV TARGET_AR=$AR
 ENV TARGET_CC=$CC
 ENV TARGET_CXX=$CXX

--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -150,7 +150,7 @@ def cargo(
     }
 
     rustflags += [
-        "-Clink-arg=-Wl,--compress-debug-sections=zstd",
+        "-Clink-arg=-Wl,--compress-debug-sections=zlib",
         "-Clink-arg=-Wl,-O3",
         "-Csymbol-mangling-version=v0",
         "--cfg=tokio_unstable",


### PR DESCRIPTION
Fails locally with:
```
rust-lld: error: --compress-debug-sections: LLVM was not built with LLVM_ENABLE_ZSTD or did not find zstd at build time
```
Follow-up to https://github.com/MaterializeInc/materialize/pull/30496

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
