### PR TITLE
Set boostrap replica size in cli

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -32,6 +32,7 @@ import psutil
 
 from materialize import MZ_ROOT, rustc_flags, spawn, ui
 from materialize.mzcompose import (
+    bootstrap_cluster_replica_size,
     cluster_replica_size_map,
     get_default_system_parameters,
 )
@@ -275,6 +276,7 @@ def main() -> int:
                 f"--environment-id={environment_id}",
                 "--bootstrap-role=materialize",
                 f"--cluster-replica-sizes={json.dumps(cluster_replica_size_map())}",
+                f"--bootstrap-default-cluster-replica-size={bootstrap_cluster_replica_size()}",
                 *args.args,
             ]
             if args.monitoring:


### PR DESCRIPTION
Set `--boostrap-cluster-replica-size` in `bin/environmentd` and related.

Fixes a bug reported on Slack: https://materializeinc.slack.com/archives/CM7ATT65S/p1732029052219219

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
