### PR TITLE
build(deps): Update pprof to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0966165eaf052580bd70eb1b32cb3d6245774c0104d1b2793e9650bf83b52a"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,6 +2300,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3688,7 +3717,7 @@ checksum = "194eb6220fcd2399f0342d2e8e24b8d41e22e037b2f34b1d4cf7cfba228f8cc6"
 dependencies = [
  "crossbeam-deque",
  "libc",
- "memmap2",
+ "memmap2 0.5.4",
  "numa_maps",
  "page_size",
  "tempfile",
@@ -3919,6 +3948,15 @@ name = "memmap2"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5172b50c23043ff43dd53e51392f36519d9b35a8f3a410d30ece5d1aedd58ae"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
 ]
@@ -7917,10 +7955,11 @@ dependencies = [
 
 [[package]]
 name = "pprof"
-version = "0.11.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196ded5d4be535690899a4631cc9f18cdc41b7ebf24a79400f46f48e49a11059"
+checksum = "ebbe2f8898beba44815fdc9e5a4ae9c929e21c5dc29b0c774a15555f7f58d6d0"
 dependencies = [
+ "aligned-vec",
  "backtrace",
  "cfg-if",
  "findshlibs",
@@ -9450,21 +9489,21 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symbolic-common"
-version = "10.2.0"
+version = "12.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d7c8cd6663e22c348c74cf0b2c77d196fd252c7efe5594ae05edb07d0475da"
+checksum = "e5ba5365997a4e375660bed52f5b42766475d5bc8ceb1bb13fea09c469ea0f49"
 dependencies = [
  "debugid",
- "memmap2",
+ "memmap2 0.9.5",
  "stable_deref_trait",
  "uuid",
 ]
 
 [[package]]
 name = "symbolic-demangle"
-version = "10.2.0"
+version = "12.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86dc78e43163d342e72c0175113cf0c6ffc6b2540163c8680c4ed91c992af9e2"
+checksum = "76f1b0155f588568b2df0d693b30aeedb59360b647b85fc3c23942e81e8cc97a"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",

--- a/deny.toml
+++ b/deny.toml
@@ -112,6 +112,8 @@ skip = [
     # `axum 0.7.5` depends on both `sync_wrapper 1.*` and `axum-core 0.4.3`.
     # The latter depends on `sync_wrapper 0.1.*`.
     { name = "sync_wrapper", version = "0.1.2" },
+
+    { name = "memmap2", version = "0.5.4" },
 ]
 
 # Use `tracing` instead.

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -23,7 +23,7 @@ audit-as-crates-io = true
 [policy.launchdarkly-server-sdk]
 audit-as-crates-io = true
 
-[policy.librocksdb-sys]
+[policy.mysql_async]
 audit-as-crates-io = true
 
 [policy.mz-avro]
@@ -69,16 +69,10 @@ audit-as-crates-io = true
 [policy.reqwest-retry]
 audit-as-crates-io = true
 
-[policy.rocksdb]
-audit-as-crates-io = true
-
 [policy.serde-value]
 audit-as-crates-io = true
 
 [policy.tokio-postgres]
-audit-as-crates-io = true
-
-[policy.tonic-build]
 audit-as-crates-io = true
 
 [policy.tracing-opentelemetry]
@@ -94,6 +88,10 @@ criteria = "safe-to-deploy"
 [[exemptions.ahash]]
 version = "0.8.11"
 criteria = "safe-to-deploy"
+
+[[exemptions.aligned-vec]]
+version = "0.6.1"
+criteria = "maintained-and-necessary"
 
 [[exemptions.allocator-api2]]
 version = "0.2.16"
@@ -391,6 +389,14 @@ criteria = "safe-to-deploy"
 version = "0.7.7"
 criteria = "safe-to-deploy"
 
+[[exemptions.equator]]
+version = "0.2.2"
+criteria = "maintained-and-necessary"
+
+[[exemptions.equator-macro]]
+version = "0.2.1"
+criteria = "maintained-and-necessary"
+
 [[exemptions.error-chain]]
 version = "0.12.4"
 criteria = "safe-to-deploy"
@@ -619,6 +625,10 @@ criteria = "safe-to-deploy"
 version = "0.5.4"
 criteria = "safe-to-deploy"
 
+[[exemptions.memmap2]]
+version = "0.9.5"
+criteria = "maintained-and-necessary"
+
 [[exemptions.memoffset]]
 version = "0.7.1"
 criteria = "safe-to-deploy"
@@ -646,6 +656,10 @@ criteria = "safe-to-deploy"
 [[exemptions.multimap]]
 version = "0.8.3"
 criteria = "safe-to-deploy"
+
+[[exemptions.mysql_async]]
+version = "0.34.1@git:a0dbdb7c76e6ff7a27dfa2523a398ca686413737"
+criteria = "maintained-and-necessary"
 
 [[exemptions.mz-avro]]
 version = "0.7.0"
@@ -810,6 +824,10 @@ criteria = "safe-to-deploy"
 [[exemptions.pprof]]
 version = "0.11.1"
 criteria = "safe-to-deploy"
+
+[[exemptions.pprof]]
+version = "0.14.0"
+criteria = "maintained-and-necessary"
 
 [[exemptions.ppv-lite86]]
 version = "0.2.10"
@@ -1131,9 +1149,17 @@ criteria = "safe-to-deploy"
 version = "10.2.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.symbolic-common]]
+version = "12.12.3"
+criteria = "maintained-and-necessary"
+
 [[exemptions.symbolic-demangle]]
 version = "10.2.0"
 criteria = "safe-to-deploy"
+
+[[exemptions.symbolic-demangle]]
+version = "12.1.1"
+criteria = "maintained-and-necessary"
 
 [[exemptions.sysctl]]
 version = "0.5.4"

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -18,7 +18,7 @@ jemalloc_pprof = { version = "0.6", optional = true }
 pprof_util = "0.6"
 libc = "0.2.138"
 mz-ore = { path = "../ore", default-features = false }
-pprof = "0.11.1"
+pprof = "0.14.0"
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 tempfile = "3.8.1"
 tikv-jemalloc-ctl = { version = "0.6", features = ["use_std", "stats"], optional = true }


### PR DESCRIPTION
See https://rustsec.org/advisories/RUSTSEC-2024-0408

Noticed via https://buildkite.com/materialize/security/builds/1366#01939756-58d4-4c0a-86f7-a776304c7560

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
