### PR TITLE
Sometimes we can give the type to MRE::take_safely

### DIFF
--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -239,7 +239,7 @@ pub fn enforce_linear_chains(expr: &mut MirRelationExpr) -> Result<(), ExplainEr
                 //     .map(|id| LocalId::new(1000_u64 + u64::cast_from(id_map.len()) + id))
                 //     .unwrap();
                 let id = id_gen.next().unwrap();
-                let value = input.take_safely();
+                let value = input.take_safely(None);
                 // generate a `let $fresh_id = $body in $fresh_id` to replace this input
                 let mut binding = MirRelationExpr::Let {
                     id,

--- a/src/transform/src/canonicalization/flatmap_to_map.rs
+++ b/src/transform/src/canonicalization/flatmap_to_map.rs
@@ -59,7 +59,7 @@ impl FlatMapToMap {
                         match (iter.next(), iter.next()) {
                             (None, _) => {
                                 // If there are no elements in the literal argument, no output.
-                                relation.take_safely();
+                                relation.take_safely(None);
                             }
                             (Some((row, 1)), None) => {
                                 *relation =

--- a/src/transform/src/canonicalization/topk_elision.rs
+++ b/src/transform/src/canonicalization/topk_elision.rs
@@ -56,7 +56,7 @@ impl TopKElision {
             if limit.as_ref().map_or(true, |l| l.is_literal_null()) && *offset == 0 {
                 *relation = input.take_dangerous();
             } else if limit.as_ref().and_then(|l| l.as_literal_int64()) == Some(0) {
-                relation.take_safely();
+                relation.take_safely(None);
             }
         }
     }

--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -124,6 +124,7 @@ impl EquivalencePropagation {
         let expr_type = derived
             .value::<RelationType>()
             .expect("RelationType required");
+        assert!(expr_type.is_some());
         let expr_equivalences = derived
             .value::<Equivalences>()
             .expect("Equivalences required");
@@ -132,7 +133,7 @@ impl EquivalencePropagation {
         let expr_equivalences = if let Some(e) = expr_equivalences {
             e
         } else {
-            expr.take_safely();
+            expr.take_safely_with_col_types(expr_type.clone().unwrap());
             return;
         };
 
@@ -147,7 +148,7 @@ impl EquivalencePropagation {
 
         outer_equivalences.minimize(expr_type.as_ref().map(|x| &x[..]));
         if outer_equivalences.unsatisfiable() {
-            expr.take_safely();
+            expr.take_safely_with_col_types(expr_type.clone().unwrap());
             return;
         }
 

--- a/src/transform/src/fold_constants.rs
+++ b/src/transform/src/fold_constants.rs
@@ -250,7 +250,7 @@ impl FoldConstants {
                     .iter()
                     .any(|p| p.is_literal_false() || p.is_literal_null())
                 {
-                    relation.take_safely();
+                    relation.take_safely(Some(relation_type.clone()));
                 } else if let Some((rows, ..)) = (**input).as_const() {
                     // Evaluate errors last, to reduce risk of spurious errors.
                     predicates.sort_by_key(|p| p.is_literal_err());
@@ -291,7 +291,7 @@ impl FoldConstants {
                 ..
             } => {
                 if inputs.iter().any(|e| e.is_empty()) {
-                    relation.take_safely();
+                    relation.take_safely(Some(relation_type.clone()));
                 } else if let Some(e) = inputs.iter().find_map(|i| i.as_const_err()) {
                     *relation = MirRelationExpr::Constant {
                         rows: Err(e.clone()),

--- a/src/transform/src/fusion/top_k.rs
+++ b/src/transform/src/fusion/top_k.rs
@@ -112,7 +112,7 @@ impl TopK {
                     }
 
                     if let Some(0) = limit.as_ref().and_then(|l| l.as_literal_int64()) {
-                        relation.take_safely();
+                        relation.take_safely(None);
                         break;
                     }
 

--- a/src/transform/src/non_null_requirements.rs
+++ b/src/transform/src/non_null_requirements.rs
@@ -170,7 +170,7 @@ impl NonNullRequirements {
                     {
                         // A null value was introduced in a marked column;
                         // the entire expression can be zeroed out.
-                        relation.take_safely();
+                        relation.take_safely(None);
                         Ok(())
                     } else {
                         // For each column, if it must be non-null, extract the expression's

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -595,7 +595,7 @@ impl PredicatePushdown {
                             .count()
                             > 1
                         {
-                            relation.take_safely();
+                            relation.take_safely(Some(relation.typ_with_input_types(&input_types)));
                             return Ok(());
                         }
 


### PR DESCRIPTION
More `typ()` call elimination, similar to e.g. https://github.com/MaterializeInc/materialize/pull/30878

This one goes after various `take_safely` calls, where we know the type already, so no need to call `.typ()`.

Also, this makes `take_safely()` give a better key and nullability to the constant, making use of the fact that we have an empty collection, so we have the keys `[[]]` and nothing is nullable.

### Motivation

  * This PR fixes a previously unreported bug: `take_safely` was often not giving the best possible key to the constant. Ideally, the keys that are recorded on a `MRE::Constant` should be the same as if we were to call `keys_with_input_keys` on it, so that we don't have anomalies such as `create_fast_path_plan` needing to `// For best accuracy, we need to recalculate typ.`. This PR moves one step closer to this.

  * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
