### PR TITLE
default to not installing network policies

### DIFF
--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -113,11 +113,11 @@ The following table lists the configurable parameters of the Materialize operato
 | `namespace.create` |  | ``false`` |
 | `namespace.name` |  | ``"materialize"`` |
 | `networkPolicies.egress.cidrs[0]` |  | ``"0.0.0.0/0"`` |
-| `networkPolicies.egress.enabled` |  | ``true`` |
-| `networkPolicies.enabled` |  | ``true`` |
+| `networkPolicies.egress.enabled` |  | ``false`` |
+| `networkPolicies.enabled` |  | ``false`` |
 | `networkPolicies.ingress.cidrs[0]` |  | ``"0.0.0.0/0"`` |
-| `networkPolicies.ingress.enabled` |  | ``true`` |
-| `networkPolicies.internal.enabled` |  | ``true`` |
+| `networkPolicies.ingress.enabled` |  | ``false`` |
+| `networkPolicies.internal.enabled` |  | ``false`` |
 | `observability.enabled` |  | ``false`` |
 | `observability.prometheus.enabled` |  | ``false`` |
 | `operator.args.awsAccountID` |  | ``""`` |

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -215,19 +215,19 @@ observability:
 # Network policies configuration
 networkPolicies:
   # Whether to enable network policies for securing communication between pods
-  enabled: true
+  enabled: false
   # internal communication between Materialize pods
   internal:
-    enabled: true
+    enabled: false
   # ingress to the SQL and HTTP interfaces
   # on environmentd or balancerd
   ingress:
-    enabled: true
+    enabled: false
     cidrs:
       - 0.0.0.0/0
   # egress from Materialize pods to sources and sinks
   egress:
-    enabled: true
+    enabled: false
     cidrs:
       - 0.0.0.0/0
 


### PR DESCRIPTION
### Motivation

make things easier to install into an empty cluster - if the user needs to configure network policies, they'll know

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
