### PR TITLE
build: Introduce optimized profile (20x faster incremental build, 20-50% slower runtime performance compared to Release)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -176,6 +176,19 @@ build:release-dev --config=release --config=release-lto --config=debuginfo-limit
 # tradeoff is not worth it when developing locally, but is for builds we ship to production.
 build:release-local --config=release --config=debuginfo-limited
 
+build:optimized --cxxopt=-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST
+build:optimized --copt=-O3
+build:optimized --copt=-DNDEBUG
+build:optimized --compilation_mode=opt
+build:optimized --strip=never
+build:optimized --@rules_rust//:extra_rustc_flag=-Cstrip=none
+build:optimized --@rules_rust//:extra_rustc_flag=-Cdebuginfo=0
+build:optimized --copt=-g0
+build:optimized --copt=-fno-lto
+build:optimized --linkopt=-fno-lto
+build:optimized --@rules_rust//:extra_rustc_flag=-Clto=off
+build:optimized --@rules_rust//:extra_rustc_flag=-Cincremental=on
+
 # Build with the Rust Nightly Toolchain
 build:rust-nightly --@rules_rust//rust/toolchain/channel=nightly
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,6 +266,12 @@ lto = "thin"
 # docker containers.
 debug = 2
 
+[profile.optimized]
+inherits = "release"
+lto = "off"
+debug = false
+incremental = true
+
 # IMPORTANT: when patching a dependency, you should only depend on "main",
 # "master", or an upstream release branch (e.g., "v7.x"). Do *not* depend on a
 # feature/patch branch (e.g., "fix-thing" or "pr-1234"). Feature/patch branches

--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -119,7 +119,13 @@ def get_bin_path(repo: Repository, bin: str, bazel_bins: dict[str, str]) -> Path
         assert len(paths) == 1, f"{bazel_bins[bin]} output more than 1 file"
         return paths[0]
     else:
