### PR TITLE
feature-benchmark: Two fixes for nightly (November 28)

### DIFF
--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -334,7 +334,7 @@ class InsertMultiRow(DML):
 class Update(DML):
     """Measure the time it takes for an UPDATE statement to return to client"""
 
-    SCALE = 6  # TODO: Increase scale when database-issues#8766 is fixed
+    SCALE = 7
 
     def init(self) -> list[Action]:
         return [

--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -29,6 +29,12 @@ def get_ancestor_overrides_for_performance_regressions(
     min_ancestor_mz_version_per_commit = dict()
 
     if "OptbenchTPCH" in scenario_class_name:
+        # PR#30602 (Replace ColumnKnowledge with EquivalencePropagation) increases wallclock
+        min_ancestor_mz_version_per_commit[
+            "1bd45336f8335b3487153beb7ce57f6391a7cf9c"
+        ] = MzVersion.parse_mz("v0.126.0")
+
+    if "OptbenchTPCH" in scenario_class_name:
         # PR#30506 (Remove NonNullable transform) increases wallclock
         min_ancestor_mz_version_per_commit[
             "6981cb35f6a64748293867beb67e74b804f9e723"

--- a/src/catalog/src/expr_cache.rs
+++ b/src/catalog/src/expr_cache.rs
@@ -492,9 +492,9 @@ mod tests {
     impl<T: Arbitrary + Send> ArbitraryTimeout<T> {
         // Number of attempts to generate a value before panicking. The maximum time spent
         // generating a value is `GENERATE_ATTEMPTS` * `TIMEOUT_SECS`.
-        const GENERATE_ATTEMPTS: u64 = 6;
+        const GENERATE_ATTEMPTS: u64 = 10;
         // Amount of time in seconds before we give up trying to generate a single value.
-        const TIMEOUT_SECS: u64 = 5;
+        const TIMEOUT_SECS: u64 = 10;
 
         fn new() -> Self {
             Self {


### PR DESCRIPTION
See individual commits

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
