### PR TITLE
comments: Change wording on references to PR 7572

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -230,14 +230,14 @@ ignore = [
     "RUSTSEC-2021-0153",
     # proc-macro-error is unmaintained, possible alternative: proc-macro-error2
     "RUSTSEC-2024-0370",
-    # lexical-core: Multiple soundness issues, depends on arrow upgrading
-    "RUSTSEC-2023-0086",
     # Use standard library's IsTerminal trait instead of `atty` (unmaintained)
     "RUSTSEC-2024-0375",
     # `derivative` is unmaintained; consider using an alternative (unmaintained)
     "RUSTSEC-2024-0388",
     # `instant` is unmaintained, and the author recommends using the maintained [`web-time`] crate instead.
     "RUSTSEC-2024-0384",
+    # columnar: `Read` on uninitialized buffer may cause UB (ColumnarReadExt::read_typed_vec())
+    "RUSTSEC-2021-0087",
 
 ]
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1910,7 +1910,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                         // concat uses nonstandard bool -> string casts
                         // to match historical baggage in PostgreSQL.
                         ScalarType::Bool => expr.call_unary(UnaryFunc::CastBoolToStringNonstandard(func::CastBoolToStringNonstandard)),
-                        // TODO(materialize#7572): remove call to PadChar
+                        // TODO(see <materialize#7572>): remove call to PadChar
                         ScalarType::Char { length } => expr.call_unary(UnaryFunc::PadChar(func::PadChar { length })),
                         _ => typeconv::to_string(ecx, expr)
                     });
@@ -1930,7 +1930,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                         // concat uses nonstandard bool -> string casts
                         // to match historical baggage in PostgreSQL.
                         ScalarType::Bool => expr.call_unary(UnaryFunc::CastBoolToStringNonstandard(func::CastBoolToStringNonstandard)),
-                        // TODO(materialize#7572): remove call to PadChar
+                        // TODO(see <materialize#7572>): remove call to PadChar
                         ScalarType::Char { length } => expr.call_unary(UnaryFunc::PadChar(func::PadChar { length })),
                         _ => typeconv::to_string(ecx, expr)
                     });
@@ -2702,7 +2702,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
         // https://www.postgresql.org/docs/current/functions-json.html
         "to_jsonb" => Scalar {
             params!(Any) => Operation::unary(|ecx, e| {
-                // TODO(materialize#7572): remove this
+                // TODO(see <materialize#7572>): remove this
                 let e = match ecx.scalar_type(&e) {
                     ScalarType::Char { length } => e.call_unary(UnaryFunc::PadChar(func::PadChar { length })),
                     _ => e,
@@ -3056,7 +3056,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
             params!(Float32) => AggregateFunc::MaxFloat32 => Float32, 2119;
             params!(Float64) => AggregateFunc::MaxFloat64 => Float64, 2120;
             params!(String) => AggregateFunc::MaxString => String, 2129;
-            // TODO(materialize#7572): make this its own function
+            // TODO(see <materialize#7572>): make this its own function
             params!(Char) => AggregateFunc::MaxString => Char, 2244;
             params!(Date) => AggregateFunc::MaxDate => Date, 2122;
             params!(Timestamp) => AggregateFunc::MaxTimestamp => Timestamp, 2126;
@@ -3077,7 +3077,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
             params!(Float32) => AggregateFunc::MinFloat32 => Float32, 2135;
             params!(Float64) => AggregateFunc::MinFloat64 => Float64, 2136;
             params!(String) => AggregateFunc::MinString => String, 2145;
-            // TODO(materialize#7572): make this its own function
+            // TODO(see <materialize#7572>): make this its own function
             params!(Char) => AggregateFunc::MinString => Char, 2245;
             params!(Date) => AggregateFunc::MinDate => Date, 2138;
             params!(Timestamp) => AggregateFunc::MinTimestamp => Timestamp, 2142;
@@ -3088,7 +3088,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
         },
         "jsonb_agg" => Aggregate {
             params!(Any) => Operation::unary_ordered(|ecx, e, order_by| {
-                // TODO(materialize#7572): remove this
+                // TODO(see <materialize#7572>): remove this
                 let e = match ecx.scalar_type(&e) {
                     ScalarType::Char { length } => e.call_unary(UnaryFunc::PadChar(func::PadChar { length })),
                     _ => e,
@@ -3108,7 +3108,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
         },
         "jsonb_object_agg" => Aggregate {
             params!(Any, Any) => Operation::binary_ordered(|ecx, key, val, order_by| {
-                // TODO(materialize#7572): remove this
+                // TODO(see <materialize#7572>): remove this
                 let key = match ecx.scalar_type(&key) {
                     ScalarType::Char { length } => key.call_unary(UnaryFunc::PadChar(func::PadChar { length })),
                     _ => key,
@@ -3717,7 +3717,7 @@ pub static MZ_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
         "map_agg" => Aggregate {
             params!(String, Any) => Operation::binary_ordered(|ecx, key, val, order_by| {
                 let (value_type, val) = match ecx.scalar_type(&val) {
-                    // TODO(materialize#7572): remove this
+                    // TODO(see <materialize#7572>): remove this
                     ScalarType::Char { length } => (ScalarType::Char { length }, val.call_unary(UnaryFunc::PadChar(func::PadChar { length }))),
                     typ => (typ, val),
                 };


### PR DESCRIPTION
Showd up since it's closed: https://buildkite.com/materialize/nightly/builds/10732#01940587-8d35-4d45-a5a1-d8aa0c0f0554

https://github.com/MaterializeInc/materialize/pull/7572


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
