### PR TITLE
CI test failure fixes (November 29)

### DIFF
--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -42,7 +42,7 @@ ci_collapsed_heading ":docker: Purging all existing docker containers and volume
 sudo systemctl restart docker
 docker ps --all --quiet | xargs --no-run-if-empty docker rm --force --volumes
 killall -9 clusterd || true # There might be remaining processes from a previous cargo-test run
-rm -f ~/.kube # Remove potential state from E2E Terraform tests
+rm -rf ~/.kube # Remove potential state from E2E Terraform tests
 
 ci_collapsed_heading "kind: Increase system limits..."
 sudo sysctl fs.inotify.max_user_watches=524288

--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -29,6 +29,7 @@ def get_ancestor_overrides_for_performance_regressions(
     min_ancestor_mz_version_per_commit = dict()
 
     if scenario_class_name == "CrossJoin":
+        # PR#26745 (compute: MV sink refresh) increases wallclock
         min_ancestor_mz_version_per_commit[
             "9485261eae85fb7f12a2884fdac464a68798dc8b"
         ] = MzVersion.parse_mz("v0.126.0")

--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -28,6 +28,10 @@ def get_ancestor_overrides_for_performance_regressions(
 
     min_ancestor_mz_version_per_commit = dict()
 
+    if scenario_class_name == "CrossJoin":
+        min_ancestor_mz_version_per_commit[
+            "9485261eae85fb7f12a2884fdac464a68798dc8b"
+        ] = MzVersion.parse_mz("v0.126.0")
     if "OptbenchTPCH" in scenario_class_name:
         # PR#30602 (Replace ColumnKnowledge with EquivalencePropagation) increases wallclock
         min_ancestor_mz_version_per_commit[

--- a/test/cluster/blue-green-deployment/deploy.td
+++ b/test/cluster/blue-green-deployment/deploy.td
@@ -52,7 +52,7 @@
     ),
     -- Collect ready dataflows.
     -- For a dataflow to be ready it must be hydrated and caught up.
-    -- We define a dataflow to be caught up if its local lag is less than 2 seconds.
+    -- We define a dataflow to be caught up if its local lag is less than 4 seconds.
     ready_dataflows AS (
         SELECT id
         FROM dataflows d
@@ -62,7 +62,7 @@
         LEFT JOIN mz_internal.mz_materialization_lag l ON (l.object_id = d.id)
         WHERE
             h.hydrated AND
-            (l.local_lag <= '2s' OR l.local_lag IS NULL)
+            (l.local_lag <= '4s' OR l.local_lag IS NULL)
     ),
     -- Collect dataflows that are not yet ready.
     pending_dataflows AS (

--- a/test/cluster/blue-green-deployment/setup.td
+++ b/test/cluster/blue-green-deployment/setup.td
@@ -88,7 +88,7 @@ ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;
     ),
     -- Collect ready dataflows.
     -- For a dataflow to be ready it must be hydrated and caught up.
-    -- We define a dataflow to be caught up if its local lag is less than 2 seconds.
+    -- We define a dataflow to be caught up if its local lag is less than 4 seconds.
     ready_dataflows AS (
         SELECT id
         FROM dataflows d
@@ -98,7 +98,7 @@ ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;
         LEFT JOIN mz_internal.mz_materialization_lag l ON (l.object_id = d.id)
         WHERE
             h.hydrated AND
-            (l.local_lag <= '2s' OR l.local_lag IS NULL)
+            (l.local_lag <= '4s' OR l.local_lag IS NULL)
     ),
     -- Collect dataflows that are not yet ready.
     pending_dataflows AS (


### PR DESCRIPTION
See individual commits

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
