### PR TITLE
disable authentication by default in the helm chart

### DIFF
--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -248,6 +248,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.clusters.sizes.mz_probe.memory_limit` |  | ``"776MiB"`` |
 | `operator.clusters.sizes.mz_probe.scale` |  | ``1`` |
 | `operator.clusters.sizes.mz_probe.workers` |  | ``1`` |
+| `operator.features.authentication` |  | ``false`` |
 | `operator.features.consoleImageTagMapOverride` |  | ``{}`` |
 | `operator.features.createBalancers` |  | ``true`` |
 | `operator.features.createConsole` |  | ``true`` |
@@ -259,7 +260,6 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.resources.requests.cpu` |  | ``"100m"`` |
 | `operator.resources.requests.memory` |  | ``"512Mi"`` |
 | `rbac.create` |  | ``true`` |
-| `rbac.enabled` |  | ``true`` |
 | `serviceAccount.create` |  | ``true`` |
 | `serviceAccount.name` |  | ``"orchestratord"`` |
 | `storage.storageClass.allowVolumeExpansion` |  | ``false`` |

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -72,9 +72,7 @@ spec:
         {{- range $key, $value := .Values.operator.features.consoleImageTagMapOverride }}
         - "--console-image-tag-map={{ $key }}={{ $value }}"
         {{- end }}
-
-        {{/* Authentication */}}
-        {{- if not .Values.rbac.enabled }}
+        {{- if not .Values.operator.features.authentication }}
         - "--disable-authentication"
         {{- end }}
 

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -29,6 +29,9 @@ operator:
     createConsole: true
     # Override the mapping of environmentd versions to console versions
     consoleImageTagMapOverride: {}
+    # Whether to enable environmentd rbac checks
+    # TODO: this is not yet supported in the helm chart
+    authentication: false
 
   # Cloud provider configuration
   cloudProvider:
@@ -215,7 +218,6 @@ clusterd:
 
 # RBAC (Role-Based Access Control) settings
 rbac:
-  enabled: true
   # Whether to create necessary RBAC roles and bindings
   create: true
 


### PR DESCRIPTION
### Motivation

it doesn't actually work with authentication enabled yet, so this is a better default.

additionally, move the helm chart configuration around to avoid confusion between kubernetes rbac and environmentd rbac

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
