### PR TITLE
docs: change count() signature to bigint

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -37,7 +37,7 @@
   - signature: 'bool_or(x: T) -> T'
     description: _NULL_ if all values of `x` are _NULL_, otherwise true if any values of `x` are true, otherwise false.
 
-  - signature: 'count(x: T) -> int'
+  - signature: 'count(x: T) -> bigint'
     description: Number of non-_NULL_ inputs.
 
   - signature: jsonb_agg(expression) -> jsonb


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

As reported in the community Slack, it looks like that `COUNT()` is documented to return an `int`, but in reality returns a `bigint`

<img width="367" alt="image" src="https://github.com/user-attachments/assets/688750cc-ac71-462a-9813-20f9bdf3dd7c">
