### PR TITLE
ci: Make release qualification green (hopefully)

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -170,7 +170,7 @@ steps:
         timeout_in_minutes: 2880
         parallelism: 8
         agents:
-          queue: hetzner-x86-64-dedi-8cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: feature-benchmark
@@ -438,10 +438,9 @@ steps:
               args: [--scenario=KillClusterdStorage, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-restart-source-postgres
-        label: "Checks + restart source Postgres %N"
+        label: "Checks + restart source Postgres"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:

--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -32,7 +32,7 @@ def get_ancestor_overrides_for_performance_regressions(
         # PR#30617 (storage/kafka: use separate consumer for metadata probing)
         # adds 1s of delay to Kafka source startup
         min_ancestor_mz_version_per_commit[
-            "f316f8fde68e6fa1c90328d8868a0750c86bdcf4"
+            "9f7b634e6824f73d0effcdfa86c2b8b1642a4784"
         ] = MzVersion.parse_mz("v0.127.0")
     if scenario_class_name == "InsertMultiRow":
         # PR#30622 (Refactor how we run FoldConstants) increases wallclock

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1414,6 +1414,8 @@ class RowsJoinOneToOne(Generator):
 class RowsJoinOneToMany(Generator):
     COUNT = 10_000_000
 
+    MAX_COUNT = 320_000_000  # Too long-running with 640_000_000
+
     @classmethod
     def body(cls) -> None:
         print(
@@ -1425,6 +1427,8 @@ class RowsJoinOneToMany(Generator):
 
 class RowsJoinCross(Generator):
     COUNT = 1_000_000
+
+    MAX_COUNT = 256_000_000  # Too long-running with 512_000_000
 
     @classmethod
     def body(cls) -> None:


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/release-qualification/builds/696

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
