### PR TITLE
adapter: Lazily deserialize the audit log

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -92,13 +92,13 @@ use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::connection::ConnectionId;
 use mz_adapter_types::dyncfgs::WITH_0DT_DEPLOYMENT_CAUGHT_UP_CHECK_INTERVAL;
 use mz_build_info::BuildInfo;
-use mz_catalog::builtin::{BUILTINS, BUILTINS_STATIC, MZ_STORAGE_USAGE_BY_SHARD};
+use mz_catalog::builtin::{BUILTINS, BUILTINS_STATIC, MZ_AUDIT_EVENTS, MZ_STORAGE_USAGE_BY_SHARD};
 use mz_catalog::config::{AwsPrincipalContext, BuiltinItemMigrationConfig, ClusterReplicaSizeMap};
-use mz_catalog::durable::OpenableDurableCatalogState;
+use mz_catalog::durable::{AuditLogIterator, OpenableDurableCatalogState};
 use mz_catalog::expr_cache::{GlobalExpressions, LocalExpressions};
 use mz_catalog::memory::objects::{
     CatalogEntry, CatalogItem, ClusterReplicaProcessStatus, ClusterVariantManaged, Connection,
-    DataSourceDesc, StateUpdate, Table, TableDataSource,
+    DataSourceDesc, StateDiff, StateUpdate, StateUpdateKind, Table, TableDataSource,
 };
 use mz_cloud_resources::{CloudResourceController, VpcEndpointConfig, VpcEndpointEvent};
 use mz_compute_client::as_of_selection;
