### PR TITLE
build(deps): bump aws-config version to v1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,9 +467,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a89e0000cde82447155d64eeb71720b933b4396a6fbbebad3f8b4f88ca7b54"
+checksum = "b2a4707646259764ab59fd9a50e9de2e92c637b28b36285d6f6fa030e915fbd9"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -592,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32fcc572fd5c58489ec205ec3e4e5f7d63018898a485cbf922a462af496bc300"
+checksum = "3d70fb493f4183f5102d8a8d0cc9b57aec29a762f55c0e7bf527e0f7177bb408"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6275fa8684a1192754221173b1f7a7c1260d6b0571cc2b8af09468eb0cffe5"
+checksum = "de3f37549b3e38b7ea5efd419d4d7add6ea1e55223506eb0b4fef9d25e7cc90d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30acd58272fd567e4853c5075d838be1626b59057e0249c9be5a1a7eb13bf70f"
+checksum = "3b2ff219a5d4b795cd33251c19dbe9c4b401f2b2cbe513e07c76ada644eaf34e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",

--- a/misc/cargo-vet/imports.lock
+++ b/misc/cargo-vet/imports.lock
@@ -22,6 +22,13 @@ user-id = 160111
 user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
 
+[[publisher.aws-config]]
+version = "1.2.1"
+when = "2024-04-22"
+user-id = 160111
+user-login = "aws-sdk-rust-ci"
+user-name = "AWS SDK Rust Bot"
+
 [[publisher.aws-credential-types]]
 version = "1.2.0"
 when = "2024-04-12"
@@ -50,6 +57,13 @@ user-id = 160111
 user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
 
+[[publisher.aws-sdk-sso]]
+version = "1.21.0"
+when = "2024-04-22"
+user-id = 160111
+user-login = "aws-sdk-rust-ci"
+user-name = "AWS SDK Rust Bot"
+
 [[publisher.aws-sdk-ssooidc]]
 version = "1.20.0"
 when = "2024-04-12"
@@ -57,9 +71,23 @@ user-id = 160111
 user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"
 
+[[publisher.aws-sdk-ssooidc]]
+version = "1.21.0"
+when = "2024-04-22"
+user-id = 160111
+user-login = "aws-sdk-rust-ci"
+user-name = "AWS SDK Rust Bot"
+
 [[publisher.aws-sdk-sts]]
 version = "1.20.0"
 when = "2024-04-12"
+user-id = 160111
+user-login = "aws-sdk-rust-ci"
+user-name = "AWS SDK Rust Bot"
+
+[[publisher.aws-sdk-sts]]
+version = "1.21.0"
+when = "2024-04-22"
 user-id = 160111
 user-login = "aws-sdk-rust-ci"
 user-name = "AWS SDK Rust Bot"

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -18,10 +18,10 @@ ahash = { version = "0.8.11" }
 aho-corasick = { version = "1.1.3" }
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 async-compression = { version = "0.4.5", default-features = false, features = ["gzip", "tokio", "zstd"] }
-aws-config = { version = "1.2.0", default-features = false, features = ["sso"] }
+aws-config = { version = "1.2.1", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.2.0", default-features = false, features = ["hardcoded-credentials", "test-util"] }
 aws-runtime = { version = "1.2.0", default-features = false, features = ["event-stream", "http-02x"] }
-aws-sdk-sts = { version = "1.20.0", default-features = false, features = ["rt-tokio"] }
+aws-sdk-sts = { version = "1.21.0", default-features = false, features = ["rt-tokio"] }
 aws-sigv4 = { version = "1.2.0", features = ["http0-compat", "sign-eventstream"] }
 aws-smithy-async = { version = "1.2.1", default-features = false, features = ["rt-tokio"] }
 aws-smithy-http = { version = "0.60.8", default-features = false, features = ["event-stream"] }
@@ -149,10 +149,10 @@ ahash = { version = "0.8.11" }
 aho-corasick = { version = "1.1.3" }
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 async-compression = { version = "0.4.5", default-features = false, features = ["gzip", "tokio", "zstd"] }
-aws-config = { version = "1.2.0", default-features = false, features = ["sso"] }
+aws-config = { version = "1.2.1", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.2.0", default-features = false, features = ["hardcoded-credentials", "test-util"] }
 aws-runtime = { version = "1.2.0", default-features = false, features = ["event-stream", "http-02x"] }
-aws-sdk-sts = { version = "1.20.0", default-features = false, features = ["rt-tokio"] }
+aws-sdk-sts = { version = "1.21.0", default-features = false, features = ["rt-tokio"] }
 aws-sigv4 = { version = "1.2.0", features = ["http0-compat", "sign-eventstream"] }
 aws-smithy-async = { version = "1.2.1", default-features = false, features = ["rt-tokio"] }
 aws-smithy-http = { version = "0.60.8", default-features = false, features = ["event-stream"] }


### PR DESCRIPTION
To get a newer idna library version, see https://rustsec.org/advisories/RUSTSEC-2024-0421

Noticed in https://buildkite.com/materialize/security/builds/1369

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
