### PR TITLE
adapter: remove the `enable_comment` flag

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -93,7 +93,6 @@ def get_default_system_parameters(
         "enable_alter_swap": "true",
         "enable_assert_not_null": "true",
         "enable_columnation_lgalloc": "true",
-        "enable_comment": "true",
         "enable_compute_chunked_stack": "true",
         "enable_connection_validation_syntax": "true",
         "enable_continual_task_builtins": "true",

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -7105,8 +7105,6 @@ pub fn plan_comment(
 ) -> Result<Plan, PlanError> {
     const MAX_COMMENT_LENGTH: usize = 1024;
 
-    scx.require_feature_flag(&vars::ENABLE_COMMENT)?;
-
     let CommentStatement { object, comment } = stmt;
 
     // TODO(parkmycar): Make max comment length configurable.

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2012,7 +2012,7 @@ feature_flags!(
         desc: "emitting notices for indexes with an empty key (doesn't affect EXPLAIN)",
         default: true,
         enable_for_item_parsing: true,
-    }
+    },
     {
         name: enable_alter_swap,
         desc: "the ALTER SWAP feature for objects",

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2012,13 +2012,7 @@ feature_flags!(
         desc: "emitting notices for indexes with an empty key (doesn't affect EXPLAIN)",
         default: true,
         enable_for_item_parsing: true,
-    },
-    {
-        name: enable_comment,
-        desc: "the COMMENT ON feature for objects",
-        default: true,
-        enable_for_item_parsing: true,
-    },
+    }
     {
         name: enable_alter_swap,
         desc: "the ALTER SWAP feature for objects",

--- a/test/legacy-upgrade/create-in-v0.68.0-comment.td
+++ b/test/legacy-upgrade/create-in-v0.68.0-comment.td
@@ -9,7 +9,7 @@
 
 $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 
-$ postgres-execute connection=mz_system
+$[version<=12600] postgres-execute connection=mz_system
 ALTER SYSTEM SET enable_comment = true;
 
 > CREATE TABLE comment_table ( x int8, y text );

--- a/test/sqllogictest/comment.slt
+++ b/test/sqllogictest/comment.slt
@@ -12,12 +12,6 @@ mode cockroach
 # Start from a pristine server
 reset-server
 
-# Enable comments.
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_comment TO true;
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE a ( x int8, y text, z jsonb );
 

--- a/test/sqllogictest/ct_various.slt
+++ b/test/sqllogictest/ct_various.slt
@@ -17,12 +17,6 @@ CREATE CONTINUAL TASK ct (key INT) ON INPUT input AS (
     INSERT INTO ct SELECT * FROM input;
 )
 
-# Comments and SHOW
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_comment TO true;
-----
-COMPLETE 0
-
 statement ok
 COMMENT ON CONTINUAL TASK ct IS 'foo'
 

--- a/test/testdrive-old-kafka-src-syntax/github-7822.td
+++ b/test/testdrive-old-kafka-src-syntax/github-7822.td
@@ -25,9 +25,6 @@ $ kafka-create-topic topic=v1 partitions=100
 $ set-arg-default default-storage-size=1
 $ set-arg-default single-replica-cluster=quickstart
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_comment = true;
-
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 

--- a/test/testdrive/github-7822.td
+++ b/test/testdrive/github-7822.td
@@ -25,9 +25,6 @@ $ kafka-create-topic topic=v1 partitions=100
 $ set-arg-default default-storage-size=1
 $ set-arg-default single-replica-cluster=quickstart
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_comment = true;
-
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 

--- a/test/testdrive/kafka-avro-sinks-doc-comments.td
+++ b/test/testdrive/kafka-avro-sinks-doc-comments.td
@@ -12,9 +12,6 @@ $ set-arg-default single-replica-cluster=quickstart
 
 # Test Avro UPSERT sinks doc comments
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_comment = true;
-
 > CREATE TYPE point AS (x integer, y integer);
 > CREATE TYPE custom_map AS MAP (KEY TYPE = text, VALUE TYPE = bool)
 > CREATE TABLE t (c1 point, c2 text NOT NULL, "c3_map[text=>text]" custom_map, c4 point list);


### PR DESCRIPTION
Removes the `enable_comment` flag since `COMMENT ON` has been released to GA

### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/8808

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
