### PR TITLE
[optimizer] Signal a typechecking error when Dummy escapes MIR

### DIFF
--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -1953,6 +1953,19 @@ impl MirScalarExpr {
         contains
     }
 
+    /// True iff the expression contains a `Dummy`.
+    pub fn contains_dummy(&self) -> bool {
+        let mut contains = false;
+        self.visit_pre(|e| {
+            if let MirScalarExpr::Literal(row, _) = e {
+                if let Ok(row) = row {
+                    contains |= row.iter().any(|d| d == Datum::Dummy);
+                }
+            }
+        });
+        contains
+    }
+
     /// The size of the expression as a tree.
     pub fn size(&self) -> usize {
         let mut size = 0;

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -784,7 +784,11 @@ impl Optimizer {
             // - `CollectIndexRequests` needs a normalized plan.
             //   https://github.com/MaterializeInc/database-issues/issues/6371
             Box::new(fold_constants_fixpoint()),
-            Box::new(Typecheck::new(ctx.typecheck()).disallow_new_globals()),
+            Box::new(
+                Typecheck::new(ctx.typecheck())
+                    .disallow_new_globals()
+                    .disallow_dummy(),
+            ),
         ];
         Self {
             name: "physical",


### PR DESCRIPTION
Following up on https://github.com/MaterializeInc/materialize/pull/30851, the final `Typecheck` pass (at the end of the physical optimizer) will signal error if any `Dummy` values have persisted.

NB that errors in `Typecheck` do _not_ prevent running the query itself, but will simply mean logging an error.

The test run is green, with no evidence of the error firing in sqllogictest or the testdrive tests. Watching for this error will let us identify the queries that have been having `Dummy` values---or, at least, those queries that are going through the main MIR optimizer.

### Motivation

  * This PR fixes a recognized bug.

https://github.com/MaterializeInc/database-issues/issues/8837
https://github.com/MaterializeInc/database-issues/issues/6471

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
