### PR TITLE
0dt test: Unflake by waiting for sink to create kafka topic

### DIFF
--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -192,6 +192,8 @@ def workflow_read_only(c: Composition) -> None:
         > SELECT * FROM mysql_source_table;
         A 0
 
+        $ kafka-verify-topic sink=materialize.public.kafka_sink
+
         > CREATE SOURCE kafka_sink_source
           IN CLUSTER cluster
           FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-${{testdrive.seed}}')
@@ -478,6 +480,8 @@ def workflow_basic(c: Composition) -> None:
         > CREATE TABLE mysql_source_table FROM SOURCE mysql_source1 (REFERENCE public.mysql_source_table);
         > SELECT * FROM mysql_source_table;
         A 0
+
+        $ kafka-verify-topic sink=materialize.public.kafka_sink
 
         > CREATE SOURCE kafka_sink_source
           IN CLUSTER cluster


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/test/builds/95306#019363ab-7327-443e-9824-d431600db62f

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
