### PR TITLE
Fix balancerd tests

### DIFF
--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -100,6 +100,8 @@ SERVICES = [
             "--tls-cert=/secrets/balancerd.crt",
             "--default-config=balancerd_inject_proxy_protocol_header_http=true",
             "--internal-tls",
+            # Nonsensical but we don't need cancellations here
+            "--cancellation-resolver-dir=/secrets/",
         ],
         depends_on=["test-certs"],
         volumes=[
@@ -228,6 +230,8 @@ def workflow_plaintext(c: Composition) -> None:
                 "--tls-key=/secrets/balancerd.key",
                 "--tls-cert=/secrets/balancerd.crt",
                 "--default-config=balancerd_inject_proxy_protocol_header_http=true",
+                # Nonsensical but we don't need cancellations here
+                "--cancellation-resolver-dir=/secrets/",
             ],
             depends_on=["test-certs"],
             volumes=[

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1684,6 +1684,8 @@ SERVICES = [
             "--tls-key=/secrets/balancerd.key",
             "--tls-cert=/secrets/balancerd.crt",
             "--internal-tls",
+            # Nonsensical but we don't need cancellations here
+            "--cancellation-resolver-dir=/secrets",
         ],
         depends_on=["test-certs"],
         volumes=[


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/10667#0193b848-0b1d-44ea-9c8f-af671467f357

Follow-up to https://github.com/MaterializeInc/materialize/pull/30799
In our tests we have to pass both the cancellation-resolver-dir and frontegg-resolver-template.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
