### PR TITLE
remove balancer ports from environmentd

### DIFF
--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -162,30 +162,6 @@ pub struct Args {
         default_value = "127.0.0.1:6879"
     )]
     internal_persist_pubsub_listen_addr: SocketAddr,
-    /// The address on which to listen for SQL connections from the balancers.
-    ///
-    /// Connections to this address are not subject to encryption.
-    /// Care should be taken to not expose this address to the public internet
-    /// or other unauthorized parties.
-    #[clap(
-        long,
-        value_name = "HOST:PORT",
-        env = "BALANCER_SQL_LISTEN_ADDR",
-        default_value = "127.0.0.1:6880"
-    )]
-    balancer_sql_listen_addr: SocketAddr,
-    /// The address on which to listen for trusted HTTP connections.
-    ///
-    /// Connections to this address are not subject to encryption.
-    /// Care should be taken to not expose this address to the public internet
-    /// or other unauthorized parties.
-    #[clap(
-        long,
-        value_name = "HOST:PORT",
-        env = "BALANCER_HTTP_LISTEN_ADDR",
-        default_value = "127.0.0.1:6881"
-    )]
-    balancer_http_listen_addr: SocketAddr,
     /// Enable cross-origin resource sharing (CORS) for HTTP requests from the
     /// specified origin.
     ///
@@ -1002,8 +978,6 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         let listeners = Listeners::bind(ListenersConfig {
             sql_listen_addr: args.sql_listen_addr,
             http_listen_addr: args.http_listen_addr,
-            balancer_sql_listen_addr: args.balancer_sql_listen_addr,
-            balancer_http_listen_addr: args.balancer_http_listen_addr,
             internal_sql_listen_addr: args.internal_sql_listen_addr,
             internal_http_listen_addr: args.internal_http_listen_addr,
         })
