### PR TITLE
Eliminate unnecessary `.typ()` call from `keys_with_input_keys`

### DIFF
--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -1107,13 +1107,18 @@ impl MirRelationExpr {
                                         {
                                             if first_id == second_id {
                                                 result.extend(
-                                                    inputs[0].typ().keys.drain(..).filter(|key| {
-                                                        key.iter().all(|c| {
-                                                            outputs.get(*c) == Some(c)
-                                                                && base_projection.get(*c)
-                                                                    == Some(c)
+                                                    input_keys
+                                                        .next()
+                                                        .unwrap()
+                                                        .into_iter()
+                                                        .filter(|key| {
+                                                            key.iter().all(|c| {
+                                                                outputs.get(*c) == Some(c)
+                                                                    && base_projection.get(*c)
+                                                                        == Some(c)
+                                                            })
                                                         })
-                                                    }),
+                                                        .cloned(),
                                                 );
                                             }
                                         }


### PR DESCRIPTION
That's the whole point of `keys_with_input_keys` that we already have the input key available, so we don't need to call `.typ()` to get the key of an input. So, this PR substitutes the `typ` call with `input_keys.next().unwrap()` (which is a pattern that already occurs several times in `keys_with_input_keys`).

### Motivation

   * This PR refactors existing code, similar to https://github.com/MaterializeInc/materialize/pull/30876 and https://github.com/MaterializeInc/materialize/pull/30871

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
