### PR TITLE
Fix s3 connection in cockroach for backup tests, new Redpanda versions

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -543,7 +543,8 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
-              args: [--scenario=KafkaSources, --actions=10000, --cockroach-tag=latest, --max-execution-time=30m]
+              # TODO: Reenable --cockroach-tag=latest when https://github.com/cockroachdb/cockroach/issues/136678 is fixed
+              args: [--scenario=KafkaSources, --actions=10000, --max-execution-time=30m]
 
       - id: zippy-alter-connection
         label: "Zippy w/ alter connection"

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -143,7 +143,7 @@ IGNORE_RE = re.compile(
     # Will print a separate panic line which will be handled and contains the relevant information (new style)
     | internal\ error:\ unexpected\ panic\ during\ query\ optimization
     # redpanda INFO logging
-    | larger\ sizes\ prevent\ running\ out\ of\ memory
+    | [Ll]arger\ sizes\ prevent\ running\ out\ of\ memory
     # Old versions won't support new parameters
     | (platform-checks|legacy-upgrade|upgrade-matrix|feature-benchmark)-materialized-.* \| .*cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage
     # Fencing warnings are OK in fencing/0dt tests

--- a/misc/python/materialize/cloudtest/k8s/redpanda.py
+++ b/misc/python/materialize/cloudtest/k8s/redpanda.py
@@ -24,6 +24,7 @@ from materialize.cloudtest import DEFAULT_K8S_NAMESPACE
 from materialize.cloudtest.k8s.api.k8s_deployment import K8sDeployment
 from materialize.cloudtest.k8s.api.k8s_resource import K8sResource
 from materialize.cloudtest.k8s.api.k8s_service import K8sService
+from materialize.mzcompose.services.redpanda import REDPANDA_VERSION
 
 
 class RedpandaDeployment(K8sDeployment):
@@ -31,7 +32,7 @@ class RedpandaDeployment(K8sDeployment):
         super().__init__(namespace)
         container = V1Container(
             name="redpanda",
-            image="vectorized/redpanda:v24.2.2",
+            image=f"redpandadata/redpanda:{REDPANDA_VERSION}",
             command=[
                 "/usr/bin/rpk",
                 "redpanda",

--- a/misc/python/materialize/mzcompose/services/cockroach.py
+++ b/misc/python/materialize/mzcompose/services/cockroach.py
@@ -21,6 +21,7 @@ from materialize.mzcompose.service import (
 
 
 class Cockroach(Service):
+    # TODO: Bump version to >= v24.3.0 when https://github.com/cockroachdb/cockroach/issues/136678 is fixed
     DEFAULT_COCKROACH_TAG = "v24.2.0"
 
     def __init__(

--- a/misc/python/materialize/mzcompose/services/redpanda.py
+++ b/misc/python/materialize/mzcompose/services/redpanda.py
@@ -13,7 +13,7 @@ from materialize.mzcompose.service import (
     ServiceConfig,
 )
 
-REDPANDA_VERSION = "v24.2.7"
+REDPANDA_VERSION = "v24.3.1"
 
 
 class Redpanda(Service):
@@ -27,7 +27,7 @@ class Redpanda(Service):
         ports: list[int] | None = None,
     ) -> None:
         if image is None:
-            image = f"vectorized/redpanda:{version}"
+            image = f"redpandadata/redpanda:{version}"
 
         if ports is None:
             ports = [9092, 8081]
@@ -37,7 +37,7 @@ class Redpanda(Service):
             aliases = ["kafka", "schema-registry"]
 
         # Most of these options are simply required when using Redpanda in Docker.
-        # See: https://vectorized.io/docs/quick-start-docker/#Single-command-for-a-1-node-cluster
+        # See: https://docs.redpanda.com/current/get-started/quick-start/#Single-command-for-a-1-node-cluster
         # The `enable_transactions` and `enable_idempotence` feature flags enable
         # features Materialize requires that are present by default in Apache Kafka
         # but not in Redpanda.

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -28,7 +28,8 @@ REDPANDA_VERSIONS = [
     "v23.1.21",
     "v23.2.29",
     "v23.3.21",
-    "v24.1.17",
+    "v24.1.18",
+    "v24.2.12",
     REDPANDA_VERSION,
     "latest",
 ]


### PR DESCRIPTION
Cockroach issue: https://github.com/cockroachdb/cockroach/issues/136678
See https://materializeinc.slack.com/archives/CTESPM7FU/p1733228518997239
Should fix the failure seen in https://buildkite.com/materialize/nightly/builds/10595#01938b85-c061-425b-967b-c70bff89ace2
Running full nightly to make sure no regressions: https://buildkite.com/materialize/nightly/builds/10600
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
