### PR TITLE
urldecode the username/password in s3 urls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5723,6 +5723,7 @@ dependencies = [
  "tokio-postgres",
  "tracing",
  "url",
+ "urlencoding",
  "uuid",
  "workspace-hack",
 ]

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -59,6 +59,7 @@ tokio = { version = "1.38.0", default-features = false, features = ["fs", "macro
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
 url = "2.3.1"
+urlencoding = "2.1.2"
 uuid = { version = "1.7.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -109,7 +109,14 @@ impl BlobConfig {
 
                 let credentials = match url.password() {
                     None => None,
-                    Some(password) => Some((url.username().to_string(), password.to_string())),
+                    Some(password) => Some((
+                        String::from_utf8_lossy(&urlencoding::decode_binary(
+                            url.username().as_bytes(),
+                        ))
+                        .into_owned(),
+                        String::from_utf8_lossy(&urlencoding::decode_binary(password.as_bytes()))
+                            .into_owned(),
+                    )),
                 };
 
                 let config = S3BlobConfig::new(


### PR DESCRIPTION
### Motivation

aws s3 only uses alphanumeric client id/secret here, but other s3 compatible systems might not

### Tips for reviewer

i'm not actually sure if this is sufficient or if there are other places that might need fixes here - let me know

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
