### PR TITLE
pg-cdc+mysql-cdc tests: Fix old version passing

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -568,7 +568,6 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc-old-syntax
-              args: ["--mysql-version=8.4.0"]
         agents:
           queue: hetzner-aarch64-4cpu-8gb
 

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -243,20 +243,22 @@ steps:
   - group: "MySQL: other versions"
     key: mysql-versions
     steps:
-      - id: mysql-cdc-5_7_44
-        label: "MySQL CDC w/ 5.7.44"
+      - id: mysql-cdc-5_7
+        label: "MySQL CDC w/ 5.7"
         depends_on: build-x86_64
         timeout_in_minutes: 60
         agents:
           # no matching manifest of MySQL 5.7.x for linux/arm64/v8 in the manifest list entries
           # Increased memory usage following new source syntax
-          queue: hetzner-x86-64-8cpu-16gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc
               args: [ "--mysql-version=5.7.44" ]
-      - id: mysql-cdc-8_0_36
-        label: "MySQL CDC w/ 8.0.36"
+        skip: "Fails when restarted"
+
+      - id: mysql-cdc-8_0
+        label: "MySQL CDC w/ 8.0"
         depends_on: build-aarch64
         timeout_in_minutes: 60
         agents:
@@ -264,75 +266,53 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc
-              args: [ "--mysql-version=8.0.36" ]
+              args: [ "--mysql-version=8.0.40" ]
 
   - group: "Postgres: other versions"
     key: postgres-versions
     steps:
-      - id: pg-cdc-16_4
-        label: "Postgres CDC w/ 16.4"
+      - id: pg-cdc-16
+        label: "Postgres CDC w/ 16"
         depends_on: build-aarch64
         timeout_in_minutes: 60
         inputs: [test/pg-cdc]
         plugins:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc
-              args: [ "--pg-version=16.4" ]
+              args: [ "--pg-version=16.6" ]
         agents:
           queue: hetzner-aarch64-4cpu-8gb
-      - id: pg-cdc-15_6
-        label: "Postgres CDC w/ 15.6"
+      - id: pg-cdc-15
+        label: "Postgres CDC w/ 15"
         depends_on: build-aarch64
         timeout_in_minutes: 60
         inputs: [test/pg-cdc]
         plugins:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc
-              args: [ "--pg-version=15.6" ]
+              args: [ "--pg-version=15.10" ]
         agents:
           queue: hetzner-aarch64-4cpu-8gb
-      - id: pg-cdc-14_11
-        label: "Postgres CDC w/ 14.11"
+      - id: pg-cdc-14
+        label: "Postgres CDC w/ 14"
         depends_on: build-aarch64
         timeout_in_minutes: 60
         inputs: [test/pg-cdc]
         plugins:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc
-              args: [ "--pg-version=14.11" ]
+              args: [ "--pg-version=14.15" ]
         agents:
           queue: hetzner-aarch64-4cpu-8gb
-      - id: pg-cdc-13_14
-        label: "Postgres CDC w/ 13.14"
+      - id: pg-cdc-13
+        label: "Postgres CDC w/ 13"
         depends_on: build-aarch64
         timeout_in_minutes: 60
         inputs: [test/pg-cdc]
         plugins:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc
-              args: [ "--pg-version=13.14" ]
-        agents:
-          queue: hetzner-aarch64-4cpu-8gb
-      - id: pg-cdc-12_18
-        label: "Postgres CDC w/ 12.18"
-        depends_on: build-aarch64
-        timeout_in_minutes: 60
-        inputs: [test/pg-cdc]
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: pg-cdc
-              args: [ "--pg-version=12.18" ]
-        agents:
-          queue: hetzner-aarch64-4cpu-8gb
-      - id: pg-cdc-11_22
-        label: "Postgres CDC w/ 11.22"
-        depends_on: build-aarch64
-        timeout_in_minutes: 60
-        inputs: [test/pg-cdc]
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: pg-cdc
-              args: [ "--pg-version=11.22" ]
+              args: [ "--pg-version=13.18" ]
         agents:
           queue: hetzner-aarch64-4cpu-8gb
 

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -406,7 +406,6 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc
-              args: ["--mysql-version=8.4.0"]
         agents:
           queue: hetzner-aarch64-4cpu-8gb
 

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -91,9 +91,7 @@ class WorkflowArgumentParser(argparse.ArgumentParser):
         args: Sequence[str] | None = None,
         namespace: argparse.Namespace | None = None,
     ) -> tuple[argparse.Namespace, list[str]]:
