### PR TITLE
[persist] Improve our S3-related error reporting

### DIFF
--- a/src/persist/src/error.rs
+++ b/src/persist/src/error.rs
@@ -66,7 +66,8 @@ impl PartialEq for Error {
 
 impl From<ExternalError> for Error {
     fn from(e: ExternalError) -> Self {
-        Error::String(e.to_string())
+        // Print the chain of causes along with each error by default.
+        Error::String(format!("{e:#}"))
     }
 }
 

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -108,7 +108,11 @@ impl std::fmt::Display for Determinate {
     }
 }
 
-impl std::error::Error for Determinate {}
+impl std::error::Error for Determinate {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.inner.source()
+    }
+}
 
 impl Determinate {
     /// Return a new Determinate wrapping the given error.
@@ -142,7 +146,11 @@ impl std::fmt::Display for Indeterminate {
     }
 }
 
-impl std::error::Error for Indeterminate {}
+impl std::error::Error for Indeterminate {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.inner.source()
+    }
+}
 
 /// An impl of PartialEq purely for convenience in tests and debug assertions.
 #[cfg(any(test, debug_assertions))]
@@ -193,7 +201,14 @@ impl std::fmt::Display for ExternalError {
     }
 }
 
-impl std::error::Error for ExternalError {}
+impl std::error::Error for ExternalError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ExternalError::Determinate(e) => e.source(),
+            ExternalError::Indeterminate(e) => e.source(),
+        }
+    }
+}
 
 /// An impl of PartialEq purely for convenience in tests and debug assertions.
 #[cfg(any(test, debug_assertions))]


### PR DESCRIPTION
- Preserve the error chain when converting between error types
- Preserve the actual error types in our S3 binding (including causes!) instead of string-formatting it away.

### Motivation

This would have made https://github.com/MaterializeInc/materialize/pull/30795 trivial to diagnose.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
