### PR TITLE
enable telemetry by default in the helm chart

### DIFF
--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -271,6 +271,9 @@ The following table lists the configurable parameters of the Materialize operato
 | `storage.storageClass.provisioner` |  | ``""`` |
 | `storage.storageClass.reclaimPolicy` |  | ``"Delete"`` |
 | `storage.storageClass.volumeBindingMode` |  | ``"WaitForFirstConsumer"`` |
+| `telemetry.enabled` |  | ``true`` |
+| `telemetry.segmentApiKey` |  | ``"hMWi3sZ17KFMjn2sPWo9UJGpOQqiba4A"`` |
+| `telemetry.segmentClientSide` |  | ``true`` |
 | `tls.defaultCertificateSpecs` |  | ``{}`` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -140,5 +140,12 @@ spec:
         - "--collect-pod-metrics"
         {{- end }}
         {{- end }}
+        {{/* Telemetry */}}
+        {{- if .Values.telemetry.enabled }}
+        - "--segment-api-key={{ .Values.telemetry.segmentApiKey }}"
+        {{- if .Values.telemetry.segmentClientSide }}
+        - "--segment-client-side"
+        {{- end }}
+        {{- end }}
         resources:
           {{- toYaml .Values.operator.resources | nindent 10 }}

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -238,6 +238,11 @@ observability:
     # Whether to enable Prometheus integration for monitoring (disabled here)
     enabled: false
 
+telemetry:
+  enabled: true
+  segmentApiKey: hMWi3sZ17KFMjn2sPWo9UJGpOQqiba4A
+  segmentClientSide: true
+
 # Network policies configuration
 networkPolicies:
   # Whether to enable network policies for securing communication between pods

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -53,6 +53,11 @@ pub struct Args {
     disable_authentication: bool,
 
     #[clap(long)]
+    segment_api_key: Option<String>,
+    #[clap(long)]
+    segment_client_side: bool,
+
+    #[clap(long)]
     console_image_tag_default: String,
     #[clap(long)]
     console_image_tag_map: Vec<KeyValueArg<String, String>>,

--- a/src/orchestratord/src/controller/materialize/resources.rs
+++ b/src/orchestratord/src/controller/materialize/resources.rs
@@ -979,6 +979,13 @@ fn create_environmentd_statefulset_object(
         ]);
     }
 
+    if let Some(segment_api_key) = &config.segment_api_key {
+        args.push(format!("--segment-api-key={}", segment_api_key));
+        if config.segment_client_side {
+            args.push("--segment-client-side".into());
+        }
+    }
+
     let mut volumes = Vec::new();
     let mut volume_mounts = Vec::new();
     if issuer_ref_defined(


### PR DESCRIPTION
### Motivation

bringing in line with the emulator

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
