### PR TITLE
bazel: Fix pipelined compilation, take 3

### DIFF
--- a/src/adapter/BUILD.bazel
+++ b/src/adapter/BUILD.bazel
@@ -24,6 +24,7 @@ rust_library(
     compile_data = [],
     crate_features = [],
     data = [],
+    disable_pipelining = True,
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -119,6 +119,11 @@ harness = false
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]
 
+[package.metadata.cargo-gazelle.lib]
+# TODO(parkmycar): No idea what, but something in this crate is non-deterministic and it breaks
+# pipelining.
+disable_pipelining = true
+
 [package.metadata.cargo-gazelle.test.sql]
 data = ["tests/testdata/sql"]
 

--- a/src/expr/BUILD.bazel
+++ b/src/expr/BUILD.bazel
@@ -25,7 +25,7 @@ rust_library(
     compile_data = ["Cargo.toml"],
     crate_features = ["default"],
     data = [],
-    disable_pipelining = True,
+    disable_pipelining = False,
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -88,3 +88,5 @@ normal = ["workspace-hack"]
 [package.metadata.cargo-gazelle.lib]
 # `num_enum` which depends on `proc-macro-crate` tries to read from the Cargo.toml at compile time.
 compile_data = ["Cargo.toml"]
+# Explicitly enable pipelining.
+disable_pipelining = false

--- a/src/repr/BUILD.bazel
+++ b/src/repr/BUILD.bazel
@@ -29,7 +29,7 @@ rust_library(
         "tracing_",
     ],
     data = [],
-    disable_pipelining = True,
+    disable_pipelining = False,
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -108,6 +108,8 @@ normal = ["workspace-hack"]
 [package.metadata.cargo-gazelle.lib]
 # `num_enum` which depends on `proc-macro-crate` tries to read from the Cargo.toml at compile time.
 compile_data = ["Cargo.toml"]
+# Explicitly enable pipelining.
+disable_pipelining = false
 
 [package.metadata.cargo-gazelle.test.lib]
 data = ["src/adt/snapshots/*"]


### PR DESCRIPTION
I actually know how to debug this issue now ([steps](https://github.com/bazelbuild/rules_rust/issues/1584#issuecomment-2483313847)), and I figured out that something in the `adapter` crate is non-deterministic, although I'm not sure what. For now I turned off pipelined compilation for the `adapter` crate and will dogfood this locally for a few days before turning it on for CI.

### Motivation

Bazel improve compile times.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
