### PR TITLE
tests: Limit release qualification scenarios

### DIFF
--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -341,7 +341,7 @@ class InsertMultiRow(DML):
 class Update(DML):
     """Measure the time it takes for an UPDATE statement to return to client"""
 
-    SCALE = 7
+    SCALE = 6
 
     def init(self) -> list[Action]:
         return [
@@ -915,6 +915,7 @@ class DeltaJoinMaintained(Dataflow):
     initialized as a constant view"""
 
     SCALE = 7
+    FIXED_SCALE = True
 
     def version(self) -> ScenarioVersion:
         return ScenarioVersion.create(1, 1, 0)
@@ -1153,7 +1154,8 @@ $ kafka-ingest format=avro topic=kafka-upsert key-format=avro key-schema=${{keys
 
 
 class KafkaUpsertUnique(Kafka):
-    SCALE = 7
+    SCALE = 6
+    FIXED_SCALE = True
 
     def version(self) -> ScenarioVersion:
         return ScenarioVersion.create(1, 1, 0)

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1414,7 +1414,7 @@ class RowsJoinOneToOne(Generator):
 class RowsJoinOneToMany(Generator):
     COUNT = 10_000_000
 
-    MAX_COUNT = 160_000_000  # Too long-running with 320_000_000
+    MAX_COUNT = 80_000_000  # Too long-running with 160_000_000
 
     @classmethod
     def body(cls) -> None:
@@ -1428,7 +1428,7 @@ class RowsJoinOneToMany(Generator):
 class RowsJoinCross(Generator):
     COUNT = 1_000_000
 
-    MAX_COUNT = 256_000_000  # Too long-running with 512_000_000
+    MAX_COUNT = 64_000_000  # Too long-running with 128_000_000
 
     @classmethod
     def body(cls) -> None:


### PR DESCRIPTION
Based on failures in https://buildkite.com/materialize/release-qualification/builds/699#_

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
