### PR TITLE
Try fat LTO

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -155,11 +155,12 @@ build:release --compilation_mode=opt
 # `rules_rust` defaults to stripping debug symbols for release builds, undo that.
 build:release --strip=never
 build:release --@rules_rust//:extra_rustc_flag=-Cstrip=none
+build:release --@rules_rust//:extra_rustc_flag="-Ccodegen-units=1"
 
 # We only enable Link Time Optimization for CI builds and not local release builds.
-build:release-lto --copt=-flto=thin
-build:release-lto --linkopt=-flto=thin
-build:release-lto --@rules_rust//:extra_rustc_flag=-Clto=thin
+build:release-lto --copt=-flto
+build:release-lto --linkopt=-flto
+build:release-lto --@rules_rust//:extra_rustc_flag=-Clto
 
 # Builds from `main` or tagged builds.
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,7 +255,8 @@ rustc-demangle = { opt-level = 3 }
 
 [profile.release]
 # Compile time seems similar to "lto = false", runtime ~10% faster
-lto = "thin"
+lto = "fat"
+codegen-units = 1
 
 # Emit full debug info, allowing us to easily analyze core dumps from
 # staging (and, in an emergency, also prod).

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -25,7 +25,7 @@ steps:
           - "*"
         artifact_paths: bazel-explain.log
         depends_on: []
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
           queue: builder-linux-x86_64
 
@@ -36,7 +36,7 @@ steps:
           - "*"
         artifact_paths: bazel-explain.log
         depends_on: []
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
           queue: builder-linux-aarch64-mem
 

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -38,7 +38,7 @@ steps:
         inputs:
           - "*"
         depends_on: []
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         priority: 50
         agents:
           queue: builder-linux-x86_64
@@ -67,7 +67,7 @@ steps:
           - "*"
         depends_on: []
         priority: 50
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
           queue: builder-linux-aarch64-mem
 
@@ -95,7 +95,7 @@ steps:
           - "*"
         artifact_paths: bazel-explain.log
         depends_on: []
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
           queue: builder-linux-x86_64
 
@@ -107,7 +107,7 @@ steps:
           - "*"
         artifact_paths: bazel-explain.log
         depends_on: []
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
           queue: builder-linux-aarch64-mem
 


### PR DESCRIPTION
I want to see if it makes a difference. Maybe something to do only for release-tagged

Results: https://docs.google.com/spreadsheets/d/12aAx12hPSKSgfDLCY-lIQGHp8SSC2k-9OGO_LHlMcnk/edit?gid=1880129053#gid=1880129053

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
