### PR TITLE
Refactor how we run `FoldConstants`

### DIFF
--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -524,9 +524,9 @@ impl Transform for FuseAndCollapse {
 }
 
 /// Run the [`FuseAndCollapse`] transforms in a fixpoint.
-pub fn fuse_and_collapse() -> Fixpoint {
+pub fn fuse_and_collapse_fixpoint() -> Fixpoint {
     Fixpoint {
-        name: "fuse_and_collapse",
+        name: "fuse_and_collapse_fixpoint",
         limit: 100,
         transforms: FuseAndCollapse::default().transforms,
     }
@@ -593,7 +593,7 @@ impl Optimizer {
             // 2. Collapse constants, joins, unions, and lets as much as possible.
             // TODO: lift filters/maps to maximize ability to collapse
             // things down?
-            Box::new(fuse_and_collapse()),
+            Box::new(fuse_and_collapse_fixpoint()),
             // 3. Needs to happen before ColumnKnowledge, LiteralLifting, EquivalencePropagation
             // make (literal) filters look more complicated than what the NonNegative Analysis can
             // recognize.

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -798,9 +798,6 @@ mod inlining {
                             &expr
                         };
                         match stripped_value {
-                            // TODO: One could imagine CSEing multiple occurrences of a global Get
-                            // to make us read from Persist only once.
-                            // See <https://github.com/MaterializeInc/database-issues/issues/6363>
                             MirRelationExpr::Get { .. } | MirRelationExpr::Constant { .. } => true,
                             _ => false,
                         }

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -540,8 +540,8 @@ EXPLAIN WITH(types, no fast path) SELECT 1 > ANY (VALUES(col_null)), 1 > ANY (VA
 ----
 Explained Query:
   Return // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
-    Project (#7, #4, #8, #9, #5, #6) // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
-      Map ((#0 > #1), (#1 > #0), (1 > #0), null, null) // { types: "(integer?, integer, integer?, integer, boolean, boolean?, boolean?, boolean?, boolean?, boolean?)" }
+    Project (#5, #4, #8, #9, #6, #7) // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
+      Map ((1 > #0), (#0 > #1), (#1 > #0), null, null) // { types: "(integer?, integer, integer?, integer, boolean, boolean?, boolean?, boolean?, boolean?, boolean?)" }
         Join on=(#0 = #2 AND #1 = #3) type=differential // { types: "(integer?, integer, integer?, integer, boolean)" }
           ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
             ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
@@ -572,8 +572,8 @@ EXPLAIN WITH(types, no fast path) SELECT 1 < ALL (VALUES(col_null)), 1 < ALL (VA
 ----
 Explained Query:
   Return // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
-    Project (#7..=#10, #5, #6) // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
-      Map ((#0 < #1), (#1 < #0), (1 < #0), NOT(#4), null, null) // { types: "(integer?, integer, integer?, integer, boolean, boolean?, boolean?, boolean?, boolean, boolean?, boolean?)" }
+    Project (#5, #8..=#10, #6, #7) // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
+      Map ((1 < #0), (#0 < #1), (#1 < #0), NOT(#4), null, null) // { types: "(integer?, integer, integer?, integer, boolean, boolean?, boolean?, boolean?, boolean, boolean?, boolean?)" }
         Join on=(#0 = #2 AND #1 = #3) type=differential // { types: "(integer?, integer, integer?, integer, boolean)" }
           ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
             ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }

--- a/test/sqllogictest/transform/fold_constants.slt
+++ b/test/sqllogictest/transform/fold_constants.slt
@@ -152,10 +152,10 @@ DROP TABLE t1;
 statement ok
 DROP TABLE t2;
 
-###
+# Window function tests
 # These tests were mostly copied (at some point) from `window_funcs.slt`, but here they have `WITH ... VALUES ...`, i.e.
 # constant inputs. These are good to have because constant folding is a different code path from the normal execution.
-###
+# ----------------------------------------------------------------------------------------------------------------------
 
 mode cockroach
 


### PR DESCRIPTION
This PR refactors how we run `FoldConstants` in the first commit, and then does some minor cleanups in subsequent commits. (It's best to review it commit-by-commit.)

As discussed in https://github.com/MaterializeInc/database-issues/issues/5346, the problem with the current way we call `FoldConstants` is that `FoldConstants` can't inline Lets, which can instead be done by `NormalizeLets`. Therefore, this PR's first commit creates a function that bundles together `FoldConstants` with `NormalizeLets` into a fixpoint loop, so they can alternate when needed, and thus run the constant folding to completion. This new function is now called every time where the old code used to just call `FoldConstants`.

Additionally, the PR also adds `ReduceScalars` in the same fixpoint loop, because that const-folds scalar expressions. (There was always a call to `ReduceScalars` immediately after `FoldConstants`, so this part is just a refactoring, where we make this "official".)

There is only a trivial slt change, but in the past I've seen chaos in optimizer traces several times, where constant folding happened in a haphazard way rather then running to completion at the first call. So, it was just a matter of luck that things somehow always worked out fine at the end even with the old code in all our slts.

Note that `fold_constants_fixpoint()` can be quadratic in the number of Lets in the worst case, but I think this is a smaller problem than things not getting const-folded all the way. (In the long term, we could consider changing `FoldConstants` itself, so that it can do Let inlining on the fly, and then we wouldn't need to alternate with `NormalizeLets`. But this is not a trivial thing, as evidenced by the complexity of the inlining code in `NormalizeLets`.)

### Motivation

   * This PR refactors existing code: https://github.com/MaterializeInc/database-issues/issues/5346

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
