### PR TITLE
miri test: Disable slow proptest_uuid_sort_order

### DIFF
--- a/src/repr/src/stats2.rs
+++ b/src/repr/src/stats2.rs
@@ -581,6 +581,7 @@ mod tests {
     use uuid::Uuid;
 
     #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // slow
     fn proptest_uuid_sort_order() {
         fn test(mut og: Vec<Uuid>) {
             let mut as_bytes: Vec<_> = og.iter().map(|u| u.as_bytes().clone()).collect();


### PR DESCRIPTION
Failed 3 times before: https://ci-failures.dev.materialize.com/?key=test-failures&tfFilters=%5B%7B%22id%22%3A%22build_date%22%2C%22value%22%3A%5Bnull%2Cnull%5D%7D%2C%7B%22id%22%3A%22content%22%2C%22value%22%3A%22proptest_uuid_sort_order%22%7D%5D

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
