### PR TITLE
bump chrono-tz to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa48fa079165080f11d7753fd0bc175b7d391f276b965fe4b55bfad67856e463"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -1371,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9998fb9f7e9b2111641485bf8beb32f92945f97f92a3d061f744cfef335f751"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
 dependencies = [
  "parse-zoneinfo",
  "phf",

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = "1.0.66"
 bytes = "1.3.0"
 bytesize = "1.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
-chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
+chrono-tz = { version = "0.9.0", features = ["serde", "case-insensitive"] }
 crc32fast = "1.4.2"
 csv = "1.1.6"
 dec = "0.4.8"

--- a/src/pgtz/Cargo.toml
+++ b/src/pgtz/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 chrono = { version = "0.4.35", default-features = false, features = ["serde", "std"] }
-chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
+chrono-tz = { version = "0.9.0", features = ["serde", "case-insensitive"] }
 mz-lowertest = { path = "../lowertest", default-features = false }
 mz-ore = { path = "../ore", features = ["test"], default-features = false }
 mz-proto = { path = "../proto", features = ["chrono"], default-features = false }
@@ -25,7 +25,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = tru
 
 [build-dependencies]
 anyhow = "1.0.66"
-chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
+chrono-tz = { version = "0.9.0", features = ["serde", "case-insensitive"] }
 mz-build-tools = { path = "../build-tools", default-features = false }
 mz-ore = { path = "../ore", default-features = false }
 phf_codegen = "0.11.1"

--- a/src/proto/Cargo.toml
+++ b/src/proto/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 anyhow = "1.0.66"
 bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["serde", "std"], optional = true }
-chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"], optional = true }
+chrono-tz = { version = "0.9.0", features = ["serde", "case-insensitive"], optional = true }
 globset = "0.4.14"
 http = "1.1.0"
 mz-ore = { path = "../ore", default-features = false, features = ["proptest", "test"] }

--- a/src/proto/src/chrono.rs
+++ b/src/proto/src/chrono.rs
@@ -132,7 +132,8 @@ impl RustType<ProtoTz> for chrono_tz::Tz {
     }
 
     fn from_proto(proto: ProtoTz) -> Result<Self, TryFromProtoError> {
-        Tz::from_str(&proto.name).map_err(TryFromProtoError::DateConversionError)
+        Tz::from_str(&proto.name)
+            .map_err(|parse_error| TryFromProtoError::DateConversionError(parse_error.to_string()))
     }
 }
 

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -33,7 +33,7 @@ bytes = "1.3.0"
 cfg-if = "1.0.0"
 columnation = "0.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["serde", "std"] }
-chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
+chrono-tz = { version = "0.9.0", features = ["serde", "case-insensitive"] }
 compact_bytes = "0.1.2"
 dec = "0.4.8"
 differential-dataflow = "0.13.2"


### PR DESCRIPTION
bump chrono-tz to 0.9.0

### Motivation
Match the version in the cloud repo, to avoid duplicate deps.

### Tips for reviewer

There is actually a 0.10.0 available, but I don't want to deal with that right now.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
