### PR TITLE
feature-benchmark: Add MaterializedViewSink

### DIFF
--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -1501,6 +1501,93 @@ $ kafka-verify-topic sink=materialize.public.sink1 await-value-schema=true await
         )
 
 
+class MaterializedViewSink(Sink):
+    """Measure the time it takes to emit 1M records to a reuse_topic=true sink. As we have limited
+    means to figure out when the complete output has been emited, we have no option but to re-ingest
+    the data to determine completion.
+    """
+
+    def shared(self) -> Action:
+        return TdAction(
+            self.keyschema()
+            + self.schema()
+            + f"""
+$ kafka-create-topic topic=sink-input partitions=16
+
+$ kafka-ingest format=avro topic=sink-input key-format=avro key-schema=${{keyschema}} schema=${{schema}} repeat={self.n()}
+{{"f1": ${{kafka-ingest.iteration}} }} {{"f2": ${{kafka-ingest.iteration}} }}
+"""
+        )
+
+    def init(self) -> Action:
+        return TdAction(
+            f"""
+>[version<7800]  CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
+>[version>=7800] CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${{testdrive.kafka-addr}}', SECURITY PROTOCOL PLAINTEXT);
+
+> DROP CLUSTER IF EXISTS source_cluster CASCADE
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn
+  FOR CONFLUENT SCHEMA REGISTRY
+  URL '${{testdrive.schema-registry-url}}';
+
+> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+
+> CREATE SOURCE source1
+  IN CLUSTER source_cluster
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-input-${{testdrive.seed}}');
+
+> CREATE TABLE source1_tbl FROM SOURCE source1 (REFERENCE "testdrive-sink-input-${{testdrive.seed}}")
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE UPSERT;
+
+> CREATE MATERIALIZED VIEW mv AS SELECT * FROM source1_tbl;
+
+> SELECT COUNT(*) FROM mv;
+{self.n()}
+"""
+        )
+
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            f"""
+> DROP SINK IF EXISTS sink1;
+> DROP SOURCE IF EXISTS sink1_check CASCADE;
+  /* A */
+
+> DROP CLUSTER IF EXISTS sink_cluster CASCADE
+> CREATE CLUSTER sink_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+
+> CREATE SINK sink1
+  IN CLUSTER sink_cluster
+  FROM mv
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-output-${{testdrive.seed}}')
+  KEY (f1)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+$ kafka-verify-topic sink=materialize.public.sink1 await-value-schema=true await-key-schema=true
+
+# Wait until all the records have been emited from the sink, as observed by the sink1_check source
+
+> CREATE SOURCE sink1_check
+  IN CLUSTER source_cluster
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-output-${{testdrive.seed}}');
+
+> CREATE TABLE sink1_check_tbl FROM SOURCE sink1_check (REFERENCE "testdrive-sink-output-${{testdrive.seed}}")
+  KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE UPSERT;
+
+> CREATE MATERIALIZED VIEW sink1_check_v AS SELECT COUNT(*) FROM sink1_check_tbl;
+
+> SELECT * FROM sink1_check_v
+  /* B */
+"""
+            + str(self.n())
+        )
+
+
 class ManyKafkaSourcesOnSameCluster(Scenario):
     """Measure the time it takes to ingest data from many Kafka sources"""
 

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -198,14 +198,20 @@ where
     let (desired, descs, sink_frontier, mint_token) = mint::render(
         sink_id,
         persist_api.clone(),
-        as_of,
+        as_of.clone(),
         active_worker_id,
         compute_state.read_only_rx.clone(),
         &desired,
     );
 
-    let (batches, write_token) =
-        write::render(sink_id, persist_api.clone(), &desired, &persist, &descs);
+    let (batches, write_token) = write::render(
+        sink_id,
+        persist_api.clone(),
+        as_of,
+        &desired,
+        &persist,
+        &descs,
+    );
 
     let append_token = append::render(sink_id, persist_api, active_worker_id, &descs, &batches);
 
