### PR TITLE
set allowed_cluster_replica_sizes by default in self-hosted

### DIFF
--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -868,6 +868,18 @@ fn create_environmentd_statefulset_object(
         config.secrets_controller
     ));
 
+    if let Some(cluster_replica_sizes) = &config.environmentd_cluster_replica_sizes {
+        if let Ok(cluster_replica_sizes) =
+            serde_json::from_str::<BTreeMap<String, serde_json::Value>>(cluster_replica_sizes)
+        {
+            let cluster_replica_sizes: Vec<_> =
+                cluster_replica_sizes.keys().map(|s| s.as_str()).collect();
+            args.push(format!(
+                "--system-parameter-default=allowed_cluster_replica_sizes='{}'",
+                cluster_replica_sizes.join("', '")
+            ));
+        }
+    }
     if !config.cloud_provider.is_cloud() {
         args.push("--system-parameter-default=cluster_enable_topology_spread=false".into());
     }


### PR DESCRIPTION
### Motivation

make the create cluster page work in self-hosted (cc/ @SangJunBak )

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
