### PR TITLE
upsert test: Workaround for bug

### DIFF
--- a/test/upsert/autospill/03-rocksdb.td
+++ b/test/upsert/autospill/03-rocksdb.td
@@ -22,7 +22,8 @@ fish:AREALLYBIGFISHAREALLYBIGFISHAREALLYBIGFISHAREALLYBIGFISH
 3
 
 > SELECT
-    SUM(u.bytes_indexed) > 0,
+    -- TODO: Reenable when database-issues#8802 is fixed
+    -- SUM(u.bytes_indexed) > 0,
     -- This + the assertion below that ensures the byte count goes to 0 tests
     -- that we correctly transition the `bytes_indexed` count to the
     -- in-rocksdb. In the past, we would accidentally SUM the previous and
@@ -34,7 +35,7 @@ fish:AREALLYBIGFISHAREALLYBIGFISHAREALLYBIGFISHAREALLYBIGFISH
   WHERE t.name = 'autospill_tbl'
   GROUP BY t.name
   ORDER BY t.name
-true true 3
+true 3
 
 $ set-from-sql var=previous-bytes-2
 SELECT
@@ -56,11 +57,12 @@ animal:
 # bytes_indexed will still have tombstones, but should be smaller than when
 # there are full values.
 > SELECT
-    SUM(u.bytes_indexed) < ${previous-bytes-2},
+    -- TODO: Reenable when database-issues#8802 is fixed
+    -- SUM(u.bytes_indexed) < ${previous-bytes-2},
     SUM(u.records_indexed)
   FROM mz_tables t
   JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
   WHERE t.name = 'autospill_tbl'
   GROUP BY t.name
   ORDER BY t.name
-true 0
+0


### PR DESCRIPTION
See https://github.com/MaterializeInc/database-issues/issues/8802

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
