### PR TITLE
Prototype `Reduce` pushdown through `Union`.

### DIFF
--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -53,6 +53,7 @@ use std::iter::FromIterator;
 use mz_expr::visit::Visit;
 use mz_expr::{AggregateExpr, JoinInputMapper, MirRelationExpr, MirScalarExpr};
 
+use crate::analysis::DerivedView;
 use crate::TransformCtx;
 
 /// Pushes Reduce operators toward sources.
@@ -68,11 +69,12 @@ impl crate::Transform for ReductionPushdown {
     fn transform(
         &self,
         relation: &mut MirRelationExpr,
-        _: &mut TransformCtx,
+        ctx: &mut TransformCtx,
     ) -> Result<(), crate::TransformError> {
         // `try_visit_mut_pre` is used here because after pushing down a reduction,
         // we want to see if we can push the same reduction further down.
         let result = relation.try_visit_mut_pre(&mut |e| self.action(e));
+        self.push_through_union(relation, ctx);
         mz_repr::explain::trace_plan(&*relation);
         result
     }
@@ -154,6 +156,149 @@ impl ReductionPushdown {
             }
         }
         Ok(())
+    }
+
+    /// Attempts to employ disjointness reasoning to push `Reduce` through `Union`.
+    ///
+    /// When a `Reduce` is atop a `Union`, if the union inputs can be partitioned
+    /// into classes where for each member of each class, the key expressions are
+    /// disjoint from the key expressions of all members of all other classes, we
+    /// can push the `Reduce` down to each component and union their results.
+    ///
+    /// We perform this disjointness analysis by extending each union input with
+    /// the key columns, then projecting onto them, and then pairwise merging the
+    /// equivalences and seeing if they are unsatisfiable.
+    pub fn push_through_union(&self, relation: &mut MirRelationExpr, ctx: &mut TransformCtx) {
+        use crate::analysis::equivalences::Equivalences;
+        use crate::analysis::{Arity, DerivedBuilder, RelationType};
+
+        let mut builder = DerivedBuilder::new(ctx.features);
+        builder.require(Arity);
+        builder.require(RelationType);
+        builder.require(Equivalences);
+        let derived = builder.visit(relation);
+        let derived = derived.as_view();
+
+        let mut todo = vec![(relation, derived)];
+        while let Some((expr, view)) = todo.pop() {
+            if let Some(replacement) = Self::assess_disjointness(expr, view) {
+                *expr = replacement;
+            } else {
+                todo.extend(expr.children_mut().rev().zip(view.children_rev()));
+            }
+        }
+    }
+
+    fn assess_disjointness(expr: &MirRelationExpr, view: DerivedView) -> Option<MirRelationExpr> {
+        use crate::analysis::equivalences::Equivalences;
+        use crate::analysis::{Arity, RelationType};
+
+        if let MirRelationExpr::Reduce {
+            input,
+            group_key,
+            aggregates,
+            expected_group_size,
+            ..
+        } = expr
+        {
+            if let MirRelationExpr::Union { .. } = &**input {
+                // Form the union input equivalences restricted to the `group_key` expressions.
+                let arity = *view.last_child().value::<Arity>().expect("Arity required");
+                let child_equivs = view
+                    .last_child()
+                    .children_rev()
+                    .map(|view| {
+                        let mut equivs = view
+                            .value::<Equivalences>()
+                            .expect("Equivalences required")
+                            .clone();
+                        if let Some(equivs) = &mut equivs {
+                            let types = view
+                                .value::<RelationType>()
+                                .expect("RelationType required")
+                                .as_ref()
+                                .unwrap()
+                                .clone();
+                            for (index, key_expr) in group_key.iter().enumerate() {
+                                equivs.classes.push(vec![
+                                    key_expr.clone(),
+                                    MirScalarExpr::column(arity + index),
+                                ]);
+                            }
+                            equivs.minimize(&Some(types.clone()));
+                            equivs.project(arity..arity + group_key.len());
+                            equivs.minimize(&Some(types.clone()));
+                        }
+                        equivs
+                    })
+                    .collect::<Vec<_>>();
+
+                // Assess the pairwise overlap of the equivalences.
+                let mut potential_overlap = Vec::new();
+                for i in 0..child_equivs.len() {
+                    if let Some(equiv_i) = &child_equivs[i] {
+                        for j in 0..i {
+                            if let Some(equiv_j) = &child_equivs[j] {
+                                let mut temp = equiv_i.clone();
+                                temp.classes.extend(equiv_j.classes.iter().cloned());
+                                temp.minimize(&None);
+                                if !temp.unsatisfiable() {
+                                    potential_overlap.push((i, j));
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Form connected components of potential overlap.
+                let mut root = (0..child_equivs.len()).collect::<Vec<_>>();
+                for (mut i, mut j) in potential_overlap {
+                    while i != root[i] {
+                        i = root[i];
+                    }
+                    while j != root[j] {
+                        j = root[j];
+                    }
+                    root[i] = std::cmp::min(root[i], root[j]);
+                    root[j] = std::cmp::min(root[i], root[j]);
+                }
+                let mut components: BTreeMap<_, Vec<_>> = BTreeMap::default();
+                for i in 0..root.len() {
+                    while root[i] != root[root[i]] {
+                        root[i] = root[root[i]];
+                    }
+                    components.entry(root[i]).or_default().push(i);
+                }
+
+                // This is interesting only with multiple components.
+                if components.len() > 1 {
+                    // Form new expression as a union of reduces of unions of components.
+                    let mut union_parts = Vec::with_capacity(components.len());
+                    for component in components.values() {
+                        let members = component
+                            .into_iter()
+                            .map(|i| input.children().nth(*i).unwrap().clone())
+                            .collect::<Vec<_>>();
+                        let union_expr =
+                            MirRelationExpr::union_many(members, mz_repr::RelationType::empty());
+                        let reduce_expr = MirRelationExpr::Reduce {
+                            input: Box::new(union_expr),
+                            group_key: group_key.clone(),
+                            aggregates: aggregates.clone(),
+                            monotonic: false,
+                            expected_group_size: expected_group_size.clone(),
+                        };
+                        union_parts.push(reduce_expr);
+                    }
+
+                    return Some(MirRelationExpr::union_many(
+                        union_parts,
+                        mz_repr::RelationType::empty(),
+                    ));
+                }
+            }
+        }
+        None
     }
 }
 

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -994,9 +994,9 @@ Explained Query:
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
       cte l3 =
-        Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
-          Union // { arity: 2 }
-            Map (null) // { arity: 2 }
+        Union // { arity: 2 }
+          Map (null) // { arity: 2 }
+            Distinct project=[#0{creatorpersonid}] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#1) // { arity: 1 }
@@ -1010,6 +1010,7 @@ Explained Query:
                             Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
                   Get l0 // { arity: 2 }
+          Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
             Project (#1{personid}, #2) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l2 =
@@ -1100,9 +1101,9 @@ Explained Query:
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
       cte l3 =
-        Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
-          Union // { arity: 2 }
-            Map (null) // { arity: 2 }
+        Union // { arity: 2 }
+          Map (null) // { arity: 2 }
+            Distinct project=[#0{creatorpersonid}] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#1) // { arity: 1 }
@@ -1116,6 +1117,7 @@ Explained Query:
                             Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
                   Get l0 // { arity: 2 }
+          Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
             Project (#1{personid}, #2) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l2 =
@@ -1207,9 +1209,9 @@ Explained Query:
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
       cte l3 =
-        Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
-          Union // { arity: 2 }
-            Map (null) // { arity: 2 }
+        Union // { arity: 2 }
+          Map (null) // { arity: 2 }
+            Distinct project=[#0{creatorpersonid}] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#1) // { arity: 1 }
@@ -1225,6 +1227,7 @@ Explained Query:
                             Get l1 // { arity: 4 }
                 Project (#2) // { arity: 1 }
                   Get l2 // { arity: 3 }
+          Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
             Project (#2, #3) // { arity: 2 }
               Filter (#0{name} = "Bob_Geldof") // { arity: 4 }
                 Get l1 // { arity: 4 }
@@ -4472,91 +4475,82 @@ Explained Query:
         Distinct project=[#0..=#5] // { arity: 6 }
           Union // { arity: 6 }
             Project (#0..=#2{personid}, #4, #3, #5) // { arity: 6 }
-              Map (false, 0, 0) // { arity: 6 }
-                Distinct project=[#0..=#2{personid}] // { arity: 3 }
-                  Union // { arity: 3 }
-                    Project (#1, #0, #0) // { arity: 3 }
-                      Map (10995116285979, false) // { arity: 2 }
-                        Get l11 // { arity: 0 }
-                    Project (#1{personid}, #0, #0) // { arity: 3 }
-                      Map (true) // { arity: 2 }
-                        CrossJoin type=differential // { arity: 1 }
-                          implementation
-                            %1:l11[×]U » %0:l0[×]
-                          ArrangeBy keys=[[]] // { arity: 1 }
+              Map (0, 0) // { arity: 6 }
+                Union // { arity: 4 }
+                  Project (#1, #0, #0, #2) // { arity: 4 }
+                    Map (10995116285979, false, false) // { arity: 3 }
+                      Get l4 // { arity: 0 }
+                  Project (#1{personid}, #0, #0, #2{personid}) // { arity: 4 }
+                    Map (true, false) // { arity: 3 }
+                      CrossJoin type=differential // { arity: 1 }
+                        implementation
+                          %1:l4[×]U » %0[×]
+                        ArrangeBy keys=[[]] // { arity: 1 }
+                          Distinct project=[#0{personid}] // { arity: 1 }
                             Get l0 // { arity: 1 }
-                          ArrangeBy keys=[[]] // { arity: 0 }
-                            Get l11 // { arity: 0 }
+                        ArrangeBy keys=[[]] // { arity: 0 }
+                          Get l4 // { arity: 0 }
             Project (#0..=#3, #7, #8) // { arity: 6 }
               Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
                 CrossJoin type=delta // { arity: 7 }
                   implementation
-                    %0:l8 » %1[×]U » %2[×]U
-                    %1 » %2[×]U » %0:l8[×]
-                    %2 » %1[×]U » %0:l8[×]
+                    %0:l9 » %1[×]U » %2[×]U
+                    %1 » %2[×]U » %0:l9[×]
+                    %2 » %1[×]U » %0:l9[×]
                   ArrangeBy keys=[[]] // { arity: 5 }
-                    Get l8 // { arity: 5 }
+                    Get l9 // { arity: 5 }
                   ArrangeBy keys=[[]] // { arity: 1 }
                     TopK limit=1 // { arity: 1 }
                       Project (#4) // { arity: 1 }
-                        Get l4 // { arity: 5 }
+                        Get l5 // { arity: 5 }
                   ArrangeBy keys=[[]] // { arity: 1 }
                     Union // { arity: 1 }
-                      Get l10 // { arity: 1 }
+                      Get l11 // { arity: 1 }
                       Map (null) // { arity: 1 }
                         Union // { arity: 0 }
                           Negate // { arity: 0 }
                             Project () // { arity: 0 }
-                              Get l10 // { arity: 1 }
+                              Get l11 // { arity: 1 }
                           Constant // { arity: 0 }
                             - ()
       cte l11 =
-        Distinct project=[] // { arity: 0 }
-          Project () // { arity: 0 }
-            Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
-              implementation
-                %0:l3[#0]UK » %1:l2[#0]K
-              ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                Get l3 // { arity: 1 }
-              Get l2 // { arity: 1 }
-      cte l10 =
         Project (#1) // { arity: 1 }
           Map ((#0{min} / 2)) // { arity: 2 }
             Union // { arity: 1 }
-              Get l9 // { arity: 1 }
+              Get l10 // { arity: 1 }
               Map (null) // { arity: 1 }
                 Union // { arity: 0 }
                   Negate // { arity: 0 }
                     Project () // { arity: 0 }
-                      Get l9 // { arity: 1 }
+                      Get l10 // { arity: 1 }
                   Constant // { arity: 0 }
                     - ()
-      cte l9 =
+      cte l10 =
         Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
           Project (#1, #3) // { arity: 2 }
             Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
               implementation
-                %0:l8[#0]Kef » %1:l8[#0]Kef
+                %0:l9[#0]Kef » %1:l9[#0]Kef
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
                   Filter (#0 = false) // { arity: 5 }
-                    Get l8 // { arity: 5 }
+                    Get l9 // { arity: 5 }
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
                   Filter (#0 = true) // { arity: 5 }
-                    Get l8 // { arity: 5 }
-      cte l8 =
+                    Get l9 // { arity: 5 }
+      cte l9 =
         TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
           Union // { arity: 5 }
             Project (#3, #4, #1, #7, #8) // { arity: 5 }
               Map ((#6 + integer_to_bigint(#2{w})), false) // { arity: 9 }
                 Join on=(#0{src} = #5) type=differential // { arity: 7 }
                   implementation
-                    %0:l1[#0]KA » %1:l4[#2]K
+                    %0:l1[#0]KA » %1:l5[#2]K
                   Get l1 // { arity: 3 }
                   ArrangeBy keys=[[#2]] // { arity: 4 }
                     Project (#0..=#3) // { arity: 4 }
-                      Get l4 // { arity: 5 }
+                      Get l5 // { arity: 5 }
             Project (#0..=#3, #9) // { arity: 5 }
               Map ((#4 OR #8)) // { arity: 10 }
                 Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
@@ -4568,40 +4562,49 @@ Explained Query:
                   ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                     Union // { arity: 4 }
                       Map (true) // { arity: 4 }
-                        Get l7 // { arity: 3 }
+                        Get l8 // { arity: 3 }
                       Project (#0..=#2, #6) // { arity: 4 }
                         Map (false) // { arity: 7 }
                           Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                             implementation
-                              %1:l6[#0..=#2]UKKK » %0[#0..=#2]KKK
+                              %1:l7[#0..=#2]UKKK » %0[#0..=#2]KKK
                             ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                               Union // { arity: 3 }
                                 Negate // { arity: 3 }
-                                  Get l7 // { arity: 3 }
-                                Get l5 // { arity: 3 }
-                            Get l6 // { arity: 3 }
-      cte l7 =
+                                  Get l8 // { arity: 3 }
+                                Get l6 // { arity: 3 }
+                            Get l7 // { arity: 3 }
+      cte l8 =
         Project (#0..=#2) // { arity: 3 }
           Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
             implementation
-              %1[#0..=#2]UKKKA » %0:l6[#0..=#2]UKKK
-            Get l6 // { arity: 3 }
+              %1[#0..=#2]UKKKA » %0:l7[#0..=#2]UKKK
+            Get l7 // { arity: 3 }
             ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
               Distinct project=[#0..=#2] // { arity: 3 }
                 Project (#0..=#2) // { arity: 3 }
-                  Get l4 // { arity: 5 }
-      cte l6 =
+                  Get l5 // { arity: 5 }
+      cte l7 =
         ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-          Get l5 // { arity: 3 }
-      cte l5 =
+          Get l6 // { arity: 3 }
+      cte l6 =
         Distinct project=[#0..=#2] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
             Get l12 // { arity: 6 }
-      cte l4 =
+      cte l5 =
         TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
           Project (#0..=#3, #5) // { arity: 5 }
             Filter (#4 = false) // { arity: 6 }
               Get l12 // { arity: 6 }
+      cte l4 =
+        Distinct project=[] // { arity: 0 }
+          Project () // { arity: 0 }
+            Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
+              implementation
+                %0:l3[#0]UK » %1:l2[#0]K
+              ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
+                Get l3 // { arity: 1 }
+              Get l2 // { arity: 1 }
       cte l3 =
         Distinct project=[#0{dst}] // { arity: 1 }
           Union // { arity: 1 }

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -1001,9 +1001,9 @@ Explained Query:
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
       cte l3 =
-        Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
-          Union // { arity: 2 }
-            Map (null) // { arity: 2 }
+        Union // { arity: 2 }
+          Map (null) // { arity: 2 }
+            Distinct project=[#0{creatorpersonid}] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#1) // { arity: 1 }
@@ -1017,6 +1017,7 @@ Explained Query:
                             Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
                   Get l0 // { arity: 2 }
+          Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
             Project (#1{personid}, #2) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l2 =
@@ -1107,9 +1108,9 @@ Explained Query:
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
       cte l3 =
-        Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
-          Union // { arity: 2 }
-            Map (null) // { arity: 2 }
+        Union // { arity: 2 }
+          Map (null) // { arity: 2 }
+            Distinct project=[#0{creatorpersonid}] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#1) // { arity: 1 }
@@ -1123,6 +1124,7 @@ Explained Query:
                             Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
                   Get l0 // { arity: 2 }
+          Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
             Project (#1{personid}, #2) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l2 =
@@ -1214,9 +1216,9 @@ Explained Query:
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
       cte l3 =
-        Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
-          Union // { arity: 2 }
-            Map (null) // { arity: 2 }
+        Union // { arity: 2 }
+          Map (null) // { arity: 2 }
+            Distinct project=[#0{creatorpersonid}] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#1) // { arity: 1 }
@@ -1232,6 +1234,7 @@ Explained Query:
                             Get l1 // { arity: 4 }
                 Project (#2) // { arity: 1 }
                   Get l2 // { arity: 3 }
+          Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
             Project (#2, #3) // { arity: 2 }
               Filter (#0{name} = "Bob_Geldof") // { arity: 4 }
                 Get l1 // { arity: 4 }
@@ -4479,91 +4482,82 @@ Explained Query:
         Distinct project=[#0..=#5] // { arity: 6 }
           Union // { arity: 6 }
             Project (#0..=#2{personid}, #4, #3, #5) // { arity: 6 }
-              Map (false, 0, 0) // { arity: 6 }
-                Distinct project=[#0..=#2{personid}] // { arity: 3 }
-                  Union // { arity: 3 }
-                    Project (#1, #0, #0) // { arity: 3 }
-                      Map (10995116285979, false) // { arity: 2 }
-                        Get l11 // { arity: 0 }
-                    Project (#1{personid}, #0, #0) // { arity: 3 }
-                      Map (true) // { arity: 2 }
-                        CrossJoin type=differential // { arity: 1 }
-                          implementation
-                            %1:l11[×]U » %0:l0[×]
-                          ArrangeBy keys=[[]] // { arity: 1 }
+              Map (0, 0) // { arity: 6 }
+                Union // { arity: 4 }
+                  Project (#1, #0, #0, #2) // { arity: 4 }
+                    Map (10995116285979, false, false) // { arity: 3 }
+                      Get l4 // { arity: 0 }
+                  Project (#1{personid}, #0, #0, #2{personid}) // { arity: 4 }
+                    Map (true, false) // { arity: 3 }
+                      CrossJoin type=differential // { arity: 1 }
+                        implementation
+                          %1:l4[×]U » %0[×]
+                        ArrangeBy keys=[[]] // { arity: 1 }
+                          Distinct project=[#0{personid}] // { arity: 1 }
                             Get l0 // { arity: 1 }
-                          ArrangeBy keys=[[]] // { arity: 0 }
-                            Get l11 // { arity: 0 }
+                        ArrangeBy keys=[[]] // { arity: 0 }
+                          Get l4 // { arity: 0 }
             Project (#0..=#3, #7, #8) // { arity: 6 }
               Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
                 CrossJoin type=delta // { arity: 7 }
                   implementation
-                    %0:l8 » %1[×]U » %2[×]U
-                    %1 » %2[×]U » %0:l8[×]
-                    %2 » %1[×]U » %0:l8[×]
+                    %0:l9 » %1[×]U » %2[×]U
+                    %1 » %2[×]U » %0:l9[×]
+                    %2 » %1[×]U » %0:l9[×]
                   ArrangeBy keys=[[]] // { arity: 5 }
-                    Get l8 // { arity: 5 }
+                    Get l9 // { arity: 5 }
                   ArrangeBy keys=[[]] // { arity: 1 }
                     TopK limit=1 // { arity: 1 }
                       Project (#4) // { arity: 1 }
-                        Get l4 // { arity: 5 }
+                        Get l5 // { arity: 5 }
                   ArrangeBy keys=[[]] // { arity: 1 }
                     Union // { arity: 1 }
-                      Get l10 // { arity: 1 }
+                      Get l11 // { arity: 1 }
                       Map (null) // { arity: 1 }
                         Union // { arity: 0 }
                           Negate // { arity: 0 }
                             Project () // { arity: 0 }
-                              Get l10 // { arity: 1 }
+                              Get l11 // { arity: 1 }
                           Constant // { arity: 0 }
                             - ()
       cte l11 =
-        Distinct project=[] // { arity: 0 }
-          Project () // { arity: 0 }
-            Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
-              implementation
-                %0:l3[#0]UK » %1:l2[#0]K
-              ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                Get l3 // { arity: 1 }
-              Get l2 // { arity: 1 }
-      cte l10 =
         Project (#1) // { arity: 1 }
           Map ((#0{min} / 2)) // { arity: 2 }
             Union // { arity: 1 }
-              Get l9 // { arity: 1 }
+              Get l10 // { arity: 1 }
               Map (null) // { arity: 1 }
                 Union // { arity: 0 }
                   Negate // { arity: 0 }
                     Project () // { arity: 0 }
-                      Get l9 // { arity: 1 }
+                      Get l10 // { arity: 1 }
                   Constant // { arity: 0 }
                     - ()
-      cte l9 =
+      cte l10 =
         Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
           Project (#1, #3) // { arity: 2 }
             Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
               implementation
-                %0:l8[#0]Kef » %1:l8[#0]Kef
+                %0:l9[#0]Kef » %1:l9[#0]Kef
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
                   Filter (#0 = false) // { arity: 5 }
-                    Get l8 // { arity: 5 }
+                    Get l9 // { arity: 5 }
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
                   Filter (#0 = true) // { arity: 5 }
-                    Get l8 // { arity: 5 }
-      cte l8 =
+                    Get l9 // { arity: 5 }
+      cte l9 =
         TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
           Union // { arity: 5 }
             Project (#3, #4, #1, #7, #8) // { arity: 5 }
               Map ((#6 + integer_to_bigint(#2{w})), false) // { arity: 9 }
                 Join on=(#0{src} = #5) type=differential // { arity: 7 }
                   implementation
-                    %0:l1[#0]KA » %1:l4[#2]K
+                    %0:l1[#0]KA » %1:l5[#2]K
                   Get l1 // { arity: 3 }
                   ArrangeBy keys=[[#2]] // { arity: 4 }
                     Project (#0..=#3) // { arity: 4 }
-                      Get l4 // { arity: 5 }
+                      Get l5 // { arity: 5 }
             Project (#0..=#3, #9) // { arity: 5 }
               Map ((#4 OR #8)) // { arity: 10 }
                 Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
@@ -4575,40 +4569,49 @@ Explained Query:
                   ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                     Union // { arity: 4 }
                       Map (true) // { arity: 4 }
-                        Get l7 // { arity: 3 }
+                        Get l8 // { arity: 3 }
                       Project (#0..=#2, #6) // { arity: 4 }
                         Map (false) // { arity: 7 }
                           Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                             implementation
-                              %1:l6[#0..=#2]UKKK » %0[#0..=#2]KKK
+                              %1:l7[#0..=#2]UKKK » %0[#0..=#2]KKK
                             ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                               Union // { arity: 3 }
                                 Negate // { arity: 3 }
-                                  Get l7 // { arity: 3 }
-                                Get l5 // { arity: 3 }
-                            Get l6 // { arity: 3 }
-      cte l7 =
+                                  Get l8 // { arity: 3 }
+                                Get l6 // { arity: 3 }
+                            Get l7 // { arity: 3 }
+      cte l8 =
         Project (#0..=#2) // { arity: 3 }
           Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
             implementation
-              %1[#0..=#2]UKKKA » %0:l6[#0..=#2]UKKK
-            Get l6 // { arity: 3 }
+              %1[#0..=#2]UKKKA » %0:l7[#0..=#2]UKKK
+            Get l7 // { arity: 3 }
             ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
               Distinct project=[#0..=#2] // { arity: 3 }
                 Project (#0..=#2) // { arity: 3 }
-                  Get l4 // { arity: 5 }
-      cte l6 =
+                  Get l5 // { arity: 5 }
+      cte l7 =
         ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-          Get l5 // { arity: 3 }
-      cte l5 =
+          Get l6 // { arity: 3 }
+      cte l6 =
         Distinct project=[#0..=#2] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
             Get l12 // { arity: 6 }
-      cte l4 =
+      cte l5 =
         TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
           Project (#0..=#3, #5) // { arity: 5 }
             Filter (#4 = false) // { arity: 6 }
               Get l12 // { arity: 6 }
+      cte l4 =
+        Distinct project=[] // { arity: 0 }
+          Project () // { arity: 0 }
+            Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
+              implementation
+                %0:l3[#0]UK » %1:l2[#0]K
+              ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
+                Get l3 // { arity: 1 }
+              Get l2 // { arity: 1 }
       cte l3 =
         Distinct project=[#0{dst}] // { arity: 1 }
           Union // { arity: 1 }

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -21,15 +21,13 @@ Explained Query:
     Get l0
   With Mutually Recursive
     cte l0 =
-      Project (#1)
-        Map (1)
-          Distinct project=[#0] monotonic
-            Union
-              Project (#1)
-                Map (7)
-                  Get l0
-              Constant
-                - (2)
+      Map (1)
+        Union
+          Distinct project=[] monotonic
+            Project ()
+              Get l0
+          Constant
+            - ()
 
 Target cluster: mz_catalog_server
 


### PR DESCRIPTION
When we have `Reduce` over `Union`, we may be able to push down the `Reduce` if its key expressions can be seen to be disjoint on the union inputs. More generally, if there are multiple connected components of union inputs under the "not incompatible" relation, we can push the reduce down to each connected component and union the results.

The arranged state is not increased, as we are certain it is partitioned among the subexpressions. The pushdown can result in wins when the union inputs have more specific properties that further optimize the reduce (e.g. are constants, have unique keys, certain columns are literals).

There is a risk to the pushdown, which is that if we were relying on the arranged outputs of the `Reduce` for .. say a join input or the arrangement for a `CREATE INDEX` command, we would need to re-arrange the results, and we would not feel quite as smart. So, we should just race and merge this. At the same time, the moments that feel bad here are similar to the moments that we know how to work around with "product of sum" join processing (which is tbd, but this is another reason to want it).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
