### PR TITLE
sql: add support for CREATE TABLE ... FROM WEBHOOK

### DIFF
--- a/misc/python/materialize/checks/all_checks/webhook.py
+++ b/misc/python/materialize/checks/all_checks/webhook.py
@@ -116,8 +116,11 @@ class Webhook(Check):
                 > SHOW CREATE SOURCE webhook_json
                 materialize.public.webhook_json "CREATE SOURCE \\"materialize\\".\\"public\\".\\"webhook_json\\" IN CLUSTER \\"webhook_cluster\\" FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS"
 
-                > SHOW CREATE SOURCE webhook_bytes
+                >[version<12800] SHOW CREATE SOURCE webhook_bytes
                 materialize.public.webhook_bytes "CREATE SOURCE \\"materialize\\".\\"public\\".\\"webhook_bytes\\" IN CLUSTER \\"webhook_cluster\\" FROM WEBHOOK BODY FORMAT BYTES"
+
+                >[version>=12800] SHOW CREATE SOURCE webhook_bytes
+                materialize.public.webhook_bytes "CREATE TABLE \\"materialize\\".\\"public\\".\\"webhook_bytes\\" FROM WEBHOOK BODY FORMAT BYTES"
            """
             )
         )

--- a/misc/python/materialize/checks/all_checks/webhook.py
+++ b/misc/python/materialize/checks/all_checks/webhook.py
@@ -29,7 +29,9 @@ class Webhook(Check):
 
                 > CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS;
 
-                > CREATE SOURCE webhook_bytes IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT BYTES;
+                >[version<12800] CREATE SOURCE webhook_bytes FROM WEBHOOK BODY FORMAT BYTES;
+
+                >[version>=12800] CREATE TABLE webhook_bytes FROM WEBHOOK BODY FORMAT BYTES;
 
                 $ webhook-append database=materialize schema=public name=webhook_text
                 fooä

--- a/src/sql-parser/tests/testdata/create
+++ b/src/sql-parser/tests/testdata/create
@@ -260,21 +260,21 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT J
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([]) }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([]) }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON ARRAY INCLUDE HEADERS
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON ARRAY INCLUDE HEADERS
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: true }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([]) }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: true }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([]) }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS ( 'x-signature' )
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS ('x-signature')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }]) }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }]) }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -283,7 +283,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS ('x-signature', 'event-timestamp')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: false, header_name: "event-timestamp" }]) }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: false, header_name: "event-timestamp" }]) }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -292,7 +292,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS ('x-signature', NOT 'event-timestamp', 'x-another-one')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: true, header_name: "event-timestamp" }, CreateWebhookSourceFilterHeader { block: false, header_name: "x-another-one" }]) }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: true, header_name: "event-timestamp" }, CreateWebhookSourceFilterHeader { block: false, header_name: "x-another-one" }]) }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -302,7 +302,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS ('x-signature', 'x-another-one', NOT 'x-auth', NOT 'x-authorization')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: false, header_name: "x-another-one" }, CreateWebhookSourceFilterHeader { block: true, header_name: "x-auth" }, CreateWebhookSourceFilterHeader { block: true, header_name: "x-authorization" }]) }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: false, header_name: "x-another-one" }, CreateWebhookSourceFilterHeader { block: true, header_name: "x-auth" }, CreateWebhookSourceFilterHeader { block: true, header_name: "x-authorization" }]) }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -313,7 +313,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADER 'x-timestamp' AS x_timestamp INCLUDE HEADER 'hash' AS hash BYTES INCLUDE HEADERS (NOT 'x-signature', 'x-another-one')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [CreateWebhookSourceMapHeader { header_name: "x-timestamp", column_name: Ident("x_timestamp"), use_bytes: false }, CreateWebhookSourceMapHeader { header_name: "hash", column_name: Ident("hash"), use_bytes: true }], column: Some([CreateWebhookSourceFilterHeader { block: true, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: false, header_name: "x-another-one" }]) }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [CreateWebhookSourceMapHeader { header_name: "x-timestamp", column_name: Ident("x_timestamp"), use_bytes: false }, CreateWebhookSourceMapHeader { header_name: "hash", column_name: Ident("hash"), use_bytes: true }], column: Some([CreateWebhookSourceFilterHeader { block: true, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: false, header_name: "x-another-one" }]) }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -323,7 +323,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADER 'x-signature' AS x_signature INCLUDE HEADER 'x-bytes' AS bytes BYTES
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [CreateWebhookSourceMapHeader { header_name: "x-signature", column_name: Ident("x_signature"), use_bytes: false }, CreateWebhookSourceMapHeader { header_name: "x-bytes", column_name: Ident("bytes"), use_bytes: true }], column: None }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [CreateWebhookSourceMapHeader { header_name: "x-signature", column_name: Ident("x_signature"), use_bytes: false }, CreateWebhookSourceMapHeader { header_name: "x-bytes", column_name: Ident("bytes"), use_bytes: true }], column: None }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -332,7 +332,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADER 'x-case-sensitive' AS "caseSensitive" BYTES
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [CreateWebhookSourceMapHeader { header_name: "x-case-sensitive", column_name: Ident("caseSensitive"), use_bytes: true }], column: None }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [CreateWebhookSourceMapHeader { header_name: "x-case-sensitive", column_name: Ident("caseSensitive"), use_bytes: true }], column: None }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -348,21 +348,21 @@ CREATE SOURCE IF NOT EXISTS webhook_text IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE IF NOT EXISTS webhook_text IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_text")]), if_not_exists: true, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_text")]), is_table: false, if_not_exists: true, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json_no_headers IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON
 ----
 CREATE SOURCE webhook_json_no_headers IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json_no_headers")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json_no_headers")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_bytes IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT BYTES
 ----
 CREATE SOURCE webhook_bytes IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT BYTES
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_bytes")]), if_not_exists: false, body_format: Bytes, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_bytes")]), is_table: false, if_not_exists: false, body_format: Bytes, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: None, in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_proto IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT PROTOBUF INCLUDE HEADERS
@@ -383,14 +383,14 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT J
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (headers['signature'] = 'test')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: None, using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: None, using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK ( headers['signature'] = hmac(sha256, 'body=' || body) )
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (headers['signature'] = hmac(sha256, 'body=' || body))
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: None, using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Function(Function { name: Name(UnresolvedItemName([Ident("hmac")])), args: Args { args: [Identifier([Ident("sha256")]), Op { op: Op { namespace: None, op: "||" }, expr1: Value(String("body=")), expr2: Some(Identifier([Ident("body")])) }], order_by: [] }, filter: None, over: None, distinct: false })) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: None, using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Function(Function { name: Name(UnresolvedItemName([Ident("hmac")])), args: Args { args: [Identifier([Ident("sha256")]), Op { op: Op { namespace: None, op: "||" }, expr1: Value(String("body=")), expr2: Some(Identifier([Ident("body")])) }], order_by: [] }, filter: None, over: None, distinct: false })) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -402,7 +402,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET test_key) headers['signature'] = 'test')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -417,7 +417,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET test_key, SECRET other_key) headers['signature'] = 'test')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: None, use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: None, use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -432,7 +432,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET test_key AS foo, SECRET other_key) headers['signature'] = 'test')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: Some(Ident("foo")), use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: Some(Ident("foo")), use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -462,7 +462,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET test_key AS bar, SECRET other_key) headers['signature'] = 'test')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: Some(Ident("bar")), use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: Some(Ident("bar")), use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -474,7 +474,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET bytes_key BYTES) headers['signature'] = bytes_key)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: None, use_bytes: true }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: None, use_bytes: true }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -486,7 +486,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET bytes_key AS bytes) headers['signature'] = bytes_key)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: Some(Ident("bytes")), use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: Some(Ident("bytes")), use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -498,7 +498,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET bytes_key AS bytes BYTES) headers['signature'] = bytes_key)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: Some(Ident("bytes")), use_bytes: true }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: Some(Ident("bytes")), use_bytes: true }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -510,7 +510,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET secret_key, SECRET other_key AS foo BYTES) headers['signature'] = bytes_key)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("secret_key")])), alias: None, use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: Some(Ident("foo")), use_bytes: true }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), is_table: false, if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("secret_key")])), alias: None, use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: Some(Ident("foo")), use_bytes: true }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -550,21 +550,21 @@ CREATE SOURCE webhook_no_cluster FROM WEBHOOK BODY FORMAT TEXT
 ----
 CREATE SOURCE webhook_no_cluster FROM WEBHOOK BODY FORMAT TEXT
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_no_cluster")]), if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: None, in_cluster: None })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_no_cluster")]), is_table: false, if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: None, in_cluster: None })
 
 parse-statement
 CREATE SOURCE webhook_include_headers_no_cluster FROM WEBHOOK BODY FORMAT TEXT INCLUDE HEADERS
 ----
 CREATE SOURCE webhook_include_headers_no_cluster FROM WEBHOOK BODY FORMAT TEXT INCLUDE HEADERS
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_include_headers_no_cluster")]), if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([]) }, validate_using: None, in_cluster: None })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_include_headers_no_cluster")]), is_table: false, if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([]) }, validate_using: None, in_cluster: None })
 
 parse-statement
 CREATE SOURCE webhook_validation_no_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK ( headers['signature'] = 'test' )
 ----
 CREATE SOURCE webhook_validation_no_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK (headers['signature'] = 'test')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_validation_no_cluster")]), if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: None, using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: None })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_validation_no_cluster")]), is_table: false, if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: None, using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: None })
 
 parse-statement
 CREATE SOURCE webhook_with_headers_and_body IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -576,7 +576,7 @@ CREATE SOURCE webhook_with_headers_and_body IN CLUSTER webhook_cluster FROM WEBH
 ----
 CREATE SOURCE webhook_with_headers_and_body IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK (WITH (HEADERS, BODY) headers['signature'] = body)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers_and_body")]), if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [], headers: [CreateWebhookSourceHeader { alias: None, use_bytes: false }], bodies: [CreateWebhookSourceBody { alias: None, use_bytes: false }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers_and_body")]), is_table: false, if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [], headers: [CreateWebhookSourceHeader { alias: None, use_bytes: false }], bodies: [CreateWebhookSourceBody { alias: None, use_bytes: false }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -588,7 +588,7 @@ CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK (WITH (HEADERS AS h1) headers['signature'] = body)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers")]), if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [], headers: [CreateWebhookSourceHeader { alias: Some(Ident("h1")), use_bytes: false }], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers")]), is_table: false, if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [], headers: [CreateWebhookSourceHeader { alias: Some(Ident("h1")), use_bytes: false }], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -600,7 +600,7 @@ CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK (WITH (HEADERS AS h1, SECRET my_secret) headers['signature'] = body)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers")]), if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("my_secret")])), alias: None, use_bytes: false }], headers: [CreateWebhookSourceHeader { alias: Some(Ident("h1")), use_bytes: false }], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers")]), is_table: false, if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("my_secret")])), alias: None, use_bytes: false }], headers: [CreateWebhookSourceHeader { alias: Some(Ident("h1")), use_bytes: false }], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -612,7 +612,7 @@ CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK (WITH (BODY, BODY AS b2 BYTES) headers['signature'] = body)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers")]), if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [], headers: [], bodies: [CreateWebhookSourceBody { alias: None, use_bytes: false }, CreateWebhookSourceBody { alias: Some(Ident("b2")), use_bytes: true }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers")]), is_table: false, if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [], headers: [], bodies: [CreateWebhookSourceBody { alias: None, use_bytes: false }, CreateWebhookSourceBody { alias: Some(Ident("b2")), use_bytes: true }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_with_headers_thrice IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -624,7 +624,7 @@ CREATE SOURCE webhook_with_headers_thrice IN CLUSTER webhook_cluster FROM WEBHOO
 ----
 CREATE SOURCE webhook_with_headers_thrice IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK (WITH (HEADERS AS headers_bytes BYTES, HEADERS AS other_headers, HEADERS) headers['signature'] = body)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers_thrice")]), if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [], headers: [CreateWebhookSourceHeader { alias: Some(Ident("headers_bytes")), use_bytes: true }, CreateWebhookSourceHeader { alias: Some(Ident("other_headers")), use_bytes: false }, CreateWebhookSourceHeader { alias: None, use_bytes: false }], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers_thrice")]), is_table: false, if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [], headers: [CreateWebhookSourceHeader { alias: Some(Ident("headers_bytes")), use_bytes: true }, CreateWebhookSourceHeader { alias: Some(Ident("other_headers")), use_bytes: false }, CreateWebhookSourceHeader { alias: None, use_bytes: false }], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -636,7 +636,7 @@ CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK (WITH (BODY AS b2 BYTES, SECRET kool_secret BYTES) headers['signature'] = body)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers")]), if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("kool_secret")])), alias: None, use_bytes: true }], headers: [], bodies: [CreateWebhookSourceBody { alias: Some(Ident("b2")), use_bytes: true }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers")]), is_table: false, if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("kool_secret")])), alias: None, use_bytes: true }], headers: [], bodies: [CreateWebhookSourceBody { alias: Some(Ident("b2")), use_bytes: true }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Some(Unresolved(Ident("webhook_cluster"))) })
 
 parse-statement
 CREATE SOURCE webhook_invalid_with IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -649,6 +649,25 @@ CREATE SOURCE webhook_invalid_with IN CLUSTER webhook_cluster FROM WEBHOOK
 error: Expected right parenthesis, found BODY
         WITH (SECRET kool_secret BODY)
                                  ^
+
+parse-statement
+CREATE TABLE my_webhook FROM WEBHOOK BODY FORMAT TEXT
+----
+CREATE TABLE my_webhook FROM WEBHOOK BODY FORMAT TEXT
+=>
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("my_webhook")]), is_table: true, if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: None, in_cluster: None })
+
+parse-statement
+CREATE TABLE webhook_with_headers FROM WEBHOOK
+    BODY FORMAT TEXT
+    CHECK (
+        WITH (SECRET kool_secret BYTES, BODY AS b2 BYTES)
+        headers['signature'] = body
+    )
+----
+CREATE TABLE webhook_with_headers FROM WEBHOOK BODY FORMAT TEXT CHECK (WITH (BODY AS b2 BYTES, SECRET kool_secret BYTES) headers['signature'] = body)
+=>
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers")]), is_table: true, if_not_exists: false, body_format: Text, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("kool_secret")])), alias: None, use_bytes: true }], headers: [], bodies: [CreateWebhookSourceBody { alias: Some(Ident("b2")), use_bytes: true }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: None })
 
 parse-statement
 CREATE DATABASE IF NOT EXISTS db

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -348,6 +348,7 @@ pub fn create_statement(
 
         Statement::CreateWebhookSource(CreateWebhookSourceStatement {
             name,
+            is_table: _,
             if_not_exists,
             include_headers: _,
             body_format: _,

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1213,7 +1213,6 @@ impl SystemVars {
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL,
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER,
             &USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION,
-            &ENABLE_CREATE_TABLE_FROM_SOURCE,
             &FORCE_SOURCE_TABLE_SYNTAX,
             &OPTIMIZER_E2E_LATENCY_WARNING_THRESHOLD,
         ];
@@ -2187,10 +2186,6 @@ impl SystemVars {
     /// Returns the `user_storage_managed_collections_batch_duration` configuration parameter.
     pub fn user_storage_managed_collections_batch_duration(&self) -> Duration {
         *self.expect_value(&USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION)
-    }
-
-    pub fn enable_create_table_from_source(&self) -> bool {
-        *self.expect_value(&ENABLE_CREATE_TABLE_FROM_SOURCE)
     }
 
     pub fn force_source_table_syntax(&self) -> bool {

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1525,13 +1525,6 @@ pub static NETWORK_POLICY: VarDefinition = VarDefinition::new_lazy(
     true,
 );
 
-pub static ENABLE_CREATE_TABLE_FROM_SOURCE: VarDefinition = VarDefinition::new(
-    "enable_create_table_from_source",
-    value!(bool; false),
-    "Whether to allow CREATE TABLE .. FROM SOURCE syntax.",
-    true,
-);
-
 pub static FORCE_SOURCE_TABLE_SYNTAX: VarDefinition = VarDefinition::new(
     "force_source_table_syntax",
     value!(bool; false),
@@ -2200,6 +2193,12 @@ feature_flags!(
     {
         name: enable_network_policies,
         desc: "ENABLE NETWORK POLICIES",
+        default: false,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_create_table_from_source,
+        desc: "Whether to allow CREATE TABLE .. FROM SOURCE syntax.",
         default: false,
         enable_for_item_parsing: true,
     },

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -83,7 +83,6 @@ transaction_isolation                    "strict serializable"   "Sets the curre
 unsafe_new_transaction_wall_time         ""                      "Sets the wall time for all new explicit or implicit transactions to control the value of `now()`. If not set, uses the system's clock."
 welcome_message                          on                      "Whether to send a notice with a welcome message after a successful connection (Materialize)."
 enable_consolidate_after_union_negate    on                      "consolidation after Unions that have a Negated input (Materialize)."
-enable_create_table_from_source          on                      "Whether to allow CREATE TABLE .. FROM SOURCE syntax."
 force_source_table_syntax                off                     "Force use of new source model (CREATE TABLE .. FROM SOURCE) and migrate existing sources"
 
 > SET application_name = 'foo'

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -540,3 +540,11 @@ SHOW cluster;
 
 > SELECT c.name = '${current-cluster}' FROM mz_clusters c JOIN mz_sources s ON c.id = s.cluster_id WHERE s.name = 'webhook_in_current';
 true
+
+> CREATE TABLE webhook_as_table FROM WEBHOOK BODY FORMAT TEXT;
+
+$ webhook-append name=webhook_as_table
+aaa_1
+
+> SELECT * FROM webhook_as_table;
+aaa_1


### PR DESCRIPTION
This PR implements support for the `CREATE TABLE ... FROM WEBHOOK` syntax which is needed for the larger "Source Versioning" project, if the `enable_create_table_from_source` feature flag is enabled. This change is purely adding support for parsing the syntax and nothing about planning or sequencing changes.

One oddity is `CREATE TABLE ... FROM SOURCE` does not support specifying `IN CLUSTER`, the dataflow that writes data into the table gets installed on the same cluster the `SOURCE` is installed on. Webhooks don't get installed on a cluster today so not supporting `CREATE TABLE ... FROM WEBHOOK IN CLUSTER ...` doesn't lose any functionality, but it is the one difference between this new and the existing syntax.

### Motivation

Closes https://github.com/MaterializeInc/database-issues/issues/8494

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
