### PR TITLE
storage: retain counter statistics across epochs

### DIFF
--- a/test/cluster/storage/01-create-sources.td
+++ b/test/cluster/storage/01-create-sources.td
@@ -7,9 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# To ensure we get statistics in time
-$ set-sql-timeout duration=180s
-
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 ALTER SYSTEM SET kafka_default_metadata_fetch_interval = 1000
@@ -63,15 +60,15 @@ one
 
 > SELECT s.name,
   SUM(u.updates_committed) > 0,
-  SUM(u.messages_received),
+  SUM(u.messages_received) >= 2,
   SUM(u.offset_known),
   SUM(u.offset_committed)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
-remote1 true 2 1 1
-remote2 true 2 1 1
+remote1 true true 1 1
+remote2 true true 1 1
 
 > SELECT s.name,
   SUM(u.updates_committed)

--- a/test/cluster/storage/02-after-environmentd-restart.td
+++ b/test/cluster/storage/02-after-environmentd-restart.td
@@ -21,15 +21,15 @@ one
 # ensure after envd has restarted, we have maintained statistics.
 > SELECT s.name,
   SUM(u.updates_committed) > 0,
-  SUM(u.messages_received),
+  SUM(u.messages_received) >= 2,
   SUM(u.offset_known),
   SUM(u.offset_committed)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
-remote1 true 2 1 1
-remote2 true 2 1 1
+remote1 true true 1 1
+remote2 true true 1 1
 
 > SELECT s.name,
   SUM(u.updates_committed)
@@ -56,15 +56,15 @@ two
 # Ensure that offsets/counters can be updated correctly.
 > SELECT s.name,
   SUM(u.updates_committed) > 0,
-  SUM(u.messages_received),
+  SUM(u.messages_received) >= 4,
   SUM(u.offset_known),
   SUM(u.offset_committed)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
-remote1 true 4 2 2
-remote2 true 4 2 2
+remote1 true true 2 2
+remote2 true true 2 2
 
 > SELECT s.name,
   SUM(u.updates_committed)

--- a/test/testdrive/source-statistics.td
+++ b/test/testdrive/source-statistics.td
@@ -86,9 +86,6 @@ fish          fish    1000
 birdmore      geese   56
 mammalmore    moosemoose   2
 
-# statistics are only populated every minute by default
-$ set-sql-timeout duration=2minutes
-
 # Also test a source with multiple sub-sources.
 # NOTE: We give this source a unique name because we want to query for it with
 # a `SUBSCRIBE ... AS OF AT LEAST 0` below and want to avoid receiving results
@@ -103,26 +100,34 @@ $ set-sql-timeout duration=2minutes
 > CREATE TABLE organizations FROM SOURCE auction_house_in_source_statistics_td (REFERENCE organizations);
 > CREATE TABLE users FROM SOURCE auction_house_in_source_statistics_td (REFERENCE users);
 
-# NOTE: These queries are slow to succeed because the default metrics scraping
-# interval is 30 seconds.
-> SELECT s.name,
-  bool_and(u.snapshot_committed),
-  SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
+> SELECT
+      s.name,
+      bool_and(u.snapshot_committed),
+      SUM(u.messages_received) >= 4,
+      SUM(u.updates_staged),
+      SUM(u.updates_committed),
+      SUM(u.bytes_received) > 0,
+      bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('metrics_test_source')
   GROUP BY s.name
   ORDER BY s.name
-metrics_test_source true 4 2 2 true true
+metrics_test_source true true 2 2 true true
 
 > DROP SOURCE metrics_test_source CASCADE
 
 # Note that only the base-source has `messages_received`, but the sub-sources have `messages_committed`.
 # Committed will usually, for auction sources, add up to received, but we don't test this (right now) because of
 # jitter on when metrics are produced for each sub-source.
-> SELECT s.name,
-  bool_and(u.snapshot_committed),
-  SUM(u.messages_received) > 0, SUM(u.updates_staged) > 0, SUM(u.updates_committed) > 0, SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
+> SELECT
+      s.name,
+      bool_and(u.snapshot_committed),
+      SUM(u.messages_received) > 0,
+      SUM(u.updates_staged) > 0,
+      SUM(u.updates_committed) > 0,
+      SUM(u.bytes_received) > 0,
+      bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('accounts', 'auction_house_in_source_statistics_td', 'auctions', 'bids', 'organizations', 'users')
@@ -159,14 +164,14 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 # We can't control this, so have to accept the range.
 > SELECT
     s.name,
