### PR TITLE
0dt: fix caught-up check for empty write frontiers

### DIFF
--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -327,7 +327,9 @@ impl Coordinator {
                 CollectionType::Storage => self.controller.storage.collection_hydrated(id)?,
             };
 
-            if within_lag && collection_hydrated {
+            // We don't expect collections to get hydrated, ingestions to be
+            // started, etc. when they are already at the empty write frontier.
+            if live_write_frontier.is_empty() || (within_lag && collection_hydrated) {
                 // This is a bit spammy, but log caught-up collections while we
                 // investigate why environments are cutting over but then a lot
                 // of compute collections are _not_ in fact hydrated on

--- a/test/cloudtest/test_disk.py
+++ b/test/cloudtest/test_disk.py
@@ -64,8 +64,8 @@ def test_disk_replica(mz: MaterializeApplication) -> None:
         "SELECT r.cluster_id, r.id as replica_id FROM mz_cluster_replicas r, mz_clusters c WHERE c.id = r.cluster_id AND c.name = 'testdrive_no_reset_disk_cluster1';"
     )[0]
 
-    source_global_id = mz.environmentd.sql_query(
-        "SELECT id FROM mz_sources WHERE name = 'source1';"
+    source_tbl_global_id = mz.environmentd.sql_query(
+        "SELECT id FROM mz_tables WHERE name = 'source1_tbl';"
     )[0][0]
 
     # verify that the replica's scratch directory contains data files for source1
@@ -79,7 +79,7 @@ def test_disk_replica(mz: MaterializeApplication) -> None:
         "-c",
         "ls /scratch/storage/upsert",
     )
-    assert source_global_id in on_disk_sources
+    assert source_tbl_global_id in on_disk_sources
 
 
 def test_always_use_disk_replica(mz: MaterializeApplication) -> None:
@@ -137,8 +137,8 @@ def test_always_use_disk_replica(mz: MaterializeApplication) -> None:
         "SELECT r.cluster_id, r.id as replica_id FROM mz_cluster_replicas r, mz_clusters c WHERE c.id = r.cluster_id AND c.name = 'disk_cluster2';"
     )[0]
 
-    source_global_id = mz.environmentd.sql_query(
-        "SELECT id FROM mz_sources WHERE name = 'source1';"
+    source_tbl_global_id = mz.environmentd.sql_query(
+        "SELECT id FROM mz_tables WHERE name = 'source1_tbl';"
     )[0][0]
 
     # verify that the replica's scratch directory contains data files for source1
@@ -152,7 +152,7 @@ def test_always_use_disk_replica(mz: MaterializeApplication) -> None:
         "-c",
         "ls /scratch/storage/upsert",
     )
-    assert source_global_id in on_disk_sources
+    assert source_tbl_global_id in on_disk_sources
 
 
 def test_no_disk_replica(mz: MaterializeApplication) -> None:


### PR DESCRIPTION
This fixes a problem that came from the combination of two changes:

- In https://github.com/MaterializeInc/materialize/pull/30518 we
introduced a hydration check for sources
- In https://github.com/MaterializeInc/materialize/pull/30536 we
  introduced re-hydration of load-generator sources in read-only mode

Load-generator sources have a tendency to be finished, that is their
write frontier goes to `[]` (the empty antichain). In those cases,
storage will not render any ingestion dataflow and we would therefore
wait indefinitely for one to be hydrated.

The fix is to treat collections whose write frontier is the empty
antichain as caught up.

I stacked this on top of https://github.com/MaterializeInc/materialize/pull/30577, which fixes other nightly failures that other changes of mine introduced.

Also, what a doozy... :see_no_evil: logical merge skew with myself...

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