@@ -977,7 +977,7 @@ pub struct Config {
     pub controller_config: ControllerConfig,
     pub controller_envd_epoch: NonZeroI64,
     pub storage: Box<dyn mz_catalog::durable::DurableCatalogState>,
-    pub audit_logs_handle: thread::JoinHandle<Vec<StateUpdate>>,
+    pub audit_logs_iterator: AuditLogIterator,
     pub timestamp_oracle_url: Option<SensitiveUrl>,
     pub unsafe_mode: bool,
     pub all_features: bool,
@@ -1788,7 +1788,7 @@ impl Coordinator {
         mut builtin_table_updates: Vec<BuiltinTableUpdate>,
         cached_global_exprs: BTreeMap<GlobalId, GlobalExpressions>,
         uncached_local_exprs: BTreeMap<GlobalId, LocalExpressions>,
-        audit_logs_handle: std::thread::JoinHandle<Vec<StateUpdate>>,
+        audit_logs_iterator: AuditLogIterator,
     ) -> Result<(), AdapterError> {
         let bootstrap_start = Instant::now();
         info!("startup: coordinator init: bootstrap beginning");
@@ -2247,21 +2247,27 @@ impl Coordinator {
 
         let builtin_update_start = Instant::now();
         info!("startup: coordinator init: bootstrap: generate builtin updates beginning");
+
         if self.controller.read_only() {
             info!("coordinator init: bootstrap: stashing builtin table updates while in read-only mode");
 
+            // TODO(jkosh44) Optimize deserializing the audit log in read-only mode.
             let audit_join_start = Instant::now();
-            info!("startup: coordinator init: bootstrap: join audit log deserialization beginning");
-            let audit_log_updates = audit_logs_handle
-                .join()
-                .expect("unable to deserialize audit log");
+            info!("startup: coordinator init: bootstrap: audit log deserialization beginning");
+            let audit_log_updates: Vec<_> = audit_logs_iterator
+                .map(|(audit_log, ts)| StateUpdate {
+                    kind: StateUpdateKind::AuditLog(audit_log),
+                    ts,
+                    diff: StateDiff::Addition,
+                })
+                .collect();
             let audit_log_builtin_table_updates = self
                 .catalog()
                 .state()
                 .generate_builtin_table_updates(audit_log_updates);
             builtin_table_updates.extend(audit_log_builtin_table_updates);
             info!(
-                "startup: coordinator init: bootstrap: join audit log deserialization complete in {:?}",
+                "startup: coordinator init: bootstrap: audit log deserialization complete in {:?}",
                 audit_join_start.elapsed()
             );
             self.buffered_builtin_table_updates
@@ -2269,7 +2275,7 @@ impl Coordinator {
                 .expect("in read-only mode")
                 .append(&mut builtin_table_updates);
         } else {
-            self.bootstrap_tables(&entries, builtin_table_updates, audit_logs_handle)
+            self.bootstrap_tables(&entries, builtin_table_updates, audit_logs_iterator)
                 .await;
         };
         info!(
@@ -2384,7 +2390,7 @@ impl Coordinator {
         &mut self,
         entries: &[CatalogEntry],
         mut builtin_table_updates: Vec<BuiltinTableUpdate>,
-        audit_logs_handle: thread::JoinHandle<Vec<StateUpdate>>,
+        audit_logs_iterator: AuditLogIterator,
     ) {
         /// Smaller helper struct of metadata for bootstrapping tables.
         struct TableMetadata<'a> {
@@ -2442,9 +2448,26 @@ impl Coordinator {
         };
 
         let mut retraction_tasks = Vec::new();
-        let system_tables = table_metas
+        let mut system_tables: Vec<_> = table_metas
             .iter()
-            .filter(|meta| meta.id.is_system() && !is_storage_usage_by_shard(meta));
+            .filter(|meta| meta.id.is_system() && !is_storage_usage_by_shard(meta))
+            .collect();
+
+        // Special case audit events because it's append only.
+        let (audit_events_idx, _) = system_tables
+            .iter()
+            .find_position(|table| {
+                table.id == self.catalog().resolve_builtin_table(&MZ_AUDIT_EVENTS)
+            })
+            .expect("mz_audit_events must exist");
+        let audit_events = system_tables.remove(audit_events_idx);
+        let audit_log_task = self.bootstrap_audit_log_table(
+            audit_events.id,
+            audit_events.name,
+            audit_events.table,
+            audit_logs_iterator,
+            read_ts,
+        );
 
         for system_table in system_tables {
             let table_id = system_table.id;
@@ -2462,7 +2485,7 @@ impl Coordinator {
                     .await
                     .unwrap_or_terminate("cannot fail to fetch snapshot");
                 let contents_len = current_contents.len();
-                debug!("coordinator init: table ({table_id}) size {contents_len}",);
+                debug!("coordinator init: table ({table_id}) size {contents_len}");
 
                 // Retract the current contents.
                 current_contents
@@ -2485,9 +2508,9 @@ impl Coordinator {
 
         let audit_join_start = Instant::now();
         info!("startup: coordinator init: bootstrap: join audit log deserialization beginning");
-        let audit_log_updates = audit_logs_handle
-            .join()
-            .expect("unable to deserialize audit log");
+        let audit_log_updates = audit_log_task
+            .await
+            .expect("cannot fail to fetch audit log updates");
         let audit_log_builtin_table_updates = self
             .catalog()
             .state()
@@ -2512,6 +2535,55 @@ impl Coordinator {
         if let Some(write_ts) = write_ts {
             self.apply_local_write(write_ts).await;
         }
+    }
+
+    /// Prepare updates to the audit log table. The audit log table append only and very large, so
+    /// we only need to find the events present in `audit_logs_iterator` but not in the audit log
+    /// table.
+    #[instrument]
+    fn bootstrap_audit_log_table<'a>(
+        &mut self,
+        table_id: CatalogItemId,
+        name: &'a QualifiedItemName,
+        table: &'a Table,
+        audit_logs_iterator: AuditLogIterator,
+        read_ts: Timestamp,
+    ) -> JoinHandle<Vec<StateUpdate>> {
+        let full_name = self.catalog().resolve_full_name(name, None);
+        debug!("coordinator init: reconciling audit log: {full_name} ({table_id})");
+        let current_contents_fut = self
+            .controller
+            .storage
+            .snapshot(table.global_id_writes(), read_ts);
+        spawn(|| format!("snapshot-audit-log-{table_id}"), async move {
+            let current_contents = current_contents_fut
+                .await
+                .unwrap_or_terminate("cannot fail to fetch snapshot");
+            let contents_len = current_contents.len();
+            debug!("coordinator init: audit log table ({table_id}) size {contents_len}");
+
+            // Fetch the largest audit log event ID that has been written to the table.
+            let max_table_id = current_contents
+                .into_iter()
+                .filter(|(_, diff)| *diff == 1)
+                .map(|(row, _diff)| row.unpack_first().unwrap_uint64())
+                .sorted()
+                .rev()
+                .next();
+
+            // Filter audit log catalog updates to those that are not present in the table.
+            audit_logs_iterator
+                .take_while(|(audit_log, _)| match max_table_id {
+                    Some(id) => audit_log.event.sortable_id() > id,
+                    None => true,
+                })
+                .map(|(audit_log, ts)| StateUpdate {
+                    kind: StateUpdateKind::AuditLog(audit_log),
+                    ts,
+                    diff: StateDiff::Addition,
+                })
+                .collect::<Vec<_>>()
+        })
     }
 
     /// Initializes all storage collections required by catalog objects in the storage controller.
@@ -3715,7 +3787,7 @@ pub fn serve(
         controller_config,
         controller_envd_epoch,
         mut storage,
-        audit_logs_handle,
+        audit_logs_iterator,
         timestamp_oracle_url,
         unsafe_mode,
         all_features,
@@ -4099,7 +4171,7 @@ pub fn serve(
                             builtin_table_updates,
                             cached_global_exprs,
                             uncached_local_exprs,
-                            audit_logs_handle,
+                            audit_logs_iterator,
                         )
                         .await?;
                     coord

--- a/src/environmentd/src/deployment/preflight.rs
+++ b/src/environmentd/src/deployment/preflight.rs
@@ -200,7 +200,7 @@ pub async fn preflight_0dt(
             .await
             .expect("incompatible catalog/persist version");
 
-            openable_adapter_storage
+            let (_catalog, _audit_logs) = openable_adapter_storage
                 .open(boot_ts, &bootstrap_args)
                 .await
                 .unwrap_or_terminate("unexpected error while fencing out old deployment");

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -544,19 +544,19 @@ impl Listeners {
         };
 
         // Load the adapter durable storage.
-        let (adapter_storage, audit_logs_handle) = if read_only {
+        let (adapter_storage, audit_logs_iterator) = if read_only {
             // TODO: behavior of migrations when booting in savepoint mode is
             // not well defined.
-            let (adapter_storage, audit_logs_handle) = openable_adapter_storage
+            let (adapter_storage, audit_logs_iterator) = openable_adapter_storage
                 .open_savepoint(boot_ts, &bootstrap_args)
                 .await?;
             // In read-only mode, we intentionally do not call `set_is_leader`,
             // because we are by definition not the leader if we are in
             // read-only mode.
 
-            (adapter_storage, audit_logs_handle)
+            (adapter_storage, audit_logs_iterator)
         } else {
-            let (adapter_storage, audit_logs_handle) = openable_adapter_storage
+            let (adapter_storage, audit_logs_iterator) = openable_adapter_storage
                 .open(boot_ts, &bootstrap_args)
                 .await?;
 
@@ -565,7 +565,7 @@ impl Listeners {
             // fenced out all other environments using the adapter storage.
             deployment_state.set_is_leader();
 
-            (adapter_storage, audit_logs_handle)
+            (adapter_storage, audit_logs_iterator)
         };
 
         // Enable Persist compaction if we're not in read only.
@@ -620,7 +620,7 @@ impl Listeners {
             controller_config: config.controller,
             controller_envd_epoch: envd_epoch,
             storage: adapter_storage,
-            audit_logs_handle,
+            audit_logs_iterator,
             timestamp_oracle_url: config.timestamp_oracle_url,
             unsafe_mode: config.unsafe_mode,
             all_features: config.all_features,


### PR DESCRIPTION
On startup the adapter reconciles the contents of most builtin tables
via the following procedure:

  1. Read in the updates from the relevant durable catalog collection.
  2. Generate builtin table updates from the updates.
  3. Read in the current contents of the builtin table.
  4. Generate builtin table retractions from the current contents.
  5. Consolidate the two sets of builtin tables updates.
  6. Append the consolidated builtin table updates to the builtin
     table.

The audit log is extremely large and deserializing all updates in step
(1) can take an extremely long time. Previously, this deserialization
was done in a background thread to try and hide some of the latency.

The audit log is append only and un-migratable, so the above process is
very wasteful. We know that most of the updates from step (1) will
cancel out with all updates from step (3) and we'll only be left with a
small amount of additions to the builtin table. In the common happy
case, they'll cancel out completely.

This commit special cases the reconciliation process for the audit log
so that it follows the following optimized procedure:

  1. Read in the audit log updates from the durable catalog, but don't
     deserialize any events.
  2. Read in the current contents of mz_audit_events.
  3. Sort mz_audit_events by ID and find the largest ID.
  4. Only deserialize the audit log updates from the durable catalog,
     that have an ID larger than the max ID.
  5. Generate builtin table updates from the deserialized updates.
  6. Append the updates to mz_audit_events.

Note: When/if we make the durable catalog shard queryable via SQL, then
we can remove the entire reconciliation process (including the contents
of this commit), which will be a huge win for startup times.

Works towards resolving #MaterializeInc/database-issues/issues/8384

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
