### PR TITLE
Fix build from merge skew

### DIFF
--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -1342,7 +1342,7 @@ mod explain {
             if config.equivalences {
                 for (expr, equivs) in std::iter::zip(
                     subtree_refs.iter(),
-                    derived.results::<Equivalences>().unwrap().into_iter(),
+                    derived.results::<Equivalences>().into_iter(),
                 ) {
                     let analyses = annotations.entry(expr).or_default();
                     analyses.equivalences = Some(match equivs.as_ref() {


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/test/builds/95791#01939264-eef7-4ac1-99f6-7389fa781c05

Merge skew from https://github.com/MaterializeInc/materialize/pull/30634 and https://github.com/MaterializeInc/materialize/pull/30690

Verified locally:
```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6m 04s
```
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
