### PR TITLE
make the subcommand for bin/orchestratord required

### DIFF
--- a/misc/python/materialize/cli/orchestratord.py
+++ b/misc/python/materialize/cli/orchestratord.py
@@ -37,7 +37,7 @@ def main():
         "--kind-cluster-name",
         default=os.environ.get("KIND_CLUSTER_NAME", "kind"),
     )
-    subparsers = parser.add_subparsers(dest="subcommand")
+    subparsers = parser.add_subparsers(required=True)
 
     parser_run = subparsers.add_parser("run")
     parser_run.add_argument("--dev", action="store_true")
@@ -59,10 +59,7 @@ def main():
     parser_environment.set_defaults(func=environment)
 
     args = parser.parse_args()
-    if args.subcommand is None:
-        run(args)
-    else:
-        args.func(args)
+    args.func(args)
 
 
 def run(args: argparse.Namespace):


### PR DESCRIPTION
### Motivation

argument parsing becomes a bit annoying otherwise

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
