### PR TITLE
bazel: Small tweak to disk cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -71,6 +71,7 @@ common --experimental_remote_merkle_tree_cache_size=5000
 common --bes_upload_mode=fully_async
 # Make sure any local disk cache stays within a reasonable size.
 common --experimental_disk_cache_gc_max_size=80G
+common --experimental_disk_cache_gc_max_age=14d
 
 # Tells `xz` to use all available cores.
 action_env=XZ_OPT=-T0

--- a/misc/bazel/README.md
+++ b/misc/bazel/README.md
@@ -85,9 +85,10 @@ common --local_resources=cpu="HOST_CPUS-1"
 # Define a shared disk cache so builds from different Materialize repos can share artifacts.
 build --disk_cache=~/.cache/bazel
 
-# Optional. The workspace RC already sets a max disk cache size, but you can override that if you
-# have more limited disk space.
+# Optional. The workspace RC already sets a max disk cache size, and artifact age
+# but you can override that if you have more limited disk space.
 common --experimental_disk_cache_gc_max_size=40G
+common --experimental_disk_cache_gc_max_age=7d
 ```
 
 ### Building a crate


### PR DESCRIPTION
Along with a max size for the disk cache (which already exists) this PR also sets a max age for local artifacts at 14 days.

### Motivation

Improve the Bazel experience

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