@@ -1108,14 +1082,6 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     println!(
         " Internal HTTP address: {}",
         server.internal_http_local_addr()
-    );
-    println!(
-        " Balancerd SQL address: {}",
-        server.balancer_sql_local_addr()
-    );
-    println!(
-        " Balancerd HTTP address: {}",
-        server.balancer_http_local_addr()
     );
     println!(
         " Internal Persist PubSub address: {}",

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -193,11 +193,6 @@ pub struct ListenersConfig {
     pub sql_listen_addr: SocketAddr,
     /// The IP address and port to listen for HTTP connections on.
     pub http_listen_addr: SocketAddr,
-    /// The IP address and port to listen on for pgwire connections from the cloud
-    /// balancer pods.
-    pub balancer_sql_listen_addr: SocketAddr,
-    /// The IP address and port to listen for HTTP connections from the cloud balancer pods.
-    pub balancer_http_listen_addr: SocketAddr,
     /// The IP address and port to listen for pgwire connections from the cloud
     /// system on.
     pub internal_sql_listen_addr: SocketAddr,
@@ -219,8 +214,6 @@ pub struct Listeners {
     // Drop order matters for these fields.
     sql: (ListenerHandle, Pin<Box<dyn ConnectionStream>>),
     http: (ListenerHandle, Pin<Box<dyn ConnectionStream>>),
-    balancer_sql: (ListenerHandle, Pin<Box<dyn ConnectionStream>>),
-    balancer_http: (ListenerHandle, Pin<Box<dyn ConnectionStream>>),
     internal_sql: (ListenerHandle, Pin<Box<dyn ConnectionStream>>),
     internal_http: (ListenerHandle, Pin<Box<dyn ConnectionStream>>),
 }
@@ -241,23 +234,17 @@ impl Listeners {
         ListenersConfig {
             sql_listen_addr,
             http_listen_addr,
-            balancer_sql_listen_addr,
-            balancer_http_listen_addr,
             internal_sql_listen_addr,
             internal_http_listen_addr,
         }: ListenersConfig,
     ) -> Result<Listeners, io::Error> {
         let sql = mz_server_core::listen(&sql_listen_addr).await?;
         let http = mz_server_core::listen(&http_listen_addr).await?;
-        let balancer_sql = mz_server_core::listen(&balancer_sql_listen_addr).await?;
-        let balancer_http = mz_server_core::listen(&balancer_http_listen_addr).await?;
         let internal_sql = mz_server_core::listen(&internal_sql_listen_addr).await?;
         let internal_http = mz_server_core::listen(&internal_http_listen_addr).await?;
         Ok(Listeners {
             sql,
             http,
-            balancer_sql,
-            balancer_http,
             internal_sql,
             internal_http,
         })
@@ -269,8 +256,6 @@ impl Listeners {
         Listeners::bind(ListenersConfig {
             sql_listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             http_listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
-            balancer_sql_listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
-            balancer_http_listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             internal_sql_listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             internal_http_listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         })
@@ -289,8 +274,6 @@ impl Listeners {
         let Listeners {
             sql: (sql_listener, sql_conns),
             http: (http_listener, http_conns),
-            balancer_sql: (balancer_sql_listener, balancer_sql_conns),
-            balancer_http: (balancer_http_listener, balancer_http_conns),
             internal_sql: (internal_sql_listener, internal_sql_conns),
             internal_http: (internal_http_listener, internal_http_conns),
         } = self;
@@ -761,50 +744,6 @@ impl Listeners {
             })
         });
 
-        // Launch HTTP server exposed to balancers
-        task::spawn(|| "balancer_http_server", {
-            let balancer_http_server = HttpServer::new(HttpConfig {
-                source: "balancer",
-                // TODO(Alex): implement self-signed TLS for all internal connections
-                tls: None,
-                frontegg: config.frontegg.clone(),
-                adapter_client: adapter_client.clone(),
-                allowed_origin: config.cors_allowed_origin,
-                active_connection_counter: active_connection_counter.clone(),
-                helm_chart_version: config.helm_chart_version.clone(),
-                concurrent_webhook_req: webhook_concurrency_limit.semaphore(),
-                metrics: http_metrics,
-            });
-            mz_server_core::serve(ServeConfig {
-                conns: balancer_http_conns,
-                server: balancer_http_server,
-                // `environmentd` does not currently need to dynamically
-                // configure graceful termination behavior.
-                dyncfg: None,
-            })
-        });
-
-        // Launch SQL server exposed to balancers
-        task::spawn(|| "balancer_sql_server", {
-            let balancer_sql_server = mz_pgwire::Server::new(mz_pgwire::Config {
-                label: "balancer_pgwire",
-                tls: None,
-                adapter_client: adapter_client.clone(),
-                frontegg: config.frontegg.clone(),
-                metrics,
-                internal: false,
-                active_connection_counter: active_connection_counter.clone(),
-                helm_chart_version: config.helm_chart_version.clone(),
-            });
-            mz_server_core::serve(ServeConfig {
-                conns: balancer_sql_conns,
-                server: balancer_sql_server,
-                // `environmentd` does not currently need to dynamically
-                // configure graceful termination behavior.
-                dyncfg: None,
-            })
-        });
-
         // Start telemetry reporting loop.
         if let Some(segment_client) = segment_client {
             telemetry::start_reporting(telemetry::Config {
@@ -840,8 +779,6 @@ impl Listeners {
         Ok(Server {
             sql_listener,
             http_listener,
-            balancer_sql_listener,
-            balancer_http_listener,
             internal_sql_listener,
             internal_http_listener,
             _adapter_handle: adapter_handle,
@@ -884,8 +821,6 @@ pub struct Server {
     // Drop order matters for these fields.
     sql_listener: ListenerHandle,
     http_listener: ListenerHandle,
-    balancer_sql_listener: ListenerHandle,
-    balancer_http_listener: ListenerHandle,
     internal_sql_listener: ListenerHandle,
     internal_http_listener: ListenerHandle,
     _adapter_handle: mz_adapter::Handle,
@@ -898,14 +833,6 @@ impl Server {
 
     pub fn http_local_addr(&self) -> SocketAddr {
         self.http_listener.local_addr()
-    }
-
-    pub fn balancer_sql_local_addr(&self) -> SocketAddr {
-        self.balancer_sql_listener.local_addr()
-    }
-
-    pub fn balancer_http_local_addr(&self) -> SocketAddr {
-        self.balancer_http_listener.local_addr()
     }
 
     pub fn internal_sql_local_addr(&self) -> SocketAddr {


### PR DESCRIPTION
Remove balancer ports from environmentd.

### Motivation


   * This PR refactors existing code.
Removes some legacy unused ports which made configuring things much more complicated, especially in self-hosted.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
    https://github.com/MaterializeInc/cloud/pull/10507
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
