### PR TITLE
Revert "ci: Try zstd compression for debug sections"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -94,11 +94,12 @@ build:debug --@rules_rust//:extra_rustc_flag="-Csplit-debuginfo=unpacked"
 
 # TODO(parkmycar): Enable this for macOS. `toolchains_llvm` defaults to ld64 which
 # doesn't support zlib compression.
-build:linux --linkopt="-Wl,--compress-debug-sections=zstd"
-build:linux --@rules_rust//:extra_rustc_flag="-Clink-arg=-Wl,--compress-debug-sections=zstd"
-build:linux --linkopt="-Wl,-O3"
+build:linux --linkopt="-Wl,--compress-debug-sections=zlib"
+build:linux --@rules_rust//:extra_rustc_flag="-Clink-arg=-Wl,--compress-debug-sections=zlib"
+# Specifying "-O2" uses level 6 zlib compression.
+build:linux --linkopt="-Wl,-O2"
 build:linux --@rules_rust//:extra_rustc_flag="-Clink-arg=-Wl,-O2"
-build:linux --copt="-gz=zstd"
+build:linux --copt="-gz=zlib"
 
 # Match the DWARF version used by Rust
 #


### PR DESCRIPTION
This reverts commit e39999ca84c6d176665b01c7a9e875106dc0a44b.

Checked locally if this helps with file/line numbers in panics, and it does indeed. Before this PR:
```
./materialized
thread 'main' panicked at src/materialized/src/bin/materialized.rs:18:18:
Unknown executable: Some("materialized2")
stack backtrace:
[hangs indefinitely!]
```
Sometimes the backtrace is printed correctly but without file/line:
```
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: materialized::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
With this PR works reliably:
```
thread 'main' panicked at src/materialized/src/bin/materialized.rs:18:18:
Unknown executable: Some("materialized")
stack backtrace:
   0: rust_begin_unwind
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/panicking.rs:652:5
   1: core::panicking::panic_fmt
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/panicking.rs:72:14
   2: main
             at src/materialized/src/bin/materialized.rs:18:18
   3: call_once<fn(), ()>
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
I had no idea Rust was broken with zstd compression in debug sections. I'll open a bug in Rust for this.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
