### PR TITLE
Update rdkafka to remove a segfault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8458,7 +8458,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.29.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#727ae0719709276bf58a281a7fc4e50ac1c54dbc"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#c8d7ae601896af0efe9d737dfb0f84bea25b8518"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -8475,7 +8475,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "4.3.0+2.5.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#727ae0719709276bf58a281a7fc4e50ac1c54dbc"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#c8d7ae601896af0efe9d737dfb0f84bea25b8518"
 dependencies = [
  "cmake",
  "libc",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -991,18 +991,18 @@ version = "0.29.0@git:1e27332856a433235aeba7f82d46d06e3f646b69"
 [[audits.rdkafka]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
-version = "0.29.0@git:727ae0719709276bf58a281a7fc4e50ac1c54dbc"
-importable = false
-
-[[audits.rdkafka]]
-who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
-criteria = "safe-to-deploy"
 version = "0.29.0@git:80fffc098a94b81b20f1bb3713ac2f96e622b8e9"
 
 [[audits.rdkafka]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.29.0@git:843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
+
+[[audits.rdkafka]]
+who = "Jan Teske <jteske@posteo.net>"
+criteria = "safe-to-deploy"
+version = "0.29.0@git:c8d7ae601896af0efe9d737dfb0f84bea25b8518"
+importable = false
 
 [[audits.rdkafka]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
@@ -1030,9 +1030,9 @@ criteria = "safe-to-deploy"
 version = "4.3.0+2.4.0@git:f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
 
 [[audits.rdkafka-sys]]
-who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+who = "Jan Teske <jteske@posteo.net>"
 criteria = "safe-to-deploy"
-version = "4.3.0+2.5.0@git:727ae0719709276bf58a281a7fc4e50ac1c54dbc"
+version = "4.3.0+2.5.0@git:c8d7ae601896af0efe9d737dfb0f84bea25b8518"
 importable = false
 
 [[audits.redox_syscall]]

--- a/test/testdrive/kafka-recreate-topic.td
+++ b/test/testdrive/kafka-recreate-topic.td
@@ -88,10 +88,6 @@ $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
 
 $ kafka-create-topic topic=topic1 partitions=1
 
-# TODO: Reenable when database-issues#8823 is fixed
-$ skip-if
-SELECT true
-
 ! SELECT * FROM source1_tbl
 contains:topic was recreated: high watermark of partition 0 regressed from 1 to 0
 


### PR DESCRIPTION
This PR updates rdkafka to the latest commit available in our fork, to pull in https://github.com/MaterializeInc/librdkafka/pull/1, fixing a possible metadata cache corruption.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8823

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
