### PR TITLE
docs: update aws and gcp self-managed page with terraform instructions

### DIFF
--- a/doc/user/content/self-managed/_index.md
+++ b/doc/user/content/self-managed/_index.md
@@ -19,11 +19,7 @@ Kubernetes environment. For self-managed Materialize, Materialize offers:
 
 The self-managed Materialize requires the following:
 
-- Kubernetes (v1.19+) environment.
-
-- PostgreSQL or CockroachDB as a metadata database.
-
-- Blob storage.
+{{% self-managed/requirements-list %}}
 
 See the [Installation guide](/self-managed/installation/) for more information.
 

--- a/doc/user/content/self-managed/installation/_index.md
+++ b/doc/user/content/self-managed/installation/_index.md
@@ -5,16 +5,30 @@ robots: "noindex, nofollow"
 disable_list: true
 ---
 
+You can install self-managed Materialize on a Kubernetes cluster running locally
+or on a cloud provider.
+
 ## Install locally
 
-- [Install locally on kind](/self-managed/installation/install-on-local-kind/)
-
-- [Install locally on minikube](/self-managed/installation/install-on-local-minikube/)
+{{< multilinkbox >}}
+{{< linkbox title="Using Docker/kind" >}}
+[Install locally on kind](/self-managed/installation/install-on-local-kind/)
+{{</ linkbox >}}
+{{< linkbox  title="Using Docker/minikube" >}}
+[Install locally on minikube](/self-managed/installation/install-on-local-minikube/)
+{{</ linkbox >}}
+{{</ multilinkbox >}}
 
 ## Install on cloud provider
 
-- [Install on AWS](/self-managed/installation/install-on-aws/)
-- [Install on GCP](/self-managed/installation/install-on-gcp/)
+{{< multilinkbox >}}
+{{< linkbox title="AWS" >}}
+[Install on AWS](/self-managed/installation/install-on-aws/)
+{{</ linkbox >}}
+{{< linkbox title="GCP" >}}
+[Install on GCP](/self-managed/installation/install-on-gcp/)
+{{</ linkbox >}}
+{{</ multilinkbox >}}
 
 ## See also
 

--- a/doc/user/content/self-managed/installation/install-on-aws.md
+++ b/doc/user/content/self-managed/installation/install-on-aws.md
@@ -107,33 +107,12 @@ for evaluation purposes only. The module deploys a sample infrastructure on AWS
 
 
    ```bash
-   cluster_name      = "my-test-eks"
-   environment       = "my-test"
-   vpc_name          = "my-test-vpc"
-   bucket_name       = "my-test-bucket"
-   service_account_name = "my-test-materialize-svc"
-   db_identifier     = "my-test-db"
+
+   # resources are prefixed with ${namespace}-${environment}
+   namespace         = "enter-your-namespace"       # Enter a namespace
+   environment       = "enter-your-environment"     # Enter an environment name
    database_password = "enter-your-secure-password" # Enter a secure password
 
-   tags = {
-     Environment = "my-test"
-     Team        = "my-test-team"
-     Project     = "my-test-project"
-   }
-
-   node_group_ami_type       = "AL2023_ARM_64_STANDARD"
-   node_group_instance_types = ["r6g.2xlarge"]
-   node_group_desired_size   = 2
-   node_group_min_size       = 1
-   node_group_max_size       = 3
-
-   db_instance_class    = "db.t3.large"
-   db_allocated_storage = 20
-   db_multi_az          = false
-
-   enable_monitoring = false
-   metrics_retention_days = 0
-   enable_cluster_creator_admin_permissions = true
    ```
 
 1. Initialize the terraform directory.

--- a/doc/user/content/self-managed/installation/install-on-aws.md
+++ b/doc/user/content/self-managed/installation/install-on-aws.md
@@ -77,17 +77,9 @@ for evaluation purposes only. The module deploys a sample infrastructure on AWS
 
 {{< warning >}}
 
-The sample Terraform module is for **evaluation purposes only** and not intended
-for production use. It is provided to help you get started with Materialize for
-evaluation purposes only. Materialize does not support nor recommends this
-module for production use. Materialize does not guarantee tests for changes to
-the module.
+{{< self-managed/terraform-disclaimer >}}
 
