### PR TITLE
ci: Switch a few nightly jobs over to Hetzner, move one to Release Qualification

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -73,8 +73,7 @@ steps:
           composition: cargo-test
           args: [--miri-full]
     agents:
-      # TODO(def-) Switch back to Hetzner
-      queue: builder-linux-aarch64-mem
+      queue: hetzner-aarch64-16cpu-32gb
     sanitizer: skip
 
   - group: Benchmarks
@@ -821,61 +820,49 @@ steps:
               composition: platform-checks
               args: [--scenario=UpgradeEntireMzFourVersions, "--seed=$BUILDKITE_JOB_ID"]
 
-      - id: checks-0dt-restart-entire-mz
-        label: "Checks 0dt restart of the entire Mz"
-        depends_on: build-aarch64
-        timeout_in_minutes: 240
-        agents:
-          # TODO(def-): Switch back to hetzner
-          queue: linux-aarch64-large
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: platform-checks
-              args: [--scenario=ZeroDowntimeRestartEntireMz, "--seed=$BUILDKITE_JOB_ID"]
-
       - id: checks-0dt-restart-entire-mz-forced-migrations
-        label: "Checks 0dt restart of the entire Mz with forced migrations"
+        label: "Checks 0dt restart of the entire Mz with forced migrations %N"
         depends_on: build-aarch64
-        timeout_in_minutes: 240
+        timeout_in_minutes: 60
+        parallelism: 2
         agents:
-          # TODO(def-): Switch back to hetzner
-          queue: linux-aarch64-large
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=ZeroDowntimeRestartEntireMzForcedMigrations, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-upgrade-entire-mz
-        label: "Checks 0dt upgrade, whole-Mz restart"
+        label: "Checks 0dt upgrade, whole-Mz restart %N"
         depends_on: build-aarch64
-        timeout_in_minutes: 240
+        timeout_in_minutes: 60
+        parallelism: 2
         agents:
-          # TODO(def-): Switch back to hetzner
-          queue: linux-aarch64-large
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=ZeroDowntimeUpgradeEntireMz, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-upgrade-entire-mz-two-versions
-        label: "Checks 0dt upgrade across two versions"
+        label: "Checks 0dt upgrade across two versions %N"
         depends_on: build-aarch64
-        timeout_in_minutes: 240
+        timeout_in_minutes: 60
+        parallelism: 2
         agents:
-          # TODO(def-): Switch back to hetzner
-          queue: linux-aarch64-large
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=ZeroDowntimeUpgradeEntireMzTwoVersions, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-upgrade-entire-mz-four-versions
-        label: "Checks 0dt upgrade across four versions"
+        label: "Checks 0dt upgrade across four versions %N"
         depends_on: build-aarch64
-        timeout_in_minutes: 240
+        timeout_in_minutes: 60
+        parallelism: 2
         agents:
-          # TODO(def-): Switch back to hetzner
-          queue: linux-aarch64-large
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -474,6 +474,18 @@ steps:
               composition: platform-checks
               args: [--scenario=DropCreateDefaultReplica, "--seed=$BUILDKITE_JOB_ID"]
 
+      - id: checks-0dt-restart-entire-mz
+        label: "Checks 0dt restart of the entire Mz %N"
+        depends_on: build-aarch64
+        timeout_in_minutes: 60
+        parallelism: 2
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=ZeroDowntimeRestartEntireMz, "--seed=$BUILDKITE_JOB_ID"]
+
   - id: limits
     label: "Product limits (finding new limits) %N"
     depends_on: build-aarch64


### PR DESCRIPTION
Since it's very similar to another one in nightly, so unlikely to find extra bugs

Green runs:
https://buildkite.com/materialize/nightly/builds/10552
https://buildkite.com/materialize/release-qualification/builds/689
https://buildkite.com/materialize/nightly/builds/10550
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
