### PR TITLE
[persist] Clean up some unused / restrictive code in stats

### DIFF
--- a/src/persist-types/src/stats2.rs
+++ b/src/persist-types/src/stats2.rs
@@ -19,9 +19,7 @@ use arrow::array::{
 use crate::stats::primitive::{
     truncate_bytes, truncate_string, PrimitiveStats, TruncateBound, TRUNCATE_LEN,
 };
-use crate::stats::{
-    ColumnNullStats, ColumnStatKinds, ColumnarStats, DynStats, OptionStats,
-};
+use crate::stats::{ColumnNullStats, ColumnStatKinds, ColumnarStats, DynStats, OptionStats};
 
 /// A type that can incrementally collect stats from a sequence of values.
 pub trait ColumnarStatsBuilder<T>: Debug {
@@ -34,17 +32,6 @@ pub trait ColumnarStatsBuilder<T>: Debug {
     fn from_column(col: &Self::ArrowColumn) -> Self
     where
         Self: Sized;
-    /// Derive statistics from an opaque column of data.
-    ///
-    /// Returns `None` if the opaque column is not the same type as
-    /// [`Self::ArrowColumn`].
-    fn from_column_dyn(col: &dyn arrow::array::Array) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        let col = col.as_any().downcast_ref::<Self::ArrowColumn>()?;
-        Some(Self::from_column(col))
-    }
 
     /// Finish this collector returning the final aggregated statistics.
     fn finish(self) -> Self::FinishedStats

--- a/src/persist-types/src/stats2.rs
+++ b/src/persist-types/src/stats2.rs
@@ -20,7 +20,7 @@ use crate::stats::primitive::{
     truncate_bytes, truncate_string, PrimitiveStats, TruncateBound, TRUNCATE_LEN,
 };
 use crate::stats::{
-    ColumnNullStats, ColumnStatKinds, ColumnarStats, DynStats, NoneStats, OptionStats,
+    ColumnNullStats, ColumnStatKinds, ColumnarStats, DynStats, OptionStats,
 };
 
 /// A type that can incrementally collect stats from a sequence of values.
@@ -181,28 +181,5 @@ where
             nulls: Some(ColumnNullStats { count: self.none }),
             values: self.some.finish().into(),
         }
-    }
-}
-
-/// Empty statistics for a column of data.
-#[derive(Debug)]
-pub struct NoneStatsBuilder<A>(std::marker::PhantomData<A>);
-
-impl<T, A: arrow::array::Array + 'static> ColumnarStatsBuilder<T> for NoneStatsBuilder<A> {
-    type ArrowColumn = A;
-    type FinishedStats = NoneStats;
-
-    fn from_column(_col: &Self::ArrowColumn) -> Self
-    where
-        Self: Sized,
-    {
-        NoneStatsBuilder(std::marker::PhantomData)
-    }
-
-    fn finish(self) -> Self::FinishedStats
-    where
-        Self::FinishedStats: Sized,
-    {
-        NoneStats
     }
 }

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -59,7 +59,7 @@ use crate::row::{
     ProtoArray, ProtoArrayDimension, ProtoDatum, ProtoDatumOther, ProtoDict, ProtoDictElement,
     ProtoNumeric, ProtoRange, ProtoRangeInner, ProtoRow,
 };
-use crate::stats2::{fixed_stats_from_column, stats_for_json, NumericStatsBuilder};
+use crate::stats2::{fixed_stats_from_column, numeric_stats_from_column, stats_for_json};
 use crate::{Datum, ProtoRelationDesc, RelationDesc, Row, RowPacker, ScalarType, Timestamp};
 
 // TODO(parkmycar): Benchmark the difference between `FixedSizeBinaryArray` and `BinaryArray`.
