### PR TITLE
0dt source rehydration testing: Postgres, MySQL, Kafka

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1674,6 +1674,16 @@ steps:
     agents:
       queue: hetzner-aarch64-4cpu-8gb
 
+  - id: 0dt
+    label: Zero downtime
+    depends_on: build-aarch64
+    timeout_in_minutes: 120
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: 0dt
+    agents:
+      queue: hetzner-aarch64-8cpu-16gb
+
   - group: "Language tests"
     key: language-tests
     steps:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -733,16 +733,6 @@ steps:
       # Requires BUILDKITE_SENTRY_DSN
       queue: linux-aarch64-small
 
-  - id: 0dt
-    label: Zero downtime
-    depends_on: build-aarch64
-    timeout_in_minutes: 30
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: 0dt
-    agents:
-      queue: hetzner-aarch64-8cpu-16gb
-
   - id: rtr-combined
     label: RTR with all sources
     depends_on: build-aarch64

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -1500,6 +1500,7 @@ class Composition:
         status: DeploymentStatus,
         mz_service: str = "materialized",
         timeout: int | None = None,
+        sleep_time: float | None = 1.0,
     ) -> None:
         timeout = timeout or (1800 if ui.env_is_truthy("CI_COVERAGE_ENABLED") else 900)
         print(
@@ -1508,7 +1509,8 @@ class Composition:
         )
 
         result = {}
-        for i in range(1, timeout):
+        timeout_time = time.time() + timeout
+        while time.time() < timeout_time:
             try:
                 result = json.loads(
                     self.exec(
@@ -1526,7 +1528,8 @@ class Composition:
             except:
                 pass
             print(".", end="")
-            time.sleep(1)
+            if sleep_time:
+                time.sleep(sleep_time)
         raise UIError(
             f"Timed out waiting for {mz_service} to reach Mz deployment status {status.value}, still in status {result.get('status')}"
         )

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -1105,8 +1105,10 @@ def workflow_mysql_source_rehydration(c: Composition) -> None:
         user="mz_system",
     )
 
-    inserts = " ".join(
-        [f"INSERT INTO mysql_source_table VALUES ({i});" for i in range(count)]
+    inserts = (
+        "INSERT INTO mysql_source_table VALUES "
+        + ", ".join([f"({i})" for i in range(count)])
+        + ";"
     )
 
     start_time = time.time()
@@ -1150,6 +1152,7 @@ def workflow_mysql_source_rehydration(c: Composition) -> None:
                 f"""
         $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
         $ mysql-execute name=mysql
+        USE public;
         {inserts}
         > SELECT COUNT(*) FROM mysql_source_table;
         {count*(i+1)}

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -98,7 +98,6 @@ def workflow_read_only(c: Composition) -> None:
         CREATE CLUSTER cluster SIZE '2-1';
         GRANT ALL ON CLUSTER cluster TO materialize;
         ALTER SYSTEM SET cluster = cluster;
-        ALTER SYSTEM SET enable_0dt_deployment = true;
     """,
         service="mz_old",
         port=6877,
@@ -385,7 +384,6 @@ def workflow_basic(c: Composition) -> None:
         CREATE CLUSTER cluster SIZE '2-1';
         GRANT ALL ON CLUSTER cluster TO materialize;
         ALTER SYSTEM SET cluster = cluster;
-        ALTER SYSTEM SET enable_0dt_deployment = true;
     """,
         service="mz_old",
         port=6877,
@@ -863,6 +861,340 @@ def workflow_basic(c: Composition) -> None:
             """
             )
         )
