### PR TITLE
slt: Bump timeout

### DIFF
--- a/ci/slt/pipeline.template.yml
+++ b/ci/slt/pipeline.template.yml
@@ -30,7 +30,7 @@ steps:
 
   - id: sqllogictest
     label: ":bulb: SQL logic tests %N"
-    timeout_in_minutes: 180
+    timeout_in_minutes: 240
     parallelism: 10
     agents:
       queue: hetzner-aarch64-8cpu-16gb


### PR DESCRIPTION
The tests have become slower but I've failed to find a culprit so far. Timeout occurred in https://buildkite.com/materialize/slt/builds/6097#_

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