@@ -1179,7 +1179,7 @@ impl DatumColumnDecoder {
             DatumColumnDecoder::I64(a) => PrimitiveStats::<i64>::from_column(a).into(),
             DatumColumnDecoder::F32(a) => PrimitiveStats::<f32>::from_column(a).into(),
             DatumColumnDecoder::F64(a) => PrimitiveStats::<f64>::from_column(a).into(),
-            DatumColumnDecoder::Numeric(a) => NumericStatsBuilder::from_column(a).finish().into(),
+            DatumColumnDecoder::Numeric(a) => numeric_stats_from_column(a),
             DatumColumnDecoder::String(a) => PrimitiveStats::<String>::from_column(a).into(),
             DatumColumnDecoder::Bytes(a) => PrimitiveStats::<Vec<u8>>::from_column(a).into(),
             DatumColumnDecoder::Date(a) => PrimitiveStats::<i32>::from_column(a).into(),

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -2219,11 +2219,11 @@ mod tests {
             .iter()
             .map(|(name, ty)| {
                 let col_stats = stats.cols.get(name.as_str()).unwrap();
-                let (lower, upper) =
+                let lower_upper =
                     crate::stats2::col_values(&ty.scalar_type, &col_stats.values, &arena);
                 let null_count = col_stats.nulls.map_or(0, |n| n.count);
 
-                ((lower, upper), null_count)
+                (lower_upper, null_count)
             })
             .unzip();
         // Track how many nulls we saw for each column so we can assert stats match.
@@ -2237,18 +2237,14 @@ mod tests {
             // Check for each Datum in each Row that we're within our stats bounds.
             for (c_idx, (rnd_datum, ty)) in rnd_row.iter().zip_eq(desc.typ().columns()).enumerate()
             {
-                let (lower, upper) = stats[c_idx];
+                let lower_upper = stats[c_idx];
 
                 // Assert our stat bounds are correct.
                 if rnd_datum.is_null() {
                     actual_nulls[c_idx] += 1;
-                } else if lower.is_some() || upper.is_some() {
-                    if let Some(lower) = lower {
-                        assert!(rnd_datum >= lower, "{rnd_datum:?} is not >= {lower:?}");
-                    }
-                    if let Some(upper) = upper {
-                        assert!(rnd_datum <= upper, "{rnd_datum:?} is not <= {upper:?}");
-                    }
+                } else if let Some((lower, upper)) = lower_upper {
+                    assert!(rnd_datum >= lower, "{rnd_datum:?} is not >= {lower:?}");
+                    assert!(rnd_datum <= upper, "{rnd_datum:?} is not <= {upper:?}");
                 } else {
                     match &ty.scalar_type {
                         // JSON stats are handled separately.

--- a/src/repr/src/stats2.rs
+++ b/src/repr/src/stats2.rs
@@ -13,12 +13,13 @@
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::fmt::Formatter;
+use std::fmt::{Debug, Formatter};
 
 use anyhow::Context;
 use arrow::array::{BinaryArray, FixedSizeBinaryArray};
 use chrono::{NaiveDateTime, NaiveTime};
 use dec::OrderedDecimal;
+use mz_ore::soft_panic_or_log;
 use mz_persist_types::columnar::FixedSizeCodec;
 use mz_persist_types::stats::bytes::{BytesStats, FixedSizeBytesStats, FixedSizeBytesStatsKind};
 use mz_persist_types::stats::json::{JsonMapElementStats, JsonStats};
@@ -41,6 +42,16 @@ use crate::adt::numeric::{Numeric, PackedNumeric};
 use crate::adt::timestamp::{CheckedTimestamp, PackedNaiveDateTime};
 use crate::row::ProtoDatum;
 use crate::{Datum, RowArena, ScalarType};
+
+fn soft_expect_or_log<A, B: Debug>(result: Result<A, B>) -> Option<A> {
+    match result {
+        Ok(a) => Some(a),
+        Err(e) => {
+            soft_panic_or_log!("failed to decode stats: {e:?}");
+            None
+        }
+    }
+}
 
 /// Return the stats for a fixed-size bytes column, defaulting to an appropriate value if
 /// no values are present.
@@ -90,22 +101,22 @@ pub fn col_values<'a>(
     typ: &ScalarType,
     stats: &'a ColumnStatKinds,
     arena: &'a RowArena,
-) -> (Option<Datum<'a>>, Option<Datum<'a>>) {
+) -> Option<(Datum<'a>, Datum<'a>)> {
     use PrimitiveStatsVariants::*;
 
     /// Helper method to map the lower and upper bounds of some stats to Datums.
-    fn map_stats<'a, T, F>(stats: &'a T, f: F) -> (Option<Datum<'a>>, Option<Datum<'a>>)
+    fn map_stats<'a, T, F>(stats: &'a T, f: F) -> Option<(Datum<'a>, Datum<'a>)>
     where
         T: ColumnStats,
         F: Fn(T::Ref<'a>) -> Datum<'a>,
     {
-        (stats.lower().map(&f), stats.upper().map(&f))
+        Some((f(stats.lower()?), f(stats.upper()?)))
     }
 
     match (typ, stats) {
         (ScalarType::Bool, ColumnStatKinds::Primitive(Bool(stats))) => {
             let map_datum = |val| if val { Datum::True } else { Datum::False };
-            (stats.lower().map(map_datum), stats.upper().map(map_datum))
+            map_stats(stats, map_datum)
         }
         (ScalarType::PgLegacyChar, ColumnStatKinds::Primitive(U8(stats))) => {
             map_stats(stats, Datum::UInt8)
@@ -147,16 +158,12 @@ pub fn col_values<'a>(
                 kind: FixedSizeBytesStatsKind::PackedNumeric,
             })),
         ) => {
-            let lower = PackedNumeric::from_bytes(lower)
-                .expect("failed to roundtrip Numeric")
-                .into_value();
-            let upper = PackedNumeric::from_bytes(upper)
-                .expect("failed to roundtrip Numeric")
-                .into_value();
-            (
-                Some(Datum::Numeric(OrderedDecimal(lower))),
-                Some(Datum::Numeric(OrderedDecimal(upper))),
-            )
+            let lower = soft_expect_or_log(PackedNumeric::from_bytes(lower))?.into_value();
+            let upper = soft_expect_or_log(PackedNumeric::from_bytes(upper))?.into_value();
+            Some((
+                Datum::Numeric(OrderedDecimal(lower)),
+                Datum::Numeric(OrderedDecimal(upper)),
+            ))
         }
         (
             ScalarType::String
@@ -165,75 +172,58 @@ pub fn col_values<'a>(
             | ScalarType::VarChar { .. },
             ColumnStatKinds::Primitive(String(stats)),
         ) => map_stats(stats, Datum::String),
-        (ScalarType::Bytes, ColumnStatKinds::Bytes(BytesStats::Primitive(stats))) => (
-            Some(Datum::Bytes(&stats.lower)),
-            Some(Datum::Bytes(&stats.upper)),
-        ),
-        (ScalarType::Date, ColumnStatKinds::Primitive(I32(stats))) => map_stats(stats, |x| {
-            Datum::Date(Date::from_pg_epoch(x).expect("failed to roundtrip Date"))
-        }),
+        (ScalarType::Bytes, ColumnStatKinds::Bytes(BytesStats::Primitive(stats))) => {
+            Some((Datum::Bytes(&stats.lower), Datum::Bytes(&stats.upper)))
+        }
+        (ScalarType::Date, ColumnStatKinds::Primitive(I32(stats))) => {
+            let lower = soft_expect_or_log(Date::from_pg_epoch(stats.lower))?;
+            let upper = soft_expect_or_log(Date::from_pg_epoch(stats.upper))?;
+            Some((Datum::Date(lower), Datum::Date(upper)))
+        }
         (ScalarType::Time, ColumnStatKinds::Bytes(BytesStats::FixedSize(stats))) => {
-            let lower = PackedNaiveTime::from_bytes(&stats.lower)
-                .expect("failed to roundtrip NaiveTime")
-                .into_value();
-            let upper = PackedNaiveTime::from_bytes(&stats.upper)
-                .expect("failed to roundtrip NaiveTime")
-                .into_value();
-
-            (Some(Datum::Time(lower)), Some(Datum::Time(upper)))
+            let lower = soft_expect_or_log(PackedNaiveTime::from_bytes(&stats.lower))?.into_value();
+            let upper = soft_expect_or_log(PackedNaiveTime::from_bytes(&stats.upper))?.into_value();
+            Some((Datum::Time(lower), Datum::Time(upper)))
         }
         (ScalarType::Timestamp { .. }, ColumnStatKinds::Bytes(BytesStats::FixedSize(stats))) => {
-            let lower = PackedNaiveDateTime::from_bytes(&stats.lower)
-                .expect("failed to roundtrip PackedNaiveDateTime")
-                .into_value();
+            let lower =
+                soft_expect_or_log(PackedNaiveDateTime::from_bytes(&stats.lower))?.into_value();
             let lower =
                 CheckedTimestamp::from_timestamplike(lower).expect("failed to roundtrip timestamp");
-            let upper = PackedNaiveDateTime::from_bytes(&stats.upper)
-                .expect("failed to roundtrip Timestamp")
-                .into_value();
+            let upper =
+                soft_expect_or_log(PackedNaiveDateTime::from_bytes(&stats.upper))?.into_value();
             let upper =
                 CheckedTimestamp::from_timestamplike(upper).expect("failed to roundtrip timestamp");
 
-            (Some(Datum::Timestamp(lower)), Some(Datum::Timestamp(upper)))
+            Some((Datum::Timestamp(lower), Datum::Timestamp(upper)))
         }
         (ScalarType::TimestampTz { .. }, ColumnStatKinds::Bytes(BytesStats::FixedSize(stats))) => {
-            let lower = PackedNaiveDateTime::from_bytes(&stats.lower)
-                .expect("failed to roundtrip PackedNaiveDateTime")
+            let lower = soft_expect_or_log(PackedNaiveDateTime::from_bytes(&stats.lower))?
                 .into_value()
                 .and_utc();
-            let lower =
-                CheckedTimestamp::from_timestamplike(lower).expect("failed to roundtrip timestamp");
-            let upper = PackedNaiveDateTime::from_bytes(&stats.upper)
-                .expect("failed to roundtrip Timestamp")
+            let lower = soft_expect_or_log(CheckedTimestamp::from_timestamplike(lower))?;
+            let upper = soft_expect_or_log(PackedNaiveDateTime::from_bytes(&stats.upper))?
                 .into_value()
                 .and_utc();
-            let upper =
-                CheckedTimestamp::from_timestamplike(upper).expect("failed to roundtrip timestamp");
+            let upper = soft_expect_or_log(CheckedTimestamp::from_timestamplike(upper))?;
 
-            (
-                Some(Datum::TimestampTz(lower)),
-                Some(Datum::TimestampTz(upper)),
-            )
+            Some((Datum::TimestampTz(lower), Datum::TimestampTz(upper)))
         }
         (ScalarType::MzTimestamp, ColumnStatKinds::Primitive(U64(stats))) => {
             map_stats(stats, |x| Datum::MzTimestamp(crate::Timestamp::from(x)))
         }
         (ScalarType::Interval, ColumnStatKinds::Bytes(BytesStats::FixedSize(stats))) => {
-            let lower = PackedInterval::from_bytes(&stats.lower)
-                .map(|x| x.into_value())
-                .expect("failed to roundtrip Interval");
-            let upper = PackedInterval::from_bytes(&stats.upper)
-                .map(|x| x.into_value())
-                .expect("failed to roundtrip Interval");
-            (Some(Datum::Interval(lower)), Some(Datum::Interval(upper)))
+            let lower = soft_expect_or_log(PackedInterval::from_bytes(&stats.lower))?.into_value();
+            let upper = soft_expect_or_log(PackedInterval::from_bytes(&stats.upper))?.into_value();
+            Some((Datum::Interval(lower), Datum::Interval(upper)))
         }
         (ScalarType::Uuid, ColumnStatKinds::Bytes(BytesStats::FixedSize(stats))) => {
-            let lower = Uuid::from_slice(&stats.lower).expect("failed to roundtrip Uuid");
-            let upper = Uuid::from_slice(&stats.upper).expect("failed to roundtrip Uuid");
-            (Some(Datum::Uuid(lower)), Some(Datum::Uuid(upper)))
+            let lower = soft_expect_or_log(Uuid::from_slice(&stats.lower))?;
+            let upper = soft_expect_or_log(Uuid::from_slice(&stats.upper))?;
+            Some((Datum::Uuid(lower), Datum::Uuid(upper)))
         }
         // JSON stats are handled elsewhere.
-        (ScalarType::Jsonb, ColumnStatKinds::Bytes(BytesStats::Json(_))) => (None, None),
+        (ScalarType::Jsonb, ColumnStatKinds::Bytes(BytesStats::Json(_))) => None,
         // We don't maintain stats on any of these types.
         (
             ScalarType::AclItem
@@ -245,7 +235,7 @@ pub fn col_values<'a>(
             | ScalarType::Record { .. }
             | ScalarType::Int2Vector,
             ColumnStatKinds::None,
-        ) => (None, None),
+        ) => None,
         // V0 Columnar Stat Types that differ from the above.
         (
             ScalarType::Numeric { .. }
@@ -267,11 +257,11 @@ pub fn col_values<'a>(
                     .expect("ProtoDatum should be valid Datum")
             });
 
-            (Some(lower), Some(upper))
+            Some((lower, upper))
         }
         (typ, stats) => {
             mz_ore::soft_panic_or_log!("found unexpected {stats:?} for column {typ:?}");
-            (None, None)
+            None
         }
     }
 }

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1760,8 +1760,7 @@ impl ColumnDecoder<SourceData> for SourceDataColumnarDecoder {
             nulls: Some(ColumnNullStats {
                 count: self.err_decoder.null_count(),
             }),
-            values: PrimitiveStats::<Vec<u8>>::from_column(&self.err_decoder)
-                .into(),
+            values: PrimitiveStats::<Vec<u8>>::from_column(&self.err_decoder).into(),
         };
         // The top level struct is non-nullable and every entry is either an
         // `Ok(Row)` or an `Err(String)`. As a result, we can compute the number

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -28,7 +28,7 @@ use load_generator::{LoadGeneratorOutput, LoadGeneratorSourceExportDetails};
 use mz_ore::assert_none;
 use mz_persist_types::columnar::{ColumnDecoder, ColumnEncoder, Schema2};
 use mz_persist_types::stats::{
-    ColumnNullStats, ColumnStatKinds, ColumnarStats, OptionStats, PrimitiveStats, StructStats,
+    ColumnNullStats, ColumnStatKinds, ColumnarStats, PrimitiveStats, StructStats,
 };
 use mz_persist_types::stats2::ColumnarStatsBuilder;
 use mz_persist_types::Codec;
