### PR TITLE
SLT: Fix two test failures

### DIFF
--- a/test/sqllogictest/transform/fold_vs_dataflow/3_number_aggfns_dataflow.slt
+++ b/test/sqllogictest/transform/fold_vs_dataflow/3_number_aggfns_dataflow.slt
@@ -57,19 +57,27 @@ Explained Query:
     Project (#0..=#17, #24..=#29)
       Map ((#0 / bigint_to_real(case when (#18 = 0) then null else #18 end)), (#1 / bigint_to_double(case when (#19 = 0) then null else #19 end)), (#2 / bigint_to_numeric(case when (#20 = 0) then null else #20 end)), (#3 / bigint_to_real(case when (#21 = 0) then null else #21 end)), (#4 / bigint_to_double(case when (#22 = 0) then null else #22 end)), (#5 / bigint_to_numeric(case when (#23 = 0) then null else #23 end)))
         Union
-          Get l0
+          Project (#12..=#17, #0..=#11, #18..=#23)
+            Get l1
           Map (null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, 0, 0, 0, 0, 0, 0)
             Union
               Negate
                 Project ()
-                  Get l0
+                  Get l1
               Constant
                 - ()
   With
+    cte l1 =
+      CrossJoin type=differential
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[min(#0), min(#1), min(#2), min((#0 + #0)), min((#1 + #1)), min((#2 + #2)), max(#0), max(#1), max(#2), max((#0 + #0)), max((#1 + #1)), max((#2 + #2))]
+            Get l0
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[sum(#0), sum(#1), sum(#2), sum((#0 + #0)), sum((#1 + #1)), sum((#2 + #2)), count(#0), count(#1), count(#2), count((#0 + #0)), count((#1 + #1)), count((#2 + #2))]
+            Get l0
     cte l0 =
-      Reduce aggregates=[sum(#0), sum(#1), sum(#2), sum((#0 + #0)), sum((#1 + #1)), sum((#2 + #2)), min(#0), min(#1), min(#2), min((#0 + #0)), min((#1 + #1)), min((#2 + #2)), max(#0), max(#1), max(#2), max((#0 + #0)), max((#1 + #1)), max((#2 + #2)), count(#0), count(#1), count(#2), count((#0 + #0)), count((#1 + #1)), count((#2 + #2))]
-        Project (#0..=#2)
-          ReadStorage materialize.public.t_using_dataflow_rendering
+      Project (#0..=#2)
+        ReadStorage materialize.public.t_using_dataflow_rendering
 
 Source materialize.public.t_using_dataflow_rendering
 


### PR DESCRIPTION
This might have changed in https://github.com/MaterializeInc/materialize/pull/17013 or https://github.com/MaterializeInc/materialize/pull/30583
Seen failing in https://buildkite.com/materialize/slt/builds/6101
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
