### PR TITLE
[DNM] Complain if optimizer transformation causes a type regression

### DIFF
--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -833,7 +833,29 @@ impl Optimizer {
         mut relation: MirRelationExpr,
         ctx: &mut TransformCtx,
     ) -> Result<mz_expr::OptimizedMirRelationExpr, TransformError> {
+        // Capture the type before and after transformation.
+        let old_type = relation.typ();
         let transform_result = self.transform(&mut relation, ctx);
+        let new_type = relation.typ();
+        // Notice if types and their nullability have regressed.
+        use crate::typecheck::relation_subtype_difference;
+        soft_assert_or_log!(
+            relation_subtype_difference(&new_type.column_types[..], &old_type.column_types[..])
+                .is_empty(),
+            "Relation column types have regressed, from {:?} to {:?}",
+            old_type.column_types,
+            new_type.column_types,
+        );
+        // Notice if unique keys have regressed.
+        soft_assert_or_log!(
+            old_type.keys.iter().all(|o_key| new_type
+                .keys
+                .iter()
+                .any(|n_key| n_key.iter().all(|nk| o_key.contains(nk)))),
+            "Relation unique keys have regressed, from {:?} to {:?}",
+            old_type.keys,
+            new_type.keys,
+        );
 
         // Make sure we are not swallowing any notice.
         // TODO: we should actually wire up notices that come from here. This is not urgent, because


### PR DESCRIPTION
Adds a soft assert in case any types change, nullability regresses, or unique keys are lost. This exists as a smoke test to see how often this happens (as of last run: often). The goal is not to merge this, so much as to watch it. We could merge it if we reach a point where we think it shouldn't fire, but watching it fire repeatedly in prod is not yet helpful.
 
The type regressions this find are around nullability and unique keys, arguably not "type" properties, as they are semantic rather than syntactic. At least, not surprising that we may regress here, and conversation starter around what our type system means to guarantee.

### Motivation

Edit by @ggevay: Associated issue: https://github.com/MaterializeInc/database-issues/issues/8076

This issue has been closed, but it did not complete work that resolves the test that this looks for.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
