### PR TITLE
Add some logging to debug timestamp selection for REFRESH MVs

### DIFF
--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -28,7 +28,7 @@ use mz_sql::session::metadata::SessionMetadata;
 use mz_storage_client::client::TimestamplessUpdate;
 use mz_timestamp_oracle::WriteTimestamp;
 use tokio::sync::{oneshot, Notify, OwnedMutexGuard, OwnedSemaphorePermit, Semaphore};
-use tracing::{debug_span, warn, Instrument, Span};
+use tracing::{debug_span, info, warn, Instrument, Span};
 
 use crate::catalog::BuiltinTableUpdate;
 use crate::coord::{Coordinator, Message, PendingTxn, PlanValidity};
@@ -520,6 +520,7 @@ impl Coordinator {
             .metrics
             .append_table_duration_seconds
             .with_label_values(&[]);
+        info!("Appending to tables at {timestamp}, advancing to {advance_to}");
         let append_fut = self
             .controller
             .storage

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -54,7 +54,7 @@ use mz_sql_parser::ast::{
 use mz_storage_types::sources::Timeline;
 use opentelemetry::trace::TraceContextExt;
 use tokio::sync::{mpsc, oneshot};
-use tracing::{debug_span, warn, Instrument};
+use tracing::{debug_span, info, warn, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::command::{
@@ -1149,6 +1149,7 @@ impl Coordinator {
                     warn!(%cmvs.name, %oracle_timestamp, %timestamp, "REFRESH MV's inputs are not readable at the oracle read ts");
                 }
 
+                info!("Resolved `mz_now()` to {timestamp} for REFRESH MV");
                 Ok(Some(timestamp))
             } else {
                 Ok(None)


### PR DESCRIPTION
Logging for https://github.com/MaterializeInc/database-issues/issues/8821
as discussed at
https://materializeinc.slack.com/archives/C0761MZ3QD9/p1733845868029119?thread_ts=1733597183.408179&cid=C0761MZ3QD9
so that we'll have more info the next time it happens in CI.

The placement of the log in `appends.rs` is @jkosh44's suggestion on Slack.

### Motivation

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
