### PR TITLE
adapter: refactor max connection handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5941,6 +5941,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "bytesize",
+ "derivative",
  "mz-ore",
  "mz-server-core",
  "tokio",

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -69,7 +69,7 @@ use mz_sql::plan::{Plan, PlanNotice, StatementDesc};
 use mz_sql::rbac;
 use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::user::{MZ_SYSTEM_ROLE_ID, SUPPORT_USER, SYSTEM_USER};
-use mz_sql::session::vars::{ConnectionCounter, SystemVars};
+use mz_sql::session::vars::SystemVars;
 use mz_sql_parser::ast::QualifiedReplica;
 use mz_storage_types::connections::inline::{ConnectionResolver, InlinedConnection};
 use mz_storage_types::connections::ConnectionContext;
@@ -627,7 +627,6 @@ impl Catalog {
         enable_expression_cache_override: Option<bool>,
     ) -> Result<Catalog, anyhow::Error> {
         let metrics_registry = &MetricsRegistry::new();
-        let active_connection_count = Arc::new(std::sync::Mutex::new(ConnectionCounter::new(0, 0)));
         let secrets_reader = Arc::new(InMemorySecretsController::new());
         // Used as a lower boundary of the boot_ts, but it's ok to use now() for
         // debugging/testing.
@@ -667,7 +666,6 @@ impl Catalog {
                 aws_privatelink_availability_zones: None,
                 http_host_name: None,
                 connection_context: ConnectionContext::for_tests(secrets_reader),
-                active_connection_count,
                 builtin_item_migration_config: BuiltinItemMigrationConfig::Legacy,
                 persist_client,
                 enable_expression_cache_override,
@@ -1276,6 +1274,10 @@ impl Catalog {
 
     pub fn system_config(&self) -> &SystemVars {
         self.state.system_config()
+    }
+
+    pub fn system_config_mut(&mut self) -> &mut SystemVars {
+        self.state.system_config_mut()
     }
 
     pub fn ensure_not_reserved_role(&self, role_id: &RoleId) -> Result<(), Error> {

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -234,6 +234,11 @@ impl Catalog {
                 );
         }
 
+        let mut system_configuration = SystemVars::new().set_unsafe(config.unsafe_mode);
+        if config.all_features {
+            system_configuration.enable_all_feature_flags_by_default();
+        }
+
         let mut state = CatalogState {
             database_by_name: BTreeMap::new(),
             database_by_id: BTreeMap::new(),
@@ -247,14 +252,7 @@ impl Catalog {
             roles_by_id: BTreeMap::new(),
             network_policies_by_id: BTreeMap::new(),
             network_policies_by_name: BTreeMap::new(),
-            system_configuration: {
-                let mut s =
-                    SystemVars::new(config.active_connection_count).set_unsafe(config.unsafe_mode);
-                if config.all_features {
-                    s.enable_all_feature_flags_by_default();
-                }
-                s
-            },
+            system_configuration,
             default_privileges: DefaultPrivileges::default(),
             system_privileges: PrivilegeMap::default(),
             comments: CommentsMap::default(),

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -2079,6 +2079,11 @@ impl CatalogState {
         &self.system_configuration
     }
 
+    /// Return a mutable reference to the current system configuration.
+    pub fn system_config_mut(&mut self) -> &mut SystemVars {
+        &mut self.system_configuration
+    }
+
     /// Serializes the catalog's in-memory state.
     ///
     /// There are no guarantees about the format of the serialized state, except

--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -46,10 +46,11 @@ impl SystemParameterBackend {
     pub async fn push(&mut self, params: &mut SynchronizedParameters) {
         for param in params.modified() {
             let mut vars = BTreeMap::new();
+            info!(name = param.name, value = param.value, "updating parameter");
             vars.insert(param.name.clone(), param.value.clone());
             match self.session_client.set_system_vars(vars).await {
                 Ok(()) => {
-                    info!(name = param.name, value = param.value, "sync parameter");
+                    info!(name = param.name, value = param.value, "update success");
                 }
                 Err(error) => match error {
                     AdapterError::ReadOnly => {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3943,9 +3943,9 @@ pub fn serve(
                 // If superuser_reserved > max_connections, prefer max_connections.
                 //
                 // In this scenario all normal users would be locked out because all connections
-                // would be reserved for superusers so complain loudly if this is the case.
+                // would be reserved for superusers so complain if this is the case.
                 let superuser_reserved = if superuser_reserved >= limit {
-                    soft_panic_or_log!(
+                    tracing::warn!(
                         "superuser_reserved ({superuser_reserved}) is greater than max connections ({limit})!"
                     );
                     limit

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -111,7 +111,7 @@ use mz_controller::ControllerConfig;
 use mz_controller_types::{ClusterId, ReplicaId, WatchSetId};
 use mz_expr::{MapFilterProject, OptimizedMirRelationExpr, RowSetFinishing};
 use mz_orchestrator::{OfflineReason, ServiceProcessMetrics};
-use mz_ore::cast::{CastFrom, CastLossy};
+use mz_ore::cast::{CastFrom, CastInto, CastLossy};
 use mz_ore::channel::trigger::Trigger;
 use mz_ore::future::TimeoutError;
 use mz_ore::metrics::MetricsRegistry;
@@ -141,7 +141,7 @@ use mz_sql::plan::{
     OnTimeoutAction, Params, QueryWhen,
 };
 use mz_sql::session::user::User;
-use mz_sql::session::vars::{ConnectionCounter, SystemVars};
+use mz_sql::session::vars::SystemVars;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::ExplainStage;
 use mz_storage_client::client::TimestamplessUpdate;
@@ -1003,7 +1003,7 @@ pub struct Config {
     pub aws_account_id: Option<String>,
     pub aws_privatelink_availability_zones: Option<Vec<String>>,
     pub connection_context: ConnectionContext,
-    pub active_connection_count: Arc<Mutex<ConnectionCounter>>,
+    pub connection_limit_callback: Box<dyn Fn(u64, u64) -> () + Send + Sync + 'static>,
     pub webhook_concurrency_limit: WebhookConcurrencyLimiter,
     pub http_host_name: Option<String>,
     pub tracing_handle: TracingHandle,
@@ -3706,8 +3706,8 @@ pub fn serve(
         aws_account_id,
         aws_privatelink_availability_zones,
         connection_context,
+        connection_limit_callback,
         remote_system_parameters,
-        active_connection_count,
         webhook_concurrency_limit,
         http_host_name,
         tracing_handle,
@@ -3854,7 +3854,6 @@ pub fn serve(
                 aws_principal_context,
                 aws_privatelink_availability_zones,
                 connection_context,
-                active_connection_count,
                 http_host_name,
                 builtin_item_migration_config,
                 persist_client: persist_client.clone(),
@@ -3932,6 +3931,28 @@ pub fn serve(
                 flags::pg_timstamp_oracle_config(catalog.system_config());
             pg_timestamp_oracle_params.apply(config);
         }
+
+        // Register a callback so whenever the MAX_CONNECTIONS or SUPERUSER_RESERVED_CONNECTIONS
+        // system variables change, we update our connection limits.
+        let connection_limit_callback: Arc<dyn Fn(&SystemVars) + Send + Sync> =
+            Arc::new(move |system_vars: &SystemVars| {
+                let limit: u64 = system_vars.max_connections().cast_into();
+                let superuser_reserved: u64 =
+                    system_vars.superuser_reserved_connections().cast_into();
+
+                // If superuser_reserved > max_connections, prefer max_connections.
+                let superuser_reserved = std::cmp::min(limit, superuser_reserved);
+
+                (connection_limit_callback)(limit, superuser_reserved);
+            });
+        catalog.system_config_mut().register_callback(
+            &mz_sql::session::vars::MAX_CONNECTIONS,
+            Arc::clone(&connection_limit_callback),
+        );
+        catalog.system_config_mut().register_callback(
+            &mz_sql::session::vars::SUPERUSER_RESERVED_CONNECTIONS,
+            connection_limit_callback,
+        );
 
         let parent_span = tracing::Span::current();
         let thread = thread::Builder::new()

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -926,10 +926,10 @@ impl From<mz_sql_parser::ast::IdentError> for AdapterError {
     }
 }
 
-impl From<mz_sql::session::vars::ConnectionError> for AdapterError {
-    fn from(value: mz_sql::session::vars::ConnectionError) -> Self {
+impl From<mz_pgwire_common::ConnectionError> for AdapterError {
+    fn from(value: mz_pgwire_common::ConnectionError) -> Self {
         match value {
-            mz_sql::session::vars::ConnectionError::TooManyConnections { current, limit } => {
+            mz_pgwire_common::ConnectionError::TooManyConnections { current, limit } => {
                 AdapterError::ResourceExhaustion {
                     resource_type: "connection".into(),
                     limit_name: "max_connections".into(),

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -15,8 +15,8 @@ use std::fs::File;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process;
+use std::sync::Arc;
 use std::sync::LazyLock;
-use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use anyhow::Context;
@@ -53,7 +53,6 @@ use mz_persist_client::{PersistClient, PersistLocation};
 use mz_repr::{Diff, Timestamp};
 use mz_service::secrets::SecretsReaderCliArgs;
 use mz_sql::catalog::EnvironmentId;
-use mz_sql::session::vars::ConnectionCounter;
 use mz_storage_types::connections::ConnectionContext;
 use serde::{Deserialize, Serialize};
 use tracing::{error, Instrument};
@@ -608,7 +607,6 @@ async fn upgrade_check(
                 secrets_reader,
                 None,
             ),
-            active_connection_count: Arc::new(Mutex::new(ConnectionCounter::new(0, 0))),
             builtin_item_migration_config: BuiltinItemMigrationConfig::Legacy,
             persist_client,
             enable_expression_cache_override: None,

--- a/src/catalog/src/config.rs
+++ b/src/catalog/src/config.rs
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Arc;
 
 use bytesize::ByteSize;
 use ipnet::IpNet;
@@ -22,7 +21,6 @@ use mz_persist_client::PersistClient;
 use mz_repr::CatalogItemId;
 use mz_sql::catalog::CatalogError as SqlCatalogError;
 use mz_sql::catalog::EnvironmentId;
-use mz_sql::session::vars::ConnectionCounter;
 use serde::{Deserialize, Serialize};
 
 use crate::durable::{CatalogError, DurableCatalogState};
@@ -84,8 +82,6 @@ pub struct StateConfig {
     pub http_host_name: Option<String>,
     /// Context for source and sink connections.
     pub connection_context: mz_storage_types::connections::ConnectionContext,
-    /// Global connection limit and count
-    pub active_connection_count: Arc<std::sync::Mutex<ConnectionCounter>>,
     pub builtin_item_migration_config: BuiltinItemMigrationConfig,
     pub persist_client: PersistClient,
     /// Overrides the current value of the [`mz_adapter_types::dyncfgs::ENABLE_EXPRESSION_CACHE`]

--- a/src/pgwire-common/Cargo.toml
+++ b/src/pgwire-common/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = "0.1.68"
 byteorder = "1.4.3"
 bytes = "1.3.0"
 bytesize = "1.1.0"
+derivative = "2.2.0"
 mz-ore = { path = "../ore", features = ["network"], default-features = false }
 mz-server-core = { path = "../server-core", default-features = false }
 tokio = "1.38.0"

--- a/src/pgwire-common/src/conn.rs
+++ b/src/pgwire-common/src/conn.rs
@@ -8,9 +8,11 @@
 // by the Apache License, Version 2.0.
 
 use std::pin::Pin;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
 use async_trait::async_trait;
+use derivative::Derivative;
 use mz_ore::netio::AsyncReady;
 use mz_server_core::TlsMode;
 use tokio::io::{self, AsyncRead, AsyncWrite, Interest, ReadBuf, Ready};
@@ -116,4 +118,148 @@ where
             Conn::Ssl(inner) => inner.ready(interest).await,
         }
     }
+}
+
+/// Metadata about a user that is required to allocate a [`ConnectionHandle`].
+#[derive(Debug, Clone, Copy)]
+pub struct UserMetadata {
+    pub is_admin: bool,
+    pub should_limit_connections: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConnectionCounter {
+    inner: Arc<Mutex<ConnectionCounterInner>>,
+}
+
+impl ConnectionCounter {
+    /// Returns a [`ConnectionHandle`] which must be kept alive for the entire duration of the
+    /// external connection.
+    ///
+    /// Dropping the [`ConnectionHandle`] decrements the connection count.
+    pub fn allocate_connection(
+        &self,
+        metadata: impl Into<UserMetadata>,
+    ) -> Result<Option<ConnectionHandle>, ConnectionError> {
+        let mut inner = self.inner.lock().expect("environmentd panicked");
+        let metadata = metadata.into();
+
+        if !metadata.should_limit_connections {
+            return Ok(None);
+        }
+
+        if (metadata.is_admin && inner.reserved_remaining() > 0)
+            || inner.non_reserved_remaining() > 0
+        {
+            inner.inc_connection_count();
+            Ok(Some(self.create_handle()))
+        } else {
+            Err(ConnectionError::TooManyConnections {
+                current: inner.current,
+                limit: inner.limit,
+            })
+        }
+    }
+
+    /// Updates the maximum number of connections we allow.
+    pub fn update_limit(&self, new_limit: u64) {
+        let mut inner = self.inner.lock().expect("environmentd panicked");
+        inner.limit = new_limit;
+    }
+
+    /// Updates the number of connections we reserve for superusers.
+    pub fn update_superuser_reserved(&self, new_reserve: u64) {
+        let mut inner = self.inner.lock().expect("environmentd panicked");
+        inner.superuser_reserved = new_reserve;
+    }
+
+    fn create_handle(&self) -> ConnectionHandle {
+        let inner = Arc::clone(&self.inner);
+        let decrement_fn = Box::new(move || {
+            let mut inner = inner.lock().expect("environmentd panicked");
+            inner.dec_connection_count();
+        });
+
+        ConnectionHandle {
+            decrement_fn: Some(decrement_fn),
+        }
+    }
+}
+
+impl Default for ConnectionCounter {
+    fn default() -> Self {
+        let inner = ConnectionCounterInner::new(10, 3);
+        ConnectionCounter {
+            inner: Arc::new(Mutex::new(inner)),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ConnectionCounterInner {
+    /// Current number of connections.
+    current: u64,
+    /// Total number of connections allowed.
+    limit: u64,
+    /// Number of connections we'll reserve for super users.
+    superuser_reserved: u64,
+}
+
+impl ConnectionCounterInner {
+    fn new(limit: u64, superuser_reserved: u64) -> Self {
+        ConnectionCounterInner {
+            current: 0,
+            limit,
+            superuser_reserved,
+        }
+    }
+
+    fn inc_connection_count(&mut self) {
+        self.current += 1;
+    }
+
+    fn dec_connection_count(&mut self) {
+        self.current -= 1;
+    }
+
+    /// The number of connections still available to superusers.
+    fn reserved_remaining(&self) -> u64 {
+        // Use a saturating sub in case the limit is reduced below the number
+        // of current connections.
+        self.limit.saturating_sub(self.current)
+    }
+
+    /// The number of connections available to non-superusers.
+    fn non_reserved_remaining(&self) -> u64 {
+        // This ensures that at least a few connections remain for superusers.
+        let limit = self.limit.saturating_sub(self.superuser_reserved);
+        // Use a saturating sub in case the limit is reduced below the number
+        // of current connections.
+        limit.saturating_sub(self.current)
+    }
+}
+
+/// Handle to an open connection, allows us to maintain a count of all connections.
+///
+/// When Drop-ed decrements the count of open connections.
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct ConnectionHandle {
+    #[derivative(Debug = "ignore")]
+    decrement_fn: Option<Box<dyn FnOnce() -> () + Send + Sync>>,
+}
+
+impl Drop for ConnectionHandle {
+    fn drop(&mut self) {
+        match self.decrement_fn.take() {
+            Some(decrement_fn) => (decrement_fn)(),
+            None => tracing::error!("ConnectionHandle dropped twice!?"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConnectionError {
+    /// There were too many connections
+    TooManyConnections { current: u64, limit: u64 },
 }

--- a/src/pgwire-common/src/conn.rs
+++ b/src/pgwire-common/src/conn.rs
@@ -201,12 +201,13 @@ pub struct ConnectionCounterInner {
     current: u64,
     /// Total number of connections allowed.
     limit: u64,
-    /// Number of connections we'll reserve for super users.
+    /// Number of connections in `limit` we'll reserve for superusers.
     superuser_reserved: u64,
 }
 
 impl ConnectionCounterInner {
     fn new(limit: u64, superuser_reserved: u64) -> Self {
+        assert!(superuser_reserved < limit);
         ConnectionCounterInner {
             current: 0,
             limit,

--- a/src/pgwire-common/src/lib.rs
+++ b/src/pgwire-common/src/lib.rs
@@ -22,7 +22,10 @@ pub use codec::{
     decode_startup, input_err, parse_frame_len, CodecError, Cursor, DecodeState, Pgbuf,
     ACCEPT_SSL_ENCRYPTION, MAX_REQUEST_SIZE, REJECT_ENCRYPTION,
 };
-pub use conn::{Conn, CONN_UUID_KEY, MZ_FORWARDED_FOR_KEY};
+pub use conn::{
+    Conn, ConnectionCounter, ConnectionError, ConnectionHandle, UserMetadata, CONN_UUID_KEY,
+    MZ_FORWARDED_FOR_KEY,
+};
 pub use format::Format;
 pub use message::{
     ErrorResponse, FrontendMessage, FrontendStartupMessage, VERSIONS, VERSION_3, VERSION_CANCEL,

--- a/src/sql/src/session/user.rs
+++ b/src/sql/src/session/user.rs
@@ -65,6 +65,15 @@ pub struct User {
     pub external_metadata: Option<ExternalUserMetadata>,
 }
 
+impl From<&User> for mz_pgwire_common::UserMetadata {
+    fn from(user: &User) -> mz_pgwire_common::UserMetadata {
+        mz_pgwire_common::UserMetadata {
+            is_admin: user.is_external_admin(),
+            should_limit_connections: user.limit_max_connections(),
+        }
+    }
+}
+
 impl PartialEq for User {
     fn eq(&self, other: &User) -> bool {
         self.name == other.name


### PR DESCRIPTION
This PR refactors our max connection handling in a few ways:

1. It pulls the logic out of the `sql` crate and moves it into the `pgwire_common` crate. AFAICT this logic lived in the `sql` crate so it could be updated via `SystemVars`.
2. Refactors `SystemVars` to contain a generic set of callbacks so anyone can register to be notified about changes to a system variable, not just connection handling.

It also fixes a bug that has occurred in production. Previously if the max connection limit dropped below the number of current connections (e.g. reducing the LaunchDarkly flag) we could panic.

### Motivation

Fixes a known [panic](https://materializeinc.sentry.io/auth/login/materializeinc/?next=%2Fissues%2F5979946058%2Fevents%2Fff772de8c8b34c3bb11b240b93745222%2F%3Fproject%3D6780145) and refactors the code.

### Tips for reviewer

I would start by reviewing the changes in `sql/src/session/vars.rs` to see how SystemVars changed, then look at the changes in `pgwire-common/src/conn.rs`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
