### PR TITLE
[persist] Remove some usage logic that depends on the writer id

### DIFF
--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -615,10 +615,7 @@ pub async fn unreferenced_blobs(args: &StateArgs) -> Result<impl serde::Serializ
     // versions are also considered live
     let minimum_version = WriterKey::for_version(&state_versions.cfg.build_version);
     for (part, writer) in all_parts {
-        let is_unreferenced = match writer {
-            WriterKey::Id(writer) => !known_writers.contains(&writer),
-            version @ WriterKey::Version(_) => version < minimum_version,
-        };
+        let is_unreferenced = writer < minimum_version;
         if is_unreferenced && !known_parts.contains(&part) {
             unreferenced_blobs.batch_parts.insert(part);
         }

--- a/src/persist-client/src/internal/paths.rs
+++ b/src/persist-client/src/internal/paths.rs
@@ -341,7 +341,21 @@ mod tests {
             BlobKey::parse_ids(&format!("{}/{}/{}", shard_id, writer_id, part_id)),
             Ok((
                 shard_id,
-                PartialBlobKey::Batch(WriterKey::Id(writer_id), part_id)
+                PartialBlobKey::Batch(WriterKey::Id(writer_id), part_id.clone())
+            ))
+        );
+
+        let version = Version::new(1, 0, 0);
+        assert_eq!(
+            BlobKey::parse_ids(&format!(
+                "{}/{}/{}",
+                shard_id,
+                WriterKey::for_version(&version),
+                part_id
+            )),
+            Ok((
+                shard_id,
+                PartialBlobKey::Batch(WriterKey::for_version(&version), part_id)
             ))
         );
 


### PR DESCRIPTION
### Motivation

Since we never write blobs with the writer id prefix anymore, all blobs with that prefix are either present in the state or leaked. Here we simplify some checks and update some tests to use the simpler writer key comparison.

(We're thinking about changing the writer key format yet again; nice to clean up some logic related to the old format before possibly adding another one!)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
