### PR TITLE
Instance config with stricter offset is compatible

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -702,9 +702,9 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                     }
                     ComputeCommand::CreateInstance(config) => {
                         // Cluster creation should not be performed again!
-                        if Some(config) != old_instance_config {
+                        if old_instance_config.map_or(false, |old| !old.compatible_with(config)) {
                             halt!(
-                                "new instance configuration does not match existing instance configuration:\n{:?}\nvs\n{:?}",
+                                "new instance configuration not compatible with existing instance configuration:\n{:?}\nvs\n{:?}",
                                 config,
                                 old_instance_config,
                             );


### PR DESCRIPTION
Introduce InstanceConfig::compatible_with to check if two configurations
are compatible. Two configurations are considered compatible iff the
logging configuration is equal and the expiration offset of the other
configuration is stricter than or equal to the current one.

Addresses a concern with replica expiration that didn't allow us to
strengthen the value without risking replica restarts in case of envd
restarts. This doesn't solve the problem of relaxing the expiration, which
would still cause replica restarts -- there doesn't seem to be a good
alternative because the replicas aren't actually compatible.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
