### PR TITLE
persist/adapter: Add Bytes codec

### DIFF
--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -192,6 +192,25 @@ impl SimpleColumnarData for Vec<u8> {
     }
 }
 
+impl SimpleColumnarData for Bytes {
+    type ArrowBuilder = BinaryBuilder;
+    type ArrowColumn = BinaryArray;
+
+    fn goodbytes(builder: &Self::ArrowBuilder) -> usize {
+        builder.values_slice().len()
+    }
+
+    fn push(&self, builder: &mut Self::ArrowBuilder) {
+        builder.append_value(&self)
+    }
+    fn push_null(builder: &mut Self::ArrowBuilder) {
+        builder.append_null()
+    }
+    fn read(&mut self, idx: usize, column: &Self::ArrowColumn) {
+        *self = Bytes::copy_from_slice(column.value(idx));
+    }
+}
+
 impl SimpleColumnarData for ShardId {
     type ArrowBuilder = StringBuilder;
     type ArrowColumn = StringArray;
@@ -333,6 +352,22 @@ impl Schema2<Vec<u8>> for VecU8Schema {
     }
 }
 
+impl Schema2<Bytes> for VecU8Schema {
+    type ArrowColumn = BinaryArray;
+    type Statistics = NoneStats;
+
+    type Decoder = SimpleColumnarDecoder<Bytes>;
+    type Encoder = SimpleColumnarEncoder<Bytes>;
+
+    fn encoder(&self) -> Result<Self::Encoder, anyhow::Error> {
+        Ok(SimpleColumnarEncoder::default())
+    }
+
+    fn decoder(&self, col: Self::ArrowColumn) -> Result<Self::Decoder, anyhow::Error> {
+        Ok(SimpleColumnarDecoder::new(col))
+    }
+}
+
 impl Codec for Vec<u8> {
     type Storage = ();
     type Schema = VecU8Schema;
@@ -350,6 +385,36 @@ impl Codec for Vec<u8> {
 
     fn decode<'a>(buf: &'a [u8], _schema: &VecU8Schema) -> Result<Self, String> {
         Ok(buf.to_owned())
+    }
+
+    fn encode_schema(_schema: &Self::Schema) -> Bytes {
+        Bytes::new()
+    }
+
+    fn decode_schema(buf: &Bytes) -> Self::Schema {
+        assert_eq!(*buf, Bytes::new());
+        VecU8Schema
+    }
+}
+
+impl Codec for Bytes {
+    type Storage = ();
+    type Schema = VecU8Schema;
+
+    fn codec_name() -> String {
+        // Intentionally the same as the `Vec<u8>` codec for compatibility.
+        "Vec<u8>".into()
+    }
+
+    fn encode<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        buf.put(self.into_iter().as_slice())
+    }
+
+    fn decode<'a>(buf: &'a [u8], _schema: &VecU8Schema) -> Result<Self, String> {
+        Ok(Bytes::copy_from_slice(buf))
     }
 
     fn encode_schema(_schema: &Self::Schema) -> Bytes {

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -24,6 +24,11 @@ use crate::columnar::{ColumnDecoder, ColumnEncoder, Schema2};
 use crate::stats::{ColumnStatKinds, ColumnarStats, NoneStats, StructStats};
 use crate::{Codec, Codec64, Opaque, ShardId};
 
+/// All codecs that are compatible with a blob of bytes use that same name. This allows us to
+/// switch between the codecs without any incompatibility errors. The name is chosen for historical
+/// reasons.
+const BYTES_CODEC_NAME: &str = "Vec<u8>";
+
 /// An implementation of [Schema2] for [()].
 #[derive(Debug, Default, PartialEq)]
 pub struct UnitSchema;
@@ -373,7 +378,7 @@ impl Codec for Vec<u8> {
     type Schema = VecU8Schema;
 
     fn codec_name() -> String {
-        "Vec<u8>".into()
+        BYTES_CODEC_NAME.into()
     }
 
     fn encode<B>(&self, buf: &mut B)
@@ -402,8 +407,7 @@ impl Codec for Bytes {
     type Schema = VecU8Schema;
 
     fn codec_name() -> String {
-        // Intentionally the same as the `Vec<u8>` codec for compatibility.
-        "Vec<u8>".into()
+        BYTES_CODEC_NAME.into()
     }
 
     fn encode<B>(&self, buf: &mut B)


### PR DESCRIPTION
This commit adds a native Bytes codec to persist and uses this codec
in the expression cache. While there's still a fair bit of copying in
the persist codec, persist callers can more easily pass around Bytes
and avoid copying byte vecs.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
