### PR TITLE
compute: feed MV sink frontier from persist write handle

### DIFF
--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -921,6 +921,7 @@ class Composition:
                 service["command"] = []
             self.files = {}
 
+        self.capture_logs()
         self.invoke(
             "up",
             *(["--detach"] if detach else []),

--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -33,11 +33,6 @@ def get_ancestor_overrides_for_performance_regressions(
         min_ancestor_mz_version_per_commit[
             "a558d6bdc4b29abf79457eaba52914a0d6c805b7"
         ] = MzVersion.parse_mz("v0.127.0")
-    if scenario_class_name == "CrossJoin":
-        # PR#26745 (compute: MV sink refresh) increases wallclock
-        min_ancestor_mz_version_per_commit[
-            "9485261eae85fb7f12a2884fdac464a68798dc8b"
-        ] = MzVersion.parse_mz("v0.126.0")
     if "OptbenchTPCH" in scenario_class_name:
         # PR#30602 (Replace ColumnKnowledge with EquivalencePropagation) increases wallclock
         min_ancestor_mz_version_per_commit[

--- a/test/testdrive/github-3955.td
+++ b/test/testdrive/github-3955.td
@@ -9,9 +9,7 @@
 
 # Regression test for https://github.com/MaterializeInc/database-issues/issues/3955
 
-# The contents of the introspection tables depend on the replica size
 > CREATE CLUSTER test (SIZE '4-4');
-
 > SET cluster = test;
 
 # In case the environment has other replicas
@@ -28,12 +26,12 @@
   FROM
     mz_materialized_views AS views,
     mz_introspection.mz_compute_exports AS compute_exports,
-    mz_introspection.mz_compute_frontiers_per_worker AS frontiers
+    mz_introspection.mz_compute_frontiers AS frontiers
   WHERE
     views.name = 'mv' AND
     views.id = compute_exports.export_id AND
     compute_exports.export_id = frontiers.export_id AND
     time > 0
-16
+1
 
 > DROP CLUSTER test CASCADE;


### PR DESCRIPTION
This PR changes the way the MV sink produces updates to the shared sink frontier. Previously it would inspect the `persist` stream and forward that stream's frontier. The issue with this approach is that, in the face of ingestion spikes, the `persist` stream could fall behind, which would also make the MV sink's reported write frontier fall behind.

This led to a regression in the `CrossJoin` feature benchmark. In this benchmark, a large constant MV is created. As soon as the MV dataflow has produced its snapshot and has reported the empty frontier, the controller instructs the replica to drop it. If the reporting of the empty frontier is delayed because the MV sink is busy reading back the entire snapshot from persist, the controller's drop command also gets delayed. The result is that queries against the cluster get slowed down by the MV dataflow's processing, more than they would have been had the MV dataflow been dropped quickly.

Attaching the shared write frontier to the `WriteHandle`-based frontier stream used by the `mint` operator avoids the issue.

This PR also makes two minor changes to the MV sink (commits 1 and 3):
 * adjusts trace logging to include the sink ID
 * re-applies changes I originally made to address Dan's review comments in https://github.com/MaterializeInc/materialize/pull/26745 but then lost in a rebase

### Motivation

* This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8795

### Tips for reviewer

Commits are meaningful and can be reviewed separately.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
