### PR TITLE
Fix helm unittest

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -182,6 +182,7 @@ steps:
           - Cargo.toml
           - "**/Cargo.toml"
           - "**/*.rs"
+          - misc/helm-charts
         depends_on: []
         timeout_in_minutes: 40
         agents:

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -64,10 +64,10 @@ tests:
     storage.storageClass.name: ""
   asserts:
   - matchRegex:
-      path: spec.template.spec.containers[0].args[10]      # Index of the environmentd-cluster-replica-sizes argument
+      path: spec.template.spec.containers[0].args[11]      # Index of the environmentd-cluster-replica-sizes argument
       pattern: disk_limit":"0"
   - matchRegex:
-      path: spec.template.spec.containers[0].args[10]
+      path: spec.template.spec.containers[0].args[11]
       pattern: is_cc":true
 
 - it: should have a cluster with disk limit to 1552MiB when storage class is configured
@@ -75,10 +75,10 @@ tests:
     storage.storageClass.name: "my-storage-class"
   asserts:
   - matchRegex:
-      path: spec.template.spec.containers[0].args[10]
+      path: spec.template.spec.containers[0].args[11]
       pattern: disk_limit":"1552MiB"
   - matchRegex:
-      path: spec.template.spec.containers[0].args[10]
+      path: spec.template.spec.containers[0].args[11]
       pattern: is_cc":true
 
 - it: should configure for AWS provider correctly


### PR DESCRIPTION
Broken in https://github.com/MaterializeInc/materialize/pull/30727

Test didn't run, fixing that by considering the misc/helm-charts as input

Seen in https://buildkite.com/materialize/test/builds/95866#01939798-4a11-4849-b2b6-b815244c5455

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
