### PR TITLE
set a default for the console image tag to use

### DIFF
--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -60,10 +60,10 @@ spec:
         {{- if .Values.operator.args.createConsole }}
         - "--create-console"
         {{- end }}
+        - "--console-image-tag-default=25.1.0-beta.1"
         {{- range $key, $value := .Values.operator.args.consoleImageTagMapOverride }}
         - "--console-image-tag-map={{ $key }}={{ $value }}"
         {{- end }}
-        - "--console-image-tag-map=v0.125.0-dev.0--pr.gd3deb07aa502a84ebd024517344f0aa861f857df=25.1.0-beta.1"
         {{- if .Values.operator.clusters }}
         {{- if .Values.operator.clusters.sizes }}
         - '--environmentd-cluster-replica-sizes={{ include "materialize.processClusterSizes" . | fromYaml | toJson }}'

--- a/misc/python/materialize/cli/orchestratord.py
+++ b/misc/python/materialize/cli/orchestratord.py
@@ -20,7 +20,6 @@ from urllib.parse import urlparse, urlunparse
 from materialize import MZ_ROOT, ui
 
 DEV_IMAGE_TAG = "local-dev"
-CONSOLE_VERSION = "25.1.0-beta.1"
 DEFAULT_POSTGRES = (
     "postgres://root@postgres.materialize.svc.cluster.local:5432/materialize"
 )
@@ -80,7 +79,6 @@ def run(args: argparse.Namespace):
             "misc/helm-charts/operator",
             "--atomic",
             f"--set=operator.image.tag={DEV_IMAGE_TAG}",
-            f'--set-json=operator.args.consoleImageTagMapOverride={{"{DEV_IMAGE_TAG}":"{CONSOLE_VERSION}"}}',
             "--set=namespace.create=true",
             f"--set=namespace.name={args.namespace}",
         ]

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -47,6 +47,8 @@ pub struct Args {
     secrets_controller: String,
 
     #[clap(long)]
+    console_image_tag_default: String,
+    #[clap(long)]
     console_image_tag_map: Vec<KeyValueArg<String, String>>,
 
     #[clap(flatten)]
@@ -545,18 +547,13 @@ impl k8s_controller::Context for Context {
                         mz.spec.environmentd_image_ref
                     )));
                 };
-                let Some(console_image_tag) = self
+                let console_image_tag = self
                     .config
                     .console_image_tag_map
                     .iter()
                     .find(|kv| kv.key == environmentd_image_tag)
                     .map(|kv| kv.value.clone())
-                else {
-                    return Err(Error::Anyhow(anyhow::anyhow!(
-                        "no console image ref found for environmentd image ref: {}",
-                        mz.spec.environmentd_image_ref
-                    )));
-                };
+                    .unwrap_or_else(|| self.config.console_image_tag_default.clone());
                 console::Resources::new(
                     &self.config,
                     mz,


### PR DESCRIPTION
### Motivation

this will make version bumps easier

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
