### PR TITLE
[docs] typo fix

### DIFF
--- a/doc/user/layouts/partials/explain-plans/operator-table.html
+++ b/doc/user/layouts/partials/explain-plans/operator-table.html
@@ -3,9 +3,9 @@ The following table lists the operators that are available in the {{ .planType
 
 <ul>
 <li>For those operators that require memory to maintain intermediate state,
-the <strong>Uses memory</strong> is marked with <strong>Yes</strong>. </li>
+<strong>Uses memory</strong> is marked with <strong>Yes</strong>. </li>
 <li>For those operators that expand the data size (either rows or columns),
-the <strong>Can increase data size</strong> is marked with <strong>Yes</strong>. </li>
+<strong>Can increase data size</strong> is marked with <strong>Yes</strong>. </li>
 </ul>
 
 <table>


### PR DESCRIPTION
There are extra 'the's that don't parse for me.

### Motivation

  * This PR fixes a previously unreported bug.
  **typo fix**

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
