### PR TITLE
ci: Move replica isolation to nightly

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1663,6 +1663,17 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: backup-restore-postgres
 
+  - id: replica-isolation
+    label: Replica isolation
+    depends_on: build-aarch64
+    timeout_in_minutes: 90
+    inputs: [test/replica-isolation]
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: replica-isolation
+    agents:
+      queue: hetzner-aarch64-4cpu-8gb
+
   - group: "Language tests"
     key: language-tests
     steps:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -657,18 +657,6 @@ steps:
 
   # Fast tests closer to the end, doesn't matter as much if they have to wait
   # for an agent
-  - id: replica-isolation
-    label: Replica isolation
-    depends_on: build-aarch64
-    timeout_in_minutes: 30
-    inputs: [test/replica-isolation]
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: replica-isolation
-    agents:
-      # Runs faster with larger agent
-      queue: hetzner-aarch64-8cpu-16gb
-
   - id: persistence
     label: Persistence tests
     depends_on: build-aarch64


### PR DESCRIPTION
Sometimes runs slowly, hasn't found issues recently

See for example https://buildkite.com/materialize/test/builds/95252#019357ee-9d4c-47df-8483-b7ddd4dc0d5c

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
