### PR TITLE
adapter: improve expr cache log

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -440,12 +440,18 @@ impl Catalog {
         info!("startup: coordinator init: catalog open: expr cache open beginning");
         // We wait until after the `pre_item_updates` to open the cache so we can get accurate
         // dyncfgs because the `pre_item_updates` contains `SystemConfiguration` updates.
+        let enable_expr_cache_dyncfg = ENABLE_EXPRESSION_CACHE.get(state.system_config().dyncfgs());
         let expr_cache_enabled = config.enable_0dt_deployment
             && config
                 .enable_expression_cache_override
-                .unwrap_or_else(|| ENABLE_EXPRESSION_CACHE.get(state.system_config().dyncfgs()));
+                .unwrap_or(enable_expr_cache_dyncfg);
         let (expr_cache_handle, cached_local_exprs, cached_global_exprs) = if expr_cache_enabled {
-            info!("using expression cache for startup");
+            info!(
+                ?config.enable_0dt_deployment,
+                ?config.enable_expression_cache_override,
+                ?enable_expr_cache_dyncfg,
+                "using expression cache for startup"
+            );
             let current_ids = txn
                 .get_items()
                 .flat_map(|item| {


### PR DESCRIPTION
### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
