### PR TITLE
bazel: tune the "optimized" build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -113,9 +113,18 @@ build:macos --linkopt="-gdwarf-2"
 # (and, in an emergency, also prod).
 build:debuginfo-full --@rules_rust//:extra_rustc_flag=-Cdebuginfo=2
 build:debuginfo-full --copt=-g2
+build:debuginfo-full --strip=never
+build:debuginfo-full --@rules_rust//:extra_rustc_flag=-Cstrip=none
 
 build:debuginfo-limited --@rules_rust//:extra_rustc_flag=-Cdebuginfo=line-tables-only
 build:debuginfo-limited --copt=-gline-tables-only
+build:debuginfo-limited --strip=never
+build:debuginfo-limited --@rules_rust//:extra_rustc_flag=-Cstrip=none
+
+build:debuginfo-none --@rules_rust//:extra_rustc_flag=-Cdebuginfo=0
+build:debuginfo-none --copt=-g0
+build:debuginfo-none --strip=always
+build:debuginfo-none --@rules_rust//:extra_rustc_flag=-Cstrip=symbols
 
 #
 # Common Build Configuration
@@ -152,9 +161,6 @@ build:release --cxxopt=-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST
 build:release --copt=-O3
 build:release --copt=-DNDEBUG
 build:release --compilation_mode=opt
-# `rules_rust` defaults to stripping debug symbols for release builds, undo that.
-build:release --strip=never
-build:release --@rules_rust//:extra_rustc_flag=-Cstrip=none
 
 # We only enable Link Time Optimization for CI builds and not local release builds.
 build:release-lto --copt=-flto=thin
@@ -170,24 +176,21 @@ build:release-tagged --config=release --config=release-lto --config=release-stam
 #
 # Not doing a full stamp nor omitting full debug info, greatly speeds up compile times.
 build:release-dev --config=release --config=release-lto --config=debuginfo-limited
-# Local Release Builds.
-#
-# Building with LTO can improve performance but it significantly increases compile times. The
-# tradeoff is not worth it when developing locally, but is for builds we ship to production.
-build:release-local --config=release --config=debuginfo-limited
 
-build:optimized --cxxopt=-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST
-build:optimized --copt=-O3
-build:optimized --copt=-DNDEBUG
+# "Optimized" Build.
+#
+# Provides both reasonably fast compile times and runtimes.
 build:optimized --compilation_mode=opt
-build:optimized --strip=never
-build:optimized --@rules_rust//:extra_rustc_flag=-Cstrip=none
-build:optimized --@rules_rust//:extra_rustc_flag=-Cdebuginfo=0
-build:optimized --copt=-g0
+build:optimized --cxxopt=-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST
+build:optimized --copt=-O2
+build:optimized --copt=-DNDEBUG
+
+build:optimized --config=debuginfo-none
+
 build:optimized --copt=-fno-lto
 build:optimized --linkopt=-fno-lto
 build:optimized --@rules_rust//:extra_rustc_flag=-Clto=off
-build:optimized --@rules_rust//:extra_rustc_flag=-Cincremental=on
+build:optimized --@rules_rust//:extra_rustc_flag=-Cembed-bitcode=no
 
 # Build with the Rust Nightly Toolchain
 build:rust-nightly --@rules_rust//rust/toolchain/channel=nightly

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -157,11 +157,8 @@ class RepositoryDetails:
             # approach to update it.
             if ui.env_is_truthy("BUILDKITE_TAG"):
                 flags.append("--config=release-tagged")
-            elif ui.env_is_truthy("CI"):
-                flags.append("--config=release-dev")
-                bazel_utils.write_git_hash()
             else:
-                flags.append("--config=release-local")
+                flags.append("--config=release-dev")
                 bazel_utils.write_git_hash()
         elif self.profile == Profile.OPTIMIZED:
             flags.append("--config=optimized")


### PR DESCRIPTION
Tunes the `optimized` build profile introduced in https://github.com/MaterializeInc/materialize/pull/30730, and gets rid of the `release-local` profile since they are essentially the same.

Unfortunately Bazel doesn't support Rust incremental builds, although there's an issue to change `rustc` so it could. See https://github.com/rust-lang/rust/issues/132132

Otherwise the biggest change this makes is to not embed LLVM bitcode which is only used for LTO. Cargo automatically does this when LTO is disabled, but Bazel does not.

### Motivation

Faster "optimized" builds

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
