### PR TITLE
docs: indexes -- point lookup vs scans

### DIFF
--- a/doc/user/content/concepts/indexes.md
+++ b/doc/user/content/concepts/indexes.md
@@ -108,7 +108,7 @@ CREATE INDEX idx_on_my_view IN CLUSTER active_cluster ON my_view (...);
 ### Index usage
 
 {{% important %}}
-Indexes are local to a cluster. Queries in a different cluster cannot use the indexes in another cluster.
+Indexes are local to a cluster. Queries in one cluster cannot use the indexes in another, different cluster.
 {{% /important %}}
 
 Unlike some other databases, Materialize can use an index to serve query
@@ -153,7 +153,7 @@ clause:
     to perform a point lookup.
 
   - If the index is on the `quantity` field which is an integer, the query must
-    specify equality condition on `quantity` with a value that is an integer.
+    specify an equality condition on `quantity` with a value that is an integer.
 
 - Only uses `AND` (conjunction) to combine conditions for **different** fields.
 
@@ -174,7 +174,7 @@ full index scan if the `WHERE` clause:
 
 #### Examples
 
-Consider the following index on a view:
+Consider again the following index on a view:
 
 ```mzsql
 CREATE INDEX idx_orders_view_qty on orders_view (quantity);

--- a/doc/user/content/transform-data/faq.md
+++ b/doc/user/content/transform-data/faq.md
@@ -1,0 +1,22 @@
+---
+title: "FAQ: Indexes"
+description: "Frequently asked questions about indexes."
+menu:
+  main:
+    name: "FAQ: Indexes"
+    identifier: faq-indexes
+    parent: transform-data
+    weight: 100
+---
+
+## Do indexes in Materialize support `ORDER BY`?
+
+No. Indexes in Materialize do not support `ORDER BY` clauses.
+
+{{% index_usage/index-ordering %}}
+
+## Do indexes in Materialize support range queries?
+
+No. Indexes in Materialize do not support range queries.
+
+{{% index_usage/index-ordering %}}

--- a/doc/user/content/transform-data/optimization.md
+++ b/doc/user/content/transform-data/optimization.md
@@ -60,7 +60,7 @@ CREATE INDEX ON obj_name (<keys>);
   If your index contains keys not specified in the query's `WHERE` clause, then
   Materialize performs a full index scan.
 
-- Specify all (or subset of) keys that are constrained in the query pattern's
+- Specify all (or a subset of) keys that are constrained in the query pattern's
   `WHERE` clause. If the index specifies all the keys, Materialize performs a
   point lookup only. If the index specifies a subset of keys, then Materialize
   performs a point lookup on the index keys and then filters these results using

--- a/doc/user/content/transform-data/optimization.md
+++ b/doc/user/content/transform-data/optimization.md
@@ -16,7 +16,7 @@ aliases:
 Indexes in Materialize maintain the complete up-to-date query results in memory
 (and not just the index keys and the pointers to data rows). Unlike some other
 databases, Materialize can use an index to serve query results even if the query
-does not specify a `WHERE` condition on the index key(s). Serving queries from
+does not specify a `WHERE` condition on the index keys. Serving queries from
 an index is fast since the results are already up-to-date and in memory.
 
 Materialize can use [indexes](/concepts/indexes/) to further optimize query
@@ -33,7 +33,7 @@ as your expected access patterns. Use the following as a guide:
 ### `WHERE` point lookups
 
 Unlike some other databases, Materialize can use an index to serve query results
-even if the query does not specify a `WHERE` condition on the index key(s). For
+even if the query does not specify a `WHERE` condition on the index keys. For
 some queries, Materialize can perform [**point
 lookups**](/concepts/indexes/#point-lookups) on the index (as opposed to an
 index scan) if the query's `WHERE` clause:
@@ -86,6 +86,21 @@ CREATE INDEX ON obj_name (<keys>);
     `WHERE quantity = 5 OR item = 'brownie'`), try to rewrite your query using a
     `UNION` (or `UNION ALL`), where each argument of the `UNION` has one of the
     original `OR` arguments.
+
+    For example, the query can be rewritten as:
+
+    ```mzsql
+    SELECT * FROM orders_view WHERE quantity = 5
+    UNION
+    SELECT * FROM orders_view WHERE item = 'brownie';
+    ```
+
+    Depending on your usage pattern, you may want point-lookup indexes on both
+    `quantity` and `item` (i.e., create two indexes, one on `quantity` and one
+    on `item`). However, since each index will hold a copy of the data, consider
+    the tradeoff between speed and memory usage. If the memory impact of having
+    both indexes is too high, you might want to take a more global look at all
+    of your queries to determine which index to build.
 
 #### Examples
 

--- a/doc/user/data/index_usage_key_quantity.yml
+++ b/doc/user/data/index_usage_key_quantity.yml
@@ -61,6 +61,11 @@ queries:
 
   - query: |
       ```mzsql
+      -- Assume quantity is an integer
       SELECT * FROM orders_view WHERE quantity = 'hello';
