### PR TITLE
bazel: enable remote caching for developers

### DIFF
--- a/ci/deploy/pipeline.template.yml
+++ b/ci/deploy/pipeline.template.yml
@@ -12,7 +12,7 @@ priority: 30
 
 env:
   CI_BAZEL_BUILD: 1
-  CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
+  CI_BAZEL_REMOTE_CACHE: $BAZEL_REMOTE_CACHE
 
 steps:
   - command: bin/ci-builder run nightly ci/deploy/devsite.sh

--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -110,6 +110,14 @@ so it is executed.""",
     with open(Path(__file__).parent / args.pipeline / "pipeline.template.yml") as f:
         raw = f.read()
     raw = raw.replace("$RUST_VERSION", rust_version())
+
+    # On 'main' or tagged branches, we use a separate remote cache that only CI can write to.
+    if os.environ["BUILDKITE_BRANCH"] == "main" or os.environ["BUILDKITE_TAG"]:
+        bazel_remote_cache = "https://bazel-remote-pa.dev.materialize.com"
+    else:
+        bazel_remote_cache = "https://bazel-remote.dev.materialize.com"
+    raw = raw.replace("$BAZEL_REMOTE_CACHE", bazel_remote_cache)
+
     pipeline = yaml.safe_load(raw)
 
     if args.pipeline == "test":

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -12,7 +12,7 @@ priority: 0
 
 env:
   CI_BAZEL_BUILD: 1
-  CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
+  CI_BAZEL_REMOTE_CACHE: $BAZEL_REMOTE_CACHE
 
 steps:
   - group: Builds

--- a/ci/qa-canary/pipeline.template.yml
+++ b/ci/qa-canary/pipeline.template.yml
@@ -11,7 +11,7 @@ priority: 40
 
 env:
   CI_BAZEL_BUILD: 1
-  CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
+  CI_BAZEL_REMOTE_CACHE: $BAZEL_REMOTE_CACHE
 
 steps:
   - id: build-aarch64

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -12,7 +12,7 @@ priority: 40
 
 env:
   CI_BAZEL_BUILD: 1
-  CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
+  CI_BAZEL_REMOTE_CACHE: $BAZEL_REMOTE_CACHE
 
 steps:
   - group: Builds

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -17,7 +17,7 @@ dag: true
 env:
   CI_BUILDER_SCCACHE: 1
   CI_BAZEL_BUILD: 1
-  CI_BAZEL_REMOTE_CACHE: "https://bazel-remote.dev.materialize.com"
+  CI_BAZEL_REMOTE_CACHE: $BAZEL_REMOTE_CACHE
   # Note: In .cargo/config we set the default build jobs to -1 so on developer machines we keep
   # a single core open when compiling. But we want to use all of CI's resources, hence setting the
   # build jobs to "default" which will use all cores.

--- a/misc/python/materialize/build_config.py
+++ b/misc/python/materialize/build_config.py
@@ -15,7 +15,7 @@ from typing import Any
 import toml
 
 
-class Config:
+class BuildConfig:
     """Configuration for builds of Materialize.
 
     Most things should be configured via a tool's native configuration file,
@@ -39,7 +39,7 @@ class Config:
         home = Path.home()
         path = home / ".config" / "materialize" / "build.toml"
 
-        return Config(path)
+        return BuildConfig(path)
 
     def __str__(self):
         return f"{self.bazel}"
@@ -53,7 +53,7 @@ class BazelConfig:
     for flags that Bazel does not have an easy way to configure itself.
 
     [bazel]
