### PR TITLE
Nightly test fixes (December 6)

### DIFF
--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -114,16 +114,16 @@ spec:
         {{/* Network Policies */}}
         {{- if .Values.networkPolicies.enabled }}
         {{- if .Values.networkPolicies.internal.enabled }}
-        - "--network-policies-internal-enabled=true"
+        - "--network-policies-internal-enabled"
         {{- end }}
         {{- if .Values.networkPolicies.ingress.enabled }}
-        - "--network-policies-ingress-enabled=true"
+        - "--network-policies-ingress-enabled"
         {{- range $cidr := .Values.networkPolicies.ingress.cidrs }}
         - "--network-policies-ingress-cidrs={{$cidr}}"
         {{- end }}
         {{- end }}
         {{- if .Values.networkPolicies.egress.enabled }}
-        - "--network-policies-egress-enabled=true"
+        - "--network-policies-egress-enabled"
         {{- range $cidr := .Values.networkPolicies.egress.cidrs }}
         - "--network-policies-egress-cidrs={{$cidr}}"
         {{- end }}

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -145,6 +145,9 @@ class Executor:
                         if query == "commit;":
                             self.log("commit")
                             self.cur.connection.commit()
+                        elif query == "rollback;":
+                            self.log("rollback")
+                            self.cur.connection.rollback()
                         else:
                             self.cur.execute(query.encode())
                     except Exception as e:

--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -346,6 +346,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         else:
             raise ValueError("Never completed")
 
+        time.sleep(10)
+
         environmentd_port_forward_process = subprocess.Popen(
             [
                 "kubectl",


### PR DESCRIPTION
1st commit:

> parallel-workload: Fix rollback error
> 
> [worker_2] Query failed: rollback; too many values to unpack (expected 1)
> 
> Seen in https://buildkite.com/materialize/nightly/builds/10631#01939961-e109-456f-b890-eaa7f7f0a11e

2nd commit:

> Fix helm chart deployment template
> 
> Following https://github.com/MaterializeInc/materialize/pull/30728
> 
> Seen failing in https://buildkite.com/materialize/nightly/builds/10631#01939961-e0e3-4196-888e-426667aa97e2
> 
> > error: The value 'true' was provided to '--network-policies-internal-enabled' but it wasn't expecting any more values

We should probably run the terraform e2e test in a PR when something in misc/helm-charts is touched, I'll try to come up with a good way.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
