### PR TITLE
storage: fix reporting of empty sink frontiers

### DIFF
--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -686,8 +686,10 @@ fn sink_collection<G: Scope<Timestamp = Timestamp>>(
             // directly to make sure this doesn't compile if someone attempts to make this operator
             // generic over partial orders in the future.
             let Some(mut upper) = resume_upper.clone().into_option() else {
+                write_frontier.borrow_mut().clear();
                 return Ok(());
             };
+
             let mut deferred_updates = vec![];
             let mut extra_updates = vec![];
             // We must wait until we have data to commit before starting a transaction because


### PR DESCRIPTION
When a sink dataflow is installed, it can happen that the `resume_upper` is determined to be the empty frontier, e.g. when the sink has previously produced all its output already. In this case we immediately shut down the sink dataflow. Prior to this change, we'd do so without updating the shared sink frontier, so neither the `StorageState` nor the controller would learn about the fact that the sink dataflow has shut down. This is fixed in this PR.

### Motivation

  * This PR fixes a recognized bug.

Part of https://github.com/MaterializeInc/database-issues/issues/8842

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
