### PR TITLE
Various CI fixes (November 18)

### DIFF
--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -28,6 +28,12 @@ def get_ancestor_overrides_for_performance_regressions(
 
     min_ancestor_mz_version_per_commit = dict()
 
+    if "OptbenchTPCH" in scenario_class_name:
+        # PR#30506 (Remove NonNullable transform) increases wallclock
+        min_ancestor_mz_version_per_commit[
+            "6981cb35f6a64748293867beb67e74b804f9e723"
+        ] = MzVersion.parse_mz("v0.126.0")
+
     if scenario_class_name == "KafkaUpsertUnique":
         # PR#29718 (storage: continual feedback upsert operator) increases CPU and memory
         min_ancestor_mz_version_per_commit[

--- a/src/catalog/src/expr_cache.rs
+++ b/src/catalog/src/expr_cache.rs
@@ -483,6 +483,7 @@ mod tests {
 
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
+    #[ignore] // TODO: Reenable when database-issues#8739 is fixed
     async fn expression_cache() {
         let local_tree = LocalExpressions::arbitrary()
             .new_tree(&mut TestRunner::default())
@@ -788,6 +789,7 @@ mod tests {
 
         #[mz_ore::test]
         #[cfg_attr(miri, ignore)]
+        #[ignore] // TODO: Reenable when database-issues#8739 is fixed
         fn local_expr_cache_roundtrip((key, val) in any::<(CacheKey, LocalExpressions)>()) {
             let bincode_val = bincode::serialize(&val).expect("must serialize");
             let (encoded_key, encoded_val) = ExpressionCodec::encode(&key, &bincode_val);
@@ -800,6 +802,7 @@ mod tests {
 
         #[mz_ore::test]
         #[cfg_attr(miri, ignore)]
+        #[ignore] // TODO: Reenable when database-issues#8739 is fixed
         fn global_expr_cache_roundtrip((key, val) in any::<(CacheKey, GlobalExpressions)>()) {
             let bincode_val = bincode::serialize(&val).expect("must serialize");
             let (encoded_key, encoded_val) = ExpressionCodec::encode(&key, &bincode_val);

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -671,7 +671,9 @@ class TablesCommaJoinWithJoinCondition(Generator):
 
 
 class TablesCommaJoinWithCondition(Generator):
-    COUNT = min(Generator.COUNT, 100)  # Otherwise is very slow
+    COUNT = min(
+        Generator.COUNT, 50
+    )  # TODO: Bump back to 100 when database-issues#8755 is fixed
 
     @classmethod
     def body(cls) -> None:
@@ -1312,7 +1314,9 @@ class FilterSubqueries(Generator):
     because of excessive memory allocations in the `RedundantJoin` transform.
     """
 
-    COUNT = 100
+    COUNT = min(
+        Generator.COUNT, 50
+    )  # TODO: Bump back to 100 when database-issues#8755 is fixed
 
     MAX_COUNT = 111  # Too long-running with count=200
 


### PR DESCRIPTION
See individual commits
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