@@ -1756,8 +1756,13 @@ impl ColumnDecoder<SourceData> for SourceDataColumnarDecoder {
 
     fn stats(&self) -> StructStats {
         let len = self.err_decoder.len();
-        let err_stats =
-            OptionStats::<PrimitiveStats<Vec<u8>>>::from_column(&self.err_decoder).finish();
+        let err_stats = ColumnarStats {
+            nulls: Some(ColumnNullStats {
+                count: self.err_decoder.null_count(),
+            }),
+            values: PrimitiveStats::<Vec<u8>>::from_column(&self.err_decoder)
+                .into(),
+        };
         // The top level struct is non-nullable and every entry is either an
         // `Ok(Row)` or an `Err(String)`. As a result, we can compute the number
         // of `Ok` entries by subtracting the number of `Err` entries from the

--- a/src/storage-types/src/stats.rs
+++ b/src/storage-types/src/stats.rs
@@ -195,13 +195,13 @@ impl RelationPartStats<'_> {
         };
         let col_stats = ok_stats.cols.get(name.as_str())?;
 
-        let (min, max) = mz_repr::stats2::col_values(&typ.scalar_type, &col_stats.values, arena);
+        let min_max = mz_repr::stats2::col_values(&typ.scalar_type, &col_stats.values, arena);
         let null_count = col_stats.nulls.as_ref().map_or(0, |nulls| nulls.count);
         let total_count = self.len();
 
-        let values = match (total_count, min, max) {
-            (Some(total_count), _, _) if total_count == null_count => ResultSpec::nothing(),
-            (_, Some(min), Some(max)) => ResultSpec::value_between(min, max),
+        let values = match (total_count, min_max) {
+            (Some(total_count), _) if total_count == null_count => ResultSpec::nothing(),
+            (_, Some((min, max))) => ResultSpec::value_between(min, max),
             _ => ResultSpec::value_all(),
         };
         let nulls = if null_count > 0 {


### PR DESCRIPTION
Many of our stats abstractions date to when we calculated stats both incrementally and in batch, but we only do the latter now... which means we can tidy up quite a bit of structure that we no longer need.

### Motivation

Previously-unspecified refactoring. (This code came up in a recent incident, and while I don't think this refactoring has removed any bugs, I think it does make it more straightforward to follow.)

### Tips for reviewer

Split into small commits to make it easier to digest!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
