### PR TITLE
remove Drop impl for SystemParameterFrontend

### DIFF
--- a/src/adapter/src/config/frontend.rs
+++ b/src/adapter/src/config/frontend.rs
@@ -89,14 +89,6 @@ impl SystemParameterFrontend {
     }
 }
 
-impl Drop for SystemParameterFrontend {
-    fn drop(&mut self) {
-        tracing::info!("closing LaunchDarkly client");
-        self.ld_client.close();
-        tracing::info!("closed LaunchDarkly client");
-    }
-}
-
 fn ld_config(sync_config: &SystemParameterSyncConfig) -> ld::Config {
     ld::ConfigBuilder::new(&sync_config.ld_sdk_key)
         .event_processor(ld::EventProcessorBuilder::new().on_success({


### PR DESCRIPTION
### Motivation

we're seeing this timeout during environmentd startup in cloud sometimes and it doesn't seem to be all that useful

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
