### PR TITLE
adapter: Update dyncfgs with system parameters

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -169,8 +169,14 @@ impl CatalogState {
             "all timestamps should be equal: {updates:?}"
         );
 
+        let mut update_system_config = false;
+
         let mut builtin_table_updates = Vec::with_capacity(updates.len());
         for StateUpdate { kind, ts: _, diff } in updates {
+            if matches!(kind, StateUpdateKind::SystemConfiguration(_)) {
+                update_system_config = true;
+            }
+
             match diff {
                 StateDiff::Retraction => {
                     // We want the builtin table retraction to match the state of the catalog
@@ -188,6 +194,11 @@ impl CatalogState {
                 }
             }
         }
+
+        if update_system_config {
+            self.system_configuration.dyncfg_updates();
+        }
+
         Ok(builtin_table_updates)
     }
 

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -435,7 +435,6 @@ impl Catalog {
             .apply_updates_for_bootstrap(pre_item_updates, &mut LocalExpressionCache::Closed)
             .await;
         builtin_table_updates.extend(builtin_table_update);
-        state.system_config_mut().dyncfg_updates();
 
         let expr_cache_start = Instant::now();
         info!("startup: coordinator init: catalog open: expr cache open beginning");

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -435,6 +435,7 @@ impl Catalog {
             .apply_updates_for_bootstrap(pre_item_updates, &mut LocalExpressionCache::Closed)
             .await;
         builtin_table_updates.extend(builtin_table_update);
+        state.system_config_mut().dyncfg_updates();
 
         let expr_cache_start = Instant::now();
         info!("startup: coordinator init: catalog open: expr cache open beginning");


### PR DESCRIPTION
Previously, the adapter would update it's dyncfg values only in the
following scenarios:

  - When retrieving the current compute configuration.
  - When retrieving the current storage configuration.
  - When receiving periodic configuration updates from launch darkly.

Importantly dyncfgs are un-intuitively not updated as a direct result
of a system configuration parameter changing. One specific consequence
of this is that when starting up, all dyncfgs contain their default
values until the first launch darkly sync or when first retrieving
storage/compute configurations, whichever happens first.

This commit explicitly updates the adapter dyncfg values after any
system configuration parameter is changed. This makes it much more
obvious that the system configuration parameters and dyncfg values are
in-sync. Additionally, the dyncfgs will now contain accurate values as
soon as we load in the system configuration parameters.

Fixes #MaterializeInc/database-issues/issues/8816

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
