### PR TITLE
Remove unnecessary minio bucket creation from docs

### DIFF
--- a/misc/helm-charts/testing/README.md
+++ b/misc/helm-charts/testing/README.md
@@ -33,12 +33,6 @@ This directory contains simple examples for deploying MinIO, PostgreSQL, and Red
     kubectl get pods -w -n materialize
     ```
 
-3. Create a bucket in MinIO (replace `minio-123456-abcdef` with the actual pod name):
-
-    ```bash
-    kubectl exec -it minio-69c8d67494-clvwk -n materialize -- /bin/sh -c "mc alias set local http://localhost:9000 minio minio123; mc mb local/bucket"
-    ```
-
 ## Node labels for ephemeral storage
 
 When running Materialize locally on Kubernetes (e.g., Docker Desktop, Minikube, Kind), specific node labels need to be added to ensure that pods are scheduled correctly. These labels are required for the pod to satisfy node affinity rules defined in the deployment.


### PR DESCRIPTION
Remove unnecessary minio bucket creation from docs

### Motivation

This step is now automatically done by a postStart command in the minio pod.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
