### PR TITLE
docs: fix releases left-hand menu

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -194,7 +194,7 @@ weight = 15
 
 [[menu.main]]
 identifier = "releases-previews"
-name = "Releases and previews"
+name = "Releases"
 weight = 65
 
 #


### PR DESCRIPTION
Heh ... the force-push on https://github.com/MaterializeInc/materialize/pull/30726 undid the change 🤣 

https://github.com/MaterializeInc/materialize/compare/6d98e84a51f90778e50c346f4b4752dee8c63573..179fa3cb2235dcaa0011a8704774ec183de48c69