### PR TITLE
Add ProjectionPushdown call after Demand in physical_optimizer

### DIFF
--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -37,19 +37,22 @@ use crate::TransformCtx;
 ///
 /// Nowadays, this transform is mostly obsoleted by `ProjectionPushdown`.
 /// However, I know of one thing that it still does that `ProjectionPushdown`
-/// doesn't do (might possibly be more such things):
+/// doesn't do (there might be more such things):
 /// if you have something like
-// ```
-//     Project (#0, #1)
-//       Join on=(#0 = #1)
-// ```
-// then this is turned into
-// ```
-//     Project (#0, #0)
-//       Join on=(#0 = #1)
-// ```
-// This can be beneficial for projecting out some columns earlier inside a complex join (by the LIR
-// planning), and then recovering them after the join (if needed) by duplicating existing columns.
+/// ```code
+///     Project (#0, #1)
+///       Join on=(#0 = #1)
+/// ```
+/// then this is turned into
+/// ```code
+///     Project (#0, #0)
+///       Join on=(#0 = #1)
+/// ```
+/// This can be beneficial for projecting out some columns earlier inside a complex join (by the LIR
+/// planning), and then recovering them after the join (if needed) by duplicating existing columns.
+///
+/// After the last run of `Demand`, there should always be a `ProjectionPushdown`, so that dummies
+/// are eliminated from plans.
 #[derive(Debug)]
 pub struct Demand {
     recursion_guard: RecursionGuard,

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -44,6 +44,7 @@ use crate::fold_constants::FoldConstants;
 use crate::join_implementation::JoinImplementation;
 use crate::literal_constraints::LiteralConstraints;
 use crate::literal_lifting::LiteralLifting;
+use crate::movement::ProjectionPushdown;
 use crate::non_null_requirements::NonNullRequirements;
 use crate::normalize_lets::NormalizeLets;
 use crate::normalize_ops::NormalizeOps;
@@ -57,6 +58,8 @@ use crate::threshold_elision::ThresholdElision;
 use crate::typecheck::{SharedContext, Typecheck};
 use crate::union_cancel::UnionBranchCancellation;
 use crate::will_distinct::WillDistinct;
+
+pub use dataflow::optimize_dataflow;
 
 pub mod analysis;
 pub mod canonicalization;
@@ -89,8 +92,6 @@ pub mod threshold_elision;
 pub mod typecheck;
 pub mod union_cancel;
 pub mod will_distinct;
-
-pub use dataflow::optimize_dataflow;
 
 /// Compute the conjunction of a variadic number of expressions.
 #[macro_export]
@@ -763,6 +764,8 @@ impl Optimizer {
                     Box::new(EquivalencePropagation::default()),
                     Box::new(fold_constants_fixpoint()),
                     Box::new(Demand::default()),
+                    // Demand might have introduced dummies, so let's also do a ProjectionPushdown.
+                    Box::new(ProjectionPushdown::default()),
                     Box::new(LiteralLifting::default()),
                 ],
             }),

--- a/test/sqllogictest/advent-of-code/2023/aoc_1210.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1210.slt
@@ -398,22 +398,22 @@ Explained Query:
     With
       cte l19 =
         Reduce aggregates=[count(*)]