@@ -639,6 +645,7 @@ mod write {
     pub fn render<S>(
         sink_id: GlobalId,
         persist_api: PersistApi,
+        as_of: Antichain<Timestamp>,
         desired: &DesiredStreams<S>,
         persist: &PersistStreams<S>,
         descs: &Stream<S, BatchDescription>,
@@ -676,7 +683,7 @@ mod write {
 
             let writer = persist_api.open_writer().await;
             let sink_metrics = persist_api.open_metrics().await;
-            let mut state = State::new(sink_id, worker_id, writer, sink_metrics);
+            let mut state = State::new(sink_id, worker_id, writer, sink_metrics, as_of);
 
             loop {
                 // Read from the inputs, extract `desired` updates as positive contributions to
@@ -775,6 +782,14 @@ mod write {
         /// its `lower` is >= the `persist_frontier`. Otherwise the described batch couldn't be
         /// appended anymore, rendering the batch description invalid.
         batch_description: Option<(BatchDescription, Capability<Timestamp>)>,
+        /// A request to force a consolidation of `corrections` once both frontiers become greater
+        /// than the given frontier.
+        ///
+        /// Normally we force a consolidation whenever we write a batch, but there are periods
+        /// (like read-only) mode when that doesn't happen, and we need to manually force
+        /// consolidation instead. Currently this is only used to ensure we quickly get rid of the
+        /// snapshot updates.
+        force_consolidation_after: Option<Antichain<Timestamp>>,
     }
 
     impl State {
@@ -783,8 +798,13 @@ mod write {
             worker_id: usize,
             persist_writer: WriteHandle<SourceData, (), Timestamp, Diff>,
             metrics: SinkMetrics,
+            as_of: Antichain<Timestamp>,
         ) -> Self {
             let worker_metrics = metrics.for_worker(worker_id);
+
+            // Force a consolidation of `corrections` after the snapshot updates have been fully
+            // processed, to ensure we get rid of those as quickly as possible.
+            let force_consolidation_after = Some(as_of);
 
             Self {
                 sink_id,
@@ -797,6 +817,7 @@ mod write {
                 desired_frontiers: OkErr::new_frontiers(),
                 persist_frontiers: OkErr::new_frontiers(),
                 batch_description: None,
+                force_consolidation_after,
             }
         }
 
@@ -814,12 +835,14 @@ mod write {
 
         fn advance_desired_ok_frontier(&mut self, frontier: Antichain<Timestamp>) {
             if advance(&mut self.desired_frontiers.ok, frontier) {
+                self.apply_desired_frontier_advancement();
                 self.trace("advanced `desired` ok frontier");
             }
         }
 
         fn advance_desired_err_frontier(&mut self, frontier: Antichain<Timestamp>) {
             if advance(&mut self.desired_frontiers.err, frontier) {
+                self.apply_desired_frontier_advancement();
                 self.trace("advanced `desired` err frontier");
             }
         }
@@ -838,6 +861,11 @@ mod write {
             }
         }
 
+        /// Apply the effects of a previous `desired` frontier advancement.
+        fn apply_desired_frontier_advancement(&mut self) {
+            self.maybe_force_consolidation();
+        }
+
         /// Apply the effects of a previous `persist` frontier advancement.
         fn apply_persist_frontier_advancement(&mut self) {
             let frontier = self.persist_frontiers.frontier();
@@ -854,6 +882,25 @@ mod write {
                 if PartialOrder::less_than(&desc.lower, frontier) {
                     self.batch_description = None;
                 }
+            }
+
+            self.maybe_force_consolidation();
+        }
+
+        /// If the current consolidation request has become applicable, apply it.
+        fn maybe_force_consolidation(&mut self) {
+            let Some(request) = &self.force_consolidation_after else {
+                return;
+            };
+
+            let desired_frontier = self.desired_frontiers.frontier();
+            let persist_frontier = self.persist_frontiers.frontier();
+            if PartialOrder::less_than(request, desired_frontier)
+                && PartialOrder::less_than(request, persist_frontier)
+            {
+                self.trace("forcing correction consolidation");
+                self.corrections.ok.consolidate_at_since();
+                self.corrections.err.consolidate_at_since();
             }
         }
 

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -1075,6 +1075,7 @@ mod append {
                     batch.lower().elements(),
                     batch.upper().elements(),
                 ));
+                batch.delete().await;
                 return;
             }
 


### PR DESCRIPTION
```
    NAME                                | TYPE            |      THIS       |      OTHER      |  UNIT  | THRESHOLD  |  Regression?  | 'THIS' is
    --------------------------------------------------------------------------------------------------------------------------------------------------------
    MaterializedViewSink                | wallclock       |          11.270 |          31.620 |   s    |    10%     |      no       | better:  2.8 times faster
    MaterializedViewSink                | memory_mz       |        3699.303 |        3870.010 |   MB   |    20%     |      no       | better:  4.4% less
    MaterializedViewSink                | memory_clusterd |         258.636 |         294.971 |   MB   |    50%     |      no       | better: 12.3% less
```
@teskje Does this look reasonable for you? Only look at the last commit, it's based on https://github.com/MaterializeInc/materialize/pull/30758

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
