### PR TITLE
compute: move some types to `mz_compute_types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4584,7 +4584,7 @@ dependencies = [
  "md-5",
  "mz-audit-log",
  "mz-build-tools",
- "mz-compute-client",
+ "mz-compute-types",
  "mz-controller-types",
  "mz-ore",
  "mz-proto",

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -33,7 +33,7 @@ use mz_catalog::memory::objects::{
     TableDataSource, TemporaryItem, Type, UpdateFrom,
 };
 use mz_catalog::SYSTEM_CONN_ID;
-use mz_compute_client::controller::ComputeReplicaConfig;
+use mz_compute_types::config::ComputeReplicaConfig;
 use mz_controller::clusters::{ReplicaConfig, ReplicaLogging};
 use mz_controller_types::ClusterId;
 use mz_expr::MirScalarExpr;

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -17,7 +17,7 @@ use mz_catalog::builtin::BUILTINS;
 use mz_catalog::memory::objects::{
     ClusterConfig, ClusterReplica, ClusterVariant, ClusterVariantManaged,
 };
-use mz_compute_client::controller::ComputeReplicaConfig;
+use mz_compute_types::config::ComputeReplicaConfig;
 use mz_controller::clusters::{
     ManagedReplicaAvailabilityZones, ManagedReplicaLocation, ReplicaConfig, ReplicaLocation,
     ReplicaLogging,

--- a/src/catalog-protos/BUILD.bazel
+++ b/src/catalog-protos/BUILD.bazel
@@ -32,7 +32,7 @@ rust_library(
     deps = [
         ":mz_catalog_protos_build_script",
         "//src/audit-log:mz_audit_log",
-        "//src/compute-client:mz_compute_client",
+        "//src/compute-types:mz_compute_types",
         "//src/controller-types:mz_controller_types",
         "//src/proto:mz_proto",
         "//src/repr:mz_repr",
@@ -70,7 +70,7 @@ rust_test(
     deps = [
         "//src/audit-log:mz_audit_log",
         "//src/build-tools:mz_build_tools",
-        "//src/compute-client:mz_compute_client",
+        "//src/compute-types:mz_compute_types",
         "//src/controller-types:mz_controller_types",
         "//src/ore:mz_ore",
         "//src/proto:mz_proto",
@@ -89,7 +89,7 @@ rust_doc_test(
     deps = [
         "//src/audit-log:mz_audit_log",
         "//src/build-tools:mz_build_tools",
-        "//src/compute-client:mz_compute_client",
+        "//src/compute-types:mz_compute_types",
         "//src/controller-types:mz_controller_types",
         "//src/ore:mz_ore",
         "//src/proto:mz_proto",

--- a/src/catalog-protos/Cargo.toml
+++ b/src/catalog-protos/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 
 [dependencies]
 mz-audit-log = { path = "../audit-log" }
-mz-compute-client = { path = "../compute-client" }
+mz-compute-types = { path = "../compute-types" }
 mz-controller-types = { path = "../controller-types" }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }

--- a/src/catalog-protos/src/serialization.rs
+++ b/src/catalog-protos/src/serialization.rs
@@ -15,7 +15,7 @@
 
 use std::time::Duration;
 
-use mz_compute_client::controller::ComputeReplicaLogging;
+use mz_compute_types::config::ComputeReplicaLogging;
 use mz_controller_types::ReplicaId;
 use mz_proto::{IntoRustIfSome, ProtoMapEntry, ProtoType, RustType, TryFromProtoError};
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -40,6 +40,7 @@ use mz_build_info::BuildInfo;
 use mz_cluster_client::client::ClusterReplicaLocation;
 use mz_cluster_client::metrics::ControllerMetrics;
 use mz_cluster_client::{ReplicaId, WallclockLagFn};
+use mz_compute_types::config::ComputeReplicaConfig;
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::dyncfgs::COMPUTE_REPLICA_EXPIRATION_OFFSET;
 use mz_compute_types::ComputeInstanceId;
@@ -152,31 +153,6 @@ impl PeekNotification {
             PeekResponse::Error(err) => Self::Error(err.clone()),
             PeekResponse::Canceled => Self::Canceled,
         }
-    }
-}
-
-/// Replica configuration
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ComputeReplicaConfig {
-    /// TODO(database-issues#7533): Add documentation.
-    pub logging: ComputeReplicaLogging,
-}
-
-/// Logging configuration of a replica.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
-pub struct ComputeReplicaLogging {
-    /// Whether to enable logging for the logging dataflows.
-    pub log_logging: bool,
-    /// The interval at which to log.
-    ///
-    /// A `None` value indicates that logging is disabled.
-    pub interval: Option<Duration>,
-}
-
-impl ComputeReplicaLogging {
-    /// Return whether logging is enabled.
-    pub fn enabled(&self) -> bool {
-        self.interval.is_some()
     }
 }
 

--- a/src/compute-types/src/config.rs
+++ b/src/compute-types/src/config.rs
@@ -1,0 +1,38 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Compute configuration types.
+
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// Replica configuration
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ComputeReplicaConfig {
+    /// TODO(database-issues#7533): Add documentation.
+    pub logging: ComputeReplicaLogging,
+}
+
+/// Logging configuration of a replica.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct ComputeReplicaLogging {
+    /// Whether to enable logging for the logging dataflows.
+    pub log_logging: bool,
+    /// The interval at which to log.
+    ///
+    /// A `None` value indicates that logging is disabled.
+    pub interval: Option<Duration>,
+}
+
+impl ComputeReplicaLogging {
+    /// Return whether logging is enabled.
+    pub fn enabled(&self) -> bool {
+        self.interval.is_some()
+    }
+}

--- a/src/compute-types/src/lib.rs
+++ b/src/compute-types/src/lib.rs
@@ -13,6 +13,7 @@
 
 use std::time::Duration;
 
+pub mod config;
 pub mod dataflows;
 pub mod dyncfgs;
 pub mod explain;

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -20,11 +20,10 @@ use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use futures::stream::{BoxStream, StreamExt};
 use mz_cluster_client::client::ClusterReplicaLocation;
-use mz_compute_client::controller::{
-    ComputeControllerTimestamp, ComputeReplicaConfig, ComputeReplicaLogging,
-};
+use mz_compute_client::controller::ComputeControllerTimestamp;
 use mz_compute_client::logging::LogVariant;
 use mz_compute_client::service::{ComputeClient, ComputeGrpcClient};
+use mz_compute_types::config::{ComputeReplicaConfig, ComputeReplicaLogging};
 use mz_controller_types::dyncfgs::CONTROLLER_PAST_GENERATION_REPLICA_CLEANUP_RETRY_INTERVAL;
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_orchestrator::NamespacedOrchestrator;


### PR DESCRIPTION
While working in the `storage-controller` crate I noticed I would have to rebuild the `catalog-protos` crate, because `catalog-protos` depends on `compute-client` for a single type `ComputeReplicaLogging`.

This PR moves the `ComputeReplicaConfig` and `ComputeReplicaLogging` types to `mz_compute_types` crate to reduce the chances of needing to rebuild `catalog-protos`.

### Motivation

Faster builds

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
