### PR TITLE
tests: fix nightly tests after changes to stats reporting

### DIFF
--- a/test/cloudtest/test_disk.py
+++ b/test/cloudtest/test_disk.py
@@ -64,8 +64,8 @@ def test_disk_replica(mz: MaterializeApplication) -> None:
         "SELECT r.cluster_id, r.id as replica_id FROM mz_cluster_replicas r, mz_clusters c WHERE c.id = r.cluster_id AND c.name = 'testdrive_no_reset_disk_cluster1';"
     )[0]
 
-    source_global_id = mz.environmentd.sql_query(
-        "SELECT id FROM mz_sources WHERE name = 'source1';"
+    source_tbl_global_id = mz.environmentd.sql_query(
+        "SELECT id FROM mz_tables WHERE name = 'source1_tbl';"
     )[0][0]
 
     # verify that the replica's scratch directory contains data files for source1
@@ -79,7 +79,7 @@ def test_disk_replica(mz: MaterializeApplication) -> None:
         "-c",
         "ls /scratch/storage/upsert",
     )
-    assert source_global_id in on_disk_sources
+    assert source_tbl_global_id in on_disk_sources
 
 
 def test_always_use_disk_replica(mz: MaterializeApplication) -> None:
@@ -137,8 +137,8 @@ def test_always_use_disk_replica(mz: MaterializeApplication) -> None:
         "SELECT r.cluster_id, r.id as replica_id FROM mz_cluster_replicas r, mz_clusters c WHERE c.id = r.cluster_id AND c.name = 'disk_cluster2';"
     )[0]
 
-    source_global_id = mz.environmentd.sql_query(
-        "SELECT id FROM mz_sources WHERE name = 'source1';"
+    source_tbl_global_id = mz.environmentd.sql_query(
+        "SELECT id FROM mz_tables WHERE name = 'source1_tbl';"
     )[0][0]
 
     # verify that the replica's scratch directory contains data files for source1
@@ -152,7 +152,7 @@ def test_always_use_disk_replica(mz: MaterializeApplication) -> None:
         "-c",
         "ls /scratch/storage/upsert",
     )
-    assert source_global_id in on_disk_sources
+    assert source_tbl_global_id in on_disk_sources
 
 
 def test_no_disk_replica(mz: MaterializeApplication) -> None:


### PR DESCRIPTION
The changes were introduced in
https://github.com/MaterializeInc/materialize/pull/30533

I hope I got everything, will run a nightly now and fix anything else that comes up.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
