### PR TITLE
[persist] Switch the last Persist dynamic configs to dyncfg

### DIFF
--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -33,7 +33,7 @@ use tracing::{info, warn};
 
 use crate::async_runtime::IsolatedRuntime;
 use crate::cache::StateCache;
-use crate::cfg::all_dyncfgs;
+use crate::cfg::{all_dyncfgs, COMPACTION_MEMORY_BOUND_BYTES};
 use crate::cli::args::{make_blob, make_consensus, StateArgs, StoreArgs};
 use crate::cli::inspect::FAKE_OPAQUE_CODEC;
 use crate::internal::compact::{CompactConfig, CompactReq, Compactor};
@@ -131,10 +131,11 @@ pub async fn run(command: AdminArgs) -> Result<(), anyhow::Error> {
             let configs = all_dyncfgs(ConfigSet::default());
             // TODO: Fetch the latest values of these configs from Launch Darkly.
             let cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone(), configs);
-            if args.compaction_memory_bound_bytes > 0 {
-                cfg.dynamic
-                    .set_compaction_memory_bound_bytes(args.compaction_memory_bound_bytes);
-            }
+            cfg.set_config(
+                &COMPACTION_MEMORY_BOUND_BYTES,
+                args.compaction_memory_bound_bytes,
+            );
+
             let metrics_registry = MetricsRegistry::new();
             let expected_version = command
                 .expected_version

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -27,6 +27,8 @@ use tracing::{debug, debug_span, error, warn, Instrument, Span};
 
 use crate::async_runtime::IsolatedRuntime;
 use crate::batch::PartDeletes;
+use crate::cfg::GC_BLOB_DELETE_CONCURRENCY_LIMIT;
+
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::HashSet;
 use mz_persist::location::{Blob, SeqNo};
@@ -553,24 +555,15 @@ where
         F: FnMut(&Counter),
     {
         let shard_id = machine.shard_id();
-        let delete_semaphore = Semaphore::new(
-            machine
-                .applier
-                .cfg
-                .dynamic
-                .gc_blob_delete_concurrency_limit(),
-        );
+        let concurrency_limit = GC_BLOB_DELETE_CONCURRENCY_LIMIT.get(&machine.applier.cfg);
+        let delete_semaphore = Semaphore::new(concurrency_limit);
 
         let batch_parts = std::mem::take(batch_parts);
         batch_parts
             .delete(
                 machine.applier.state_versions.blob.borrow(),
                 shard_id,
-                machine
-                    .applier
-                    .cfg
-                    .dynamic
-                    .gc_blob_delete_concurrency_limit(),
+                concurrency_limit,
                 &*machine.applier.metrics,
                 &machine.applier.metrics.retries.external.batch_delete,
             )

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1421,6 +1421,7 @@ pub mod datadriven {
         validate_truncate_batch, Batch, BatchBuilder, BatchBuilderConfig, BatchBuilderInternal,
         BatchParts, BLOB_TARGET_SIZE, STRUCTURED_ORDER,
     };
+    use crate::cfg::COMPACTION_MEMORY_BOUND_BYTES;
     use crate::fetch::{Cursor, EncodedPart};
     use crate::internal::compact::{CompactConfig, CompactReq, Compactor};
     use crate::internal::datadriven::DirectiveArgs;
@@ -1986,7 +1987,7 @@ pub mod datadriven {
             cfg.set_config(&BLOB_TARGET_SIZE, target_size);
         };
         if let Some(memory_bound) = memory_bound {
-            cfg.dynamic.set_compaction_memory_bound_bytes(memory_bound);
+            cfg.set_config(&COMPACTION_MEMORY_BOUND_BYTES, memory_bound);
         }
         let req = CompactReq {
             shard_id: datadriven.shard_id,

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -31,6 +31,7 @@ use prost::Message;
 use timely::progress::Timestamp;
 use tracing::{debug, debug_span, trace, warn, Instrument};
 
+use crate::cfg::STATE_VERSIONS_RECENT_LIVE_DIFFS_LIMIT;
 use crate::error::{CodecMismatch, CodecMismatchT};
 use crate::internal::encoding::{Rollup, UntypedState};
 use crate::internal::machine::{retry_determinate, retry_external};
@@ -555,7 +556,7 @@ impl StateVersions {
         T: Timestamp + Lattice + Codec64,
     {
         let path = shard_id.to_string();
-        let scan_limit = self.cfg.dynamic.state_versions_recent_live_diffs_limit();
+        let scan_limit = STATE_VERSIONS_RECENT_LIVE_DIFFS_LIMIT.get(&self.cfg);
         let oldest_diffs =
             retry_external(&self.metrics.retries.external.fetch_state_scan, || async {
                 self.consensus

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -766,6 +766,7 @@ mod tests {
 
     use crate::batch::BLOB_TARGET_SIZE;
     use crate::cache::PersistClientCache;
+    use crate::cfg::BATCH_BUILDER_MAX_OUTSTANDING_PARTS;
     use crate::error::{CodecConcreteType, CodecMismatch, UpperMismatch};
     use crate::internal::paths::BlobKey;
     use crate::read::ListenEvent;
@@ -777,7 +778,9 @@ mod tests {
         // amount of coverage of that in tests. Similarly, for max_outstanding.
         let mut cache = PersistClientCache::new_no_metrics();
         cache.cfg.set_config(&BLOB_TARGET_SIZE, 10);
-        cache.cfg.dynamic.set_batch_builder_max_outstanding_parts(1);
+        cache
+            .cfg
+            .set_config(&BATCH_BUILDER_MAX_OUTSTANDING_PARTS, 1);
         dyncfgs.apply(cache.cfg());
 
         // Enable compaction in tests to ensure we get coverage.

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -40,7 +40,7 @@ use tracing::{debug_span, warn, Instrument};
 use uuid::Uuid;
 
 use crate::batch::{BLOB_TARGET_SIZE, STRUCTURED_ORDER, STRUCTURED_ORDER_UNTIL_SHARD};
-use crate::cfg::RetryParameters;
+use crate::cfg::{RetryParameters, COMPACTION_MEMORY_BOUND_BYTES};
 use crate::fetch::{fetch_leased_part, FetchBatchFilter, FetchedPart, Lease, LeasedBatchPart};
 use crate::internal::encoding::Schemas;
 use crate::internal::machine::{ExpireFn, Machine};
@@ -1076,7 +1076,7 @@ where
                 Arc::clone(&self.machine.applier.shard_metrics),
                 self.metrics.read.snapshot.clone(),
                 filter,
-                self.cfg.dynamic.compaction_memory_bound_bytes(),
+                COMPACTION_MEMORY_BOUND_BYTES.get(&self.cfg),
             );
             for batch in batches {
                 for (meta, run) in batch.runs() {
@@ -1107,7 +1107,7 @@ where
                 Arc::clone(&self.machine.applier.shard_metrics),
                 self.metrics.read.snapshot.clone(),
                 filter,
-                self.cfg.dynamic.compaction_memory_bound_bytes(),
+                COMPACTION_MEMORY_BOUND_BYTES.get(&self.cfg),
             );
             for batch in batches {
                 for (meta, run) in batch.runs() {


### PR DESCRIPTION
These weren't actually configurable without a code change!

### Motivation

Previously unreported: we wanted to tweak these during a recent escalation and found them disconnected.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
