### PR TITLE
recursive CTEs have GA'd

### DIFF
--- a/doc/user/content/sql/select/recursive-ctes.md
+++ b/doc/user/content/sql/select/recursive-ctes.md
@@ -9,10 +9,6 @@ aliases:
   - /sql/recursive-ctes/
 ---
 
-{{< public-preview >}}
-Recursive CTEs using the `WITH MUTUALLY RECURSIVE` syntax
-{{</ public-preview >}}
-
 Recursive CTEs operate on the recursively-defined structures like trees or graphs implied from queries over your data.
 
 ## Syntax


### PR DESCRIPTION

### Motivation

Update the docs to reflect that fact that recursive CTE's have GA'd.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
