### PR TITLE
allow specifying listen args more than once

### DIFF
--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -110,7 +110,8 @@ pub struct Args {
         long,
         env = "SQL_LISTEN_ADDR",
         value_name = "HOST:PORT",
-        default_value = "127.0.0.1:6875"
+        default_value = "127.0.0.1:6875",
+        action = ArgAction::Set,
     )]
     sql_listen_addr: SocketAddr,
     /// The address on which to listen for untrusted HTTP connections.
@@ -122,7 +123,8 @@ pub struct Args {
         long,
         env = "HTTP_LISTEN_ADDR",
         value_name = "HOST:PORT",
-        default_value = "127.0.0.1:6876"
+        default_value = "127.0.0.1:6876",
+        action = ArgAction::Set,
     )]
     http_listen_addr: SocketAddr,
     /// The address on which to listen for trusted SQL connections.
@@ -135,7 +137,8 @@ pub struct Args {
         long,
         value_name = "HOST:PORT",
         env = "INTERNAL_SQL_LISTEN_ADDR",
-        default_value = "127.0.0.1:6877"
+        default_value = "127.0.0.1:6877",
+        action = ArgAction::Set,
     )]
     internal_sql_listen_addr: SocketAddr,
     /// The address on which to listen for trusted HTTP connections.
@@ -147,7 +150,8 @@ pub struct Args {
         long,
         value_name = "HOST:PORT",
         env = "INTERNAL_HTTP_LISTEN_ADDR",
-        default_value = "127.0.0.1:6878"
+        default_value = "127.0.0.1:6878",
+        action = ArgAction::Set,
     )]
     internal_http_listen_addr: SocketAddr,
     /// The address on which to listen for Persist PubSub connections.
@@ -159,7 +163,8 @@ pub struct Args {
         long,
         value_name = "HOST:PORT",
         env = "INTERNAL_PERSIST_PUBSUB_LISTEN_ADDR",
-        default_value = "127.0.0.1:6879"
+        default_value = "127.0.0.1:6879",
+        action = ArgAction::Set,
     )]
     internal_persist_pubsub_listen_addr: SocketAddr,
     /// Enable cross-origin resource sharing (CORS) for HTTP requests from the


### PR DESCRIPTION
### Motivation

we provide defaults for these in the environmentd dockerfile entrypoint

another followup to https://github.com/MaterializeInc/materialize/pull/30895

not sure if there's a better fix for this?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
