### PR TITLE
feature-benchmark: Increase scale of fast scenarios, reduce retries

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -650,6 +650,7 @@ steps:
               --scenario=KafkaUpsertUnique,
               --other-tag=common-ancestor,
               --ignore-other-tag-missing,
+              --scale=-1
             ]
     coverage: skip
     agents:

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -103,6 +103,11 @@ true
 class FastPathFilterIndex(FastPath):
     """Measure the time it takes for the fast path to filter our all rows from a materialized view using an index and return"""
 
+    SCALE = 7
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
+
     def init(self) -> list[Action]:
         return [
             self.table_ten(),
@@ -149,6 +154,11 @@ true
 class FastPathOrderByLimit(FastPath):
     """Benchmark the case SELECT * FROM materialized_view ORDER BY <key> LIMIT <i>"""
 
+    SCALE = 7
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
+
     def init(self) -> list[Action]:
         return [
             self.table_ten(),
@@ -179,6 +189,11 @@ true
 
 class FastPathLimit(FastPath):
     """Benchmark the case SELECT * FROM source LIMIT <i> , optimized by materialize#21615"""
+
+    SCALE = 7
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
 
     def init(self) -> list[Action]:
         return [
@@ -212,6 +227,11 @@ class DML(Scenario):
 
 class Insert(DML):
     """Measure the time it takes for an INSERT statement to return."""
+
+    SCALE = 7
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
 
     def init(self) -> Action:
         return self.table_ten()
@@ -314,11 +334,17 @@ class InsertMultiRow(DML):
 class Update(DML):
     """Measure the time it takes for an UPDATE statement to return to client"""
 
+    SCALE = 6  # TODO: Increase scale when database-issues#8766 is fixed
+
     def init(self) -> list[Action]:
         return [
             self.table_ten(),
             TdAction(
                 f"""
+$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET max_result_size = 17179869184;
+
 > CREATE TABLE t1 (f1 BIGINT);
 
 > CREATE DEFAULT INDEX ON t1;
@@ -424,6 +450,11 @@ class InsertAndSelect(DML):
     dataflow to be completely caught up.
     """
 
+    SCALE = 7
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
+
     def init(self) -> Action:
         return self.table_ten()
 
@@ -489,6 +520,11 @@ true
 
 
 class CountDistinct(Dataflow):
+    SCALE = 7
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
+
     def init(self) -> list[Action]:
         return [
             self.view_ten(),
@@ -517,6 +553,11 @@ true
 
 
 class MinMax(Dataflow):
+    SCALE = 7
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
+
     def init(self) -> list[Action]:
         return [
             self.view_ten(),
@@ -641,6 +682,11 @@ true
 
 
 class CrossJoin(Dataflow):
+    SCALE = 7
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
+
     def init(self) -> Action:
         return self.view_ten()
 
@@ -778,11 +824,20 @@ class CreateIndex(Dataflow):
     it takes for a SELECT query that would use the index to return rows.
     """
 
+    SCALE = 7
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
+
     def init(self) -> list[Action]:
         return [
             self.table_ten(),
             TdAction(
                 f"""
+$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET max_result_size = 17179869184;
+
 > CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
 > INSERT INTO t1 (f1) SELECT {self.unique_values()} FROM {self.join()}
 
@@ -813,6 +868,11 @@ class CreateIndex(Dataflow):
 
 
 class DeltaJoin(Dataflow):
+    SCALE = 7
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
+
     def init(self) -> list[Action]:
         return [
             self.view_ten(),
@@ -843,6 +903,11 @@ class DeltaJoinMaintained(Dataflow):
     empty frontier is not emitted, in contrast with one-shot SELECT processing based on data
     initialized as a constant view"""
 
+    SCALE = 7
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
+
     def init(self) -> list[Action]:
         return [
             self.table_ten(),
@@ -872,6 +937,11 @@ class DeltaJoinMaintained(Dataflow):
 
 
 class DifferentialJoin(Dataflow):
+    SCALE = 7
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
+
     def init(self) -> list[Action]:
         return [
             self.view_ten(),
@@ -942,6 +1012,11 @@ class Finish(Scenario):
 
 class FinishOrderByLimit(Finish):
     """Benchmark ORDER BY + LIMIT without the benefit of an index"""
+
+    SCALE = 7
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
 
     def init(self) -> list[Action]:
         return [
@@ -1014,6 +1089,11 @@ true
 
 
 class KafkaUpsert(Kafka):
+    SCALE = 7
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
+
     def shared(self) -> Action:
         return TdAction(
             self.keyschema()
@@ -1062,6 +1142,11 @@ $ kafka-ingest format=avro topic=kafka-upsert key-format=avro key-schema=${{keys
 
 
 class KafkaUpsertUnique(Kafka):
+    SCALE = 7
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
+
     def shared(self) -> Action:
         return TdAction(
             self.keyschema()
@@ -1563,7 +1648,10 @@ ALTER TABLE pk_table REPLICA IDENTITY FULL;
 class PgCdcStreaming(PgCdc):
     """Measure the time it takes to ingest records from Postgres post-snapshot"""
 
-    SCALE = 5
+    SCALE = 6
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
 
     def shared(self) -> Action:
         return TdAction(
@@ -1782,8 +1870,12 @@ class Coordinator(Scenario):
 
 
 class QueryLatency(Coordinator):
-    SCALE = 3
     """Measure the time it takes to run SELECT 1 queries"""
+
+    SCALE = 4
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
 
     def benchmark(self) -> MeasurementSource:
         selects = "\n".join("> SELECT 1\n1\n" for i in range(0, self.n()))

--- a/misc/python/materialize/feature_benchmark/scenarios/scale.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/scale.py
@@ -10,14 +10,17 @@
 from textwrap import dedent
 
 from materialize.feature_benchmark.measurement_source import MeasurementSource, Td
-from materialize.feature_benchmark.scenario import Scenario
+from materialize.feature_benchmark.scenario import Scenario, ScenarioVersion
 
 
 class SmallClusters(Scenario):
     """Materialized views across many small clusters."""
 
-    SCALE = 1.5  # 32 clusters
+    SCALE = 1.7  # 50 clusters
     FIXED_SCALE = True
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
 
     def benchmark(self) -> MeasurementSource:
         create = "\n".join(


### PR DESCRIPTION
For context see https://materializeinc.slack.com/archives/C0761MZ3QD9/p1732280715336919

Successful nightly: https://buildkite.com/materialize/nightly/builds/10501
Release qualification with known regression: https://buildkite.com/materialize/release-qualification/builds/688

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
