### PR TITLE
limits: Bump limits up again

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -671,9 +671,7 @@ class TablesCommaJoinWithJoinCondition(Generator):
 
 
 class TablesCommaJoinWithCondition(Generator):
-    COUNT = min(
-        Generator.COUNT, 50
-    )  # TODO: Bump back to 100 when database-issues#8755 is fixed
+    COUNT = min(Generator.COUNT, 100)
 
     @classmethod
     def body(cls) -> None:
@@ -1314,9 +1312,7 @@ class FilterSubqueries(Generator):
     because of excessive memory allocations in the `RedundantJoin` transform.
     """
 
-    COUNT = min(
-        Generator.COUNT, 50
-    )  # TODO: Bump back to 100 when database-issues#8755 is fixed
+    COUNT = min(Generator.COUNT, 100)
 
     MAX_COUNT = 111  # Too long-running with count=200
 


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/10480#01935148-e8bb-4d83-b55c-53e17e0075fa

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
