### PR TITLE
also prefix the names of kubernetes secrets

### DIFF
--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -976,6 +976,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
             secrets_reader_local_file_dir: args.orchestrator_process_secrets_directory,
             secrets_reader_kubernetes_context: Some(args.orchestrator_kubernetes_context),
             secrets_reader_aws_prefix: Some(aws_secrets_controller_prefix(&args.environment_id)),
+            secrets_reader_name_prefix: args.orchestrator_kubernetes_name_prefix.clone(),
         },
     };
 

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -495,6 +495,7 @@ impl Listeners {
                         secrets_reader_local_file_dir: Some(data_directory.join("secrets")),
                         secrets_reader_kubernetes_context: None,
                         secrets_reader_aws_prefix: None,
+                        secrets_reader_name_prefix: None,
                     },
                     connection_context,
                 },

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -97,6 +97,12 @@ pub struct KubernetesOrchestratorConfig {
     pub name_prefix: Option<String>,
 }
 
+impl KubernetesOrchestratorConfig {
+    pub fn name_prefix(&self) -> String {
+        self.name_prefix.clone().unwrap_or_default()
+    }
+}
+
 /// Specifies whether Kubernetes should pull Docker images when creating pods.
 #[derive(ArgEnum, Debug, Clone, Copy)]
 pub enum KubernetesImagePullPolicy {
@@ -1016,6 +1022,10 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             }
             (false, _) => None,
         };
+
+        if let Some(name_prefix) = &self.config.name_prefix {
+            args.push(format!("--secrets-reader-name-prefix={}", name_prefix));
+        }
 
         let volume_claim_templates = if self.config.coverage {
             Some(vec![PersistentVolumeClaim {

--- a/src/service/src/secrets.rs
+++ b/src/service/src/secrets.rs
@@ -44,6 +44,10 @@ pub struct SecretsReaderCliArgs {
         env = "SECRETS_READER_AWS_PREFIX"
     )]
     pub secrets_reader_aws_prefix: Option<String>,
+    /// When using the Kubernetes secrets reader, the prefix to use for secret
+    /// names.
+    #[structopt(long, env = "SECRETS_READER_NAME_PREFIX")]
+    pub secrets_reader_name_prefix: Option<String>,
 }
 
 #[derive(ArgEnum, Debug, Clone, Copy)]
@@ -65,7 +69,9 @@ impl SecretsReaderCliArgs {
                 let context = self
                     .secrets_reader_kubernetes_context
                     .expect("clap enforced");
-                Ok(Arc::new(KubernetesSecretsReader::new(context).await?))
+                Ok(Arc::new(
+                    KubernetesSecretsReader::new(context, self.secrets_reader_name_prefix).await?,
+                ))
             }
             SecretsControllerKind::AwsSecretsManager => {
                 let prefix = self.secrets_reader_aws_prefix.expect("clap enforced");

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1057,6 +1057,7 @@ impl<'a> RunnerInner<'a> {
                     secrets_reader_local_file_dir: Some(secrets_dir),
                     secrets_reader_kubernetes_context: None,
                     secrets_reader_aws_prefix: None,
+                    secrets_reader_name_prefix: None,
                 },
                 connection_context,
             },


### PR DESCRIPTION
### Motivation

now that we are defaulting to the kubernetes secret provider, we need to make sure that secrets from different environments in the same namespace don't conflict

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
