### PR TITLE
Stop fusing `Map` into `Reduce`

### DIFF
--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -94,47 +94,6 @@ impl ReductionPushdown {
             expected_group_size,
         } = relation
         {
-            // Map expressions can be absorbed into the Reduce at no cost.
-            if let MirRelationExpr::Map {
-                input: inner,
-                scalars,
-            } = &mut **input
-            {
-                let arity = inner.arity();
-
-                // Normalize the scalars to not be self-referential.
-                let mut scalars = scalars.clone();
-                for index in 0..scalars.len() {
-                    let (lower, upper) = scalars.split_at_mut(index);
-                    upper[0].visit_mut_post(&mut |e| {
-                        if let mz_expr::MirScalarExpr::Column(c) = e {
-                            if *c >= arity {
-                                *e = lower[*c - arity].clone();
-                            }
-                        }
-                    })?;
-                }
-                for key in group_key.iter_mut() {
-                    key.visit_mut_post(&mut |e| {
-                        if let mz_expr::MirScalarExpr::Column(c) = e {
-                            if *c >= arity {
-                                *e = scalars[*c - arity].clone();
-                            }
-                        }
-                    })?;
-                }
-                for agg in aggregates.iter_mut() {
-                    agg.expr.visit_mut_post(&mut |e| {
-                        if let mz_expr::MirScalarExpr::Column(c) = e {
-                            if *c >= arity {
-                                *e = scalars[*c - arity].clone();
-                            }
-                        }
-                    })?;
-                }
-
-                **input = inner.take_dangerous()
-            }
             if let MirRelationExpr::Join {
                 inputs,
                 equivalences,

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -846,39 +846,40 @@ Explained Query:
   Finish order_by=[#4 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0..=#4]
     Return // { arity: 5 }
       Map (((bigint_to_numeric((1 * #3{count})) + (2 * #1{sum})) + (10 * #2{sum}))) // { arity: 5 }
-        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(case when (#2) IS NULL then null else #1{count} end, 0)), sum(coalesce(case when (#4) IS NULL then null else #3{count} end, 0)), count(*)] // { arity: 4 }
-          Project (#1{count}, #3{count}, #4, #6, #7) // { arity: 5 }
-            Join on=(#0{messageid} = #2{parentmessageid} = #5{messageid}) type=delta // { arity: 8 }
-              implementation
-                %0:l0 » %1[#0]K » %2[#0]K
-                %1 » %0:l0[#0]Kef » %2[#0]K
-                %2 » %0:l0[#0]Kef » %1[#0]K
-              ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-                Project (#1{creatorpersonid}, #2) // { arity: 2 }
-                  Filter (#0{name} = "Sikh_Empire") // { arity: 3 }
-                    Get l0 // { arity: 3 }
-              ArrangeBy keys=[[#0{parentmessageid}]] // { arity: 3 }
-                Union // { arity: 3 }
-                  Map (true) // { arity: 3 }
-                    Get l1 // { arity: 2 }
-                  Map (null, null) // { arity: 3 }
-                    Threshold // { arity: 1 }
-                      Union // { arity: 1 }
-                        Negate // { arity: 1 }
-                          Project (#0{parentmessageid}) // { arity: 1 }
-                            Get l1 // { arity: 2 }
-                        Get l3 // { arity: 1 }
-              ArrangeBy keys=[[#0{messageid}]] // { arity: 3 }
-                Union // { arity: 3 }
-                  Map (true) // { arity: 3 }
-                    Get l2 // { arity: 2 }
-                  Map (null, null) // { arity: 3 }
-                    Threshold // { arity: 1 }
-                      Union // { arity: 1 }
-                        Negate // { arity: 1 }
-                          Project (#0{messageid}) // { arity: 1 }
-                            Get l2 // { arity: 2 }
-                        Get l3 // { arity: 1 }
+        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1, 0)), sum(coalesce(#2, 0)), count(*)] // { arity: 4 }
+          Project (#1, #8, #9) // { arity: 3 }
+            Map (case when (#4) IS NULL then null else #3{count} end, case when (#7) IS NULL then null else #6{count} end) // { arity: 10 }
+              Join on=(#0{messageid} = #2{parentmessageid} = #5{messageid}) type=delta // { arity: 8 }
+                implementation
+                  %0:l0 » %1[#0]K » %2[#0]K
+                  %1 » %0:l0[#0]Kef » %2[#0]K
+                  %2 » %0:l0[#0]Kef » %1[#0]K
+                ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
+                  Project (#1{creatorpersonid}, #2) // { arity: 2 }
+                    Filter (#0{name} = "Sikh_Empire") // { arity: 3 }
+                      Get l0 // { arity: 3 }
+                ArrangeBy keys=[[#0{parentmessageid}]] // { arity: 3 }
+                  Union // { arity: 3 }
+                    Map (true) // { arity: 3 }
+                      Get l1 // { arity: 2 }
+                    Map (null, null) // { arity: 3 }
+                      Threshold // { arity: 1 }
+                        Union // { arity: 1 }
+                          Negate // { arity: 1 }
+                            Project (#0{parentmessageid}) // { arity: 1 }
+                              Get l1 // { arity: 2 }
+                          Get l3 // { arity: 1 }
+                ArrangeBy keys=[[#0{messageid}]] // { arity: 3 }
+                  Union // { arity: 3 }
+                    Map (true) // { arity: 3 }
+                      Get l2 // { arity: 2 }
+                    Map (null, null) // { arity: 3 }
+                      Threshold // { arity: 1 }
+                        Union // { arity: 1 }
+                          Negate // { arity: 1 }
+                            Project (#0{messageid}) // { arity: 1 }
+                              Get l2 // { arity: 2 }
+                          Get l3 // { arity: 1 }
     With
       cte l3 =
         Distinct project=[#0{messageid}] // { arity: 1 }
@@ -1422,50 +1423,51 @@ Explained Query:
   Finish order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0, #1, #3]
     Return // { arity: 5 }
       Map (coalesce(#2{sum}, 0), (bigint_to_numeric(#1) + #3)) // { arity: 5 }
-        Reduce group_by=[#0, #1] aggregates=[sum(case when (#3) IS NULL then null else #2 end)] // { arity: 3 }
-          Project (#0, #1, #6, #7) // { arity: 4 }
-            Join on=(#0 = #2{person1id} AND #5{person2id} = case when (#4) IS NULL then null else #3{person2id} end) type=delta // { arity: 8 }
-              implementation
-                %0:l7 » %1[#0]K » %2[#0]K
-                %1 » %0:l7[#0]K » %2[#0]K
-                %2 » %1[case when (#2) IS NULL then null else #1 end]K » %0:l7[#0]K
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Get l7 // { arity: 2 }
-              ArrangeBy keys=[[#0{person1id}], [case when (#2) IS NULL then null else #1{person2id} end]] // { arity: 3 }
-                Union // { arity: 3 }
-                  Project (#1{person2id}..=#3) // { arity: 3 }
-                    Map (true) // { arity: 4 }
-                      ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-                  Map (null, null) // { arity: 3 }
-                    Threshold // { arity: 1 }
-                      Union // { arity: 1 }
-                        Negate // { arity: 1 }
-                          Project (#1) // { arity: 1 }
-                            ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-                        Distinct project=[#0] // { arity: 1 }
-                          Union // { arity: 1 }
-                            Project (#0) // { arity: 1 }
-                              Get l7 // { arity: 2 }
-                            Constant // { arity: 1 }
-                              - (null)
-              ArrangeBy keys=[[#0{person2id}]] // { arity: 3 }
-                Union // { arity: 3 }
-                  Filter (#0) IS NOT NULL // { arity: 3 }
-                    Map (true) // { arity: 3 }
-                      Get l7 // { arity: 2 }
-                  Map (null, null) // { arity: 3 }
-                    Threshold // { arity: 1 }
-                      Union // { arity: 1 }
-                        Negate // { arity: 1 }
-                          Project (#0) // { arity: 1 }
-                            Filter (#0) IS NOT NULL // { arity: 2 }
-                              Get l7 // { arity: 2 }
-                        Distinct project=[#0{person2id}] // { arity: 1 }
-                          Union // { arity: 1 }
-                            Project (#2) // { arity: 1 }
+        Reduce group_by=[#0, #1] aggregates=[sum(#2)] // { arity: 3 }
+          Project (#0, #1, #8) // { arity: 3 }
+            Map (case when (#7) IS NULL then null else #6 end) // { arity: 9 }
+              Join on=(#0 = #2{person1id} AND #5{person2id} = case when (#4) IS NULL then null else #3{person2id} end) type=delta // { arity: 8 }
+                implementation
+                  %0:l7 » %1[#0]K » %2[#0]K
+                  %1 » %0:l7[#0]K » %2[#0]K
+                  %2 » %1[case when (#2) IS NULL then null else #1 end]K » %0:l7[#0]K
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Get l7 // { arity: 2 }
+                ArrangeBy keys=[[#0{person1id}], [case when (#2) IS NULL then null else #1{person2id} end]] // { arity: 3 }
+                  Union // { arity: 3 }
+                    Project (#1{person2id}..=#3) // { arity: 3 }
+                      Map (true) // { arity: 4 }
+                        ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+                    Map (null, null) // { arity: 3 }
+                      Threshold // { arity: 1 }
+                        Union // { arity: 1 }
+                          Negate // { arity: 1 }
+                            Project (#1) // { arity: 1 }
                               ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-                            Constant // { arity: 1 }
-                              - (null)
+                          Distinct project=[#0] // { arity: 1 }
+                            Union // { arity: 1 }
+                              Project (#0) // { arity: 1 }
+                                Get l7 // { arity: 2 }
+                              Constant // { arity: 1 }
+                                - (null)
+                ArrangeBy keys=[[#0{person2id}]] // { arity: 3 }
+                  Union // { arity: 3 }
+                    Filter (#0) IS NOT NULL // { arity: 3 }
+                      Map (true) // { arity: 3 }
+                        Get l7 // { arity: 2 }
+                    Map (null, null) // { arity: 3 }
+                      Threshold // { arity: 1 }
+                        Union // { arity: 1 }
+                          Negate // { arity: 1 }
+                            Project (#0) // { arity: 1 }
+                              Filter (#0) IS NOT NULL // { arity: 2 }
+                                Get l7 // { arity: 2 }
+                          Distinct project=[#0{person2id}] // { arity: 1 }
+                            Union // { arity: 1 }
+                              Project (#2) // { arity: 1 }
+                                ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+                              Constant // { arity: 1 }
+                                - (null)
     With
       cte l7 =
         Project (#3, #4) // { arity: 2 }
@@ -2321,22 +2323,23 @@ Explained Query:
             ArrangeBy keys=[[#2{id}, #3{person2id}]] // { arity: 4 }
               Get l3 // { arity: 4 }
             ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-              Reduce group_by=[#1, #2] aggregates=[sum((case when #3 then case when #0 then 1 else 4 end else 0 end + case when #4 then case when #0 then 1 else 10 end else 0 end))] // { arity: 3 }
-                Project (#2..=#5, #8) // { arity: 5 }
-                  Join on=(#0{id} = #6{id} AND #1{person2id} = #7{person2id}) type=differential // { arity: 9 }
-                    implementation
-                      %0:l8[#0, #1]KK » %1[#0, #1]KK
-                    ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 6 }
-                      Get l8 // { arity: 6 }
-                    ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 3 }
-                      Union // { arity: 3 }
-                        Map (true) // { arity: 3 }
-                          Get l10 // { arity: 2 }
-                        Map (false) // { arity: 3 }
-                          Union // { arity: 2 }
-                            Negate // { arity: 2 }
-                              Get l10 // { arity: 2 }
-                            Get l9 // { arity: 2 }
+              Reduce group_by=[#0, #1] aggregates=[sum(#2)] // { arity: 3 }
+                Project (#3, #4, #9) // { arity: 3 }
+                  Map ((case when #5 then case when #2 then 1 else 4 end else 0 end + case when #8 then case when #2 then 1 else 10 end else 0 end)) // { arity: 10 }
+                    Join on=(#0{id} = #6{id} AND #1{person2id} = #7{person2id}) type=differential // { arity: 9 }
+                      implementation
+                        %0:l8[#0, #1]KK » %1[#0, #1]KK
+                      ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 6 }
+                        Get l8 // { arity: 6 }
+                      ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 3 }
+                        Union // { arity: 3 }
+                          Map (true) // { arity: 3 }
+                            Get l10 // { arity: 2 }
+                          Map (false) // { arity: 3 }
+                            Union // { arity: 2 }
+                              Negate // { arity: 2 }
+                                Get l10 // { arity: 2 }
+                              Get l9 // { arity: 2 }
       cte l10 =
         Project (#0{id}, #1{person2id}) // { arity: 2 }
           Join on=(#0{id} = #2{personid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
@@ -2563,26 +2566,27 @@ Explained Query:
             %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
           Get l1 // { arity: 2 }
           ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-            Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-              Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
-                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
-                  implementation
-                    %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
-                    %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                    %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                    %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                    %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                    Project (#9, #10, #12) // { arity: 3 }
-                      Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+            Reduce group_by=[#1, #2] aggregates=[sum(case when (#0{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
+              Project (#6, #12, #13) // { arity: 3 }
+                Map (least(#1{person1id}, #2{person2id}), greatest(#1{person1id}, #2{person2id})) // { arity: 14 }
+                  Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
+                    implementation
+                      %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
+                      %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                      %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                      %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                      %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                    ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                      ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                    ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                      Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
                         ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                  Get l2 // { arity: 1 }
-                  Get l2 // { arity: 1 }
+                    ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                      Project (#9, #10, #12) // { arity: 3 }
+                        Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                          ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                    Get l2 // { arity: 1 }
+                    Get l2 // { arity: 1 }
       cte l2 =
         ArrangeBy keys=[[#0{id}]] // { arity: 1 }
           Distinct project=[#0{id}] // { arity: 1 }
@@ -2953,26 +2957,27 @@ Explained Query:
           %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
         Get l1 // { arity: 2 }
         ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-          Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-            Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
-              Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
-                implementation
-                  %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
-                  %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                  %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                  %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                  %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                  ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                  Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                  Project (#9, #10, #12) // { arity: 3 }
-                    Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+          Reduce group_by=[#1, #2] aggregates=[sum(case when (#0{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
+            Project (#6, #12, #13) // { arity: 3 }
+              Map (least(#1{person1id}, #2{person2id}), greatest(#1{person1id}, #2{person2id})) // { arity: 14 }
+                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
+                  implementation
+                    %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                    %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                Get l2 // { arity: 1 }
-                Get l2 // { arity: 1 }
+                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                    Project (#9, #10, #12) // { arity: 3 }
+                      Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  Get l2 // { arity: 1 }
+                  Get l2 // { arity: 1 }
     cte l2 =
       ArrangeBy keys=[[#0{id}]] // { arity: 1 }
         Distinct project=[#0{id}] // { arity: 1 }

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -853,39 +853,40 @@ Explained Query:
   Finish order_by=[#4 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0..=#4]
     Return // { arity: 5 }
       Map (((bigint_to_numeric((1 * #3{count})) + (2 * #1{sum})) + (10 * #2{sum}))) // { arity: 5 }
-        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(case when (#2) IS NULL then null else #1{count} end, 0)), sum(coalesce(case when (#4) IS NULL then null else #3{count} end, 0)), count(*)] // { arity: 4 }
-          Project (#1{count}, #3{count}, #4, #6, #7) // { arity: 5 }
-            Join on=(#0{messageid} = #2{parentmessageid} = #5{messageid}) type=delta // { arity: 8 }
-              implementation
-                %0:l0 » %1[#0]K » %2[#0]K
-                %1 » %0:l0[#0]Kef » %2[#0]K
-                %2 » %0:l0[#0]Kef » %1[#0]K
-              ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-                Project (#1{creatorpersonid}, #2) // { arity: 2 }
-                  Filter (#0{name} = "Sikh_Empire") // { arity: 3 }
-                    Get l0 // { arity: 3 }
-              ArrangeBy keys=[[#0{parentmessageid}]] // { arity: 3 }
-                Union // { arity: 3 }
-                  Map (true) // { arity: 3 }
-                    Get l1 // { arity: 2 }
-                  Map (null, null) // { arity: 3 }
-                    Threshold // { arity: 1 }
-                      Union // { arity: 1 }
-                        Negate // { arity: 1 }
-                          Project (#0{parentmessageid}) // { arity: 1 }
-                            Get l1 // { arity: 2 }
-                        Get l3 // { arity: 1 }
-              ArrangeBy keys=[[#0{messageid}]] // { arity: 3 }
-                Union // { arity: 3 }
-                  Map (true) // { arity: 3 }
-                    Get l2 // { arity: 2 }
-                  Map (null, null) // { arity: 3 }
-                    Threshold // { arity: 1 }
-                      Union // { arity: 1 }
-                        Negate // { arity: 1 }
-                          Project (#0{messageid}) // { arity: 1 }
-                            Get l2 // { arity: 2 }
-                        Get l3 // { arity: 1 }
+        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1, 0)), sum(coalesce(#2, 0)), count(*)] // { arity: 4 }
+          Project (#1, #8, #9) // { arity: 3 }
+            Map (case when (#4) IS NULL then null else #3{count} end, case when (#7) IS NULL then null else #6{count} end) // { arity: 10 }
+              Join on=(#0{messageid} = #2{parentmessageid} = #5{messageid}) type=delta // { arity: 8 }
+                implementation
+                  %0:l0 » %1[#0]K » %2[#0]K
+                  %1 » %0:l0[#0]Kef » %2[#0]K
+                  %2 » %0:l0[#0]Kef » %1[#0]K
+                ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
+                  Project (#1{creatorpersonid}, #2) // { arity: 2 }
+                    Filter (#0{name} = "Sikh_Empire") // { arity: 3 }
+                      Get l0 // { arity: 3 }
+                ArrangeBy keys=[[#0{parentmessageid}]] // { arity: 3 }
+                  Union // { arity: 3 }
+                    Map (true) // { arity: 3 }
+                      Get l1 // { arity: 2 }
+                    Map (null, null) // { arity: 3 }
+                      Threshold // { arity: 1 }
+                        Union // { arity: 1 }
+                          Negate // { arity: 1 }
+                            Project (#0{parentmessageid}) // { arity: 1 }
+                              Get l1 // { arity: 2 }
+                          Get l3 // { arity: 1 }
+                ArrangeBy keys=[[#0{messageid}]] // { arity: 3 }
+                  Union // { arity: 3 }
+                    Map (true) // { arity: 3 }
+                      Get l2 // { arity: 2 }
+                    Map (null, null) // { arity: 3 }
+                      Threshold // { arity: 1 }
+                        Union // { arity: 1 }
+                          Negate // { arity: 1 }
+                            Project (#0{messageid}) // { arity: 1 }
+                              Get l2 // { arity: 2 }
+                          Get l3 // { arity: 1 }
     With
       cte l3 =
         Distinct project=[#0{messageid}] // { arity: 1 }
@@ -1429,50 +1430,51 @@ Explained Query:
   Finish order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0, #1, #3]
     Return // { arity: 5 }
       Map (coalesce(#2{sum}, 0), (bigint_to_numeric(#1) + #3)) // { arity: 5 }
-        Reduce group_by=[#0, #1] aggregates=[sum(case when (#3) IS NULL then null else #2 end)] // { arity: 3 }
-          Project (#0, #1, #6, #7) // { arity: 4 }
-            Join on=(#0 = #2{person1id} AND #5{person2id} = case when (#4) IS NULL then null else #3{person2id} end) type=delta // { arity: 8 }
-              implementation
-                %0:l7 » %1[#0]K » %2[#0]K
-                %1 » %0:l7[#0]K » %2[#0]K
-                %2 » %1[case when (#2) IS NULL then null else #1 end]K » %0:l7[#0]K
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Get l7 // { arity: 2 }
-              ArrangeBy keys=[[#0{person1id}], [case when (#2) IS NULL then null else #1{person2id} end]] // { arity: 3 }
-                Union // { arity: 3 }
-                  Project (#1{person2id}..=#3) // { arity: 3 }
-                    Map (true) // { arity: 4 }
-                      ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-                  Map (null, null) // { arity: 3 }
-                    Threshold // { arity: 1 }
-                      Union // { arity: 1 }
-                        Negate // { arity: 1 }
-                          Project (#1) // { arity: 1 }
-                            ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-                        Distinct project=[#0] // { arity: 1 }
-                          Union // { arity: 1 }
-                            Project (#0) // { arity: 1 }
-                              Get l7 // { arity: 2 }
-                            Constant // { arity: 1 }
-                              - (null)
-              ArrangeBy keys=[[#0{person2id}]] // { arity: 3 }
-                Union // { arity: 3 }
-                  Filter (#0) IS NOT NULL // { arity: 3 }
-                    Map (true) // { arity: 3 }
-                      Get l7 // { arity: 2 }
-                  Map (null, null) // { arity: 3 }
-                    Threshold // { arity: 1 }
-                      Union // { arity: 1 }
-                        Negate // { arity: 1 }
-                          Project (#0) // { arity: 1 }
-                            Filter (#0) IS NOT NULL // { arity: 2 }
-                              Get l7 // { arity: 2 }
-                        Distinct project=[#0{person2id}] // { arity: 1 }
-                          Union // { arity: 1 }
-                            Project (#2) // { arity: 1 }
+        Reduce group_by=[#0, #1] aggregates=[sum(#2)] // { arity: 3 }
+          Project (#0, #1, #8) // { arity: 3 }
+            Map (case when (#7) IS NULL then null else #6 end) // { arity: 9 }
+              Join on=(#0 = #2{person1id} AND #5{person2id} = case when (#4) IS NULL then null else #3{person2id} end) type=delta // { arity: 8 }
+                implementation
+                  %0:l7 » %1[#0]K » %2[#0]K
+                  %1 » %0:l7[#0]K » %2[#0]K
+                  %2 » %1[case when (#2) IS NULL then null else #1 end]K » %0:l7[#0]K
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Get l7 // { arity: 2 }
+                ArrangeBy keys=[[#0{person1id}], [case when (#2) IS NULL then null else #1{person2id} end]] // { arity: 3 }
+                  Union // { arity: 3 }
+                    Project (#1{person2id}..=#3) // { arity: 3 }
+                      Map (true) // { arity: 4 }
+                        ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+                    Map (null, null) // { arity: 3 }
+                      Threshold // { arity: 1 }
+                        Union // { arity: 1 }
+                          Negate // { arity: 1 }
+                            Project (#1) // { arity: 1 }
                               ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-                            Constant // { arity: 1 }
-                              - (null)
+                          Distinct project=[#0] // { arity: 1 }
+                            Union // { arity: 1 }
+                              Project (#0) // { arity: 1 }
+                                Get l7 // { arity: 2 }
+                              Constant // { arity: 1 }
+                                - (null)
+                ArrangeBy keys=[[#0{person2id}]] // { arity: 3 }
+                  Union // { arity: 3 }
+                    Filter (#0) IS NOT NULL // { arity: 3 }
+                      Map (true) // { arity: 3 }
+                        Get l7 // { arity: 2 }
+                    Map (null, null) // { arity: 3 }
+                      Threshold // { arity: 1 }
+                        Union // { arity: 1 }
+                          Negate // { arity: 1 }
+                            Project (#0) // { arity: 1 }
+                              Filter (#0) IS NOT NULL // { arity: 2 }
+                                Get l7 // { arity: 2 }
+                          Distinct project=[#0{person2id}] // { arity: 1 }
+                            Union // { arity: 1 }
+                              Project (#2) // { arity: 1 }
+                                ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+                              Constant // { arity: 1 }
+                                - (null)
     With
       cte l7 =
         Project (#3, #4) // { arity: 2 }
@@ -2328,22 +2330,23 @@ Explained Query:
             ArrangeBy keys=[[#2{id}, #3{person2id}]] // { arity: 4 }
               Get l3 // { arity: 4 }
             ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-              Reduce group_by=[#1, #2] aggregates=[sum((case when #3 then case when #0 then 1 else 4 end else 0 end + case when #4 then case when #0 then 1 else 10 end else 0 end))] // { arity: 3 }
-                Project (#2..=#5, #8) // { arity: 5 }
-                  Join on=(#0{id} = #6{id} AND #1{person2id} = #7{person2id}) type=differential // { arity: 9 }
-                    implementation
-                      %0:l8[#0, #1]KK » %1[#0, #1]KK
-                    ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 6 }
-                      Get l8 // { arity: 6 }
-                    ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 3 }
-                      Union // { arity: 3 }
-                        Map (true) // { arity: 3 }
-                          Get l10 // { arity: 2 }
-                        Map (false) // { arity: 3 }
-                          Union // { arity: 2 }
-                            Negate // { arity: 2 }
-                              Get l10 // { arity: 2 }
-                            Get l9 // { arity: 2 }
+              Reduce group_by=[#0, #1] aggregates=[sum(#2)] // { arity: 3 }
+                Project (#3, #4, #9) // { arity: 3 }
+                  Map ((case when #5 then case when #2 then 1 else 4 end else 0 end + case when #8 then case when #2 then 1 else 10 end else 0 end)) // { arity: 10 }
+                    Join on=(#0{id} = #6{id} AND #1{person2id} = #7{person2id}) type=differential // { arity: 9 }
+                      implementation
+                        %0:l8[#0, #1]KK » %1[#0, #1]KK
+                      ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 6 }
+                        Get l8 // { arity: 6 }
+                      ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 3 }
+                        Union // { arity: 3 }
+                          Map (true) // { arity: 3 }
+                            Get l10 // { arity: 2 }
+                          Map (false) // { arity: 3 }
+                            Union // { arity: 2 }
+                              Negate // { arity: 2 }
+                                Get l10 // { arity: 2 }
+                              Get l9 // { arity: 2 }
       cte l10 =
         Project (#0{id}, #1{person2id}) // { arity: 2 }
           Join on=(#0{id} = #2{personid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
@@ -2570,26 +2573,27 @@ Explained Query:
             %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
           Get l1 // { arity: 2 }
           ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-            Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-              Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
-                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
-                  implementation
-                    %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
-                    %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                    %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                    %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                    %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                    Project (#9, #10, #12) // { arity: 3 }
-                      Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+            Reduce group_by=[#1, #2] aggregates=[sum(case when (#0{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
+              Project (#6, #12, #13) // { arity: 3 }
+                Map (least(#1{person1id}, #2{person2id}), greatest(#1{person1id}, #2{person2id})) // { arity: 14 }
+                  Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
+                    implementation
+                      %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
+                      %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                      %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                      %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                      %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                    ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                      ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                    ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                      Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
                         ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                  Get l2 // { arity: 1 }
-                  Get l2 // { arity: 1 }
+                    ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                      Project (#9, #10, #12) // { arity: 3 }
+                        Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                          ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                    Get l2 // { arity: 1 }
+                    Get l2 // { arity: 1 }
       cte l2 =
         ArrangeBy keys=[[#0{id}]] // { arity: 1 }
           Distinct project=[#0{id}] // { arity: 1 }
@@ -2960,26 +2964,27 @@ Explained Query:
           %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
         Get l1 // { arity: 2 }
         ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-          Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-            Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
-              Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
-                implementation
-                  %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
-                  %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                  %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                  %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                  %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                  ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                  Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                  Project (#9, #10, #12) // { arity: 3 }
-                    Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+          Reduce group_by=[#1, #2] aggregates=[sum(case when (#0{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
+            Project (#6, #12, #13) // { arity: 3 }
+              Map (least(#1{person1id}, #2{person2id}), greatest(#1{person1id}, #2{person2id})) // { arity: 14 }
+                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
+                  implementation
+                    %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                    %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                Get l2 // { arity: 1 }
-                Get l2 // { arity: 1 }
+                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                    Project (#9, #10, #12) // { arity: 3 }
+                      Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  Get l2 // { arity: 1 }
+                  Get l2 // { arity: 1 }
     cte l2 =
       ArrangeBy keys=[[#0{id}]] // { arity: 1 }
         Distinct project=[#0{id}] // { arity: 1 }


### PR DESCRIPTION
Reduction pushdown would fuse map expressions into reduce, even if it results in an exponential blow-up (not that it was checking). We should not do this. We should figure out instead where these expressions should live, whether we should simplify them, or simply migrate them all out of reduce to an MFP stage instead.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
