### PR TITLE
kafka-source: specify a group ID for the metadata consumer

### DIFF
--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -374,6 +374,10 @@ impl SourceRender for KafkaSourceConnection {
                             // Allow Kafka monitoring tools to identify this
                             // consumer.
                             "client.id" => format!("{client_id}-metadata"),
+                            // For some currently unknown reason, the metadata thread can become
+                            // unable to fetch new offsets when no group ID is specified and the
+                            // topic gets recreated. See database-issues#8823.
+                            "group.id" => format!("{group_id}-metadata"),
                         },
                         InTask::Yes,
                     )

--- a/test/testdrive/kafka-recreate-topic.td
+++ b/test/testdrive/kafka-recreate-topic.td
@@ -88,10 +88,6 @@ $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
 
 $ kafka-create-topic topic=topic1 partitions=1
 
-# TODO: Reenable when database-issues#8823 is fixed
-$ skip-if
-SELECT true
-
 ! SELECT * FROM source1_tbl
 contains:topic was recreated: high watermark of partition 0 regressed from 1 to 0
 


### PR DESCRIPTION
The hope is that this will resolve issues observed in our tests where the metadata thread got stuck with "OperationTimedOut" errors when its target partition was deleted and recreated.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8823 (I hope)

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
