### PR TITLE
Fix most uses of deprecated clap configurations

### DIFF
--- a/src/balancerd/src/bin/balancerd.rs
+++ b/src/balancerd/src/bin/balancerd.rs
@@ -129,7 +129,7 @@ pub struct ServiceArgs {
     #[clap(
         long,
         env = "CONFIG_SYNC_TIMEOUT",
-        parse(try_from_str = humantime::parse_duration),
+        value_parser = humantime::parse_duration,
         default_value = "30s"
     )]
     config_sync_timeout: Duration,
@@ -140,7 +140,7 @@ pub struct ServiceArgs {
     #[clap(
         long,
         env = "CONFIG_SYNC_LOOP_INTERVAL",
-        parse(try_from_str = humantime::parse_duration),
+        value_parser = humantime::parse_duration,
     )]
     config_sync_loop_interval: Option<Duration>,
 

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -80,7 +80,7 @@ pub struct Args {
     /// An external ID to be supplied to all AWS AssumeRole operations.
     ///
     /// Details: <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>
-    #[clap(long, env = "AWS_EXTERNAL_ID", value_name = "ID", parse(from_str = AwsExternalIdPrefix::new_from_cli_argument_or_environment_variable))]
+    #[clap(long, env = "AWS_EXTERNAL_ID", value_name = "ID", value_parser = AwsExternalIdPrefix::new_from_cli_argument_or_environment_variable)]
     aws_external_id_prefix: Option<AwsExternalIdPrefix>,
 
     /// The ARN for a Materialize-controlled role to assume before assuming

--- a/src/cloud-resources/src/vpc_endpoint.rs
+++ b/src/cloud-resources/src/vpc_endpoint.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::BTreeMap;
+use std::convert::Infallible;
 use std::fmt::{self, Debug};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -48,8 +49,8 @@ impl AwsExternalIdPrefix {
     ///
     pub fn new_from_cli_argument_or_environment_variable(
         aws_external_id_prefix: &str,
-    ) -> AwsExternalIdPrefix {
-        AwsExternalIdPrefix(aws_external_id_prefix.into())
+    ) -> Result<AwsExternalIdPrefix, Infallible> {
+        Ok(AwsExternalIdPrefix(aws_external_id_prefix.into()))
     }
 }
 

--- a/src/clusterd/src/lib.rs
+++ b/src/clusterd/src/lib.rs
@@ -97,7 +97,7 @@ struct Args {
     /// An external ID to be supplied to all AWS AssumeRole operations.
     ///
     /// Details: <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>
-    #[clap(long, env = "AWS_EXTERNAL_ID", value_name = "ID", parse(from_str = AwsExternalIdPrefix::new_from_cli_argument_or_environment_variable))]
+    #[clap(long, env = "AWS_EXTERNAL_ID", value_name = "ID", value_parser = AwsExternalIdPrefix::new_from_cli_argument_or_environment_variable)]
     aws_external_id_prefix: Option<AwsExternalIdPrefix>,
 
     /// The ARN for a Materialize-controlled role to assume before assuming

--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -22,7 +22,7 @@ use std::time::{Duration, Instant};
 use std::{cmp, env, iter, thread};
 
 use anyhow::{bail, Context};
-use clap::{ArgEnum, Parser};
+use clap::{ArgAction, ArgEnum, Parser};
 use fail::FailScenario;
 use http::header::HeaderValue;
 use ipnet::IpNet;
@@ -177,8 +177,8 @@ pub struct Args {
     #[clap(
         long,
         env = "ANNOUNCE_EGRESS_ADDRESS",
-        multiple = true,
-        use_delimiter = true
+        action = ArgAction::Append,
+        use_value_delimiter = true
     )]
     announce_egress_address: Vec<IpNet>,
     /// The external host name to connect to the HTTP server of this
@@ -334,7 +334,7 @@ pub struct Args {
     #[clap(
         long,
         env = "AWS_SECRETS_CONTROLLER_TAGS",
-        multiple = true,
+        action = ArgAction::Append,
         value_delimiter = ';',
         required_if_eq("secrets-controller", "aws-secrets-manager")
     )]
@@ -398,14 +398,14 @@ pub struct Args {
     #[clap(
         long,
         env = "STORAGE_USAGE_COLLECTION_INTERVAL",
-        parse(try_from_str = humantime::parse_duration),
+        value_parser = humantime::parse_duration,
         default_value = "3600s"
     )]
     storage_usage_collection_interval_sec: Duration,
     /// The period for which to retain usage records. Note that the retention
     /// period is only evaluated at server start time, so rebooting the server
     /// is required to discard old records.
