### PR TITLE
bazel: enable verbose failures

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -144,6 +144,8 @@ build:check --output_groups=build_metadata
 #
 # `/dev/shm` is a RAM backed temporary filesystem, it should speedup sandbox creation.
 build:ci --sandbox_base=/dev/shm
+# Always enable verbose failures in CI, makes it easier to debug failures.
+build:ci --verbose_failures
 
 # Release Build Configuration
 #

--- a/ci/deploy/pipeline.template.yml
+++ b/ci/deploy/pipeline.template.yml
@@ -11,7 +11,7 @@
 priority: 30
 
 env:
-  CI_BAZEL_BUILD: 0
+  CI_BAZEL_BUILD: 1
   CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
 
 steps:

--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -697,18 +697,14 @@ def trim_builds(
                 step["concurrency"] = 1
                 step["concurrency_group"] = f"rust-build-aarch64/{hash(deps)}"
         elif step.get("id") == "build-x86_64":
-            (deps, check) = get_deps(
-                Arch.X86_64, bazel=ui.env_is_truthy("CI_BAZEL_BUILD", "1")
-            )
+            (deps, check) = get_deps(Arch.X86_64, bazel=True)
             if check:
                 step["skip"] = True
             else:
                 step["concurrency"] = 1
                 step["concurrency_group"] = f"build-x86_64/{hash(deps)}"
         elif step.get("id") == "build-aarch64":
-            (deps, check) = get_deps(
-                Arch.AARCH64, bazel=ui.env_is_truthy("CI_BAZEL_BUILD", "1")
-            )
+            (deps, check) = get_deps(Arch.AARCH64, bazel=True)
             if check:
                 step["skip"] = True
             else:

--- a/ci/mkpipeline.sh
+++ b/ci/mkpipeline.sh
@@ -45,7 +45,7 @@ steps:
   - wait
   - label: mkpipeline
     env:
-      CI_BAZEL_BUILD: 0
+      CI_BAZEL_BUILD: 1
       CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
     command: bin/ci-builder run stable bin/pyactivate -m ci.mkpipeline $pipeline $@
     priority: 200

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -11,7 +11,7 @@
 priority: 0
 
 env:
-  CI_BAZEL_BUILD: 0
+  CI_BAZEL_BUILD: 1
   CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
 
 steps:

--- a/ci/qa-canary/pipeline.template.yml
+++ b/ci/qa-canary/pipeline.template.yml
@@ -10,7 +10,7 @@
 priority: 40
 
 env:
-  CI_BAZEL_BUILD: 0
+  CI_BAZEL_BUILD: 1
   CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
 
 steps:

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -11,7 +11,7 @@
 priority: 40
 
 env:
-  CI_BAZEL_BUILD: 0
+  CI_BAZEL_BUILD: 1
   CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
 
 steps:

--- a/ci/slt/pipeline.template.yml
+++ b/ci/slt/pipeline.template.yml
@@ -11,7 +11,7 @@
 priority: -40
 
 env:
-  CI_BAZEL_BUILD: 0
+  CI_BAZEL_BUILD: 1
   CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
 
 steps:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -16,7 +16,7 @@ dag: true
 
 env:
   CI_BUILDER_SCCACHE: 1
-  CI_BAZEL_BUILD: 0
+  CI_BAZEL_BUILD: 1
   CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
   # Note: In .cargo/config we set the default build jobs to -1 so on developer machines we keep
   # a single core open when compiling. But we want to use all of CI's resources, hence setting the


### PR DESCRIPTION
Enable verbose failures for Bazel builds in CI so it's easier to debug issues.

Also reverts #30657 

### Motivation

Make it easier to fix build failures when they arise

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
