### PR TITLE
persist/storage: communicate projection pushdown via `shard_source`

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -84,6 +84,7 @@ def get_default_system_parameters(
         "compute_dataflow_max_inflight_bytes": "134217728",  # 128 MiB
         "compute_hydration_concurrency": "2",
         "compute_replica_expiration_offset": "3d",
+        "compute_apply_column_demands": "true",
         "disk_cluster_replicas_default": "true",
         "enable_0dt_deployment": "true" if zero_downtime else "false",
         "enable_0dt_deployment_panic_after_timeout": "true",
@@ -143,7 +144,6 @@ def get_default_system_parameters(
         "persist_use_critical_since_snapshot": "false" if zero_downtime else "true",
         "persist_use_critical_since_source": "false" if zero_downtime else "true",
         "persist_part_decode_format": "row_with_validate",
-        "persist_apply_projection_pushdown": "true",
         "statement_logging_default_sample_rate": "0.01",
         "statement_logging_max_sample_rate": "0.01",
         "storage_source_decode_fuel": "100000",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -143,6 +143,7 @@ def get_default_system_parameters(
         "persist_use_critical_since_snapshot": "false" if zero_downtime else "true",
         "persist_use_critical_since_source": "false" if zero_downtime else "true",
         "persist_part_decode_format": "row_with_validate",
+        "persist_apply_projection_pushdown": "true",
         "statement_logging_default_sample_rate": "0.01",
         "statement_logging_max_sample_rate": "0.01",
         "storage_source_decode_fuel": "100000",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1047,6 +1047,7 @@ class FlipFlagsAction(Action):
         self.flags_with_values["persist_encoding_enable_dictionary"] = (
             BOOLEAN_FLAG_VALUES
         )
+        self.flags_with_values["compute_apply_column_demands"] = BOOLEAN_FLAG_VALUES
 
     def run(self, exe: Executor) -> bool:
         flag_name = self.rng.choice(list(self.flags_with_values.keys()))

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -149,6 +149,15 @@ pub const COMPUTE_REPLICA_EXPIRATION_OFFSET: Config<Duration> = Config::new(
     "The expiration time offset for replicas. Zero disables expiration.",
 );
 
+/// When enabled, applies the column demands from a MapFilterProject onto the RelationDesc used to
+/// read out of Persist. This allows Persist to prune unneeded columns as a performance
+/// optimization.
+pub const COMPUTE_APPLY_COLUMN_DEMANDS: Config<bool> = Config::new(
+    "compute_apply_column_demands",
+    false,
+    "When enabled, passes applys column demands to the RelationDesc used to read out of Persist.",
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -169,4 +178,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&COPY_TO_S3_MULTIPART_PART_SIZE_BYTES)
         .add(&ENABLE_COMPUTE_REPLICA_EXPIRATION)
         .add(&COMPUTE_REPLICA_EXPIRATION_OFFSET)
+        .add(&COMPUTE_APPLY_COLUMN_DEMANDS)
 }

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -235,12 +235,12 @@ pub fn build_compute_dataflow<A: Allocate>(
                             let new_desc =
                                 source.storage_metadata.relation_desc.apply_demand(&demands);
                             let new_arity = demands.len();
-                            let remap = demands
+                            let remap: BTreeMap<_, _> = demands
                                 .into_iter()
                                 .enumerate()
                                 .map(|(new, old)| (old, new))
                                 .collect();
-                            ops.permute(remap, new_arity);
+                            ops.permute_fn(|old_idx| remap[&old_idx], new_arity);
                             read_schema = Some(new_desc);
                         }
 

--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -133,6 +133,7 @@ where
         &compute_state.txns_ctx,
         &compute_state.worker_config,
         target.clone(),
+        None,
         source_as_of,
         SnapshotMode::Include,
         Antichain::new(), // we want all updates

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -337,6 +337,7 @@ where
         &compute_state.txns_ctx,
         &compute_state.worker_config,
         target,
+        None,
         as_of,
         SnapshotMode::Include,
         until,

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -29,6 +29,7 @@ use mz_persist::indexed::columnar::{ColumnarRecords, ColumnarRecordsStructuredEx
 use mz_persist::indexed::encoding::{BlobTraceBatchPart, BlobTraceUpdates};
 use mz_persist::location::{Blob, SeqNo};
 use mz_persist::metrics::ColumnarMetrics;
+use mz_persist_types::arrow::ArrayOrd;
 use mz_persist_types::columnar::{ColumnDecoder, Schema2};
 use mz_persist_types::stats::PartStats;
 use mz_persist_types::{Codec, Codec64};
@@ -839,13 +840,13 @@ impl<K: Codec, V: Codec, T: Timestamp + Lattice + Codec64, D> FetchedPart<K, V, 
                 }
                 match &migration {
                     PartMigration::SameSchema { both } => {
-                        let key_size_before = structured.key.get_array_memory_size();
+                        let key_size_before = ArrayOrd::new(&structured.key).goodbytes();
 
                         let key = decode::<K>("key", &*both.key, &structured.key);
                         let val = decode::<V>("val", &*both.val, &structured.val);
 
                         if let Some(key_decoder) = key.as_ref() {
-                            let key_size_after = key_decoder.byte_size();
+                            let key_size_after = key_decoder.goodbytes();
                             let key_diff = key_size_before.saturating_sub(key_size_after);
                             metrics
                                 .pushdown
@@ -870,8 +871,8 @@ impl<K: Codec, V: Codec, T: Timestamp + Lattice + Codec64, D> FetchedPart<K, V, 
                             .migration_migrate_seconds
                             .inc_by(start.elapsed().as_secs_f64());
 
-                        let key_before_size = structured.key.get_array_memory_size();
-                        let key_after_size = key.get_array_memory_size();
+                        let key_before_size = ArrayOrd::new(&structured.key).goodbytes();
+                        let key_after_size = ArrayOrd::new(&key).goodbytes();
                         let key_diff = key_before_size.saturating_sub(key_after_size);
                         metrics
                             .pushdown

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -2377,6 +2377,7 @@ pub struct PushdownMetrics {
     pub(crate) parts_faked_bytes: IntCounter,
     pub(crate) parts_stats_trimmed_count: IntCounter,
     pub(crate) parts_stats_trimmed_bytes: IntCounter,
+    pub(crate) parts_projection_trimmed_bytes: IntCounter,
     pub part_stats: PartStatsMetrics,
 }
 
@@ -2430,6 +2431,10 @@ impl PushdownMetrics {
             parts_stats_trimmed_bytes: registry.register(metric!(
                 name: "mz_persist_pushdown_parts_stats_trimmed_bytes",
                 help: "total bytes trimmed from part stats",
+            )),
+            parts_projection_trimmed_bytes: registry.register(metric!(
+                name: "mz_persist_pushdown_parts_projection_trimmed_bytes",
+                help: "total bytes trimmed from columnar data because of projection pushdown",
             )),
             part_stats: PartStatsMetrics::new(registry),
         }

--- a/src/persist-client/src/schema.rs
+++ b/src/persist-client/src/schema.rs
@@ -614,6 +614,14 @@ mod tests {
         fn is_null(&self, _: usize) -> bool {
             false
         }
+        fn byte_size(&self) -> usize {
+            let size_of_values = self
+                .0
+                .iter()
+                .map(|val| val.get_array_memory_size())
+                .sum::<usize>();
+            size_of_values + std::mem::size_of::<Vec<StringArray>>()
+        }
         fn stats(&self) -> StructStats {
             StructStats {
                 len: self.0[0].len(),

--- a/src/persist-client/src/schema.rs
+++ b/src/persist-client/src/schema.rs
@@ -501,6 +501,7 @@ mod tests {
     use mz_dyncfg::ConfigUpdates;
     use mz_ore::error::ErrorExt;
     use mz_ore::{assert_contains, assert_err, assert_ok};
+    use mz_persist_types::arrow::ArrayOrd;
     use mz_persist_types::codec_impls::UnitSchema;
     use mz_persist_types::columnar::{ColumnDecoder, ColumnEncoder, Schema2};
     use mz_persist_types::stats::{NoneStats, StructStats};
@@ -614,13 +615,11 @@ mod tests {
         fn is_null(&self, _: usize) -> bool {
             false
         }
-        fn byte_size(&self) -> usize {
-            let size_of_values = self
-                .0
+        fn goodbytes(&self) -> usize {
+            self.0
                 .iter()
-                .map(|val| val.get_array_memory_size())
-                .sum::<usize>();
-            size_of_values + std::mem::size_of::<Vec<StringArray>>()
+                .map(|val| ArrayOrd::String(val.clone()).goodbytes())
+                .sum()
         }
         fn stats(&self) -> StructStats {
             StructStats {

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -94,6 +94,10 @@ impl ColumnDecoder<()> for UnitColumnar {
         }
     }
 
+    fn byte_size(&self) -> usize {
+        std::mem::size_of::<UnitColumnar>()
+    }
+
     fn stats(&self) -> StructStats {
         StructStats {
             len: self.len,
@@ -281,6 +285,9 @@ impl<T: SimpleColumnarData> ColumnDecoder<T> for SimpleColumnarDecoder<T> {
     }
     fn is_null(&self, idx: usize) -> bool {
         self.0.is_null(idx)
+    }
+    fn byte_size(&self) -> usize {
+        self.0.get_array_memory_size()
     }
 
     fn stats(&self) -> StructStats {
@@ -599,6 +606,10 @@ impl<T> ColumnDecoder<T> for TodoColumnarDecoder<T> {
     }
 
     fn is_null(&self, _idx: usize) -> bool {
+        panic!("TODO")
+    }
+
+    fn byte_size(&self) -> usize {
         panic!("TODO")
     }
 

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -96,7 +96,7 @@ impl ColumnDecoder<()> for UnitColumnar {
     }
 
     fn goodbytes(&self) -> usize {
-        std::mem::size_of::<UnitColumnar>()
+        0
     }
 
     fn stats(&self) -> StructStats {

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -20,6 +20,7 @@ use arrow::array::{
 use bytes::{BufMut, Bytes};
 use timely::order::Product;
 
+use crate::arrow::ArrayOrd;
 use crate::columnar::{ColumnDecoder, ColumnEncoder, Schema2};
 use crate::stats::{ColumnStatKinds, ColumnarStats, NoneStats, StructStats};
 use crate::{Codec, Codec64, Opaque, ShardId};
@@ -94,7 +95,7 @@ impl ColumnDecoder<()> for UnitColumnar {
         }
     }
 
-    fn byte_size(&self) -> usize {
+    fn goodbytes(&self) -> usize {
         std::mem::size_of::<UnitColumnar>()
     }
 
@@ -286,8 +287,8 @@ impl<T: SimpleColumnarData> ColumnDecoder<T> for SimpleColumnarDecoder<T> {
     fn is_null(&self, idx: usize) -> bool {
         self.0.is_null(idx)
     }
-    fn byte_size(&self) -> usize {
-        self.0.get_array_memory_size()
+    fn goodbytes(&self) -> usize {
+        ArrayOrd::new(&self.0).goodbytes()
     }
 
     fn stats(&self) -> StructStats {
@@ -609,7 +610,7 @@ impl<T> ColumnDecoder<T> for TodoColumnarDecoder<T> {
         panic!("TODO")
     }
 
-    fn byte_size(&self) -> usize {
+    fn goodbytes(&self) -> usize {
         panic!("TODO")
     }
 

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -70,6 +70,9 @@ pub trait ColumnDecoder<T> {
     /// Returns if the value at `idx` is null.
     fn is_null(&self, idx: usize) -> bool;
 
+    /// Returns the number of bytes used by this decoder.
+    fn byte_size(&self) -> usize;
+
     /// Returns statistics for the column. This structure is defined by Persist,
     /// but the contents are determined by the client; Persist will preserve
     /// them in the part metadata and make them available to readers.

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -71,7 +71,7 @@ pub trait ColumnDecoder<T> {
     fn is_null(&self, idx: usize) -> bool;
 
     /// Returns the number of bytes used by this decoder.
-    fn byte_size(&self) -> usize;
+    fn goodbytes(&self) -> usize;
 
     /// Returns statistics for the column. This structure is defined by Persist,
     /// but the contents are determined by the client; Persist will preserve

--- a/src/persist-types/src/schema.rs
+++ b/src/persist-types/src/schema.rs
@@ -357,6 +357,7 @@ fn backward_compatible_struct(old: &Fields, new: &Fields) -> Option<ArrayMigrati
                 fn recursively_all_nullable(migration: &ArrayMigration) -> bool {
                     match migration {
                         NoOp => true,
+                        ReplaceWithNull => false,
                         List(_field, child) => recursively_all_nullable(child),
                         Struct(children) => children.iter().all(|child| match child {
                             AddFieldNullableAtEnd { .. } | DropField { .. } => false,

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -53,10 +53,10 @@ pub use crate::datum_vec::{DatumVec, DatumVecBorrow};
 pub use crate::diff::Diff;
 pub use crate::global_id::GlobalId;
 pub use crate::relation::{
-    arb_relation_desc_diff, arb_row_for_relation, ColumnName, ColumnType, NotNullViolation,
-    PropRelationDescDiff, ProtoColumnName, ProtoColumnType, ProtoRelationDesc, ProtoRelationType,
-    RelationDesc, RelationDescBuilder, RelationType, RelationVersion, RelationVersionSelector,
-    VersionedRelationDesc,
+    arb_relation_desc_diff, arb_row_for_relation, ColumnIndex, ColumnName, ColumnType,
+    NotNullViolation, PropRelationDescDiff, ProtoColumnName, ProtoColumnType, ProtoRelationDesc,
+    ProtoRelationType, RelationDesc, RelationDescBuilder, RelationType, RelationVersion,
+    RelationVersionSelector, VersionedRelationDesc,
 };
 pub use crate::row::encode::{preserves_order, RowColumnarDecoder, RowColumnarEncoder};
 pub use crate::row::iter::{IntoRowIterator, RowIterator};

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -53,10 +53,10 @@ pub use crate::datum_vec::{DatumVec, DatumVecBorrow};
 pub use crate::diff::Diff;
 pub use crate::global_id::GlobalId;
 pub use crate::relation::{
-    arb_relation_desc_diff, arb_row_for_relation, ColumnIndex, ColumnName, ColumnType,
-    NotNullViolation, PropRelationDescDiff, ProtoColumnName, ProtoColumnType, ProtoRelationDesc,
-    ProtoRelationType, RelationDesc, RelationDescBuilder, RelationType, RelationVersion,
-    RelationVersionSelector, VersionedRelationDesc,
+    arb_relation_desc_diff, arb_relation_desc_projection, arb_row_for_relation, ColumnIndex,
+    ColumnName, ColumnType, NotNullViolation, PropRelationDescDiff, ProtoColumnName,
+    ProtoColumnType, ProtoRelationDesc, ProtoRelationType, RelationDesc, RelationDescBuilder,
+    RelationType, RelationVersion, RelationVersionSelector, VersionedRelationDesc,
 };
 pub use crate::row::encode::{preserves_order, RowColumnarDecoder, RowColumnarEncoder};
 pub use crate::row::iter::{IntoRowIterator, RowIterator};

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -133,15 +133,6 @@ impl Row {
             packer.try_push_proto(d)?;
         }
 
-        let num_columns = desc.typ().column_types.len();
-        mz_ore::soft_assert_eq_or_log!(
-            self.iter().count(),
-            num_columns,
-            "wrong number of columns when decoding a Row!, got {row:?}, expected {desc:?}",
-            row = self,
-            desc = desc,
-        );
-
         Ok(())
     }
 

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -121,24 +121,21 @@ impl Row {
         proto: &ProtoRow,
         desc: &RelationDesc,
     ) -> Result<(), String> {
-        let mut col_idx = 0;
         let mut packer = self.packer();
-        for d in proto.datums.iter() {
+        for (col_idx, _, _) in desc.iter_all() {
+            let d = match proto.datums.get(col_idx.to_raw()) {
+                Some(x) => x,
+                None => {
+                    packer.push(Datum::Null);
+                    continue;
+                }
+            };
             packer.try_push_proto(d)?;
-            col_idx += 1;
         }
 
         let num_columns = desc.typ().column_types.len();
-        if col_idx < num_columns {
-            let missing_columns = col_idx..num_columns;
-            for _ in missing_columns {
-                packer.push(Datum::Null);
-                col_idx += 1;
-            }
-        }
-
         mz_ore::soft_assert_eq_or_log!(
-            col_idx,
+            self.iter().count(),
             num_columns,
             "wrong number of columns when decoding a Row!, got {row:?}, expected {desc:?}",
             row = self,

--- a/src/repr/src/row/encode.rs
+++ b/src/repr/src/row/encode.rs
@@ -1243,43 +1243,14 @@ impl DatumColumnDecoder {
             DatumColumnDecoder::MzAclItem(a) => ArrayOrd::Binary(a.clone()).goodbytes(),
             DatumColumnDecoder::Range(a) => ArrayOrd::Binary(a.clone()).goodbytes(),
             DatumColumnDecoder::Json(a) => ArrayOrd::String(a.clone()).goodbytes(),
-            DatumColumnDecoder::Array {
-                dim_offsets,
-                dims,
-                val_offsets,
-                vals,
-                nulls,
-            } => {
-                dim_offsets.inner().inner().len()
-                    + ArrayOrd::FixedSizeBinary(dims.clone()).goodbytes()
-                    + val_offsets.inner().inner().len()
-                    + vals.goodbytes()
-                    + nulls.as_ref().map(|b| b.len()).unwrap_or(0)
+            DatumColumnDecoder::Array { dims, vals, .. } => {
+                (dims.len() * PackedArrayDimension::SIZE) + vals.goodbytes()
             }
-            DatumColumnDecoder::List {
-                offsets,
-                values,
-                nulls,
-            } => {
-                offsets.inner().inner().len()
-                    + values.goodbytes()
-                    + nulls.as_ref().map(|b| b.len()).unwrap_or(0)
+            DatumColumnDecoder::List { values, .. } => values.goodbytes(),
+            DatumColumnDecoder::Map { keys, vals, .. } => {
+                ArrayOrd::String(keys.clone()).goodbytes() + vals.goodbytes()
             }
-            DatumColumnDecoder::Map {
-                offsets,
-                keys,
-                vals,
-                nulls,
-            } => {
-                offsets.inner().inner().len()
-                    + ArrayOrd::String(keys.clone()).goodbytes()
-                    + vals.goodbytes()
-                    + nulls.as_ref().map(|b| b.len()).unwrap_or(0)
-            }
-            DatumColumnDecoder::Record { fields, nulls } => {
-                fields.iter().map(|f| f.goodbytes()).sum::<usize>()
-                    + nulls.as_ref().map(|b| b.len()).unwrap_or(0)
-            }
+            DatumColumnDecoder::Record { fields, .. } => fields.iter().map(|f| f.goodbytes()).sum(),
             DatumColumnDecoder::RecordEmpty(a) => ArrayOrd::Bool(a.clone()).goodbytes(),
         }
     }

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -35,7 +35,6 @@ use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::{Codec, Codec64};
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, RelationDesc, Row, RowArena, Timestamp};
 use mz_storage_types::controller::{CollectionMetadata, TxnsCodecRow};
-use mz_storage_types::dyncfgs::PERSIST_APPLY_PROJECTION_PUSHDOWN;
 use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::SourceData;
 use mz_storage_types::stats::RelationPartStats;
@@ -319,8 +318,8 @@ where
 
     // N.B. `read_schema` may be a subset of the total columns for this shard.
     let read_desc = match read_schema {
-        Some(desc) if PERSIST_APPLY_PROJECTION_PUSHDOWN.get(&cfg.configs) => desc,
-        None | Some(_) => metadata.relation_desc,
+        Some(desc) => desc,
+        None => metadata.relation_desc,
     };
 
     let desc_transformer = match flow_control {

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -33,8 +33,9 @@ use mz_persist_client::fetch::{SerdeLeasedBatchPart, ShardSourcePart};
 use mz_persist_client::operators::shard_source::{shard_source, SnapshotMode};
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::{Codec, Codec64};
-use mz_repr::{Datum, DatumVec, Diff, GlobalId, RelationType, Row, RowArena, Timestamp};
+use mz_repr::{Datum, DatumVec, Diff, GlobalId, RelationDesc, Row, RowArena, Timestamp};
 use mz_storage_types::controller::{CollectionMetadata, TxnsCodecRow};
+use mz_storage_types::dyncfgs::PERSIST_APPLY_PROJECTION_PUSHDOWN;
 use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::SourceData;
 use mz_storage_types::stats::RelationPartStats;
@@ -141,6 +142,7 @@ pub fn persist_source<G>(
     // dataflow.
     worker_dyncfgs: &ConfigSet,
     metadata: CollectionMetadata,
+    read_schema: Option<RelationDesc>,
     as_of: Option<Antichain<Timestamp>>,
     snapshot_mode: SnapshotMode,
     until: Antichain<Timestamp>,
@@ -204,6 +206,7 @@ where
             source_id,
             Arc::clone(&persist_clients),
             metadata.clone(),
+            read_schema,
             as_of.clone(),
             snapshot_mode,
             until.clone(),
@@ -274,6 +277,7 @@ pub fn persist_source_core<'g, G>(
     source_id: GlobalId,
     persist_clients: Arc<PersistClientCache>,
     metadata: CollectionMetadata,
+    read_schema: Option<RelationDesc>,
     as_of: Option<Antichain<Timestamp>>,
     snapshot_mode: SnapshotMode,
     until: Antichain<Timestamp>,
@@ -299,7 +303,6 @@ where
 {
     let cfg = persist_clients.cfg().clone();
     let name = source_id.to_string();
-    let desc = metadata.relation_desc.clone();
     let ignores_data = map_filter_project
         .as_ref()
         .map_or(false, |x| x.ignores_input());
@@ -313,6 +316,12 @@ where
         ProjectionPushdown::FetchAll
     };
     let filter_plan = map_filter_project.as_ref().map(|p| (*p).clone());
+
+    // N.B. `read_schema` may be a subset of the total columns for this shard.
+    let read_desc = match read_schema {
+        Some(desc) if PERSIST_APPLY_PROJECTION_PUSHDOWN.get(&cfg.configs) => desc,
+        None | Some(_) => metadata.relation_desc,
+    };
 
     let desc_transformer = match flow_control {
         Some(flow_control) => Some(move |mut scope: _, descs: &Stream<_, _>, chosen_worker| {
@@ -350,7 +359,7 @@ where
         snapshot_mode,
         until.clone(),
         desc_transformer,
-        Arc::new(metadata.relation_desc),
+        Arc::new(read_desc.clone()),
         Arc::new(UnitSchema),
         move |stats, frontier| {
             let Some(lower) = frontier.as_option().copied() else {
@@ -369,8 +378,8 @@ where
                 ResultSpec::value_between(Datum::MzTimestamp(lower), Datum::MzTimestamp(upper));
             if let Some(plan) = &filter_plan {
                 let metrics = &metrics.pushdown.part_stats;
-                let stats = RelationPartStats::new(&filter_name, metrics, &desc, stats);
-                filter_may_match(desc.typ(), time_range, stats, plan)
+                let stats = RelationPartStats::new(&filter_name, metrics, &read_desc, stats);
+                filter_may_match(&read_desc, time_range, stats, plan)
             } else {
                 true
             }
@@ -385,13 +394,13 @@ where
 }
 
 fn filter_may_match(
-    relation_type: &RelationType,
+    relation_desc: &RelationDesc,
     time_range: ResultSpec,
     stats: RelationPartStats,
     plan: &MfpPlan,
 ) -> bool {
     let arena = RowArena::new();
-    let mut ranges = ColumnSpecs::new(relation_type, &arena);
+    let mut ranges = ColumnSpecs::new(relation_desc.typ(), &arena);
     ranges.push_unmaterializable(UnmaterializableFunc::MzNow, time_range);
 
     if stats.err_count().into_iter().any(|count| count > 0) {
@@ -399,9 +408,11 @@ fn filter_may_match(
         return true;
     }
 
-    for (id, _) in relation_type.column_types.iter().enumerate() {
-        let result_spec = stats.col_stats(id, &arena);
-        ranges.push_column(id, result_spec);
+    // N.B. We may have pushed down column "demands" into Persist, so this
+    // relation desc may have a different set of columns than the stats.
+    for (pos, (idx, _, _)) in relation_desc.iter_all().enumerate() {
+        let result_spec = stats.col_stats(idx, &arena);
+        ranges.push_column(pos, result_spec);
     }
     let result = ranges.mfp_plan_filter(plan).range;
     result.may_contain(Datum::True) || result.may_fail()
@@ -603,6 +614,9 @@ impl PendingWork {
                             |time| !until.less_equal(time),
                             row_builder,
                         ) {
+                            // Earlier we decided this Part doesn't need to be fetched, but to
+                            // audit our logic we fetched it any way. If the MFP returned data it
+                            // means our earlier decision to not fetch this part was incorrect.
                             if let Some(_stats) = &is_filter_pushdown_audit {
                                 // NB: The tag added by this scope is used for alerting. The panic
                                 // message may be changed arbitrarily, but the tag key and val must

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -228,6 +228,12 @@ pub const STORAGE_USE_CONTINUAL_FEEDBACK_UPSERT: Config<bool> = Config::new(
     "Whether to use the new continual feedback upsert operator.",
 );
 
+pub const PERSIST_APPLY_PROJECTION_PUSHDOWN: Config<bool> = Config::new(
+    "persist_apply_projection_pushdown",
+    true,
+    "When enabled, passes column projection info down into Persist.",
+);
+
 /// Adds the full set of all storage `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -253,4 +259,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&STORAGE_SUSPEND_AND_RESTART_DELAY)
         .add(&STORAGE_RECLOCK_TO_LATEST)
         .add(&STORAGE_USE_CONTINUAL_FEEDBACK_UPSERT)
+        .add(&PERSIST_APPLY_PROJECTION_PUSHDOWN)
 }

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -228,12 +228,6 @@ pub const STORAGE_USE_CONTINUAL_FEEDBACK_UPSERT: Config<bool> = Config::new(
     "Whether to use the new continual feedback upsert operator.",
 );
 
-pub const PERSIST_APPLY_PROJECTION_PUSHDOWN: Config<bool> = Config::new(
-    "persist_apply_projection_pushdown",
-    false,
-    "When enabled, passes column projection info down into Persist.",
-);
-
 /// Adds the full set of all storage `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -259,5 +253,4 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&STORAGE_SUSPEND_AND_RESTART_DELAY)
         .add(&STORAGE_RECLOCK_TO_LATEST)
         .add(&STORAGE_USE_CONTINUAL_FEEDBACK_UPSERT)
-        .add(&PERSIST_APPLY_PROJECTION_PUSHDOWN)
 }

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -230,7 +230,7 @@ pub const STORAGE_USE_CONTINUAL_FEEDBACK_UPSERT: Config<bool> = Config::new(
 
 pub const PERSIST_APPLY_PROJECTION_PUSHDOWN: Config<bool> = Config::new(
     "persist_apply_projection_pushdown",
-    true,
+    false,
     "When enabled, passes column projection info down into Persist.",
 );
 

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1667,10 +1667,9 @@ impl SourceDataRowColumnarDecoder {
     }
 
     pub fn goodbytes(&self) -> usize {
-        let self_size = std::mem::size_of::<SourceDataRowColumnarDecoder>();
         match self {
-            SourceDataRowColumnarDecoder::Row(decoder) => self_size + decoder.goodbytes(),
-            SourceDataRowColumnarDecoder::EmptyRow => self_size,
+            SourceDataRowColumnarDecoder::Row(decoder) => decoder.goodbytes(),
+            SourceDataRowColumnarDecoder::EmptyRow => 0,
         }
     }
 }

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -2000,6 +2000,9 @@ mod tests {
         }
         let col = encoder.finish();
 
+        // The top-level StructArray for SourceData should always be non-nullable.
+        assert!(!col.is_nullable());
+
         // Reallocate our arrays with lgalloc.
         let col = realloc_array(&col, &metrics);
 

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1664,6 +1664,14 @@ impl SourceDataRowColumnarDecoder {
             }
         }
     }
+
+    pub fn byte_size(&self) -> usize {
+        let self_size = std::mem::size_of::<SourceDataRowColumnarDecoder>();
+        match self {
+            SourceDataRowColumnarDecoder::Row(decoder) => self_size + decoder.byte_size(),
+            SourceDataRowColumnarDecoder::EmptyRow => self_size,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -1752,6 +1760,12 @@ impl ColumnDecoder<SourceData> for SourceDataColumnarDecoder {
         assert!(!err_null || !row_null, "SourceData should never be null!");
 
         false
+    }
+
+    fn byte_size(&self) -> usize {
+        self.row_decoder.byte_size()
+            + self.err_decoder.get_array_memory_size()
+            + std::mem::size_of::<SourceDataColumnarDecoder>()
     }
 
     fn stats(&self) -> StructStats {

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1943,16 +1943,20 @@ mod tests {
     use bytes::Bytes;
     use mz_expr::EvalError;
     use mz_ore::assert_err;
+    use mz_ore::metrics::MetricsRegistry;
     use mz_persist::indexed::columnar::arrow::{realloc_any, realloc_array};
     use mz_persist::metrics::ColumnarMetrics;
     use mz_persist_types::parquet::EncodingConfig;
     use mz_persist_types::schema::{backward_compatible, Migration};
+    use mz_persist_types::stats::{PartStats, PartStatsMetrics};
     use mz_repr::{
-        arb_relation_desc_diff, PropRelationDescDiff, ProtoRelationDesc, RelationDescBuilder,
-        ScalarType,
+        arb_relation_desc_diff, arb_relation_desc_projection, ColumnIndex, DatumVec,
+        PropRelationDescDiff, ProtoRelationDesc, RelationDescBuilder, RowArena, ScalarType,
     };
     use proptest::prelude::*;
     use proptest::strategy::{Union, ValueTree};
+
+    use crate::stats::RelationPartStats;
 
     use super::*;
 
@@ -1970,9 +1974,14 @@ mod tests {
     }
 
     #[track_caller]
-    fn roundtrip_source_data(desc: RelationDesc, datas: Vec<SourceData>, config: &EncodingConfig) {
+    fn roundtrip_source_data(
+        desc: &RelationDesc,
+        datas: Vec<SourceData>,
+        read_desc: &RelationDesc,
+        config: &EncodingConfig,
+    ) {
         let metrics = ColumnarMetrics::disconnected();
-        let mut encoder = <RelationDesc as Schema2<SourceData>>::encoder(&desc).unwrap();
+        let mut encoder = <RelationDesc as Schema2<SourceData>>::encoder(desc).unwrap();
         for data in &datas {
             encoder.append(data);
         }
@@ -2024,23 +2033,68 @@ mod tests {
             .clone();
 
         // Try generating stats for the data, just to make sure we don't panic.
-        let _ = <RelationDesc as Schema2<SourceData>>::decoder_any(&desc, &rnd_col)
+        let stats = <RelationDesc as Schema2<SourceData>>::decoder_any(desc, &rnd_col)
             .expect("valid decoder")
             .stats();
 
         // Read back all of our data and assert it roundtrips.
         let mut rnd_data = SourceData(Ok(Row::default()));
-        let decoder = <RelationDesc as Schema2<SourceData>>::decoder(&desc, rnd_col).unwrap();
-        for (idx, og_data) in datas.into_iter().enumerate() {
+        let decoder =
+            <RelationDesc as Schema2<SourceData>>::decoder(desc, rnd_col.clone()).unwrap();
+        for (idx, og_data) in datas.iter().enumerate() {
             decoder.decode(idx, &mut rnd_data);
-            assert_eq!(og_data, rnd_data);
+            assert_eq!(og_data, &rnd_data);
+        }
+
+        // Read back all of our data a second time with a projection applied, and make sure the
+        // stats are valid.
+        let stats_metrics = PartStatsMetrics::new(&MetricsRegistry::new());
+        let stats = RelationPartStats {
+            name: "test",
+            metrics: &stats_metrics,
+            stats: &PartStats { key: stats },
+            desc: read_desc,
+        };
+        let mut datum_vec = DatumVec::new();
+        let arena = RowArena::default();
+        let decoder = <RelationDesc as Schema2<SourceData>>::decoder(read_desc, rnd_col).unwrap();
+
+        for (idx, og_data) in datas.iter().enumerate() {
+            decoder.decode(idx, &mut rnd_data);
+            match (&og_data.0, &rnd_data.0) {
+                (Ok(og_row), Ok(rnd_row)) => {
+                    // Filter down to just the Datums in the projection schema.
+                    {
+                        let datums = datum_vec.borrow_with(og_row);
+                        let projected_datums =
+                            datums.iter().enumerate().filter_map(|(idx, datum)| {
+                                read_desc
+                                    .contains_index(&ColumnIndex::from_raw(idx))
+                                    .then_some(datum)
+                            });
+                        let og_projected_row = Row::pack(projected_datums);
+                        assert_eq!(&og_projected_row, rnd_row);
+                    }
+
+                    // Validate the stats for all of our projected columns.
+                    {
+                        let proj_datums = datum_vec.borrow_with(rnd_row);
+                        for (pos, (idx, _, _)) in read_desc.iter_all().enumerate() {
+                            let spec = stats.col_stats(idx, &arena);
+                            assert!(spec.may_contain(proj_datums[pos]));
+                        }
+                    }
+                }
+                (Err(_), Err(_)) => assert_eq!(og_data, &rnd_data),
+                (_, _) => panic!("decoded to a different type? {og_data:?} {rnd_data:?}"),
+            }
         }
 
         // Verify that the RelationDesc itself roundtrips through
         // {encode,decode}_schema.
-        let encoded_schema = SourceData::encode_schema(&desc);
+        let encoded_schema = SourceData::encode_schema(desc);
         let roundtrip_desc = SourceData::decode_schema(&encoded_schema);
-        assert_eq!(desc, roundtrip_desc);
+        assert_eq!(desc, &roundtrip_desc);
 
         // Verify that the RelationDesc is backward compatible with itself (this
         // mostly checks for `unimplemented!` type panics).
@@ -2066,13 +2120,19 @@ mod tests {
         }
         let num_rows = Union::new_weighted(weights);
 
-        let strat = (any::<RelationDesc>(), num_rows).prop_flat_map(|(desc, num_rows)| {
-            proptest::collection::vec(arb_source_data_for_relation_desc(&desc), num_rows)
-                .prop_map(move |datas| (desc.clone(), datas))
-        });
+        // TODO(parkmycar): There are so many clones going on here, and maybe we can avoid them?
+        let strat = (any::<RelationDesc>(), num_rows)
+            .prop_flat_map(|(desc, num_rows)| {
+                arb_relation_desc_projection(desc.clone())
+                    .prop_map(move |read_desc| (desc.clone(), read_desc, num_rows.clone()))
+            })
+            .prop_flat_map(|(desc, read_desc, num_rows)| {
+                proptest::collection::vec(arb_source_data_for_relation_desc(&desc), num_rows)
+                    .prop_map(move |datas| (desc.clone(), datas, read_desc.clone()))
+            });
 
-        proptest!(|((config, (desc, source_datas)) in (any::<EncodingConfig>(), strat))| {
-            roundtrip_source_data(desc, source_datas, &config);
+        proptest!(|((config, (desc, source_datas, read_desc)) in (any::<EncodingConfig>(), strat))| {
+            roundtrip_source_data(&desc, source_datas, &read_desc, &config);
         });
     }
 
@@ -2088,7 +2148,7 @@ mod tests {
             EvalError::DateOutOfRange.into(),
         )))];
         let config = EncodingConfig::default();
-        roundtrip_source_data(desc, source_datas, &config);
+        roundtrip_source_data(&desc, source_datas, &desc, &config);
     }
 
     fn is_sorted(array: &dyn Array) -> bool {
@@ -2226,7 +2286,7 @@ mod tests {
         // Note: This case should be covered by the `all_source_data_roundtrips` test above, but
         // it's a special case that we explicitly want to exercise.
         proptest!(|((config, (desc, source_datas)) in (any::<EncodingConfig>(), rows))| {
-            roundtrip_source_data(desc, source_datas, &config);
+            roundtrip_source_data(&desc, source_datas, &desc, &config);
         });
     }
 

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -63,6 +63,7 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
         &storage_state.txns_ctx,
         storage_state.storage_configuration.config_set(),
         sink.from_storage_metadata.clone(),
+        None,
         Some(sink.as_of.clone()),
         snapshot_mode,
         timely::progress::Antichain::new(),

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -281,6 +281,7 @@ where
                             export_id,
                             persist_clients,
                             storage_metadata,
+                            None,
                             Some(as_of),
                             SnapshotMode::Include,
                             Antichain::new(),


### PR DESCRIPTION
Continuation of https://github.com/MaterializeInc/materialize/pull/29539

Implements a limited form of projection pushdown by applying the `demands` of a `MapFilterProject` onto the `RelationDesc` of a collection, and using the resulting `RelationDesc` in `shard_source`. All of the columns will still be fetched from S3, but when decoding structured data we'll drop the unneeded columns, and decoding `ProtoRow` data we'll skip the unneeded `Datum`s.

### Motivation

Progress towards: https://github.com/MaterializeInc/database-issues/issues/8402

Fixes https://github.com/MaterializeInc/database-issues/issues/8825

### Tips for reviewers

The implementation for the feature is in the first commit, and can be reviewed on its own. The later commits add testing and metrics and theoretically could be their own PRs, so it might be nice to review one commit at a time.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
