### PR TITLE
[optimizer] debugging: capture id and plan in a span when lowering MIR

### DIFF
--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -17,6 +17,7 @@ use mz_expr::{
     MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, TableFunc,
 };
 use mz_ore::{assert_none, soft_assert_eq_or_log, soft_panic_or_log};
+use mz_repr::explain::ExplainConfig;
 use mz_repr::optimize::OptimizerFeatures;
 use mz_repr::GlobalId;
 use timely::progress::Timestamp;
@@ -105,7 +106,10 @@ impl Context {
             self.debug_info.id = build.id;
             let plan = &build.plan;
             let (plan, keys) =
-                span!(target: "optimizer", Level::INFO, "lower_mir_expr", "id" = ?build.id, "plan" = ?plan)
+                span!(target: "optimizer", Level::INFO, "lower_mir_expr", "id" = ?build.id, "plan" = plan.explain(&ExplainConfig {
+                    redacted: true,
+                    ..Default::default()
+                }, None))
                     .in_scope(|| self.lower_mir_expr(plan))?;
 
             self.arrangements.insert(Id::Global(build.id), keys);


### PR DESCRIPTION
We've seen some one-shot selects with joins that are missing arrangements; adding a span here should let us see more about the issue.

### Motivation

  * This PR fixes a previously unreported bug.

Logs are triggering a [`soft_assert_or_log` in `lowering.rs`](https://github.com/mgree/materialize/blob/debug-missing-arrangement/src/compute-types/src/plan/lowering.rs#L653), but it's not clear what the high-level query is that's causing the issue.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
