### PR TITLE
test: Prevent timeout in expr cache tests

### DIFF
--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -328,7 +328,7 @@ impl Arbitrary for MirRelationExpr {
     type Parameters = ();
 
     fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
-        const VEC_LEN: usize = 4;
+        const VEC_LEN: usize = 2;
 
         // A strategy for generating the leaf cases.
         let leaf = Union::new([
@@ -348,7 +348,7 @@ impl Arbitrary for MirRelationExpr {
         ])
         .boxed();
 
-        leaf.prop_recursive(2, 3, 5, |inner| {
+        leaf.prop_recursive(2, 2, 2, |inner| {
             Union::new([
                 // Let
                 (any::<LocalId>(), inner.clone(), inner.clone())


### PR DESCRIPTION
Previously, the expression cache tests were timing out because of how long they spent generating random expressions. This commit tries to resolve the issue by

  - Simplifying the random expression generator.
  - Adding timeouts and retries if an expression is taking too long generate.

Resolves #8739

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
