### PR TITLE
gcs: explicitly set content-length to 0 for create multipart call

### DIFF
--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -796,6 +796,10 @@ impl S3Blob {
             .create_multipart_upload()
             .bucket(&self.bucket)
             .key(&path)
+            .customize()
+            .mutate_request(|req| {
+                req.headers_mut().insert("Content-Length", "0");
+            })
             .send()
             .instrument(debug_span!("s3set_multi_start"))
             .await

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -798,6 +798,10 @@ impl S3Blob {
             .key(&path)
             .customize()
             .mutate_request(|req| {
+                // By default the Rust AWS SDK does not set the Content-Length
+                // header on POST calls with empty bodies. This is fine for S3,
+                // but when running against GCS's S3 interop mode these calls
+                // will be rejected unless we set this header manually.
                 req.headers_mut().insert("Content-Length", "0");
             })
             .send()


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

The S3 `create_multipart_upload` call is a POST request, and it appears [GCP's load balancers require POST requests to have a `Content-Length` header](https://stackoverflow.com/questions/73903875/how-to-allow-empty-post-bodies-avoid-411) which is not being set by our AWS Rust SDK, so calls to GCS's S3 shim fail

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