+      SELECT * FROM orders_view WHERE quantity::TEXT = 'hello';
       ```
-    index_usage: Index scan, assuming `quantity` is an integer.
+    index_usage: |
+      Index scan, assuming `quantity` field in `orders_view` is an integer.
+      In the first query, the quantity is implicitly cast to text.
+      In the second query, the quantity is explicitly cast to text.

--- a/doc/user/data/index_usage_key_quantity.yml
+++ b/doc/user/data/index_usage_key_quantity.yml
@@ -1,0 +1,66 @@
+# CREATE INDEX idx_orders_view_qty on orders_view (quantity);
+queries:
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view;
+      ```
+    index_usage: Index scan.
+
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view WHERE quantity = 10;
+      ```
+    index_usage: Point lookup.
+
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view WHERE quantity IN (10, 20);
+      ```
+    index_usage: Point lookup.
+
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view WHERE quantity = 10 OR quantity = 20;
+      ```
+    index_usage: |
+      Point lookup. Query uses `OR` to combine conditions on the **same** field.
+
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view WHERE quantity = 10 AND price = 5.00;
+      ```
+    index_usage: |
+      Point lookup on `quantity`, then filter on `price`.
+
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view WHERE (quantity, price) = (10, 5.00);
+      ```
+    index_usage: |
+      Point lookup on `quantity`, then filter on `price`.
+
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view WHERE quantity = 10 OR price = 5.00;
+      ```
+    index_usage: |
+      Index scan. Query uses `OR` to combine conditions on **different** fields.
+
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view WHERE quantity <= 10;
+      ```
+    index_usage: Index scan.
+
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view WHERE round(quantity) = 20;
+      ```
+    index_usage: Index scan.
+
+
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view WHERE quantity = 'hello';
+      ```
+    index_usage: Index scan, assuming `quantity` is an integer.

--- a/doc/user/data/index_usage_key_quantity_price.yml
+++ b/doc/user/data/index_usage_key_quantity_price.yml
@@ -1,0 +1,53 @@
+# CREATE INDEX idx_orders_view_qty on orders_view (quantity);
+queries:
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view;
+      ```
+    index_usage: Index scan.
+
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view WHERE quantity = 10;
+      ```
+    index_usage: |
+      Index scan. Query does not include equality conditions on **all** indexed
+      fields.
+
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view WHERE quantity = 10 AND price = 2.50;
+      ```
+    index_usage: Point lookup.
+
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view WHERE quantity = 10 OR price = 2.50;
+      ```
+    index_usage: |
+      Index scan. Query uses `OR` to combine conditions on **different** fields.
+
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view
+      WHERE quantity = 10 AND (price = 2.50 OR price = 3.00);
+      ```
+    index_usage: |
+      Point lookup. Query uses `OR` to combine conditions on **same** field and `AND` to combine conditions on **different** fields.
+
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view
+      WHERE quantity = 10 AND price = 2.50 AND item = 'cupcake';
+      ```
+    index_usage: |
+      Point lookup on the index keys `quantity` and `price`, then filter on
+      `item`.
+
+  - query: |
+      ```mzsql
+      SELECT * FROM orders_view
+      WHERE quantity = 10 AND price = 2.50 OR item = 'cupcake';
+      ```
+    index_usage: |
+      Index scan. Query uses `OR` to combine conditions on **different** fields.

--- a/doc/user/layouts/partials/index-usages-tables/table-index-usage-queries.html
+++ b/doc/user/layouts/partials/index-usages-tables/table-index-usage-queries.html
@@ -1,0 +1,19 @@
+<table>
+<thead>
+<tr>
+<th>Query</th>
+<th>Index usage</th>
+
+</tr>
+</thead>
+<tbody>
+{{ range .queries }}
+<tr>
+<td>{{ .query | markdownify }}</td>
+<td>
+{{ .index_usage | markdownify }}
+</td>
+</tr>
+{{ end }}
+</tbody>
+</table>

--- a/doc/user/layouts/shortcodes/index_usage/index-ordering.html
+++ b/doc/user/layouts/shortcodes/index_usage/index-ordering.html
@@ -4,6 +4,9 @@ of key length and value).
 
 As such, indexes in Materialize currently do not provide optimizations for:
 
-- Range queries.
+- Range queries; that is queries using <code>&gt;</code>, <code>&gt;=</code>,
+  <code>&lt;</code>, <code>&lt;=</code>, `BETWEEN` clauses (e.g., `WHERE
+  quantity > 10`,  <code>price >= 10 AND price <= 50</code>, and `WHERE quantity
+  BETWEEN 10 AND 20`).
 
 - `GROUP BY`, `ORDER BY` and `LIMIT` clauses.

--- a/doc/user/layouts/shortcodes/index_usage/index-ordering.html
+++ b/doc/user/layouts/shortcodes/index_usage/index-ordering.html
@@ -1,4 +1,4 @@
-Indexes in Materialize does not order its keys using the data type's natural
+Indexes in Materialize do not order their keys using the data type's natural
 ordering and instead orders by its internal representation of the key (the tuple
 of key length and value).
 

--- a/doc/user/layouts/shortcodes/index_usage/index-ordering.html
+++ b/doc/user/layouts/shortcodes/index_usage/index-ordering.html
@@ -1,0 +1,9 @@
+Indexes in Materialize does not order its keys using the data type's natural
+ordering and instead orders by its internal representation of the key (the tuple
+of key length and value).
+
+As such, indexes in Materialize currently do not provide optimizations for:
+
+- Range queries.
+
+- `GROUP BY`, `ORDER BY` and `LIMIT` clauses.

--- a/doc/user/layouts/shortcodes/index_usage/index-usage-table.html
+++ b/doc/user/layouts/shortcodes/index_usage/index-usage-table.html
@@ -1,0 +1,4 @@
+{{ $dataFile := .Get "data" }}
+{{ $data := index $.Site.Data $dataFile }}
+
+{{ partial "index-usages-tables/table-index-usage-queries.html" $data }}


### PR DESCRIPTION
For the new year.
Updates from the indexes 101 meeting.

- To the Indexes concepts page, fashioned the findings into how indexes are used (scanned/point lookups) in Materialize
- To the Optimization page, fashioned the findings into how to create indexes to support point lookups.
- Added an initial FAQ page (because sooner or later, we'll need them).

The other tweaks from that meeting's findings: https://github.com/MaterializeInc/materialize/pull/30404/