-        cargo_profile = "release" if repo.rd.release_mode else "debug"
+        cargo_profile = (
+            "release"
+            if repo.rd.profile == mzbuild.Profile.RELEASE
+            else (
+                "optimized" if repo.rd.profile == mzbuild.Profile.OPTIMIZED else "debug"
+            )
+        )
         return repo.rd.cargo_target_dir() / cargo_profile / bin
 
 

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -94,6 +94,11 @@ def main() -> int:
         action="store_true",
     )
     parser.add_argument(
+        "--optimized",
+        help="Build artifacts in optimized mode, with optimizations (but no LTO and debug symbols)",
+        action="store_true",
+    )
+    parser.add_argument(
         "--timings",
         help="Output timing information",
         action="store_true",
@@ -484,6 +489,8 @@ def _cargo_command(args: argparse.Namespace, subcommand: str) -> list[str]:
     command += [subcommand]
     if args.release:
         command += ["--release"]
+    if args.optimized:
+        command += ["--profile", "optimized"]
     if args.timings:
         command += ["--timings"]
     if args.no_default_features:
@@ -494,16 +501,11 @@ def _cargo_command(args: argparse.Namespace, subcommand: str) -> list[str]:
 
 
 def _cargo_artifact_path(args: argparse.Namespace, program: str) -> pathlib.Path:
-    if args.release:
-        if args.sanitizer != "none":
-            artifact_path = MZ_ROOT / "target" / SANITIZER_TARGET / "release"
-        else:
-            artifact_path = MZ_ROOT / "target" / "release"
+    dir_name = "release" if args.release else "optimized" if args.optimized else "debug"
+    if args.sanitizer != "none":
+        artifact_path = MZ_ROOT / "target" / SANITIZER_TARGET / dir_name
     else:
-        if args.sanitizer != "none":
-            artifact_path = MZ_ROOT / "target" / SANITIZER_TARGET / "debug"
-        else:
-            artifact_path = MZ_ROOT / "target" / "debug"
+        artifact_path = MZ_ROOT / "target" / dir_name
 
     return artifact_path / program
 

--- a/misc/python/materialize/cloudtest/app/cloudtest_application_base.py
+++ b/misc/python/materialize/cloudtest/app/cloudtest_application_base.py
@@ -45,7 +45,9 @@ class CloudtestApplicationBase(Application):
     def acquire_images(self) -> None:
         repo = mzbuild.Repository(
             self.mz_root,
-            release_mode=self.release_mode,
+            profile=(
+                mzbuild.Profile.RELEASE if self.release_mode else mzbuild.Profile.DEV
+            ),
             coverage=self.coverage_mode(),
             bazel=self.bazel(),
             bazel_remote_cache=self.bazel_remote_cache(),

--- a/misc/python/materialize/cloudtest/k8s/api/k8s_resource.py
+++ b/misc/python/materialize/cloudtest/k8s/api/k8s_resource.py
@@ -93,7 +93,9 @@ class K8sResource:
 
             repo = mzbuild.Repository(
                 MZ_ROOT,
-                release_mode=release_mode,
+                profile=(
+                    mzbuild.Profile.RELEASE if release_mode else mzbuild.Profile.DEV
+                ),
                 coverage=coverage,
                 sanitizer=sanitizer,
                 bazel=bazel,

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -32,6 +32,7 @@ import tarfile
 import time
 from collections import OrderedDict
 from collections.abc import Callable, Iterable, Iterator, Sequence
+from enum import Enum, auto
 from functools import cache
 from pathlib import Path
 from tempfile import TemporaryFile
@@ -57,6 +58,12 @@ class Fingerprint(bytes):
         return base64.b32encode(self).decode()
 
 
+class Profile(Enum):
+    RELEASE = auto()
+    OPTIMIZED = auto()
+    DEV = auto()
+
+
 class RepositoryDetails:
     """Immutable details about a `Repository`.
 
@@ -65,7 +72,7 @@ class RepositoryDetails:
     Attributes:
         root: The path to the root of the repository.
         arch: The CPU architecture to build for.
-        release_mode: Whether the repository is being built in release mode.
+        profile: What profile the repository is being built with.
         coverage: Whether the repository has code coverage instrumentation
             enabled.
         sanitizer: Whether to use a sanitizer (address, hwaddress, cfi, thread, leak, memory, none)
@@ -81,7 +88,7 @@ class RepositoryDetails:
         self,
         root: Path,
         arch: Arch,
-        release_mode: bool,
+        profile: Profile,
         coverage: bool,
         sanitizer: Sanitizer,
         image_registry: str,
@@ -91,7 +98,7 @@ class RepositoryDetails:
     ):
         self.root = root
         self.arch = arch
-        self.release_mode = release_mode
+        self.profile = profile
         self.coverage = coverage
         self.sanitizer = sanitizer
         self.cargo_workspace = cargo.Workspace(root)
@@ -144,18 +151,20 @@ class RepositoryDetails:
         """Returns a set of Bazel config flags to set for the build."""
         flags = []
 
-        if self.release_mode:
+        if self.profile == Profile.RELEASE:
             # If we're a tagged build, then we'll use stamping to update our
             # build info, otherwise we'll use our side channel/best-effort
             # approach to update it.
             if ui.env_is_truthy("BUILDKITE_TAG"):
-                flags.extend(["--config=release-tagged"])
+                flags.append("--config=release-tagged")
             elif ui.env_is_truthy("CI"):
-                flags.extend(["--config=release-dev"])
+                flags.append("--config=release-dev")
                 bazel_utils.write_git_hash()
             else:
-                flags.extend(["--config=release-local"])
+                flags.append("--config=release-local")
                 bazel_utils.write_git_hash()
+        elif self.profile == Profile.OPTIMIZED:
+            flags.append("--config=optimized")
 
         if self.bazel_remote_cache:
             flags.append(f"--remote_cache={self.bazel_remote_cache}")
@@ -312,8 +321,10 @@ class CargoPreImage(PreImage):
         # Cargo images depend on the release mode and whether
         # coverage/sanitizer is enabled.
         flags: list[str] = []
-        if self.rd.release_mode:
+        if self.rd.profile == Profile.RELEASE:
             flags += "release"
+        if self.rd.profile == Profile.OPTIMIZED:
+            flags += "optimized"
         if self.rd.coverage:
             flags += "coverage"
         if self.rd.sanitizer != Sanitizer.none:
@@ -463,8 +474,10 @@ class CargoBuild(CargoPreImage):
             packages.add(rd.cargo_workspace.crate_for_example(example).name)
         cargo_build.extend(f"--package={p}" for p in packages)
 
-        if rd.release_mode:
+        if rd.profile == Profile.RELEASE:
             cargo_build.append("--release")
+        if rd.profile == Profile.OPTIMIZED:
+            cargo_build.extend(["--profile", "optimized"])
         if rd.sanitizer != Sanitizer.none:
             # ASan doesn't work with jemalloc
             cargo_build.append("--no-default-features")
@@ -544,7 +557,11 @@ class CargoBuild(CargoPreImage):
         return prep
 
     def build(self, build_output: dict[str, Any]) -> None:
-        cargo_profile = "release" if self.rd.release_mode else "debug"
+        cargo_profile = (
+            "release"
+            if self.rd.profile == Profile.RELEASE
+            else "optimized" if self.rd.profile == Profile.OPTIMIZED else "debug"
+        )
 
         def copy(src: Path, relative_dst: Path) -> None:
             exe_path = self.path / relative_dst
@@ -1131,7 +1148,7 @@ class Repository:
     Args:
         root: The path to the root of the repository.
         arch: The CPU architecture to build for.
-        release_mode: Whether to build the repository in release mode.
+        profile: What profile to build the repository in.
         coverage: Whether to enable code coverage instrumentation.
         sanitizer: Whether to a sanitizer (address, thread, leak, memory, none)
         image_registry: The Docker image registry to pull images from and push
@@ -1147,7 +1164,7 @@ class Repository:
         self,
         root: Path,
         arch: Arch = Arch.host(),
-        release_mode: bool = True,
+        profile: Profile = Profile.RELEASE,
         coverage: bool = False,
         sanitizer: Sanitizer = Sanitizer.none,
         image_registry: str = "materialize",
@@ -1158,7 +1175,7 @@ class Repository:
         self.rd = RepositoryDetails(
             root,
             arch,
-            release_mode,
+            profile,
             coverage,
             sanitizer,
             image_registry,
@@ -1210,8 +1227,8 @@ class Repository:
 
         This function installs the following options:
 
-          * The mutually-exclusive `--dev`/`--release` options to control the
-            `release_mode` repository attribute.
+          * The mutually-exclusive `--dev`/`--optimized`/`--release` options to control the
+            `profile` repository attribute.
           * The `--coverage` boolean option to control the `coverage` repository
             attribute.
 
@@ -1229,6 +1246,11 @@ class Repository:
             "--release",
             action="store_true",
             help="build Rust binaries with the release profile (default)",
+        )
+        build_mode.add_argument(
+            "--optimized",
+            action="store_true",
+            help="build Rust binaries with the optimized profile (optimizations, no LTO, no debug symbols)",
         )
         parser.add_argument(
             "--coverage",
@@ -1280,7 +1302,11 @@ class Repository:
         """
         return cls(
             root,
-            release_mode=args.release,
+            profile=(
+                Profile.RELEASE
+                if args.release
+                else Profile.OPTIMIZED if args.optimized else Profile.DEV
+            ),
             coverage=args.coverage,
             sanitizer=args.sanitizer,
             image_registry=args.image_registry,


### PR DESCRIPTION
Motivation is to have a build that is fast for local iteration, especially incremental builds, but still has more runtime performance than debug builds.

My test case to measure incremental build time after touching a single file:
```
$ cargo build --profile optimized --bin materialized
$ touch src/adapter/src/lib.rs
$ cargo build --profile optimized --bin materialized
    Finished `optimized` profile [optimized] target(s) in 18.89s
```
vs release:
```
$ cargo build --release --bin materialized
$ touch src/adapter/src/lib.rs
$ cargo build --release --bin materialized
    Finished `release` profile [optimized + debuginfo] target(s) in 7m 08s
```
vs dev:
```
$ cargo build --bin materialized
$ touch src/adapter/src/lib.rs
$ cargo build --bin materialized
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 20.75s
```
I'm not sure if the performance is good enough. Edit:

Quick benchmark:
```
materialize=> SELECT count(*) FROM generate_series(1, 10000000);
  count
----------
 10000000
(1 row)

Time: 1106.650 ms (00:01.107)
```
vs release:
```
materialize=> SELECT count(*) FROM generate_series(1, 10000000);
  count
----------
 10000000
(1 row)

Time: 736.516 ms
```
vs dev:
```
materialize=> SELECT count(*) FROM generate_series(1, 10000000);
  count
----------
 10000000
(1 row)

Time: 6434.752 ms (00:06.435)
```

I'm not sure if we should switch the default to optimized for local building, it would make life easier for most, but if you actually need the maximum performance you'll have to manually specify `--release`. Release also has the advantage of often having builds on Dockerhub already. Taking the Release build when it's on Dockerhub, but building with Optimized otherwise would be confusing since you can get a container with variable configuration.
One suggestion would be to switch the default to `--optimized` for the `bin/{environmentd,sqllogictest}` executables, but not for `bin/mzcompose`. On the other hand, this doesn't have debug symbols, so a bit more annoying than the current default of Debug build in `run.py`. No changes necessary for now I guess.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
