### PR TITLE
terraform e2e test: Fix flakiness by sleeping longer

### DIFF
--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -320,6 +320,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             ],
             cwd=path,
         )
+        # These sleeps are a bit unclean, we should instead only consider
+        # environmentd as running when it is has started listening on its ports
+        time.sleep(30)
         port_forward_process = subprocess.Popen(
             [
                 "kubectl",
@@ -334,7 +337,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             ],
             preexec_fn=os.setpgrp,
         )
-        time.sleep(10)
+        time.sleep(30)
 
         with c.override(
             Testdrive(


### PR DESCRIPTION
environmentd is reported as "Running" in kubectl before it is actually listening on its ports

Seen failing in https://buildkite.com/materialize/nightly/builds/10541#01936b08-6eb4-49de-a7c8-2b102b7f6733
```
	E1127 00:48:20.551735    2205 portforward.go:406] an error occurred forwarding 6875 -> 6875: error forwarding port 6875 to pod 487c65896791af9e19f77eaaed22bcf62281e447c5b20257c3fab99ece85ede7, uid : failed to execute portforward in network namespace "/var/run/netns/cni-b7379791-8739-599d-2a1f-6717e8afb3f9": failed to connect to localhost:6875 inside namespace "487c65896791af9e19f77eaaed22bcf62281e447c5b20257c3fab99ece85ede7", IPv4: dial tcp4 127.0.0.1:6875: connect: connection refused IPv6 dial tcp6: address localhost: no suitable address found
```

@doy-materialize Is there something we can do about this from Kubernetes side to wait until environmentd is actually reachable before it reports as "Running"?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
