### PR TITLE
bump the helm chart version

### DIFF
--- a/misc/helm-charts/operator/Chart.yaml
+++ b/misc/helm-charts/operator/Chart.yaml
@@ -12,7 +12,7 @@ apiVersion: v2
 name: materialize-operator
 description: Materialize Kubernetes Operator Helm Chart
 type: application
-version: 0.1.0
-appVersion: "v0.125.0-dev.0--pr.gd3deb07aa502a84ebd024517344f0aa861f857df"
+version: 25.1.0-beta.1
+appVersion: v0.125.0
 icon: https://materialize.com/favicon.ico
 home: https://materialize.com

--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -1,6 +1,6 @@
 # Materialize Kubernetes Operator Helm Chart
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.125.0-dev.0--pr.gd3deb07aa502a84ebd024517344f0aa861f857df](https://img.shields.io/badge/AppVersion-v0.125.0--dev.0----pr.gd3deb07aa502a84ebd024517344f0aa861f857df-informational?style=flat-square)
+![Version: 25.1.0-beta.1](https://img.shields.io/badge/Version-25.1.0--beta.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.125.0](https://img.shields.io/badge/AppVersion-v0.125.0-informational?style=flat-square)
 
 Materialize Kubernetes Operator Helm Chart
 
@@ -249,7 +249,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.clusters.sizes.mz_probe.workers` |  | ``1`` |
 | `operator.image.pullPolicy` |  | ``"IfNotPresent"`` |
 | `operator.image.repository` |  | ``"materialize/orchestratord"`` |
-| `operator.image.tag` |  | ``"v0.125.0-dev.0--pr.gd3deb07aa502a84ebd024517344f0aa861f857df"`` |
+| `operator.image.tag` |  | ``"v0.125.0"`` |
 | `operator.nodeSelector` |  | ``{}`` |
 | `operator.resources.limits.memory` |  | ``"512Mi"`` |
 | `operator.resources.requests.cpu` |  | ``"100m"`` |
@@ -271,7 +271,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```shell
 helm install my-materialize-operator \
-  --set operator.image.tag=v0.125.0-dev.0--pr.gd3deb07aa502a84ebd024517344f0aa861f857df \
+  --set operator.image.tag=v0.125.0 \
   materialize/materialize-operator
 ```
 
@@ -306,7 +306,7 @@ metadata:
   name: 12345678-1234-1234-1234-123456789012
   namespace: materialize-environment
 spec:
-  environmentdImageRef: materialize/environmentd:v0.125.0-dev.0--pr.gd3deb07aa502a84ebd024517344f0aa861f857df
+  environmentdImageRef: materialize/environmentd:v0.125.0
   backendSecretName: materialize-backend
   environmentdResourceRequirements:
     limits:

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: materialize/orchestratord:v0.125.0-dev.0--pr.gd3deb07aa502a84ebd024517344f0aa861f857df
+          value: materialize/orchestratord:v0.125.0
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -13,7 +13,7 @@ operator:
     # The Docker repository for the operator image
     repository: materialize/orchestratord
     # The tag/version of the operator image to be used
-    tag: v0.125.0-dev.0--pr.gd3deb07aa502a84ebd024517344f0aa861f857df
+    tag: v0.125.0
     # Policy for pulling the image: "IfNotPresent" avoids unnecessary re-pulling of images
     pullPolicy: IfNotPresent
   args:

--- a/misc/helm-charts/testing/environmentd.yaml
+++ b/misc/helm-charts/testing/environmentd.yaml
@@ -29,7 +29,7 @@ metadata:
   name: 12345678-1234-1234-1234-123456789012
   namespace: materialize-environment
 spec:
-  environmentdImageRef: materialize/environmentd:v0.125.0-dev.0--pr.gd3deb07aa502a84ebd024517344f0aa861f857df
+  environmentdImageRef: materialize/environmentd:v0.125.0
   requestRollout: 22222222-2222-2222-2222-222222222222
   forceRollout: 33333333-3333-3333-3333-333333333333
   inPlaceRollout: false


### PR DESCRIPTION
### Motivation

sync the versions used in the helm chart with the actual database release

we're working on automating this in #30493 for future releases, but this should at least move us toward how we want this to be managed

### Tips for reviewer

this isn't going to quite work as-is, because #30512 added a new command line flag to the helm chart that didn't exist in v0.125.0, but i think this is just a thing we're going to have to deal with (i'm pretty sure that everything that currently tries to use the helm chart explicitly sets the orchestratord version to use, and we don't have any external users yet).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
