### PR TITLE
adapter: downgrade log to debug

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -87,7 +87,7 @@ use mz_storage_types::connections::ConnectionContext;
 use serde::Serialize;
 use timely::progress::Antichain;
 use tokio::sync::mpsc;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 // DO NOT add any more imports from `crate` outside of `crate::catalog`.
 use crate::catalog::{Catalog, ConnCatalog};
@@ -1145,7 +1145,7 @@ impl CatalogState {
                     Some(local_expr)
                         if local_expr.optimizer_features == optimizer_config.features =>
                     {
-                        info!("local expression cache hit for {global_id:?}");
+                        debug!("local expression cache hit for {global_id:?}");
                         (view.expr, local_expr.local_mir)
                     }
                     Some(_) | None => {
@@ -1195,7 +1195,7 @@ impl CatalogState {
                     Some(local_expr)
                         if local_expr.optimizer_features == optimizer_config.features =>
                     {
-                        info!("local expression cache hit for {global_id:?}");
+                        debug!("local expression cache hit for {global_id:?}");
                         (materialized_view.expr, local_expr.local_mir)
                     }
                     Some(_) | None => {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2786,7 +2786,7 @@ impl Coordinator {
                                 if global_expressions.optimizer_features
                                     == optimizer_config.features =>
                             {
-                                info!("global expression cache hit for {global_id:?}");
+                                debug!("global expression cache hit for {global_id:?}");
                                 (
                                     global_expressions.global_mir,
                                     global_expressions.physical_plan,
@@ -2871,7 +2871,7 @@ impl Coordinator {
                                 if global_expressions.optimizer_features
                                     == optimizer_config.features =>
                             {
-                                info!("global expression cache hit for {global_id:?}");
+                                debug!("global expression cache hit for {global_id:?}");
                                 (
                                     global_expressions.global_mir,
                                     global_expressions.physical_plan,
@@ -2964,7 +2964,7 @@ impl Coordinator {
                                 if global_expressions.optimizer_features
                                     == optimizer_config.features =>
                             {
-                                info!("global expression cache hit for {global_id:?}");
+                                debug!("global expression cache hit for {global_id:?}");
                                 (
                                     global_expressions.global_mir,
                                     global_expressions.physical_plan,


### PR DESCRIPTION
### Motivation
This PR refactors existing code.


### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
