### PR TITLE
feature-benchmark: Create index on table, not source

### DIFF
--- a/misc/python/materialize/feature_benchmark/scenarios/concurrency.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/concurrency.py
@@ -10,6 +10,7 @@
 from materialize.feature_benchmark.action import Action, TdAction
 from materialize.feature_benchmark.measurement_source import MeasurementSource, Td
 from materialize.feature_benchmark.scenario import Scenario
+from materialize.feature_benchmark.scenario_version import ScenarioVersion
 
 
 class Concurrency(Scenario):
@@ -21,6 +22,9 @@ class ParallelIngestion(Concurrency):
 
     SOURCES = 10
     FIXED_SCALE = True  # Disk slowness in CRDB leading to CRDB going down
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
 
     def shared(self) -> Action:
         return TdAction(
@@ -72,7 +76,7 @@ $ kafka-ingest format=avro topic=kafka-parallel-ingestion key-format=avro key-sc
         create_indexes = "\n".join(
             [
                 f"""
-> CREATE DEFAULT INDEX ON s{s}
+> CREATE DEFAULT INDEX ON s{s}_tbl
 """
                 for s in sources
             ]


### PR DESCRIPTION
Thanks to @teskje for noticing: https://materializeinc.slack.com/archives/C01LKF361MZ/p1732700985898469

Had to bump the version since this will change performance of the scenario (it was basically broken before)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
