### PR TITLE
catalog: Deserialize audit log in background

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -552,7 +552,8 @@ impl Catalog {
         let mut storage = openable_storage
             .open(now().into(), &bootstrap_args)
             .await
-            .expect("can open durable catalog");
+            .expect("can open durable catalog")
+            .0;
         // Drain updates.
         let _ = storage
             .sync_to_current_updates()
@@ -578,7 +579,7 @@ impl Catalog {
             .with_default_deploy_generation()
             .build()
             .await?;
-        let storage = openable_storage.open(now().into(), bootstrap_args).await?;
+        let storage = openable_storage.open(now().into(), bootstrap_args).await?.0;
         let system_parameter_defaults = BTreeMap::default();
         Self::open_debug_catalog_inner(
             persist_client,

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -551,7 +551,8 @@ async fn upgrade_check(
                 cluster_replica_size_map: cluster_replica_sizes.clone(),
             },
         )
-        .await?;
+        .await?
+        .0;
 
     // If this upgrade has new builtin replicas, then we need to assign some size to it. It doesn't
     // really matter what size since it's not persisted, so we pick a random valid one.

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -99,11 +99,19 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     ///   - Catalog migrations fail.
     ///
     /// `initial_ts` is used as the initial timestamp for new environments.
+    ///
+    /// Also returns a handle to a thread that is deserializing all of the audit logs.
     async fn open_savepoint(
         mut self: Box<Self>,
         initial_ts: Timestamp,
         bootstrap_args: &BootstrapArgs,
-    ) -> Result<Box<dyn DurableCatalogState>, CatalogError>;
+    ) -> Result<
+        (
+            Box<dyn DurableCatalogState>,
+            std::thread::JoinHandle<Vec<memory::objects::StateUpdate>>,
+        ),
+        CatalogError,
+    >;
 
     /// Opens the catalog in read only mode. All mutating methods
     /// will return an error.
@@ -120,11 +128,19 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// needed.
     ///
     /// `initial_ts` is used as the initial timestamp for new environments.
+    ///
+    /// Also returns a handle to a thread that is deserializing all of the audit logs.
     async fn open(
         mut self: Box<Self>,
         initial_ts: Timestamp,
         bootstrap_args: &BootstrapArgs,
-    ) -> Result<Box<dyn DurableCatalogState>, CatalogError>;
+    ) -> Result<
+        (
+            Box<dyn DurableCatalogState>,
+            std::thread::JoinHandle<Vec<memory::objects::StateUpdate>>,
+        ),
+        CatalogError,
+    >;
 
     /// Opens the catalog for manual editing of the underlying data. This is helpful for
     /// fixing a corrupt catalog.

--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -332,6 +332,7 @@ impl StateUpdateKindJson {
                         value: String::new(),
                     },
                 ),
+                StateUpdateKind::AuditLog(proto::AuditLogKey { event: None }, ()),
             ]
             .into_iter()
             .map(|kind| {
@@ -341,6 +342,18 @@ impl StateUpdateKindJson {
             .collect()
         });
         DESERIALIZABLE_KINDS.contains(self.kind())
+    }
+
+    /// Returns true if this is an audit log update. Otherwise, returns false.
+    pub(crate) fn is_audit_log(&self) -> bool {
+        // Construct a fake audit log so we can extract exactly what the kind field will serialize
+        // as.
+        static AUDIT_LOG_KIND: LazyLock<String> = LazyLock::new(|| {
+            let audit_log = StateUpdateKind::AuditLog(proto::AuditLogKey { event: None }, ());
+            let json_kind: StateUpdateKindJson = audit_log.into();
+            json_kind.kind().to_string()
+        });
+        &*AUDIT_LOG_KIND == self.kind()
     }
 }
 

