### PR TITLE
DNM: Hoist join constants

### DIFF
--- a/src/transform/src/fusion/join.rs
+++ b/src/transform/src/fusion/join.rs
@@ -48,12 +48,13 @@ impl crate::Transform for Join {
     fn transform(
         &self,
         relation: &mut MirRelationExpr,
-        _: &mut TransformCtx,
+        ctx: &mut TransformCtx,
     ) -> Result<(), TransformError> {
         // We need to stick with post-order here because `action` only fuses a
         // Join with its direct children. This means that we can only fuse a
         // tree of Join nodes in a single pass if we work bottom-up.
-        let mut transformed = false;
+        let mut transformed = Self::hoist_constants(relation, ctx)?;
+
         relation.try_visit_mut_post(&mut |relation| {
             transformed |= Self::action(relation)?;
             Ok::<_, TransformError>(())
@@ -242,6 +243,132 @@ impl Join {
         }
 
         Ok(false)
+    }
+
+    /// Hoist constant collections of a single row to be maps around the join.
+    pub fn hoist_constants(
+        relation: &mut MirRelationExpr,
+        ctx: &mut TransformCtx,
+    ) -> Result<bool, TransformError> {
+        use crate::analysis::Arity;
+        use crate::analysis::DerivedBuilder;
+
+        let mut builder = DerivedBuilder::new(ctx.features);
+        builder.require(Arity);
+        let derived = builder.visit(relation);
+        let derived = derived.as_view();
+
+        let mut updated = false;
+        let mut todo = vec![(&mut *relation, derived)];
+        while let Some((expr, view)) = todo.pop() {
+            if let MirRelationExpr::Join {
+                inputs,
+                equivalences,
+                ..
+            } = expr
+            {
+                // If any input is a constant collection of a single weight one row ...
+                let hoistable = inputs
+                    .iter()
+                    .map(|e| {
+                        if let MirRelationExpr::Constant { rows: Ok(data), .. } = e {
+                            data.len() == 1 && data[0].1 == 1
+                        } else {
+                            false
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                if hoistable.iter().any(|x| *x) {
+                    let mut children: Vec<_> = view.children_rev().collect::<Vec<_>>();
+                    children.reverse();
+
+                    // The starting arity of non-hoisted columns.
+                    let mut base_arity = 0;
+                    // The starting arity of hoisted constant columns.
+                    let mut hoist_arity = 0;
+                    for (index, view) in children.iter().enumerate() {
+                        let child_arity = view.value::<Arity>().expect("Arity required");
+                        if !hoistable[index] {
+                            hoist_arity += child_arity;
+                        }
+                    }
+
+                    // Extract all constant collections into a list of literals we will map
+                    // on to the join result, then permute into position, and then apply the
+                    // equivalences to as a filter.
+                    let mut scalars = Vec::new();
+                    let mut columns = Vec::new();
+
+                    for (index, input) in inputs.iter().enumerate() {
+                        let child_arity =
+                            *children[index].value::<Arity>().expect("Arity required");
+
+                        if hoistable[index] {
+                            // These if statements should not be false; they are just to destructure.
+                            if let MirRelationExpr::Constant {
+                                rows: Ok(data),
+                                typ,
+                            } = input
+                            {
+                                if data.len() == 1 && data[0].1 == 1 {
+                                    // Inform the projection that its values can be found at the end.
+                                    for _ in 0..typ.column_types.len() {
+                                        columns.push(hoist_arity);
+                                        hoist_arity += 1;
+                                    }
+                                    // Assemble the scalar literals
+                                    use itertools::Itertools;
+                                    for (datum, col_typ) in
+                                        data[0].0.iter().zip_eq(typ.column_types.iter())
+                                    {
+                                        scalars.push(MirScalarExpr::literal_ok(
+                                            datum,
+                                            col_typ.scalar_type.clone(),
+                                        ));
+                                    }
+                                }
+                            }
+                        } else {
+                            for _ in 0..child_arity {
+                                columns.push(base_arity);
+                                base_arity += 1;
+                            }
+                        }
+                    }
+
+                    // The join should now be reformed by removing hoisted inputs, mapping literals,
+                    // projecting to re-order them, and imposing equivalences as a filter atop it.
+                    let mut mfp = MapFilterProject::new(base_arity);
+                    mfp = mfp
+                        .map(scalars)
+                        .project(columns)
+                        .filter(unpack_equivalences(equivalences));
+                    mfp.optimize();
+                    let (map, filter, project) = mfp.as_map_filter_project();
+
+                    for (index, hoist) in hoistable.iter().enumerate().rev() {
+                        if *hoist {
+                            inputs.remove(index);
+                        }
+                    }
+                    equivalences.clear();
+
+                    *expr = expr
+                        .take_dangerous()
+                        .map(map)
+                        .filter(filter)
+                        .project(project);
+                    updated = true;
+                } else {
+                    todo.extend(expr.children_mut().rev().zip(view.children_rev()));
+                }
+            } else {
+                todo.extend(expr.children_mut().rev().zip(view.children_rev()));
+            }
+        }
+
+        Ok(updated)
     }
 }
 

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -650,7 +650,7 @@ impl Optimizer {
                     // Converts `Cross Join {Constant(Literal) + Input}` to
                     // `Map {Cross Join (Input, Constant()), Literal}`.
                     // Join fusion will clean this up to `Map{Input, Literal}`
-                    Box::new(LiteralLifting::default()),
+                    // Box::new(LiteralLifting::default()),
                     // Identifies common relation subexpressions.
                     Box::new(cse::relation_cse::RelationCSE::new(false)),
                     Box::new(FuseAndCollapse::default()),
@@ -716,7 +716,7 @@ impl Optimizer {
                     Box::new(EquivalencePropagation::default()),
                     Box::new(fold_constants_fixpoint()),
                     Box::new(Demand::default()),
-                    Box::new(LiteralLifting::default()),
+                    // Box::new(LiteralLifting::default()),
                 ],
             }),
             Box::new(LiteralConstraints),

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -1164,29 +1164,18 @@ WHERE EXISTS (SELECT FROM c AS ref_7 WHERE EXISTS (SELECT ref_0."?column?" AS c2
 Explained Query:
   Return // { arity: 2 }
     Map (4) // { arity: 2 }
-      CrossJoin type=differential // { arity: 1 }
-        implementation
-          %0[×] » %1[×]
-        ArrangeBy keys=[[]] // { arity: 0 }
+      Union // { arity: 1 }
+        Get l0 // { arity: 1 }
+        Map (null) // { arity: 1 }
           Union // { arity: 0 }
-            Get l0 // { arity: 0 }
             Negate // { arity: 0 }
-              Get l0 // { arity: 0 }
+              Distinct project=[] // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l0 // { arity: 1 }
             Constant // { arity: 0 }
               - ()
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l1 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Distinct project=[] // { arity: 0 }
-                    Project () // { arity: 0 }
-                      Get l1 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
   With
-    cte l1 =
+    cte l0 =
       Union // { arity: 1 }
         Project (#2) // { arity: 1 }
           Map (null) // { arity: 3 }
@@ -1197,10 +1186,6 @@ Explained Query:
               Reduce aggregates=[count(*)] // { arity: 1 }
                 Project () // { arity: 0 }
                   ReadStorage materialize.public.a // { arity: 2 }
-    cte l0 =
-      Distinct project=[] // { arity: 0 }
-        Project () // { arity: 0 }
-          ReadStorage materialize.public.c // { arity: 1 }
 
 Source materialize.public.a
 Source materialize.public.c


### PR DESCRIPTION
A facsimile of #29683 that only looks to hoist single constant rows through joins, but does so across multiway joins.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
