### PR TITLE
build(deps): Downgrade pydantic again

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -32,14 +32,16 @@ pandas==2.2.3
 pandas-stubs==2.2.3.241126
 parameterized==0.9.0
 paramiko==3.5.0
-pdoc==15.0.0
+pdoc==15.0.1
 # We can revert back to standard pg8000 versions once https://github.com/tlocke/pg8000/pull/161 is released
 pg8000@git+https://github.com/tlocke/pg8000@46c00021ade1d19466b07ed30392386c5f0a6b8e
 prettytable==3.12.0
 psutil==6.1.0
 psycopg==3.2.3
 psycopg-binary==3.2.3
-pydantic==2.10.4
+# pydantic >= 2.9 causes pdoc 15.0.1 to fail: UserWarning: Error parsing type annotation dict[str, Any] | None for pydantic.main.BaseModel.__pydantic_extra__: 'function' object is not subscriptable
+# See also https://github.com/mitmproxy/pdoc/issues/741
+pydantic==2.8.2
 pyelftools==0.31
 pyjwt==2.9.0
 PyMySQL==1.1.1


### PR DESCRIPTION
Reverts https://github.com/MaterializeInc/materialize/pull/30911

Also upgrades pdoc, but unfortunately newest version of pdoc still fails

Seen failing in https://buildkite.com/materialize/deploy/builds/17206#019414f3-9a6e-4a27-b030-76d435115a0d

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