--- a/src/catalog/src/durable/persist/tests.rs
+++ b/src/catalog/src/durable/persist/tests.rs
@@ -51,7 +51,8 @@ async fn test_upgrade_shard() {
     let _persist_state = persist_openable_state
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .expect("failed to open persist catalog");
+        .expect("failed to open persist catalog")
+        .0;
 
     assert_eq!(
         Some(first_version.clone()),
@@ -111,7 +112,8 @@ async fn test_upgrade_shard() {
     let _persist_state = persist_openable_state
         .open_savepoint(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .expect("failed to open savepoint persist catalog");
+        .expect("failed to open savepoint persist catalog")
+        .0;
 
     assert_eq!(
         Some(first_version.clone()),
@@ -140,7 +142,8 @@ async fn test_upgrade_shard() {
     let _persist_state = persist_openable_state
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .expect("failed to open readonly persist catalog");
+        .expect("failed to open readonly persist catalog")
+        .0;
 
     assert_eq!(
         Some(second_version),
@@ -180,7 +183,8 @@ async fn test_version_regression() {
     let _persist_state = persist_openable_state
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .expect("failed to open persist catalog");
+        .expect("failed to open persist catalog")
+        .0;
 
     assert_eq!(
         Some(first_version.clone()),
@@ -201,7 +205,8 @@ async fn test_version_regression() {
     let _persist_state = persist_openable_state
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .expect("failed to open readonly persist catalog");
+        .expect("failed to open readonly persist catalog")
+        .0;
 
     assert_eq!(
         Some(second_version.clone()),

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -3643,13 +3643,15 @@ mod tests {
             .await
             .open(SYSTEM_TIME().into(), &test_bootstrap_args())
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let mut savepoint_state = state_builder
             .unwrap_build()
             .await
             .open_savepoint(SYSTEM_TIME().into(), &test_bootstrap_args())
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         let initial_snapshot = savepoint_state.sync_to_current_updates().await.unwrap();
         assert!(!initial_snapshot.is_empty());

--- a/src/catalog/tests/debug.rs
+++ b/src/catalog/tests/debug.rs
@@ -176,7 +176,8 @@ async fn test_debug<'a>(state_builder: TestCatalogStateBuilder) {
     let _ = openable_state1
         .open(NOW_ZERO().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Check epoch
     let mut openable_state2 = state_builder.clone().unwrap_build().await;
@@ -347,7 +348,8 @@ async fn test_debug_edit_fencing<'a>(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let mut debug_state = state_builder
         .clone()
@@ -401,7 +403,8 @@ async fn test_debug_edit_fencing<'a>(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Now debug state should be fenced.
     let err = debug_state
@@ -440,7 +443,8 @@ async fn test_debug_delete_fencing<'a>(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Drain state updates.
     let _ = state.sync_to_current_updates().await;
 
@@ -496,7 +500,8 @@ async fn test_debug_delete_fencing<'a>(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Now debug state should be fenced.
     let err = debug_state
@@ -551,7 +556,8 @@ async fn test_concurrent_debugs(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let state_handle = mz_ore::task::spawn(|| "state", async move {
         // Eventually this state should get fenced by the edit below.
         let err = run_state(&mut state).await.unwrap_err();
@@ -583,7 +589,8 @@ async fn test_concurrent_debugs(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let configs = state.snapshot().await.unwrap().configs;
     assert_eq!(configs.get(&key).unwrap(), &value);
 
@@ -619,6 +626,7 @@ async fn test_concurrent_debugs(state_builder: TestCatalogStateBuilder) {
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
         .unwrap()
+        .0
         .snapshot()
         .await
         .unwrap()

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -141,7 +141,8 @@ async fn test_is_initialized(state_builder: TestCatalogStateBuilder) {
     let state = openable_state1
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     state.expire().await;
 
     let mut openable_state2 = state_builder.unwrap_build().await;
@@ -185,7 +186,8 @@ async fn test_get_deployment_generation(state_builder: TestCatalogStateBuilder) 
         let state = openable_state
             .open(SYSTEM_TIME().into(), &test_bootstrap_args())
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         state.expire().await;
     }
 
@@ -243,7 +245,8 @@ async fn test_open_savepoint(state_builder: TestCatalogStateBuilder) {
             .await
             .open(SYSTEM_TIME().into(), &test_bootstrap_args())
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         assert_eq!(state.epoch(), Epoch::new(2).expect("known to be non-zero"));
         Box::new(state).expire().await;
     }
@@ -256,7 +259,8 @@ async fn test_open_savepoint(state_builder: TestCatalogStateBuilder) {
             .await
             .open_savepoint(SYSTEM_TIME().into(), &test_bootstrap_args())
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         // Drain initial updates.
         let _ = state
             .sync_to_current_updates()
@@ -361,7 +365,8 @@ async fn test_open_savepoint(state_builder: TestCatalogStateBuilder) {
             .await
             .open(SYSTEM_TIME().into(), &test_bootstrap_args())
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         // Write should not have persisted.
         let db = state
             .snapshot()
@@ -406,7 +411,8 @@ async fn test_open_read_only(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Drain initial updates.
     let _ = state
         .sync_to_current_updates()
@@ -481,7 +487,8 @@ async fn test_open(state_builder: TestCatalogStateBuilder) {
             // Use `NOW_ZERO` for consistent timestamps in the snapshots.
             .open(NOW_ZERO().into(), &test_bootstrap_args())
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         assert_eq!(state.epoch(), Epoch::new(2).expect("known to be non-zero"));
         // Check initial snapshot.
@@ -513,7 +520,8 @@ async fn test_open(state_builder: TestCatalogStateBuilder) {
             .await
             .open(SYSTEM_TIME().into(), &test_bootstrap_args())
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         assert_eq!(state.epoch(), Epoch::new(3).expect("known to be non-zero"));
         assert_eq!(state.snapshot().await.unwrap(), snapshot);
@@ -528,7 +536,8 @@ async fn test_open(state_builder: TestCatalogStateBuilder) {
             .await
             .open(SYSTEM_TIME().into(), &test_bootstrap_args())
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         assert_eq!(state.epoch(), Epoch::new(4).expect("known to be non-zero"));
         assert_eq!(state.snapshot().await.unwrap(), snapshot);
@@ -560,7 +569,8 @@ async fn test_unopened_deploy_generation_fencing(state_builder: TestCatalogState
             .await
             .open(SYSTEM_TIME().into(), &test_bootstrap_args())
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         // drain catalog updates.
         let _ = state.sync_to_current_updates().await.unwrap();
         let mut txn = state.transaction().await.unwrap();
@@ -589,7 +599,8 @@ async fn test_unopened_deploy_generation_fencing(state_builder: TestCatalogState
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Unopened catalog should be fenced now with a deploy generation fence.
     let err = openable_state
@@ -659,7 +670,8 @@ async fn test_opened_epoch_fencing(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Open catalog, which will bump the epoch.
     let _state = state_builder
@@ -668,7 +680,8 @@ async fn test_opened_epoch_fencing(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Opened catalog should be fenced now with an epoch fence.
     let err = state.snapshot().await.unwrap_err();
@@ -707,7 +720,8 @@ async fn test_opened_deploy_generation_fencing(state_builder: TestCatalogStateBu
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Open catalog, which will bump the epoch AND deploy generation.
     let _state = state_builder
@@ -717,7 +731,8 @@ async fn test_opened_deploy_generation_fencing(state_builder: TestCatalogStateBu
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Opened catalog should be fenced now with an epoch fence.
     let err = state.snapshot().await.unwrap_err();
@@ -760,7 +775,8 @@ async fn test_fencing_during_write(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Drain updates.
     let _ = state.sync_to_current_updates().await;
     let mut txn = state.transaction().await.unwrap();
@@ -774,7 +790,8 @@ async fn test_fencing_during_write(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Drain updates.
     let _ = state.sync_to_current_updates().await;
 
@@ -800,7 +817,8 @@ async fn test_fencing_during_write(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Committing results in a deploy generation fence error.
     let commit_ts = txn.upper();
@@ -840,7 +858,8 @@ async fn test_persist_version_fencing() {
         let _persist_state = persist_openable_state
             .open(SYSTEM_TIME().into(), &test_bootstrap_args())
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         persist_cache.cfg.build_version = reader_version.clone();
         let persist_client = persist_cache
@@ -903,7 +922,8 @@ async fn test_concurrent_open(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let state_handle = mz_ore::task::spawn(|| "state", async move {
         // Eventually this state should get fenced by the open below.
         let err = run_state(&mut state).await.unwrap_err();
@@ -920,7 +940,8 @@ async fn test_concurrent_open(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     state_handle.await.unwrap();
 
@@ -930,5 +951,6 @@ async fn test_concurrent_open(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 }

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -44,7 +44,8 @@ async fn test_confirm_leadership(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     assert_ok!(state1.confirm_leadership().await);
 
     let mut state2 = state_builder
@@ -52,7 +53,8 @@ async fn test_confirm_leadership(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     assert_ok!(state2.confirm_leadership().await);
 
     let err = state1.confirm_leadership().await.unwrap_err();
@@ -91,7 +93,8 @@ async fn test_allocate_id(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let start_id = state.get_next_id(id_type).await.unwrap();
     let commit_ts = state.current_upper().await;
@@ -169,7 +172,8 @@ async fn test_audit_logs(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Drain initial updates.
     let _ = state
         .sync_to_current_updates()
@@ -231,7 +235,8 @@ async fn test_items(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Drain initial updates.
     let _ = state
         .sync_to_current_updates()
@@ -288,7 +293,8 @@ async fn test_schemas(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Drain initial updates.
     let _ = state
         .sync_to_current_updates()
@@ -353,14 +359,16 @@ async fn test_non_writer_commits(state_builder: TestCatalogStateBuilder) {
         .await
         .open(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let mut savepoint_state = state_builder
         .clone()
         .unwrap_build()
         .await
         .open_savepoint(SYSTEM_TIME().into(), &test_bootstrap_args())
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let mut reader_state = state_builder
         .clone()
         .unwrap_build()

--- a/src/environmentd/src/deployment/preflight.rs
+++ b/src/environmentd/src/deployment/preflight.rs
@@ -75,7 +75,7 @@ pub async fn preflight_legacy(
             .open_savepoint(boot_ts.clone(), &bootstrap_args)
             .await
         {
-            Ok(adapter_storage) => Box::new(adapter_storage).expire().await,
+            Ok((adapter_storage, _)) => Box::new(adapter_storage).expire().await,
             Err(CatalogError::Durable(e)) if e.can_recover_with_write_mode() => {
                 // This is theoretically possible if catalog implementation A is
                 // initialized, implementation B is uninitialized, and we are going to


### PR DESCRIPTION
This commit optimizes the startup process to deserialize the audit log
in the background. Opening the durable catalog involves deserializing
all updates, migrating them, and then storing them in memory. Later the
in-memory catalog will take each update and generate a builtin table
update and apply that update in-memory. Throughout the startup process
audit logs are heavily special cased and only used to generate builtin
table updates. Additionally, audit logs are by far the largest catalog
collection and can take a long time to deserialize.

This commit creates a new thread at the beginning of the startup
process that deserializes all audit log updates. A handle for the
thread is plumbed throughout startup and then joined only when we
actually need the builtin table updates. By deserializing these updates
in the background we can reduce the total time spent in startup.

In order for this all to work, we have to disallow migrating audit log
updates, because now the audit log updates skip over migrations. In
practice this is OK, because the audit log has its own versioning
scheme that allows us to add new audit log variants without a
migration. The only thing we lose is the ability to re-write old audit
logs.

This speedup works only because other parts of startup take long enough
to hide the time spent deserializing the audit log. As other parts of
startup get faster, joining on the deserializing thread will get
slower. Some additional optimizations we can make in the future are:

  - Remove the audit log from the catalog.
  - Make the catalog shard queryable and remove the need to generate
    builtin table updates.
  - Now that the audit log is truly append-only, we could lazily
    deserialize the audit log updates in order by ID (how to order them
    is something we'd need to figure out), and stop once we've found
    the latest audit log update that is already in the builtin table.
    In general that will usually be the first audit log update we
    deserialize, unless we crashed after committing a catalog
    transaction but before updating the builtin tables.

Works towards resolving #MaterializeInc/database-issues/issues/8384

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
