### PR TITLE
test: make github-8810.td work with `--replicas 4`

### DIFF
--- a/test/testdrive/github-8810.td
+++ b/test/testdrive/github-8810.td
@@ -9,6 +9,8 @@
 
 # Regression test for https://github.com/MaterializeInc/database-issues/issues/8810.
 
+$ set-arg-default single-replica-cluster=quickstart
+
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET storage_statistics_interval = '1s';
 ALTER SYSTEM SET storage_statistics_collection_interval = '1s';
@@ -19,6 +21,7 @@ $ kafka-create-topic topic=data
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 
 > CREATE SOURCE src
+  IN CLUSTER ${arg.single-replica-cluster}
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
 
 > SELECT rehydration_latency < '5' FROM mz_internal.mz_source_statistics


### PR DESCRIPTION
`github-8810.td` currently breaks the Nightly job "🏎️ testdrive 4 replicas" because it doesn't consider that the default cluster could have more than one replica. That is fixed here.

### Motivation

  * This PR fixes a nightly test.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
