### PR TITLE
allow disabling rbac in orchestratord

### DIFF
--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -258,6 +258,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.resources.requests.cpu` |  | ``"100m"`` |
 | `operator.resources.requests.memory` |  | ``"512Mi"`` |
 | `rbac.create` |  | ``true`` |
+| `rbac.enabled` |  | ``true`` |
 | `serviceAccount.create` |  | ``true`` |
 | `serviceAccount.name` |  | ``"orchestratord"`` |
 | `storage.storageClass.allowVolumeExpansion` |  | ``false`` |

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -70,6 +70,11 @@ spec:
         - "--console-image-tag-map={{ $key }}={{ $value }}"
         {{- end }}
 
+        {{/* Authentication */}}
+        {{- if not .Values.rbac.enabled }}
+        - "--disable-authentication"
+        {{- end }}
+
         {{/* Cluster Configuration */}}
         {{- if .Values.operator.clusters }}
         {{- if .Values.operator.clusters.sizes }}

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -214,6 +214,7 @@ clusterd:
 
 # RBAC (Role-Based Access Control) settings
 rbac:
+  enabled: true
   # Whether to create necessary RBAC roles and bindings
   create: true
 

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -49,6 +49,8 @@ pub struct Args {
     secrets_controller: String,
     #[clap(long)]
     collect_pod_metrics: bool,
+    #[clap(long)]
+    disable_authentication: bool,
 
     #[clap(long)]
     console_image_tag_default: String,

--- a/src/orchestratord/src/controller/materialize/resources.rs
+++ b/src/orchestratord/src/controller/materialize/resources.rs
@@ -888,6 +888,9 @@ fn create_environmentd_statefulset_object(
     if !config.cloud_provider.is_cloud() {
         args.push("--system-parameter-default=cluster_enable_topology_spread=false".into())
     }
+    if config.disable_authentication {
+        args.push("--system-parameter-default=enable_rbac_checks=false".into());
+    }
 
     // Add persist arguments.
 
@@ -1356,17 +1359,13 @@ fn create_balancerd_deployment_object(config: &super::Args, mz: &Materialize) ->
             "--https-resolver-template={}.{}.svc.cluster.local:{}",
             mz.environmentd_service_name(),
             mz.namespace(),
-            // TODO after implementing self-hosted auth,
-            // point at config.environmentd_http_port
-            config.environmentd_internal_http_port
+            config.environmentd_http_port
         ),
         format!(
             "--static-resolver-addr={}.{}.svc.cluster.local:{}",
             mz.environmentd_service_name(),
             mz.namespace(),
-            // TODO after implementing self-hosted auth,
-            // point at config.environmentd_sql_port
-            config.environmentd_internal_sql_port
+            config.environmentd_sql_port
         ),
     ];
 


### PR DESCRIPTION
### Motivation

we want to be able to log in as the materialize user on the balancer port, and this should work until we actually get a working authentication story for the self-hosted materialize

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
