### PR TITLE
Add preliminary support for other cloud providers to orchestratord

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5589,6 +5589,7 @@ dependencies = [
  "mz-orchestrator-tracing",
  "mz-ore",
  "mz-prof-http",
+ "mz-sql",
  "mz-tls-util",
  "prometheus",
  "rand",

--- a/src/orchestratord/BUILD.bazel
+++ b/src/orchestratord/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
         "//src/orchestrator-tracing:mz_orchestrator_tracing",
         "//src/ore:mz_ore",
         "//src/prof-http:mz_prof_http",
+        "//src/sql:mz_sql",
         "//src/tls-util:mz_tls_util",
     ] + all_crate_deps(normal = True),
 )
@@ -79,6 +80,7 @@ rust_test(
         "//src/orchestrator-tracing:mz_orchestrator_tracing",
         "//src/ore:mz_ore",
         "//src/prof-http:mz_prof_http",
+        "//src/sql:mz_sql",
         "//src/tls-util:mz_tls_util",
     ] + all_crate_deps(
         normal = True,
@@ -99,6 +101,7 @@ rust_doc_test(
         "//src/orchestrator-tracing:mz_orchestrator_tracing",
         "//src/ore:mz_ore",
         "//src/prof-http:mz_prof_http",
+        "//src/sql:mz_sql",
         "//src/tls-util:mz_tls_util",
     ] + all_crate_deps(
         normal = True,
@@ -133,6 +136,7 @@ rust_binary(
         "//src/orchestrator-tracing:mz_orchestrator_tracing",
         "//src/ore:mz_ore",
         "//src/prof-http:mz_prof_http",
+        "//src/sql:mz_sql",
         "//src/tls-util:mz_tls_util",
     ] + all_crate_deps(normal = True),
 )

--- a/src/orchestratord/Cargo.toml
+++ b/src/orchestratord/Cargo.toml
@@ -30,6 +30,7 @@ mz-ore = { path = "../ore" }
 mz-orchestrator-kubernetes = { path = "../orchestrator-kubernetes" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
 mz-prof-http = { path = "../prof-http" }
+mz-sql = { path = "../sql" }
 mz-tls-util = { path = "../tls-util" }
 prometheus = { version = "0.13.3", default-features = false }
 rand = "0.8.5"

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -23,6 +23,7 @@ use mz_cloud_resources::crd::materialize::v1alpha1::{Materialize, MaterializeSta
 use mz_orchestrator_kubernetes::KubernetesImagePullPolicy;
 use mz_orchestrator_tracing::TracingCliArgs;
 use mz_ore::{cast::CastFrom, cli::KeyValueArg, instrument};
+use mz_sql::catalog::CloudProvider;
 
 mod console;
 mod resources;
@@ -125,37 +126,6 @@ pub struct Args {
 
     #[clap(long, default_value = "9000")]
     console_http_port: i32,
-}
-
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
-pub enum CloudProvider {
-    Aws,
-    Local,
-}
-
-impl std::str::FromStr for CloudProvider {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value.to_lowercase().as_ref() {
-            "aws" => Ok(Self::Aws),
-            "local" => Ok(Self::Local),
-            _ => Err("invalid cloud provider".to_string()),
-        }
-    }
-}
-
-impl std::fmt::Display for CloudProvider {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::Aws => "aws",
-                Self::Local => "local",
-            }
-        )
-    }
 }
 
 #[derive(clap::Parser)]

--- a/src/orchestratord/src/controller/materialize/resources.rs
+++ b/src/orchestratord/src/controller/materialize/resources.rs
@@ -38,12 +38,13 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tracing::trace;
 
-use super::{matching_image_from_environmentd_image_ref, CloudProvider};
+use super::matching_image_from_environmentd_image_ref;
 use crate::k8s::{apply_resource, delete_resource, get_resource};
 use mz_cloud_resources::crd::materialize::v1alpha1::Materialize;
 use mz_environmentd::DeploymentStatus;
 use mz_orchestrator_tracing::TracingCliArgs;
 use mz_ore::instrument;
