### PR TITLE
Guard `TopK::limit` substitution

### DIFF
--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -529,8 +529,13 @@ impl EquivalencePropagation {
                         .expect("RelationType required");
                     let reducer = input_equivalences.reducer();
                     if let Some(expr) = limit {
+                        let old_expr = expr.clone();
                         reducer.reduce_expr(expr);
+                        let acceptable_sub = literal_domination(&old_expr, expr);
                         expr.reduce(input_types.as_ref().unwrap());
+                        if !acceptable_sub && !literal_domination(&old_expr, expr) {
+                            expr.clone_from(&old_expr);
+                        }
                     }
                 }
 


### PR DESCRIPTION
We recklessly substitute expressions in `TopK::limit`, but should guard this behavior by only performing substitutions that result in literals replacing expressions. This avoids the peril of introducing expressions referencing non-key columns, which results in catastrophic failure.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
