### PR TITLE
Remove deprecated clap args_override_self

### DIFF
--- a/src/ore/src/cli.rs
+++ b/src/ore/src/cli.rs
@@ -67,7 +67,7 @@ where
         })
         .collect();
 
-    let mut clap = O::command().args_override_self(true);
+    let mut clap = O::command();
 
     if !config.enable_version_flag {
         clap = clap.disable_version_flag(true);

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -17,6 +17,7 @@ use std::{io, process};
 
 use aws_credential_types::Credentials;
 use aws_types::region::Region;
+use clap::ArgAction;
 use globset::GlobBuilder;
 use itertools::Itertools;
 use mz_build_info::{build_info, BuildInfo};
@@ -59,11 +60,11 @@ struct Args {
     )]
     var: Vec<String>,
     /// A random number to distinguish each testdrive run.
-    #[clap(long, value_name = "N")]
+    #[clap(long, value_name = "N", action = ArgAction::Set)]
     seed: Option<u32>,
     /// Whether to reset Materialize state before executing each script and
     /// to clean up AWS state after each script.
-    #[clap(long)]
+    #[clap(long, action = ArgAction::SetTrue)]
     no_reset: bool,
     /// Force the use of the specified temporary directory.
     ///
@@ -136,14 +137,16 @@ struct Args {
     #[clap(
         long,
         default_value = "postgres://materialize@localhost:6875",
-        value_name = "URL"
+        value_name = "URL",
+        action = ArgAction::Set,
     )]
     materialize_url: tokio_postgres::Config,
     /// materialize internal SQL connection string.
     #[clap(
         long,
         default_value = "postgres://materialize@localhost:6877",
-        value_name = "INTERNAL_URL"
+        value_name = "INTERNAL_URL",
+        action = ArgAction::Set,
     )]
     materialize_internal_url: tokio_postgres::Config,
     #[clap(long)]
@@ -172,7 +175,8 @@ struct Args {
     #[clap(
         long,
         value_name = "PERSIST_CONSENSUS_URL",
-        required_if_eq("validate-catalog-store", "true")
+        required_if_eq("validate-catalog-store", "true"),
+        action = ArgAction::Set,
     )]
     persist_consensus_url: Option<SensitiveUrl>,
     /// Handle to the persist blob storage.
@@ -188,7 +192,8 @@ struct Args {
     #[clap(
         long,
         value_name = "ENCRYPTION://HOST:PORT",
-        default_value = "localhost:9092"
+        default_value = "localhost:9092",
+        action = ArgAction::Set,
     )]
     kafka_addr: String,
     /// Default number of partitions to create for topics


### PR DESCRIPTION
Remove deprecated clap `args_override_self`.

### Motivation

This is the last remaining instance of deprecated clap calls.

### Tips for reviewer

The most likely issues with this will be from us supplying the same argument multiple times, but not using a collection type (ie: Vec). Previously the last supplied value would have "won", but now that results in an error.

I have added special handling in places where we were passing the same argument multiple times in testdrive, but I think these should probably be considered bugs in the tests. CC @def- 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
