### PR TITLE
source/pg: detect replication slot overcompaction

### DIFF
--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -202,6 +202,16 @@ class PostgresCdc(Scenario):
             PostgresDML: 100,
         }
 
+    def finalization(self) -> list[ActionOrFactory]:
+        # Postgres sources can't be backup up and restored since Postgres
+        # refuses to re-read previously confirmed LSNs
+        return [
+            MzStart,
+            BalancerdStart,
+            StoragedStart,
+            ValidateAll(),
+        ]
+
 
 class MySqlCdc(Scenario):
     """A Zippy test using MySQL CDC exclusively."""
@@ -396,6 +406,16 @@ class PostgresCdcLarge(Scenario):
             ValidateView: 20,
             PostgresDML: 100,
         }
+
+    def finalization(self) -> list[ActionOrFactory]:
+        # Postgres sources can't be backup up and restored since Postgres
+        # refuses to re-read previously confirmed LSNs
+        return [
+            MzStart,
+            BalancerdStart,
+            StoragedStart,
+            ValidateAll(),
+        ]
 
 
 class MySqlCdcLarge(Scenario):

--- a/test/pg-cdc-resumption/mzcompose.py
+++ b/test/pg-cdc-resumption/mzcompose.py
@@ -67,9 +67,6 @@ def workflow_disruptions(c: Composition) -> None:
         restart_mz_after_initial_snapshot,
         restart_mz_while_cdc_changes,
         drop_replication_slot_when_mz_is_on,
-        drop_replication_slot_when_mz_is_off,
-        # this does not work
-        # drop_replication_slot_and_change_data_when_mz_is_off
     ]
 
     scenarios = buildkite.shard_list(scenarios, lambda s: s.__name__)
@@ -322,70 +319,6 @@ def drop_replication_slot_when_mz_is_on(c: Composition) -> None:
         "alter-table.td",
         "alter-mz.td",
     )
-
-
-def drop_replication_slot_when_mz_is_off(c: Composition) -> None:
-    c.run_testdrive_files(
-        "wait-for-snapshot.td",
-        "delete-rows-t1.td",
-    )
-
-    time.sleep(12)
-
-    c.kill("materialized")
-
-    pg_conn = _create_pg_connection(c)
-    slot_names = _get_all_pg_replication_slots(pg_conn)
-    _drop_pg_replication_slots(pg_conn, slot_names)
-
-    assert (
-        len(_get_all_pg_replication_slots(pg_conn)) == 0
-    ), "Not all slots were dropped"
-
-    c.up("materialized")
-
-    c.run_testdrive_files(
-        "delete-rows-t2.td",
-        "alter-table.td",
-        "alter-mz.td",
-    )
-
-    slot_names = _get_all_pg_replication_slots(pg_conn)
-    assert len(slot_names) > 0, "No replication slot was recreated"
-
-
-def drop_replication_slot_and_change_data_when_mz_is_off(c: Composition) -> None:
-    c.run_testdrive_files(
-        "wait-for-snapshot.td",
-        "delete-rows-t1.td",
-    )
-
-    time.sleep(12)
-
-    c.kill("materialized")
-
-    pg_conn = _create_pg_connection(c)
-    slot_names = _get_all_pg_replication_slots(pg_conn)
-    _drop_pg_replication_slots(pg_conn, slot_names)
-
-    assert (
-        len(_get_all_pg_replication_slots(pg_conn)) == 0
-    ), "Not all slots were dropped"
-
-    # run delete-rows-t2.td in pg
-    pg_conn = _create_pg_connection(c)
-    cursor = pg_conn.cursor()
-    cursor.execute("DELETE FROM t2 WHERE f1 % 2 = 1;")
-
-    c.up("materialized")
-
-    c.run_testdrive_files(
-        "alter-table.td",
-        "alter-mz.td",
-    )
-
-    slot_names = _get_all_pg_replication_slots(pg_conn)
-    assert len(slot_names) > 0, "No replication slot was recreated"
 
 
 def _create_pg_connection(c: Composition) -> Connection:

--- a/test/pg-cdc/dropped-slot-errors.td
+++ b/test/pg-cdc/dropped-slot-errors.td
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE t1 (pk SERIAL PRIMARY KEY, f2 text);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE CLUSTER storage REPLICAS (r1 (SIZE '1'))
+
+> CREATE SECRET pgpass AS 'postgres'
+
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+> CREATE SOURCE mz_source
+  IN CLUSTER storage
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source');
+
+> CREATE TABLE t1 FROM SOURCE mz_source (REFERENCE t1);
+
+# Wait for the initial snapshot to be ingested
+> SELECT * FROM t1
+
+# Stop ingestion by dropping the replica
+> DROP CLUSTER REPLICA storage.r1;
+
+# Now drop the replication slot
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots
+
+# Resume the ingestion by adding a replica to the cluster.
+> CREATE CLUSTER REPLICA storage.r1 SIZE = '1';
+
+> SELECT error ~~ 'postgres: slot overcompacted. Requested LSN % but only LSNs % are available%' FROM mz_internal.mz_source_statuses WHERE name = 't1';
+true


### PR DESCRIPTION
The source would previously select a resumption point based on the resumption points of its outputs (which is correct) advanced by the resumption point available upstream (which is incorrect).

The reason is that if the upstream slot gets dropped and recreated or somehow compacts further that it should we lose the ability to read updates at the LSN offsets we need. When that happens it is crucial to detect that and put the source in an errored state, otherwise we risk presenting incorrect to the user.

This PR tightens our reasoning for choosing the expected resumption point such that the advancement that would previously be done unconditionally is only performed for outputs that have not been ingested yet.

Fixes MaterializeInc/database-issues#8669

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