-    SUM(u.messages_received),
+    SUM(u.messages_received) >= 18,
     SUM(u.bytes_received) > 0
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
-upsert 18 true
+upsert true true
 
 # Upsert stats are on the UPSERT sub source/table, not the main source.
 > SELECT
@@ -206,14 +211,14 @@ $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} 
 {"key": "mammalmore"}
 
 > SELECT s.name,
-    SUM(u.messages_received),
+    SUM(u.messages_received) >= 20,
     SUM(u.bytes_received) > 0
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
-upsert 20 true
+upsert true true
 
 > SELECT t.name,
     bool_and(u.snapshot_committed),
@@ -231,12 +236,12 @@ upsert_tbl true "${updates-committed}" "${updates-committed}" true 2
 # check pre-aggregated view
 
 > SELECT s.name,
-    u.messages_received,
+    u.messages_received >= 20,
     u.bytes_received > 0
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
-upsert 20 true
+upsert true true
 
 > SELECT t.name,
     u.snapshot_committed,

--- a/test/testdrive/statistics-maintenance.td
+++ b/test/testdrive/statistics-maintenance.td
@@ -56,12 +56,12 @@ sink1 1 1 true true
 
 > SELECT s.name,
   SUM(u.updates_committed) > 0,
-  SUM(u.messages_received)
+  SUM(u.messages_received) >= 2
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
-upsert1 true 2
+upsert1 true true
 
 # Shut down the cluster
 > ALTER CLUSTER cluster1 SET (REPLICATION FACTOR = 0)
@@ -76,12 +76,12 @@ sink1 1 1 true true
 
 > SELECT s.name,
   SUM(u.updates_committed) > 0,
-  SUM(u.messages_received)
+  SUM(u.messages_received) >= 2
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
-upsert1 true 2
+upsert1 true true
 
 # Ingest some more data, and ensure counters are maintained
 
@@ -100,9 +100,9 @@ sink1 2 2 true true
 
 > SELECT s.name,
   SUM(u.updates_committed) > 0,
-  SUM(u.messages_received)
+  SUM(u.messages_received) >= 4
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
-upsert1 true 4
+upsert1 true true


### PR DESCRIPTION
Storage dataflows (computing sources and sinks) may be recreated for various reasons (ingestion errors, addition of new source exports, ALTER SINK, ...). When a storage dataflow is recreated, its statistics epoch is increased, as a means of differentiating statistics collected for the old dataflow instance from statistics collected for the new dataflow instance.

Prior to this change, increasing the epoch would reset all collected statistics and cause all in-flight statistics with the old epoch to be ignored. For gauge statistics that report a current point-in-time value this is the correct behavior as values emitted by the old dataflow might be wrong for the new dataflow. However, for counter statistics that keep track of the number of events of a certain type that have occurred so far, the behavior is less desirable. After all, the counted event did occur and not reporting it just because it raced with a dataflow restart can lead to confusing results. For example, we might report zero `updates_committed` for a source that clearly contains updates, because a new table was added in the time between when the updates were committed and when their statistics could be reported.

[The semantics of our counter statistics are weak enough to allow this kind of undercounting](https://materialize.com/docs/sql/system-catalog/mz_internal/#counter-metrics), but it is still annoying, both from a UX perspective and for writing tests that try to ensure the statistics collection is working as expected.

This PR attempts to improve things by ensuring that counter statistics are retained through epoch changes, rather than discarded. Gauge statistics are still cleared/reset as before.

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/database-issues/issues/7020
Removes a blocker for https://github.com/MaterializeInc/materialize/pull/30703

Making performance changes to the Kafka source changes how statistics race with dataflow restarts, which breaks tests because some counter statistics are now thrown away and reported as `0`.

### Tips for reviewer

I think mid-term we want to refactor the storage statistics code to be simpler. I didn't attempt this here because most of this will have to change anyway once we start tracking source/sink incarnations at the controller/protocol level (https://github.com/MaterializeInc/database-issues/issues/7066).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