+use mz_sql::catalog::CloudProvider;
 
 #[derive(Debug, Serialize)]
 pub struct Resources {

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -1200,6 +1200,12 @@ pub enum CloudProvider {
     Cloudtest,
     /// Amazon Web Services.
     Aws,
+    /// Google Cloud Platform
+    Gcp,
+    /// Microsoft Azure
+    Azure,
+    /// Other generic cloud provider
+    Generic,
 }
 
 impl fmt::Display for CloudProvider {
@@ -1210,6 +1216,9 @@ impl fmt::Display for CloudProvider {
             CloudProvider::MzCompose => f.write_str("mzcompose"),
             CloudProvider::Cloudtest => f.write_str("cloudtest"),
             CloudProvider::Aws => f.write_str("aws"),
+            CloudProvider::Gcp => f.write_str("gcp"),
+            CloudProvider::Azure => f.write_str("azure"),
+            CloudProvider::Generic => f.write_str("generic"),
         }
     }
 }
@@ -1218,12 +1227,15 @@ impl FromStr for CloudProvider {
     type Err = InvalidCloudProviderError;
 
     fn from_str(s: &str) -> Result<CloudProvider, InvalidCloudProviderError> {
-        match s {
+        match s.to_lowercase().as_ref() {
             "local" => Ok(CloudProvider::Local),
             "docker" => Ok(CloudProvider::Docker),
             "mzcompose" => Ok(CloudProvider::MzCompose),
             "cloudtest" => Ok(CloudProvider::Cloudtest),
             "aws" => Ok(CloudProvider::Aws),
+            "gcp" => Ok(CloudProvider::Gcp),
+            "azure" => Ok(CloudProvider::Azure),
+            "generic" => Ok(CloudProvider::Generic),
             _ => Err(InvalidCloudProviderError),
         }
     }
@@ -1780,6 +1792,33 @@ mod tests {
                 Ok(EnvironmentId {
                     cloud_provider: CloudProvider::Aws,
                     cloud_provider_region: "us-east-1".into(),
+                    organization_id: "1497a3b7-a455-4fc4-8752-b44a94b5f90a".parse().unwrap(),
+                    ordinal: 0,
+                }),
+            ),
+            (
+                "gcp-us-central1-1497a3b7-a455-4fc4-8752-b44a94b5f90a-0",
+                Ok(EnvironmentId {
+                    cloud_provider: CloudProvider::Gcp,
+                    cloud_provider_region: "us-central1".into(),
+                    organization_id: "1497a3b7-a455-4fc4-8752-b44a94b5f90a".parse().unwrap(),
+                    ordinal: 0,
+                }),
+            ),
+            (
+                "azure-australiaeast-1497a3b7-a455-4fc4-8752-b44a94b5f90a-0",
+                Ok(EnvironmentId {
+                    cloud_provider: CloudProvider::Azure,
+                    cloud_provider_region: "australiaeast".into(),
+                    organization_id: "1497a3b7-a455-4fc4-8752-b44a94b5f90a".parse().unwrap(),
+                    ordinal: 0,
+                }),
+            ),
+            (
+                "generic-moon-station-11-darkside-1497a3b7-a455-4fc4-8752-b44a94b5f90a-0",
+                Ok(EnvironmentId {
+                    cloud_provider: CloudProvider::Generic,
+                    cloud_provider_region: "moon-station-11-darkside".into(),
                     organization_id: "1497a3b7-a455-4fc4-8752-b44a94b5f90a".parse().unwrap(),
                     ordinal: 0,
                 }),


### PR DESCRIPTION
Adds preliminary support for other cloud providers to orchestratord.

Does not add any special handling of them, but accepts GCP, Azure, and Generic cloud providers.

In the future, we may want to expand our support for these to include their equivalent of IAM roles, to support advanced features such as non-password-based access to persist buckets or assuming roles, but that is all out of scope for now.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


  * This PR fixes a previously unreported bug.

With self-hosted, our customers may run this in other cloud providers.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
