### PR TITLE
Fix nightlies after private preview message rewording

### DIFF
--- a/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
@@ -257,6 +257,22 @@ def is_any_date_time_expression(expression: Expression) -> bool:
     )
 
 
+def is_timezone_conversion_expression(expression: Expression) -> bool:
+    return expression.matches(
+        partial(
+            matches_fun_by_any_name,
+            function_names_in_lower_case={"timezone"},
+        ),
+        True,
+    ) or expression.matches(
+        partial(
+            matches_op_by_any_pattern,
+            patterns={"$ AT TIME ZONE $::TEXT"},
+        ),
+        True,
+    )
+
+
 def is_known_to_return_non_integer_number(expression: Expression):
     return_type_spec = expression.resolve_return_type_spec()
 

--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -350,7 +350,11 @@ class FlagUpdate(Scenario):
                     actions=[
                         OpenLoop(
                             action=ReuseConnQuery(
-                                "ALTER SYSTEM SET unsafe_enable_table_keys = true",
+                                # The particular flag and value used here
+                                # doesn't matter. It just needs to be a flag
+                                # that exists in both versions to be
+                                # benchmarked.
+                                "ALTER SYSTEM SET enable_disk_cluster_replicas = true",
                                 conn_info=conn_infos["mz_system"],
                             ),
                             dist=Periodic(per_second=1),

--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -22,6 +22,7 @@ from materialize.output_consistency.ignore_filter.expression_matchers import (
     is_any_date_time_expression,
     is_known_to_involve_exact_data_types,
     is_operation_tagged,
+    is_timezone_conversion_expression,
     matches_fun_by_any_name,
     matches_fun_by_name,
     matches_op_by_any_pattern,
@@ -64,6 +65,7 @@ MZ_VERSION_0_107_0 = MzVersion.parse_mz("v0.107.0")
 MZ_VERSION_0_109_0 = MzVersion.parse_mz("v0.109.0")
 MZ_VERSION_0_117_0 = MzVersion.parse_mz("v0.117.0")
 MZ_VERSION_0_118_0 = MzVersion.parse_mz("v0.118.0")
+MZ_VERSION_0_128_0 = MzVersion.parse_mz("v0.128.0")
 
 
 class VersionConsistencyIgnoreFilter(GenericInconsistencyIgnoreFilter):
@@ -337,6 +339,14 @@ class VersionPostExecutionInconsistencyIgnoreFilter(
             return YesIgnore(
                 "Added support for implicit cast from date to mz_timestamp with PR#29494"
             )
+
+        if (
+            self.lower_version <= MZ_VERSION_0_128_0 <= self.higher_version
+        ) and query_template.matches_any_expression(
+            is_timezone_conversion_expression,
+            True,
+        ):
+            return YesIgnore("Changed error message for private preview features")
 
         return super()._shall_ignore_error_mismatch(
             error, query_template, contains_aggregation


### PR DESCRIPTION
This is fallout introduced by 34e78364. Three changes:

  * Teaching the output consistency checks to ignore changes to the private preview message wording when `timezone` or `AT TIME ZONE` is called.

  * Ignoring failures in testdrive when unsafe functions can't be enabled because the server is running in safe mode.

  * Adjusting the parallel benchmark to use a non-renamed feature flag for the benchmark that tests the performance impact of toggling a feature flag. (I could have alternatively added conditional logic to choose the right name for the version, but just using a different flag seemed easier.)

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
