### PR TITLE
docs: Bump v0.126 patch version to 2

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -52,8 +52,7 @@ build:macos --experimental_inprocess_symlink_creation
 # Tracks stashed sandboxes in-memory so it uses less I/O on reuse.
 #
 # Bazel's sandbox performance on macOS doesn't scale very well, see: <https://github.com/bazelbuild/bazel/issues/8230>
-# TODO(parkmycar): This might be causing build failures, see https://buildkite.com/materialize/test/builds/95517#019376c0-e43d-4fb4-9420-46ccb4c95d9d
-# build --experimental_inmemory_sandbox_stashes
+build --experimental_inmemory_sandbox_stashes
 
 # Always have Bazel output why it rebuilt something, should make debugging builds easier.
 #

--- a/doc/user/content/releases/v0.126.md
+++ b/doc/user/content/releases/v0.126.md
@@ -2,6 +2,7 @@
 title: "Materialize v0.126"
 date: 2024-12-04
 released: false
+patch: 2
 _build:
   render: never
 ---


### PR DESCRIPTION
This should fix feature benchmark in test pipeline

Also reverted the one Bazel change I tried, which had no effect (v0.126.1 with it still failed to build)
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
