### PR TITLE
Remove `ThresholdElision` from the end of the physical pass

### DIFF
--- a/test/sqllogictest/transform/threshold_elision.slt
+++ b/test/sqllogictest/transform/threshold_elision.slt
@@ -167,8 +167,6 @@ EOF
 
 # Complex example: EXCEPT ALL.
 # Here ThresholdElision can only match in after some prior simplifications
-# and for some reason (TBD later) this means that we need to run it at the
-# end of the physical pass.
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(non negative) FOR
 (
@@ -210,8 +208,6 @@ EOF
 
 # Complex example: EXCEPT.
 # Here ThresholdElision can only match in after some prior simplifications
-# and for some reason (TBD later) this means that we need to run it at the
-# end of the physical pass.
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(non negative) FOR
 (
@@ -540,6 +536,33 @@ Explained Query:
                 Get l0 // { non_negative: true }
 
 Source materialize.public.people
+
+Target cluster: quickstart
+
+EOF
+
+statement ok
+CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
+
+# Literal filter, which would be made unrecognizable by
+# ColumnKnowledge, LiteralLifting, EquivalencePropagation.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non negative) FOR
+SELECT f1 FROM t1 EXCEPT SELECT f1 FROM t1 WHERE f1 = 5;
+----
+Explained Query:
+  Union // { non_negative: false }
+    Distinct project=[#0] // { non_negative: true }
+      Project (#0) // { non_negative: true }
+        ReadStorage materialize.public.t1 // { non_negative: true }
+    Negate // { non_negative: false }
+      Map (5) // { non_negative: true }
+        Distinct project=[] // { non_negative: true }
+          Project () // { non_negative: true }
+            Filter (#0 = 5) // { non_negative: true }
+              ReadStorage materialize.public.t1 // { non_negative: true }
+
+Source materialize.public.t1
 
 Target cluster: quickstart
 


### PR DESCRIPTION
This PR removes the call to `ThresholdElision` that is at the end of the physical pass. Having that call there is not nice conceptually, because `ThresholdElision` is not really a physical optimization. Also, eventually we want to move `JoinImplementation` to the lowering, so we should try to reduce the number of transforms that run after it.

Fortunately, we can now simply remove this call without breaking anything. Presumably, some other part of the optimizer became more well-behaved since when `ThresholdElision` was placed at the end of the physical pass. I'm guessing that `fixpoint_logical_cleanup_pass_01` became more complete, so the plan already gets to a nicer form in that loop. As a specific example, I think `CanonicalizeMfp` was not called in that loop in those times when `ThresholdElision` was being introduced.

(2 calls to `ThresholdElision` remain after this PR. Both of these are needed, as shown by tests in `threshold_elision.slt`.)

### Motivation

   * This PR refactors existing code. https://github.com/MaterializeInc/database-issues/issues/8786

### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
