### PR TITLE
Columnar in logging dataflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,8 +1754,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "columnar"
-version = "0.2.0"
-source = "git+https://github.com/frankmcsherry/columnar#ea1be6ddb64fe984dfe847f82c5f5c60f5815835"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58a4c12223e2d2140bbf4be9fb38b3a612804230c91388dfa4e56a8a6464bf3"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -1767,8 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "columnar_derive"
-version = "0.2.0"
-source = "git+https://github.com/frankmcsherry/columnar#ea1be6ddb64fe984dfe847f82c5f5c60f5815835"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "087b1ac5c4ecad28348b6a9957e3dbd44ac7d041d267370acfdbbfa66b514c7d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10372,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.16.0"
-source = "git+https://github.com/antiguru/timely-dataflow?branch=logger_flush#56ec0d7473e7fee0a79f40525843fa6089873347"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#291de98e10f778799557b187888df0e78fb58f39"
 dependencies = [
  "bincode",
  "byteorder",
@@ -10390,12 +10392,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.2"
-source = "git+https://github.com/antiguru/timely-dataflow?branch=logger_flush#56ec0d7473e7fee0a79f40525843fa6089873347"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#291de98e10f778799557b187888df0e78fb58f39"
 
 [[package]]
 name = "timely_communication"
 version = "0.16.1"
-source = "git+https://github.com/antiguru/timely-dataflow?branch=logger_flush#56ec0d7473e7fee0a79f40525843fa6089873347"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#291de98e10f778799557b187888df0e78fb58f39"
 dependencies = [
  "byteorder",
  "columnar",
@@ -10410,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.13.1"
-source = "git+https://github.com/antiguru/timely-dataflow?branch=logger_flush#56ec0d7473e7fee0a79f40525843fa6089873347"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#291de98e10f778799557b187888df0e78fb58f39"
 dependencies = [
  "columnation",
  "flatcontainer",
@@ -10420,7 +10422,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.13.1"
-source = "git+https://github.com/antiguru/timely-dataflow?branch=logger_flush#56ec0d7473e7fee0a79f40525843fa6089873347"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#291de98e10f778799557b187888df0e78fb58f39"
 dependencies = [
  "timely_container",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -1755,8 +1755,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 [[package]]
 name = "columnar"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d754936b0b004c01c338b3d81c39e0a81d2ead5b6ee9fa64bfa140e6c430b80d"
+source = "git+https://github.com/frankmcsherry/columnar#ea1be6ddb64fe984dfe847f82c5f5c60f5815835"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -1769,8 +1768,7 @@ dependencies = [
 [[package]]
 name = "columnar_derive"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "174af3249fb00e9845597cb3a8259f05ff62b4060650b6af6adb4e05df277f7a"
+source = "git+https://github.com/frankmcsherry/columnar#ea1be6ddb64fe984dfe847f82c5f5c60f5815835"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5113,6 +5111,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "bytesize",
+ "columnar",
  "core_affinity",
  "crossbeam-channel",
  "dec",
@@ -5199,6 +5198,7 @@ dependencies = [
 name = "mz-compute-types"
 version = "0.0.0"
 dependencies = [
+ "columnar",
  "columnation",
  "differential-dataflow",
  "itertools 0.12.1",
@@ -7309,6 +7309,8 @@ version = "0.0.0"
 dependencies = [
  "ahash",
  "bincode",
+ "bytemuck",
+ "columnar",
  "columnation",
  "differential-dataflow",
  "either",
@@ -10370,8 +10372,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b134806db44c8452ba2a9b18e6112f3d5e0a0185c6e58524269a08ca2891149c"
+source = "git+https://github.com/antiguru/timely-dataflow?branch=logger_flush#56ec0d7473e7fee0a79f40525843fa6089873347"
 dependencies = [
  "bincode",
  "byteorder",
@@ -10389,14 +10390,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99223f9594ab7d4dd36b55b1d7eb9bd2cd205f4304b5cc5381d5cdd417ec06f2"
+source = "git+https://github.com/antiguru/timely-dataflow?branch=logger_flush#56ec0d7473e7fee0a79f40525843fa6089873347"
 
 [[package]]
 name = "timely_communication"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00d5c7f7bbb132a32220890240e5d951fc9582f82fb94452c011a8033c39f7a"
+source = "git+https://github.com/antiguru/timely-dataflow?branch=logger_flush#56ec0d7473e7fee0a79f40525843fa6089873347"
 dependencies = [
  "byteorder",
  "columnar",
@@ -10411,8 +10410,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b763064e76ba4f650dcdb035d82bcaad09986971fab002276e0b4cb10b3aa5"
+source = "git+https://github.com/antiguru/timely-dataflow?branch=logger_flush#56ec0d7473e7fee0a79f40525843fa6089873347"
 dependencies = [
  "columnation",
  "flatcontainer",
@@ -10422,8 +10420,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8300263e23bebac4ec9fbbeee65954a25402037609b7716d20191ed35829b14"
+source = "git+https://github.com/antiguru/timely-dataflow?branch=logger_flush#56ec0d7473e7fee0a79f40525843fa6089873347"
 dependencies = [
  "timely_container",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10373,8 +10373,9 @@ dependencies = [
 
 [[package]]
 name = "timely"
-version = "0.16.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#291de98e10f778799557b187888df0e78fb58f39"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ace21eb2a22c1b80b0b9b5be0627eb0f95a128a5751e866aefc90a85e3007d3"
 dependencies = [
  "bincode",
  "byteorder",
@@ -10392,12 +10393,14 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.2"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#291de98e10f778799557b187888df0e78fb58f39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99223f9594ab7d4dd36b55b1d7eb9bd2cd205f4304b5cc5381d5cdd417ec06f2"
 
 [[package]]
 name = "timely_communication"
-version = "0.16.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#291de98e10f778799557b187888df0e78fb58f39"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de7b73d69bd229dae4ea989beb7e48e652c0a576774134e6fed59e29f2a6f52c"
 dependencies = [
  "byteorder",
  "columnar",
@@ -10411,8 +10414,9 @@ dependencies = [
 
 [[package]]
 name = "timely_container"
-version = "0.13.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#291de98e10f778799557b187888df0e78fb58f39"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb051808b458a14146900968293da6166b1e6df5dab7c4d1d163f4734b7431"
 dependencies = [
  "columnation",
  "flatcontainer",
@@ -10421,8 +10425,9 @@ dependencies = [
 
 [[package]]
 name = "timely_logging"
-version = "0.13.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#291de98e10f778799557b187888df0e78fb58f39"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6760517ac4ffa29d00841b0fccf513ece5da896f159045a43970fdb228726d9"
 dependencies = [
  "timely_container",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -285,16 +285,6 @@ incremental = true
 # merged), after which point it becomes impossible to build that historical
 # version of Materialize.
 [patch.crates-io]
-#columnar = { git = "https://github.com/frankmcsherry/columnar" }
-#columnar = { git = "https://github.com/antiguru/columnar", branch = "inline_as_bytes" }
-#columnar = { path = "../columnar" }
-#differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow" }
-#differential-dataflow = { git = "https://github.com/antiguru/differential-dataflow", branch = "logging_fallout", version = "0.13.2" }
-#differential-dataflow = { path = "../differential-dataflow" }
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
-#timely = { git = "https://github.com/antiguru/timely-dataflow", branch = "logger_flush" }
-#timely = { path = "../timely-dataflow/timely" }
-
 # Waiting on https://github.com/sfackler/rust-postgres/pull/752.
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -285,14 +285,14 @@ incremental = true
 # merged), after which point it becomes impossible to build that historical
 # version of Materialize.
 [patch.crates-io]
-columnar = { git = "https://github.com/frankmcsherry/columnar" }
-#columnar = { git = "https://github.com/antiguru/columnar", branch = "attrs" }
+#columnar = { git = "https://github.com/frankmcsherry/columnar" }
+#columnar = { git = "https://github.com/antiguru/columnar", branch = "inline_as_bytes" }
 #columnar = { path = "../columnar" }
 #differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow" }
 #differential-dataflow = { git = "https://github.com/antiguru/differential-dataflow", branch = "logging_fallout", version = "0.13.2" }
 #differential-dataflow = { path = "../differential-dataflow" }
-#timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
-timely = { git = "https://github.com/antiguru/timely-dataflow", branch = "logger_flush" }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
+#timely = { git = "https://github.com/antiguru/timely-dataflow", branch = "logger_flush" }
 #timely = { path = "../timely-dataflow/timely" }
 
 # Waiting on https://github.com/sfackler/rust-postgres/pull/752.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -285,6 +285,16 @@ incremental = true
 # merged), after which point it becomes impossible to build that historical
 # version of Materialize.
 [patch.crates-io]
+columnar = { git = "https://github.com/frankmcsherry/columnar" }
+#columnar = { git = "https://github.com/antiguru/columnar", branch = "attrs" }
+#columnar = { path = "../columnar" }
+#differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow" }
+#differential-dataflow = { git = "https://github.com/antiguru/differential-dataflow", branch = "logging_fallout", version = "0.13.2" }
+#differential-dataflow = { path = "../differential-dataflow" }
+#timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
+timely = { git = "https://github.com/antiguru/timely-dataflow", branch = "logger_flush" }
+#timely = { path = "../timely-dataflow/timely" }
+
 # Waiting on https://github.com/sfackler/rust-postgres/pull/752.
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }

--- a/src/compute-types/Cargo.toml
+++ b/src/compute-types/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
+columnar = "0.2.0"
 columnation = "0.1.0"
 differential-dataflow = "0.13.3"
 itertools = "0.12.1"

--- a/src/compute-types/Cargo.toml
+++ b/src/compute-types/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-columnar = "0.2.0"
+columnar = "0.2.2"
 columnation = "0.1.0"
 differential-dataflow = "0.13.3"
 itertools = "0.12.1"

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -43,7 +43,7 @@ impl Context {
     pub fn new(debug_name: String, features: &OptimizerFeatures) -> Self {
         Self {
             arrangements: Default::default(),
-            next_lir_id: LirId(std::num::NonZero::<u64>::MIN),
+            next_lir_id: LirId(1),
             debug_info: LirDebugInfo {
                 debug_name,
                 id: GlobalId::Transient(0),

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 anyhow = "1.0.66"
 async-stream = "0.3.3"
 bytesize = "1.1.0"
+columnar = "0.2.0"
 crossbeam-channel = "0.5.8"
 dec = { version = "0.4.8", features = ["serde"] }
 differential-dataflow = "0.13.3"

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 anyhow = "1.0.66"
 async-stream = "0.3.3"
 bytesize = "1.1.0"
-columnar = "0.2.0"
+columnar = "0.2.2"
 crossbeam-channel = "0.5.8"
 dec = { version = "0.4.8", features = ["serde"] }
 differential-dataflow = "0.13.3"

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -597,7 +597,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
 
         // Log the receipt of the peek.
         if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-            logger.log(pending.as_log_event(true));
+            logger.log(&pending.as_log_event(true));
         }
 
         self.process_peek(&mut Antichain::new(), pending);
@@ -891,7 +891,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
 
         // Log responding to the peek request.
         if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-            logger.log(log_event);
+            logger.log(&log_event);
         }
     }
 

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -263,10 +263,10 @@ where
         .stream
         .unary(Pipeline, "ArrangementSize", |_cap, info| {
             let address = info.address;
-            logger.log(ComputeEvent::ArrangementHeapSizeOperator(
+            logger.log(&ComputeEvent::ArrangementHeapSizeOperator(
                 ArrangementHeapSizeOperator {
                     operator_id,
-                    address,
+                    address: address.to_vec(),
                 },
             ));
             move |input, output| {
@@ -281,7 +281,7 @@ where
 
                 let size = size.try_into().expect("must fit");
                 if size != old_size {
-                    logger.log(ComputeEvent::ArrangementHeapSize(ArrangementHeapSize {
+                    logger.log(&ComputeEvent::ArrangementHeapSize(ArrangementHeapSize {
                         operator_id,
                         delta_size: size - old_size,
                     }));
@@ -289,7 +289,7 @@ where
 
                 let capacity = capacity.try_into().expect("must fit");
                 if capacity != old_capacity {
-                    logger.log(ComputeEvent::ArrangementHeapCapacity(
+                    logger.log(&ComputeEvent::ArrangementHeapCapacity(
                         ArrangementHeapCapacity {
                             operator_id,
                             delta_capacity: capacity - old_capacity,
@@ -299,7 +299,7 @@ where
 
                 let allocations = allocations.try_into().expect("must fit");
                 if allocations != old_allocations {
-                    logger.log(ComputeEvent::ArrangementHeapAllocations(
+                    logger.log(&ComputeEvent::ArrangementHeapAllocations(
                         ArrangementHeapAllocations {
                             operator_id,
                             delta_allocations: allocations - old_allocations,

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -264,8 +264,6 @@ pub struct LirMetadata {
     /// The LIR operator, as a string (see `FlatPlanNode::humanize`).
     operator: String,
     /// The LIR identifier of the parent (if any).
-    /// Since `LirId`s are strictly positive, Rust can steal the low bit.
-    /// (See `test_option_lirid_fits_in_usize`.)
     parent_lir_id: Option<LirId>,
     /// How nested the operator is (for nice indentation).
     nesting: u8,

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -18,10 +18,9 @@ use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
 use differential_dataflow::logging::{
     BatchEvent, BatcherEvent, DifferentialEvent, DropEvent, MergeEvent, TraceShare,
 };
-use differential_dataflow::Hashable;
 use mz_ore::cast::CastFrom;
-use mz_repr::{Datum, Diff, RowRef, Timestamp};
-use mz_timely_util::containers::{Col2ValBatcher, ColumnBuilder};
+use mz_repr::{Datum, Diff, Timestamp};
+use mz_timely_util::containers::{columnar_exchange, Col2ValBatcher, ColumnBuilder};
 use mz_timely_util::replay::MzReplay;
 use timely::communication::Allocate;
 use timely::container::CapacityContainerBuilder;
@@ -165,7 +164,7 @@ pub(super) fn construct<A: Allocate>(
             if config.index_logs.contains_key(&variant) {
                 let trace = collection
                     .mz_arrange_core::<_, Col2ValBatcher<_, _, _, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
-                        ExchangeCore::new(|((key, _val), _time, _diff): &((&RowRef, &RowRef), _, _)| key.hashed()),
+                        ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<mz_repr::Row, mz_repr::Row, Timestamp, mz_repr::Diff>),
                         &format!("Arrange {variant:?}"),
                     )
                     .trace;

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -298,7 +298,7 @@ impl DemuxHandler<'_, '_> {
                 .expect("under/overflow");
             if *sharing == 0 {
                 self.state.sharing.remove(&operator_id);
-                logger.log(ComputeEvent::ArrangementHeapSizeOperatorDrop(
+                logger.log(&ComputeEvent::ArrangementHeapSizeOperatorDrop(
                     ArrangementHeapSizeOperatorDrop { operator_id },
                 ));
             }

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -168,7 +168,7 @@ impl<A: Allocate + 'static> LoggingContext<'_, A> {
         &self,
         event_queue: EventQueue<CB::Container>,
     ) -> Logger<CB> {
-        let mut logger = BatchLogger::<_, _>::new(event_queue.link, self.interval_ms);
+        let mut logger = BatchLogger::new(event_queue.link, self.interval_ms);
         Logger::new(
             self.now,
             self.start_offset,
@@ -185,7 +185,7 @@ impl<A: Allocate + 'static> LoggingContext<'_, A> {
     fn reachability_logger(&self) -> Logger<TrackerEventBuilder> {
         let event_queue = self.r_event_queue.clone();
 
-        let mut logger = BatchLogger::<_, _>::new(event_queue.link, self.interval_ms);
+        let mut logger = BatchLogger::new(event_queue.link, self.interval_ms);
         let mut massaged = Vec::new();
         let mut builder = ColumnBuilder::default();
 

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -14,15 +14,13 @@ use differential_dataflow::dynamic::pointstamp::PointStamp;
 use differential_dataflow::logging::{DifferentialEvent, DifferentialEventBuilder};
 use differential_dataflow::Collection;
 use mz_compute_client::logging::{LogVariant, LoggingConfig};
-use mz_ore::flatcontainer::{MzRegionPreference, OwnedRegionOpinion};
 use mz_repr::{Diff, Timestamp};
 use mz_storage_operators::persist_source::Subtime;
 use mz_storage_types::errors::DataflowError;
-use mz_timely_util::containers::Column;
+use mz_timely_util::containers::{Column, ColumnBuilder};
 use mz_timely_util::operator::CollectionExt;
 use timely::communication::Allocate;
-use timely::container::flatcontainer::FlatStack;
-use timely::container::ContainerBuilder;
+use timely::container::{ContainerBuilder, PushInto};
 use timely::logging::{ProgressEventTimestamp, TimelyEvent, TimelyEventBuilder};
 use timely::logging_core::Logger;
 use timely::order::Product;
@@ -83,14 +81,10 @@ pub fn initialize<A: Allocate + 'static>(
     (logger, traces)
 }
 
-/// Type to specify the region for holding reachability events. Only intended to be interpreted
-/// as [`MzRegionPreference`].
-type ReachabilityEventRegionPreference = (
-    OwnedRegionOpinion<Vec<usize>>,
-    OwnedRegionOpinion<Vec<(usize, usize, bool, Option<Timestamp>, Diff)>>,
+pub(super) type ReachabilityEvent = (
+    Vec<usize>,
+    Vec<(usize, usize, bool, Option<Timestamp>, Diff)>,
 );
-pub(super) type ReachabilityEventRegion =
-    <(Duration, ReachabilityEventRegionPreference) as MzRegionPreference>::Region;
 
 struct LoggingContext<'a, A: Allocate> {
     worker: &'a mut timely::worker::Worker<A>,
@@ -99,7 +93,7 @@ struct LoggingContext<'a, A: Allocate> {
     now: Instant,
     start_offset: Duration,
     t_event_queue: EventQueue<Vec<(Duration, TimelyEvent)>>,
-    r_event_queue: EventQueue<FlatStack<ReachabilityEventRegion>>,
+    r_event_queue: EventQueue<Column<(Duration, ReachabilityEvent)>>,
     d_event_queue: EventQueue<Vec<(Duration, DifferentialEvent)>>,
     c_event_queue: EventQueue<Column<(Duration, ComputeEvent)>>,
     shared_state: Rc<RefCell<SharedLoggingState>>,
@@ -182,29 +176,21 @@ impl<A: Allocate + 'static> LoggingContext<'_, A> {
                 if data.is_none() {
                     event_queue.activator.activate();
                 }
-                logger.publish_batch(time, data);
+                logger.publish_batch(time, data.take());
             },
         )
     }
 
     fn reachability_logger(&self) -> Logger<TrackerEventBuilder> {
         let event_queue = self.r_event_queue.clone();
-        let mut logger = BatchLogger::<FlatStack<ReachabilityEventRegion>, _>::new(
-            event_queue.link,
-            self.interval_ms,
-        );
-        Logger::new(
-            self.now,
-            self.start_offset,
-            move |time, data: &mut Option<Vec<_>>| {
-                let Some(data) = data.as_mut() else {
-                    logger.publish_batch(time, &mut None);
-                    event_queue.activator.activate();
-                    return;
-                };
 
-                let mut massaged = Vec::new();
-                let mut container = FlatStack::default();
+        let mut logger = BatchLogger::<_, _>::new(event_queue.link, self.interval_ms);
+        let mut massaged = Vec::new();
+        let mut builder = ColumnBuilder::default();
+
+        let action = move |batch_time: &Duration, data: &mut Option<Vec<_>>| {
+            if let Some(data) = data {
+                // Handle data
                 for (time, event) in data.drain(..) {
                     match event {
                         TrackerEvent::SourceUpdate(update) => {
@@ -216,7 +202,7 @@ impl<A: Allocate + 'static> LoggingContext<'_, A> {
                                 },
                             ));
 
-                            container.copy((time, (update.tracker_id, &massaged)));
+                            builder.push_into((time, (&update.tracker_id, &massaged)));
                             massaged.clear();
                         }
                         TrackerEvent::TargetUpdate(update) => {
@@ -228,15 +214,26 @@ impl<A: Allocate + 'static> LoggingContext<'_, A> {
                                 },
                             ));
 
-                            container.copy((time, (update.tracker_id, &massaged)));
+                            builder.push_into((time, (&update.tracker_id, &massaged)));
                             massaged.clear();
                         }
                     }
+                    while let Some(container) = builder.extract() {
+                        logger.publish_batch(&time, Some(std::mem::take(container)));
+                    }
                 }
-                logger.publish_batch(time, &mut Some(container));
+            } else {
+                // Handle a flush
+                while let Some(container) = builder.finish() {
+                    logger.publish_batch(batch_time, Some(std::mem::take(container)));
+                }
+
+                logger.publish_batch(batch_time, None);
                 event_queue.activator.activate();
-            },
-        )
+            }
+        };
+
+        Logger::new(self.now, self.start_offset, action)
     }
 }
 

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -15,11 +15,10 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use columnar::Index;
-use differential_dataflow::Hashable;
 use mz_compute_client::logging::LoggingConfig;
 use mz_ore::cast::CastFrom;
-use mz_repr::{Datum, Diff, Row, RowRef, Timestamp};
-use mz_timely_util::containers::{Col2ValBatcher, Column, ColumnBuilder};
+use mz_repr::{Datum, Diff, Row, Timestamp};
+use mz_timely_util::containers::{columnar_exchange, Col2ValBatcher, Column, ColumnBuilder};
 use mz_timely_util::replay::MzReplay;
 use timely::communication::Allocate;
 use timely::dataflow::channels::pact::ExchangeCore;
@@ -105,7 +104,7 @@ pub(super) fn construct<A: Allocate>(
             if config.index_logs.contains_key(&variant) {
                 let trace = updates
                     .mz_arrange_core::<_, Col2ValBatcher<_, _, _, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
-                        ExchangeCore::new(|((key, _val), _time, _diff): &((&RowRef, &RowRef), _, _)| key.hashed()),
+                        ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<Row, Row, Timestamp, Diff>),
                         &format!("Arrange {variant:?}"),
                     )
                     .trace;

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -12,27 +12,24 @@
 use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::rc::Rc;
+use std::time::Duration;
 
-use differential_dataflow::AsCollection;
+use columnar::{Columnar, Index};
+use differential_dataflow::Hashable;
 use mz_compute_client::logging::LoggingConfig;
-use mz_expr::{permutation_for_arrangement, MirScalarExpr};
 use mz_ore::cast::CastFrom;
-use mz_ore::flatcontainer::{MzRegionPreference, OwnedRegionOpinion};
-use mz_ore::iter::IteratorExt;
-use mz_repr::{Datum, Diff, RowArena, SharedRow, Timestamp};
-use mz_timely_util::operator::consolidate_pact;
+use mz_repr::{Datum, Diff, Row, RowRef, Timestamp};
+use mz_timely_util::containers::{Col2ValBatcher, Column, ColumnBuilder};
 use mz_timely_util::replay::MzReplay;
 use timely::communication::Allocate;
-use timely::container::flatcontainer::FlatStack;
-use timely::container::CapacityContainerBuilder;
-use timely::dataflow::channels::pact::Pipeline;
-use timely::dataflow::operators::core::Map;
+use timely::dataflow::channels::pact::ExchangeCore;
+use timely::Container;
 
-use crate::extensions::arrange::MzArrange;
-use crate::logging::initialize::ReachabilityEventRegion;
-use crate::logging::{EventQueue, LogCollection, LogVariant, TimelyLog};
-use crate::row_spine::{RowRowBatcher, RowRowBuilder};
-use crate::typedefs::{FlatKeyValBatcherDefault, RowRowSpine};
+use crate::extensions::arrange::MzArrangeCore;
+use crate::logging::initialize::ReachabilityEvent;
+use crate::logging::{prepare_log_collection, EventQueue, LogCollection, LogVariant, TimelyLog};
+use crate::row_spine::RowRowBuilder;
+use crate::typedefs::RowRowSpine;
 
 /// Constructs the logging dataflow for reachability logs.
 ///
@@ -43,7 +40,7 @@ use crate::typedefs::{FlatKeyValBatcherDefault, RowRowSpine};
 pub(super) fn construct<A: Allocate>(
     worker: &mut timely::worker::Worker<A>,
     config: &LoggingConfig,
-    event_queue: EventQueue<FlatStack<ReachabilityEventRegion>>,
+    event_queue: EventQueue<Column<(Duration, ReachabilityEvent)>>,
 ) -> BTreeMap<LogVariant, LogCollection> {
     let interval_ms = std::cmp::max(1, config.interval.as_millis());
     let worker_index = worker.index();
@@ -52,16 +49,9 @@ pub(super) fn construct<A: Allocate>(
     // A dataflow for multiple log-derived arrangements.
     let traces = worker.dataflow_named("Dataflow: timely reachability logging", move |scope| {
         let enable_logging = config.enable_logging;
-        type UpdatesKey = (
-            bool,
-            OwnedRegionOpinion<Vec<usize>>,
-            usize,
-            usize,
-            Option<Timestamp>,
-        );
-        type UpdatesRegion = <((UpdatesKey, ()), Timestamp, Diff) as MzRegionPreference>::Region;
+        type UpdatesKey = (bool, Vec<usize>, usize, usize, Option<Timestamp>);
 
-        type CB = CapacityContainerBuilder<FlatStack<UpdatesRegion>>;
+        type CB = ColumnBuilder<((UpdatesKey, ()), Timestamp, Diff)>;
         let (updates, token) = Some(event_queue.link).mz_replay::<_, CB, _>(
             scope,
             "reachability logs",
@@ -76,7 +66,7 @@ pub(super) fn construct<A: Allocate>(
                 for (time, (addr, massaged)) in data.iter() {
                     let time_ms = ((time.as_millis() / interval_ms) + 1) * interval_ms;
                     let time_ms: Timestamp = time_ms.try_into().expect("must fit");
-                    for (source, port, update_type, ts, diff) in massaged {
+                    for (source, port, update_type, ts, diff) in massaged.into_iter() {
                         let datum = (update_type, addr, source, port, ts);
                         session.give(((datum, ()), time_ms, diff));
                     }
@@ -85,62 +75,36 @@ pub(super) fn construct<A: Allocate>(
         );
 
         // Restrict results by those logs that are meant to be active.
-        let logs_active = vec![LogVariant::Timely(TimelyLog::Reachability)];
+        let logs_active = [LogVariant::Timely(TimelyLog::Reachability)];
 
-        let updates = consolidate_pact::<
-            FlatKeyValBatcherDefault<UpdatesKey, (), Timestamp, Diff, _>,
-            _,
-            _,
-            _,
-            _,
-        >(&updates, Pipeline, "Consolidate Timely reachability")
-        .container::<FlatStack<UpdatesRegion>>();
+        let mut addr_row = Row::default();
+        let updates = prepare_log_collection(
+            &updates,
+            TimelyLog::Reachability,
+            move |datum, (), packer| {
+                let (update_type, addr, source, port, ts) = datum;
+                let update_type = if update_type { "source" } else { "target" };
+                addr_row.packer().push_list(
+                    addr.iter()
+                        .chain(std::iter::once(source))
+                        .map(|id| Datum::UInt64(u64::cast_from(id))),
+                );
+                packer.pack_slice(&[
+                    addr_row.iter().next().unwrap(),
+                    Datum::UInt64(u64::cast_from(port)),
+                    Datum::UInt64(u64::cast_from(worker_index)),
+                    Datum::String(update_type),
+                    Datum::from(<Option<Timestamp>>::into_owned(ts)),
+                ]);
+            }
+        );
 
         let mut result = BTreeMap::new();
         for variant in logs_active {
             if config.index_logs.contains_key(&variant) {
-                let key = variant.index_by();
-                let (_, value) = permutation_for_arrangement(
-                    &key.iter()
-                        .cloned()
-                        .map(MirScalarExpr::Column)
-                        .collect::<Vec<_>>(),
-                    variant.desc().arity(),
-                );
-
-                let updates = updates
-                    .map(
-                        move |(((update_type, addr, source, port, ts), _), time, diff)| {
-                            let row_arena = RowArena::default();
-                            let update_type = if update_type { "source" } else { "target" };
-                            let binding = SharedRow::get();
-                            let mut row_builder = binding.borrow_mut();
-                            row_builder.packer().push_list(
-                                addr.iter()
-                                    .copied()
-                                    .chain_one(source)
-                                    .map(|id| Datum::UInt64(u64::cast_from(id))),
-                            );
-                            let datums = &[
-                                row_arena.push_unary_row(row_builder.clone()),
-                                Datum::UInt64(u64::cast_from(port)),
-                                Datum::UInt64(u64::cast_from(worker_index)),
-                                Datum::String(update_type),
-                                Datum::from(ts.clone()),
-                            ];
-                            row_builder.packer().extend(key.iter().map(|k| datums[*k]));
-                            let key_row = row_builder.clone();
-                            row_builder
-                                .packer()
-                                .extend(value.iter().map(|k| datums[*k]));
-                            let value_row = row_builder.clone();
-                            ((key_row, value_row), time, diff)
-                        },
-                    )
-                    .as_collection();
-
                 let trace = updates
-                    .mz_arrange::<RowRowBatcher<_, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+                    .mz_arrange_core::<_, Col2ValBatcher<_, _, _, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+                        ExchangeCore::new(|((key, _val), _time, _diff): &((&RowRef, &RowRef), _, _)| key.hashed()),
                         &format!("Arrange {variant:?}"),
                     )
                     .trace;

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -53,8 +53,7 @@ pub(super) fn construct<A: Allocate>(
     event_queue: EventQueue<Vec<(Duration, TimelyEvent)>>,
     shared_state: Rc<RefCell<SharedLoggingState>>,
 ) -> BTreeMap<LogVariant, LogCollection> {
-    let logging_interval_ms =
-        u64::try_from(std::cmp::max(1, config.interval.as_millis())).expect("must fit");
+    let logging_interval_ms = std::cmp::max(1, config.interval.as_millis());
     let worker_id = worker.index();
     let peers = worker.peers();
     let dataflow_index = worker.next_dataflow_index();
@@ -436,7 +435,7 @@ struct DemuxHandler<'a, 'b> {
     /// Demux output buffers.
     output: &'a mut DemuxOutput<'b>,
     /// The logging interval specifying the time granularity for the updates.
-    logging_interval_ms: u64,
+    logging_interval_ms: u128,
     /// The number of timely workers.
     peers: usize,
     /// The current event time.
@@ -447,7 +446,7 @@ impl DemuxHandler<'_, '_> {
     /// Return the timestamp associated with the current event, based on the event time and the
     /// logging interval.
     fn ts(&self) -> Timestamp {
-        let time_ms = u64::try_from(self.time.as_millis()).expect("must fit");
+        let time_ms = self.time.as_millis();
         let interval = self.logging_interval_ms;
         let rounded = (time_ms / interval + 1) * interval;
         rounded.try_into().expect("must fit")

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -566,7 +566,7 @@ impl DemuxHandler<'_, '_> {
     fn handle_dataflow_shutdown(&mut self, dataflow_index: usize) {
         // Notify compute logging about the shutdown.
         if let Some(logger) = &self.shared_state.compute_logger {
-            logger.log(ComputeEvent::DataflowShutdown(DataflowShutdown {
+            logger.log(&ComputeEvent::DataflowShutdown(DataflowShutdown {
                 dataflow_index,
             }));
         }

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -203,7 +203,7 @@ pub(super) fn construct<A: Allocate>(
                     Datum::UInt64(datum.duration_pow),
                     datum
                         .requested_pow
-                        .map(|v| Datum::UInt64(v))
+                        .map(Datum::UInt64)
                         .unwrap_or(Datum::Null),
                 ]);
                 session.give((data, time, diff));

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -956,7 +956,7 @@ where
             // ActiveComputeState can't have a catalog reference, so we'll need to capture the names
             // in some other structure and have that structure impl ExprHumanizer
             let metadata = if should_compute_lir_metadata {
-                let operator: Box<str> = node.expr.humanize(&DummyHumanizer).into();
+                let operator = node.expr.humanize(&DummyHumanizer);
                 let operator_id_start = self.scope.peek_identifier();
                 Some((operator, operator_id_start))
             } else {
@@ -983,8 +983,7 @@ where
         }
 
         if let Some(lir_mapping_metadata) = lir_mapping_metadata {
-            let mapping: Box<[(LirId, LirMetadata)]> = lir_mapping_metadata.into();
-            self.log_lir_mapping(object_id, mapping);
+            self.log_lir_mapping(object_id, lir_mapping_metadata);
         }
 
         collections
@@ -1186,16 +1185,16 @@ where
 
     fn log_dataflow_global_id(&self, dataflow_index: usize, global_id: GlobalId) {
         if let Some(logger) = &self.compute_logger {
-            logger.log(ComputeEvent::DataflowGlobal(DataflowGlobal {
+            logger.log(&ComputeEvent::DataflowGlobal(DataflowGlobal {
                 dataflow_index,
                 global_id,
             }));
         }
     }
 
-    fn log_lir_mapping(&self, global_id: GlobalId, mapping: Box<[(LirId, LirMetadata)]>) {
+    fn log_lir_mapping(&self, global_id: GlobalId, mapping: Vec<(LirId, LirMetadata)>) {
         if let Some(logger) = &self.compute_logger {
-            logger.log(ComputeEvent::LirMapping(LirMapping { global_id, mapping }));
+            logger.log(&ComputeEvent::LirMapping(LirMapping { global_id, mapping }));
         }
     }
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -744,7 +744,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
             for (_, peek) in std::mem::take(&mut compute_state.pending_peeks) {
                 // Log dropping the peek request.
                 if let Some(logger) = compute_state.compute_logger.as_mut() {
-                    logger.log(peek.as_log_event(false));
+                    logger.log(&peek.as_log_event(false));
                 }
             }
 

--- a/src/compute/src/sink/copy_to_s3_oneshot.rs
+++ b/src/compute/src/sink/copy_to_s3_oneshot.rs
@@ -67,7 +67,7 @@ where
         // is necessary to ensure the files written from each compute replica are identical.
         // While this is not technically guaranteed, the current implementation uses a FIFO channel.
         // In the storage copy_to operator we assert the ordering of rows to detect any regressions.
-        let input = consolidate_pact::<KeyBatcher<_, _, _>, _, _, _>(
+        let input = consolidate_pact::<KeyBatcher<_, _, _>, _, _>(
             &sinked_collection
                 .map(move |row| {
                     let batch = row.hashed() % batch_count;
@@ -81,7 +81,7 @@ where
         let input = input.map(Clone::clone).as_collection();
 
         // We need to consolidate the error collection to ensure we don't act on retracted errors.
-        let error = consolidate_pact::<KeyBatcher<_, _, _>, _, _, _>(
+        let error = consolidate_pact::<KeyBatcher<_, _, _>, _, _>(
             &err_collection
                 .map(move |row| {
                     let batch = row.hashed() % batch_count;

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -13,7 +13,9 @@
 
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::operators::arrange::TraceAgent;
-use differential_dataflow::trace::implementations::chunker::ColumnationChunker;
+use differential_dataflow::trace::implementations::chunker::{
+    ColumnationChunker, ContainerChunker,
+};
 use differential_dataflow::trace::implementations::merge_batcher::{ColMerger, MergeBatcher};
 use differential_dataflow::trace::implementations::ord_neu::{
     FlatValBatcher, FlatValBuilder, FlatValSpine, OrdValBatch,
@@ -23,6 +25,7 @@ use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
 use mz_ore::flatcontainer::MzRegionPreference;
 use mz_repr::Diff;
 use mz_storage_types::errors::DataflowError;
+use timely::container::columnation::TimelyStack;
 use timely::container::flatcontainer::impls::tuple::{TupleABCRegion, TupleABRegion};
 use timely::dataflow::ScopeParent;
 
@@ -194,6 +197,13 @@ pub type RowErrBuilder<T, R> = RowValBuilder<DataflowError, T, R>;
 pub type KeyBatcher<K, T, D> = KeyValBatcher<K, (), T, D>;
 pub type KeyValBatcher<K, V, T, D> =
     MergeBatcher<Vec<((K, V), T, D)>, ColumnationChunker<((K, V), T, D)>, ColMerger<(K, V), T, D>>;
+
+pub type KeyBatcherColumnar<K, T, D> = KeyValBatcher<K, (), T, D>;
+pub type KeyValBatcherColumnar<K, V, T, D> = MergeBatcher<
+    Vec<((K, V), T, D)>,
+    ContainerChunker<TimelyStack<((K, V), T, D)>>,
+    ColMerger<(K, V), T, D>,
+>;
 
 pub type FlatKeyValBatch<K, V, T, R> = OrdValBatch<MzFlatLayout<K, V, T, R>>;
 pub type FlatKeyValSpine<K, V, T, R> = FlatValSpine<MzFlatLayout<K, V, T, R>>;

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -13,9 +13,7 @@
 
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::operators::arrange::TraceAgent;
-use differential_dataflow::trace::implementations::chunker::{
-    ColumnationChunker, ContainerChunker,
-};
+use differential_dataflow::trace::implementations::chunker::ColumnationChunker;
 use differential_dataflow::trace::implementations::merge_batcher::{ColMerger, MergeBatcher};
 use differential_dataflow::trace::implementations::ord_neu::{
     FlatValBatcher, FlatValBuilder, FlatValSpine, OrdValBatch,
@@ -25,7 +23,6 @@ use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
 use mz_ore::flatcontainer::MzRegionPreference;
 use mz_repr::Diff;
 use mz_storage_types::errors::DataflowError;
-use timely::container::columnation::TimelyStack;
 use timely::container::flatcontainer::impls::tuple::{TupleABCRegion, TupleABRegion};
 use timely::dataflow::ScopeParent;
 
@@ -197,13 +194,6 @@ pub type RowErrBuilder<T, R> = RowValBuilder<DataflowError, T, R>;
 pub type KeyBatcher<K, T, D> = KeyValBatcher<K, (), T, D>;
 pub type KeyValBatcher<K, V, T, D> =
     MergeBatcher<Vec<((K, V), T, D)>, ColumnationChunker<((K, V), T, D)>, ColMerger<(K, V), T, D>>;
-
-pub type KeyBatcherColumnar<K, T, D> = KeyValBatcher<K, (), T, D>;
-pub type KeyValBatcherColumnar<K, V, T, D> = MergeBatcher<
-    Vec<((K, V), T, D)>,
-    ContainerChunker<TimelyStack<((K, V), T, D)>>,
-    ColMerger<(K, V), T, D>,
->;
 
 pub type FlatKeyValBatch<K, V, T, R> = OrdValBatch<MzFlatLayout<K, V, T, R>>;
 pub type FlatKeyValSpine<K, V, T, R> = FlatValSpine<MzFlatLayout<K, V, T, R>>;

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -31,7 +31,7 @@ arrow = { version = "53.3.0", default-features = false }
 bitflags = "1.3.2"
 bytes = "1.3.0"
 cfg-if = "1.0.0"
-columnar = "0.2.0"
+columnar = "0.2.2"
 columnation = "0.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["serde", "std"] }
 compact_bytes = "0.1.2"

--- a/src/repr/src/global_id.rs
+++ b/src/repr/src/global_id.rs
@@ -11,6 +11,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Error};
+use columnar::Columnar;
 use columnation::{Columnation, CopyRegion};
 use mz_lowertest::MzReflect;
 use mz_ore::id_gen::AtomicIdGen;
@@ -50,6 +51,7 @@ include!(concat!(env!("OUT_DIR"), "/mz_repr.global_id.rs"));
     Serialize,
     Deserialize,
     MzReflect,
+    Columnar,
 )]
 pub enum GlobalId {
     /// System namespace.

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -11,6 +11,7 @@ use std::convert::TryFrom;
 use std::num::TryFromIntError;
 use std::time::Duration;
 
+use columnar::Columnar;
 use dec::TryFromDecimalError;
 use mz_proto::{RustType, TryFromProtoError};
 use proptest_derive::Arbitrary;
@@ -34,6 +35,7 @@ include!(concat!(env!("OUT_DIR"), "/mz_repr.timestamp.rs"));
     Hash,
     Default,
     Arbitrary,
+    Columnar,
 )]
 pub struct Timestamp {
     /// note no `pub`.

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -37,6 +37,7 @@ include!(concat!(env!("OUT_DIR"), "/mz_repr.timestamp.rs"));
     Arbitrary,
     Columnar,
 )]
+#[columnar(derive(PartialEq, Eq, PartialOrd, Ord))]
 pub struct Timestamp {
     /// note no `pub`.
     internal: u64,

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 ahash = { version = "0.8.11", default-features = false }
 bincode = "1.3.3"
 bytemuck = "1.21.0"
-columnar = "0.2.0"
+columnar = "0.2.2"
 columnation = "0.1.0"
 differential-dataflow = "0.13.3"
 either = "1"

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -12,6 +12,8 @@ workspace = true
 [dependencies]
 ahash = { version = "0.8.11", default-features = false }
 bincode = "1.3.3"
+bytemuck = "1.21.0"
+columnar = "0.2.0"
 columnation = "0.1.0"
 differential-dataflow = "0.13.3"
 either = "1"

--- a/src/timely-util/src/containers.rs
+++ b/src/timely-util/src/containers.rs
@@ -9,5 +9,376 @@
 
 //! Reusable containers.
 
+use differential_dataflow::trace::implementations::merge_batcher::{ColMerger, MergeBatcher};
+use timely::container::columnation::TimelyStack;
+
 pub mod array;
 pub mod stack;
+
+pub use container::Column;
+
+mod container {
+
+    use columnar::bytes::serialization::decode;
+    use columnar::common::IterOwn;
+    use columnar::Columnar;
+    use columnar::Container as _;
+    use columnar::{AsBytes, Clear, FromBytes, Index, Len};
+    use timely::bytes::arc::Bytes;
+    use timely::container::PushInto;
+    use timely::container::SizableContainer;
+    use timely::dataflow::channels::ContainerBytes;
+    use timely::Container;
+
+    /// A container based on a columnar store, encoded in aligned bytes.
+    pub enum Column<C: Columnar> {
+        /// The typed variant of the container.
+        Typed(C::Container),
+        /// The binary variant of the container.
+        Bytes(Bytes),
+        /// Relocated, aligned binary data, if `Bytes` doesn't work for some reason.
+        ///
+        /// Reasons could include misalignment, cloning of data, or wanting
+        /// to release the `Bytes` as a scarce resource.
+        Align(Box<[u64]>),
+    }
+
+    impl<C: Columnar> Column<C> {
+        /// Borrows the container as a reference.
+        fn borrow(&self) -> <C::Container as columnar::Container<C>>::Borrowed<'_> {
+            match self {
+                Column::Typed(t) => t.borrow(),
+                Column::Bytes(b) => <<C::Container as columnar::Container<C>>::Borrowed<'_> as FromBytes>::from_bytes(&mut decode(bytemuck::cast_slice(b))),
+                Column::Align(a) => <<C::Container as columnar::Container<C>>::Borrowed<'_> as FromBytes>::from_bytes(&mut decode(a)),
+            }
+        }
+    }
+
+    impl<C: Columnar> Default for Column<C> {
+        fn default() -> Self {
+            Self::Typed(Default::default())
+        }
+    }
+
+    impl<C: Columnar> Clone for Column<C>
+    where
+        C::Container: Clone,
+    {
+        fn clone(&self) -> Self {
+            match self {
+                // TODO: We could go from `Typed` to `Align` if we wanted to.
+                Column::Typed(t) => Column::Typed(t.clone()),
+                Column::Bytes(b) => {
+                    assert_eq!(b.len() % 8, 0);
+                    let mut alloc: Vec<u64> = vec![0; b.len() / 8];
+                    bytemuck::cast_slice_mut(&mut alloc[..]).copy_from_slice(&b[..]);
+                    Self::Align(alloc.into())
+                }
+                Column::Align(a) => Column::Align(a.clone()),
+            }
+        }
+    }
+
+    impl<C: Columnar> Container for Column<C> {
+        type ItemRef<'a> = C::Ref<'a>;
+        type Item<'a> = C::Ref<'a>;
+
+        fn len(&self) -> usize {
+            self.borrow().len()
+        }
+
+        // This sets the `Bytes` variant to be an empty `Typed` variant, appropriate for pushing into.
+        fn clear(&mut self) {
+            match self {
+                Column::Typed(t) => t.clear(),
+                Column::Bytes(_) => *self = Column::Typed(Default::default()),
+                Column::Align(_) => *self = Column::Typed(Default::default()),
+            }
+        }
+
+        type Iter<'a> = IterOwn<<C::Container as columnar::Container<C>>::Borrowed<'a>>;
+
+        fn iter(&self) -> Self::Iter<'_> {
+            self.borrow().into_iter()
+        }
+
+        type DrainIter<'a> = IterOwn<<C::Container as columnar::Container<C>>::Borrowed<'a>>;
+
+        fn drain(&mut self) -> Self::DrainIter<'_> {
+            self.borrow().into_iter()
+        }
+    }
+
+    impl<C: Columnar> SizableContainer for Column<C> {
+        fn at_capacity(&self) -> bool {
+            match self {
+                Self::Typed(t) => {
+                    let length_in_bytes = t.borrow().length_in_words() * 8;
+                    length_in_bytes >= (1 << 20)
+                }
+                Self::Bytes(_) => true,
+                Self::Align(_) => true,
+            }
+        }
+        fn ensure_capacity(&mut self, _stash: &mut Option<Self>) {}
+    }
+
+    impl<C: Columnar, T> PushInto<T> for Column<C>
+    where
+        C::Container: columnar::Push<T>,
+    {
+        #[inline]
+        fn push_into(&mut self, item: T) {
+            use columnar::Push;
+            match self {
+                Column::Typed(t) => t.push(item),
+                Column::Align(_) | Column::Bytes(_) => {
+                    // We really oughtn't be calling this in this case.
+                    // We could convert to owned, but need more constraints on `C`.
+                    unimplemented!("Pushing into Column::Bytes without first clearing");
+                }
+            }
+        }
+    }
+
+    impl<C: Columnar> ContainerBytes for Column<C> {
+        fn from_bytes(bytes: Bytes) -> Self {
+            // Our expectation / hope is that `bytes` is `u64` aligned and sized.
+            // If the alignment is borked, we can relocate. IF the size is borked,
+            // not sure what we do in that case.
+            assert_eq!(bytes.len() % 8, 0);
+            if let Ok(_) = bytemuck::try_cast_slice::<_, u64>(&bytes) {
+                Self::Bytes(bytes)
+            } else {
+                println!("Re-locating bytes for alignment reasons");
+                let mut alloc: Vec<u64> = vec![0; bytes.len() / 8];
+                bytemuck::cast_slice_mut(&mut alloc[..]).copy_from_slice(&bytes[..]);
+                Self::Align(alloc.into())
+            }
+        }
+
+        fn length_in_bytes(&self) -> usize {
+            match self {
+                // We'll need one u64 for the length, then the length rounded up to a multiple of 8.
+                Column::Typed(t) => 8 * t.borrow().length_in_words(),
+                Column::Bytes(b) => b.len(),
+                Column::Align(a) => 8 * a.len(),
+            }
+        }
+
+        fn into_bytes<W: ::std::io::Write>(&self, writer: &mut W) {
+            match self {
+                Column::Typed(t) => {
+                    use columnar::Container;
+                    // Columnar data is serialized as a sequence of `u64` values, with each `[u8]` slice
+                    // serialize as first its length in bytes, and then as many `u64` values as needed.
+                    // Padding should be added, but only for alignment; no specific values are required.
+                    for (align, bytes) in t.borrow().as_bytes() {
+                        assert!(align <= 8);
+                        let length: u64 = bytes.len().try_into().unwrap();
+                        writer
+                            .write_all(bytemuck::cast_slice(std::slice::from_ref(&length)))
+                            .unwrap();
+                        writer.write_all(bytes).unwrap();
+                        let padding: usize = ((8 - (length % 8)) % 8).try_into().unwrap();
+                        writer.write_all(&[0; 8][..padding]).unwrap();
+                    }
+                }
+                Column::Bytes(b) => writer.write_all(b).unwrap(),
+                Column::Align(a) => writer.write_all(bytemuck::cast_slice(a)).unwrap(),
+            }
+        }
+    }
+}
+
+pub use builder::ColumnBuilder;
+mod builder {
+    use std::collections::VecDeque;
+
+    use columnar::{AsBytes, Clear, Columnar, Len, Push};
+    use timely::container::PushInto;
+    use timely::container::{ContainerBuilder, LengthPreservingContainerBuilder};
+
+    use super::Column;
+
+    /// A container builder for `Column<C>`.
+    pub struct ColumnBuilder<C: Columnar> {
+        /// Container that we're writing to.
+        current: C::Container,
+        /// Empty allocation.
+        empty: Option<Column<C>>,
+        /// Completed containers pending to be sent.
+        pending: VecDeque<Column<C>>,
+    }
+
+    impl<C: Columnar, T> PushInto<T> for ColumnBuilder<C>
+    where
+        C::Container: Push<T>,
+    {
+        #[inline]
+        fn push_into(&mut self, item: T) {
+            self.current.push(item);
+            // If there is less than 10% slop with 2MB backing allocations, mint a container.
+            use columnar::Container;
+            let words = self.current.borrow().length_in_words();
+            let round = (words + ((1 << 18) - 1)) & !((1 << 18) - 1);
+            if round - words < round / 10 {
+                let mut alloc = Vec::with_capacity(round);
+                columnar::bytes::serialization::encode(
+                    &mut alloc,
+                    self.current.borrow().as_bytes(),
+                );
+                self.pending
+                    .push_back(Column::Align(alloc.into_boxed_slice()));
+                self.current.clear();
+            }
+        }
+    }
+
+    impl<C: Columnar> Default for ColumnBuilder<C> {
+        fn default() -> Self {
+            ColumnBuilder {
+                current: Default::default(),
+                empty: None,
+                pending: Default::default(),
+            }
+        }
+    }
+
+    impl<C: Columnar> ContainerBuilder for ColumnBuilder<C>
+    where
+        C::Container: Clone,
+    {
+        type Container = Column<C>;
+
+        #[inline]
+        fn extract(&mut self) -> Option<&mut Self::Container> {
+            if let Some(container) = self.pending.pop_front() {
+                self.empty = Some(container);
+                self.empty.as_mut()
+            } else {
+                None
+            }
+        }
+
+        #[inline]
+        fn finish(&mut self) -> Option<&mut Self::Container> {
+            if !self.current.is_empty() {
+                self.pending
+                    .push_back(Column::Typed(std::mem::take(&mut self.current)));
+            }
+            self.empty = self.pending.pop_front();
+            self.empty.as_mut()
+        }
+    }
+
+    impl<C: Columnar> LengthPreservingContainerBuilder for ColumnBuilder<C> where C::Container: Clone {}
+}
+
+/// A batcher for columnar storage.
+pub type Col2ValBatcher<K, V, T, R> = MergeBatcher<
+    Column<((K, V), T, R)>,
+    batcher::Chunker<TimelyStack<((K, V), T, R)>>,
+    ColMerger<(K, V), T, R>,
+>;
+pub type Col2KeyBatcher<K, T, R> = Col2ValBatcher<K, (), T, R>;
+
+/// Types for consolidating, merging, and extracting columnar update collections.
+pub mod batcher {
+    use std::collections::VecDeque;
+
+    use columnar::Columnar;
+    use differential_dataflow::difference::Semigroup;
+    use timely::container::{ContainerBuilder, PushInto};
+    use timely::Container;
+
+    use crate::containers::Column;
+
+    #[derive(Default)]
+    pub struct Chunker<C> {
+        /// Buffer into which we'll consolidate.
+        ///
+        /// Also the buffer where we'll stage responses to `extract` and `finish`.
+        /// When these calls return, the buffer is available for reuse.
+        empty: C,
+        /// Consolidated buffers ready to go.
+        ready: VecDeque<C>,
+    }
+
+    impl<C: Container + Clone + 'static> ContainerBuilder for Chunker<C> {
+        type Container = C;
+
+        fn extract(&mut self) -> Option<&mut Self::Container> {
+            if let Some(ready) = self.ready.pop_front() {
+                self.empty = ready;
+                Some(&mut self.empty)
+            } else {
+                None
+            }
+        }
+
+        fn finish(&mut self) -> Option<&mut Self::Container> {
+            self.extract()
+        }
+    }
+
+    impl<'a, D, T, R, C2> PushInto<&'a mut Column<(D, T, R)>> for Chunker<C2>
+    where
+        D: Columnar,
+        for<'b> D::Ref<'b>: Ord + Copy,
+        T: Columnar,
+        for<'b> T::Ref<'b>: Ord + Copy,
+        R: Columnar + Semigroup + for<'b> Semigroup<R::Ref<'b>>,
+        for<'b> R::Ref<'b>: Ord,
+        C2: Container + for<'b> PushInto<&'b (D, T, R)>,
+    {
+        fn push_into(&mut self, container: &'a mut Column<(D, T, R)>) {
+            // Sort input data
+            // TODO: consider `Vec<usize>` that we retain, containing indexes.
+            let mut permutation = Vec::with_capacity(container.len());
+            permutation.extend(container.drain());
+            permutation.sort();
+
+            self.empty.clear();
+            // Iterate over the data, accumulating diffs for like keys.
+            let mut iter = permutation.drain(..);
+            if let Some((data, time, diff)) = iter.next() {
+                let mut owned_data = D::into_owned(data);
+                let mut owned_time = T::into_owned(time);
+
+                let mut prev_data = data;
+                let mut prev_time = time;
+                let mut prev_diff = <R as Columnar>::into_owned(diff);
+
+                for (data, time, diff) in iter {
+                    if (&prev_data, &prev_time) == (&data, &time) {
+                        prev_diff.plus_equals(&diff);
+                    } else {
+                        if !prev_diff.is_zero() {
+                            D::copy_from(&mut owned_data, prev_data);
+                            T::copy_from(&mut owned_time, prev_time);
+                            let tuple = (owned_data, owned_time, prev_diff);
+                            self.empty.push_into(&tuple);
+                            owned_data = tuple.0;
+                            owned_time = tuple.1;
+                        }
+                        prev_data = data;
+                        prev_time = time;
+                        prev_diff = <R as Columnar>::into_owned(diff);
+                    }
+                }
+
+                if !prev_diff.is_zero() {
+                    D::copy_from(&mut owned_data, prev_data);
+                    T::copy_from(&mut owned_time, prev_time);
+                    let tuple = (owned_data, owned_time, prev_diff);
+                    self.empty.push_into(&tuple);
+                }
+            }
+
+            if !self.empty.is_empty() {
+                self.ready.push_back(std::mem::take(&mut self.empty));
+            }
+        }
+    }
+}

--- a/src/timely-util/src/containers.rs
+++ b/src/timely-util/src/containers.rs
@@ -410,7 +410,7 @@ mod provided_builder {
     use timely::Container;
 
     /// A container builder that doesn't support pushing elements, and is only suitable for pushing
-    /// whole containers at Timely [`Session`]s. See [`give_container`] for more information.
+    /// whole containers at Timely sessions. See [`give_container`] for more information.
     ///
     ///  [`give_container`]: timely::dataflow::channels::pushers::buffer::Session::give_container
     pub struct ProvidedBuilder<C> {

--- a/src/timely-util/src/containers.rs
+++ b/src/timely-util/src/containers.rs
@@ -382,3 +382,36 @@ pub mod batcher {
         }
     }
 }
+
+pub use provided_builder::ProvidedBuilder;
+
+mod provided_builder {
+    use timely::container::ContainerBuilder;
+    use timely::Container;
+
+    /// A container builder that doesn't support pushing elements, and is only suitable for pushing
+    /// whole containers at session.
+    pub struct ProvidedBuilder<C> {
+        _marker: std::marker::PhantomData<C>,
+    }
+
+    impl<C> Default for ProvidedBuilder<C> {
+        fn default() -> Self {
+            Self {
+                _marker: std::marker::PhantomData,
+            }
+        }
+    }
+
+    impl<C: Container + Clone + 'static> ContainerBuilder for ProvidedBuilder<C> {
+        type Container = C;
+
+        fn extract(&mut self) -> Option<&mut Self::Container> {
+            None
+        }
+
+        fn finish(&mut self) -> Option<&mut Self::Container> {
+            None
+        }
+    }
+}

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -21,10 +21,11 @@ use differential_dataflow::logging::DifferentialEventBuilder;
 use differential_dataflow::trace::{Batcher, Builder, Description};
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use timely::container::columnation::{Columnation, TimelyStack};
-use timely::container::{ContainerBuilder, PushInto, SizableContainer};
+use timely::container::{ContainerBuilder, PushInto};
 use timely::dataflow::channels::pact::{Exchange, ParallelizationContract, Pipeline};
 use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::channels::ContainerBytes;
+use timely::dataflow::operators::core::Map;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder as OperatorBuilderRc;
 use timely::dataflow::operators::generic::operator::{self, Operator};
 use timely::dataflow::operators::generic::{InputHandleCore, OperatorInfo, OutputHandleCore};
@@ -707,9 +708,9 @@ where
                 h.finish()
             });
             // Access to `arrange_core` is OK because we specify the trace and don't hold on to it.
-            consolidate_pact::<Ba, _, _, _, _>(&self.map(|k| (k, ())).inner, exchange, name)
+            consolidate_pact::<Ba, _, _, _>(&self.map(|k| (k, ())).inner, exchange, name)
+                .map(|((k, ()), time, diff)| (k.clone(), time.clone(), diff.clone()))
                 .as_collection()
-                .map(|(k, ())| k)
         } else {
             self
         }
@@ -729,9 +730,9 @@ where
         let exchange =
             Exchange::new(move |update: &((D1, ()), G::Timestamp, R)| (update.0).0.hashed());
 
-        consolidate_pact::<Ba, _, _, _, _>(&self.map(|k| (k, ())).inner, exchange, name)
+        consolidate_pact::<Ba, _, _, _>(&self.map(|k| (k, ())).inner, exchange, name)
+            .map(|((k, ()), time, diff)| (k.clone(), time.clone(), diff.clone()))
             .as_collection()
-            .map(|(k, ())| k)
     }
 }
 
@@ -773,19 +774,19 @@ where
 /// The data are accumulated in place, each held back until their timestamp has completed.
 ///
 /// This serves as a low-level building-block for more user-friendly functions.
-pub fn consolidate_pact<B, P, G, CI, CO>(
+pub fn consolidate_pact<B, P, G, CI>(
     stream: &StreamCore<G, CI>,
     pact: P,
     name: &str,
-) -> StreamCore<G, CO>
+) -> StreamCore<G, B::Output>
 where
     G: Scope,
     B: Batcher<Input = CI, Time = G::Timestamp> + 'static,
-    B::Output: Container,
-    for<'a> CO: PushInto<<B::Output as Container>::Item<'a>>,
+    B::Output: Container + Clone,
+    // for<'a> CO: PushInto<<B::Output as Container>::Item<'a>>,
     P: ParallelizationContract<G::Timestamp, CI>,
     CI: Container + Data,
-    CO: SizableContainer + Data,
+    // CO: SizableContainer + Data,
 {
     stream.unary_frontier(pact, name, |_cap, info| {
         // Acquire a logger for arrange events.
@@ -834,7 +835,7 @@ where
                             let mut session = output.session(&capabilities.elements()[index]);
                             // Extract updates not in advance of `upper`.
                             let output =
-                                batcher.seal::<ConsolidateBuilder<_, B::Output, CO>>(upper.clone());
+                                batcher.seal::<ConsolidateBuilder<_, B::Output>>(upper.clone());
                             for mut batch in output {
                                 session.give_container(&mut batch);
                             }
@@ -870,25 +871,21 @@ where
 }
 
 /// A builder that wraps a session for direct output to a stream.
-struct ConsolidateBuilder<T, I, O> {
-    buffer: Vec<O>,
+struct ConsolidateBuilder<T, I> {
     _marker: PhantomData<(T, I)>,
 }
 
-impl<T, I, O> Builder for ConsolidateBuilder<T, I, O>
+impl<T, I> Builder for ConsolidateBuilder<T, I>
 where
     T: Timestamp,
     I: Container,
-    O: SizableContainer,
-    for<'a> O: PushInto<I::Item<'a>>,
 {
     type Input = I;
     type Time = T;
-    type Output = Vec<O>;
+    type Output = Vec<I>;
 
     fn new() -> Self {
         Self {
-            buffer: Vec::default(),
             _marker: PhantomData,
         }
     }
@@ -897,35 +894,15 @@ where
         Self::new()
     }
 
-    fn push(&mut self, chunk: &mut Self::Input) {
-        // TODO(mh): This is less efficient than it could be because it extracts each item
-        // individually and then pushes it. However, it is not a regression over the previous
-        // implementation. In the future, we want to either clone many elements in one go,
-        // or ensure that `Vec<Input>` == `Output`, which would avoid looking at the container
-        // contents at all.
-        'element: for element in chunk.drain() {
-            if let Some(last) = self.buffer.last_mut() {
-                if !last.at_capacity() {
-                    last.push_into(element);
-                    continue 'element;
-                }
-            }
-            let mut new = O::default();
-            new.ensure_capacity(&mut None);
-            new.push_into(element);
-            self.buffer.push(new);
-        }
+    fn push(&mut self, _chunk: &mut Self::Input) {
+        unimplemented!("ConsolidateBuilder::push")
     }
 
     fn done(self, _: Description<Self::Time>) -> Self::Output {
-        self.buffer
+        unimplemented!("ConsolidateBuilder::done")
     }
 
-    fn seal(chain: &mut Vec<Self::Input>, description: Description<Self::Time>) -> Self::Output {
-        let mut builder = Self::new();
-        for mut input in chain.drain(..) {
-            builder.push(&mut input);
-        }
-        builder.done(description)
+    fn seal(chain: &mut Vec<Self::Input>, _description: Description<Self::Time>) -> Self::Output {
+        std::mem::take(chain)
     }
 }

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -707,7 +707,6 @@ where
                 data.hash(&mut h);
                 h.finish()
             });
-            // Access to `arrange_core` is OK because we specify the trace and don't hold on to it.
             consolidate_pact::<Ba, _, _>(&self.map(|k| (k, ())).inner, exchange, name)
                 .map(|((k, ()), time, diff)| (k.clone(), time.clone(), diff.clone()))
                 .as_collection()


### PR DESCRIPTION
Convert logging dataflows to columnar

The aim of this PR is to convert some of the logging dataflows to use columnar data on dataflow edges, wherever it makes sense to do so. It introduces building blocks that we need to move columnar data across dataflow edges, and feed them into merge batchers to create arrangements from columnar data.

The PR is rather large, and it is best viewed file-by-file. The rough structure is:
* containers in timely-util to support columnar data on dataflow edges and as input to arrangements.
* Each of the log dataflows separately.
* Improvement of the `consolidate_pact` function.
* Introduction of `consolidate_and_pack` to simplify adding new introspection sources.

The goal of this PR is to show how we can use columnar data in Materialize as a replacement for vectors. It doesn't yet use any columnar data in rendering of LIR plans.

The PR doesn't touch the dataflow edges from the demux operator to calling `consolidate_and_pack` because the edges use a `ConsolidatingContainerBuilder`, which is more efficient for vector-based containers (and in fact, lacks an implementation for any other container).

Part of MaterializeInc/database-issues#3748.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
