### PR TITLE
Orchestratord enable_internal_statement_logging

### DIFF
--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -121,6 +121,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `observability.enabled` |  | ``false`` |
 | `observability.podMetrics.enabled` |  | ``false`` |
 | `observability.prometheus.enabled` |  | ``false`` |
+| `operator.args.enableInternalStatementLogging` |  | ``true`` |
 | `operator.args.startupLogFilter` |  | ``"INFO,mz_orchestratord=TRACE"`` |
 | `operator.cloudProvider.providers.aws.accountID` |  | ``""`` |
 | `operator.cloudProvider.providers.aws.enabled` |  | ``false`` |

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
         {{- range $key, $value := include "materialize-operator.selectorLabels" . | fromYaml }}
         - "--orchestratord-pod-selector-labels={{ $key }}={{ $value }}"
         {{- end }}
+        {{- if .Values.operator.args.enableInternalStatementLogging }}
+        - "--enable-internal-statement-logging"
+        {{- end }}
 
         {{/* AWS Configuration */}}
         {{- if eq .Values.operator.cloudProvider.type "aws" }}

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -64,10 +64,10 @@ tests:
     storage.storageClass.name: ""
   asserts:
   - matchRegex:
-      path: spec.template.spec.containers[0].args[9]      # Index of the environmentd-cluster-replica-sizes argument
+      path: spec.template.spec.containers[0].args[10]      # Index of the environmentd-cluster-replica-sizes argument
       pattern: disk_limit":"0"
   - matchRegex:
-      path: spec.template.spec.containers[0].args[9]
+      path: spec.template.spec.containers[0].args[10]
       pattern: is_cc":true
 
 - it: should have a cluster with disk limit to 1552MiB when storage class is configured
@@ -75,10 +75,10 @@ tests:
     storage.storageClass.name: "my-storage-class"
   asserts:
   - matchRegex:
-      path: spec.template.spec.containers[0].args[9]
+      path: spec.template.spec.containers[0].args[10]
       pattern: disk_limit":"1552MiB"
   - matchRegex:
-      path: spec.template.spec.containers[0].args[9]
+      path: spec.template.spec.containers[0].args[10]
       pattern: is_cc":true
 
 - it: should configure for AWS provider correctly

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -20,6 +20,7 @@ operator:
   args:
     # Log filtering settings for startup logs
     startupLogFilter: "INFO,mz_orchestratord=TRACE"
+    enableInternalStatementLogging: true
 
   features:
     # Flag to indicate whether to create balancerd pods for the environments

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -64,6 +64,8 @@ pub struct Args {
     scheduler_name: Option<String>,
     #[clap(long)]
     enable_security_context: bool,
+    #[clap(long)]
+    enable_internal_statement_logging: bool,
 
     #[clap(long)]
     orchestratord_pod_selector_labels: Vec<KeyValueArg<String, String>>,

--- a/src/orchestratord/src/controller/materialize/resources.rs
+++ b/src/orchestratord/src/controller/materialize/resources.rs
@@ -886,7 +886,11 @@ fn create_environmentd_statefulset_object(
     ));
 
     if !config.cloud_provider.is_cloud() {
-        args.push("--system-parameter-default=cluster_enable_topology_spread=false".into())
+        args.push("--system-parameter-default=cluster_enable_topology_spread=false".into());
+    }
+
+    if config.enable_internal_statement_logging {
+        args.push("--system-parameter-default=enable_internal_statement_logging=true".into());
     }
 
     // Add persist arguments.


### PR DESCRIPTION
Orchestratord enable_internal_statement_logging by default.

### Motivation


  * This PR adds a known-desirable feature.
https://github.com/MaterializeInc/cloud/issues/10504

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
