### PR TITLE
Tidy `Join` logic in `EquivalencePropagation`

### DIFF
--- a/src/transform/src/analysis/equivalences.rs
+++ b/src/transform/src/analysis/equivalences.rs
@@ -305,6 +305,10 @@ pub struct EquivalenceClasses {
     /// This map reflects an equivalence relation based on a prior version of `self.classes`.
     /// As users may add to `self.classes`, `self.remap` may become stale. We refresh `remap`
     /// only in `self.refresh()`, to the equivalence relation that derives from `self.classes`.
+    ///
+    /// It is important to `self.remap.clear()` if you invalidate it by mutating rather than
+    /// appending to `self.classes`. This will be corrected in the next call to `self.refresh()`,
+    /// but until then `remap` could be arbitrarily wrong. This should be improved in the future.
     remap: BTreeMap<MirScalarExpr, MirScalarExpr>,
 }
 
@@ -355,7 +359,7 @@ impl EquivalenceClasses {
     /// Restore equivalence relation structure to `self.classes` and refresh `self.remap`.
     ///
     /// This method takes roughly linear time, and returns true iff `self.remap` has changed.
-    /// This is the only method that changes `self.remap`, and is a perfect place to decide
+    /// This is the only method that refreshes `self.remap`, and is a perfect place to decide
     /// whether the equivalence classes it represents have experienced any changes since the
     /// last refresh.
     fn refresh(&mut self) -> bool {

--- a/src/transform/src/analysis/equivalences.rs
+++ b/src/transform/src/analysis/equivalences.rs
@@ -630,6 +630,8 @@ impl EquivalenceClasses {
                 expr.permute(permutation);
             }
         }
+        self.remap.clear();
+        self.minimize(&None);
     }
 
     /// Subject the constraints to the column projection, reworking and removing equivalences.
@@ -712,6 +714,7 @@ impl EquivalenceClasses {
                 MirScalarExpr::Column(col2),
             ]);
         }
+        self.remap.clear();
         self.minimize(&None);
     }
 

