### PR TITLE
Don't upload materialized debuginfo

### DIFF
--- a/misc/python/materialize/ci_util/upload_debug_symbols_to_s3.py
+++ b/misc/python/materialize/ci_util/upload_debug_symbols_to_s3.py
@@ -17,7 +17,7 @@ from materialize import elf
 DEBUGINFO_S3_BUCKET = "materialize-debuginfo"
 
 # The binaries for which debuginfo should be uploaded to S3 and Polar Signals.
-DEBUGINFO_BINS = {"environmentd", "clusterd", "balancerd", "materialized"}
+DEBUGINFO_BINS = {"environmentd", "clusterd", "balancerd"}
 
 
 def upload_debuginfo_to_s3(bin_path: Path, dbg_path: Path, is_tag_build: bool) -> str:


### PR DESCRIPTION
Too large?

See https://materializeinc.slack.com/archives/C0761MZ3QD9/p1733397068662869

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
