### PR TITLE
storage/kafka: use separate consumer for metadata probing

### DIFF
--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -28,6 +28,12 @@ def get_ancestor_overrides_for_performance_regressions(
 
     min_ancestor_mz_version_per_commit = dict()
 
+    if scenario_class_name in ("KafkaUpsertUnique", "ParallelIngestion"):
+        # PR#30617 (storage/kafka: use separate consumer for metadata probing)
+        # adds 1s of delay to Kafka source startup
+        min_ancestor_mz_version_per_commit[
+            "f316f8fde68e6fa1c90328d8868a0750c86bdcf4"
+        ] = MzVersion.parse_mz("v0.127.0")
     if scenario_class_name == "InsertMultiRow":
         # PR#30622 (Refactor how we run FoldConstants) increases wallclock
         min_ancestor_mz_version_per_commit[

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -324,7 +324,8 @@ impl SourceRender for KafkaSourceConnection {
                 let (stats_tx, stats_rx) = crossbeam_channel::unbounded();
                 let health_status = Arc::new(Mutex::new(Default::default()));
                 let notificator = Arc::new(Notify::new());
-                let consumer: Result<BaseConsumer<_>, _> = connection
+
+                let reader_consumer: Result<BaseConsumer<_>, _> = connection
                     .create_with_context(
                         &config.config,
                         GlueConsumerContext {
@@ -363,37 +364,63 @@ impl SourceRender for KafkaSourceConnection {
                     )
                     .await;
 
-                let consumer = match consumer {
-                    Ok(consumer) => Arc::new(consumer),
-                    Err(e) => {
-                        let update = HealthStatusUpdate::halting(
-                            format!(
-                                "failed creating kafka consumer: {}",
-                                e.display_with_causes()
-                            ),
-                            None,
-                        );
-                        for (output, update) in outputs.iter().repeat_clone(update) {
-                            health_output.give(
-                                &health_cap,
-                                HealthStatusMessage {
-                                    index: output.output_index,
-                                    namespace: if matches!(e, ContextCreationError::Ssh(_)) {
-                                        StatusNamespace::Ssh
-                                    } else {
-                                        Self::STATUS_NAMESPACE.clone()
-                                    },
-                                    update,
-                                },
+                // Consumers use a single connection to talk to the upstream, so if we'd use the
+                // same consumer in the reader and the metadata thread, metadata probes issued by
+                // the latter could be delayed by data fetches issued by the former. We avoid that
+                // by giving the metadata thread its own consumer.
+                let metadata_consumer: Result<BaseConsumer<_>, _> = connection
+                    .create_with_context(
+                        &config.config,
+                        MzClientContext::default(),
+                        &btreemap! {
+                            // Use the user-configured topic metadata refresh
+                            // interval.
+                            "topic.metadata.refresh.interval.ms" =>
+                                topic_metadata_refresh_interval
+                                .as_millis()
+                                .to_string(),
+                            // Allow Kafka monitoring tools to identify this
+                            // consumer.
+                            "client.id" => format!("{client_id}-metadata"),
+                        },
+                        InTask::Yes,
+                    )
+                    .await;
+
+                let (reader_consumer, metadata_consumer) =
+                    match (reader_consumer, metadata_consumer) {
+                        (Ok(r), Ok(m)) => (r, m),
+                        (Err(e), _) | (_, Err(e)) => {
+                            let update = HealthStatusUpdate::halting(
+                                format!(
+                                    "failed creating kafka consumer: {}",
+                                    e.display_with_causes()
+                                ),
+                                None,
                             );
+                            for (output, update) in outputs.iter().repeat_clone(update) {
+                                health_output.give(
+                                    &health_cap,
+                                    HealthStatusMessage {
+                                        index: output.output_index,
+                                        namespace: if matches!(e, ContextCreationError::Ssh(_)) {
+                                            StatusNamespace::Ssh
+                                        } else {
+                                            Self::STATUS_NAMESPACE.clone()
+                                        },
+                                        update,
+                                    },
+                                );
+                            }
+                            // IMPORTANT: wedge forever until the `SuspendAndRestart` is processed.
+                            // Returning would incorrectly present to the remap operator as progress to the
+                            // empty frontier which would be incorrectly recorded to the remap shard.
+                            std::future::pending::<()>().await;
+                            unreachable!("pending future never returns");
                         }
-                        // IMPORTANT: wedge forever until the `SuspendAndRestart` is processed.
-                        // Returning would incorrectly present to the remap operator as progress to the
-                        // empty frontier which would be incorrectly recorded to the remap shard.
-                        std::future::pending::<()>().await;
-                        unreachable!("pending future never returns");
-                    }
-                };
+                    };
+
+                let reader_consumer = Arc::new(reader_consumer);
 
                 // Note that we wait for this AFTER we downgrade to the source `resume_upper`. This
                 // allows downstream operators (namely, the `reclock_operator`) to downgrade to the
@@ -410,7 +437,6 @@ impl SourceRender for KafkaSourceConnection {
                 let metadata_thread_handle = {
                     let partition_info = Arc::downgrade(&partition_info);
                     let topic = topic.clone();
-                    let consumer = Arc::clone(&consumer);
 
                     // We want a fairly low ceiling on our polling frequency, since we rely
                     // on this heartbeat to determine the health of our Kafka connection.
@@ -439,7 +465,7 @@ impl SourceRender for KafkaSourceConnection {
                                 let probe_ts =
                                     mz_repr::Timestamp::try_from((now_fn)()).expect("must fit");
                                 let result = fetch_partition_info(
-                                    consumer.client(),
+                                    metadata_consumer.client(),
                                     &topic,
                                     config
                                         .config
@@ -479,7 +505,7 @@ impl SourceRender for KafkaSourceConnection {
                                         ));
 
                                         let ssh_status =
-                                            consumer.client().context().tunnel_status();
+                                            metadata_consumer.client().context().tunnel_status();
                                         let ssh_status = match ssh_status {
                                             SshTunnelStatus::Running => {
                                                 Some(HealthStatusUpdate::running())
@@ -516,7 +542,7 @@ impl SourceRender for KafkaSourceConnection {
                     source_name: config.name.clone(),
                     id: config.id,
                     partition_consumers: Vec::new(),
-                    consumer: Arc::clone(&consumer),
+                    consumer: Arc::clone(&reader_consumer),
                     worker_id: config.worker_id,
                     worker_count: config.worker_count,
                     last_offsets: outputs
@@ -540,7 +566,7 @@ impl SourceRender for KafkaSourceConnection {
                 let offset_committer = KafkaResumeUpperProcessor {
                     config: config.clone(),
                     topic_name: topic.clone(),
-                    consumer,
+                    consumer: reader_consumer,
                     progress_statistics: Arc::clone(&reader.progress_statistics),
                 };
 


### PR DESCRIPTION
In the Kafka source, give the metadata thread its own consumer so it doesn't get blocked by fetches concurrently performed by the reader thread.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8751

### Tips for reviewer

The diff is nicer with whitespace changes hidden.

There is a 1s regression in Kafka source startup time that's expected. See [this Slack thread](https://materializeinc.slack.com/archives/C0761MZ3QD9/p1732280715336919) for details.
The 1s regression can also cause larger regressions in our feature benchmarks, caused by load getting shifted into the measurement period where it was previously happening in the setup period. These are not actual regressions but artifacts of the way we measure runtime in the feature benchmarks. See [this Slack thread](https://materializeinc.slack.com/archives/C01LKF361MZ/p1732816474670379) for details.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