-          Project ()
-            Union
-              Negate
-                Project (#0, #1)
-                  Join on=(#0 = #2 AND #1 = #3) type=differential
-                    ArrangeBy keys=[[#0, #1]]
+          Union
+            Negate
+              Project ()
+                Join on=(#0 = #2 AND #1 = #3) type=differential
+                  ArrangeBy keys=[[#0, #1]]
+                    Project (#0, #1)
                       Get l18
-                    ArrangeBy keys=[[#0, #1]]
-                      Distinct project=[#0, #1]
-                        Project (#0, #1)
-                          Get l8
+                  ArrangeBy keys=[[#0, #1]]
+                    Distinct project=[#0, #1]
+                      Project (#0, #1)
+                        Get l8
+            Project ()
               Get l18
       cte l18 =
-        Project (#0, #1)
-          Filter (#2 = true)
-            Get l17
+        Filter (#2 = true)
+          Get l17
   With Mutually Recursive
     cte l17 =
       Distinct project=[#0..=#2]

--- a/test/sqllogictest/transform/demand.slt
+++ b/test/sqllogictest/transform/demand.slt
@@ -26,6 +26,93 @@ select x from (select x, 1/a from (select 2 as x), t);
 2
 2
 
+# A `dummy` used to occur in the following plan before putting an extra call to `ProjectionPushdown` after the `Demand`
+# call in the physical optimizer, because at the time of the first `Demand` call, the column that is later dummied in
+# the second call is still being used in a join constraint, but this join is then eliminated by `RedundantJoin`.
+query T multiline
+explain with(arity, join implementations)
+select
+  case when (((false)
+          and (true))
+        and ((numrange(0,0)) -|- (case when (cast(null as mz_aclitem)) = (cast(null as mz_aclitem)) then numrange(0,0) else numrange(0,0) end
+            )))
+      and (((10::uint8) & (case when (TIMESTAMPTZ '2023-01-01 01:23:45+06') >= ((TIMESTAMPTZ '95143-12-31 23:59:59+06' + INTERVAL '167 MILLENNIUM')) then 2::uint8 else 2::uint8 end
+            )) < (pg_catalog.mod(
+          CAST(null::uint8 as uint8),
+          CAST(null::uint8 as uint8)))) then mz_catalog.kafka_murmur2(
+      CAST(cast('\xDEADBEEF' as bytea) as bytea)) else mz_catalog.kafka_murmur2(
+      CAST(cast('\xDEADBEEF' as bytea) as bytea)) end
+     as c0,
+  (mz_unsafe.mz_avg_promotion(
+      CAST(0::uint4 as uint4))) / (null::numeric) as c1,
+  mz_catalog.try_parse_monotonic_iso8601_timestamp(
+    CAST(pg_catalog.obj_description(
+      CAST(mz_internal.aclitem_grantee(
+        CAST(cast(null as aclitem) as aclitem)) as oid),
+      CAST((('[]'::jsonb) -> (pg_catalog.session_user())) ->> (pg_catalog.pg_get_viewdef(
+          CAST(case when ('{}'::map[text=>text]) ?| (array['a', 'b', null, '']::text[]) then null::oid else null::oid end
+             as oid),
+          CAST(true as bool))) as text)) as text)) as c2,
+  '2024-12-18 12:54:29.994+00'::timestamptz as c3
+from
+  (select distinct
+        mz_catalog.map_agg(
+          CAST(cast(coalesce(null::text,
+            null::text) as text) as text),
+          null) as c0,
+        mz_catalog.mz_environment_id() as c1,
+        (mz_catalog.mz_environment_id()) || ((null::uint4) + (4294967295::uint4)) as c2,
+        pg_catalog.tstzrange(
+          CAST((INTERVAL '2147483647 MONTHS') + (TIMESTAMPTZ '2023-01-01 01:23:45+06') as timestamptz),
+          CAST(TIMESTAMPTZ '2023-01-01 01:23:45+06' as timestamptz)) as c3,
+        pg_catalog.version() as c4
+      from
+        (select
+              36 as c0,
+              33 as c1
+            from
+              (select
+                    4 as c0
+                  from
+                    "mz_catalog"."mz_columns" as ref_2
+                  where (false) <> (true)
+                  limit coalesce(13, 72)) as subq_0
+            where (true) = (true)
+            limit coalesce(82, 50)) as subq_1
+      where (pg_catalog.mod(
+          CAST(case when ((TIMESTAMPTZ '0001-01-01 00:00:00+06' - INTERVAL '4713 YEARS')) >= ((TIMESTAMPTZ '95143-12-31 23:59:59+06' + INTERVAL '167 MILLENNIUM')) then null::int2 else null::int2 end
+             as int2),
+          CAST(10::int2 as int2))) > (null::int2)
+      limit coalesce(90, 42)) as subq_2
+where true
+limit coalesce(43, 120);
+----
+Explained Query:
+  Finish limit=43 output=[#0..=#3]
+    Return // { arity: 4 }
+      Map (833564499, null, null, 2024-12-18 12:54:29.994 UTC) // { arity: 4 }
+        TopK limit=90 // { arity: 0 }
+          Union // { arity: 0 }
+            Get l0 // { arity: 0 }
+            Negate // { arity: 0 }
+              Get l0 // { arity: 0 }
+            Constant // { arity: 0 }
+              - ()
+    With
+      cte l0 =
+        Distinct project=[] // { arity: 0 }
+          TopK limit=13 // { arity: 0 }
+            Filter error("timestamp out of range") // { arity: 0 }
+              Project () // { arity: 0 }
+                ReadIndex on=mz_columns mz_columns_ind=[*** full scan ***] // { arity: 8 }
+
+Used Indexes:
+  - mz_catalog.mz_columns_ind (*** full scan ***)
+
+Target cluster: mz_catalog_server
+
+EOF
+
 ## -------------------- Tests for WITH MUTUALLY RECURSIVE --------------------
 
 # Demand creates the `#0 + #0` from `#0 + #2`.


### PR DESCRIPTION
This PR should make the occurrences of
```
protobuf decoding found Dummy datum
```
go to 0, thereby solving https://github.com/MaterializeInc/database-issues/issues/8837 and https://github.com/MaterializeInc/database-issues/issues/6471.

The assert in those issues will now give us an actual signal about how much `ProjectionPushdown` covers `Demand`, which will be interesting to know for our efforts to unify these two transforms.

Plus, I think another reason why we originally added that assert is that [we are not 100% sure that the only way a dummy can appear is through an optimization hiccup such as the above, or there are other sneaky ways in which dummies permeated environments](https://github.com/MaterializeInc/database-issues/issues/6471#issuecomment-2369843378). If the Sentry errors go to 0 after adding a ProjectionPushdown after the last Demand call, then we'd get a better signal for this as well.

Testing: The test that I added in `demand.slt` was found by sqlsmith, with changing the assert to be a hard assert. I've also run sqlsmith with the changes in this PR, and dummies haven't occurred. Also, there is one beneficial test change in an existing slt.

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