-    #[clap(long, env = "STORAGE_USAGE_RETENTION_PERIOD", parse(try_from_str = humantime::parse_duration))]
+    #[clap(long, env = "STORAGE_USAGE_RETENTION_PERIOD", value_parser = humantime::parse_duration)]
     storage_usage_retention_period: Option<Duration>,
 
     // === Adapter options. ===
@@ -449,7 +449,7 @@ pub struct Args {
     #[clap(
         long,
         env = "LAUNCHDARKLY_KEY_MAP",
-        multiple = true,
+        action = ArgAction::Append,
         value_delimiter = ';'
     )]
     launchdarkly_key_map: Vec<KeyValueArg<String, String>>,
@@ -457,7 +457,7 @@ pub struct Args {
     #[clap(
         long,
         env = "CONFIG_SYNC_TIMEOUT",
-        parse(try_from_str = humantime::parse_duration),
+        value_parser = humantime::parse_duration,
         default_value = "30s"
     )]
     config_sync_timeout: Duration,
@@ -469,7 +469,7 @@ pub struct Args {
     #[clap(
         long,
         env = "CONFIG_SYNC_LOOP_INTERVAL",
-        parse(try_from_str = humantime::parse_duration),
+        value_parser = humantime::parse_duration,
     )]
     config_sync_loop_interval: Option<Duration>,
     /// A scratch directory that can be used for ephemeral storage.
@@ -544,7 +544,7 @@ pub struct Args {
     #[clap(
         long,
         env = "SYSTEM_PARAMETER_DEFAULT",
-        multiple = true,
+        action = ArgAction::Append,
         value_delimiter = ';'
     )]
     system_parameter_default: Vec<KeyValueArg<String, String>>,
@@ -561,15 +561,15 @@ pub struct Args {
     /// Prefix for an external ID to be supplied to all AWS AssumeRole operations.
     ///
     /// Details: <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>
-    #[clap(long, env = "AWS_EXTERNAL_ID_PREFIX", value_name = "ID", parse(from_str = AwsExternalIdPrefix::new_from_cli_argument_or_environment_variable))]
+    #[clap(long, env = "AWS_EXTERNAL_ID_PREFIX", value_name = "ID", value_parser = AwsExternalIdPrefix::new_from_cli_argument_or_environment_variable)]
     aws_external_id_prefix: Option<AwsExternalIdPrefix>,
     /// The list of supported AWS PrivateLink availability zone ids.
     /// Must be zone IDs, of format e.g. "use-az1".
     #[clap(
         long,
         env = "AWS_PRIVATELINK_AVAILABILITY_ZONES",
-        multiple = true,
-        use_delimiter = true
+        action = ArgAction::Append,
+        use_value_delimiter = true
     )]
     aws_privatelink_availability_zones: Option<Vec<String>>,
 

--- a/src/mz/src/bin/mz/mixin.rs
+++ b/src/mz/src/bin/mz/mixin.rs
@@ -33,9 +33,9 @@ pub fn validate_profile_name(val: &str) -> Result<String, String> {
 #[derive(Debug, clap::Args)]
 pub struct EndpointArgs {
     /// Use the specified cloud endpoint.
-    #[clap(long, hidden = true, env = "CLOUD_ENDPOINT")]
+    #[clap(long, hide = true, env = "CLOUD_ENDPOINT")]
     pub cloud_endpoint: Option<Url>,
     /// Use the specified admin endpoint.
-    #[clap(long, hidden = true, env = "ADMIN_ENDPOINT")]
+    #[clap(long, hide = true, env = "ADMIN_ENDPOINT")]
     pub admin_endpoint: Option<Url>,
 }

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -134,7 +134,7 @@ pub struct TracingCliArgs {
         env = "OPENTELEMETRY_SCHED_DELAY",
         default_value = "5000ms",
         requires = "opentelemetry-endpoint",
-        parse(try_from_str = humantime::parse_duration)
+        value_parser = humantime::parse_duration,
     )]
     pub opentelemetry_sched_delay: Duration,
     /// The max time to attempt exporting a batch.
@@ -143,7 +143,7 @@ pub struct TracingCliArgs {
         env = "OPENTELEMETRY_MAX_EXPORT_TIMEOUT",
         default_value = "30s",
         requires = "opentelemetry-endpoint",
-        parse(try_from_str = humantime::parse_duration)
+        value_parser = humantime::parse_duration,
     )]
     pub opentelemetry_max_export_timeout: Duration,
     /// Export OpenTelemetry tracing events to the provided endpoint.
