### PR TITLE
[persist / adapter] PARTITION BY for tables

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1577,6 +1577,8 @@ impl_display_t!(CreateTableStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TableOptionName {
+    // The `PARTITION BY` option
+    PartitionBy,
     // The `RETAIN HISTORY` option
     RetainHistory,
     /// A special option to test that we do redact values.
@@ -1586,6 +1588,9 @@ pub enum TableOptionName {
 impl AstDisplay for TableOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
+            TableOptionName::PartitionBy => {
+                f.write_str("PARTITION BY");
+            }
             TableOptionName::RetainHistory => {
                 f.write_str("RETAIN HISTORY");
             }
@@ -1604,6 +1609,7 @@ impl WithOptionName for TableOptionName {
     /// on the conservative side and return `true`.
     fn redact_value(&self) -> bool {
         match self {
+            TableOptionName::PartitionBy => false,
             TableOptionName::RetainHistory => false,
             TableOptionName::RedactedTest => true,
         }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1637,6 +1637,8 @@ pub enum TableFromSourceOptionName {
     Details,
 
     IgnoreKeys,
+    /// Partition the given table by the provided columns.
+    PartitionBy,
 }
 
 impl AstDisplay for TableFromSourceOptionName {
@@ -1647,6 +1649,7 @@ impl AstDisplay for TableFromSourceOptionName {
             TableFromSourceOptionName::Timeline => "TIMELINE",
             TableFromSourceOptionName::Details => "DETAILS",
             TableFromSourceOptionName::IgnoreKeys => "IGNORE KEYS",
+            TableFromSourceOptionName::PartitionBy => "PARTITION BY",
         })
     }
 }
@@ -1664,7 +1667,8 @@ impl WithOptionName for TableFromSourceOptionName {
             | TableFromSourceOptionName::TextColumns
             | TableFromSourceOptionName::ExcludeColumns
             | TableFromSourceOptionName::Timeline
-            | TableFromSourceOptionName::IgnoreKeys => false,
+            | TableFromSourceOptionName::IgnoreKeys
+            | TableFromSourceOptionName::PartitionBy => false,
         }
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4831,65 +4831,73 @@ impl<'a> Parser<'a> {
     fn parse_table_from_source_option(
         &mut self,
     ) -> Result<TableFromSourceOption<Raw>, ParserError> {
-        let option =
-            match self.expect_one_of_keywords(&[TEXT, EXCLUDE, IGNORE, DETAILS, TIMELINE])? {
-                ref keyword @ (TEXT | EXCLUDE) => {
-                    self.expect_keyword(COLUMNS)?;
+        let option = match self
+            .expect_one_of_keywords(&[TEXT, EXCLUDE, IGNORE, DETAILS, PARTITION, TIMELINE])?
+        {
+            ref keyword @ (TEXT | EXCLUDE) => {
+                self.expect_keyword(COLUMNS)?;
 
-                    let _ = self.consume_token(&Token::Eq);
+                let _ = self.consume_token(&Token::Eq);
 
-                    let value =
-                        self.parse_option_sequence(Parser::parse_identifier)?
-                            .map(|inner| {
-                                WithOptionValue::Sequence(
-                                    inner.into_iter().map(WithOptionValue::Ident).collect_vec(),
-                                )
-                            });
+                let value = self
+                    .parse_option_sequence(Parser::parse_identifier)?
+                    .map(|inner| {
+                        WithOptionValue::Sequence(
+                            inner.into_iter().map(WithOptionValue::Ident).collect_vec(),
+                        )
+                    });
 
-                    TableFromSourceOption {
-                        name: match *keyword {
-                            TEXT => TableFromSourceOptionName::TextColumns,
-                            EXCLUDE => TableFromSourceOptionName::ExcludeColumns,
-                            _ => unreachable!(),
-                        },
-                        value,
-                    }
+                TableFromSourceOption {
+                    name: match *keyword {
+                        TEXT => TableFromSourceOptionName::TextColumns,
+                        EXCLUDE => TableFromSourceOptionName::ExcludeColumns,
+                        _ => unreachable!(),
+                    },
+                    value,
                 }
-                DETAILS => TableFromSourceOption {
-                    name: TableFromSourceOptionName::Details,
-                    value: self.parse_optional_option_value()?,
-                },
-                IGNORE => {
-                    match self.expect_one_of_keywords(&[COLUMNS, KEYS])? {
-                        COLUMNS => {
-                            let _ = self.consume_token(&Token::Eq);
+            }
+            DETAILS => TableFromSourceOption {
+                name: TableFromSourceOptionName::Details,
+                value: self.parse_optional_option_value()?,
+            },
+            IGNORE => {
+                match self.expect_one_of_keywords(&[COLUMNS, KEYS])? {
+                    COLUMNS => {
+                        let _ = self.consume_token(&Token::Eq);
 
-                            let value = self.parse_option_sequence(Parser::parse_identifier)?.map(
-                                |inner| {
+                        let value =
+                            self.parse_option_sequence(Parser::parse_identifier)?
+                                .map(|inner| {
                                     WithOptionValue::Sequence(
                                         inner.into_iter().map(WithOptionValue::Ident).collect_vec(),
                                     )
-                                },
-                            );
-                            TableFromSourceOption {
-                                // IGNORE is historical syntax for this option.
-                                name: TableFromSourceOptionName::ExcludeColumns,
-                                value,
-                            }
+                                });
+                        TableFromSourceOption {
+                            // IGNORE is historical syntax for this option.
+                            name: TableFromSourceOptionName::ExcludeColumns,
+                            value,
                         }
-                        KEYS => TableFromSourceOption {
-                            name: TableFromSourceOptionName::IgnoreKeys,
-                            value: self.parse_optional_option_value()?,
-                        },
-                        _ => unreachable!(),
                     }
+                    KEYS => TableFromSourceOption {
+                        name: TableFromSourceOptionName::IgnoreKeys,
+                        value: self.parse_optional_option_value()?,
+                    },
+                    _ => unreachable!(),
                 }
-                TIMELINE => TableFromSourceOption {
-                    name: TableFromSourceOptionName::Timeline,
+            }
+            PARTITION => {
+                self.expect_keyword(BY)?;
+                TableFromSourceOption {
+                    name: TableFromSourceOptionName::PartitionBy,
                     value: self.parse_optional_option_value()?,
-                },
-                _ => unreachable!(),
-            };
+                }
+            }
+            TIMELINE => TableFromSourceOption {
+                name: TableFromSourceOptionName::Timeline,
+                value: self.parse_optional_option_value()?,
+            },
+            _ => unreachable!(),
+        };
         Ok(option)
     }
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -327,6 +327,14 @@ CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (IGNORE KEYS = 'true')
 CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("baz")])), with_options: [TableFromSourceOption { name: IgnoreKeys, value: Some(Value(String("true"))) }], include_metadata: [], format: None, envelope: None })
 
 parse-statement
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (PARTITION BY (a, b))
+----
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (PARTITION BY = (a, b))
+=>
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("baz")])), with_options: [TableFromSourceOption { name: PartitionBy, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a")])), UnresolvedItemName(UnresolvedItemName([Ident("b")]))])) }], include_metadata: [], format: None, envelope: None })
+
+
+parse-statement
 CREATE DATABASE IF EXISTS foo
 ----
 error: Expected NOT, found EXISTS

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -41,9 +41,23 @@ CREATE TABLE t (a int NOT NULL GARBAGE)
 parse-statement
 CREATE TABLE t (c int) WITH (foo = 'bar', a = 123)
 ----
-error: Expected RETAIN, found identifier "foo"
+error: Expected one of PARTITION or RETAIN, found identifier "foo"
 CREATE TABLE t (c int) WITH (foo = 'bar', a = 123)
                              ^
+
+parse-statement
+CREATE TABLE t (c int) WITH (PARTITION BY (c))
+----
+CREATE TABLE t (c int4) WITH (PARTITION BY = (c))
+=>
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false, with_options: [TableOption { name: PartitionBy, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("c")]))])) }] })
+
+parse-statement
+CREATE TABLE t (c int, d int) WITH (PARTITION BY = (c, d))
+----
+CREATE TABLE t (c int4, d int4) WITH (PARTITION BY = (c, d))
+=>
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("d"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false, with_options: [TableOption { name: PartitionBy, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("c")])), UnresolvedItemName(UnresolvedItemName([Ident("d")]))])) }] })
 
 parse-statement
 CREATE TABLE types_table (char_col char, bpchar_col bpchar, text_col text, bool_col boolean, date_col date, time_col time, timestamp_col timestamp, uuid_col uuid, double_col double precision);
