### PR TITLE
storage: reduce scope of the `StorageCollections` trait

### DIFF
--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -766,25 +766,18 @@ mod tests {
     use std::collections::BTreeSet;
 
     use async_trait::async_trait;
-    use futures::future::BoxFuture;
     use mz_compute_types::dataflows::{IndexDesc, IndexImport};
     use mz_compute_types::sinks::ComputeSinkConnection;
     use mz_compute_types::sinks::ComputeSinkDesc;
     use mz_compute_types::sinks::MaterializedViewSinkConnection;
     use mz_compute_types::sources::SourceInstanceArguments;
     use mz_compute_types::sources::SourceInstanceDesc;
-    use mz_persist_client::stats::{SnapshotPartsStats, SnapshotStats};
     use mz_repr::RelationDesc;
     use mz_repr::RelationType;
     use mz_repr::Timestamp;
-    use mz_storage_client::controller::{CollectionDescription, StorageMetadata, StorageTxn};
     use mz_storage_client::storage_collections::CollectionFrontiers;
-    use mz_storage_types::connections::inline::InlinedConnection;
     use mz_storage_types::controller::{CollectionMetadata, StorageError};
-    use mz_storage_types::parameters::StorageParameters;
     use mz_storage_types::read_holds::ReadHoldError;
-    use mz_storage_types::sources::SourceExportDataConfig;
-    use mz_storage_types::sources::{GenericSourceConnection, SourceDesc};
     use mz_storage_types::time_dependence::{TimeDependence, TimeDependenceError};
 
     use super::*;
@@ -806,27 +799,10 @@ mod tests {
     impl StorageCollections for StorageFrontiers {
         type Timestamp = Timestamp;
 
-        async fn initialize_state(
-            &self,
-            _txn: &mut (dyn StorageTxn<Self::Timestamp> + Send),
-            _init_ids: BTreeSet<GlobalId>,
-            _drop_ids: BTreeSet<GlobalId>,
-        ) -> Result<(), StorageError<Self::Timestamp>> {
-            unimplemented!()
-        }
-
-        fn update_parameters(&self, _config_params: StorageParameters) {
-            unimplemented!()
-        }
-
         fn collection_metadata(
             &self,
             _id: GlobalId,
         ) -> Result<CollectionMetadata, StorageError<Self::Timestamp>> {
-            unimplemented!()
-        }
-
-        fn active_collection_metadatas(&self) -> Vec<(GlobalId, CollectionMetadata)> {
             unimplemented!()
         }
 
@@ -848,88 +824,7 @@ mod tests {
             Ok(frontiers)
         }
 
-        fn active_collection_frontiers(&self) -> Vec<CollectionFrontiers<Self::Timestamp>> {
-            unimplemented!()
-        }
-
         fn check_exists(&self, _id: GlobalId) -> Result<(), StorageError<Self::Timestamp>> {
-            unimplemented!()
-        }
-
-        async fn snapshot_stats(
-            &self,
-            _id: GlobalId,
-            _as_of: Antichain<Self::Timestamp>,
-        ) -> Result<SnapshotStats, StorageError<Self::Timestamp>> {
-            unimplemented!()
-        }
-
-        async fn snapshot_parts_stats(
-            &self,
-            _id: GlobalId,
-            _as_of: Antichain<Self::Timestamp>,
-        ) -> BoxFuture<'static, Result<SnapshotPartsStats, StorageError<Self::Timestamp>>> {
-            unimplemented!()
-        }
-
-        async fn prepare_state(
-            &self,
-            _txn: &mut (dyn StorageTxn<Self::Timestamp> + Send),
-            _ids_to_add: BTreeSet<GlobalId>,
-            _ids_to_drop: BTreeSet<GlobalId>,
-        ) -> Result<(), StorageError<Self::Timestamp>> {
-            unimplemented!()
-        }
-
-        async fn create_collections_for_bootstrap(
-            &self,
-            _storage_metadata: &StorageMetadata,
-            _register_ts: Option<Self::Timestamp>,
-            _collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
-            _migrated_storage_collections: &BTreeSet<GlobalId>,
-        ) -> Result<(), StorageError<Self::Timestamp>> {
-            unimplemented!()
-        }
-
-        async fn alter_ingestion_source_desc(
-            &self,
-            _ingestion_id: GlobalId,
-            _source_desc: SourceDesc,
-        ) -> Result<(), StorageError<Self::Timestamp>> {
-            unimplemented!()
-        }
-
-        async fn alter_ingestion_export_data_configs(
-            &self,
-            _source_exports: BTreeMap<GlobalId, SourceExportDataConfig>,
-        ) -> Result<(), StorageError<Self::Timestamp>> {
-            unimplemented!()
-        }
-
-        async fn alter_ingestion_connections(
-            &self,
-            _source_connections: BTreeMap<GlobalId, GenericSourceConnection<InlinedConnection>>,
-        ) -> Result<(), StorageError<Self::Timestamp>> {
-            unimplemented!()
-        }
-
-        fn alter_table_desc(
-            &self,
-            _table_id: GlobalId,
-            _new_desc: RelationDesc,
-        ) -> Result<(), StorageError<Self::Timestamp>> {
-            unimplemented!()
-        }
-
-        fn drop_collections_unvalidated(
-            &self,
-            _storage_metadata: &StorageMetadata,
-            _identifiers: Vec<GlobalId>,
-        ) {
-            unimplemented!()
-        }
-
-        fn set_read_policies(&self, _policies: Vec<(GlobalId, ReadPolicy<Self::Timestamp>)>) {
             unimplemented!()
         }
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -56,6 +56,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::client::{AppendOnlyUpdate, StatusUpdate, TimestamplessUpdate};
 use crate::statistics::WebhookStatistics;
+use crate::storage_collections::StorageCollections;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub enum IntrospectionType {
@@ -299,6 +300,11 @@ pub trait StorageController: Debug {
 
     /// Get the current configuration, including parameters updated with `update_parameters`.
     fn config(&self) -> &StorageConfiguration;
+
+    /// Returns a handle to the corresponding StorageCollections implementation of this controller.
+    fn storage_collections(
+        &self,
+    ) -> Arc<dyn StorageCollections<Timestamp = Self::Timestamp> + Send + Sync>;
 
     /// Returns the [CollectionMetadata] of the collection identified by `id`.
     fn collection_metadata(

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -322,7 +322,8 @@ where
     fn storage_collections(
         &self,
     ) -> Arc<dyn StorageCollections<Timestamp = Self::Timestamp> + Send + Sync> {
-        Arc::clone(&self.storage_collections) as Arc<_>
+        let ret: _ = Arc::clone(&self.storage_collections);
+        ret
     }
 
     fn collection_metadata(
@@ -1010,8 +1011,7 @@ where
     ) -> Result<(), StorageError<Self::Timestamp>> {
         // Also have to let StorageCollections know!
         self.storage_collections
-            .alter_ingestion_connections(source_connections.clone())
-            .await?;
+            .alter_ingestion_connections(source_connections.clone())?;
 
         let mut ingestions_to_run = BTreeSet::new();
 
@@ -1055,8 +1055,7 @@ where
     ) -> Result<(), StorageError<Self::Timestamp>> {
         // Also have to let StorageCollections know!
         self.storage_collections
-            .alter_ingestion_export_data_configs(source_exports.clone())
-            .await?;
+            .alter_ingestion_export_data_configs(source_exports.clone())?;
 
         let mut ingestions_to_run = BTreeSet::new();
 
@@ -2241,7 +2240,6 @@ where
     ) -> Result<(), StorageError<T>> {
         self.storage_collections
             .initialize_state(txn, init_ids, drop_ids)
-            .await
     }
 
     async fn prepare_state(
@@ -2252,7 +2250,6 @@ where
     ) -> Result<(), StorageError<T>> {
         self.storage_collections
             .prepare_state(txn, ids_to_add, ids_to_drop)
-            .await
     }
 
     async fn real_time_recent_timestamp(
@@ -2421,7 +2418,7 @@ where
         let storage_collections = storage_collections::StorageCollectionsImpl::new(
             persist_location.clone(),
             Arc::clone(&persist_clients),
-            &metrics_registry,
+            metrics_registry,
             now.clone(),
             Arc::clone(&txns_metrics),
             envd_epoch,

--- a/src/storage-controller/src/statistics.rs
+++ b/src/storage-controller/src/statistics.rs
@@ -109,7 +109,12 @@ pub(super) fn spawn_statistics_scraper<StatsWrapper, Stats, T>(
 where
     StatsWrapper: AsStats<Stats> + Debug + Send + 'static,
     Stats: PackableStats + Clone + Debug + Send + 'static,
-    T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulation,
+    T: Timestamp
+        + Lattice
+        + Codec64
+        + From<EpochMillis>
+        + TimestampManipulation
+        + Into<mz_repr::Timestamp>,
 {
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
 


### PR DESCRIPTION

The `StorageCollections` trait is meant to expose a simple interface to components outside of storage that allows them to monitor frontiers and such.
    
Naturally, there is a lot of overlap and communication between the data held in the `StorageCollectionsImpl` and the `StorageController`, but because the latter was only having access to the former via a trait object it necessitated the trait to have many more methods and surface area just so that the two could cooperate.
    
In reality, the storage controller and storage collections are tightly coupled and putting a trait between them is adding unnecessary complexity.
    
This PR specializes the type of `StorageCollections` in the storage controller. This allows the storage controller to call non-exposed methods, non-public methods on the `StorageCollectionsImpl` value and allows to drastically reduce the surface area offered by the trait. So much so that its implementation can could be replaced by just some shared pieces of data over an `Arc<Mutex<_>>`.

This PR is only code movement and deletion. Future PRs will build on this new structure by consolidating and simplifying collection handling.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