-For simplicity, this tutorial stores your RDS PostgreSQL secret in a file. In
-practice, refer to your organization's official security and
-Terraform/infrastructure practices.
-
-{{< /important >}}
+{{< /warning >}}
 
 1. Clone or download the [Materialize's sample Terraform
    repo](https://github.com/MaterializeInc/terraform-aws-materialize).
@@ -184,12 +176,16 @@ Terraform/infrastructure practices.
    - `materialize_s3_role_arn` (Used during [B. Install the Materialize
      Operator](#b-install-the-materialize-operator))
 
-   - `database_endpoint` (Used during [C. Install
-     Materialize](#c-install-materialize))
-
    - `persist_backend_url` (Used during [C. Install
      Materialize](#c-install-materialize))
 
+   - `metadata_backend_url` (Used during [C. Install
+     Materialize](#c-install-materialize)). You can get the connection strings by running the
+     following command:
+
+     ```bash
+     terraform output -json metadata_backend_url | jq
+     ```
 
 1. Configure `kubectl` to connect to your EKS cluster, replacing:
 
@@ -312,9 +308,7 @@ To deploy Materialize:
 
 1. {{< warning>}}
 
-   For simplicity, this tutorial stores your RDS Postgres secret in a file. In
-   practice, refer to your organization's official security and Terraform/infrastructure
-   practices.
+   {{< self-managed/terraform-disclaimer >}}
 
    {{< /warning >}}
 
@@ -330,23 +324,18 @@ To deploy Materialize:
       namespace: materialize-environment
     stringData:
       persist_backend_url: "your-persist-backend-url"
-      metadata_backend_url: "postgres://db_user:db_password@database_endpoint/db_name?sslmode=require"
+      metadata_backend_url: "your-metadata-backend-url"
     ```
 
     - For `your-persist-backend-url`, set to the value from the [Terraform
       output](#terraform-output).
 
-    - For `your-metadata-backend-url`, update with your values:
+    - For `your-metadata-backend-url`, set to the value from the [Terraform
+      output](#terraform-output).
 
-      - Default `db_user` is `materialize`,
-      - `db_password` is the value you specified in the `terraform.tfvars` file.
-      - `database_endpoint` is the value from the [Terraform
-        output](#terraform-output).
-      - Default `db_name` is `materialize`.
-
-        {{< tip >}}
-        URL encode your database password.
-        {{< /tip >}}
+      {{< tip >}}
+      You may need to URL encode your database password.
+      {{< /tip >}}
 
 1. Create a YAML file `my-materialize.yaml` for your Materialize
    configuration.

--- a/doc/user/content/self-managed/installation/install-on-aws.md
+++ b/doc/user/content/self-managed/installation/install-on-aws.md
@@ -367,7 +367,7 @@ To deploy Materialize:
      name: "${var.service_account_name}"
      namespace: materialize-environment
    spec:
-     environmentdImageRef: materialize/environmentd:latest
+     environmentdImageRef: materialize/environmentd:v0.127.0
      environmentdResourceRequirements:
        limits:
          memory: 16Gi

--- a/doc/user/content/self-managed/installation/install-on-aws.md
+++ b/doc/user/content/self-managed/installation/install-on-aws.md
@@ -130,7 +130,7 @@ Terraform/infrastructure practices.
    }
 
    node_group_ami_type       = "AL2023_ARM_64_STANDARD"
-   node_group_instance_types = ["r6g.medium"]
+   node_group_instance_types = ["r6g.2xlarge"]
    node_group_desired_size   = 2
    node_group_min_size       = 1
    node_group_max_size       = 3
@@ -237,8 +237,8 @@ Terraform/infrastructure practices.
 
 1. Check out the {{% self-managed/latest_version %}} tag.
 
-1. Create a `my-materialize-values.yaml` configuration file for the Materialize
-   operator. Update with:
+1. Create a `my-materialize-operator-values.yaml` configuration file for the
+   Materialize operator. Update with:
 
    - your region,
 
@@ -248,7 +248,7 @@ Terraform/infrastructure practices.
      output](#terraform-output) for the `materialize_s3_role_arn`.)
 
       ```yaml
-      # my-materialize-values.yaml
+      # my-materialize-operator-values.yaml
 
       operator:
         cloudProvider:
@@ -281,11 +281,11 @@ Terraform/infrastructure practices.
    for details.
 
 1. Install the Materialize operator `materialize-operator`, specifying the path
-   to your `my-materialize-values.yaml` file:
+   to your `my-materialize-operator-values.yaml` file:
 
    ```shell
    helm install materialize-operator misc/helm-charts/operator \
-      -f my-materialize-values.yaml  \
+      -f my-materialize-operator-values.yaml  \
       --namespace materialize --create-namespace
    ```
 

--- a/doc/user/content/self-managed/installation/install-on-aws.md
+++ b/doc/user/content/self-managed/installation/install-on-aws.md
@@ -237,7 +237,7 @@ for evaluation purposes only. The module deploys a sample infrastructure on AWS
       ```
 
    For production, if you have [opted for locally-attached storage](/self-managed/operational-guidelines/#locally-attached-nvme-storage-openebs),
-   include the storage configuration your configuration file.  See the
+   include the storage configuration in your configuration file.  See the
    [Locally-attached NVMe storage
    (OpenEBS)](/self-managed/operational-guidelines/#locally-attached-nvme-storage-openebs)
    for details.
@@ -279,13 +279,7 @@ To deploy Materialize:
 
 <a name="deploy-materialize-secrets"></a>
 
-1. {{< warning>}}
-
-   {{< self-managed/terraform-disclaimer >}}
-
-   {{< /warning >}}
-
-   For your backend configuration, create a file
+1. For your backend configuration, create a file
    `materialize-backend-secret.yaml` for your [Kubernetes
    Secret](https://kubernetes.io/docs/concepts/configuration/secret/).
 

--- a/doc/user/content/self-managed/installation/install-on-aws.md
+++ b/doc/user/content/self-managed/installation/install-on-aws.md
@@ -312,7 +312,7 @@ To deploy Materialize:
 
    {{< /warning >}}
 
-1. For your backend configuration, create a file
+   For your backend configuration, create a file
    `materialize-backend-secret.yaml` for your [Kubernetes
    Secret](https://kubernetes.io/docs/concepts/configuration/secret/).
 

--- a/doc/user/content/self-managed/installation/install-on-aws.md
+++ b/doc/user/content/self-managed/installation/install-on-aws.md
@@ -4,7 +4,16 @@ description: ""
 robots: "noindex, nofollow"
 ---
 
-The following tutorial deploys Materialize onto AWS.
+Self-managed Materialize requires:
+
+- A Kubernetes (v1.19+) environment.
+
+- PostgreSQL or CockroachDB as a metadata database.
+
+- Blob storage.
+
+The tutorial deploys Materialize to AWS Elastic Kubernetes Service (EKS) with a
+PostgreSQL RDS database as the metadata database and AWS S3 for blob storage.
 
 {{< important >}}
 
@@ -14,115 +23,206 @@ For testing purposes only. For testing purposes only. For testing purposes only.
 
 ## Prerequisites
 
-### AWS Kubernetes environment
-
-When operating in AWS, we recommend:
-
-- Using the `r7gd` and `r6gd` families of instances (and `r8gd` once available)
-  when running with local disk
-
-- Using the `r8g`, `r7g`, and `r6g` families when running without local disk
-
-[//]: # "TODO: Add Terraform and non-Terraform instructions here (tabbed)."
-
-Materialize provides a [sampleTerraform
-module](https://github.com/MaterializeInc/terraform-aws-materialize/blob/main/README.md)
-to deploy a sample infrastructure on AWS with the following components:
-
-- EKS component
-- Networking component
-- Storage component
-- Database component for metadata storage
-
-See the
-[README](https://github.com/MaterializeInc/terraform-aws-materialize/blob/main/README.md)
-for information on how to deploy the infrastructure.
-
-### `kubectl`
-
-Install `kubectl` and configure cluster access. For details, see the [Amazon EKS
-documentation](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html).
-
-Configure `kubectl` to connect to your EKS cluster, replacing
-`<your-region>` with the region of your EKS cluster:
-
-```bash
-aws eks update-kubeconfig --name materialize-cluster --region <your-region>
-```
-
-{{< note >}}
-
-The exact authentication method may vary depending on your EKS configuration.
-
-{{< /note >}}
-
-To verify, run the following command:
-
-```bash
-kubectl get nodes
-```
-
-For help with `kubectl` commands, see [kubectl Quick
-reference](https://kubernetes.io/docs/reference/kubectl/quick-reference/).
-
 ### Helm 3.2.0+
 
 If you don't have Helm version 3.2.0+ installed, refer to the [Helm
 documentation](https://helm.sh/docs/intro/install/).
 
+### AWS CLI
 
-## A. Install the Materialize Operator
+If you do not have the AWS CLI installed,
 
-1. If installing for the first time, create a namespace. The default
-   configuration uses the `materialize` namespace.
+- Install the AWS CLI. For details, see the [AWS
+  documentation](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html).
+
+- Configure with your AWS credentials. For details, see the [AWS
+  documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+
+### AWS Kubernetes environment
+
+- A Kubernetes (v1.19+) environment.
+
+- PostgreSQL or CockroachDB as a metadata database.
+
+- Blob storage.
+
+When operating in AWS, we recommend:
+
+- Using the `r8g`, `r7g`, and `r6g` families when running without local disk.
+
+- Using the `r7gd` and `r6gd` families of instances (and `r8gd` once available)
+  when running with local disk (Recommended for production.  See [Operational guidelines](/self-managed/operational-guidelines/#locally-attached-nvme-storage-openebs) for more information.)
+
+See [A. Set up AWS Kubernetes environment](#a-set-up-aws-kubernetes-environment)
+for details.
+
+## A. Set up AWS Kubernetes environment
+
+{{< tabs  >}}
+
+{{< tab "Terraform" >}}
+
+Materialize provides a [sample Terraform
+module](https://github.com/MaterializeInc/terraform-aws-materialize/blob/main/README.md)
+for evaluation purposes only. The module deploys a sample infrastructure on AWS
+with the following components:
+
+- EKS component
+- Networking component
+- Storage component (S3 for blob storage)
+- Database component for metadata storage (PostgreSQL RDS)
+
+{{< warning >}}
+
+The sample Terraform module is for **evaluation purposes only** and not intended
+for production use. It is provided to help you get started with Materialize for
+evaluation purposes only. Materialize does not support nor recommends this
+module for production use. Materialize does not guarantee tests for changes to
+the module.
+
+For simplicity, this tutorial stores your RDS Postgres secret in a file. In
+practice, refer to your organization's official security and
+Terraform/infrastructure practices.
+
+{{< /important >}}
+
+1. If you do not have Terraform installed, [install
+   Terraform](https://developer.hashicorp.com/terraform/install?product_intent=terraform).
+
+1. Clone or download the [Materialize's sample Terraform
+   repo](https://github.com/MaterializeInc/terraform-aws-materialize).
+
+1. Go to the Materialize Terraform repo directory.
 
    ```bash
-   kubectl create namespace materialize
+   cd terraform-aws-materialize
    ```
 
-1. Create a `my-AWS-values.yaml` configuration file for the Materialize
-   operator. Update with details from your AWS Kubernetes environment. For more
-   information on cloud provider configuration, see the [Materialize Operator
-   Configuration](/self-managed/configuration/#operator-parameters).
+1. Copy the `terraform.tfvars.example` file to `terraform.tfvars`.
 
-      ```yaml
-      # my-AWS-values.yaml
-      # Note: Updated with recent config changes in main branch and not v0.125.2 branch
+   ```bash
+   cp terraform.tfvars.example terraform.tfvars
+   ```
 
-      operator:
-        args:
-          startupLogFilter: INFO
-        cloudProvider:
-          providers:
-            aws:
-              accountID:  "<your-aws-account-id>"
-              enabled: true
-              iam:
-                roles:
-                  connection: null
-                  environment: null
-          region: "<your-aws-region>"
-          type: "aws"
+1. Edit the `terraform.tfvars` file to set the values for your AWS environment.
+   In particular,
 
-      namespace:
-        create: false
-        name: "materialize"
+   - set your `database_password` to a secure password.
+   - set your `node_group_ami_type` to a `"AL2023_ARM_64_STANDARD"`.
+   - set your `node_group_instance_types` to a supported instance type for
+     ARM64.
 
-      # Adjust network policies as needed
-      networkPolicies:
-        enabled: true
-        egress:
-          enabled: true
-          cidrs: ["0.0.0.0/0"]
-        ingress:
-          enabled: true
-          cidrs: ["0.0.0.0/0"]
-        internal:
-          enabled: true
+
+
+   ```bash
+   cluster_name      = "my-test-eks"
+   environment       = "my-test"
+   vpc_name          = "my-test-vpc"
+
+   bucket_name       = "my-test-bucket"
+   db_identifier     = "my-test-db"
+   database_password = "enter-your-secure-password"
+
+   tags = {
+     Environment = "my-test"
+     Team        = "my-test-team"
+     Project     = "my-test-project"
+   }
+
+   node_group_ami_type       = "AL2023_ARM_64_STANDARD"
+   node_group_instance_types = ["r6g.medium"]
+   node_group_desired_size   = 3
+   node_group_min_size       = 2
+   node_group_max_size       = 5
+
+   db_instance_class    = "db.t3.large"
+   db_allocated_storage = 20
+   db_multi_az          = false
+
+   enable_cluster_creator_admin_permissions = true
+   ```
+
+1. Initialize the terraform directory.
+
+    ```bash
+    terraform init
+    ```
+
+1. Create a terraform plan and review the changes.
+
+    ```bash
+    terraform plan -out my-plan.tfplan
+    ```
+
+1. If you are satisfied with the changes, apply the terraform plan.
+
+    ```bash
+    terraform apply my-plan.tfplan
+    ```
+
+   <a name="terraform-output"></a>
+   Upon successful completion, various fields and their values are output:
+
+   ```bash
+   ...
+
+   Apply complete! Resources: 71 added, 0 changed, 0 destroyed.
+
+   Outputs:
+   database_endpoint = "my-test-db.abcdefg8dsto.us-east-1.rds.amazonaws.com:5432"
+   eks_cluster_endpoint = "https://0123456789A00BCD000E11BE12345A01.gr7.us-east-1.eks.amazonaws.com"
+   materialize_s3_role_arn = "arn:aws:iam::000111222333:role/my-test-materialize-s3-role"
+   metadata_backend_url = <sensitive>
+   oidc_provider_arn = "arn:aws:iam::000111222333:oidc-provider/oidc.eks. us-east-1.amazonaws.com/id/0123456789A00BCD000E11BE12345A01"
+   persist_backend_url = "s3://my-test-bucket/ my-test:serviceaccount:materialize-environment:12345678-1234-1234-1234-1234 56789012"
+   s3_bucket_name = "my-test-bucket"
+   vpc_id = "vpc-0abc000bed1d111bd"
+   ```
+
+1. Note your specific values for the following fields:
+
+   - `materialize_s3_role_arn` (Used during [B. Install the Materialize
+     Operator](#b-install-the-materialize-operator))
+
+   - `database_endpoint` (Used during [C. Install
+     Materialize](#c-install-materialize))
+
+   - `persist_backend_url` (Used during [C. Install
+     Materialize](#c-install-materialize))
+
+
+1. If you do not have `kubectl` installed,
+
+   - Install `kubectl`. See the [Amazon EKS: install `kubectl`
+     documentation](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html).
+
+   - Configure `kubectl` to  connect to your EKS cluster, replacing:
+
+      - `<your-cluster-name>` with the name of your EKS cluster (specified in
+        `terraform.tfvars`)
+
+      - `<your-region>` with the region of your EKS cluster
+
+      ```bash
+      aws eks update-kubeconfig --name <your-cluster-name> --region <your-region>
       ```
 
-   For production, if you have [opted for locally-attached storage](/self-managed/operational-guidelines/#locally-attached-nvme-storage-openebs),
-   include the storage configuration your configuration file.  See the [Locally-attached NVMe storage (OpenEBS)](/self-managed/operational-guidelines/#locally-attached-nvme-storage-openebs)
+      To verify that you have configured correctly, run the following command:
+
+      ```bash
+      kubectl get nodes
+      ```
+
+   For help with `kubectl` commands, see [kubectl Quick
+   reference](https://kubernetes.io/docs/reference/kubectl/quick-reference/).
+
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+
+## B. Install the Materialize Operator
 
 1. Clone/download the [Materialize
    repo](https://github.com/MaterializeInc/materialize).
@@ -133,32 +233,99 @@ documentation](https://helm.sh/docs/intro/install/).
    cd materialize
    ```
 
-1. Install the Materialize operator with the release name
-   `my-materialize-operator`, specifying the path to your `my-AWS-values.yaml`
-   file:
+1. Check out the {{% self-managed/latest_version %}} tag.
+
+1. Create a `my-materialize-values.yaml` configuration file for the Materialize
+   operator. Update with:
+
+   - your region,
+
+   - your AWS Account ID, and
+
+   - your `materialize_s3_role_arn`. (Refer to your [Terraform
+     output](#terraform-output) for the `materialize_s3_role_arn`.)
+
+      ```yaml
+      # my-materialize-values.yaml
+
+      operator:
+        cloudProvider:
+          type: "aws"
+          region: "<your-aws-region>" # e.g. us-west-2
+          providers:
+            aws:
+              enabled: true
+              accountID: "<your-aws-account-id>" # e.g. 123456789012
+              iam:
+                roles:
+                  environment: "<your-materialize-s3-role-arn>" # e.g. arn:aws:iam::123456789012:role/materialize-s3-role
+      networkPolicies:
+        enabled: true
+        egress:
+          enabled: true
+          cidrs: ["0.0.0.0/0"]
+        ingress:
+          enabled: true
+            cidrs: ["0.0.0.0/0"]
+          internal:
+            enabled: true
+
+      ```
+
+   For production, if you have [opted for locally-attached storage](/self-managed/operational-guidelines/#locally-attached-nvme-storage-openebs),
+   include the storage configuration your configuration file.  See the
+   [Locally-attached NVMe storage
+   (OpenEBS)](/self-managed/operational-guidelines/#locally-attached-nvme-storage-openebs)
+   for details.
+
+1. Install the Materialize operator `materialize-operator`, specifying the path
+   to your `my-materialize-values.yaml` file:
 
    ```shell
-   helm install my-materialize-operator -f path/to/my-AWS-values.yaml materialize/misc/helm-charts/operator
+   helm install materialize-operator misc/helm-charts/operator \
+      -f my-materialize-values.yaml  \
+      --namespace materialize --create-namespace
    ```
 
-1. Verify the installation:
+1. Verify the installation and check the status:
 
     ```shell
     kubectl get all -n materialize
     ```
 
-## B. Install Materialize
+    Wait for the components to be in the `Running` state:
+
+    ```none
+    NAME                                        READY   STATUS    RESTARTS   AGE
+    pod/materialize-operator-84ff4b4648-brjhl   1/1     Running   0          12s
+
+    NAME                                   READY   UP-TO-DATE   AVAILABLE   AGE
+    deployment.apps/materialize-operator   1/1     1            1           12s
+
+    NAME                                              DESIRED   CURRENT   READY   AGE
+    replicaset.apps/materialize-operator-84ff4b4648   1         1         1       12s
+    ```
+
+    If you run into an error during deployment, refer to the
+    [Troubleshooting](/self-hosted/troubleshooting) guide.
+
+## C. Install Materialize
 
 To deploy Materialize:
 
-1. Create a [Kubernetes
-   Secret](https://kubernetes.io/docs/concepts/configuration/secret/) for your
-   backend configuration information and save in a file (e.g.,
-   `materialize-backend-secret.yaml`).
+<a name="deploy-materialize-secrets"></a>
 
-   Replace `${terraform_output.metadata_backend_url}` and
-   `{terraform_output.persist_backend_url}` with the actual values from the
-   Terraform output.
+1. {{< warning>}}
+
+   For simplicity, this tutorial stores your RDS Postgres secret in a file. In
+   practice, refer to your organization's official security and Terraform/infrastructure
+   practices.
+
+   {{< /warning >}}
+
+1. For your backend configuration, create a file
+   `materialize-backend-secret.yaml` for your [Kubernetes
+   Secret](https://kubernetes.io/docs/concepts/configuration/secret/).
 
     ```yaml
     apiVersion: v1
@@ -167,16 +334,31 @@ To deploy Materialize:
       name: materialize-backend
       namespace: materialize-environment
     stringData:
-      metadata_backend_url: "${terraform_output.metadata_backend_url}"
-      persist_backend_url: "${terraform_output.persist_backend_url}"
+      metadata_backend_url: "postgres://db_user:db_password@database_endpoint/db_name?sslmode=require"
+      persist_backend_url: "your-persist-backend-url"
     ```
 
-1. Create a YAML file (e.g., `my-materialize.yaml`) for your Materialize
+    - For `your-metadata-backend-url`, update with your values:
+
+      - Default `db_user` is `materialize`,
+      - `db_password` is the value you specified in the `terraform.tfvars` file.
+      - `database_endpoint` is the value from the [Terraform
+        output](#terraform-output).
+      - Default `db_name` is `materialize`.
+
+      {{< tip >}}
+      URL encode your database password.
+      {{< /tip >}}
+
+
+    - For `your-persist-backend-url`, set to the value from the [Terraform
+      output](#terraform-output).
+
+1. Create a YAML file `my-materialize.yaml` for your Materialize
    configuration.
 
    Replace `${var.service_account_name}` with the the desired name for your
-   Materialize. It should be a UUID (e.g.,
-   `12345678-1234-1234-1234-123456789012`).
+   Materialize.
 
    ```yaml
    apiVersion: materialize.cloud/v1alpha1
@@ -210,12 +392,79 @@ To deploy Materialize:
    kubectl apply -f my-materialize.yaml
    ```
 
-1. Verify the installation:
+1. Verify the installation and check the status:
 
    ```bash
-   kubectl get materializes -n materialize-environment
-   kubectl get pods -n materialize-environment
+   kubectl get all -n materialize-environment
    ```
+
+   Wait for the components to be in the `Running` state.
+
+   ```none
+   NAME                                             READY   STATUS    RESTARTS   AGE
+   pod/mzm3otrsfcv7-balancerd-59454965d4-jjw4c      1/1     Running   0          37s
+   pod/mzm3otrsfcv7-cluster-s1-replica-s1-gen-1-0   1/1     Running   0          43s
+   pod/mzm3otrsfcv7-cluster-s2-replica-s2-gen-1-0   1/1     Running   0          43s
+   pod/mzm3otrsfcv7-cluster-s3-replica-s3-gen-1-0   1/1     Running   0          43s
+   pod/mzm3otrsfcv7-cluster-u1-replica-u1-gen-1-0   1/1     Running   0          42s
+   pod/mzm3otrsfcv7-console-68b5cddfbf-xvs97        1/1     Running   0          30s
+   pod/mzm3otrsfcv7-console-68b5cddfbf-z5zml        1/1     Running   0          30s
+   pod/mzm3otrsfcv7-environmentd-1-0                1/1     Running   0          47s
+
+   NAME                                               TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                                        AGE
+   service/mzm3otrsfcv7-balancerd                     ClusterIP   None         <none>        6876/TCP,6875/TCP                              37s
+   service/mzm3otrsfcv7-cluster-s1-replica-s1-gen-1   ClusterIP   None         <none>        2100/TCP,2103/TCP,2101/TCP,2102/TCP,6878/TCP   43s
+   service/mzm3otrsfcv7-cluster-s2-replica-s2-gen-1   ClusterIP   None         <none>        2100/TCP,2103/TCP,2101/TCP,2102/TCP,6878/TCP   43s
+   service/mzm3otrsfcv7-cluster-s3-replica-s3-gen-1   ClusterIP   None         <none>        2100/TCP,2103/TCP,2101/TCP,2102/TCP,6878/TCP   43s
+   service/mzm3otrsfcv7-cluster-u1-replica-u1-gen-1   ClusterIP   None         <none>        2100/TCP,2103/TCP,2101/TCP,2102/TCP,6878/TCP   43s
+   service/mzm3otrsfcv7-console                       ClusterIP   None         <none>        8080/TCP                                       30s
+   service/mzm3otrsfcv7-environmentd                  ClusterIP   None         <none>        6875/TCP,6876/TCP,6877/TCP,6878/TCP            38s
+   service/mzm3otrsfcv7-environmentd-1                ClusterIP   None         <none>        6875/TCP,6876/TCP,6877/TCP,6878/TCP            47s
+   service/mzm3otrsfcv7-persist-pubsub-1              ClusterIP   None         <none>        6879/TCP                                       47s
+
+   NAME                                     READY   UP-TO-DATE   AVAILABLE   AGE
+   deployment.apps/mzm3otrsfcv7-balancerd   1/1     1            1           38s
+   deployment.apps/mzm3otrsfcv7-console     2/2     2            2           30s
+
+   NAME                                                DESIRED   CURRENT   READY   AGE
+   replicaset.apps/mzm3otrsfcv7-balancerd-59454965d4   1         1         1       37s
+   replicaset.apps/mzm3otrsfcv7-console-68b5cddfbf     2         2         2       30s
+
+   NAME                                                        READY   AGE
+   statefulset.apps/mzm3otrsfcv7-cluster-s1-replica-s1-gen-1   1/1     43s
+   statefulset.apps/mzm3otrsfcv7-cluster-s2-replica-s2-gen-1   1/1     43s
+   statefulset.apps/mzm3otrsfcv7-cluster-s3-replica-s3-gen-1   1/1     43s
+   statefulset.apps/mzm3otrsfcv7-cluster-u1-replica-u1-gen-1   1/1     43s
+   statefulset.apps/mzm3otrsfcv7-environmentd-1                1/1     47s
+   ```
+
+1. Open the Materialize console in your browser:
+
+   1. From the previous `kubectl` output, find the Materialize console service.
+
+      ```none
+      NAME                           TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
+      service/mzm3otrsfcv7-console   ClusterIP   None         <none>        8080/TCP   30s
+      ```
+
+   1. Forward the Materialize console service to your local machine (substitute
+      your service name for `mzm3otrsfcv7-console`):
+
+      ```shell
+      while true;
+      do kubectl port-forward svc/mzm3otrsfcv7-console 8080:8080 -n materialize-environment 2>&1 |
+      grep -q "portforward.go" && echo "Restarting port forwarding due to an error." || break;
+      done;
+      ```
+      {{< note >}}
+      Due to a [known Kubernetes issue](https://github.com/kubernetes/kubernetes/issues/78446),
+      interrupted long-running requests through a standard port-forward cause the port forward to hang. The command above
+      automatically restarts the port forwarding if an error occurs, ensuring a more stable
+      connection. It detects failures by monitoring for "portforward.go" error messages.
+      {{< /note >}}
+
+   1. Open a browser and navigate to
+      [http://localhost:8080](http://localhost:8080).
 
 ## Troubleshooting
 
@@ -238,6 +487,8 @@ kubectl get pv
 kubectl get pvc -A
 ```
 
+See also [Troubleshooting](/self-hosted/troubleshooting).
+
 ## Cleanup
 
 Delete the Materialize environment:
@@ -256,6 +507,12 @@ up:
 ```bash
 kubectl delete namespace materialize
 kubectl delete namespace materialize-environment
+```
+
+In your Terraform directory, run:
+
+```bash
+terraform destroy
 ```
 
 ## See also

--- a/doc/user/content/self-managed/installation/install-on-aws.md
+++ b/doc/user/content/self-managed/installation/install-on-aws.md
@@ -6,11 +6,7 @@ robots: "noindex, nofollow"
 
 Self-managed Materialize requires:
 
-- A Kubernetes (v1.19+) environment.
-
-- PostgreSQL or CockroachDB as a metadata database.
-
-- Blob storage.
+{{% self-managed/requirements-list %}}
 
 The tutorial deploys Materialize to AWS Elastic Kubernetes Service (EKS) with a
 PostgreSQL RDS database as the metadata database and AWS S3 for blob storage.
@@ -23,10 +19,10 @@ For testing purposes only. For testing purposes only. For testing purposes only.
 
 ## Prerequisites
 
-### Helm 3.2.0+
+### Terraform
 
-If you don't have Helm version 3.2.0+ installed, refer to the [Helm
-documentation](https://helm.sh/docs/intro/install/).
+If you don't have Terraform installed, [install
+Terraform](https://developer.hashicorp.com/terraform/install?product_intent=terraform).
 
 ### AWS CLI
 
@@ -38,13 +34,20 @@ If you do not have the AWS CLI installed,
 - Configure with your AWS credentials. For details, see the [AWS
   documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
 
+### kubectl
+
+If you do not have `kubectl`, install. See the [Amazon EKS: install `kubectl`
+documentation](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html)
+for details.
+
+### Helm 3.2.0+
+
+If you do not have Helm 3.2.0+, install. See the [Helm
+documentation](https://helm.sh/docs/intro/install/).
+
 ### AWS Kubernetes environment
 
-- A Kubernetes (v1.19+) environment.
-
-- PostgreSQL or CockroachDB as a metadata database.
-
-- Blob storage.
+{{% self-managed/requirements-list %}}
 
 When operating in AWS, we recommend:
 
@@ -54,7 +57,7 @@ When operating in AWS, we recommend:
   when running with local disk (Recommended for production.  See [Operational guidelines](/self-managed/operational-guidelines/#locally-attached-nvme-storage-openebs) for more information.)
 
 See [A. Set up AWS Kubernetes environment](#a-set-up-aws-kubernetes-environment)
-for details.
+for a sample setup.
 
 ## A. Set up AWS Kubernetes environment
 
@@ -80,14 +83,11 @@ evaluation purposes only. Materialize does not support nor recommends this
 module for production use. Materialize does not guarantee tests for changes to
 the module.
 
-For simplicity, this tutorial stores your RDS Postgres secret in a file. In
+For simplicity, this tutorial stores your RDS PostgreSQL secret in a file. In
 practice, refer to your organization's official security and
 Terraform/infrastructure practices.
 
 {{< /important >}}
-
-1. If you do not have Terraform installed, [install
-   Terraform](https://developer.hashicorp.com/terraform/install?product_intent=terraform).
 
 1. Clone or download the [Materialize's sample Terraform
    repo](https://github.com/MaterializeInc/terraform-aws-materialize).
@@ -191,32 +191,26 @@ Terraform/infrastructure practices.
      Materialize](#c-install-materialize))
 
 
-1. If you do not have `kubectl` installed,
+1. Configure `kubectl` to connect to your EKS cluster, replacing:
 
-   - Install `kubectl`. See the [Amazon EKS: install `kubectl`
-     documentation](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html).
+   - `<your-cluster-name>` with the name of your EKS cluster (specified in
+     `terraform.tfvars`)
 
-   - Configure `kubectl` to  connect to your EKS cluster, replacing:
+   - `<your-region>` with the region of your EKS cluster. By default, the
+     sample Terraform module uses `us-east-1`.
 
-      - `<your-cluster-name>` with the name of your EKS cluster (specified in
-        `terraform.tfvars`)
+   ```bash
+   aws eks update-kubeconfig --name <your-cluster-name> --region <your-region>
+   ```
 
-      - `<your-region>` with the region of your EKS cluster. By default, the
-        sample Terraform module uses `us-east-1`.
+   To verify that you have configured correctly, run the following command:
 
-      ```bash
-      aws eks update-kubeconfig --name <your-cluster-name> --region <your-region>
-      ```
-
-      To verify that you have configured correctly, run the following command:
-
-      ```bash
-      kubectl get nodes
-      ```
+   ```bash
+   kubectl get nodes
+   ```
 
    For help with `kubectl` commands, see [kubectl Quick
    reference](https://kubernetes.io/docs/reference/kubectl/quick-reference/).
-
 
 {{< /tab >}}
 
@@ -514,7 +508,6 @@ kubectl delete namespace materialize-environment
 ```
 
 In your Terraform directory, run:
-
 
 ```bash
 terraform destroy

--- a/doc/user/content/self-managed/installation/install-on-aws.md
+++ b/doc/user/content/self-managed/installation/install-on-aws.md
@@ -11,12 +11,6 @@ Self-managed Materialize requires:
 The tutorial deploys Materialize to AWS Elastic Kubernetes Service (EKS) with a
 PostgreSQL RDS database as the metadata database and AWS S3 for blob storage.
 
-{{< important >}}
-
-For testing purposes only. For testing purposes only. For testing purposes only. ....
-
-{{< /important >}}
-
 ## Prerequisites
 
 ### Terraform
@@ -70,10 +64,10 @@ module](https://github.com/MaterializeInc/terraform-aws-materialize/blob/main/RE
 for evaluation purposes only. The module deploys a sample infrastructure on AWS
 (region `us-east-1`) with the following components:
 
-- EKS component
-- Networking component
-- Storage component (S3 for blob storage)
-- Database component for metadata storage (PostgreSQL RDS)
+- A Kuberneted (EKS) cluster
+- A dedicated VPC
+- An S3 for blob storage
+- An RDS PostgreSQL cluster and database for metadata storage
 
 {{< warning >}}
 

--- a/doc/user/content/self-managed/installation/install-on-aws.md
+++ b/doc/user/content/self-managed/installation/install-on-aws.md
@@ -266,9 +266,9 @@ Terraform/infrastructure practices.
           cidrs: ["0.0.0.0/0"]
         ingress:
           enabled: true
-            cidrs: ["0.0.0.0/0"]
-          internal:
-            enabled: true
+          cidrs: ["0.0.0.0/0"]
+        internal:
+          enabled: true
 
       ```
 

--- a/doc/user/content/self-managed/installation/install-on-aws.md
+++ b/doc/user/content/self-managed/installation/install-on-aws.md
@@ -515,11 +515,18 @@ kubectl delete namespace materialize-environment
 
 In your Terraform directory, run:
 
+
 ```bash
 terraform destroy
 ```
 
 When prompted, type `yes` to confirm the deletion.
+
+{{< tip>}}
+To delete your S3 bucket, you may need to empty the S3 bucket first.  If the
+`terraform destroy` command fails because the S3 bucket is not empty, empty the
+S3 bucket first and rerun the `terraform destroy` command.
+{{</ tip >}}
 
 ## See also
 

--- a/doc/user/content/self-managed/installation/install-on-aws.md
+++ b/doc/user/content/self-managed/installation/install-on-aws.md
@@ -131,14 +131,16 @@ Terraform/infrastructure practices.
 
    node_group_ami_type       = "AL2023_ARM_64_STANDARD"
    node_group_instance_types = ["r6g.medium"]
-   node_group_desired_size   = 3
-   node_group_min_size       = 2
-   node_group_max_size       = 5
+   node_group_desired_size   = 2
+   node_group_min_size       = 1
+   node_group_max_size       = 3
 
    db_instance_class    = "db.t3.large"
    db_allocated_storage = 20
    db_multi_az          = false
 
+   enable_monitoring = false
+   metrics_retention_days = 0
    enable_cluster_creator_admin_permissions = true
    ```
 

--- a/doc/user/content/self-managed/installation/install-on-gcp.md
+++ b/doc/user/content/self-managed/installation/install-on-gcp.md
@@ -49,6 +49,9 @@ If you do not have `kubectl`,
   [Install the
   gke-gcloud-auth-plugin](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin).
 
+  During the Kubernetes environment setup, you will configure `kubectl` to
+  interact with your GKE cluster.
+
 For help with `kubectl` commands, see [kubectl Quick
 reference](https://kubernetes.io/docs/reference/kubectl/quick-reference/).
 

--- a/doc/user/content/self-managed/installation/install-on-gcp.md
+++ b/doc/user/content/self-managed/installation/install-on-gcp.md
@@ -82,7 +82,7 @@ evaluation purposes only. The module deploys a sample infrastructure on GCP
 (region `us-central1`) with the following components:
 
 - Google Kubernetes Engine (GKE) cluster
-- Cloud SQL PostgreSQL database for metadata storage 
+- Cloud SQL PostgreSQL database for metadata storage
 - Cloud Storage bucket for blob storage
 - A dedicated VPC
 - Service accounts with proper IAM permissions
@@ -327,13 +327,7 @@ evaluation purposes only. The module deploys a sample infrastructure on GCP
 
 To deploy Materialize:
 
-1. {{< warning>}}
-
-   {{< self-managed/terraform-disclaimer >}}
-
-   {{< /warning >}}
-
-   For your backend configuration, create a file
+1. For your backend configuration, create a file
    `materialize-backend-secret.yaml` for your [Kubernetes
    Secret](https://kubernetes.io/docs/concepts/configuration/secret/).
 

--- a/doc/user/content/self-managed/installation/install-on-gcp.md
+++ b/doc/user/content/self-managed/installation/install-on-gcp.md
@@ -25,7 +25,7 @@ examples/simple Terraform module.
 
 ### Google cloud project
 
-If you do not have a GCP project for your Materialize environment, create one.
+If you do not have a GCP project to use for this tutorial, create one.
 
 ### gcloud CLI
 

--- a/doc/user/content/self-managed/installation/install-on-gcp.md
+++ b/doc/user/content/self-managed/installation/install-on-gcp.md
@@ -4,34 +4,50 @@ description: ""
 robots: "noindex, nofollow"
 ---
 
-The following tutorial deploys Materialize onto GCP.
+Self-managed Materialize requires:
+
+{{% self-managed/requirements-list %}}
+
+The tutorial deploys Materialize to GCP Google Kubernetes Engine (GKE) cluster
+with a Cloud SQL PostgreSQL database as the metadata database and Cloud Storage
+bucket for blob storage.
 
 {{< important >}}
 
-For testing purposes only. For testing purposes only.  For testing purposes only. ....
+For testing purposes only. For testing purposes only. For testing purposes only. ....
 
 {{< /important >}}
 
 ## Prerequisites
 
-### GCP Kubernetes environment
+### gcloud CLI
 
-Materialize provides a [Terraform
-module](https://github.com/MaterializeInc/terraform-google-materialize) to
-deploy a sample infrastructure on GCP with the following:
+If you do not have the gcloud CLI installed,
 
-- GKE component
-- Storage component
-- Database component for metadata storage
+- Install the gcloud CLI. For details, see the [Install the gcloud CLI
+  documentation](https://cloud.google.com/sdk/docs/install).
 
-See the
-[README](https://github.com/MaterializeInc/terraform-google-materialize/blob/main/README.md)
-for information on how to deploy the infrastructure.
+- Initialize the gcloud CLI and select a project to use. For details, see the
+  [Initializing the gcloud CLI
+  documentation](https://cloud.google.com/sdk/docs/initializing).
 
-### `kubectl`
 
-Install `kubectl` and configure cluster access.
-For details, see the [GCP documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl).
+### Terraform
+
+If you don't have Terraform installed, [install
+Terraform](https://developer.hashicorp.com/terraform/install?product_intent=terraform).
+
+### kubectl
+
+If you do not have `kubectl`,
+
+- Install `kubectl`. See [Install kubectl and configure cluster
+  access](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl)
+  for details.
+
+- Install the `gke-gcloud-auth-plugin` plugin for `kubectl`. For details, see
+  [Install the
+  gke-gcloud-auth-plugin](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin).
 
 For help with `kubectl` commands, see [kubectl Quick
 reference](https://kubernetes.io/docs/reference/kubectl/quick-reference/).
@@ -41,38 +57,195 @@ reference](https://kubernetes.io/docs/reference/kubectl/quick-reference/).
 If you don't have Helm version 3.2.0+ installed, refer to the [Helm
 documentation](https://helm.sh/docs/intro/install/).
 
+### GCP Kubernetes environment
 
-## A. Install the Materialize Operator
+{{% self-managed/requirements-list %}}
 
-1. If installing for the first time, create a namespace. The default
-   configuration uses the `materialize` namespace.
+See [A. Set up GCP Kubernetes environment](#a-set-up-gcp-kubernetes-environment)
+for a sample setup.
+
+## A. Set up GCP Kubernetes environment
+
+{{< tabs  >}}
+
+{{< tab "Terraform" >}}
+
+Materialize provides a [sample Terraform
+module](https://github.com/MaterializeInc/terraform-google-materialize) for
+evaluation purposes only. The module deploys a sample infrastructure on GCP
+(region `us-east-1`) with the following components:
+
+- Google Kubernetes Engine (GKE) cluster
+- Database component for metadata storage (Cloud SQL PostgreSQL database)
+- Storage component for blob storage (Cloud Storage bucket)
+- Required networking and security configurations
+- Service accounts with proper IAM permissions
+
+{{< warning >}}
+
+The sample Terraform module is for **evaluation purposes only** and not intended
+for production use. It is provided to help you get started with Materialize for
+evaluation purposes only. Materialize does not support nor recommends this
+module for production use. Materialize does not guarantee tests for changes to
+the module.
+
+For simplicity, this tutorial stores your Cloud SQL PostgreSQL secret in a file.
+In practice, refer to your organization's official security and
+Terraform/infrastructure practices.
+
+{{< /important >}}
+
+1. Enable the following services for your GCP project:
 
    ```bash
-   kubectl create namespace materialize
+   gcloud services enable container.googleapis.com        # For creating Kubernetes clusters
+   gcloud services enable sqladmin.googleapis.com         # For creating databases
+   gcloud services enable cloudresourcemanager.googleapis.com # For managing GCP resources
+   gcloud services enable servicenetworking.googleapis.com  # For private network connections
+   gcloud services enable iamcredentials.googleapis.com     # For security and authentication
    ```
 
-1. Create a `my-GCP-values.yaml` configuration file for the Materialize
-   operator. Update with details from your GCP Kubernetes environment. For more
-   information on cloud provider configuration, see the [Materialize Operator
-   Configuration](/self-managed/configuration/#operator-parameters).
+   When finished, you should see output similar to the following:
+
+   ```bash
+   Operation "operations/acf.p2-87743450299-3cfd3269-06b9-48da-bbfd-83ce5f979208" finished successfully.
+   Operation "operations/acat.p2-87743450299-9456bdf0-486f-41b9-9f04-87bae9d31217" finished successfully.
+   Operation "operations/acat.p2-87743450299-83fa25df-e36b-427e-ab98-0067ee6905fe" finished successfully.
+   Operation "operations/acat.p2-87743450299-6298c59f-b6fc-4a7f-9d27-b2e7c7d24648" finished successfully.
+   ```
+
+1. Grant the service account the neccessary IAM roles.
+
+
+   b. Enter your GCP project ID.
+
+      ```bash
+      read -s PROJECT_ID
+      ```
+
+   a. Find your service account email for your GCP project
+
+      ```bash
+      gcloud iam service-accounts list --project $PROJECT_ID
+      ```
+
+   c. Enter your service account email.
+
+      ```bash
+      read -s SERVICE_ACCOUNT
+      ```
+
+   d. Grant the service account the neccessary IAM roles.
+
+      ```bash
+      gcloud projects add-iam-policy-binding $PROJECT_ID \
+      --member="serviceAccount:$SERVICE_ACCOUNT" \
+      --role="roles/editor"
+
+      gcloud projects add-iam-policy-binding $PROJECT_ID \
+      --member="serviceAccount:$SERVICE_ACCOUNT" \
+      --role="roles/iam.serviceAccountAdmin"
+
+      gcloud projects add-iam-policy-binding $PROJECT_ID \
+      --member="serviceAccount:$SERVICE_ACCOUNT" \
+      --role="roles/servicenetworking.networksAdmin"
+      ```
+
+
+1. Clone or download the [Materialize's sample Terraform
+   repo](https://github.com/MaterializeInc/terraform-google-materialize).
+
+1. Go to the `examples/simple` folder in the Materialize Terraform repo
+   directory.
+
+   ```bash
+   cd terraform-google-materialize/examples/simple
+   ```
+
+1. Initialize the terraform directory.
+
+    ```bash
+    terraform init
+    ```
+
+1. Create a terraform plan and review the changes, replacing `your-password`
+   with a securepassword for your Cloud SQL database.
+
+    ```bash
+    terraform plan -var project_id=$PROJECT_ID -var database_password="your-password" -out my-plan.tfplan
+    ```
+
+1. If you are satisfied with the changes, apply the terraform plan.
+
+    ```bash
+    terraform apply my-plan.tfplan
+    ```
+
+   <a name="terraform-output"></a>
+   Upon successful completion, various fields and their values are output:
+
+   ```bash
+   Apply complete! Resources: 16 added, 0 changed, 0 destroyed.
+
+   Outputs:
+
+   connection_strings = <sensitive>
+   gke_cluster = <sensitive>
+   service_accounts = {
+     "gke_sa" = "mz-simple-gke-sa@your-project-id.iam.gserviceaccount.com"
+     "materialize_sa" = "mz-simple-materialize-sa@your-project-id.iam.gserviceaccount.com"
+   }
+   ```
+
+1. Configure `kubectl` to connect to your EKS cluster:
+
+   ```bash
+   gcloud container clusters get-credentials $(terraform output -json gke_cluster | jq -r .name) \
+    --region $(terraform output -json gke_cluster | jq -r .location) --project $PROJECT_ID
+   ```
+
+   To verify that you have configured correctly, run the following command:
+
+   ```bash
+   kubectl cluster-info
+   ```
+
+   For help with `kubectl` commands, see [kubectl Quick
+   reference](https://kubernetes.io/docs/reference/kubectl/quick-reference/).
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+## B. Install the Materialize Operator
+
+1. Clone/download the [Materialize
+   repo](https://github.com/MaterializeInc/materialize).
+
+1. Go to the Materialize repo directory.
+
+   ```bash
+   cd materialize
+   ```
+
+1. Check out the {{% self-managed/latest_version %}} tag.
+
+1. Create a `my-materialize-operator-values.yaml` configuration file for
+   the Materialize operator.  Update with:
+
+   - your GCP region (the sample Terraform module uses `us-east-1`).
+
 
       ```yaml
-      # my-GCP-values.yaml
-      # Note: Updated with recent config changes in main branch and not v0.125.2 branch
+      # my-materialize-operator-values.yaml
 
       operator:
-        args:
-          startupLogFilter: INFO
         cloudProvider:
+          type: "gcp"
+          region: "your-gcp-region"  # e.g., us-central1
           providers:
             gcp:
               enabled: true
-          region: "<your-gcp-region>"
-          type: "gcp"
-
-      namespace:
-        create: false
-        name: "materialize"
 
       # Adjust network policies as needed
       networkPolicies:
@@ -88,41 +261,42 @@ documentation](https://helm.sh/docs/intro/install/).
       ```
 
 
-1. Clone/download the [Materialize
-   repo](https://github.com/MaterializeInc/materialize).
-
-1. Go to the Materialize repo directory.
-
-   ```bash
-   cd materialize
-   ```
-
-1. Install the Materialize operator with the release name
-   `my-materialize-operator`, specifying the path to your
-   `my-GCP-values.yaml` file:
+1. Install the Materialize operator `materialize-operator`, specifying the path
+   to your `my-materialize-operator-values.yaml` file:
 
    ```shell
-   helm install my-materialize-operator -f path/to/my-GCP-values.yaml materialize/misc/helm-charts/operator
+   helm install materialize-operator misc/helm-charts/operator \
+      -f my-materialize-operator-values.yaml  \
+      --namespace materialize --create-namespace
    ```
 
-1. Verify the installation:
+1. Verify the installation and check the status:
 
     ```shell
     kubectl get all -n materialize
     ```
 
-## B. Install Materialize
+    Wait for the components to be in the `Running` state:
+
+    ```none
+    NAME                                        READY   STATUS    RESTARTS   AGE
+    pod/materialize-operator-59cb6768cb-vk87l   1/1     Running   0          14s
+
+    NAME                                   READY   UP-TO-DATE   AVAILABLE   AGE
+    deployment.apps/materialize-operator   1/1     1            1           15s
+
+    NAME                                              DESIRED   CURRENT   READY   AGE
+    replicaset.apps/materialize-operator-59cb6768cb   1         1         1       15s
+    ```
+
+
+## C. Install Materialize
 
 To deploy Materialize:
 
-1. Create a [Kubernetes
-   Secret](https://kubernetes.io/docs/concepts/configuration/secret/) for your
-   backend configuration information and save in a file (e.g.,
-   `materialize-backend-secret.yaml`).
-
-   Replace `${terraform_output.metadata_backend_url}` and
-   `{terraform_output.persist_backend_url}` with the actual values from the
-   Terraform output.
+1. For your backend configuration, create a file
+   `materialize-backend-secret.yaml` for your [Kubernetes
+   Secret](https://kubernetes.io/docs/concepts/configuration/secret/).
 
     ```yaml
     apiVersion: v1
@@ -131,25 +305,38 @@ To deploy Materialize:
       name: materialize-backend
       namespace: materialize-environment
     stringData:
-      metadata_backend_url: "${terraform_output.metadata_backend_url}"
-      persist_backend_url: "${terraform_output.persist_backend_url}"
+      persist_backend_url: "your-persist-backend-url"
+      metadata_backend_url: "postgres://db_user:db_password@database_endpoint/db_name?sslmode=require"
     ```
+
+    - For `your-persist-backend-url`, set to the your google storate uri (e.g., `gs://some-example-bucket`).
+
+    - For `your-metadata-backend-url`, update with your values:
+
+      - Default `db_user` is `materialize`,
+      - `db_password` is the value you specified during Terraform plan.
+      - `database_endpoint` is the Google Cloud SQL database connection name
+        (e.g., `some-name:us-central1:mz-simple-pg`).
+      - Default `db_name` is `materialize`.
+
+        {{< tip >}}
+        URL encode your database password.
+        {{< /tip >}}
 
 1. Create a YAML file (e.g., `my-materialize.yaml`) for your Materialize
    configuration.
 
-   Replace `${var.service_account_name}` with the the desired name for your
-   Materialize. It should be a UUID (e.g.,
-   `12345678-1234-1234-1234-123456789012`).
+   Replace `your-service-account-name` with the service account name as
+   specified in the Terraform output.
 
    ```yaml
    apiVersion: materialize.cloud/v1alpha1
    kind: Materialize
    metadata:
-     name: "${var.service_account_name}"
+     name: "your-service-account-name"      # e.g. my-simple-materialize-sa
      namespace: materialize-environment
    spec:
-     environmentdImageRef: materialize/environmentd:latest
+     environmentdImageRef: materialize/environmentd:v0.127.0
      environmentdResourceRequirements:
        limits:
          memory: 16Gi
@@ -221,6 +408,17 @@ up:
 kubectl delete namespace materialize
 kubectl delete namespace materialize-environment
 ```
+
+In your Terraform directory, run:
+
+```bash
+terraform destroy
+```
+
+When prompted for your GCP Project ID, enter the value for your GCP Project ID.
+Specify the actual value and not the environment variable.
+
+When prompted to proceed, type `yes` to confirm the deletion.
 
 ## See also
 

--- a/doc/user/content/self-managed/installation/install-on-gcp.md
+++ b/doc/user/content/self-managed/installation/install-on-gcp.md
@@ -26,9 +26,13 @@ If you do not have a GCP project, create one.
 
 ### gcloud CLI
 
-If you do not have the gcloud CLI installed, install the gcloud CLI. For
-details, see the [Install the gcloud CLI
-documentation](https://cloud.google.com/sdk/docs/install).
+If you do not have the gcloud CLI installed, 
+
+- Install the gcloud CLI. For details, see the [Install the gcloud CLI
+  documentation](https://cloud.google.com/sdk/docs/install).
+
+- Initialize the gcloud CLI to specify the GCP project you want to use. For
+  details, see the [Install the gcloud CLI documentation](https://cloud.google.com/sdk/docs/install).
 
 ### Terraform
 
@@ -165,11 +169,10 @@ Terraform/infrastructure practices.
 1. Clone or download the [Materialize's sample Terraform
    repo](https://github.com/MaterializeInc/terraform-google-materialize).
 
-1. Go to the `examples/simple` folder in the Materialize Terraform repo
-   directory.
+1. Go to the Materialize Terraform repo directory.
 
    ```bash
-   cd terraform-google-materialize/examples/simple
+   cd terraform-google-materialize
    ```
 
 1. Copy the `terraform.tfvars.example` file to `terraform.tfvars`.
@@ -185,7 +188,7 @@ Terraform/infrastructure practices.
 
    ```bash
     # GCP Project Configuration
-    project_id = "your-gcp-project-id" # Enter your GCP project ID
+    project_id = "enter-your-gcp-project-id" # Enter your GCP project ID
     region     = "us-central1"
     prefix     = "mz-simple"
 
@@ -195,12 +198,27 @@ Terraform/infrastructure practices.
       version  = "POSTGRES_15"
       password = "enter-secure-passowrd" # At least 12 characters
     }
+
+    gke_config = {
+      node_count     = 1
+      machine_type   = "e2-standard-4"
+      disk_size_gb   = 50
+      min_nodes      = 1
+      max_nodes      = 2
+      node_locations = []
+   }
    ```
+
+1. Initialize the terraform directory.
+
+    ```bash
+    terraform init
+    ```
 
 1. Create a terraform plan and review the changes.
 
     ```bash
-    terraform init
+    terraform plan -out my-plan.tfplan  
     ```
 
 1. If you are satisfied with the changes, apply the terraform plan.
@@ -267,7 +285,8 @@ Terraform/infrastructure practices.
 1. Create a `my-materialize-operator-values.yaml` configuration file for
    the Materialize operator.  Update with:
 
-   - your GCP region (the sample Terraform module uses `us-east-1`).
+   - your GCP region (the sample Terraform module uses a default region of
+     `us-central1`).
 
 
       ```yaml

--- a/doc/user/content/self-managed/installation/install-on-gcp.md
+++ b/doc/user/content/self-managed/installation/install-on-gcp.md
@@ -14,8 +14,6 @@ bucket for blob storage.
 
 {{< important >}}
 
-For testing purposes only. For testing purposes only. For testing purposes only. ....
-
 Assumes the `gke_config.machine_type = "e2-standard-4"` in the sample
 examples/simple Terraform module.
 
@@ -84,9 +82,9 @@ evaluation purposes only. The module deploys a sample infrastructure on GCP
 (region `us-central1`) with the following components:
 
 - Google Kubernetes Engine (GKE) cluster
-- Database component for metadata storage (Cloud SQL PostgreSQL database)
-- Storage component for blob storage (Cloud Storage bucket)
-- Required networking and security configurations
+- Cloud SQL PostgreSQL database for metadata storage 
+- Cloud Storage bucket for blob storage
+- A dedicated VPC
 - Service accounts with proper IAM permissions
 
 {{< warning >}}

--- a/doc/user/content/self-managed/installation/install-on-local-kind.md
+++ b/doc/user/content/self-managed/installation/install-on-local-kind.md
@@ -9,11 +9,7 @@ robots: "noindex, nofollow"
 The following tutorial deploys self-managed Materialize onto a local
 [`kind`](https://kind.sigs.k8s.io/) cluster. Self-managed Materialize requires:
 
-- A Kubernetes (v1.19+) environment.
-
-- PostgreSQL or CockroachDB as a metadata database.
-
-- Blob storage.
+{{% self-managed/requirements-list %}}
 
 The tutorial uses a local `kind` cluster and deploys the following components:
 

--- a/doc/user/content/self-managed/installation/install-on-local-minikube.md
+++ b/doc/user/content/self-managed/installation/install-on-local-minikube.md
@@ -7,11 +7,7 @@ robots: "noindex, nofollow"
 The following tutorial deploys Materialize onto a local
 [`minikube`](https://minikube.sigs.k8s.io/docs/start/) cluster. Self-managed Materialize requires:
 
-- A Kubernetes (v1.19+) environment.
-
-- PostgreSQL or CockroachDB as a metadata database.
-
-- Blob storage.
+{{% self-managed/requirements-list %}}
 
 The tutorial deploys the following components onto your local `minikube`
 cluster:

--- a/doc/user/layouts/shortcodes/important.html
+++ b/doc/user/layouts/shortcodes/important.html
@@ -1,4 +1,4 @@
 <div class="important">
   <strong class="gutter">
-   ! Important: </strong> {{ .Inner | $.Page.RenderString }}
+   ! Important: </strong> {{ .Inner | replaceRE "^\\s+" "" | $.Page.RenderString }}
 </div>

--- a/doc/user/layouts/shortcodes/self-managed/requirements-list.html
+++ b/doc/user/layouts/shortcodes/self-managed/requirements-list.html
@@ -1,0 +1,5 @@
+- A Kubernetes (v1.29+) environment.
+
+- PostgreSQL or CockroachDB as a metadata database.
+
+- Blob storage.

--- a/doc/user/layouts/shortcodes/self-managed/requirements-list.html
+++ b/doc/user/layouts/shortcodes/self-managed/requirements-list.html
@@ -1,5 +1,5 @@
 - A Kubernetes (v1.29+) environment.
 
-- PostgreSQL or CockroachDB as a metadata database.
+- PostgreSQL as a metadata database.
 
 - Blob storage.

--- a/doc/user/layouts/shortcodes/self-managed/requirements-list.html
+++ b/doc/user/layouts/shortcodes/self-managed/requirements-list.html
@@ -1,4 +1,4 @@
-- A Kubernetes (v1.29+) environment.
+- A Kubernetes (v1.29+) cluster.
 
 - PostgreSQL as a metadata database.
 

--- a/doc/user/layouts/shortcodes/self-managed/terraform-disclaimer.html
+++ b/doc/user/layouts/shortcodes/self-managed/terraform-disclaimer.html
@@ -1,0 +1,9 @@
+The sample Terraform module is for **evaluation purposes only** and not intended
+for production use. It is provided to help you get started with Materialize for
+evaluation purposes only. Materialize does not support nor recommends this
+module for production use. Materialize does not guarantee tests for changes to
+the module.
+
+For simplicity, this tutorial stores various secrets in a file as well as print
+to the terminal. In practice, refer to your organization's official security and
+Terraform/infrastructure practices.

--- a/doc/user/layouts/shortcodes/self-managed/terraform-disclaimer.html
+++ b/doc/user/layouts/shortcodes/self-managed/terraform-disclaimer.html
@@ -1,9 +1,8 @@
-The sample Terraform module is for **evaluation purposes only** and not intended
-for production use. It is provided to help you get started with Materialize for
-evaluation purposes only. Materialize does not support nor recommends this
-module for production use. Materialize does not guarantee tests for changes to
-the module.
+To help you get started with Materialize for evaluation purposes, Materialize
+provides a sample Terraform module. The sample Terraform module is for
+**evaluation purposes only** and not intended for production use. Materialize
+does not support nor recommends this module for production use.
 
-For simplicity, this tutorial stores various secrets in a file as well as print
-to the terminal. In practice, refer to your organization's official security and
-Terraform/infrastructure practices.
+For simplicity, this tutorial stores various secrets in a file as well as prints
+them to the terminal. In practice, refer to your organization's official
+security and Terraform/infrastructure practices.

--- a/doc/user/layouts/shortcodes/tip.html
+++ b/doc/user/layouts/shortcodes/tip.html
@@ -1,4 +1,4 @@
 <div class="tip">
   <strong class="gutter">
-    💡 Tip: </strong> {{ .Inner | $.Page.RenderString }}
+    💡 Tip: </strong> {{ .Inner  | replaceRE "^\\s+" "" | $.Page.RenderString }}
 </div>


### PR DESCRIPTION

https://preview.materialize.com/materialize/30846/self-managed/installation/install-on-aws/  

- running from module at root.  The examples/simple requires couple of more changes (updates to the versions file, some node ami and instance types - to use the ARM one, etc). 

https://preview.materialize.com/materialize/30846/self-managed/installation/install-on-gcp/ 

- running from examples/simple, but assumes some changes in the examples/simple module.  To test (need to change machine_type), locally added the following config to the main.tf materialize module block:

```none
  gke_config = {
    node_count     = 1
    machine_type   = "e2-standard-4"
    disk_size_gb   = 50
    min_nodes      = 1
    max_nodes      = 2
    node_locations = []
  }
```


Future updates:

- Per https://github.com/MaterializeInc/terraform-aws-materialize/pull/15 -- Sections B & C may soon be deleted  + updates to tfvar section to specify different variables