### PR TITLE
cluster tests: Disable another part of source stats tests

### DIFF
--- a/test/cluster/storage/02-after-environmentd-restart.td
+++ b/test/cluster/storage/02-after-environmentd-restart.td
@@ -20,7 +20,6 @@ one
 
 # ensure after envd has restarted, we have maintained statistics.
 > SELECT s.name,
-  SUM(u.updates_committed) > 0,
   SUM(u.messages_received) >= 2,
   SUM(u.offset_known),
   SUM(u.offset_committed)
@@ -28,16 +27,8 @@ one
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
-remote1 true true 1 1
-remote2 true true 1 1
-
-> SELECT s.name,
-  SUM(u.updates_committed)
-  FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
-  WHERE s.name IN ('webhook_text')
-  GROUP BY s.id, s.name
-webhook_text 1
+remote1 true 1 1
+remote2 true 1 1
 
 $ kafka-ingest format=bytes topic=remote1
 two
@@ -55,7 +46,6 @@ two
 
 # Ensure that offsets/counters can be updated correctly.
 > SELECT s.name,
-  SUM(u.updates_committed) > 0,
   SUM(u.messages_received) >= 4,
   SUM(u.offset_known),
   SUM(u.offset_committed)
@@ -63,13 +53,5 @@ two
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
-remote1 true true 2 2
-remote2 true true 2 2
-
-> SELECT s.name,
-  SUM(u.updates_committed)
-  FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
-  WHERE s.name IN ('webhook_text')
-  GROUP BY s.id, s.name
-webhook_text 2
+remote1 true 2 2
+remote2 true 2 2


### PR DESCRIPTION
Another occurrence of https://github.com/MaterializeInc/database-issues/issues/8848

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
