### PR TITLE
product limits test: Some further timeouts

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1256,6 +1256,8 @@ class Coalesce(Generator):
 
 
 class Concat(Generator):
+    MAX_COUNT = 250_000  # Too long-running with 500_000
+
     @classmethod
     def body(cls) -> None:
         print("> CREATE TABLE t (f STRING)")
@@ -1384,6 +1386,8 @@ class RowsAggregate(Generator):
 
 class RowsOrderByLimit(Generator):
     COUNT = 10_000_000
+
+    MAX_COUNT = 80_000_000  # Too long-running with 160_000_000
 
     @classmethod
     def body(cls) -> None:


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/release-qualification/builds/682#_

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
