### PR TITLE
dbt-materialize: upgrade to dbt-postgres v1.9.0

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,9 @@
 # dbt-materialize Changelog
 
+## 1.9.0 - 2024-12-17
+
+* Upgrade to `dbt-postgres` v1.9.0.
+
 ## 1.8.6 - 2024-09-25
 
 * Enable the `cluster` configuration for seeds, which allows specifying a target

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.8.6"
+version = "1.9.0"

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -264,16 +264,6 @@
   comment on column {{ relation }}.{{ adapter.quote(column_name) if quote else column_name }} is {{ escaped_comment }};
 {% endmacro %}
 
-{% macro materialize__alter_relation_comment(relation, comment) -%}
-  {% set escaped_comment = postgres_escape_comment(comment) %}
-  {% if relation.is_materialized_view -%}
-    {% set relation_type = "materialized view" %}
-  {%- else -%}
-    {%- set relation_type = relation.type -%}
-  {%- endif -%}
-  comment on {{ relation_type }} {{ relation }} is {{ escaped_comment }};
-{% endmacro %}
-
 -- In the dbt-adapter we extend the Relation class to include sinks and indexes
 {% macro materialize__list_relations_without_caching(schema_relation) %}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -26,7 +26,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.8.6",
+    version="1.9.0",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",
@@ -42,11 +42,11 @@ setup(
         ]
     },
     install_requires=[
-        "dbt-common>=0.1.0a1,<2.0",
-        "dbt-adapters>=0.1.0a1,<2.0",
+        "dbt-common>=1.10,<2.0",
+        "dbt-adapters>=1.7,<2.0",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
         "dbt-core>=1.8.0",
-        "dbt-postgres~=1.8.0",
+        "dbt-postgres>=1.8,<1.10",
     ],
     extras_require={
         "dev": [

--- a/misc/dbt-materialize/tests/adapter/test_run_hooks.py
+++ b/misc/dbt-materialize/tests/adapter/test_run_hooks.py
@@ -21,6 +21,7 @@ from dbt.tests.adapter.hooks.test_run_hooks import (
     BasePrePostRunHooks,
 )
 from dbt.tests.util import run_dbt
+from dbt_common.exceptions import DbtDatabaseError
 from fixtures import run_hook, test_run_operation
 
 
@@ -58,6 +59,7 @@ class TestPrePostRunHooksMaterialize(BasePrePostRunHooks):
 
 class TestAfterRunHooksMaterialize(BaseAfterRunHooks):
     def test_missing_column_pre_hook(self, project):
-        run_dbt(["run"], expect_pass=False)
+        with pytest.raises(DbtDatabaseError):
+            run_dbt(["run"], expect_pass=False)
 
     pass


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

As per the upgrade guide for the newly released dbt-core v1.9.0: https://github.com/dbt-labs/dbt-core/discussions/11125