### PR TITLE
Move minio bucket creation to postStart hook.

### DIFF
--- a/misc/helm-charts/testing/minio.yaml
+++ b/misc/helm-charts/testing/minio.yaml
@@ -64,20 +64,37 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5
-      initContainers:
-      - name: create-buckets
-        image: minio/mc
-        env:
-        - name: MINIO_ACCESS_KEY
-          value: "minio"
-        - name: MINIO_SECRET_KEY
-          value: "minio123"
-        command: ["/bin/sh", "-c"]
-        args:
-        - |
-          mc alias set myminio http://minio:9000 minio minio123 && \
-          mc mb -p myminio/persist && \
-          mc mb -p local/bucket
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - "bash"
+                - "-euc"
+                - |
+                  function setup_buckets() {
+                      while true; do
+                          echo "Waiting for minio to become ready..."
+                          if curl --fail localhost:9000/minio/health/ready; then
+                              echo "Minio is ready"
+                              break
+                          fi
+                          sleep 1
+                      done
+
+                      echo "Creating local alias"
+                      mc alias set local http://localhost:9000 minio minio123
+                      echo $?
+
+                      echo "Creating local/persist bucket"
+                      mc mb -p local/persist
+                      echo $?
+
+                      echo "Creating local/bucket bucket"
+                      mc mb -p local/bucket
+                      echo $?
+                  }
+
+                  setup_buckets 2>&1 > poststart.log
       volumes:
       - name: storage
         emptyDir: {}


### PR DESCRIPTION
Move minio bucket creation to postStart hook.

Having this creation in an init container can never work, as minio doesn't start until after the init container is up.

Additionally, the myminio alias relied on a service which would not become ready until after the postStart hook, so changing to just point at localhost.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


  * This PR fixes a previously unreported bug.
Testing minio.yaml fails to come up.
https://materializeinc.slack.com/archives/C07PN7KSB0T/p1731989611785929

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
