### PR TITLE
ci-builder: Fix build with Rust 1.80.1 and detect WORKSPACE changes

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -103,7 +103,7 @@ fi
 # *inside* this image. See materialize.git.expand_globs in the Python code for
 # details on this computation.
 files=$(cat \
-        <(git diff --name-only -z 4b825dc642cb6eb9a060e54bf8d69288fbee4904 ci/builder .bazelversion) \
+        <(git diff --name-only -z 4b825dc642cb6eb9a060e54bf8d69288fbee4904 ci/builder .bazelversion WORKSPACE) \
         <(git ls-files --others --exclude-standard -z ci/builder) \
     | LC_ALL=C sort -z \
     | xargs -0 "$shasum")

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -203,10 +203,10 @@ RUN mkdir rust \
     && cargo install --root /usr/local --version ="0.9.28" --locked cargo-hakari \
     && cargo install --root /usr/local --version "=0.9.72" --locked cargo-nextest \
     && cargo install --root /usr/local --version "=0.6.11" --locked cargo-llvm-cov \
-    && cargo install --root /usr/local --version "=0.1.50" --features=vendored-openssl cargo-udeps \
-    && cargo install --root /usr/local --version "=0.2.15" --no-default-features --features=s3,openssl/vendored sccache \
-    && cargo install --root /usr/local --version "=0.3.6" cargo-binutils \
-    && cargo install --root /usr/local --version "=0.13.0" wasm-pack
+    && cargo install --root /usr/local --version "=0.1.50" --locked --features=vendored-openssl cargo-udeps \
+    && cargo install --root /usr/local --version "=0.2.15" --locked --no-default-features --features=s3,openssl/vendored sccache \
+    && cargo install --root /usr/local --version "=0.3.6" --locked cargo-binutils \
+    && cargo install --root /usr/local --version "=0.13.0" --locked wasm-pack
 
 # Link the system lld into the cross-compiling sysroot.
 


### PR DESCRIPTION
Noticed in https://buildkite.com/materialize/test/builds/95579#01938475-432c-424d-a738-fcbda4a4f283

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
