### PR TITLE
storage,adapter: in caught_up.rs, add hydration check for storage collections

### DIFF
--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -324,10 +324,7 @@ impl Coordinator {
                         .collection_hydrated(cluster.id, id)
                         .await?
                 }
-                CollectionType::Storage => {
-                    // TODO: Hydration check for storage collections!
-                    true
-                }
+                CollectionType::Storage => self.controller.storage.collection_hydrated(id)?,
             };
 
             if within_lag && collection_hydrated {

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -305,6 +305,16 @@ pub trait StorageController: Debug {
         id: GlobalId,
     ) -> Result<CollectionMetadata, StorageError<Self::Timestamp>>;
 
+    /// Returns `true` iff the given collection/ingestion has been hydrated.
+    ///
+    /// For this check, zero-replica clusters are always considered hydrated.
+    /// Their collections would never normally be considered hydrated but it's
+    /// clearly intentional that they have no replicas.
+    fn collection_hydrated(
+        &self,
+        collection_id: GlobalId,
+    ) -> Result<bool, StorageError<Self::Timestamp>>;
+
     /// Returns the since/upper frontiers of the identified collection.
     fn collection_frontiers(
         &self,


### PR DESCRIPTION
This was somewhat annoying to fix because metrics/stats reporting was busted for UPSERT/sources (and potentially other things). The first commit fixes that.

Fixes https://github.com/MaterializeInc/database-issues/issues/8746

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
