### PR TITLE
[optimizer] cache the previous hash in `TransformCtx`

### DIFF
--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -125,6 +125,8 @@ pub struct TransformCtx<'a> {
     pub df_meta: &'a mut DataflowMetainfo,
     /// Metrics for the optimizer.
     pub metrics: Option<&'a OptimizerMetrics>,
+    /// The last hash of the query, if known.
+    pub last_hash: Option<u64>,
 }
 
 const FOLD_CONSTANTS_LIMIT: usize = 10000;
@@ -150,6 +152,7 @@ impl<'a> TransformCtx<'a> {
             typecheck_ctx,
             df_meta,
             metrics,
+            last_hash: None,
         }
     }
 
@@ -173,6 +176,7 @@ impl<'a> TransformCtx<'a> {
             df_meta,
             typecheck_ctx,
             metrics,
+            last_hash: None,
         }
     }
 
@@ -200,16 +204,19 @@ pub trait Transform: fmt::Debug {
         relation: &mut MirRelationExpr,
         args: &mut TransformCtx,
     ) -> Result<(), TransformError> {
-        let before = relation.hash_to_u64();
+        let hash_before = args.last_hash.unwrap_or_else(|| relation.hash_to_u64());
+
+        // actually run the transform, recording the time taken
         let start = std::time::Instant::now();
         let res = self.actually_perform_transform(relation, args);
         let duration = start.elapsed();
-        let after = relation.hash_to_u64();
 
+        let hash_after = relation.hash_to_u64();
+        args.last_hash = Some(hash_after);
         if let Some(metrics) = args.metrics {
             let transform_name = self.name();
             metrics.observe_transform_time(transform_name, duration);
-            metrics.inc_transform(before != after, transform_name);
+            metrics.inc_transform(hash_before != hash_after, transform_name);
         }
 
         res

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -204,7 +204,10 @@ pub trait Transform: fmt::Debug {
         relation: &mut MirRelationExpr,
         args: &mut TransformCtx,
     ) -> Result<(), TransformError> {
-        let hash_before = args.global_id.and_then(|id| args.last_hash.get(&id).copied()).unwrap_or_else(|| relation.hash_to_u64());
+        let hash_before = args
+            .global_id
+            .and_then(|id| args.last_hash.get(&id).copied())
+            .unwrap_or_else(|| relation.hash_to_u64());
 
         mz_ore::soft_assert_eq_no_log!(hash_before, relation.hash_to_u64(), "cached hash clash");
         // actually run the transform, recording the time taken


### PR DESCRIPTION
#30806 adds some metrics on transforms, but the work of hashing is non-trivial on very large queries. We can reduce hashing by half: store the previous hash in `TransformCtx`. (Using `TransformCtx` is @ggevay's idea; I was going to do something much more invasive.)

This shows a ~3s speedup on the `InsertMultiRow` benchmark on my machine (8s -> 5s).

### Motivation

  * This PR fixes a recognized bug.
  https://github.com/MaterializeInc/database-issues/issues/8832

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
