### PR TITLE
Don't `LiteralLift` constant expressions

### DIFF
--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -700,15 +700,6 @@ impl Optimizer {
             //   also not good database-issues#4639.
             //   (The same is true for FoldConstants, Demand, and LiteralLifting to a lesser
             //   extent.)
-            //
-            // Also note that FoldConstants and LiteralLifting are not confluent. They can
-            // oscillate between e.g.:
-            //         Constant
-            //           - (4)
-            // and
-            //         Map (4)
-            //           Constant
-            //             - ()
             Box::new(Fixpoint {
                 name: "fixpoint_physical_01",
                 limit: 100,

--- a/src/transform/src/literal_lifting.rs
+++ b/src/transform/src/literal_lifting.rs
@@ -62,12 +62,14 @@ impl crate::Transform for LiteralLifting {
         relation: &mut MirRelationExpr,
         _: &mut TransformCtx,
     ) -> Result<(), crate::TransformError> {
-        let literals = self.action(relation, &mut BTreeMap::new())?;
-        if !literals.is_empty() {
-            // Literals return up the root should be re-installed.
-            *relation = relation.take_dangerous().map(literals);
+        if relation.as_const().is_none() {
+            let literals = self.action(relation, &mut BTreeMap::new())?;
+            if !literals.is_empty() {
+                // Literals return up the root should be re-installed.
+                *relation = relation.take_dangerous().map(literals);
+            }
+            mz_repr::explain::trace_plan(&*relation);
         }
-        mz_repr::explain::trace_plan(&*relation);
         Ok(())
     }
 }

--- a/src/transform/tests/test_transforms/literal_lifting.spec
+++ b/src/transform/tests/test_transforms/literal_lifting.spec
@@ -63,13 +63,10 @@ Constant // { types: "(text, bigint, bigint, bigint, text)" }
   - (1, "oh", 2, 5, "foo")
   - (1, "my", 2, 7, "foo")
 ----
-Map ("foo")
-  Project (#2, #0, #3, #1)
-    Map (1, 2)
-      Constant
-        - ("my", 3)
-        - ("oh", 5)
-        - ("my", 7)
+Constant
+  - (1, "my", 2, 3, "foo")
+  - (1, "oh", 2, 5, "foo")
+  - (1, "my", 2, 7, "foo")
 
 
 # Lift prefix and suffix from constant collections.

--- a/src/transform/tests/testdata/lifting
+++ b/src/transform/tests/testdata/lifting
@@ -108,12 +108,9 @@ Constant
 build apply=LiteralLifting
 (constant [[1 2 3] [1 4 3]] [int64 int64 int64])
 ----
-Map (3)
-  Project (#1, #0)
-    Map (1)
-      Constant
-        - (2)
-        - (4)
+Constant
+  - (1, 2, 3)
+  - (1, 4, 3)
 
 build apply=LiteralLifting
 (union
@@ -306,9 +303,6 @@ With
 build format=types apply=LiteralLifting
 (constant [[1 2 3] [1 4 3]] ([int64 int64 int64] [[1 2]]))
 ----
-Map (3) // { types: "(Int64, Int64, Int64)", keys: "([1])" }
-  Project (#1, #0) // { types: "(Int64, Int64)", keys: "([1])" }
-    Map (1) // { types: "(Int64, Int64)", keys: "([0])" }
-      Constant // { types: "(Int64)", keys: "([0])" }
-        - (2)
-        - (4)
+Constant // { types: "(Int64, Int64, Int64)", keys: "([1], [1, 2])" }
+  - (1, 2, 3)
+  - (1, 4, 3)


### PR DESCRIPTION
The `LiteralLifting` and `FoldConstants` transforms would fight, because the former thinks it is a good idea to take a constant expression and turn it in to a map of literals around a smaller constant. This is not correct, and instead we'll bail out early if we find literal lifting looking at a constant.

This does not change the behavior on constants found in a non-constant expression, which currently still need some amount of lifting. The primary function of literal lifting is reducing cross joins with single constant rows to a cross join with the `()` row, which we can remove. That's .. still needed for the moment, though once we solve that we can remove the whole `LiteralLifting` transform.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
