### PR TITLE
compute/mv-sink: force consolidation after the snapshot

### DIFF
--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -1075,6 +1075,9 @@ mod append {
                     batch.lower().elements(),
                     batch.upper().elements(),
                 ));
+
+                // Ensure the batch's data gets properly cleaned up before dropping it.
+                batch.delete().await;
                 return;
             }
 

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -198,14 +198,20 @@ where
     let (desired, descs, sink_frontier, mint_token) = mint::render(
         sink_id,
         persist_api.clone(),
-        as_of,
+        as_of.clone(),
         active_worker_id,
         compute_state.read_only_rx.clone(),
         &desired,
     );
 
-    let (batches, write_token) =
-        write::render(sink_id, persist_api.clone(), &desired, &persist, &descs);
+    let (batches, write_token) = write::render(
+        sink_id,
+        persist_api.clone(),
+        as_of,
+        &desired,
+        &persist,
+        &descs,
+    );
 
     let append_token = append::render(sink_id, persist_api, active_worker_id, &descs, &batches);
 
@@ -639,6 +645,7 @@ mod write {
     pub fn render<S>(
         sink_id: GlobalId,
         persist_api: PersistApi,
+        as_of: Antichain<Timestamp>,
         desired: &DesiredStreams<S>,
         persist: &PersistStreams<S>,
         descs: &Stream<S, BatchDescription>,
@@ -676,7 +683,7 @@ mod write {
 
             let writer = persist_api.open_writer().await;
             let sink_metrics = persist_api.open_metrics().await;
-            let mut state = State::new(sink_id, worker_id, writer, sink_metrics);
+            let mut state = State::new(sink_id, worker_id, writer, sink_metrics, as_of);
 
             loop {
                 // Read from the inputs, extract `desired` updates as positive contributions to
@@ -775,6 +782,14 @@ mod write {
         /// its `lower` is >= the `persist_frontier`. Otherwise the described batch couldn't be
         /// appended anymore, rendering the batch description invalid.
         batch_description: Option<(BatchDescription, Capability<Timestamp>)>,
+        /// A request to force a consolidation of `corrections` once both `desired_frontiers` and
+        /// `persist_frontiers` become greater than the given frontier.
+        ///
+        /// Normally we force a consolidation whenever we write a batch, but there are periods
+        /// (like read-only mode) when that doesn't happen, and we need to manually force
+        /// consolidation instead. Currently this is only used to ensure we quickly get rid of the
+        /// snapshot updates.
+        force_consolidation_after: Option<Antichain<Timestamp>>,
     }
 
     impl State {
@@ -783,8 +798,13 @@ mod write {
             worker_id: usize,
             persist_writer: WriteHandle<SourceData, (), Timestamp, Diff>,
             metrics: SinkMetrics,
+            as_of: Antichain<Timestamp>,
         ) -> Self {
             let worker_metrics = metrics.for_worker(worker_id);
+
+            // Force a consolidation of `corrections` after the snapshot updates have been fully
+            // processed, to ensure we get rid of those as quickly as possible.
+            let force_consolidation_after = Some(as_of);
 
             Self {
                 sink_id,
@@ -797,6 +817,7 @@ mod write {
                 desired_frontiers: OkErr::new_frontiers(),
                 persist_frontiers: OkErr::new_frontiers(),
                 batch_description: None,
+                force_consolidation_after,
             }
         }
 
@@ -814,12 +835,14 @@ mod write {
 
         fn advance_desired_ok_frontier(&mut self, frontier: Antichain<Timestamp>) {
             if advance(&mut self.desired_frontiers.ok, frontier) {
+                self.apply_desired_frontier_advancement();
                 self.trace("advanced `desired` ok frontier");
             }
         }
 
         fn advance_desired_err_frontier(&mut self, frontier: Antichain<Timestamp>) {
             if advance(&mut self.desired_frontiers.err, frontier) {
+                self.apply_desired_frontier_advancement();
                 self.trace("advanced `desired` err frontier");
             }
         }
@@ -838,6 +861,11 @@ mod write {
             }
         }
 
+        /// Apply the effects of a previous `desired` frontier advancement.
+        fn apply_desired_frontier_advancement(&mut self) {
+            self.maybe_force_consolidation();
+        }
+
         /// Apply the effects of a previous `persist` frontier advancement.
         fn apply_persist_frontier_advancement(&mut self) {
             let frontier = self.persist_frontiers.frontier();
@@ -854,6 +882,28 @@ mod write {
                 if PartialOrder::less_than(&desc.lower, frontier) {
                     self.batch_description = None;
                 }
+            }
+
+            self.maybe_force_consolidation();
+        }
+
+        /// If the current consolidation request has become applicable, apply it.
+        fn maybe_force_consolidation(&mut self) {
+            let Some(request) = &self.force_consolidation_after else {
+                return;
+            };
+
+            let desired_frontier = self.desired_frontiers.frontier();
+            let persist_frontier = self.persist_frontiers.frontier();
+            if PartialOrder::less_than(request, desired_frontier)
+                && PartialOrder::less_than(request, persist_frontier)
+            {
+                self.trace("forcing correction consolidation");
+                self.corrections.ok.consolidate_at_since();
+                self.corrections.err.consolidate_at_since();
+
+                // Remove the consolidation request, now that we have fulfilled it.
+                self.force_consolidation_after = None;
             }
         }
 

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -387,6 +387,15 @@ fn operator_name(sink_id: GlobalId, sub_operator: &str) -> String {
 mod mint {
     use super::*;
 
+    /// Render the `mint` operator.
+    ///
+    /// The parameters passed in are:
+    ///  * `sink_id`: The `GlobalId` of the sink export.
+    ///  * `persist_api`: An object providing access to the output persist shard.
+    ///  * `as_of`: The first time for which the sink may produce output.
+    ///  * `active_worker_id`: The ID of the worker that runs this (single-threaded) operator.
+    ///  * `read_only_tx`: A receiver that reports the sink is in read-only mode.
+    ///  * `desired`: The ok/err streams that should be sinked to persist.
     pub fn render<S>(
         sink_id: GlobalId,
         persist_api: PersistApi,
@@ -642,6 +651,15 @@ mod mint {
 mod write {
     use super::*;
 
+    /// Render the `write` operator.
+    ///
+    /// The parameters passed in are:
+    ///  * `sink_id`: The `GlobalId` of the sink export.
+    ///  * `persist_api`: An object providing access to the output persist shard.
+    ///  * `as_of`: The first time for which the sink may produce output.
+    ///  * `desired`: The ok/err streams that should be sinked to persist.
+    ///  * `persist`: The ok/err streams read back from the output persist shard.
+    ///  * `descs`: The stream of batch descriptions produced by the `mint` operator.
     pub fn render<S>(
         sink_id: GlobalId,
         persist_api: PersistApi,
@@ -972,6 +990,13 @@ mod write {
 mod append {
     use super::*;
 
+    /// Render the `append` operator.
+    ///
+    /// The parameters passed in are:
+    ///  * `sink_id`: The `GlobalId` of the sink export.
+    ///  * `persist_api`: An object providing access to the output persist shard.
+    ///  * `descs`: The stream of batch descriptions produced by the `mint` operator.
+    ///  * `batches`: The stream of written batches produced by the `write` operator.
     pub fn render<S>(
         sink_id: GlobalId,
         persist_api: PersistApi,


### PR DESCRIPTION
This PR makes the MV sink always perform a consolidation of (the relevant parts of) the correction buffer after it has received all updates for the snapshot, both from `desired` and `persist`. We know that these updates will cancel out, so we have an opportunity to shed a large amount of memory by forcing a consolidation at this time. This is especially important in read-only mode when the MV sink does not produce any batches, which is the process that normally forces consolidation to happen.

[Slack thread for context.](https://materializeinc.slack.com/archives/C077SARJZ45/p1733491638706019)

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8814

### Tips for reviewer

There might be more general approaches that force consolidation not only after the snapshot but also after other large data spikes during steady state. I didn't explore these here because (a) they are more complicated, (b) they involve some risk that we'll end up doing too much consolidation and regress performance that way. Special casing the snapshot is sufficient to avoid the motivating hydration issue, and we can iterate later if we find out that there are scenarios it doesn't cover.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