+
+
+def workflow_kafka_source_rehydration(c: Composition) -> None:
+    """Verify Kafka source rehydration in 0dt deployment"""
+    c.down(destroy_volumes=True)
+    c.up("zookeeper", "kafka", "schema-registry", "mz_old")
+    c.up("testdrive", persistent=True)
+
+    count = 1000000
+    repeats = 20
+
+    # Make sure cluster is owned by the system so it doesn't get dropped
+    # between testdrive runs.
+    c.sql(
+        """
+        DROP CLUSTER IF EXISTS cluster CASCADE;
+        CREATE CLUSTER cluster SIZE '1';
+        GRANT ALL ON CLUSTER cluster TO materialize;
+        ALTER SYSTEM SET cluster = cluster;
+    """,
+        service="mz_old",
+        port=6877,
+        user="mz_system",
+    )
+
+    start_time = time.time()
+    c.testdrive(
+        dedent(
+            f"""
+        > SET CLUSTER = cluster;
+
+        > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${{testdrive.kafka-addr}}', SECURITY PROTOCOL = 'PLAINTEXT';
+        > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${{testdrive.schema-registry-url}}';
+
+        $ kafka-create-topic topic=kafka-large
+        $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=kafka-large repeat={count}
+        key0A,key${{kafka-ingest.iteration}}:value0A,${{kafka-ingest.iteration}}
+        > CREATE SOURCE kafka_source
+          IN CLUSTER cluster
+          FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-large-${{testdrive.seed}}');
+
+        > CREATE TABLE kafka_source_tbl (key1, key2, value1, value2)
+          FROM SOURCE kafka_source (REFERENCE "testdrive-kafka-large-${{testdrive.seed}}")
+          KEY FORMAT CSV WITH 2 COLUMNS DELIMITED BY ','
+          VALUE FORMAT CSV WITH 2 COLUMNS DELIMITED BY ','
+          ENVELOPE UPSERT;
+        # TODO: This should also work with a default index
+        # > CREATE DEFAULT INDEX ON kafka_source_tbl
+        > SELECT COUNT(*) FROM kafka_source_tbl
+        {count}
+        """
+        )
+    )
+    for i in range(1, repeats):
+        c.testdrive(
+            dedent(
+                f"""
+        $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=kafka-large repeat={count}
+        key{i}A,key{i}${{kafka-ingest.iteration}}:value{i}A,${{kafka-ingest.iteration}}
+        > SELECT COUNT(*) FROM kafka_source_tbl
+        {count*(i+1)}
+        """
+            )
+        )
+
+    elapsed = time.time() - start_time
+    print(f"initial ingestion took {elapsed} seconds")
+
+    with c.override(
+        Materialized(
+            name="mz_new",
+            sanity_restart=False,
+            deploy_generation=1,
+            system_parameter_defaults=SYSTEM_PARAMETER_DEFAULTS,
+            restart="on-failure",
+            external_metadata_store=True,
+            # environment_extra=["FAILPOINTS=hydration=sleep(12000)"],
+        )
+    ):
+        c.up("mz_new")
+        start_time = time.time()
+        c.await_mz_deployment_status(DeploymentStatus.READY_TO_PROMOTE, "mz_new")
+        elapsed = time.time() - start_time
+        print(f"re-hydration took {elapsed} seconds")
+        c.promote_mz("mz_new")
+        start_time = time.time()
+        c.await_mz_deployment_status(
+            DeploymentStatus.IS_LEADER, "mz_new", sleep_time=None
+        )
+        elapsed = time.time() - start_time
+        print(f"promotion took {elapsed} seconds")
+        print("sleeping so that the global query timestamp can advance")
+        time.sleep(5)
+        start_time = time.time()
+        result = c.sql_query("SELECT COUNT(*) FROM kafka_source_tbl", service="mz_new")
+        elapsed = time.time() - start_time
+        print(f"final check took {elapsed} seconds")
+        duration = time.time() - start_time
+        assert result[0][0] == count * repeats, f"Wrong result: {result}"
+        assert (
+            duration < 10
+        ), f"Took {duration}s to SELECT on Kafka source after 0dt upgrade, is it hydrated?"
+
+
+def workflow_pg_source_rehydration(c: Composition) -> None:
+    """Verify Postgres source rehydration in 0dt deployment"""
+    c.down(destroy_volumes=True)
+    c.up("postgres", "mz_old")
+    c.up("testdrive", persistent=True)
+
+    count = 1000000
+    repeats = 100
+
+    # Make sure cluster is owned by the system so it doesn't get dropped
+    # between testdrive runs.
+    c.sql(
+        """
+        DROP CLUSTER IF EXISTS cluster CASCADE;
+        CREATE CLUSTER cluster SIZE '1';
+        GRANT ALL ON CLUSTER cluster TO materialize;
+        ALTER SYSTEM SET cluster = cluster;
+    """,
+        service="mz_old",
+        port=6877,
+        user="mz_system",
+    )
+
+    inserts = (
+        "INSERT INTO postgres_source_table VALUES "
+        + ", ".join([f"({i})" for i in range(count)])
+        + ";"
+    )
+
+    start_time = time.time()
+    c.testdrive(
+        dedent(
+            f"""
+        > SET CLUSTER = cluster;
+
+        $ postgres-execute connection=postgres://postgres:postgres@postgres
+        CREATE USER postgres1 WITH SUPERUSER PASSWORD 'postgres';
+        ALTER USER postgres1 WITH replication;
+        DROP PUBLICATION IF EXISTS postgres_source;
+        DROP TABLE IF EXISTS postgres_source_table;
+        CREATE TABLE postgres_source_table (f1 INTEGER);
+        ALTER TABLE postgres_source_table REPLICA IDENTITY FULL;
+        {inserts}
+        CREATE PUBLICATION postgres_source FOR ALL TABLES;
+
+        > CREATE SECRET pgpass AS 'postgres';
+        > CREATE CONNECTION pg FOR POSTGRES
+          HOST 'postgres',
+          DATABASE postgres,
+          USER postgres1,
+          PASSWORD SECRET pgpass;
+        > CREATE SOURCE postgres_source
+          IN CLUSTER cluster
+          FROM POSTGRES CONNECTION pg
+          (PUBLICATION 'postgres_source');
+        > CREATE TABLE postgres_source_table FROM SOURCE postgres_source (REFERENCE postgres_source_table)
+        # TODO: This should also work with a default index
+        # > CREATE DEFAULT INDEX ON postgres_source_table
+        > SELECT COUNT(*) FROM postgres_source_table;
+        {count}
+        """
+        ),
+        quiet=True,
+    )
+
+    for i in range(1, repeats):
+        c.testdrive(
+            dedent(
+                f"""
+        $ postgres-execute connection=postgres://postgres:postgres@postgres
+        {inserts}
+        > SELECT COUNT(*) FROM postgres_source_table
+        {count*(i+1)}
+        """
+            ),
+            quiet=True,
+        )
+
+    elapsed = time.time() - start_time
+    print(f"initial ingestion took {elapsed} seconds")
+
+    with c.override(
+        Materialized(
+            name="mz_new",
+            sanity_restart=False,
+            deploy_generation=1,
+            system_parameter_defaults=SYSTEM_PARAMETER_DEFAULTS,
+            restart="on-failure",
+            external_metadata_store=True,
+            # environment_extra=["FAILPOINTS=hydration=sleep(12000)"],
+        )
+    ):
+        c.up("mz_new")
+        start_time = time.time()
+        c.await_mz_deployment_status(DeploymentStatus.READY_TO_PROMOTE, "mz_new")
+        elapsed = time.time() - start_time
+        print(f"re-hydration took {elapsed} seconds")
+        c.promote_mz("mz_new")
+        start_time = time.time()
+        c.await_mz_deployment_status(
+            DeploymentStatus.IS_LEADER, "mz_new", sleep_time=None
+        )
+        elapsed = time.time() - start_time
+        print(f"promotion took {elapsed} seconds")
+        start_time = time.time()
+        result = c.sql_query(
+            "SELECT COUNT(*) FROM postgres_source_table", service="mz_new"
+        )
+        elapsed = time.time() - start_time
+        print(f"final check took {elapsed} seconds")
+        duration = time.time() - start_time
+        assert result[0][0] == count * repeats, f"Wrong result: {result}"
+        assert (
+            duration < 10
+        ), f"Took {duration}s to SELECT on Postgres source after 0dt upgrade, is it hydrated?"
+
+
+def workflow_mysql_source_rehydration(c: Composition) -> None:
+    """Verify Postgres source rehydration in 0dt deployment"""
+    c.down(destroy_volumes=True)
+    c.up("mysql", "mz_old")
+    c.up("testdrive", persistent=True)
+
+    count = 1000000
+    repeats = 100
+
+    # Make sure cluster is owned by the system so it doesn't get dropped
+    # between testdrive runs.
+    c.sql(
+        """
+        DROP CLUSTER IF EXISTS cluster CASCADE;
+        CREATE CLUSTER cluster SIZE '1';
+        GRANT ALL ON CLUSTER cluster TO materialize;
+        ALTER SYSTEM SET cluster = cluster;
+    """,
+        service="mz_old",
+        port=6877,
+        user="mz_system",
+    )
+
+    inserts = " ".join(
+        [f"INSERT INTO mysql_source_table VALUES ({i});" for i in range(count)]
+    )
+
+    start_time = time.time()
+    c.testdrive(
+        dedent(
+            f"""
+        > SET CLUSTER = cluster;
+
+        $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+        $ mysql-execute name=mysql
+        # create the database if it does not exist yet but do not drop it
+        CREATE DATABASE IF NOT EXISTS public;
+        USE public;
+        CREATE USER mysql1 IDENTIFIED BY 'mysql';
+        GRANT REPLICATION SLAVE ON *.* TO mysql1;
+        GRANT ALL ON public.* TO mysql1;
+        CREATE TABLE mysql_source_table (f1 INTEGER);
+        {inserts}
+
+        > CREATE SECRET mysqlpass AS 'mysql';
+        > CREATE CONNECTION mysql TO MYSQL (
+          HOST 'mysql',
+          USER mysql1,
+          PASSWORD SECRET mysqlpass);
+        > CREATE SOURCE mysql_source
+          IN CLUSTER cluster
+          FROM MYSQL CONNECTION mysql;
+        > CREATE TABLE mysql_source_table FROM SOURCE mysql_source (REFERENCE public.mysql_source_table);
+        # TODO: This should also work with a default index
+        # > CREATE DEFAULT INDEX ON mysql_source_table
+        > SELECT COUNT(*) FROM mysql_source_table;
+        {count}
+        """
+        ),
+        quiet=True,
+    )
+
+    for i in range(1, repeats):
+        c.testdrive(
+            dedent(
+                f"""
+        $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+        $ mysql-execute name=mysql
+        {inserts}
+        > SELECT COUNT(*) FROM mysql_source_table;
+        {count*(i+1)}
+        """
+            ),
+            quiet=True,
+        )
+
+    elapsed = time.time() - start_time
+    print(f"initial ingestion took {elapsed} seconds")
+
+    with c.override(
+        Materialized(
+            name="mz_new",
+            sanity_restart=False,
+            deploy_generation=1,
+            system_parameter_defaults=SYSTEM_PARAMETER_DEFAULTS,
+            restart="on-failure",
+            external_metadata_store=True,
+            # environment_extra=["FAILPOINTS=hydration=sleep(12000)"],
+        )
+    ):
+        c.up("mz_new")
+        start_time = time.time()
+        c.await_mz_deployment_status(DeploymentStatus.READY_TO_PROMOTE, "mz_new")
+        elapsed = time.time() - start_time
+        print(f"re-hydration took {elapsed} seconds")
+        c.promote_mz("mz_new")
+        start_time = time.time()
+        c.await_mz_deployment_status(
+            DeploymentStatus.IS_LEADER, "mz_new", sleep_time=None
+        )
+        elapsed = time.time() - start_time
+        print(f"promotion took {elapsed} seconds")
+        start_time = time.time()
+        result = c.sql_query(
+            "SELECT COUNT(*) FROM mysql_source_table", service="mz_new"
+        )
+        elapsed = time.time() - start_time
+        print(f"final check took {elapsed} seconds")
+        duration = time.time() - start_time
+        assert result[0][0] == count * repeats, f"Wrong result: {result}"
+        assert (
+            duration < 10
+        ), f"Took {duration}s to SELECT on Postgres source after 0dt upgrade, is it hydrated?"
 
 
 def fetch_reconciliation_metrics(c: Composition, process: str) -> tuple[int, int]:


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
