### PR TITLE
Only decode rows up to demand

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -367,6 +367,10 @@ where
     /// If `key` is set, this is a promise that `logic` will produce no results on
     /// records for which the key does not evaluate to the value. This is used to
     /// leap directly to exactly those records.
+    ///
+    /// The `max_demand` parameter limits the number of columns decoded from the
+    /// input. Only the first `max_demand` columns are decoded. Pass `usize::MAX` to
+    /// decode all columns.
     pub fn flat_map<D, I, L>(
         &self,
         key: Option<Row>,
@@ -597,6 +601,7 @@ where
                     panic!("The collection arranged by {:?} doesn't exist.", key)
                 });
                 if ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION.get(config_set) {
+                    // Decode all columns, pass max_demand as usize::MAX.
                     let (ok, err) = arranged.flat_map(None, usize::MAX, |borrow, t, r| {
                         Some((SharedRow::pack(borrow.iter()), t, r))
                     });
@@ -611,9 +616,8 @@ where
 
     /// Constructs and applies logic to elements of a collection and returns the results.
     ///
-    /// `constructor` takes a permutation and produces the logic to apply on elements. The logic
-    /// conceptually receives `(&Row, &Row)` pairs in the form of a slice. Only after borrowing
-    /// the elements and applying the permutation the datums will be in the expected order.
+    /// The function applies `logic` on elements. The logic conceptually receives
+    /// `(&Row, &Row)` pairs in the form of a datum vec in the expected order.
     ///
     /// If `key_val` is set, this is a promise that `logic` will produce no results on
     /// records for which the key does not evaluate to the value. This is used when we
@@ -621,6 +625,10 @@ where
     /// It is important that `logic` still guard against data that does not satisfy
     /// this constraint, as this method does not statically know that it will have
     /// that arrangement.
+    ///
+    /// The `max_demand` parameter limits the number of columns decoded from the
+    /// input. Only the first `max_demand` columns are decoded. Pass `usize::MAX` to
+    /// decode all columns.
     pub fn flat_map<D, I, L>(
         &self,
         key_val: Option<(Vec<MirScalarExpr>, Option<Row>)>,

--- a/src/repr/src/datum_vec.rs
+++ b/src/repr/src/datum_vec.rs
@@ -46,6 +46,18 @@ impl DatumVec {
         borrow.extend(row.iter());
         borrow
     }
+
+    /// Borrow an instance with a specific lifetime, and pre-populate with a `Row` with up to
+    /// `limit` elements.
+    pub fn borrow_with_limit<'a>(
+        &'a mut self,
+        row: &'a RowRef,
+        limit: usize,
+    ) -> DatumVecBorrow<'a> {
+        let mut borrow = self.borrow();
+        borrow.extend(row.iter().take(limit));
+        borrow
+    }
 }
 
 /// A borrowed allocation of `Datum` with a specific lifetime.

--- a/src/repr/src/datum_vec.rs
+++ b/src/repr/src/datum_vec.rs
@@ -48,7 +48,8 @@ impl DatumVec {
     }
 
     /// Borrow an instance with a specific lifetime, and pre-populate with a `Row` with up to
-    /// `limit` elements.
+    /// `limit` elements. If `limit` is greater than the number of elements in `row`, the borrow
+    /// will contain all elements of `row`.
     pub fn borrow_with_limit<'a>(
         &'a mut self,
         row: &'a RowRef,


### PR DESCRIPTION
Decode rows in rendering up to a demand limit.

Add functionality to only decode a relevant prefix of rows based on what a map-filter-project demands. This can skip some work if all relevant columns are at the beginning of a row.

The PR has the downside that performance improvement isn't uniform. If we're demanding all columns of a row, we have to do the same work as today. If we're demanding no columns, or a column at the front of a row, we have to do less work. I think this change is worthwhile because it improves queries that are either not on index keys, or during hydration.

A follow-up change should apply the same pattern to peeks.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
