### PR TITLE
Replace `ColumnKnowledge` with `EquivalencePropagation`

### DIFF
--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -629,11 +629,6 @@ impl Optimizer {
                     // Predicate pushdown sets the equivalence classes of joins.
                     Box::new(PredicatePushdown::default()),
                     Box::new(EquivalencePropagation::default()),
-                    // Lifts the information `col = literal`
-                    // TODO (database-issues#2062): this also tries to lift `!isnull(col)` but
-                    // less well than the previous transform. Eliminate
-                    // redundancy between the two transforms.
-                    Box::new(ColumnKnowledge::default()),
                     // Lifts the information `col1 = col2`
                     Box::new(Demand::default()),
                     Box::new(FuseAndCollapse::default()),
@@ -718,7 +713,7 @@ impl Optimizer {
                 name: "fixpoint_physical_01",
                 limit: 100,
                 transforms: vec![
-                    Box::new(ColumnKnowledge::default()),
+                    Box::new(EquivalencePropagation::default()),
                     Box::new(fold_constants_fixpoint()),
                     Box::new(Demand::default()),
                     Box::new(LiteralLifting::default()),

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -60,6 +60,7 @@ use crate::will_distinct::WillDistinct;
 pub mod analysis;
 pub mod canonicalization;
 pub mod canonicalize_mfp;
+pub mod column_knowledge;
 pub mod compound;
 pub mod cse;
 pub mod dataflow;

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -60,7 +60,6 @@ use crate::will_distinct::WillDistinct;
 pub mod analysis;
 pub mod canonicalization;
 pub mod canonicalize_mfp;
-pub mod column_knowledge;
 pub mod compound;
 pub mod cse;
 pub mod dataflow;
@@ -616,7 +615,7 @@ impl Optimizer {
             // TODO: lift filters/maps to maximize ability to collapse
             // things down?
             Box::new(fuse_and_collapse_fixpoint()),
-            // 3. Needs to happen before ColumnKnowledge, LiteralLifting, EquivalencePropagation
+            // 3. Needs to happen before LiteralLifting, EquivalencePropagation
             // make (literal) filters look more complicated than what the NonNegative Analysis can
             // recognize.
             Box::new(ThresholdElision),
@@ -691,11 +690,11 @@ impl Optimizer {
             // - Currently, JoinImplementation can't be before LiteralLifting because the latter
             //   sometimes creates `Unimplemented` joins (despite LiteralLifting already having been
             //   run in the logical optimizer).
-            // - Not running ColumnKnowledge in the same fixpoint loop with JoinImplementation
+            // - Not running EquivalencePropagation in the same fixpoint loop with JoinImplementation
             //   is slightly hurting our plans. However, I'd say we should fix these problems by
-            //   making ColumnKnowledge (and/or JoinImplementation) smarter (database-issues#5289), rather than
+            //   making EquivalencePropagation (and/or JoinImplementation) smarter (database-issues#5289), rather than
             //   having them in the same fixpoint loop. If they would be in the same fixpoint loop,
-            //   then we either run the risk of ColumnKnowledge invalidating a join plan (database-issues#5260),
+            //   then we either run the risk of EquivalencePropagation invalidating a join plan (database-issues#5260),
             //   or we would have to run JoinImplementation an unbounded number of times, which is
             //   also not good database-issues#4639.
             //   (The same is true for FoldConstants, Demand, and LiteralLifting to a lesser

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -266,8 +266,8 @@ mod tests {
         // transforms?
         match name {
             "CanonicalizeMfp" => Ok(Box::new(mz_transform::canonicalize_mfp::CanonicalizeMfp)),
-            "ColumnKnowledge" => Ok(Box::new(
-                mz_transform::column_knowledge::ColumnKnowledge::default(),
+            "EquivalencePropagation" => Ok(Box::new(
+                mz_transform::equivalence_propagation::EquivalencePropagation::default(),
             )),
             "Demand" => Ok(Box::new(mz_transform::demand::Demand::default())),
             "Fusion" => Ok(Box::new(mz_transform::fusion::Fusion)),

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -257,7 +257,9 @@ fn apply_transform<T: mz_transform::Transform>(
     // Parse the relation, returning early on parse error.
     let mut relation = try_parse_mir(catalog, input)?;
 
-    let features = mz_repr::optimize::OptimizerFeatures::default();
+    let mut features = mz_repr::optimize::OptimizerFeatures::default();
+    // Apply a non-default feature flag to test the right implementation.
+    features.enable_letrec_fixpoint_analysis = true;
     let typecheck_ctx = mz_transform::typecheck::empty_context();
     let mut df_meta = DataflowMetainfo::default();
     let mut transform_ctx =

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -158,9 +158,9 @@ fn handle_apply(
             let transform = ANF::default();
             apply_transform(transform, catalog, input)
         }
-        "column_knowledge" => {
-            use mz_transform::column_knowledge::ColumnKnowledge;
-            let transform = ColumnKnowledge::default();
+        "equivalence_propagation" => {
+            use mz_transform::equivalence_propagation::EquivalencePropagation;
+            let transform = EquivalencePropagation::default();
             apply_transform(transform, catalog, input)
         }
         "flatmap_to_map" => {

--- a/src/transform/tests/test_transforms/column_knowledge.spec
+++ b/src/transform/tests/test_transforms/column_knowledge.spec
@@ -46,7 +46,7 @@ Source defined as t3
 
 # Infer and apply constant value knowledge.
 # Cases: Map, FlatMap, Filter, Project, Reduce, Let/Get.
-apply pipeline=column_knowledge
+apply pipeline=equivalence_propagation
 Return
   FlatMap generate_series(#1, #0 + 3, 1)
     Project (#2, #0)
@@ -78,7 +78,7 @@ With
 # Cases: Map, Filter, Project, Reduce, Let/Get.
 # TODO: The type of `(#1) IS NULL` in the map is `BOOLEAN NOT NULL`,
 #       so the first group_by key component should be reduced to `false`.
-apply pipeline=column_knowledge
+apply pipeline=equivalence_propagation
 Return
   Filter (#0) IS NULL
     Project (#2)
@@ -104,7 +104,7 @@ With
 
 # Infer and apply constant value knowledge.
 # Cases: Union.
-apply pipeline=column_knowledge
+apply pipeline=equivalence_propagation
 Return
   Filter #1 > 1 AND #2 IS NULL
     Union
@@ -138,7 +138,7 @@ With
 
 # Infer and apply constant value knowledge.
 # Cases: Join.
-apply pipeline=column_knowledge
+apply pipeline=equivalence_propagation
 Return
   Map (#0 + #1 + #2, #2 * #3)
     Join on=((#0 + #1) = #2)
@@ -162,7 +162,7 @@ With
 
 # Apply knowledge to TopK limit
 # Cases: TopK.
-apply pipeline=column_knowledge
+apply pipeline=equivalence_propagation
 TopK group_by=[#0] order_by=[#1 asc nulls_first] limit=(#1 + 2) offset=1
   Filter (#1 = 5)
     Get t0
@@ -177,7 +177,7 @@ TopK group_by=[#0] order_by=[#1 asc nulls_first] limit=7 offset=1
 
 
 # Single binding, value knowledge
-apply pipeline=column_knowledge
+apply pipeline=equivalence_propagation
 Return
   Project (#0, #1, #3, #4, #5, #6)
     Map ((#0) IS NULL, (#0) IS NULL, (#2) IS NULL)
@@ -228,7 +228,7 @@ With
 
 
 # Single binding, value knowledge
-apply pipeline=column_knowledge
+apply pipeline=equivalence_propagation
 Return
   Map (#0 + #1)
     Get l0
@@ -253,7 +253,7 @@ With Mutually Recursive
 
 
 # Single binding, NOT NULL knowledge
-apply pipeline=column_knowledge
+apply pipeline=equivalence_propagation
 Return
   Map (#1 IS NOT NULL)
     Get l0
@@ -278,7 +278,7 @@ With Mutually Recursive
 
 
 # Multiple bindings, value knowledge
-apply pipeline=column_knowledge
+apply pipeline=equivalence_propagation
 Return
   Get l1
 With Mutually Recursive
@@ -325,7 +325,7 @@ With Mutually Recursive
 #
 # This also illustrates a missed opportunity here, because if we are a bit
 # smarter we will know that l1 can only have 'false' in its first component.
-apply pipeline=column_knowledge
+apply pipeline=equivalence_propagation
 Return
   Get l1
 With Mutually Recursive
@@ -369,7 +369,7 @@ With Mutually Recursive
 
 
 # # TODO
-# apply pipeline=column_knowledge
+# apply pipeline=equivalence_propagation
 # Return
 #   Map (#0 + #1)
 #     Get l1

--- a/src/transform/tests/test_transforms/column_knowledge.spec
+++ b/src/transform/tests/test_transforms/column_knowledge.spec
@@ -198,7 +198,7 @@ With
 ----
 Return
   Project (#0, #1, #3..=#6)
-    Map ((#0) IS NULL, (#0) IS NULL, (#2) IS NULL)
+    Map ((#0) IS NULL, #4, (#2) IS NULL)
       Union
         Map (null, null)
           Union

--- a/src/transform/tests/test_transforms/column_knowledge.spec
+++ b/src/transform/tests/test_transforms/column_knowledge.spec
@@ -69,9 +69,7 @@ With
     Filter false
       Reduce group_by=[2] aggregates=[sum(3), max(4)]
         Filter true AND false
-          Map (3)
-            Filter (#0 = 1) AND (#1 = 2)
-              Get t0
+          Constant <empty>
 
 
 # Infer and apply nullability knowledge.
@@ -96,10 +94,10 @@ Return
       Get l0
 With
   cte l0 =
-    Reduce group_by=[(#2) IS NULL, false] aggregates=[count(false)]
-      Map ((#1) IS NULL, false)
+    Reduce group_by=[false, false] aggregates=[count(false)]
+      Map (false, false)
         Filter false AND (#1) IS NULL
-          Get t0
+          Constant <empty>
 
 
 # Infer and apply constant value knowledge.
@@ -122,9 +120,7 @@ With
 ----
 Return
   Filter true AND false
-    Union
-      Get l0
-      Get l1
+    Constant <empty>
 With
   cte l1 =
     Project (#0, #0, #1)
@@ -225,6 +221,30 @@ With
 
 ## LetRec cases
 ## ------------
+
+# Single binding, value knowledge
+apply pipeline=equivalence_propagation
+Return
+  Get l0
+With Mutually Recursive
+  cte l0 = // { types: "(bigint)" }
+    Distinct project=[#0]
+      Union
+        Constant // { types: "(bigint)" }
+          - (1)
+        Filter (#0 = 1)
+          Get l0
+----
+Return
+  Get l0
+With Mutually Recursive
+  cte l0 =
+    Distinct project=[1]
+      Union
+        Constant
+          - (1)
+        Filter true
+          Get l0
 
 
 # Single binding, value knowledge

--- a/test/sqllogictest/advent-of-code/2023/aoc_1219.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1219.slt
@@ -394,7 +394,7 @@ Explained Query:
                     Get l0
     cte l0 =
       Project (#0, #2, #6..=#9)
-        Map (array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2)), substr(#3, 2, 1), ((#4 = "<") OR (#4 = ">")), case when #5 then substr(#3, 1, 1) else "x" end, case when #5 then substr(#3, 2, 1) else ">" end, case when #5 then text_to_integer(array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 1)) else 0 end, case when #5 then array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 2) else #3 end)
+        Map (array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2)), substr(#3, 2, 1), ((#4 = "<") OR (#4 = ">")), case when #5 then substr(#3, 1, 1) else "x" end, case when #5 then #4 else ">" end, case when #5 then text_to_integer(array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 1)) else 0 end, case when #5 then array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 2) else #3 end)
           FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#1) array_length 1), 1)
             Project (#3, #4)
               Filter (#3) IS NOT NULL

--- a/test/sqllogictest/record.slt
+++ b/test/sqllogictest/record.slt
@@ -30,8 +30,8 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT record, (record).f2 FROM (SELECT ROW(a, a) AS record FROM t1);
 ----
 Explained Query:
-  Project (#2, #3) // { arity: 2 }
-    Map (row(#0, #0), record_get[1](#2)) // { arity: 4 }
+  Project (#2, #0) // { arity: 2 }
+    Map (row(#0, #0)) // { arity: 3 }
       ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -13,7 +13,7 @@ ALTER SYSTEM SET enable_table_keys = true
 COMPLETE 0
 
 #
-# Test various cases of column knowledge propagation
+# Test various cases of equivalence propagation
 #
 
 mode cockroach
@@ -595,25 +595,6 @@ Target cluster: quickstart
 
 EOF
 
-statement ok
-CREATE TABLE json_table(data JSONB);
-
-# Include map prefix in the `column_types` passed to `column_knowledge::optimize` (https://github.com/MaterializeInc/database-issues/issues/4460)
-
-query T multiline
-EXPLAIN WITH(arity, types) SELECT COALESCE(field, '') FROM (SELECT data->>'field' AS field FROM json_table);
-----
-Explained Query:
-  Project (#1) // { arity: 1, types: "(text)" }
-    Map (coalesce((#0 ->> "field"), "")) // { arity: 2, types: "(jsonb?, text)" }
-      ReadStorage materialize.public.json_table // { arity: 1, types: "(jsonb?)" }
-
-Source materialize.public.json_table
-
-Target cluster: quickstart
-
-EOF
-
 # WITH MUTUALLY RECURSIVE support
 # -------------------------------
 
@@ -635,47 +616,6 @@ Explained Query:
     Map (8) // { arity: 3, types: "(integer, integer, integer)" }
       Get l0 // { arity: 2, types: "(integer, integer)" }
   With Mutually Recursive
-    cte l0 =
-      Map (3, 5) // { arity: 2, types: "(integer, integer)" }
-        Distinct project=[] // { arity: 0, types: "()" }
-          Union // { arity: 0, types: "()" }
-            Project () // { arity: 0, types: "()" }
-              Filter (#0 = 3) AND (#1 = 5) // { arity: 2, types: "(integer, integer)" }
-                ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
-            Project () // { arity: 0, types: "()" }
-              Get l0 // { arity: 2, types: "(integer, integer)" }
-
-Source materialize.public.t1
-  filter=((#0 = 3) AND (#1 = 5))
-
-Target cluster: quickstart
-
-EOF
-
-# Give up when reaching RECURSION LIMIT
-# Same as the previous query, but with RECURSION LIMIT 1.
-# As of materialize#27389 this does not give up after the recursion limit,
-# as doing so is not necessary for equivalence propagation.
-# Issue database-issues#8294 tracks tests that may not be serving their intended
-# purpose; perhaps we can remove the test if we remove the
-# column_knowledge transform.
-query T multiline
-EXPLAIN WITH(arity, types)
-WITH MUTUALLY RECURSIVE (RECURSION LIMIT 1)
-  c0(f1 integer, f2 integer) AS (
-    SELECT * FROM (
-      SELECT * FROM t1
-      UNION
-      SELECT * FROM c0
-    ) WHERE f1 = 3 AND f2 = 5
-  )
-SELECT f1, f2, f1 + f2 FROM c0;
-----
-Explained Query:
-  Return // { arity: 3, types: "(integer, integer, integer)" }
-    Map (8) // { arity: 3, types: "(integer, integer, integer)" }
-      Get l0 // { arity: 2, types: "(integer, integer)" }
-  With Mutually Recursive [recursion_limit=1]
     cte l0 =
       Map (3, 5) // { arity: 2, types: "(integer, integer)" }
         Distinct project=[] // { arity: 0, types: "()" }

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -98,7 +98,7 @@ NULL
 1
 3
 
-# Test that column knowledge can propagate across inputs of a join.
+# Test that equivalence propagation can propagate across inputs of a join.
 # no indexes other than the default foo(a,b) and bar(a,b)
 query T multiline
 EXPLAIN WITH(arity, join implementations) select * from (select * from foo where a = 1) filtered_foo, bar where filtered_foo.a = bar.a

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -783,7 +783,7 @@ WHERE
 2  l2  32
 3  l3  33
 
-# This is similar to the previous query, but it also tests that ColumnKnowledge and LiteralLifting don't mess up
+# This is similar to the previous query, but it also tests that EquivalencePropagation and LiteralLifting don't mess up
 # the IndexedFilter join.
 
 query T multiline
@@ -819,7 +819,7 @@ WHERE
 ----
 2  l2  32
 
-# ColumnKnowledge is being propagated from one join input to the other: even though the literal constraint mentions
+# EquivalencePropagation is being propagated from one join input to the other: even though the literal constraint mentions
 # only `t1`, the `t1.a = t2.a` join constraint allows us to propagate the literal constraint from `t1.a` to `t2.a`, and
 # then insert an IndexedFilter also for `t2.a`.
 # Note that the final join's key disappears: this is ok, it happens because we know that t1.a and t2.a are both 2, so


### PR DESCRIPTION
The `ColumnKnowledge` transform is largely dominated by `EquivalencePropagation`, to the extent that we now have no tests that observe the absence of `ColumnKnowledge` when replaced by `EquivalencePropagation`.

This PR has some additional tidying that we'll want (various references to this transform, and the file itself still included in the repo), but ideally we should be able to agree on the shape of that without much iteration.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
