### PR TITLE
cdc tests: Remove out of date comments

### DIFF
--- a/test/mysql-cdc-old-syntax/mzcompose.py
+++ b/test/mysql-cdc-old-syntax/mzcompose.py
@@ -71,7 +71,6 @@ def get_targeted_mysql_version(parser: WorkflowArgumentParser) -> str:
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     workflows_with_internal_sharding = ["cdc"]
-    # Otherwise we are running all workflows
     sharded_workflows = workflows_with_internal_sharding + buildkite.shard_list(
         [w for w in c.workflows if w not in workflows_with_internal_sharding],
         lambda w: w,

--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -71,7 +71,6 @@ def get_targeted_mysql_version(parser: WorkflowArgumentParser) -> str:
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     workflows_with_internal_sharding = ["cdc"]
-    # Otherwise we are running all workflows
     sharded_workflows = workflows_with_internal_sharding + buildkite.shard_list(
         [w for w in c.workflows if w not in workflows_with_internal_sharding],
         lambda w: w,

--- a/test/pg-cdc-old-syntax/mzcompose.py
+++ b/test/pg-cdc-old-syntax/mzcompose.py
@@ -322,7 +322,6 @@ def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     workflows_with_internal_sharding = ["cdc"]
-    # Otherwise we are running all workflows
     sharded_workflows = workflows_with_internal_sharding + buildkite.shard_list(
         [w for w in c.workflows if w not in workflows_with_internal_sharding],
         lambda w: w,

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -322,7 +322,6 @@ def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     workflows_with_internal_sharding = ["cdc"]
-    # Otherwise we are running all workflows
     sharded_workflows = workflows_with_internal_sharding + buildkite.shard_list(
         [w for w in c.workflows if w not in workflows_with_internal_sharding],
         lambda w: w,


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/30903

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
