### PR TITLE
testdrive: Remove another source stats flaky test

### DIFF
--- a/test/testdrive-old-kafka-src-syntax/statistics-deletion.td
+++ b/test/testdrive-old-kafka-src-syntax/statistics-deletion.td
@@ -89,17 +89,6 @@ one:two
 sink_size 1 1 true true
 sink_cluster 1 1 true true
 
-> SELECT s.name,
-  SUM(u.updates_committed) > 0
-  FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
-  WHERE s.name IN ('upsert_size', 'upsert_cluster', 's', 'bids')
-  GROUP BY s.id, s.name
-upsert_size true
-upsert_cluster true
-s false
-s false
-
 # We have to obtain these before we delete the sink.
 $ set-from-sql var=sink-size-id
 SELECT s.id

--- a/test/testdrive/statistics-deletion.td
+++ b/test/testdrive/statistics-deletion.td
@@ -93,17 +93,6 @@ one:two
 sink_size 1 1 true true
 sink_cluster 1 1 true true
 
-> SELECT s.name,
-  SUM(u.updates_committed) > 0
-  FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
-  WHERE s.name IN ('upsert_size', 'upsert_cluster', 's', 'bids')
-  GROUP BY s.id, s.name
-upsert_size true
-upsert_cluster true
-s false
-s false
-
 # We have to obtain these before we delete the sink.
 $ set-from-sql var=sink-size-id
 SELECT s.id


### PR DESCRIPTION
See https://github.com/MaterializeInc/database-issues/issues/8848

Noticed in https://buildkite.com/materialize/nightly/builds/10749#01941a20-f3a3-44af-9cb3-1eb9555d4dc2

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
