### PR TITLE
[persist] Fix regression in the batch-builder refactoring

### DIFF
--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -688,8 +688,8 @@ where
                 if same_order {
                     ordered_runs.push((desc, meta, run));
                 } else {
-                    // The downstream consolidation step will handle a length-N run that's not in
-                    // the desired order by splitting it up into N length-1 runs. This preserves
+                    // The downstream consolidation step will handle a long run that's not in
+                    // the desired order by splitting it up into many single-element runs. This preserves
                     // correctness, but it means that we may end up needing to iterate through
                     // many more parts concurrently than expected, increasing memory use. Instead,
                     // we break up those runs before they're grouped together to be passed to


### PR DESCRIPTION
When we added the hollow-run change recently to spill long run metadata to S3, we explicitly overrode it for unordered data... because we want to split up all unordered data into single-part runs. However, I also accidentally removed that override as part of a large refactoring last week. 😅 This triggered a known limitation in the compaction code, which wasn't prepared to run into hollow runs in an order that doesn't match the desired order.

This fixes the issue two ways: it restores the override, and it removes the limitation in the compaction code.

### Motivation

https://github.com/MaterializeInc/database-issues/issues/8766

### Tips for reviewer

I've tested that each of these commits is enough to make the repro in the linked issue succeed. I'll also get a full nightly run going on this branch...

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
