### PR TITLE
bazel: Try disabling in-memory sandbox stash

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -52,7 +52,8 @@ build:macos --experimental_inprocess_symlink_creation
 # Tracks stashed sandboxes in-memory so it uses less I/O on reuse.
 #
 # Bazel's sandbox performance on macOS doesn't scale very well, see: <https://github.com/bazelbuild/bazel/issues/8230>
-build --experimental_inmemory_sandbox_stashes
+# TODO(parkmycar): This might be causing build failures, see https://buildkite.com/materialize/test/builds/95517#019376c0-e43d-4fb4-9420-46ccb4c95d9d
+# build --experimental_inmemory_sandbox_stashes
 
 # Always have Bazel output why it rebuilt something, should make debugging builds easier.
 #


### PR DESCRIPTION
Seen failing in v0.126.0 x86-64 build: https://buildkite.com/materialize/test/builds/95517#019376c0-e43d-4fb4-9420-46ccb4c95d9d
Successful x86-64 build on v0.126.0 state: https://buildkite.com/materialize/test/builds/95523#019376d7-b606-4a7f-a726-0ef02aa562ef
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