-    remote_cache = "localhost:8080"
+    remote_cache = "localhost:6889"
     """
 
     def __init__(self, data: dict[str, Any]):

--- a/misc/python/materialize/config.py
+++ b/misc/python/materialize/config.py
@@ -1,0 +1,147 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import os
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+import toml
+
+
+class Config:
+    """Configuration for builds of Materialize.
+
+    Most things should be configured via a tool's native configuration file,
+    e.g. `.bazelrc` or `.cargo/config.toml`. This exists for Materialize's home
+    grown tools, or to extend tools that don't support an option we need.
+
+    Looks for configuration files in `~/.config/materialize/build.toml`
+    """
+
+    def __init__(self, path: Path):
+        if path.is_file():
+            with open(path) as f:
+                raw_data = toml.load(f)
+        else:
+            raw_data = {}
+
+        self.bazel = BazelConfig(raw_data.get("bazel", {}))
+
+    @staticmethod
+    def read():
+        home = Path.home()
+        path = home / ".config" / "materialize" / "build.toml"
+
+        return Config(path)
+
+    def __str__(self):
+        return f"{self.bazel}"
+
+
+class BazelConfig:
+    """Configuration for Bazel builds.
+
+    Most configuration should go into either the repositories `.bazelrc` file
+    or documented to be included in a users' home `.bazelrc` file. This exists
+    for flags that Bazel does not have an easy way to configure itself.
+
+    [bazel]
+    remote_cache = "localhost:8080"
+    """
+
+    def __init__(self, data: dict[str, Any]):
+        self.remote_cache = data.get("remote_cache", None)
+        self.remote_cache_check_interval_minutes = data.get(
+            "remote_cache_check_interval_minutes", "5"
+        )
+
+    def __str__(self):
+        return dedent(
+            f"""
+        Bazel:
+            remote_cache = {self.remote_cache}
+        """
+        )
+
+
+class LocalState:
+    """Local state persisted by a tool.
+
+    Users should not expect this state to be durable, it can be blown away at
+    at point.
+
+    Stored at: ~/.cache/materialize/build_state.toml
+    """
+
+    def __init__(self, path: Path):
+        self.path = path
+        if path.is_file():
+            with open(path) as f:
+                self.data = toml.load(f)
+        else:
+            self.data = {}
+
+    @staticmethod
+    def default_path() -> Path:
+        home = Path.home()
+        path = home / ".cache" / "materialize" / "build_state.toml"
+        return path
+
+    @classmethod
+    def read(cls, namespace: str) -> Any | None:
+        cache = LocalState(LocalState.default_path())
+        return cache.data.get(namespace, None)
+
+    @classmethod
+    def write(cls, namespace: str, val: Any):
+        cache = LocalState(LocalState.default_path())
+        cache.data[namespace] = val
+
+        Path(os.path.dirname(cache.path)).mkdir(parents=True, exist_ok=True)
+        with open(cache.path, "w+") as f:
+            toml.dump(cache.data, f)
+
+
+class TeleportLocalState:
+    def __init__(self, data: dict[str, Any] | None):
+        self.data = data or {}
+
+    @classmethod
+    def read(cls):
+        return TeleportLocalState(LocalState.read("teleport"))
+
+    def write(self):
+        LocalState.write("teleport", self.data)
+
+    def get_pid(self, app_name: str) -> str | None:
+        existing = self.data.get(app_name, {})
+        return existing.get("pid")
+
+    def set_pid(self, app_name: str, pid: str | None):
+        existing = self.data.get(app_name, {})
+        existing["pid"] = pid
+        self.data[app_name] = existing
+
+    def get_address(self, app_name: str) -> str | None:
+        existing = self.data.get(app_name, {})
+        return existing.get("address")
+
+    def set_address(self, app_name: str, addr: str | None):
+        existing = self.data.get(app_name, {})
+        existing["address"] = addr
+        self.data[app_name] = existing
+
+    def __str__(self):
+        return dedent(
+            f"""
+        TeleportLocalState:
+            data: {self.data}
+        """
+        )

--- a/misc/python/materialize/teleport.py
+++ b/misc/python/materialize/teleport.py
@@ -1,0 +1,95 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import os
+import subprocess
+import threading
+import time
+from textwrap import dedent
+
+import psutil
+
+from materialize import config, ui
+
+
+class TeleportProxy:
+    @classmethod
+    def spawn(cls, app_name: str, port: str):
+        """Spawn a Teleport proxy for the provided app_name."""
+
+        teleport_state = config.TeleportLocalState.read()
+
+        # If there is already a Teleport proxy running, no need to restart one.
+        running_pid = TeleportProxy.check(app_name)
+        if running_pid:
+            ui.say(f"Teleport proxy already running, PID: {running_pid}")
+            return
+        else:
+            # If the existing PID doesn't exist, clear it from state.
+            teleport_state.set_pid(app_name, None)
+            teleport_state.set_address(app_name, None)
+            teleport_state.write()
+
+        # Otherwise spawn a Teleport proxy.
+        cmd_args = ["tsh", "proxy", "app", f"{app_name}", "--port", port]
+        child = subprocess.Popen(
+            cmd_args,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            preexec_fn=os.setpgrp,
+        )
+        ui.say(f"starting Teleport proxy for '{app_name}'...")
+
+        def wait(child, teleport_state, address):
+            wait_start = time.time()
+
+            while time.time() - wait_start < 2:
+                child_terminated = child.poll()
+                if child_terminated:
+                    other_tshs = [
+                        p.pid
+                        for p in psutil.process_iter(["pid", "name"])
+                        if p.name() == "tsh"
+                    ]
+                    ui.warn(
+                        dedent(
+                            f"""
+                    Teleport proxy failed to start, 'tsh' process already running!
+                        existing 'tsh' processes: {other_tshs}
+                        exit code: {child_terminated}
+                    """
+                        )
+                    )
+                    break
+
+            # Timed out! Check if the process is running.
+            child_pid_status = psutil.pid_exists(child.pid)
+            if child_pid_status:
+                # Record the PID, if the process started successfully.
+                teleport_state.set_pid(app_name, child.pid)
+                teleport_state.set_address(app_name, address)
+                teleport_state.write()
+
+        # Spawn a thread that will wait for the Teleport proxy to start, and
+        # record it's PID, or warn that it failed to start.
+        address = f"http://localhost:{port}"
+        thread = threading.Thread(target=wait, args=[child, teleport_state, address])
+        thread.start()
+
+    @classmethod
+    def check(cls, app_name: str) -> str | None:
+        """Check if a Teleport proxy is already running for the specified app_name."""
+
+        teleport_state = config.TeleportLocalState.read()
+        existing_pid = teleport_state.get_pid(app_name)
+
+        if existing_pid and psutil.pid_exists(int(existing_pid)):
+            return teleport_state.get_pid(app_name)
+        else:
+            return None

--- a/misc/python/materialize/teleport.py
+++ b/misc/python/materialize/teleport.py
@@ -15,7 +15,7 @@ from textwrap import dedent
 
 import psutil
 
-from materialize import config, ui
+from materialize import build_config, ui
 
 
 class TeleportProxy:
@@ -23,7 +23,7 @@ class TeleportProxy:
     def spawn(cls, app_name: str, port: str):
         """Spawn a Teleport proxy for the provided app_name."""
 
-        teleport_state = config.TeleportLocalState.read()
+        teleport_state = build_config.TeleportLocalState.read()
 
         # If there is already a Teleport proxy running, no need to restart one.
         running_pid = TeleportProxy.check(app_name)
@@ -86,7 +86,7 @@ class TeleportProxy:
     def check(cls, app_name: str) -> str | None:
         """Check if a Teleport proxy is already running for the specified app_name."""
 
-        teleport_state = config.TeleportLocalState.read()
+        teleport_state = build_config.TeleportLocalState.read()
         existing_pid = teleport_state.get_pid(app_name)
 
         if existing_pid and psutil.pid_exists(int(existing_pid)):


### PR DESCRIPTION
This PR makes it easy for developers to start using the Bazel remote cache when running Bazel locally. Namely it does a few things:

1. Adds a `TeleportProxy` class in Python to spawn a proxy using `tsh`, this allows developers to connect to the remote cache running in our infra.
2. Adds the concept of a Materialize Build Config which allows developers to specify the Teleport app to use for the bazel remote cache.
3. Wires these two things in `bin/bazel` to automatically spawn a teleport proxy.
4. Changes CI to use our "prod" Bazel remote cache for builds on `main` or tagged builds.
5. Updates the Bazel docs to specify how users can set this up.

Unfortunately I've identified a few areas where the build config doesn't allow for perfect cache re-use, but this is a step in the right direction.

### Motivation

Better Bazel builds

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
