### PR TITLE
storage: fix rehydration latency on source restarts

### DIFF
--- a/src/storage/src/statistics.rs
+++ b/src/storage/src/statistics.rs
@@ -965,12 +965,18 @@ impl AggregatedStatistics {
     }
 
     /// Re-initialize a source. If it already exists, then its local epoch is advanced.
-    pub fn initialize_source<F: FnOnce() -> SourceStatistics>(&mut self, id: GlobalId, stats: F) {
+    pub fn initialize_source<F: FnOnce() -> SourceStatistics>(
+        &mut self,
+        id: GlobalId,
+        resume_upper: Antichain<Timestamp>,
+        stats: F,
+    ) {
         self.local_source_statistics
             .entry(id)
             .and_modify(|(ref mut epoch, ref mut stats)| {
                 *epoch += 1;
                 stats.reset_gauges();
+                stats.meta = SourceStatisticsMetadata::new(resume_upper);
             })
             .or_insert_with(|| (0, stats()));
 

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -633,9 +633,11 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 );
 
                 for (export_id, export) in ingestion_description.source_exports.iter() {
-                    self.storage_state
-                        .aggregated_statistics
-                        .initialize_source(*export_id, || {
+                    let resume_upper = resume_uppers[export_id].clone();
+                    self.storage_state.aggregated_statistics.initialize_source(
+                        *export_id,
+                        resume_upper.clone(),
+                        || {
                             SourceStatistics::new(
                                 *export_id,
                                 self.storage_state.timely_worker_index,
@@ -643,9 +645,10 @@ impl<'w, A: Allocate> Worker<'w, A> {
                                 ingestion_id,
                                 &export.storage_metadata.data_shard,
                                 export.data_config.envelope.clone(),
-                                resume_uppers[export_id].clone(),
+                                resume_upper,
                             )
-                        });
+                        },
+                    );
                 }
 
                 for id in ingestion_description.collection_ids() {

--- a/test/testdrive/github-8810.td
+++ b/test/testdrive/github-8810.td
@@ -1,0 +1,42 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/database-issues/issues/8810.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET storage_statistics_interval = '1s';
+ALTER SYSTEM SET storage_statistics_collection_interval = '1s';
+
+$ kafka-create-topic topic=data
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+
+> CREATE SOURCE src
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+
+> SELECT rehydration_latency < '5' FROM mz_internal.mz_source_statistics
+  JOIN mz_sources USING (id)
+  WHERE name = 'src'
+true
+
+# Wait for some time to ensure a regression would increase the rehydration
+# latency to a noticeable amount.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration="5s"
+
+> CREATE TABLE tbl FROM SOURCE src
+
+# Wait for the source statistics to be refreshed. This happens every 1s, so
+# waiting for 2s should be safe.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration="2s"
+
+> SELECT rehydration_latency < '5' FROM mz_internal.mz_source_statistics
+  JOIN mz_sources USING (id)
+  WHERE name = 'src'
+true


### PR DESCRIPTION
When a source dataflow is restarted, it's necessary to reset its source statistics metadata, to ensure the reported rehydration latency will be correct.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8810

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
