### PR TITLE
slack: Notify on release blocker PRs

### DIFF
--- a/.github/workflows/slack_notify_labeled.yml
+++ b/.github/workflows/slack_notify_labeled.yml
@@ -22,7 +22,7 @@
 name: Slack Label Notifications
 
 on:
-  issues:
+  pull_request:
     types:
       - labeled
 
@@ -31,29 +31,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
-        if: ${{ github.event.label.name == 'P1' }}
-        with:
-          slack_token: ${{ secrets.SLACK_TOKEN }}
-          channel: github-p1
-          message: |
-            `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}) (assigned to: ${{ github.event.issue.assignee.login || 'unassigned' }}).
-          color: red
-          verbose: false
-      - uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
-        if: ${{ github.event.label.name == 'C-bug' }}
-        with:
-          slack_token: ${{ secrets.SLACK_TOKEN }}
-          channel: github-bugs
-          message: |
-            `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}) (assigned to: ${{ github.event.issue.assignee.login || 'unassigned' }}).
-          color: red
-          verbose: false
-      - uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
         if: ${{ github.event.label.name == 'release-blocker' }}
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           channel: release
           message: |
-            `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}) (assigned to: ${{ github.event.issue.assignee.login || 'unassigned' }}).
+            `${{ github.event.label.name }}` label has been added to "${{ github.event.pull_request.title }}" (${{ github.event.pull_request.html_url }}) (assigned to: ${{ github.event.pull_request.assignee.login || 'unassigned' }}).
           color: red
           verbose: false


### PR DESCRIPTION
Noticed in https://materializeinc.slack.com/archives/CTESPM7FU/p1732818066822189

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
