### PR TITLE
Fix broken features

### DIFF
--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.3.25"
 maplit = "1.0.2"
 mz-cloud-resources = { path = "../cloud-resources" }
 mz-orchestrator = { path = "../orchestrator" }
-mz-ore = { path = "../ore", features = ["async"]  }
+mz-ore = { path = "../ore", default-features = false, features = ["async"]  }
 mz-secrets = { path = "../secrets" }
 mz-repr = { path = "../repr" }
 k8s-openapi = { version = "0.22.0", features = ["v1_29"] }

--- a/src/orchestrator-process/Cargo.toml
+++ b/src/orchestrator-process/Cargo.toml
@@ -20,7 +20,7 @@ itertools = "0.10.5"
 libc = "0.2.138"
 maplit = "1.0.2"
 mz-orchestrator = { path = "../orchestrator" }
-mz-ore = { path = "../ore", features = ["async"] }
+mz-ore = { path = "../ore", default-features = false, features = ["async", "network"] }
 mz-repr = { path = "../repr" }
 mz-secrets = { path = "../secrets" }
 nix = "0.26.1"

--- a/src/orchestrator-tracing/BUILD.bazel
+++ b/src/orchestrator-tracing/BUILD.bazel
@@ -25,7 +25,6 @@ rust_library(
     crate_features = [
         "capture",
         "default",
-        "humantime",
         "mz-repr",
         "tokio-console",
         "tracing-capture",
@@ -64,7 +63,6 @@ rust_test(
     crate_features = [
         "capture",
         "default",
-        "humantime",
         "mz-repr",
         "tokio-console",
         "tracing-capture",

--- a/src/orchestrator-tracing/Cargo.toml
+++ b/src/orchestrator-tracing/Cargo.toml
@@ -19,7 +19,7 @@ http = "1.1.0"
 humantime = { version = "2.1.0" }
 mz-build-info = { path = "../build-info" }
 mz-orchestrator = { path = "../orchestrator" }
-mz-ore = { path = "../ore", features = ["tracing_", "cli", "test"] }
+mz-ore = { path = "../ore", default-features = false, features = ["tracing_", "cli", "test"] }
 mz-repr = { path = "../repr", optional = true }
 mz-service = { path = "../service" }
 mz-tracing = { path = "../tracing" }

--- a/src/orchestrator-tracing/Cargo.toml
+++ b/src/orchestrator-tracing/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "3.2.24", features = ["env", "derive"] }
 derivative = "2.2.0"
 futures-core = "0.3.21"
 http = "1.1.0"
-humantime = { version = "2.1.0", optional = true }
+humantime = { version = "2.1.0" }
 mz-build-info = { path = "../build-info" }
 mz-orchestrator = { path = "../orchestrator" }
 mz-ore = { path = "../ore", features = ["tracing_", "cli", "test"] }
@@ -36,7 +36,7 @@ mz-ore = { path = "../ore", features = ["network", "test"] }
 
 [features]
 default = ["tokio-console", "workspace-hack"]
-tokio-console = ["mz-ore/tokio-console", "mz-repr", "humantime"]
+tokio-console = ["mz-ore/tokio-console", "mz-repr"]
 capture = ["tracing-capture", "mz-ore/capture"]
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/orchestrator/Cargo.toml
+++ b/src/orchestrator/Cargo.toml
@@ -16,7 +16,7 @@ bytesize = "1.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["serde"] }
 derivative = "2.2.0"
 futures-core = "0.3.21"
-mz-ore = { path = "../ore"}
+mz-ore = { path = "../ore", default-features = false }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 serde = "1.0"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/ore/BUILD.bazel
+++ b/src/ore/BUILD.bazel
@@ -24,6 +24,7 @@ rust_library(
     compile_data = [],
     crate_features = [
         "anyhow",
+        "assert",
         "async",
         "async-trait",
         "bytes",
@@ -104,6 +105,7 @@ rust_test(
     crate = ":mz_ore",
     crate_features = [
         "anyhow",
+        "assert",
         "async",
         "async-trait",
         "bytes",

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -143,10 +143,11 @@ tracing_ = [
 tokio-console = ["console-subscriber", "tokio", "tokio/tracing", "network"]
 cli = ["clap"]
 stack = ["stacker"]
-test = ["anyhow", "ctor", "tracing-subscriber", "derivative"]
-metrics = ["prometheus"]
+test = ["anyhow", "ctor", "tracing-subscriber", "derivative", "assert"]
+metrics = ["prometheus", "derivative", "assert"]
 id_gen = ["hibitset", "rand", "uuid"]
 capture = ["tracing-capture"]
+assert = ["derivative", "ctor"]
 
 [[test]]
 name = "future"

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -22,8 +22,8 @@
 #![warn(missing_docs, missing_debug_implementations)]
 #![cfg_attr(nightly_doc_features, feature(doc_cfg))]
 
-#[cfg_attr(nightly_doc_features, doc(cfg(feature = "test")))]
-#[cfg(feature = "test")]
+#[cfg_attr(nightly_doc_features, doc(cfg(feature = "assert")))]
+#[cfg(feature = "assert")]
 pub mod assert;
 pub mod bits;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "bytes_")))]

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -26,7 +26,7 @@ mz-repr = { path = "../repr" }
 mz-secrets = { path = "../secrets" }
 mz-orchestrator-process = { path = "../orchestrator-process" }
 mz-orchestrator-kubernetes = { path = "../orchestrator-kubernetes" }
-mz-ore = { path = "../ore" }
+mz-ore = { path = "../ore", default-features = false }
 os_info = "3.5.1"
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }

--- a/src/tracing/Cargo.toml
+++ b/src/tracing/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.66"
-mz-ore = { path = "../ore", features = ["test"] }
+mz-ore = { path = "../ore", default-features = false, features = ["test", "tracing_"] }
 mz-proto = { path = "../proto" }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}


### PR DESCRIPTION
Many crates do not build without default features enabled, and this breaks downstream importers of these crates.

### Motivation

Still trying to import orchestratord in the cloud repo.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
