### PR TITLE
testdrive: Some fixes for duplicate args

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -558,7 +558,7 @@ steps:
           queue: hetzner-aarch64-4cpu-8gb
 
       - id: kafka-rtr
-        label: Kafka RTR tests
+        label: "Kafka RTR tests %N"
         depends_on: build-aarch64
         timeout_in_minutes: 30
         parallelism: 2

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -1353,7 +1353,7 @@ class Composition:
         args = args + [f"--source={caller.filename}:{caller.lineno}"]
 
         if mz_service is not None:
-            args += [
+            args = args + [
                 f"--materialize-url=postgres://materialize@{mz_service}:6875",
                 f"--materialize-internal-url=postgres://mz_system@{mz_service}:6877",
                 f"--persist-consensus-url=postgres://root@{mz_service}:26257?options=--search_path=consensus",

--- a/test/kafka-rtr/mzcompose.py
+++ b/test/kafka-rtr/mzcompose.py
@@ -66,7 +66,6 @@ def workflow_simple(c: Composition) -> None:
 
     seed = random.getrandbits(16)
     c.run_testdrive_files(
-        "--no-reset",
         "--max-errors=1",
         f"--seed={seed}",
         f"--temp-dir=/share/tmp/kafka-resumption-{seed}",
@@ -125,7 +124,6 @@ def workflow_resumption(c: Composition) -> None:
         print(f"Running failure mode {failure_mode}...")
 
         c.run_testdrive_files(
-            "--no-reset",
             f"--seed={seed}{i}",
             f"--temp-dir=/share/tmp/kafka-resumption-{seed}",
             "resumption/toxiproxy-setup.td",  # without toxify
@@ -137,7 +135,6 @@ def workflow_resumption(c: Composition) -> None:
         t1.start()
         time.sleep(10)
         c.run_testdrive_files(
-            "--no-reset",
             "resumption/toxiproxy-restore-connection.td",
         )
         t1.join()
@@ -152,7 +149,6 @@ def workflow_resumption(c: Composition) -> None:
         c.up("toxiproxy")
 
         c.run_testdrive_files(
-            "--no-reset",
             "resumption/mz-reset.td",
         )
 

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -79,10 +79,10 @@ class KafkaTransactionLogGreaterThan1:
             Testdrive(
                 no_reset=True,
                 seed=seed,
+                kafka_url="badkafka",
                 entrypoint_extra=[
                     "--initial-backoff=1s",
                     "--backoff-factor=0",
-                    "--kafka-addr=badkafka",
                 ],
             ),
         ):


### PR DESCRIPTION
See discussion in https://github.com/MaterializeInc/materialize/pull/30895

We still can't remove the duplicate argument handling because testdrive's usage is a bit convoluted. We create containers with a set of defaults, and then sometimes have to invoke it with different parameters through run_testdrive_files etc.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
