### PR TITLE
storage/pg: don't rely on owned capabilities

### DIFF
--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -172,11 +172,8 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
         PostgresFlavor::Yugabyte => None,
     };
 
-    let mut rewind_input = builder.new_input_for(
-        rewind_stream,
-        Exchange::new(move |_| slot_reader),
-        &data_output,
-    );
+    let mut rewind_input =
+        builder.new_disconnected_input(rewind_stream, Exchange::new(move |_| slot_reader));
     let mut slot_ready_input = builder.new_disconnected_input(slot_ready_stream, Pipeline);
     let mut output_uppers = table_info
         .iter()
@@ -313,14 +310,12 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             let Some(resume_lsn) = resume_upper.into_option() else {
                 return Ok(());
             };
-            data_cap_set.downgrade([&resume_lsn]);
             upper_cap_set.downgrade([&resume_lsn]);
-            trace!(%id, "timely-{worker_id} replication \
-                   reader started lsn={}", resume_lsn);
+            trace!(%id, "timely-{worker_id} replication reader started lsn={resume_lsn}");
 
             let mut rewinds = BTreeMap::new();
             while let Some(event) = rewind_input.next().await {
-                if let AsyncEvent::Data(cap, data) = event {
+                if let AsyncEvent::Data(_, data) = event {
                     for req in data {
                         if resume_lsn > req.snapshot_lsn + 1 {
                             let err = DefiniteError::SlotCompactedPastResumePoint(
@@ -351,7 +346,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                             );
                             return Ok(());
                         }
-                        rewinds.insert(req.output_index, (cap.clone(), req));
+                        rewinds.insert(req.output_index, req);
                     }
                 }
             }
@@ -366,7 +361,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 &connection.publication_details.slot,
                 &connection.publication_details.timeline_id,
                 &connection.publication,
-                *data_cap_set[0].time(),
+                resume_lsn,
                 committed_uppers.as_mut(),
                 &stats_output,
                 &stats_cap[0],
@@ -408,7 +403,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             // if we're about to yield, which is checked at the bottom of the loop. This avoids
             // creating excessive progress tracking traffic when there are multiple small
             // transactions ready to go.
-            let mut data_upper = *data_cap_set[0].time();
+            let mut data_upper = resume_lsn;
             // A stash of reusable vectors to convert from bytes::Bytes based data, which is not
             // compatible with `columnation`, to Vec<u8> data that is.
             let mut col_temp: Vec<Vec<u8>> = vec![];
@@ -469,10 +464,10 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                                     Err(err) => Err(err.into()),
                                 };
                                 let mut data = (oid, output_index, event);
-                                if let Some((data_cap, req)) = rewinds.get(&output_index) {
+                                if let Some(req) = rewinds.get(&output_index) {
                                     if commit_lsn <= req.snapshot_lsn {
                                         let update = (data, MzOffset::from(0), -diff);
-                                        data_output.give_fueled(data_cap, &update).await;
+                                        data_output.give_fueled(&data_cap_set[0], &update).await;
                                         data = update.0;
                                     }
                                 }
@@ -502,14 +497,14 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
 
                 let will_yield = stream.as_mut().peek().now_or_never().is_none();
                 if will_yield {
+                    trace!(%id, "timely-{worker_id} yielding at lsn={data_upper}");
+                    rewinds.retain(|_, req| data_upper <= req.snapshot_lsn);
+                    // As long as there are pending rewinds we can't downgrade our data capability
+                    // since we must be able to produce data at offset 0.
+                    if rewinds.is_empty() {
+                        data_cap_set.downgrade([&data_upper]);
+                    }
                     upper_cap_set.downgrade([&data_upper]);
-                    data_cap_set.downgrade([&data_upper]);
-                    trace!(
-                        %id,
-                        "timely-{worker_id} yielding at lsn={}",
-                        data_upper
-                    );
-                    rewinds.retain(|_, (_, req)| data_cap_set[0].time() <= &req.snapshot_lsn);
                 }
             }
             // We never expect the replication stream to gracefully end


### PR DESCRIPTION
This PR fixes a long-standing bug of postgres sources that was a result of using owned capabilities in an async operator. Fallible async operators use the standard Rust `?` operator to encode erroring control flow. Unfortunately this doesn't play well with the rest of the timely integration since when `?` is executed on an error the entire stack of local variables will be destructed. If that stack contains capabilities then timely will be notified about frontier updates that are incorrect, and if the timing is right it might have enough to persist those incorrect results to persist.

As a workaround the API for fallible async operators passes the initial capabilites through a reference to operator implementation with the expectation that the operator only uses those capabilties to communicate progress. This PR implements exactly this idea for pg rewinds.

Fixes: MaterializeInc/database-issues#7008
Fixes: MaterializeInc/database-issues#8803

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
