### PR TITLE
DNM: Try to reproduce 8798

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1533,6 +1533,7 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-dedi-16cpu-64gb
+        parallelism: 20
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -223,7 +223,7 @@ class FetchAction(Action):
         )
         query = f"SUBSCRIBE {obj}"
         if self.rng.choice([True, False]):
-            envelope = "UPSERT" if self.rng.choice([True, False]) else "DEBEZIUM"
+            envelope = "UPSERT"
             columns = self.rng.sample(obj.columns, len(obj.columns))
             key = ", ".join(column.name(True) for column in columns)
             query += f" ENVELOPE {envelope} (KEY ({key}))"
@@ -1677,7 +1677,7 @@ class ZeroDowntimeDeployAction(Action):
                 DeploymentStatus.IS_LEADER, mz_service
             )
 
-        time.sleep(self.rng.uniform(60, 120))
+        time.sleep(60)
         return True
 
 
@@ -2197,7 +2197,7 @@ write_action_list = ActionList(
         (HttpPostAction, 5),
         (CommitRollbackAction, 10),
         (ReconnectAction, 1),
-        (SourceInsertAction, 5),
+        (SourceInsertAction, 500),
         (FlipFlagsAction, 2),
     ],
     autocommit=False,
@@ -2236,9 +2236,9 @@ ddl_action_list = ActionList(
         (CreateWebhookSourceAction, 2),
         (DropWebhookSourceAction, 2),
         (CreateKafkaSinkAction, 4),
-        (DropKafkaSinkAction, 4),
-        (CreateKafkaSourceAction, 4),
-        (DropKafkaSourceAction, 4),
+        (DropKafkaSinkAction, 0),
+        (CreateKafkaSourceAction, 100),
+        (DropKafkaSourceAction, 0),
         # TODO: Reenable when database-issues#8237 is fixed
         # (CreateMySqlSourceAction, 4),
         # (DropMySqlSourceAction, 4),

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -40,20 +40,20 @@ from materialize.util import naughty_strings
 
 MAX_COLUMNS = 5
 MAX_INCLUDE_HEADERS = 5
-MAX_ROWS = 50
+MAX_ROWS = 500
 MAX_CLUSTERS = 4
-MAX_CLUSTER_REPLICAS = 2
+MAX_CLUSTER_REPLICAS = 1
 MAX_DBS = 5
 MAX_SCHEMAS = 5
 MAX_TABLES = 5
 MAX_VIEWS = 15
 MAX_INDEXES = 15
 MAX_ROLES = 15
-MAX_WEBHOOK_SOURCES = 5
-MAX_KAFKA_SOURCES = 5
-MAX_MYSQL_SOURCES = 5
-MAX_POSTGRES_SOURCES = 5
-MAX_KAFKA_SINKS = 5
+MAX_WEBHOOK_SOURCES = 2
+MAX_KAFKA_SOURCES = 10
+MAX_MYSQL_SOURCES = 2
+MAX_POSTGRES_SOURCES = 2
+MAX_KAFKA_SINKS = 2
 
 MAX_INITIAL_DBS = 1
 MAX_INITIAL_SCHEMAS = 1
@@ -62,10 +62,10 @@ MAX_INITIAL_TABLES = 2
 MAX_INITIAL_VIEWS = 2
 MAX_INITIAL_ROLES = 1
 MAX_INITIAL_WEBHOOK_SOURCES = 1
-MAX_INITIAL_KAFKA_SOURCES = 1
+MAX_INITIAL_KAFKA_SOURCES = 10
 MAX_INITIAL_MYSQL_SOURCES = 1
 MAX_INITIAL_POSTGRES_SOURCES = 1
-MAX_INITIAL_KAFKA_SINKS = 1
+MAX_INITIAL_KAFKA_SINKS = 10
 
 NAUGHTY_IDENTIFIERS = False
 
@@ -567,7 +567,7 @@ class KafkaSink(DBObject):
             formats.extend(single_column_formats)
         self.format = rng.choice(formats)
         self.envelope = (
-            "UPSERT" if self.format == "JSON" else rng.choice(["DEBEZIUM", "UPSERT"])
+            "UPSERT" if self.format == "JSON" else rng.choice(["UPSERT"])
         )
         if self.envelope == "UPSERT" or rng.choice([True, False]):
             key_cols = [


### PR DESCRIPTION
Got it once locally:
```
services.log:parallel-workload-materialized-1     | 2024-12-12T20:10:07.450881459Z thread 'timely:work-1' panicked at src/storage/src/upsert/types.rs:751:30:
```
With this:
```
while true; do bin/mzcompose --find parallel-workload down && bin/mzcompose --find parallel-workload run default --runtime=1500 --scenario=0dt-deploy --threads=16 --seed=1732754241 ; bin/mzcompose --find parallel-workload logs >> services.log; mv services.log services-$(date +%s).log; done
```
Still took ~1 hour.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
