### PR TITLE
remove the --local-development flag from orchestratord

### DIFF
--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -127,7 +127,6 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.args.createConsole` |  | ``true`` |
 | `operator.args.environmentdConnectionRoleARN` |  | ``""`` |
 | `operator.args.environmentdIAMRoleARN` |  | ``""`` |
-| `operator.args.localDevelopment` |  | ``true`` |
 | `operator.args.region` |  | ``"kind"`` |
 | `operator.args.startupLogFilter` |  | ``"INFO,mz_orchestratord=TRACE"`` |
 | `operator.clusters.defaultSizes.analytics` |  | ``"25cc"`` |

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -51,9 +51,6 @@ spec:
         {{- if .Values.operator.args.environmentdConnectionRoleARN }}
         - "--environmentd-connection-role-arn={{ .Values.operator.args.environmentdConnectionRoleARN }}"
         {{- end }}
-        {{- if .Values.operator.args.localDevelopment }}
-        - "--local-development"
-        {{- end }}
         {{- if .Values.operator.args.createBalancers }}
         - "--create-balancers"
         {{- end }}

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -70,10 +70,10 @@ tests:
       storage.storageClass.name: ""
     asserts:
       - matchRegex:
-          path: spec.template.spec.containers[0].args[10]  # Index of the environmentd-cluster-replica-sizes argument
+          path: spec.template.spec.containers[0].args[9]  # Index of the environmentd-cluster-replica-sizes argument
           pattern: disk_limit":"0"
       - matchRegex:
-          path: spec.template.spec.containers[0].args[10]
+          path: spec.template.spec.containers[0].args[9]
           pattern: is_cc":true
 
   - it: should have a cluster with disk limit to 1552MiB when storage class is configured
@@ -81,8 +81,8 @@ tests:
       storage.storageClass.name: "my-storage-class"
     asserts:
       - matchRegex:
-          path: spec.template.spec.containers[0].args[10]
+          path: spec.template.spec.containers[0].args[9]
           pattern: disk_limit":"1552MiB"
       - matchRegex:
-          path: spec.template.spec.containers[0].args[10]
+          path: spec.template.spec.containers[0].args[9]
           pattern: is_cc":true

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -23,8 +23,6 @@ operator:
     cloudProvider: "local"
     # The region where the cluster is deployed (for this example, using Kind)
     region: "kind"
-    # Flag to indicate whether the environment is for local development
-    localDevelopment: true
     # Flag to indicate whether to create balancerd pods for the environments
     createBalancers: true
     # Flag to indicate whether to create console pods for the environments

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -35,8 +35,6 @@ pub struct Args {
     #[clap(long)]
     region: String,
     #[clap(long)]
-    local_development: bool,
-    #[clap(long)]
     create_balancers: bool,
     #[clap(long)]
     create_console: bool,

--- a/src/orchestratord/src/controller/materialize/console.rs
+++ b/src/orchestratord/src/controller/materialize/console.rs
@@ -258,22 +258,12 @@ fn create_console_service_object(config: &super::Args, mz: &Materialize) -> Serv
         ..Default::default()
     }];
 
-    let spec = if config.local_development {
-        ServiceSpec {
-            type_: Some("NodePort".to_string()),
-            selector: Some(selector),
-            ports: Some(ports),
-            external_traffic_policy: Some("Local".to_string()),
-            ..Default::default()
-        }
-    } else {
-        ServiceSpec {
-            type_: Some("ClusterIP".to_string()),
-            cluster_ip: Some("None".to_string()),
-            selector: Some(selector),
-            ports: Some(ports),
-            ..Default::default()
-        }
+    let spec = ServiceSpec {
+        type_: Some("ClusterIP".to_string()),
+        cluster_ip: Some("None".to_string()),
+        selector: Some(selector),
+        ports: Some(ports),
+        ..Default::default()
     };
 
     Service {

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -1208,6 +1208,13 @@ pub enum CloudProvider {
     Generic,
 }
 
+impl CloudProvider {
+    /// Returns true if this provider actually runs in the cloud
+    pub fn is_cloud(&self) -> bool {
+        matches!(self, Self::Aws | Self::Gcp | Self::Azure | Self::Generic)
+    }
+}
+
 impl fmt::Display for CloudProvider {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {


### PR DESCRIPTION
### Motivation

it adds complexity and doesn't really do anything useful

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
