### PR TITLE
compute: fix RenderPlan's Arbitrary impl

### DIFF
--- a/src/compute-types/src/plan/render_plan.rs
+++ b/src/compute-types/src/plan/render_plan.rs
@@ -982,7 +982,10 @@ impl Arbitrary for RenderPlan {
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         any::<Plan>()
-            .prop_map(|x| RenderPlan::try_from(x).unwrap())
+            .prop_filter_map(
+                "`Plan`'s `Arbitrary` impl can generate invalid binding structure",
+                |x| RenderPlan::try_from(x).ok(),
+            )
             .boxed()
     }
 }


### PR DESCRIPTION
The `Arbitrary` impl of `Plan` can return plans with invalid binding structure, making the `Arbitrary` impl of `RenderPlan` panic. Filter out invalid `Plan`s instead.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8785

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
