### PR TITLE
feature-benchmark: Ignore regression in InsertMultiRow

### DIFF
--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -28,6 +28,11 @@ def get_ancestor_overrides_for_performance_regressions(
 
     min_ancestor_mz_version_per_commit = dict()
 
+    if scenario_class_name == "InsertMultiRow":
+        # PR#30622 (Refactor how we run FoldConstants) increases wallclock
+        min_ancestor_mz_version_per_commit[
+            "a558d6bdc4b29abf79457eaba52914a0d6c805b7"
+        ] = MzVersion.parse_mz("v0.127.0")
     if scenario_class_name == "CrossJoin":
         # PR#26745 (compute: MV sink refresh) increases wallclock
         min_ancestor_mz_version_per_commit[


### PR DESCRIPTION
See https://github.com/MaterializeInc/database-issues/issues/8801

Test runs:
https://buildkite.com/materialize/nightly/builds/10573
https://buildkite.com/materialize/release-qualification/builds/697

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
