### PR TITLE
doc/user: add self-managed banner

### DIFF
--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -31,7 +31,7 @@
     // https://weblog.west-wind.com/posts/2016/Feb/15/Flexbox-Containers-PRE-tags-and-managing-Overflow
     min-width: 0;
     max-width: 840px;
-    padding: var(--xx-small) var(--small);
+    padding: var(--large) var(--small);
 
     @media (max-width: 1260px) {
         flex: 2.5;
@@ -154,7 +154,7 @@ table.inline-headings {
     margin-left: auto;
     position: sticky;
     top: var(--nav-height);
-    padding: var(--x-small) var(--nano);
+    padding: var(--large) var(--small);
     overflow-y: auto;
     height: 100vh;
     display: flex;

--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -7,6 +7,8 @@ disableKinds = ['taxonomy']
 
 [params]
 repo = "//github.com/MaterializeInc/materialize"
+bannerMessage = "Need to run Materialize in your own private or public cloud? Get early access to **self-managed Materialize**!"
+bannerLink="https://materialize.com/blog/self-managed/?utm_medium=docs-banner&utm_source=documentation&utm_campaign=FY25_Blogs&sf_campaign=701TR00000NoNFXYA3&utm_term=&utm_content="
 
 [frontmatter]
 publishDate = ["publishDate"]

--- a/doc/user/layouts/partials/banner.html
+++ b/doc/user/layouts/partials/banner.html
@@ -4,7 +4,7 @@
         {{ if .Site.Params.bannerLink }}<a href={{ .Site.Params.bannerLink }}
         target="_blank" >
         {{ end }}
-        {{ .Site.Params.bannerMessage }}
+        {{ .Site.Params.bannerMessage | markdownify }}
         {{ if .Site.Params.bannerLink}} </a> {{ end }}
     </span>
 </div>

--- a/doc/user/layouts/partials/toc.html
+++ b/doc/user/layouts/partials/toc.html
@@ -59,7 +59,7 @@
     const headings = $(".content h2, .content h3");
     let offsets = headings.toArray().map((h) => ({
       id: h.id,
-      offset: h.offsetTop - 65,  // change to 75 if banner is displayed
+      offset: h.offsetTop - 75,  // 75 if banner is displayed, 65 otherwise
     }));
     const cutoff = $(document).height() - $(window).height() - SLOP;
     const firstBad = offsets.findIndex((o) => o.offset > cutoff);


### PR DESCRIPTION
@nisarhassan12: would you mind adjusting the CSS so the header doesn't eat into the sections below because of the added banner?

<img width="864" alt="Screenshot 2024-11-26 at 01 51 28" src="https://github.com/user-attachments/assets/0148a2fe-71bb-4bf9-9c83-c55e921ec666">