### PR TITLE
storage/sources/postgres: avoid metadata queries that are expected to fail

### DIFF
--- a/src/postgres-util/src/schemas.rs
+++ b/src/postgres-util/src/schemas.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use anyhow::anyhow;
 use tokio_postgres::types::Oid;
 use tokio_postgres::Client;
 
@@ -39,6 +40,13 @@ pub async fn publication_info(
     client: &Client,
     publication: &str,
 ) -> Result<Vec<PostgresTableDesc>, PostgresError> {
+    let server_version_num = client
+        .query_one("SHOW server_version_num", &[])
+        .await?
+        .get::<_, &str>("server_version_num")
+        .parse::<i32>()
+        .map_err(|e| PostgresError::Generic(anyhow!("unable to parse server_version_num: {e}")))?;
+
     client
         .query(
             "SELECT oid FROM pg_publication WHERE pubname = $1",
@@ -62,8 +70,7 @@ pub async fn publication_info(
                 p.pubname = $1",
             &[&publication],
         )
-        .await
-        .map_err(PostgresError::from)?;
+        .await?;
 
     let mut table_infos = vec![];
     for row in tables {
@@ -71,60 +78,37 @@ pub async fn publication_info(
 
         // The Postgres replication protocol does not support GENERATED columns
         // so we exclude them from this query. But not all Postgres-like
-        // databases have the `pg_attribute.attgenerated` column, so we maintain
-        // two different versions of the query.
-        let pg_columns_check_generated = "
-        SELECT
-            a.attname AS name,
-            a.atttypid AS typoid,
-            a.attnum AS colnum,
-            a.atttypmod AS typmod,
-            a.attnotnull AS not_null,
-            b.oid IS NOT NULL AS primary_key
-        FROM pg_catalog.pg_attribute a
-        LEFT JOIN pg_catalog.pg_constraint b
-            ON a.attrelid = b.conrelid
-            AND b.contype = 'p'
-            AND a.attnum = ANY (b.conkey)
-        WHERE a.attnum > 0::pg_catalog.int2
-            AND NOT a.attisdropped
-            AND a.attgenerated = ''
-            AND a.attrelid = $1
-        ORDER BY a.attnum";
-
-        let pg_columns_no_check_generated = "
-        SELECT
-            a.attname AS name,
-            a.atttypid AS typoid,
-            a.attnum AS colnum,
-            a.atttypmod AS typmod,
-            a.attnotnull AS not_null,
-            b.oid IS NOT NULL AS primary_key
-        FROM pg_catalog.pg_attribute a
-        LEFT JOIN pg_catalog.pg_constraint b
-            ON a.attrelid = b.conrelid
-            AND b.contype = 'p'
-            AND a.attnum = ANY (b.conkey)
-        WHERE a.attnum > 0::pg_catalog.int2
-            AND NOT a.attisdropped
-            AND a.attrelid = $1
-        ORDER BY a.attnum";
-
-        let columns_result = match client.query(pg_columns_check_generated, &[&oid]).await {
-            Ok(result) => Ok(result),
-            // Not all Postgres-like databases have the `attgenerated` column
-            // so issue a second query without the check if so.
-            Err(e)
-                if e.to_string()
-                    .contains("column a.attgenerated does not exist") =>
-            {
-                client.query(pg_columns_no_check_generated, &[&oid]).await
-            }
-            other => other,
+        // databases have the `pg_attribute.attgenerated` column.
+        let attgenerated = if server_version_num >= 120000 {
+            "a.attgenerated = ''"
+        } else {
+            "true"
         };
 
-        let columns = columns_result
-            .map_err(PostgresError::from)?
+        let pg_columns = format!(
+            "
+        SELECT
+            a.attname AS name,
+            a.atttypid AS typoid,
+            a.attnum AS colnum,
+            a.atttypmod AS typmod,
+            a.attnotnull AS not_null,
+            b.oid IS NOT NULL AS primary_key
+        FROM pg_catalog.pg_attribute a
+        LEFT JOIN pg_catalog.pg_constraint b
+            ON a.attrelid = b.conrelid
+            AND b.contype = 'p'
+            AND a.attnum = ANY (b.conkey)
+        WHERE a.attnum > 0::pg_catalog.int2
+            AND NOT a.attisdropped
+            AND {attgenerated}
+            AND a.attrelid = $1
+        ORDER BY a.attnum"
+        );
+
+        let columns = client
+            .query(&pg_columns, &[&oid])
+            .await?
             .into_iter()
             .map(|row| {
                 let name: String = row.get("name");
@@ -148,13 +132,19 @@ pub async fn publication_info(
         // PG 15 adds UNIQUE NULLS NOT DISTINCT, which would let us use `UNIQUE` constraints over
         // nullable columns as keys; i.e. aligns a PG index's NULL handling with an arrangement's
         // keys. For more info, see https://www.postgresql.org/about/featurematrix/detail/392/
-        let pg_15_plus_keys = "
+        let nulls_not_distinct = if server_version_num >= 150000 {
+            "pg_index.indnullsnotdistinct"
+        } else {
+            "false"
+        };
+        let pg_keys = format!(
+            "
         SELECT
             pg_constraint.oid,
             pg_constraint.conkey,
             pg_constraint.conname,
             pg_constraint.contype = 'p' AS is_primary,
-            pg_index.indnullsnotdistinct AS nulls_not_distinct
+            {nulls_not_distinct} AS nulls_not_distinct
         FROM
             pg_constraint
                 JOIN
@@ -163,35 +153,12 @@ pub async fn publication_info(
         WHERE
             pg_constraint.conrelid = $1
                 AND
-            pg_constraint.contype =ANY (ARRAY['p', 'u']);";
+            pg_constraint.contype =ANY (ARRAY['p', 'u']);"
+        );
 
-        // As above but for versions of PG without indnullsnotdistinct.
-        let pg_14_minus_keys = "
-        SELECT
-            pg_constraint.oid,
-            pg_constraint.conkey,
-            pg_constraint.conname,
-            pg_constraint.contype = 'p' AS is_primary,
-            false AS nulls_not_distinct
-        FROM pg_constraint
-        WHERE
-            pg_constraint.conrelid = $1
-                AND
-            pg_constraint.contype =ANY (ARRAY['p', 'u']);";
-
-        let keys = match client.query(pg_15_plus_keys, &[&oid]).await {
-            Ok(keys) => keys,
-            Err(e)
-                // PG versions prior to 15 do not contain this column.
-                if e.to_string()
-                    == "db error: ERROR: column pg_index.indnullsnotdistinct does not exist" =>
-            {
-                client.query(pg_14_minus_keys, &[&oid]).await.map_err(PostgresError::from)?
-            }
-            e => e.map_err(PostgresError::from)?,
-        };
-
-        let keys = keys
+        let keys = client
+            .query(&pg_keys, &[&oid])
+            .await?
             .into_iter()
             .map(|row| {
                 let oid: u32 = row.get("oid");


### PR DESCRIPTION
When fetching schema info from PostgreSQL, the PostgreSQL source currently issues a query that's known to be compatible only with recent versions of PostgreSQL.  If the query fails, the source retries with a version of the query that's compatible with older versions of PostgreSQL.

While this works fine for customers running versions of PostgreSQL before v15, it has an annoying side effect: those customers can observe the failed queries in their PostgreSQL log files. This has led to confusion and complaints from at least two customers.

This commit changes the PostgreSQL source to do eager server version sniffing and issue a query that's known to be compatible with the announced server version. This should avoid leaving failing queries in the upstream PostgreSQL server's logs, and hopefully avoids future customer confusion.

Fix https://github.com/MaterializeInc/database-issues/issues/8561.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
