### PR TITLE
e2e tests: Adapt to new mz region deletion api

### DIFF
--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -299,7 +299,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 def disable_region(c: Composition) -> None:
     print(f"Shutting down region {REGION} ...")
 
-    c.run("mz", "region", "disable", "--hard")
+    try:
+        c.run("mz", "region", "disable", "--hard")
+    except UIError:
+        # Can return: status 404 Not Found
+        pass
 
 
 def wait_for_cloud(c: Composition) -> None:

--- a/test/mz-e2e/mzcompose.py
+++ b/test/mz-e2e/mzcompose.py
@@ -27,6 +27,7 @@ from materialize.mzcompose.composition import (
     WorkflowArgumentParser,
 )
 from materialize.mzcompose.services.mz import Mz
+from materialize.ui import UIError
 
 REGION = "aws/us-west-2"
 ENVIRONMENT = os.getenv("ENVIRONMENT", "production")
@@ -244,7 +245,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 def disable_region(c: Composition) -> None:
     print(f"Shutting down region {REGION} ...")
 
-    c.run("mz", "region", "disable", "--hard")
+    try:
+        c.run("mz", "region", "disable", "--hard")
+    except UIError:
+        # Can return: status 404 Not Found
+        pass
 
 
 def wait_for_cloud(c: Composition) -> None:


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/30867

Seen failing in https://buildkite.com/materialize/nightly/builds/10732

Test run: https://buildkite.com/materialize/nightly/builds/10740

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
