### PR TITLE
bazel/docs: Make docs more visibile, add section on adding a new crate

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -68,7 +68,7 @@ sudo apt install docker docker-compose-plugin
 
 Materialize can also optionally be built with [Bazel](https://bazel.build/). To
 learn more about Bazel and how it's setup at Materialize, checkout our
-[Bazel documentation](../../misc/bazel/README.md).
+[Bazel documentation](/doc/developer/bazel.md).
 
 ### CockroachDB
 

--- a/misc/bazel/README.md
+++ b/misc/bazel/README.md
@@ -1,0 +1,4 @@
+# Bazel
+
+Materialize can optionally be build with [Bazel](https://bazel.build/). For
+more info please see our [Bazel Docs](/doc/developer/bazel.md).


### PR DESCRIPTION
This PR does two things:

1. Moves `misc/bazel/README.md` to `doc/developer/bazel.md` so it's more discoverable.
2. Adds a new section to the Bazel docs on adding a new crate.

### Motivation

Improve Bazel docs


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
