### PR TITLE
[typo fix] clean up join paths in LIR mapping

### DIFF
--- a/src/compute-types/src/plan/render_plan.rs
+++ b/src/compute-types/src/plan/render_plan.rs
@@ -877,7 +877,7 @@ impl<'a, T> std::fmt::Display for RenderPlanExprHumanizer<'a, T> {
 
                     write!(f, "{}", inputs[*source_relation])?;
                     for dsp in stage_plans {
-                        write!(f, "» {}", inputs[dsp.lookup_relation])?;
+                        write!(f, " » {}", inputs[dsp.lookup_relation])?;
                     }
 
                     Ok(())
@@ -889,7 +889,7 @@ impl<'a, T> std::fmt::Display for RenderPlanExprHumanizer<'a, T> {
                         write!(f, "[{}", inputs[dpp.source_relation])?;
 
                         for dsp in &dpp.stage_plans {
-                            write!(f, "» {}", inputs[dsp.lookup_relation])?;
+                            write!(f, " » {}", inputs[dsp.lookup_relation])?;
                         }
                         write!(f, "] ")?;
                     }

--- a/test/sqllogictest/introspection/attribution_sources.slt
+++ b/test/sqllogictest/introspection/attribution_sources.slt
@@ -57,7 +57,7 @@ SELECT global_id, lir_id, parent_lir_id, REPEAT(' ', nesting * 2) || operator AS
 GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
-u2  5  NULL  Join::Differential␠2»␠4
+u2  5  NULL  Join::Differential␠2␠»␠4
 u2  4  5  ␠␠Arrange␠3
 u2  3  4  ␠␠␠␠Get::Collection␠u1
 u2  2  5  ␠␠Arrange␠1
@@ -74,7 +74,7 @@ SELECT global_id, lir_id, parent_lir_id, repeat(' ', nesting * 2) || operator AS
 GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
-u2  5  NULL  Join::Differential␠2»␠4
+u2  5  NULL  Join::Differential␠2␠»␠4
 u2  4  5  ␠␠Arrange␠3
 u2  3  4  ␠␠␠␠Get::Collection␠u1
 u2  2  5  ␠␠Arrange␠1
@@ -140,7 +140,7 @@ SELECT global_id, lir_id, parent_lir_id, REPEAT(' ', nesting * 2) || operator AS
 GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
-t59  5  NULL  Join::Differential␠2»␠4
+t59  5  NULL  Join::Differential␠2␠»␠4
 t59  4  5  ␠␠Arrange␠3
 t59  3  4  ␠␠␠␠Get::Collection␠u4
 t59  2  5  ␠␠Arrange␠1
@@ -155,7 +155,7 @@ SELECT global_id, lir_id, parent_lir_id, REPEAT(' ', nesting * 2) || operator AS
 GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
-t59  5  NULL  Join::Differential␠2»␠4
+t59  5  NULL  Join::Differential␠2␠»␠4
 t59  4  5  ␠␠Arrange␠3
 t59  3  4  ␠␠␠␠Get::Collection␠u4
 t59  2  5  ␠␠Arrange␠1


### PR DESCRIPTION
The LIR mapping is missing a space in the way we display joins.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
