### PR TITLE
Allow specifying `mine` in bin/scratch commands

### DIFF
--- a/bin/gen-completion
+++ b/bin/gen-completion
@@ -50,7 +50,7 @@ case "$cmd" in
         for name in "${python_autocompletions[@]}"; do
           for shell in "${supported_shells[@]}"; do
             if [ ! -f "$directory/../misc/completions/$shell/_$name" ]; then
-              printf "missing shell completion scripts. try running \`bin/completion generate\` and checking in the changes\n"
+              printf "missing shell completion scripts. try running \`bin/gen-completion generate\` and checking in the changes\n"
               exit 1
             fi
 
@@ -58,7 +58,7 @@ case "$cmd" in
             existing=$("$shasum" < "$directory"/../misc/completions/"$shell"/_"$name")
 
             if [[ "$latest" != "$existing" ]]; then
-              printf "shell completion scripts have uncommitted changes. try running \`bin/completion generate\` and checking in the changes\n"
+              printf "shell completion scripts have uncommitted changes. try running \`bin/gen-completion generate\` and checking in the changes\n"
               exit 1
             fi
           done

--- a/misc/completions/zsh/_scratch
+++ b/misc/completions/zsh/_scratch
@@ -51,7 +51,7 @@ _shtab_scratch_destroy_options=(
 
 _shtab_scratch_forward_options=(
   "(- : *)"{-h,--help}"[show this help message and exit]"
-  ":The ID of the instance to connect to:"
+  ":The ID of the instance to connect to, or \'mine\' to specify your only live instance:"
   "(*)::The remote ports to forward locally:"
 )
 
@@ -69,17 +69,17 @@ _shtab_scratch_mine_options=(
 _shtab_scratch_push_options=(
   "(- : *)"{-h,--help}"[show this help message and exit]"
   "--rev[The git rev to checkout]:rev:"
-  ":The ID of the instance to connect to:"
+  ":The ID of the instance to connect to, or \'mine\' to specify your only live instance:"
 )
 
 _shtab_scratch_sftp_options=(
   "(- : *)"{-h,--help}"[show this help message and exit]"
-  ":The ID of the instance to connect to:"
+  ":The ID of the instance to connect to, or \'mine\' to specify your only live instance:"
 )
 
 _shtab_scratch_ssh_options=(
   "(- : *)"{-h,--help}"[show this help message and exit]"
-  ":The ID of the instance to connect to:"
+  ":The ID of the instance to connect to, or \'mine\' to specify your only live instance:"
   "(*)::The command to run via SSH, if any:"
 )
 

--- a/misc/python/materialize/cli/scratch/forward.py
+++ b/misc/python/materialize/cli/scratch/forward.py
@@ -9,21 +9,22 @@
 
 import argparse
 
-import boto3
-
 from materialize.cli.scratch import check_required_vars
-from materialize.scratch import mssh
+from materialize.scratch import get_instance, mssh
 
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:
     check_required_vars()
 
-    parser.add_argument("instance", help="The ID of the instance to connect to")
+    parser.add_argument(
+        "instance",
+        help="The ID of the instance to connect to, or 'mine' to specify your only live instance",
+    )
     parser.add_argument("ports", nargs="*", help="The remote ports to forward locally")
 
 
 def run(args: argparse.Namespace) -> None:
-    instance = boto3.resource("ec2").Instance(args.instance)
+    instance = get_instance(args.instance)
     ssh_args = []
     for port in args.ports:
         ssh_args.extend(["-L", f"{port}:127.0.0.1:{port}"])

--- a/misc/python/materialize/cli/scratch/push.py
+++ b/misc/python/materialize/cli/scratch/push.py
@@ -9,20 +9,21 @@
 
 import argparse
 
-import boto3
-
 from materialize.cli.scratch import check_required_vars
-from materialize.scratch import mkrepo
+from materialize.scratch import get_instance, mkrepo
 
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:
     check_required_vars()
 
-    parser.add_argument("instance", help="The ID of the instance to connect to")
+    parser.add_argument(
+        "instance",
+        help="The ID of the instance to connect to, or 'mine' to specify your only live instance",
+    )
     parser.add_argument("--rev", help="The git rev to checkout", default="HEAD")
 
 
 def run(args: argparse.Namespace) -> None:
-    instance = boto3.resource("ec2").Instance(args.instance)
+    instance = get_instance(args.instance)
 
     mkrepo(instance, args.rev, init=False, force=True)

--- a/misc/python/materialize/cli/scratch/sftp.py
+++ b/misc/python/materialize/cli/scratch/sftp.py
@@ -9,18 +9,19 @@
 
 import argparse
 
-import boto3
-
 from materialize.cli.scratch import check_required_vars
-from materialize.scratch import msftp
+from materialize.scratch import get_instance, msftp
 
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:
     check_required_vars()
 
-    parser.add_argument("instance", help="The ID of the instance to connect to")
+    parser.add_argument(
+        "instance",
+        help="The ID of the instance to connect to, or 'mine' to specify your only live instance",
+    )
 
 
 def run(args: argparse.Namespace) -> None:
-    instance = boto3.resource("ec2").Instance(args.instance)
+    instance = get_instance(args.instance)
     msftp(instance)

--- a/misc/python/materialize/cli/scratch/ssh.py
+++ b/misc/python/materialize/cli/scratch/ssh.py
@@ -9,21 +9,22 @@
 
 import argparse
 
-import boto3
-
 from materialize.cli.scratch import check_required_vars
-from materialize.scratch import mssh
+from materialize.scratch import get_instance, mssh
 
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:
     check_required_vars()
 
-    parser.add_argument("instance", help="The ID of the instance to connect to")
+    parser.add_argument(
+        "instance",
+        help="The ID of the instance to connect to, or 'mine' to specify your only live instance",
+    )
     parser.add_argument("command", nargs="*", help="The command to run via SSH, if any")
 
 
 def run(args: argparse.Namespace) -> None:
     # SSH will join together multiple arguments with spaces, so we don't lose
     # anything by doing the same.
-    instance = boto3.resource("ec2").Instance(args.instance)
+    instance = get_instance(args.instance)
     mssh(instance, " ".join(args.command))


### PR DESCRIPTION
We expect most users to have at most one scratch machine at any time. This makes it a little easier to manipulate that specific machine without having to copy the id around.

### Motivation

Internal discussion!

### Tips for reviewer

I've done some manual testing, including with >1 and <1 instance, but I'm not sure there's any reasonable way to write automated tests here. I think that's probably okay for a dev script?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