--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -305,7 +305,7 @@ impl EquivalencePropagation {
 
                 // Assemble the appended input types, for use in expression minimization.
                 // Do not use `expr_types`, which may reflect nullability that does not hold for the inputs.
-                let input_types = Some(
+                let mut input_types = Some(
                     children
                         .iter()
                         .flat_map(|c| {
@@ -367,7 +367,13 @@ impl EquivalencePropagation {
                         }
                     }
                 }
-                // Minimize relative to appended input types.
+                // Remove nullability information, as it has already been incorporated from input equivalences,
+                // and if it was reduced out relative to input equivalences we don't want to re-introduce it.
+                if let Some(input_types) = input_types.as_mut() {
+                    for col in input_types.iter_mut() {
+                        col.nullable = true;
+                    }
+                }
                 join_equivalences.minimize(&input_types);
 
                 // Revisit each child, determining the information to present to it, and recurring.

--- a/test/sqllogictest/advent-of-code/2023/aoc_1212.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1212.slt
@@ -125,8 +125,7 @@ Explained Query:
           Map (((#1 + #3) + 1), (#2 + 1))
             Join on=(#0 = #4 AND #1 = #5 AND #3 = #6) type=differential
               ArrangeBy keys=[[#0, #1, #3]]
-                Filter (false = (#1) IS NULL)
-                  Get l3
+                Get l3
               ArrangeBy keys=[[#0..=#2]]
                 Union
                   Negate
@@ -135,8 +134,7 @@ Explained Query:
                         Filter (#4 >= (#1 + 1)) AND (#4 <= (#1 + #2))
                           Join on=(#0 = #3) type=differential
                             ArrangeBy keys=[[#0]]
-                              Filter (false = (#1) IS NULL)
-                                Get l4
+                              Get l4
                             ArrangeBy keys=[[#0]]
                               Project (#0, #1)
                                 Filter (#2 = ".")
@@ -149,15 +147,14 @@ Explained Query:
     cte l3 =
       Project (#0..=#2, #5)
         Join on=(#0 = #3 = #6 AND #4 = (#2 + 1) AND #7 = ((#1 + #5) + 1)) type=delta
-          ArrangeBy keys=[[#0, (#2 + 1)]]
+          ArrangeBy keys=[[#0], [#0, (#2 + 1)]]
             Get l5
-          ArrangeBy keys=[[#0], [#0, #1]]
-            Project (#0, #2, #4)
-              Filter (false = (#3) IS NULL)
-                Map (array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2)), text_to_integer(#3))
-                  FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#1) array_length 1), 1)
-                    Project (#0, #2)
-                      Get l0
+          ArrangeBy keys=[[#0, #1]]
+            Project (#0, #2, #3)
+              Map (text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2))))
+                FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#1) array_length 1), 1)
+                  Project (#0, #2)
+                    Get l0
           Get l2
     cte l2 =
       ArrangeBy keys=[[#0, #1]]

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -1612,11 +1612,11 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                             "arranged": true,
                             "cardinality": null,
                             "filters": {
-                              "literal_equality": true,
+                              "literal_equality": false,
                               "like": false,
-                              "is_null": true,
+                              "is_null": false,
                               "literal_inequality": 0,
-                              "any_filter": true
+                              "any_filter": false
                             },
                             "input": 0
                           }
@@ -1640,60 +1640,24 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                     {
                       "ArrangeBy": {
                         "input": {
-                          "Filter": {
-                            "input": {
-                              "Get": {
-                                "id": {
-                                  "Local": 0
-                                },
-                                "typ": {
-                                  "column_types": [
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": false
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    }
-                                  ],
-                                  "keys": []
-                                },
-                                "access_strategy": "UnknownOrLocal"
-                              }
+                          "Get": {
+                            "id": {
+                              "Local": 0
                             },
-                            "predicates": [
-                              {
-                                "CallBinary": {
-                                  "func": "Eq",
-                                  "expr1": {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            1
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "Bool",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  },
-                                  "expr2": {
-                                    "CallUnary": {
-                                      "func": {
-                                        "IsNull": null
-                                      },
-                                      "expr": {
-                                        "Column": 1
-                                      }
-                                    }
-                                  }
+                            "typ": {
+                              "column_types": [
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": false
+                                },
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
                                 }
-                              }
-                            ]
+                              ],
+                              "keys": []
+                            },
+                            "access_strategy": "UnknownOrLocal"
                           }
                         },
                         "keys": [
@@ -1934,11 +1898,11 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                             "arranged": false,
                             "cardinality": null,
                             "filters": {
-                              "literal_equality": true,
+                              "literal_equality": false,
                               "like": false,
-                              "is_null": true,
+                              "is_null": false,
                               "literal_inequality": 0,
-                              "any_filter": true
+                              "any_filter": false
                             },
                             "input": 0
                           }
@@ -3958,9 +3922,9 @@ FROM
                                         "arranged": true,
                                         "cardinality": null,
                                         "filters": {
-                                          "literal_equality": true,
+                                          "literal_equality": false,
                                           "like": false,
-                                          "is_null": true,
+                                          "is_null": false,
                                           "literal_inequality": 0,
                                           "any_filter": true
                                         },

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -372,8 +372,7 @@ Explained Query:
     Project (#0{a}, #1{b})
       Join on=(#1{b} = #2{b}) type=differential
         ArrangeBy keys=[[#1{b}]]
-          Filter (false = (#1{b}) IS NULL)
-            Get l0
+          Get l0
         ArrangeBy keys=[[#0{b}]]
           Distinct project=[#0{b}]
             Project (#0{b})

--- a/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
@@ -241,8 +241,7 @@ Explained Query:
     Project (#0{a}, #1{b})
       Join on=(#1{b} = #2{b}) type=differential
         ArrangeBy keys=[[#1{b}]]
-          Filter (█ = (#1{b}) IS NULL)
-            Get l0
+          Get l0
         ArrangeBy keys=[[#0{b}]]
           Distinct project=[#0{b}]
             Project (#0{b})

--- a/test/sqllogictest/github-2799.slt
+++ b/test/sqllogictest/github-2799.slt
@@ -20,10 +20,9 @@ Explained Query:
   Project (#0, #1) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 3 }
       implementation
-        %1[#0]UKA » %0:t1[#0]Kenf
+        %1[#0]UKA » %0:t1[#0]K
       ArrangeBy keys=[[#0]] // { arity: 2 }
-        Filter (false = (#0) IS NULL) // { arity: 2 }
-          ReadStorage materialize.public.t1 // { arity: 2 }
+        ReadStorage materialize.public.t1 // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 1 }
         Distinct project=[#0] // { arity: 1 }
           Project (#0) // { arity: 1 }

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -167,10 +167,9 @@ Explained Query:
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2) type=differential // { arity: 3 }
         implementation
-          %1[#0]UKA » %0:l[#0]Kenf
+          %1[#0]UKA » %0:l[#0]K
         ArrangeBy keys=[[#0]] // { arity: 2 }
-          Filter (false = (#0) IS NULL) // { arity: 2 }
-            ReadStorage materialize.public.l // { arity: 2 }
+          ReadStorage materialize.public.l // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Distinct project=[#0] // { arity: 1 }
             Project (#0) // { arity: 1 }

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -2022,10 +2022,10 @@ Explained Query:
         Project (#0{creationdate}..=#11{messageid}) // { arity: 12 }
           Join on=(#12{rootpostlanguage} = #13{rootpostlanguage}) type=differential // { arity: 14 }
             implementation
-              %1[#0]UKA » %0:l0[#12]Keniif
+              %1[#0]UKA » %0:l0[#12]Kiif
             ArrangeBy keys=[[#12{rootpostlanguage}]] // { arity: 13 }
               Project (#0{creationdate}..=#10{email}, #12{rootpostlanguage}, #13) // { arity: 13 }
-                Filter (#15{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#14{content}) IS NOT NULL AND (#1{id} = #16{creatorpersonid}) AND (false = (#13{rootpostlanguage}) IS NULL) // { arity: 17 }
+                Filter (#15{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#14{content}) IS NOT NULL AND (#1{id} = #16{creatorpersonid}) // { arity: 17 }
                   Get l0 // { arity: 17 }
             ArrangeBy keys=[[#0{rootpostlanguage}]] // { arity: 1 }
               Distinct project=[#0{rootpostlanguage}] // { arity: 1 }

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -2029,10 +2029,10 @@ Explained Query:
         Project (#0{creationdate}..=#11{messageid}) // { arity: 12 }
           Join on=(#12{rootpostlanguage} = #13{rootpostlanguage}) type=differential // { arity: 14 }
             implementation
-              %1[#0]UKA » %0:l0[#12]Keniif
+              %1[#0]UKA » %0:l0[#12]Kiif
             ArrangeBy keys=[[#12{rootpostlanguage}]] // { arity: 13 }
               Project (#0{creationdate}..=#10{email}, #12{rootpostlanguage}, #13) // { arity: 13 }
-                Filter (#15{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#14{content}) IS NOT NULL AND (#1{id} = #16{creatorpersonid}) AND (false = (#13{rootpostlanguage}) IS NULL) // { arity: 17 }
+                Filter (#15{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#14{content}) IS NOT NULL AND (#1{id} = #16{creatorpersonid}) // { arity: 17 }
                   Get l0 // { arity: 17 }
             ArrangeBy keys=[[#0{rootpostlanguage}]] // { arity: 1 }
               Distinct project=[#0{rootpostlanguage}] // { arity: 1 }


### PR DESCRIPTION
We recently learned to incorporate nullability information from types into `Equivalences`, automatically. This had a curious outcome, which is that `Join` terms would inherit this information presented as constraints, essentially adding the constraints that various columns and expressions and such be non-null. This was largely fine, because we prune away redundant constraints in subsequent passes, ... unless we don't. Some of the conclusions were too clever for our clean-up pass, which doesn't reason as deeply as `Equivalences`.

The fix is to make sure the nullability information is included early, which it is by virtue of the input equivalence classes containing the information, and to then reduce the join equivalences in light of the input equivalences, and then *do not re-introduce the nullability information*. The join equivalences did have access to the information, and if it was removed in light of input equivalences, that means that the constraints are redundant. Set the column nullability of the types to "nullable" before minimizing the join equivalences, to avoid re-introducing the nullability information.

This removes some nullability filters that we introduced in https://github.com/MaterializeInc/materialize/pull/30506, which based on the changes here I strongly believe are logically redundant, even though it is hard for me to see the explanations. We could certainly work a bit harder to map out the explanation, and I could spot check a few, but the ones I did check (elsewhere in `ldbc`) matched the description above of introducing "redundant" constraints that we couldn't then remove.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
