### PR TITLE
Move analysis panics into `Derived*`

### DIFF
--- a/src/transform/src/analysis/equivalences.rs
+++ b/src/transform/src/analysis/equivalences.rs
@@ -145,7 +145,7 @@ impl Analysis for Equivalences {
                 // introduce equivalences for new columns and expressions that define them.
                 let mut equivalences = results.get(index - 1).unwrap().clone();
                 if let Some(equivalences) = &mut equivalences {
-                    let input_arity = depends.results::<Arity>().unwrap()[index - 1];
+                    let input_arity = depends.results::<Arity>()[index - 1];
                     for (pos, expr) in scalars.iter().enumerate() {
                         equivalences
                             .classes
@@ -175,7 +175,7 @@ impl Analysis for Equivalences {
                     .collect::<Vec<_>>();
                 children.reverse();
 
-                let arity = depends.results::<Arity>().unwrap();
+                let arity = depends.results::<Arity>();
                 let mut columns = 0;
                 let mut result = Some(EquivalenceClasses::default());
                 for child in children.into_iter() {
@@ -204,7 +204,7 @@ impl Analysis for Equivalences {
                 aggregates,
                 ..
             } => {
-                let input_arity = depends.results::<Arity>().unwrap()[index - 1];
+                let input_arity = depends.results::<Arity>()[index - 1];
                 let mut equivalences = results.get(index - 1).unwrap().clone();
                 if let Some(equivalences) = &mut equivalences {
                     // Introduce keys column equivalences as if a map, then project to those columns.
@@ -266,7 +266,7 @@ impl Analysis for Equivalences {
             MirRelationExpr::ArrangeBy { .. } => results.get(index - 1).unwrap().clone(),
         };
 
-        let expr_type = depends.results::<RelationType>().unwrap()[index].clone();
+        let expr_type = depends.results::<RelationType>()[index].clone();
         equivalences.as_mut().map(|e| e.minimize(&expr_type));
         equivalences
     }


### PR DESCRIPTION
Our analysis framework allows you to build on various other analyses, but to access them you need to probe the collection to get the results, and .. potentially they might not exist (due to a logic bug). There is nothing to do other than panic, and all the "user" code immediately panics with the same messages: "Analysis FOO was required, but is missing".

This PR moves those panics into the analysis container, indicating that some methods may panic when invoked with arguments that cannot be found, not unlike array out of bounds access or key not found errors.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
