### PR TITLE
Downgrade EQProp-ColumnKnowledge soft_assert

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1191,7 +1191,6 @@ steps:
         timeout_in_minutes: 58
         agents:
           queue: hetzner-aarch64-4cpu-8gb
-        skip: "flaky until database-issues#8797 is fixed"
         plugins:
           - ./ci/plugins/mzcompose:
               composition: feature-flag-consistency
@@ -1219,7 +1218,6 @@ steps:
         timeout_in_minutes: 60
         agents:
           queue: hetzner-aarch64-4cpu-8gb
-        skip: "flaky until database-issues#8797 is fixed"
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlsmith


### PR DESCRIPTION
The `soft_assert_or_log` that signals when `ColumnKnowledge` does work after `EquivalencePropagation` has been unexpectedly happening a lot in CI. We have enough examples to start fixing the issue, and we don't want to keep CI flaky while we do so. Therefore, this PR downgrades this assert to just a `tracing::error!`. This way, it won't fail CI, but it will still emit a Sentry error when it happens on staging or production.

Additionally, the PR also:
- Includes the dataflow's ID in the error msg.
- Fixes plan tracing, so that we can separately observe the result of EQProp before CK happens.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
