### PR TITLE
sqllogictest: switch `verbosity` argument from `usize` to `u8`

### DIFF
--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -39,7 +39,7 @@ struct Args {
     /// If specified twice, also show descriptions of each error.
     /// If specified thrice, also print each query before it is executed.
     #[clap(short = 'v', long = "verbose", action = ArgAction::Count)]
-    verbosity: usize,
+    verbosity: u8,
     /// Don't exit with a failing code if not all queries are successful.
     #[clap(long)]
     no_fail: bool,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -426,7 +426,7 @@ pub struct RunnerInner<'a> {
     auto_index_selects: bool,
     auto_transactions: bool,
     enable_table_keys: bool,
-    verbosity: usize,
+    verbosity: u8,
     stdout: &'a dyn WriteFmt,
     _shutdown_trigger: trigger::Trigger,
     _server_thread: JoinOnDropHandle<()>,
@@ -1797,7 +1797,7 @@ pub trait WriteFmt {
 pub struct RunConfig<'a> {
     pub stdout: &'a dyn WriteFmt,
     pub stderr: &'a dyn WriteFmt,
-    pub verbosity: usize,
+    pub verbosity: u8,
     pub postgres_url: String,
     pub no_fail: bool,
     pub fail_fast: bool,


### PR DESCRIPTION
Right now on main `sqllogictest` is broken with an error like:

```
assertion `left == right` failed: Argument `verbosity`'s selected action Count contradicts `value_parser` (ValueParser::other(usize))
  left: u8
 right: usize
```

### Motivation

Fix issue with sqllogictest

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