@@ -209,7 +209,7 @@ pub struct TracingCliArgs {
         long,
         env = "TOKIO_CONSOLE_PUBLISH_INTERVAL",
         requires = "tokio-console-listen-addr",
-        parse(try_from_str = humantime::parse_duration),
+        value_parser = humantime::parse_duration,
         default_value = "1s",
     )]
     pub tokio_console_publish_interval: Duration,
@@ -221,7 +221,7 @@ pub struct TracingCliArgs {
         long,
         env = "TOKIO_CONSOLE_RETENTION",
         requires = "tokio-console-listen-addr",
-        parse(try_from_str = humantime::parse_duration),
+        value_parser = humantime::parse_duration,
         default_value = "1h",
     )]
     pub tokio_console_retention: Duration,

--- a/src/persist-cli/src/open_loop.rs
+++ b/src/persist-cli/src/open_loop.rs
@@ -70,7 +70,7 @@ pub struct Args {
     benchmark_type: BenchmarkType,
 
     /// Runtime in a whole number of seconds
-    #[clap(long, parse(try_from_str = humantime::parse_duration), value_name = "S", default_value = "60s")]
+    #[clap(long, value_parser = humantime::parse_duration, value_name = "S", default_value = "60s")]
     runtime: Duration,
 
     /// How many records writers should emit per second.
@@ -86,7 +86,7 @@ pub struct Args {
     batch_size: usize,
 
     /// Duration between subsequent informational log outputs.
-    #[clap(long, parse(try_from_str = humantime::parse_duration), value_name = "L", default_value = "1s")]
+    #[clap(long, value_parser = humantime::parse_duration, value_name = "L", default_value = "1s")]
     logging_granularity: Duration,
 
     /// Id of the persist shard (for use in multi-process runs).

--- a/src/s3-datagen/src/main.rs
+++ b/src/s3-datagen/src/main.rs
@@ -30,7 +30,7 @@ struct Args {
     #[clap(
         short = 's',
         long,
-        parse(try_from_str = parse_object_size)
+        value_parser = parse_object_size,
     )]
     object_size: usize,
 

--- a/src/server-core/src/lib.rs
+++ b/src/server-core/src/lib.rs
@@ -523,7 +523,7 @@ pub struct TlsCliArgs {
     /// rejected.
     #[clap(
         long, env = "TLS_MODE",
-        possible_values = &["disable", "require"],
+        value_parser = ["disable", "require"],
         default_value = "disable",
         default_value_ifs = &[
             ("frontegg-tenant", None, Some("require")),

--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -17,6 +17,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use chrono::Utc;
+use clap::ArgAction;
 use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs};
 use mz_ore::cli::{self, CliConfig, KeyValueArg};
 use mz_ore::metrics::MetricsRegistry;
@@ -37,7 +38,7 @@ struct Args {
     /// If specified once, print summary for each source file.
     /// If specified twice, also show descriptions of each error.
     /// If specified thrice, also print each query before it is executed.
-    #[clap(short = 'v', long = "verbose", parse(from_occurrences))]
+    #[clap(short = 'v', long = "verbose", action = ArgAction::Count)]
     verbosity: usize,
     /// Don't exit with a failing code if not all queries are successful.
     #[clap(long)]
@@ -91,7 +92,7 @@ struct Args {
     #[clap(
         long,
         env = "SYSTEM_PARAMETER_DEFAULT",
-        multiple = true,
+        action = ArgAction::Append,
         value_delimiter = ';'
     )]
     system_parameter_default: Vec<KeyValueArg<String, String>>,

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -178,7 +178,8 @@ impl ConnectionContext {
             aws_external_id_prefix: Some(
                 AwsExternalIdPrefix::new_from_cli_argument_or_environment_variable(
                     "test-aws-external-id-prefix",
-                ),
+                )
+                .expect("infallible"),
             ),
             aws_connection_role_arn: Some(
                 "arn:aws:iam::123456789000:role/MaterializeConnection".into(),


### PR DESCRIPTION
Fixes most uses of deprecated clap configurations.

There is still one left that I don't know how to fix, where we add `MZ_` prefixes to all arg env vars, where we call `O::command().args_override_self(true)`. It is unclear to me what this does, or if it is safe to replace with the recommended `ArgAction::Set`. Some of our parsers use other `ArgAction`s, so that probably isn't safe.

### Motivation

We've been a major version behind for literal years now, and we can't upgrade without fixing these.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
