### PR TITLE
feature benchmark: Try one run per scenario and stricter conditions

### DIFF
--- a/doc/developer/feature-benchmark.md
+++ b/doc/developer/feature-benchmark.md
@@ -142,7 +142,7 @@ be reported.
 
 ## Retry policy
 
-Any scenario will be run exactly `--runs-per-scenario` times (default is 3). The run with the median wallclock duration
+Any scenario will be run exactly `--runs-per-scenario` times (default is 1). The run with the median wallclock duration
 will be chosen and other runs will be discarded.
 
 Reported performance improvements are not retried to establish reproducibility, so should be considered flakes if seen in the CI

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -117,8 +117,8 @@ def make_filter(args: argparse.Namespace) -> Filter:
 
 def make_termination_conditions(args: argparse.Namespace) -> list[TerminationCondition]:
     return [
-        NormalDistributionOverlap(threshold=0.95),
-        ProbForMin(threshold=0.90),
+        NormalDistributionOverlap(threshold=0.99),
+        ProbForMin(threshold=0.99),
         RunAtMost(threshold=args.max_measurements),
     ]
 
@@ -441,7 +441,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "--runs-per-scenario",
         metavar="N",
         type=int,
-        default=5,
+        default=1,
     )
 
     parser.add_argument(


### PR DESCRIPTION
With the increased scale my hope is that we can get away with this and save time and still get reliable benchmark results. Will run nightly on this to verify.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
