### PR TITLE
Orchestratord to configure Console TLS

### DIFF
--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -127,7 +127,7 @@ pub struct Args {
     #[clap(long, default_value = "8080")]
     balancerd_internal_http_port: i32,
 
-    #[clap(long, default_value = "9000")]
+    #[clap(long, default_value = "8080")]
     console_http_port: i32,
 
     #[clap(long, default_value = "{}")]

--- a/src/orchestratord/src/controller/materialize/tls.rs
+++ b/src/orchestratord/src/controller/materialize/tls.rs
@@ -52,10 +52,10 @@ pub fn create_certificate(
             duration: mz_cert_spec.duration.or(default_spec.duration),
             issuer_ref,
             private_key: Some(CertificatePrivateKey {
-                algorithm: Some(CertificatePrivateKeyAlgorithm::Ed25519),
+                algorithm: Some(CertificatePrivateKeyAlgorithm::Rsa),
                 encoding: Some(CertificatePrivateKeyEncoding::Pkcs8),
                 rotation_policy: Some(CertificatePrivateKeyRotationPolicy::Always),
-                size: None,
+                size: Some(4096),
             }),
             renew_before: mz_cert_spec.renew_before.or(default_spec.renew_before),
             secret_name,


### PR DESCRIPTION
* Supports configuring TLS for the console.
* Changes default console HTTP port to 8080.
* Configures console nginx listen port and service to both use the same configured HTTP port.
* Changes certificate private key algorithm from Ed25519 to RSA, due to lack of browser support for certificates signed with Ed25519.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.
Completes configuration of TLS of the console.

### Tips for reviewer
Depends on https://github.com/MaterializeInc/console/pull/3560, so this may need a new console image tag.
This is marked as a draft waiting on the console change, but is otherwise ready to review.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
