### PR TITLE
Support disabling resource_id prefixing in Materialize CRD

### DIFF
--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -149,6 +149,10 @@ pub mod v1alpha1 {
         // The issuer_ref field is required.
         // This currently is only used for environmentd, but will eventually support clusterd.
         pub internal_certificate_spec: Option<MaterializeCertSpec>,
+        // Disable `mz{resource_id}-` prefixing of kubernetes objects.
+        // This will disable support for running multiple Materializes in a single namespace.
+        #[serde(default)]
+        pub disable_resource_id_prefixing: bool,
     }
 
     impl Materialize {
@@ -249,7 +253,11 @@ pub mod v1alpha1 {
         }
 
         pub fn name_prefixed(&self, suffix: &str) -> String {
-            format!("mz{}-{}", self.resource_id(), suffix)
+            if self.spec.disable_resource_id_prefixing {
+                suffix.to_owned()
+            } else {
+                format!("mz{}-{}", self.resource_id(), suffix)
+            }
         }
 
         pub fn resource_id(&self) -> &str {

--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -928,10 +928,12 @@ fn create_environmentd_statefulset_object(
         ));
     }
     if let Some(status) = &mz.status {
-        args.push(format!(
-            "--orchestrator-kubernetes-name-prefix=mz{}-",
-            status.resource_id
-        ));
+        if !mz.spec.disable_resource_id_prefixing {
+            args.push(format!(
+                "--orchestrator-kubernetes-name-prefix=mz{}-",
+                status.resource_id
+            ));
+        }
     }
 
     // Add logging and tracing arguments.


### PR DESCRIPTION
Support disabling resource_id prefixing with a new boolean field of the Materialize CRD.


### Motivation

This makes compatibility with our SaaS much easier. We currently don't prefix objects created by the environment-controller or region-controller. This prefixing is only needed to support multiple Materialize CRs in a single namespace, which we don't do in SaaS.

### Tips for reviewer

We have two options on the road to running orchestratord in place of the environment-controller:
1. Allow disabling resource_id prefixing.
2. Update the region-controller and environment-controller to be aware of the resource_id, and probably add extra logic for a migration from unprefixed resources to new prefixed ones.

Option (2) seems hard, but would be closer to what our customers run.

This PR is an implementation of option (1).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
