### PR TITLE
Revert "builds: Switch to line-tables-only, even for tagged builds"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -158,12 +158,12 @@ build:release-lto --copt=-flto=thin
 build:release-lto --linkopt=-flto=thin
 build:release-lto --@rules_rust//:extra_rustc_flag=-Clto=thin
 
-# Tagged builds, will be used as releases.
+# Builds from `main` or tagged builds.
 #
-# Note: Not adding full debuginfo, even in release builds, to keep binary sizes
-# more reasonable.
-build:release-tagged --config=release --config=release-lto --config=release-stamp --config=debuginfo-limited
-# Builds in CI, both in PRs and on main, but without tags.
+# Note: We don't use a ramdisk for tagged builds because the full debuginfo is
+# too large and we OOD/OOM.
+build:release-tagged --config=release --config=release-lto --config=release-stamp --config=debuginfo-full
+# PRs in CI.
 #
 # Not doing a full stamp nor omitting full debug info, greatly speeds up compile times.
 build:release-dev --config=release --config=release-lto --config=debuginfo-limited

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,8 +257,14 @@ rustc-demangle = { opt-level = 3 }
 # Compile time seems similar to "lto = false", runtime ~10% faster
 lto = "thin"
 
-# Emit limited debug info for smaller binaries
-debug = "line-tables-only"
+# Emit full debug info, allowing us to easily analyze core dumps from
+# staging (and, in an emergency, also prod).
+#
+# This does not negatively impact the sizes of the main binaries
+# (clusterd and environmentd), since we split the debuginfo from those
+# and ship it separately to an s3 bucket before building their
+# docker containers.
+debug = 2
 
 # IMPORTANT: when patching a dependency, you should only depend on "main",
 # "master", or an upstream release branch (e.g., "v7.x"). Do *not* depend on a


### PR DESCRIPTION
This reverts commit 933ddba7314c5dc9493e9ab7087abfa80eacc7b8.

This is not great for debugging, see https://materializeinc.slack.com/archives/C049UQ3RSF4/p1732282239435699

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
