### PR TITLE
Add an EXPLAIN option to show the `Equivalences` Analysis

### DIFF
--- a/src/adapter/src/explain.rs
+++ b/src/adapter/src/explain.rs
@@ -90,7 +90,7 @@ where
 /// In the long term, this method and [`explain_dataflow`] should be unified. In
 /// order to do that, however, we first need to generalize the role
 /// [`DataflowMetainfo`] as a carrier of metainformation for the optimization
-/// pass in general, and not for a specific strucutre representing an
+/// pass in general, and not for a specific structure representing an
 /// intermediate result.
 pub(crate) fn explain_plan<T>(
     mut plan: T,

--- a/src/adapter/src/explain/mir.rs
+++ b/src/adapter/src/explain/mir.rs
@@ -12,8 +12,8 @@
 //! The specialized [`Explain`] implementation for an [`MirRelationExpr`]
 //! wrapped in an [`Explainable`] newtype struct allows us to interpret more
 //! [`mz_repr::explain::ExplainConfig`] options. This is the case because
-//! attribute derivation and let normalization are defined in [`mz_transform`]
-//! and conssequently are not available for the default [`Explain`]
+//! Analysis derivation and Let normalization are defined in [`mz_transform`]
+//! and consequently are not available for the default [`Explain`]
 //! implementation for [`MirRelationExpr`] in [`mz_expr`].
 
 use mz_compute_types::dataflows::DataflowDescription;

--- a/src/expr-parser/src/parser.rs
+++ b/src/expr-parser/src/parser.rs
@@ -120,12 +120,12 @@ mod relation {
         let constant = input.parse::<kw::Constant>()?;
 
         let parse_typ = |input: ParseStream| -> syn::Result<RelationType> {
-            let attrs = attributes::parse_attributes(input)?;
-            let Some(column_types) = attrs.types else {
-                let msg = "Missing expected `types` attribute for Constant line";
+            let analyses = analyses::parse_analyses(input)?;
+            let Some(column_types) = analyses.types else {
+                let msg = "Missing expected `types` analyses for Constant line";
                 Err(Error::new(input.span(), msg))?
             };
-            let keys = attrs.keys.unwrap_or_default();
+            let keys = analyses.keys.unwrap_or_default();
             Ok(RelationType { column_types, keys })
         };
 
@@ -200,13 +200,13 @@ mod relation {
 
         if recursive {
             let (mut ids, mut values, mut limits) = (vec![], vec![], vec![]);
-            for (id, attrs, value) in ctes.into_iter().rev() {
+            for (id, analyses, value) in ctes.into_iter().rev() {
                 let typ = {
-                    let Some(column_types) = attrs.types else {
-                        let msg = format!("`let {}` needs a `types` attribute", id);
+                    let Some(column_types) = analyses.types else {
+                        let msg = format!("`let {}` needs a `types` analyses", id);
                         Err(Error::new(with.span(), msg))?
                     };
-                    let keys = attrs.keys.unwrap_or_default();
+                    let keys = analyses.keys.unwrap_or_default();
                     RelationType { column_types, keys }
                 };
 
@@ -251,7 +251,7 @@ mod relation {
     fn parse_cte(
         ctx: CtxRef,
         input: ParseStream,
-    ) -> syn::Result<(LocalId, attributes::Attributes, MirRelationExpr)> {
+    ) -> syn::Result<(LocalId, analyses::Analyses, MirRelationExpr)> {
         let cte = input.parse::<kw::cte>()?;
 
         let ident = input.parse::<syn::Ident>()?;
@@ -259,12 +259,12 @@ mod relation {
 
         input.parse::<syn::Token![=]>()?;
 
-        let attrs = attributes::parse_attributes(input)?;
+        let analyses = analyses::parse_analyses(input)?;
 
         let parse_value = ParseChildren::new(input, cte.span().start());
         let value = parse_value.parse_one(ctx, parse_expr)?;
 
-        Ok((id, attrs, value))
+        Ok((id, analyses, value))
     }
 
     fn parse_project(ctx: CtxRef, input: ParseStream) -> Result {
@@ -953,7 +953,7 @@ mod scalar {
         let typ = if input.eat(kw::null) {
             packer.push(Datum::Null);
             input.parse::<syn::Token![::]>()?;
-            attributes::parse_scalar_type(input)?.nullable(true)
+            analyses::parse_scalar_type(input)?.nullable(true)
         } else {
             match input.parse::<syn::Lit>()? {
                 syn::Lit::Str(l) => {
@@ -1237,21 +1237,21 @@ mod row {
     }
 }
 
-mod attributes {
+mod analyses {
     use mz_repr::{ColumnType, ScalarType};
 
     use super::*;
 
     #[derive(Default)]
-    pub struct Attributes {
+    pub struct Analyses {
         pub types: Option<Vec<ColumnType>>,
         pub keys: Option<Vec<Vec<usize>>>,
     }
 
-    pub fn parse_attributes(input: ParseStream) -> syn::Result<Attributes> {
-        let mut attributes = Attributes::default();
+    pub fn parse_analyses(input: ParseStream) -> syn::Result<Analyses> {
+        let mut analyses = Analyses::default();
 
-        // Attributes are optional, appearing after a `//` at the end of the
+        // Analyses are optional, appearing after a `//` at the end of the
         // line. However, since the syn lexer eats comments, we assume that `//`
         // was replaced with `::` upfront.
         if input.eat(syn::Token![::]) {
@@ -1260,7 +1260,7 @@ mod attributes {
 
             let (start, end) = (inner.span().start(), inner.span().end());
             if start.line != end.line {
-                let msg = "attributes should not span more than one line".to_string();
+                let msg = "analyses should not span more than one line".to_string();
                 Err(Error::new(inner.span(), msg))?
             }
 
@@ -1270,17 +1270,17 @@ mod attributes {
                     "types" => {
                         inner.parse::<syn::Token![:]>()?;
                         let value = inner.parse::<syn::LitStr>()?.value();
-                        attributes.types = Some(parse_types.parse_str(&value)?);
+                        analyses.types = Some(parse_types.parse_str(&value)?);
                     }
                     // TODO: support keys
                     key => {
-                        let msg = format!("unexpected attribute type `{}`", key);
+                        let msg = format!("unexpected analysis type `{}`", key);
                         Err(Error::new(inner.span(), msg))?;
                     }
                 }
             }
         }
-        Ok(attributes)
+        Ok(analyses)
     }
 
     fn parse_types(input: ParseStream) -> syn::Result<Vec<ColumnType>> {
@@ -1394,7 +1394,7 @@ mod def {
         input.parse::<syn::Token![-]>()?;
         let column_name = input.parse::<syn::Ident>()?.to_string();
         input.parse::<syn::Token![:]>()?;
-        let column_type = attributes::parse_column_type(input)?;
+        let column_type = analyses::parse_column_type(input)?;
         Ok((column_name, column_type))
     }
 

--- a/src/repr/src/explain.rs
+++ b/src/repr/src/explain.rs
@@ -154,22 +154,30 @@ impl From<serde_json::Error> for ExplainError {
 /// A set of options for controlling the output of [`Explain`] implementations.
 #[derive(Clone, Debug)]
 pub struct ExplainConfig {
-    /// Show the number of columns.
+    // Analyses:
+    // (These are shown only if the Analysis is supported by the backing IR.)
+    /// Show the `SubtreeSize` Analysis in the explanation.
+    pub subtree_size: bool,
+    /// Show the number of columns, i.e., the `Arity` Analysis.
     pub arity: bool,
-    /// Show cardinality information.
+    /// Show the types, i.e., the `RelationType` Analysis.
+    pub types: bool,
+    /// Show the sets of unique keys, i.e., the `UniqueKeys` Analysis.
+    pub keys: bool,
+    /// Show the `NonNegative` Analysis.
+    pub non_negative: bool,
+    /// Show the `Cardinality` Analysis.
     pub cardinality: bool,
-    /// Show inferred column names.
+    /// Show the `ColumnNames` Analysis.
     pub column_names: bool,
+
+    // Other display options:
     /// Render implemented MIR `Join` nodes in a way which reflects the implementation.
     pub join_impls: bool,
     /// Use inferred column names when rendering scalar and aggregate expressions.
     pub humanized_exprs: bool,
-    /// Show the sets of unique keys.
-    pub keys: bool,
     /// Restrict output trees to linear chains. Ignored if `raw_plans` is set.
     pub linear_chains: bool,
-    /// Show the `non_negative` in the explanation if it is supported by the backing IR.
-    pub non_negative: bool,
     /// Show the slow path plan even if a fast path plan was created. Useful for debugging.
     /// Enforced if `timing` is set.
     pub no_fast_path: bool,
@@ -183,14 +191,11 @@ pub struct ExplainConfig {
     pub raw_syntax: bool,
     /// Anonymize literals in the plan.
     pub redacted: bool,
-    /// Show the `subtree_size` attribute in the explanation if it is supported by the backing IR.
-    pub subtree_size: bool,
     /// Print optimization timings.
     pub timing: bool,
-    /// Show the `type` attribute in the explanation.
-    pub types: bool,
     /// Show MFP pushdown information.
     pub filter_pushdown: bool,
+
     /// Optimizer feature flags.
     pub features: OptimizerFeatureOverrides,
 }

--- a/src/repr/src/explain.rs
+++ b/src/repr/src/explain.rs
@@ -170,6 +170,10 @@ pub struct ExplainConfig {
     pub cardinality: bool,
     /// Show the `ColumnNames` Analysis.
     pub column_names: bool,
+    /// Show the `Equivalences` Analysis.
+    pub equivalences: bool,
+    // TODO: add an option to show the `Monotonic` Analysis. This is non-trivial, because this
+    // Analysis needs the set of monotonic GlobalIds, which are cumbersome to pass around.
 
     // Other display options:
     /// Render implemented MIR `Join` nodes in a way which reflects the implementation.
@@ -222,6 +226,7 @@ impl Default for ExplainConfig {
             subtree_size: false,
             timing: false,
             types: false,
+            equivalences: false,
             features: Default::default(),
         }
     }
@@ -236,6 +241,7 @@ impl ExplainConfig {
             || self.keys
             || self.cardinality
             || self.column_names
+            || self.equivalences
     }
 }
 
@@ -629,6 +635,7 @@ pub struct Analyses {
     pub keys: Option<Vec<Vec<usize>>>,
     pub cardinality: Option<String>,
     pub column_names: Option<Vec<String>>,
+    pub equivalences: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -714,6 +721,11 @@ impl<'a> Display for HumanizedAnalyses<'a> {
             });
             let column_names = bracketed("(", ")", separated(", ", column_names)).to_string();
             builder.field("column_names", &column_names);
+        }
+
+        if self.config.equivalences {
+            let equivs = self.analyses.equivalences.as_ref().expect("equivalences");
+            builder.field("equivs", equivs);
         }
 
         builder.finish()
@@ -938,6 +950,7 @@ mod tests {
             raw_plans: false,
             raw_syntax: false,
             subtree_size: false,
+            equivalences: false,
             timing: true,
             types: false,
             features: Default::default(),

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -151,6 +151,7 @@ End
 Endpoint
 Enforced
 Envelope
+Equivalences
 Error
 Errors
 Escape

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3883,6 +3883,7 @@ pub enum ExplainPlanOptionName {
     SubtreeSize,
     Timing,
     Types,
+    Equivalences,
     ReoptimizeImportedViews,
     EnableNewOuterJoinLowering,
     EnableEagerDeltaJoins,
@@ -3917,6 +3918,7 @@ impl WithOptionName for ExplainPlanOptionName {
             | Self::SubtreeSize
             | Self::Timing
             | Self::Types
+            | Self::Equivalences
             | Self::ReoptimizeImportedViews
             | Self::EnableNewOuterJoinLowering
             | Self::EnableEagerDeltaJoins

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -305,3 +305,10 @@ EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW whatever
 EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW whatever
 =>
 ExplainPushdown(ExplainPushdownStatement { explainee: MaterializedView(Name(UnresolvedItemName([Ident("whatever")]))) })
+
+parse-statement
+EXPLAIN WITH (ARITY, EQUIVALENCES, HUMANIZED EXPRESSIONS) CREATE MATERIALIZED VIEW mv AS SELECT 665
+----
+EXPLAIN WITH (ARITY, EQUIVALENCES, HUMANIZED EXPRESSIONS) CREATE MATERIALIZED VIEW mv AS SELECT 665
+=>
+ExplainPlan(ExplainPlanStatement { stage: None, with_options: [ExplainPlanOption { name: Arity, value: None }, ExplainPlanOption { name: Equivalences, value: None }, ExplainPlanOption { name: HumanizedExpressions, value: None }], format: None, explainee: CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("mv")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None, with_options: [] }, false) })

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -364,6 +364,7 @@ generate_extracted_config!(
     (SubtreeSize, bool, Default(false)),
     (Timing, bool, Default(false)),
     (Types, bool, Default(false)),
+    (Equivalences, bool, Default(false)),
     (ReoptimizeImportedViews, Option<bool>, Default(None)),
     (EnableNewOuterJoinLowering, Option<bool>, Default(None)),
     (EnableEagerDeltaJoins, Option<bool>, Default(None)),
@@ -406,6 +407,7 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
             raw_syntax: v.raw_syntax,
             redacted: v.redacted,
             subtree_size: v.subtree_size,
+            equivalences: v.equivalences,
             timing: v.timing,
             types: v.types,
             // The ones that are initialized with `Default::default()` are not wired up to EXPLAIN.

--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -1196,16 +1196,16 @@ mod column_names {
 }
 
 mod explain {
-    //! Derived attributes framework and definitions.
+    //! Derived Analysis framework and definitions.
 
     use std::collections::BTreeMap;
 
     use mz_expr::explain::ExplainContext;
     use mz_expr::MirRelationExpr;
     use mz_ore::stack::RecursionLimitError;
-    use mz_repr::explain::{AnnotatedPlan, Attributes};
+    use mz_repr::explain::{Analyses, AnnotatedPlan};
 
-    // Attributes should have shortened paths when exported.
+    // Analyses should have shortened paths when exported.
     use super::DerivedBuilder;
 
     impl<'c> From<&ExplainContext<'c>> for DerivedBuilder<'c> {
@@ -1239,19 +1239,19 @@ mod explain {
     }
 
     /// Produce an [`AnnotatedPlan`] wrapping the given [`MirRelationExpr`] along
-    /// with [`Attributes`] derived from the given context configuration.
+    /// with [`Analyses`] derived from the given context configuration.
     pub fn annotate_plan<'a>(
         plan: &'a MirRelationExpr,
         context: &'a ExplainContext,
     ) -> Result<AnnotatedPlan<'a, MirRelationExpr>, RecursionLimitError> {
-        let mut annotations = BTreeMap::<&MirRelationExpr, Attributes>::default();
+        let mut annotations = BTreeMap::<&MirRelationExpr, Analyses>::default();
         let config = context.config;
 
-        // We want to annotate the plan with attributes in the following cases:
-        // 1. An attribute was explicitly requested in the ExplainConfig.
+        // We want to annotate the plan with analyses in the following cases:
+        // 1. An Analysis was explicitly requested in the ExplainConfig.
         // 2. Humanized expressions were requested in the ExplainConfig (in which
-        //    case we need to derive the ColumnNames attribute).
-        if config.requires_attributes() || config.humanized_exprs {
+        //    case we need to derive the ColumnNames Analysis).
+        if config.requires_analyses() || config.humanized_exprs {
             // get the annotation keys
             let subtree_refs = plan.post_order_vec();
             // get the annotation values
@@ -1263,8 +1263,8 @@ mod explain {
                     subtree_refs.iter(),
                     derived.results::<super::SubtreeSize>().unwrap().into_iter(),
                 ) {
-                    let attrs = annotations.entry(expr).or_default();
-                    attrs.subtree_size = Some(*subtree_size);
+                    let analyses = annotations.entry(expr).or_default();
+                    analyses.subtree_size = Some(*subtree_size);
                 }
             }
             if config.non_negative {
@@ -1272,8 +1272,8 @@ mod explain {
                     subtree_refs.iter(),
                     derived.results::<super::NonNegative>().unwrap().into_iter(),
                 ) {
-                    let attrs = annotations.entry(expr).or_default();
-                    attrs.non_negative = Some(*non_negative);
+                    let analyses = annotations.entry(expr).or_default();
+                    analyses.non_negative = Some(*non_negative);
                 }
             }
 
@@ -1282,8 +1282,8 @@ mod explain {
                     subtree_refs.iter(),
                     derived.results::<super::Arity>().unwrap().into_iter(),
                 ) {
-                    let attrs = annotations.entry(expr).or_default();
-                    attrs.arity = Some(*arity);
+                    let analyses = annotations.entry(expr).or_default();
+                    analyses.arity = Some(*arity);
                 }
             }
 
@@ -1295,8 +1295,8 @@ mod explain {
                         .unwrap()
                         .into_iter(),
                 ) {
-                    let attrs = annotations.entry(expr).or_default();
-                    attrs.types = Some(types.clone());
+                    let analyses = annotations.entry(expr).or_default();
+                    analyses.types = Some(types.clone());
                 }
             }
 
@@ -1305,8 +1305,8 @@ mod explain {
                     subtree_refs.iter(),
                     derived.results::<super::UniqueKeys>().unwrap().into_iter(),
                 ) {
-                    let attrs = annotations.entry(expr).or_default();
-                    attrs.keys = Some(keys.clone());
+                    let analyses = annotations.entry(expr).or_default();
+                    analyses.keys = Some(keys.clone());
                 }
             }
 
@@ -1315,8 +1315,8 @@ mod explain {
                     subtree_refs.iter(),
                     derived.results::<super::Cardinality>().unwrap().into_iter(),
                 ) {
-                    let attrs = annotations.entry(expr).or_default();
-                    attrs.cardinality = Some(card.to_string());
+                    let analyses = annotations.entry(expr).or_default();
+                    analyses.cardinality = Some(card.to_string());
                 }
             }
 
@@ -1325,12 +1325,12 @@ mod explain {
                     subtree_refs.iter(),
                     derived.results::<super::ColumnNames>().unwrap().into_iter(),
                 ) {
-                    let attrs = annotations.entry(expr).or_default();
+                    let analyses = annotations.entry(expr).or_default();
                     let value = column_names
                         .iter()
                         .map(|column_name| column_name.humanize(context.humanizer))
                         .collect();
-                    attrs.column_names = Some(value);
+                    analyses.column_names = Some(value);
                 }
             }
         }
@@ -1339,7 +1339,7 @@ mod explain {
     }
 }
 
-/// Definition and helper structs for the [`Cardinality`] attribute.
+/// Definition and helper structs for the [`Cardinality`] Analysis.
 mod cardinality {
     use std::collections::{BTreeMap, BTreeSet};
 

--- a/src/transform/src/analysis/equivalences.rs
+++ b/src/transform/src/analysis/equivalences.rs
@@ -16,8 +16,10 @@
 //! equivalences classes, each a list of equivalent expressions.
 
 use std::collections::BTreeMap;
+use std::fmt::Formatter;
 
 use mz_expr::{Id, MirRelationExpr, MirScalarExpr};
+use mz_ore::str::{bracketed, separated};
 use mz_repr::{ColumnType, Datum};
 
 use crate::analysis::{Analysis, Lattice};
@@ -318,7 +320,7 @@ pub struct EquivalenceClasses {
     /// The first element should be the "canonical" simplest element, that any other element
     /// can be replaced by.
     /// These classes are unified whenever possible, to minimize the number of classes.
-    /// They are only guaranteed to form an equivalence relation after a call to `minimimize`,
+    /// They are only guaranteed to form an equivalence relation after a call to `minimize`,
     /// which refreshes both `self.classes` and `self.remap`.
     pub classes: Vec<Vec<MirScalarExpr>>,
 
@@ -332,6 +334,17 @@ pub struct EquivalenceClasses {
     /// appending to `self.classes`. This will be corrected in the next call to `self.refresh()`,
     /// but until then `remap` could be arbitrarily wrong. This should be improved in the future.
     remap: BTreeMap<MirScalarExpr, MirScalarExpr>,
+}
+
+impl std::fmt::Display for EquivalenceClasses {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // Only show `classes`.
+        let classes = self
+            .classes
+            .iter()
+            .map(|class| format!("{}", bracketed("[", "]", separated(", ", class))));
+        write!(f, "{}", bracketed("[", "]", separated(", ", classes)))
+    }
 }
 
 impl EquivalenceClasses {

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -141,6 +141,7 @@ mod tests {
                     raw_plans: false,
                     raw_syntax: false,
                     subtree_size: false,
+                    equivalences: false,
                     timing: false,
                     types: format_contains("types"),
                     ..ExplainConfig::default()

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -1577,3 +1577,42 @@ Source materialize.public.t4
 Target cluster: no_replicas
 
 EOF
+
+statement ok
+CREATE TABLE t5(
+    x int,
+    y int NOT NULL,
+    z int
+);
+
+statement ok
+CREATE TABLE t6(
+    a int NOT NULL,
+    b int
+);
+
+# WITH(EQUIVALENCES)
+query T multiline
+EXPLAIN WITH(EQUIVALENCES)
+SELECT *
+FROM t5, t6
+WHERE x = a AND b IN (8,9);
+----
+Explained Query:
+  Project (#0..=#2, #0, #4) // { equivs: "[[#0, #3], [false, (#0) IS NULL, (#1) IS NULL], [true, ((#4 = 8) OR (#4 = 9))]]" }
+    Join on=(#0 = #3) type=differential // { equivs: "[[#0, #3], [false, (#0) IS NULL, (#1) IS NULL], [true, ((#4 = 8) OR (#4 = 9))]]" }
+      ArrangeBy keys=[[#0]] // { equivs: "[[false, (#0) IS NULL, (#1) IS NULL]]" }
+        Filter (#0) IS NOT NULL // { equivs: "[[false, (#0) IS NULL, (#1) IS NULL]]" }
+          ReadStorage materialize.public.t5 // { equivs: "[[false, (#1) IS NULL]]" }
+      ArrangeBy keys=[[#0]] // { equivs: "[[false, (#0) IS NULL], [true, ((#1 = 8) OR (#1 = 9))]]" }
+        Filter ((#1 = 8) OR (#1 = 9)) // { equivs: "[[false, (#0) IS NULL], [true, ((#1 = 8) OR (#1 = 9))]]" }
+          ReadStorage materialize.public.t6 // { equivs: "[[false, (#0) IS NULL]]" }
+
+Source materialize.public.t5
+  filter=((#0) IS NOT NULL)
+Source materialize.public.t6
+  filter=(((#1 = 8) OR (#1 = 9)))
+
+Target cluster: no_replicas
+
+EOF


### PR DESCRIPTION
We have a bunch of EXPLAIN options to show the results of various Analyses. These are quite useful for debugging. This PR adds an EXPLAIN option for the `Equivalences` Analysis. This makes the behavior of the `Equivalences` Analysis easier to understand, especially for people who are not already familiar with all its details.

### Motivation

  * This PR adds a known-desirable feature: https://github.com/MaterializeInc/database-issues/issues/8805

### Tips for reviewer

The first 2 commits just do very minor refactorings. The main thing is in the 3rd commit.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
