### PR TITLE
0dt test: Increase allowed time for SELECT after rehydration

### DIFF
--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -962,7 +962,7 @@ def workflow_kafka_source_rehydration(c: Composition) -> None:
         duration = time.time() - start_time
         assert result[0][0] == count * repeats, f"Wrong result: {result}"
         assert (
-            duration < 2
+            duration < 4
         ), f"Took {duration}s to SELECT on Kafka source after 0dt upgrade, is it hydrated?"
 
 
@@ -1076,7 +1076,7 @@ def workflow_pg_source_rehydration(c: Composition) -> None:
         duration = time.time() - start_time
         assert result[0][0] == count * repeats, f"Wrong result: {result}"
         assert (
-            duration < 2
+            duration < 4
         ), f"Took {duration}s to SELECT on Postgres source after 0dt upgrade, is it hydrated?"
 
 
@@ -1191,7 +1191,7 @@ def workflow_mysql_source_rehydration(c: Composition) -> None:
         duration = time.time() - start_time
         assert result[0][0] == count * repeats, f"Wrong result: {result}"
         assert (
-            duration < 2
+            duration < 4
         ), f"Took {duration}s to SELECT on MySQL source after 0dt upgrade, is it hydrated?"
 
 


### PR DESCRIPTION
Seen flaking in https://buildkite.com/materialize/nightly/builds/10591#01938824-b5dc-4a21-ad87-ee36696458e0

> builtins.AssertionError: Took 2.73917555809021s to SELECT on Kafka source after 0dt upgrade, is it hydrated?

I checked the logs but can't find anything strange, here are some durations:
- coordinator init: timestamp oracle init complete in 128.129425ms
- coordinator init: catalog open: expr cache open complete in 116.069545ms
- coordinator init: catalog open complete in 963.663792ms
- controller init: complete in 465.730237ms
- storage collections init complete in 442.866092ms
- optimize dataflow plans complete in 5.831978ms
- coordinator init: bootstrap: dataflow as-of bootstrapping complete in 10.08686ms
- coordinator init: bootstrap: postamble complete in 17.997937ms
- coordinator init: bootstrap: generate builtin updates complete in 124.65059ms
- coordinator init: bootstrap: generate secret cleanup complete in 2.370703ms
- coordinator init: bootstrap: migrate builtin tables in read-only mode complete in 30.959546ms
- coordinator init: bootstrap complete in 657.327128ms
- coordinator init: coordinator thread start complete in 1.140431537s
- coordinator init: complete in 2.301027833s

Is any of that worrying @jkosh44 ?
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