-        if args is None:
-            args = self.args
-        return super().parse_known_args(args, namespace)
+        return super().parse_known_args(args or self.args, namespace)
 
 
 class Composition:

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -278,6 +278,8 @@ def _verify_exactly_n_replication_slots_exist(pg_conn: Connection, n: int) -> No
 
 
 def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
+    pg_version = get_targeted_pg_version(parser)
+
     parser.add_argument(
         "filter",
         nargs="*",
@@ -304,7 +306,6 @@ def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
         "test-certs", "cat", "/secrets/postgres.key", capture=True
     ).stdout
 
-    pg_version = get_targeted_pg_version(parser)
     with c.override(create_postgres(pg_version=pg_version)):
         c.up("materialized", "test-certs", "postgres")
         c.run_testdrive_files(
@@ -320,38 +321,32 @@ def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    remaining_args = [arg for arg in parser.args if not arg.startswith("--pg-version")]
+    workflows_with_internal_sharding = ["cdc"]
+    # Otherwise we are running all workflows
+    sharded_workflows = workflows_with_internal_sharding + buildkite.shard_list(
+        [w for w in c.workflows if w not in workflows_with_internal_sharding],
+        lambda w: w,
+    )
+    print(
+        f"Workflows in shard with index {buildkite.get_parallelism_index()}: {sharded_workflows}"
+    )
+    for name in sharded_workflows:
+        if name == "default":
+            continue
 
-    # If args were passed then we are running the main CDC workflow
-    if remaining_args:
-        workflow_cdc(c, parser)
-    else:
-        workflows_with_internal_sharding = ["cdc"]
-        # Otherwise we are running all workflows
-        sharded_workflows = workflows_with_internal_sharding + buildkite.shard_list(
-            [w for w in c.workflows if w not in workflows_with_internal_sharding],
-            lambda w: w,
-        )
-        print(
-            f"Workflows in shard with index {buildkite.get_parallelism_index()}: {sharded_workflows}"
-        )
-        for name in sharded_workflows:
-            if name == "default":
-                continue
+        # TODO: Flaky, reenable when database-issues#7611 is fixed
+        if name == "statuses":
+            continue
 
-            # TODO: Flaky, reenable when database-issues#7611 is fixed
-            if name == "statuses":
-                continue
+        # TODO: Flaky, reenable when database-issues#8447 is fixed
+        if name == "silent-connection-drop":
+            continue
 
-            # TODO: Flaky, reenable when database-issues#8447 is fixed
-            if name == "silent-connection-drop":
-                continue
+        # clear postgres and materialized to avoid issues with special arguments conflicting with existing state
+        c.kill("postgres")
+        c.rm("postgres")
+        c.kill("materialized")
+        c.rm("materialized")
 
-            # clear postgres and materialized to avoid issues with special arguments conflicting with existing state
-            c.kill("postgres")
-            c.rm("postgres")
-            c.kill("materialized")
-            c.rm("materialized")
-
-            with c.test_case(name):
-                c.workflow(name)
+        with c.test_case(name):
+            c.workflow(name, *parser.args)

--- a/test/postgres/Dockerfile
+++ b/test/postgres/Dockerfile
@@ -9,7 +9,7 @@
 
 MZFROM test-certs as certs
 
-FROM postgres:17.0
+FROM postgres:17.2
 
 ENV POSTGRES_PASSWORD=postgres
 


### PR DESCRIPTION
Noticed by Nikhil in https://materializeinc.slack.com/archives/C01LKF361MZ/p1735098133262889

This never worked before based on what I can tell.

Also update all versions we test against while at it.

Postgres 11/12 don't work with non-localhost auth, so removed for now. MySQL 5.7 requires way more memory, so bumped it.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
