### PR TITLE
storage: address review feedback on copy to s3 sink

### DIFF
--- a/src/compute/src/sink/copy_to_s3_oneshot.rs
+++ b/src/compute/src/sink/copy_to_s3_oneshot.rs
@@ -53,7 +53,6 @@ where
             sink_id,
             response_buffer: Some(Rc::clone(&compute_state.copy_to_response_buffer)),
         })));
-        let response_protocol_weak = Rc::downgrade(&response_protocol_handle);
         let connection_context = compute_state.context.connection_context.clone();
 
         let one_time_callback = move |count: Result<u64, String>| {
@@ -137,12 +136,7 @@ where
             one_time_callback,
         );
 
-        Some(Rc::new(scopeguard::guard((), move |_| {
-            let _token = token;
-            if let Some(protocol_handle) = response_protocol_weak.upgrade() {
-                std::mem::drop(protocol_handle.borrow_mut().take())
-            }
-        })))
+        Some(token)
     }
 }
 

--- a/src/storage-types/src/sinks/s3_oneshot_sink.rs
+++ b/src/storage-types/src/sinks/s3_oneshot_sink.rs
@@ -56,9 +56,6 @@ pub async fn preflight(
     // Check that the S3 bucket path is empty before beginning the upload,
     // verify we have DeleteObject permissions,
     // and upload the INCOMPLETE sentinel file to the S3 path.
-    // Since we race against other replicas running the same sink we allow
-    // for objects to exist in the path if they were created by this sink
-    // (identified by the sink_id prefix).
 
     if let Some(files) = mz_aws_util::s3::list_bucket_path(&client, &bucket, &path_prefix).await? {
         if !files.is_empty() {


### PR DESCRIPTION
This commit addresses feedback from @teskje's post-merge review of
https://github.com/MaterializeInc/materialize/pull/30844.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
