### PR TITLE
[logging] Don't render large VALUES when redacting

### DIFF
--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -809,12 +809,23 @@ impl<T: AstInfo> AstDisplay for Values<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("VALUES ");
         let mut delim = "";
-        for row in &self.0 {
+
+        let (rows, remaining): (Box<dyn Iterator<Item = _>>, usize) = if f.redacted() {
+            (Box::new(self.0.iter().take(20)), self.0.len() - 20)
+        } else {
+            (Box::new(self.0.iter()), 0)
+        };
+        for row in rows {
             f.write_str(delim);
             delim = ", ";
             f.write_str("(");
             f.write_node(&display::comma_separated(row));
             f.write_str(")");
+        }
+        if remaining > 0 {
+            f.write_str("/* ");
+            f.write_str(&remaining.to_string());
+            f.write_str(" more rows */");
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -810,22 +810,19 @@ impl<T: AstInfo> AstDisplay for Values<T> {
         f.write_str("VALUES ");
         let mut delim = "";
 
-        let (rows, remaining): (Box<dyn Iterator<Item = _>>, usize) = if f.redacted() {
-            (Box::new(self.0.iter().take(20)), self.0.len() - 20)
-        } else {
-            (Box::new(self.0.iter()), 0)
-        };
-        for row in rows {
+        for (i, row) in self.0.iter().enumerate() {
+            if f.redacted() && i == 20 {
+                f.write_str("/* ");
+                f.write_str(&(self.0.len().saturating_sub(20)).to_string());
+                f.write_str(" more rows */");
+                break;
+            }
+
             f.write_str(delim);
             delim = ", ";
             f.write_str("(");
             f.write_node(&display::comma_separated(row));
             f.write_str(")");
-        }
-        if remaining > 0 {
-            f.write_str("/* ");
-            f.write_str(&remaining.to_string());
-            f.write_str(" more rows */");
         }
     }
 }


### PR DESCRIPTION
We attach SQL statements to spans in `coord::handle_execute_inner`, using `stmt.to_ast_string_redacted()`. In the case of a query with 100000 numbers in a `VALUES` clause, we'll log 100000 redacted numbers.

There's no point in recording that many redacted values. When we're doing redaction, we'll only log the first 20 values, leaving a comment indicating how many more there ought to be.

(This could be refined: if there are 21 `VALUES` that are meaningful, non-redacted expressions, we'll drop the last one. We could instead render the first 20 _redacted values_, and drop them after that. Such a policy would require a bit more nuance than this PR.)

### Motivation

  * This PR fixes a recognized bug.
  https://github.com/MaterializeInc/database-issues/issues/8832#event-15647939462

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
