### PR TITLE
Have `EqProp` reduce expressions more

### DIFF
--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -209,9 +209,17 @@ impl EquivalencePropagation {
                     .expect("Equivalences required");
 
                 if let Some(input_equivalences) = input_equivalences {
+                    // Get all output types, to reveal a prefix to each scaler expr.
+                    let input_types = derived
+                        .value::<RelationType>()
+                        .expect("RelationType required")
+                        .as_ref()
+                        .unwrap();
+                    let input_arity = input_types.len() - scalars.len();
                     let reducer = input_equivalences.reducer();
-                    for expr in scalars.iter_mut() {
+                    for (index, expr) in scalars.iter_mut().enumerate() {
                         reducer.reduce_expr(expr);
+                        expr.reduce(&input_types[..(input_arity + index)]);
                     }
                     let input_arity = *derived
                         .last_child()
@@ -234,9 +242,14 @@ impl EquivalencePropagation {
                     .expect("Equivalences required");
 
                 if let Some(input_equivalences) = input_equivalences {
+                    let input_types = derived
+                        .last_child()
+                        .value::<RelationType>()
+                        .expect("RelationType required");
                     let reducer = input_equivalences.reducer();
                     for expr in exprs.iter_mut() {
                         reducer.reduce_expr(expr);
+                        expr.reduce(input_types.as_ref().unwrap());
                     }
                     let input_arity = *derived
                         .last_child()
@@ -267,6 +280,7 @@ impl EquivalencePropagation {
                     let reducer = input_equivalences.reducer();
                     for expr in predicates.iter_mut() {
                         reducer.reduce_expr(expr);
+                        expr.reduce(input_types.as_ref().unwrap());
                     }
                     // Incorporate `predicates` into `outer_equivalences`.
                     let mut class = predicates.clone();
@@ -429,6 +443,7 @@ impl EquivalencePropagation {
                     }
                     for aggr in aggregates.iter_mut() {
                         reducer.reduce_expr(&mut aggr.expr);
+                        aggr.expr.reduce(input_type.as_ref().unwrap());
                         // A count expression over a non-null expression can discard the expression.
                         if aggr.func == mz_expr::AggregateFunc::Count && !aggr.distinct {
                             let mut probe = aggr.expr.clone().call_is_null();


### PR DESCRIPTION
Although `EquivalencePropagation` was reducing expressions relative to its equivalences, it was not reducing expressions in the context of their input types, which is what does things like constant folding and other inherent simplification. The `reduce` function requires type information, so the `Equivalences` reduction cannot do this by itself (it doesn't have type information).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
