### PR TITLE
Replica expiration: downgrade error to warning

### DIFF
--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -488,7 +488,14 @@ where
                 } else {
                     let frontier = input.frontier().frontier();
                     if !frontier.less_than(&expiration) && !warned {
-                        tracing::error!(
+                        // Here, we print a warning, not an error. The state is only a liveness
+                        // concern, but not relevant for correctness. Additionally, a race between
+                        // shutting down the dataflow and dropping the token can cause the dataflow
+                        // to shut down before we drop the token.  This can happen when dropping
+                        // the last remaining capability on a different worker.  We do not want to
+                        // log an error every time this happens.
+
+                        tracing::warn!(
                             name = name,
                             frontier = ?frontier,
                             expiration = ?expiration,


### PR DESCRIPTION
Replica expiration: downgrade an error to a warning

Instead of logging an error, we print a warning when the replica expiration stream operator reaches an unexpected frontier. Considering the alternatives, this seems to be the best approach at the moment.
* Logging an error produces false-positives during dataflow shutdown. Dropping the token can race with dataflow shutdown, for example if the last remaining upstream capability is on a different worker. The local worker then could first see the dataflow shutting down before the worker gets to dropping the token. We do not want to log an error in this case.
* Once we reach the state where the frontier has advanced too far, but the token hasn't been dropped, we've either encountered a bug, or a racy shutdown, but we cannot distinguish the two at that point. The worst outcome of the bug is that we prevent write progress because the operator retains a capability for the expiration time. Hence, it's not a correctness issue but a liveness problem. The issue can be simply mitigated by restarting the replica.

Alternatives include logging the warning into a channel that we periodically scan. With enough delay, we should be able to determine whether the error was a result of a race or legitimate.

Fixes MaterializeInc/database-issues#8750

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
