### PR TITLE
build: tweak the `--dev`, `--optimized`, and `--release` flags

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -1235,8 +1235,7 @@ class Repository:
         build_mode = parser.add_mutually_exclusive_group()
         build_mode.add_argument(
             "--dev",
-            dest="release",
-            action="store_false",
+            action="store_true",
             help="build Rust binaries with the dev profile",
         )
         build_mode.add_argument(
@@ -1297,13 +1296,18 @@ class Repository:
         The provided namespace must contain the options installed by
         `Repository.install_arguments`.
         """
+        if args.release:
+            profile = Profile.RELEASE
+        elif args.optimized:
+            profile = Profile.OPTIMIZED
+        elif args.dev:
+            profile = Profile.DEV
+        else:
+            profile = Profile.RELEASE
+
         return cls(
             root,
-            profile=(
-                Profile.RELEASE
-                if args.release
-                else Profile.OPTIMIZED if args.optimized else Profile.DEV
-            ),
+            profile=profile,
             coverage=args.coverage,
             sanitizer=args.sanitizer,
             image_registry=args.image_registry,


### PR DESCRIPTION
Previously if you tried to specify `--optimized` when using `mzcompose` you would still get the release profile. 

This is because the `--dev` flag is set as `store_false` which creates a default value of `True`, and it's destination was named `release`. So if you only specified `--optimized` both `args.release` and `args.optimize` would be `True` and then we default to `Profile.RELEASE`.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
