### PR TITLE
pg-cdc resumption test: Disable drop_replication_slot_when_mz_is_off scenario

### DIFF
--- a/test/pg-cdc-resumption/mzcompose.py
+++ b/test/pg-cdc-resumption/mzcompose.py
@@ -67,7 +67,8 @@ def workflow_disruptions(c: Composition) -> None:
         restart_mz_after_initial_snapshot,
         restart_mz_while_cdc_changes,
         drop_replication_slot_when_mz_is_on,
-        drop_replication_slot_when_mz_is_off,
+        # TODO: Reenable when database-issues#8669 is fixed
+        # drop_replication_slot_when_mz_is_off,
         # this does not work
         # drop_replication_slot_and_change_data_when_mz_is_off
     ]


### PR DESCRIPTION
Extremely flaky on main now, which might indicate a new bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
