### PR TITLE
Fix console port forward step

### DIFF
--- a/doc/user/content/self-managed/installation/install-on-local-kind.md
+++ b/doc/user/content/self-managed/installation/install-on-local-kind.md
@@ -24,7 +24,7 @@ The tutorial uses a local `kind` cluster and deploys the following components:
 
 {{< important >}}
 
-For testing purposes only. For testing purposes only.  For testing purposes only. ....
+For testing purposes only.
 
 {{< /important >}}
 
@@ -207,8 +207,17 @@ Check out the {{% self-managed/latest_version %}} tag.
       your service name for `mzlvmx9h6dpx-console`):
 
       ```shell
-      kubectl port-forward svc/mzlvmx9h6dpx-console 8080:8080 -n materialize-environment
+      while true;
+      do kubectl port-forward svc/mzlvmx9h6dpx-console 8080:8080 -n materialize-environment 2>&1 |
+      grep -q "portforward.go" && echo "Restarting port forwarding due to an error." || break;
+      done;
       ```
+      {{< note >}}
+      Due to a [known Kubernetes issue](https://github.com/kubernetes/kubernetes/issues/78446),
+      interrupted long-running requests through a standard port-forward cause the port forward to hang. The command above
+      automatically restarts the port forwarding if an error occurs, ensuring a more stable
+      connection. It detects failures by monitoring for "portforward.go" error messages.
+      {{< /note >}}
 
    1. Open a browser and navigate to
       [http://localhost:8080](http://localhost:8080).

--- a/doc/user/content/self-managed/installation/install-on-local-minikube.md
+++ b/doc/user/content/self-managed/installation/install-on-local-minikube.md
@@ -225,10 +225,12 @@ Check out the {{< self-managed/latest_version >}} tag.
       done;
       ```
       {{< note >}}
-Due to a [known Kubernetes issue](https://github.com/kubernetes/kubernetes/issues/78446),
-interrupted long-running requests through a standard port-forward cause the port forward to hang. The command above
-automatically restarts the port forwarding if an error occurs, ensuring a more stable
-connection. It detects failures by monitoring for "portforward.go" error messages.
+      Due to a [known Kubernetes
+      issue](https://github.com/kubernetes/kubernetes/issues/78446), interrupted
+      long-running requests through a standard port-forward cause the port
+      forward to hang. The command above automatically restarts the port
+      forwarding if an error occurs, ensuring a more stable connection. It
+      detects failures by monitoring for `"portforward.go"` error messages.
       {{< /note >}}
 
    1. Open a browser and navigate to

--- a/doc/user/content/self-managed/installation/install-on-local-minikube.md
+++ b/doc/user/content/self-managed/installation/install-on-local-minikube.md
@@ -23,7 +23,7 @@ cluster:
 
 {{< important >}}
 
-For testing purposes only. For testing purposes only.  For testing purposes only. ....
+For testing purposes only.
 
 {{< /important >}}
 
@@ -219,8 +219,17 @@ Check out the {{< self-managed/latest_version >}} tag.
    1. Forward the Materialize console service to your local machine:
 
       ```shell
-      kubectl port-forward service/mzk7x050omzi-console 8080:8080 -n materialize-environment
+      while true;
+      do kubectl port-forward svc/mzlvmx9h6dpx-console 8080:8080 -n materialize-environment 2>&1 |
+      grep -q "portforward.go" && echo "Restarting port forwarding due to an error." || break;
+      done;
       ```
+      {{< note >}}
+Due to a [known Kubernetes issue](https://github.com/kubernetes/kubernetes/issues/78446),
+interrupted long-running requests through a standard port-forward cause the port forward to hang. The command above
+automatically restarts the port forwarding if an error occurs, ensuring a more stable
+connection. It detects failures by monitoring for "portforward.go" error messages.
+      {{< /note >}}
 
    1. Open a browser and navigate to
       [https://localhost:8080](https://localhost:8080).

--- a/doc/user/layouts/shortcodes/note.html
+++ b/doc/user/layouts/shortcodes/note.html
@@ -1,3 +1,3 @@
 <div class="note">
-  <strong class="gutter">NOTE:</strong> {{ .Inner | $.Page.RenderString }}
+  <strong class="gutter">NOTE:</strong> {{ .Inner | replaceRE "^\\s+" "" | $.Page.RenderString }}
 </div>


### PR DESCRIPTION
We extend the existing port forward to retry on failure.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
  * This PR fixes a recognized bug.
Fixes https://github.com/MaterializeInc/console/issues/3582

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
