### PR TITLE
tests: Fix duplicate argument passing

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -73,6 +73,7 @@ ERROR_RE = re.compile(
     | has\ overflowed\ its\ stack
     | internal\ error:
     | \*\ FATAL:
+    | was\ provided\ more\ than\ once,\ but\ cannot\ be\ used\ multiple\ times
     | (^|\ )fatal: # used in frontegg-mock
     | [Oo]ut\ [Oo]f\ [Mm]emory
     | cannot\ migrate\ from\ catalog

--- a/misc/python/materialize/mzcompose/services/clusterd.py
+++ b/misc/python/materialize/mzcompose/services/clusterd.py
@@ -26,6 +26,7 @@ class Clusterd(Service):
         options: list[str] = [],
         restart: str = "no",
         stop_grace_period: str = "120s",
+        scratch_directory: str = "/scratch",
     ) -> None:
         environment = [
             "CLUSTERD_LOG_FILTER",
@@ -39,7 +40,7 @@ class Clusterd(Service):
 
         environment += [f"CLUSTERD_ENVIRONMENT_ID={environment_id}"]
 
-        options = ["--scratch-directory=/scratch", *options]
+        options = [f"--scratch-directory={scratch_directory}", *options]
 
         config: ServiceConfig = {}
 

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -165,9 +165,10 @@ class Materialized(Service):
 
         if force_migrations is not None and image is None:
             command += [
-                "--unsafe-mode",
                 f"--unsafe-builtin-table-fingerprint-whitespace={force_migrations}",
             ]
+            if not unsafe_mode:
+                command += ["--unsafe-mode"]
 
         self.default_storage_size = "1" if default_size == 1 else f"{default_size}-1"
 

--- a/test/data-ingest/mzcompose.py
+++ b/test/data-ingest/mzcompose.py
@@ -71,7 +71,7 @@ SERVICES = [
         additional_system_parameter_defaults={"unsafe_enable_table_keys": "true"},
         sanity_restart=False,
     ),
-    Clusterd(name="clusterd1", options=["--scratch-directory=/mzdata/source_data"]),
+    Clusterd(name="clusterd1", scratch_directory="/mzdata/source_data"),
 ]
 
 

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -189,7 +189,6 @@ def workflow_rehydration(c: Composition) -> None:
             Clusterd(
                 name="clusterd1",
                 options=[
-                    "--scratch-directory=/scratch",
                     "--announce-memory-limit=1048376000",  # 1GiB
                 ],
             ),
@@ -222,7 +221,6 @@ def workflow_rehydration(c: Composition) -> None:
             Clusterd(
                 name="clusterd1",
                 options=[
-                    "--scratch-directory=/scratch",
                     "--announce-memory-limit=1048376000",  # 1GiB
                 ],
             ),
@@ -518,9 +516,6 @@ def workflow_autospill(c: Composition) -> None:
             mz,
             Clusterd(
                 name="clusterd1",
-                options=[
-                    "--scratch-directory=/scratch",
-                ],
             ),
             Testdrive(no_reset=True, consistent_seed=True),
         ):
@@ -572,9 +567,6 @@ def workflow_load_test(c: Composition, parser: WorkflowArgumentParser) -> None:
         ),
         Clusterd(
             name="clusterd1",
-            options=[
-                "--scratch-directory=/scratch",
-            ],
         ),
     ):
         c.up("testdrive", persistent=True)


### PR DESCRIPTION
Follow-up for https://github.com/MaterializeInc/materialize/pull/30895

Alternative to https://github.com/MaterializeInc/materialize/pull/30923

Noticed in https://buildkite.com/materialize/nightly/builds/10749

Test run: https://buildkite.com/materialize/nightly/builds/10752

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
