### PR TITLE
Make orchestratord environmentd resources public

### DIFF
--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -63,16 +63,16 @@ pub enum DeploymentStatus {
 
 #[derive(Debug, Serialize)]
 pub struct Resources {
-    generation: u64,
-    environmentd_network_policies: Vec<NetworkPolicy>,
-    service_account: Box<ServiceAccount>,
-    role: Box<Role>,
-    role_binding: Box<RoleBinding>,
-    public_service: Box<Service>,
-    generation_service: Box<Service>,
-    persist_pubsub_service: Box<Service>,
-    environmentd_certificate: Box<Option<Certificate>>,
-    environmentd_statefulset: Box<StatefulSet>,
+    pub generation: u64,
+    pub environmentd_network_policies: Vec<NetworkPolicy>,
+    pub service_account: Box<ServiceAccount>,
+    pub role: Box<Role>,
+    pub role_binding: Box<RoleBinding>,
+    pub public_service: Box<Service>,
+    pub generation_service: Box<Service>,
+    pub persist_pubsub_service: Box<Service>,
+    pub environmentd_certificate: Box<Option<Certificate>>,
+    pub environmentd_statefulset: Box<StatefulSet>,
 }
 
 impl Resources {


### PR DESCRIPTION
Make orchestratord environmentd resources public, so that they may be accessed by the environment-controller for comparison before the migration to orchestratord.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

We want to have environment-controller compare the resources it is creating with the resources orchestratord would generate, so we can make them the same before cutting over to orchestratord.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
