### PR TITLE
Eliminate more `typ` and `arity` calls

### DIFF
--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -548,8 +548,6 @@ impl Context {
                 equivalences,
                 implementation,
             } => {
-                let input_mapper = JoinInputMapper::new(inputs);
-
                 // Plan each of the join inputs independently.
                 // The `plans` get surfaced upwards, and the `input_keys` should
                 // be used as part of join planning / to validate the existing
@@ -563,6 +561,9 @@ impl Context {
                     plans.push(plan);
                     input_keys.push(keys);
                 }
+
+                let input_mapper =
+                    JoinInputMapper::new_from_input_arities(input_arities.iter().copied());
 
                 // Extract temporal predicates as joins cannot currently absorb them.
                 let (plan, missing) = match implementation {

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -239,7 +239,7 @@ pub fn enforce_linear_chains(expr: &mut MirRelationExpr) -> Result<(), ExplainEr
                 //     .map(|id| LocalId::new(1000_u64 + u64::cast_from(id_map.len()) + id))
                 //     .unwrap();
                 let id = id_gen.next().unwrap();
-                let value = input.take_safely();
+                let value = input.take_safely(None);
                 // generate a `let $fresh_id = $body in $fresh_id` to replace this input
                 let mut binding = MirRelationExpr::Let {
                     id,

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -329,6 +329,8 @@ impl MapFilterProject {
                 let (mfp, expr) = Self::extract_from_expression(input);
                 (mfp.project(outputs.iter().cloned()), expr)
             }
+            // TODO: The recursion is quadratic in the number of Map/Filter/Project operators due to
+            // this call to `arity()`.
             x => (Self::new(x.arity()), x),
         }
     }

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -593,7 +593,7 @@ impl MirRelationExpr {
     /// Reports the column types of the relation given the column types of the
     /// input relations.
     ///
-    /// This method delegates to `try_col_with_input_cols`, panicing if an `Err`
+    /// This method delegates to `try_col_with_input_cols`, panicking if an `Err`
     /// variant is returned.
     pub fn col_with_input_cols<'a, I>(&self, input_types: I) -> Vec<ColumnType>
     where

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -1787,22 +1787,21 @@ impl MirRelationExpr {
             .unzip();
         assert_eq!(keys_and_values.arity() - self.arity(), data.len());
         self.let_in(id_gen, |_id_gen, get_keys| {
+            let get_keys_arity = get_keys.arity();
             Ok(MirRelationExpr::join(
                 vec![
                     // all the missing keys (with count 1)
                     keys_and_values
-                        .distinct_by((0..get_keys.arity()).collect())
+                        .distinct_by((0..get_keys_arity).collect())
                         .negate()
                         .union(get_keys.clone().distinct()),
                     // join with keys to get the correct counts
                     get_keys.clone(),
                 ],
-                (0..get_keys.arity())
-                    .map(|i| vec![(0, i), (1, i)])
-                    .collect(),
+                (0..get_keys_arity).map(|i| vec![(0, i), (1, i)]).collect(),
             )
             // get rid of the extra copies of columns from keys
-            .project((0..get_keys.arity()).collect())
+            .project((0..get_keys_arity).collect())
             // This join is logically equivalent to
             // `.map(<default_expr>)`, but using a join allows for
             // potential predicate pushdown and elision in the

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -1574,12 +1574,14 @@ impl HirScalarExpr {
                 let inner_arity = get_inner.arity();
                 let mut total_arity = inner_arity;
                 let mut join_inputs = vec![get_inner];
+                let mut join_input_arities = vec![inner_arity];
                 for (expr, subquery) in subqueries.into_iter() {
                     // Avoid lowering duplicated subqueries
                     if !subquery_map.contains_key(&expr) {
                         let subquery_arity = subquery.arity();
                         assert_eq!(subquery_arity, inner_arity + 1);
                         join_inputs.push(subquery);
+                        join_input_arities.push(subquery_arity);
                         total_arity += subquery_arity;
 
                         // Column with the value of the subquery
@@ -1589,7 +1591,8 @@ impl HirScalarExpr {
                 // Each subquery projects all the columns of the outer context (distinct_inner)
                 // plus 1 column, containing the result of the subquery. Those columns must be
                 // joined with the outer/main relation (get_inner).
-                let input_mapper = mz_expr::JoinInputMapper::new(&join_inputs);
+                let input_mapper =
+                    mz_expr::JoinInputMapper::new_from_input_arities(join_input_arities);
                 let equivalences = (0..inner_arity)
                     .map(|col| {
                         join_inputs

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -1399,7 +1399,8 @@ impl HirScalarExpr {
 
                 // Record input arity here so that any group_keys that need to mutate get_inner
                 // don't add those columns to the aggregate input.
-                let input_arity = get_inner.typ().arity();
+                let input_type = get_inner.typ();
+                let input_arity = input_type.arity();
                 // The reduction that computes the window function must be keyed on the columns
                 // from the outer context, plus the expressions in the partition key. The current
                 // subquery will be 'executed' for every distinct row from the outer context so
@@ -1428,8 +1429,6 @@ impl HirScalarExpr {
                 }
 
                 get_inner.let_in(id_gen, |id_gen, mut get_inner| {
-                    let input_type = get_inner.typ();
-
                     // Original columns of the relation
                     let fields: Box<_> = input_type
                         .column_types

--- a/src/transform/src/canonicalization/flatmap_to_map.rs
+++ b/src/transform/src/canonicalization/flatmap_to_map.rs
@@ -59,7 +59,7 @@ impl FlatMapToMap {
                         match (iter.next(), iter.next()) {
                             (None, _) => {
                                 // If there are no elements in the literal argument, no output.
-                                relation.take_safely();
+                                relation.take_safely(None);
                             }
                             (Some((row, 1)), None) => {
                                 *relation =

--- a/src/transform/src/canonicalization/topk_elision.rs
+++ b/src/transform/src/canonicalization/topk_elision.rs
@@ -56,7 +56,7 @@ impl TopKElision {
             if limit.as_ref().map_or(true, |l| l.is_literal_null()) && *offset == 0 {
                 *relation = input.take_dangerous();
             } else if limit.as_ref().and_then(|l| l.as_literal_int64()) == Some(0) {
-                relation.take_safely();
+                relation.take_safely(None);
             }
         }
     }

--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -176,7 +176,7 @@ impl Demand {
                 ),
                 MirRelationExpr::Map { input, scalars } => {
                     let relation_type = relation_type.as_ref().unwrap();
-                    let arity = input.arity();
+                    let arity = relation_type.arity() - scalars.len();
                     // contains columns whose supports have yet to be explored
                     let mut new_columns = columns.clone();
                     new_columns.retain(|c| *c >= arity);
@@ -219,7 +219,8 @@ impl Demand {
                     for expr in exprs {
                         expr.support_into(&mut columns);
                     }
-                    columns.retain(|c| *c < input.arity());
+                    let arity = input.arity();
+                    columns.retain(|c| *c < arity);
                     self.action(input, columns, gets)
                 }
                 MirRelationExpr::Filter { input, predicates } => {

--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -124,6 +124,7 @@ impl EquivalencePropagation {
         let expr_type = derived
             .value::<RelationType>()
             .expect("RelationType required");
+        assert!(expr_type.is_some());
         let expr_equivalences = derived
             .value::<Equivalences>()
             .expect("Equivalences required");
@@ -132,7 +133,7 @@ impl EquivalencePropagation {
         let expr_equivalences = if let Some(e) = expr_equivalences {
             e
         } else {
-            expr.take_safely();
+            expr.take_safely_with_col_types(expr_type.clone().unwrap());
             return;
         };
 
@@ -147,7 +148,7 @@ impl EquivalencePropagation {
 
         outer_equivalences.minimize(expr_type.as_ref().map(|x| &x[..]));
         if outer_equivalences.unsatisfiable() {
-            expr.take_safely();
+            expr.take_safely_with_col_types(expr_type.clone().unwrap());
             return;
         }
 

--- a/src/transform/src/fold_constants.rs
+++ b/src/transform/src/fold_constants.rs
@@ -250,7 +250,7 @@ impl FoldConstants {
                     .iter()
                     .any(|p| p.is_literal_false() || p.is_literal_null())
                 {
-                    relation.take_safely();
+                    relation.take_safely(Some(relation_type.clone()));
                 } else if let Some((rows, ..)) = (**input).as_const() {
                     // Evaluate errors last, to reduce risk of spurious errors.
                     predicates.sort_by_key(|p| p.is_literal_err());
@@ -291,7 +291,7 @@ impl FoldConstants {
                 ..
             } => {
                 if inputs.iter().any(|e| e.is_empty()) {
-                    relation.take_safely();
+                    relation.take_safely(Some(relation_type.clone()));
                 } else if let Some(e) = inputs.iter().find_map(|i| i.as_const_err()) {
                     *relation = MirRelationExpr::Constant {
                         rows: Err(e.clone()),

--- a/src/transform/src/fusion/top_k.rs
+++ b/src/transform/src/fusion/top_k.rs
@@ -112,7 +112,7 @@ impl TopK {
                     }
 
                     if let Some(0) = limit.as_ref().and_then(|l| l.as_literal_int64()) {
-                        relation.take_safely();
+                        relation.take_safely(None);
                         break;
                     }
 

--- a/src/transform/src/non_null_requirements.rs
+++ b/src/transform/src/non_null_requirements.rs
@@ -170,7 +170,7 @@ impl NonNullRequirements {
                     {
                         // A null value was introduced in a marked column;
                         // the entire expression can be zeroed out.
-                        relation.take_safely();
+                        relation.take_safely(None);
                         Ok(())
                     } else {
                         // For each column, if it must be non-null, extract the expression's

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -595,7 +595,7 @@ impl PredicatePushdown {
                             .count()
                             > 1
                         {
-                            relation.take_safely();
+                            relation.take_safely(Some(relation.typ_with_input_types(&input_types)));
                             return Ok(());
                         }
 


### PR DESCRIPTION
This is on top of https://github.com/MaterializeInc/materialize/pull/30881, because it relies on the new variations of `take_safely`.

Nightly (subset): https://buildkite.com/materialize/nightly/builds/10717

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