@@ -1364,7 +1378,7 @@ CREATE TABLE public.customer (
         active integer NOT NULL
 ) WITH (fillfactor = 20, user_catalog_table = true, autovacuum_vacuum_threshold = 100)
 ----
-error: Expected RETAIN, found identifier "fillfactor"
+error: Expected one of PARTITION or RETAIN, found identifier "fillfactor"
 ) WITH (fillfactor = 20, user_catalog_table = true, autovacuum_vacuum_threshold = 100)
         ^
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1599,6 +1599,7 @@ generate_extracted_config!(
     TableFromSourceOption,
     (TextColumns, Vec::<Ident>, Default(vec![])),
     (ExcludeColumns, Vec::<Ident>, Default(vec![])),
+    (PartitionBy, Vec<Ident>),
     (Timeline, String),
     (IgnoreKeys, bool),
     (Details, String)
@@ -1630,6 +1631,7 @@ pub fn plan_create_table_from_source(
     let TableFromSourceOptionExtracted {
         text_columns,
         exclude_columns,
+        partition_by,
         details,
         timeline,
         ignore_keys,
@@ -1825,6 +1827,11 @@ pub fn plan_create_table_from_source(
         }
         Some(timeline) => Timeline::User(timeline),
     };
+
+    if let Some(partition_by) = partition_by {
+        scx.require_feature_flag(&ENABLE_COLLECTION_PARTITION_BY)?;
+        check_partition_by(&desc, partition_by)?;
+    }
 
     let data_source = DataSourceDesc::IngestionExport {
         ingestion_id,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -177,11 +177,12 @@ const MANAGED_REPLICA_PATTERN: std::sync::LazyLock<regex::Regex> =
 /// Given a relation desc and a column list, checks that:
 /// - the column list is a prefix of the desc;
 /// - all the listed columns are types that have meaningful Persist-level ordering.
-fn check_partition_by(desc: &RelationDesc, partition_by: &[ColumnName]) -> Result<(), PlanError> {
+fn check_partition_by(desc: &RelationDesc, partition_by: Vec<Ident>) -> Result<(), PlanError> {
     for (idx, ((desc_name, desc_type), partition_name)) in
-        desc.iter().zip(partition_by.iter()).enumerate()
+        desc.iter().zip(partition_by.into_iter()).enumerate()
     {
-        if desc_name != partition_name {
+        let partition_name = normalize::column_name(partition_name);
+        if *desc_name != partition_name {
             sql_bail!("PARTITION BY columns should be a prefix of the relation's columns (expected {desc_name} at index {idx}, got {partition_name})");
         }
         if !preserves_order(&desc_type.scalar_type) {
@@ -412,7 +413,7 @@ pub fn plan_create_table(
 
     let create_sql = normalize::create_statement(scx, Statement::CreateTable(stmt.clone()))?;
 
-    let options = plan_table_options(scx, with_options.clone())?;
+    let options = plan_table_options(scx, &desc, with_options.clone())?;
     let compaction_window = options.iter().find_map(|o| {
         #[allow(irrefutable_let_patterns)]
         if let crate::plan::TableOption::RetainHistory(lcw) = o {
@@ -2621,11 +2622,7 @@ pub fn plan_create_materialized_view(
 
     if let Some(partition_by) = partition_by {
         scx.require_feature_flag(&ENABLE_COLLECTION_PARTITION_BY)?;
-        let partition_by: Vec<_> = partition_by
-            .into_iter()
-            .map(normalize::column_name)
-            .collect();
-        check_partition_by(&desc, &partition_by)?;
+        check_partition_by(&desc, partition_by)?;
     }
 
     let refresh_schedule = {
@@ -5741,19 +5738,27 @@ fn plan_index_options(
 
 generate_extracted_config!(
     TableOption,
+    (PartitionBy, Vec<Ident>),
     (RetainHistory, OptionalDuration),
     (RedactedTest, String)
 );
 
 fn plan_table_options(
     scx: &StatementContext,
+    desc: &RelationDesc,
     with_opts: Vec<TableOption<Aug>>,
 ) -> Result<Vec<crate::plan::TableOption>, PlanError> {
     let TableOptionExtracted {
+        partition_by,
         retain_history,
         redacted_test,
         ..
     }: TableOptionExtracted = with_opts.try_into()?;
+
+    if let Some(partition_by) = partition_by {
+        scx.require_feature_flag(&ENABLE_COLLECTION_PARTITION_BY)?;
+        check_partition_by(desc, partition_by)?;
+    }
 
     if redacted_test.is_some() {
         scx.require_feature_flag(&vars::ENABLE_REDACTED_TEST_OPTION)?;

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1580,6 +1580,7 @@ async fn purify_create_table_from_source(
         exclude_columns,
         details,
         ignore_keys: _,
+        partition_by: _,
         timeline: _,
         seen: _,
     } = with_options.clone().try_into()?;

--- a/test/testdrive/partition-by.td
+++ b/test/testdrive/partition-by.td
@@ -7,11 +7,27 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-arg-default single-replica-cluster=quickstart
+
 # Tests for the new PARTITION BY syntax for persisted collections.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_create_table_from_source = true
+
+> CREATE SOURCE auction_house
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM LOAD GENERATOR AUCTION
+  FOR TABLES (accounts);
 
 # First, check that the flag is disabled by default.
 
 ! CREATE MATERIALIZED VIEW integers (n) WITH (PARTITION BY (n)) AS VALUES (3), (2), (1);
+contains:PARTITION BY
+
+! CREATE TABLE integers (n int) WITH (PARTITION BY (n));
+contains:PARTITION BY
+
+! CREATE TABLE bids FROM SOURCE auction_house (REFERENCE bids) WITH (PARTITION BY (id));
 contains:PARTITION BY
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
@@ -33,3 +49,26 @@ contains:PARTITION BY columns should be a prefix
 ! CREATE MATERIALIZED VIEW unsupported_type (n, m) WITH (PARTITION BY (n, m))
   AS VALUES (3, '[3]'::json), (2, '[2]'::json), (1, '[1]'::json);
 contains:PARTITION BY column m has unsupported type
+
+> CREATE TABLE integers_table (n int) WITH (PARTITION BY (n));
+
+> CREATE TABLE integers_strings_table (n int, m text) WITH (PARTITION BY (n, m));
+
+! CREATE TABLE out_of_order (n int, m text) WITH (PARTITION BY (m, n));
+contains:PARTITION BY columns should be a prefix
+
+! CREATE TABLE out_of_order (n int, m text) WITH (PARTITION BY (m));
+contains:PARTITION BY columns should be a prefix
+
+! CREATE TABLE unsupported_type (n int, m jsonb) WITH (PARTITION BY (n, m));
+contains:PARTITION BY column m has unsupported type
+
+> CREATE TABLE bids FROM SOURCE auction_house (REFERENCE bids) WITH (PARTITION BY (id));
+
+> CREATE TABLE bids_2 FROM SOURCE auction_house (REFERENCE bids) WITH (PARTITION BY (id, buyer));
+
+! CREATE TABLE out_of_order FROM SOURCE auction_house (REFERENCE bids) WITH (PARTITION BY (buyer, id));
+contains:PARTITION BY columns should be a prefix
+
+! CREATE TABLE out_of_order FROM SOURCE auction_house (REFERENCE bids) WITH (PARTITION BY (buyer));
+contains:PARTITION BY columns should be a prefix


### PR DESCRIPTION
Including "source tables". (But not subsources - I think the syntax there is less obvious, and IIUC they're already on their way out.)

### Motivation

Followup to https://github.com/MaterializeInc/materialize/pull/30355 -- see that PR for more details.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
