### PR TITLE
test: Fix temporal test

### DIFF
--- a/test/sqllogictest/temporal.slt
+++ b/test/sqllogictest/temporal.slt
@@ -168,8 +168,6 @@ CREATE VIEW dev_fy2023.count_by_day AS
         NOT (CAST('2024-01-01' AS timestamp) <= date_trunc('day', ts)) AND
         CAST('2023-01-01' AS timestamp) <= date_trunc('day', ts);
 
-# This test will break in the year 10000. If you've survived that far then congratulations. Please
-# update the years 10000 and 10001 in the view dev.mock_data_days to a much larger year.
 query TIT
 SELECT *, 'fy2023' AS origin FROM dev_fy2023.count_by_day
 UNION ALL

--- a/test/sqllogictest/temporal.slt
+++ b/test/sqllogictest/temporal.slt
@@ -134,8 +134,8 @@ CREATE VIEW dev_warm.stg_data_days AS
     SELECT *
     FROM dev.mock_data_days
     WHERE
-        mz_now() <= date_trunc('year', ts + CAST('1 year' AS interval)) AND
-        ts + CAST('7 days' AS interval) - CAST('1 month' AS interval) < mz_now();
+        TIMESTAMP '2024-12-21' <= date_trunc('year', ts + CAST('1 year' AS interval)) AND
+        ts + CAST('7 days' AS interval) - CAST('1 month' AS interval) < TIMESTAMP '2024-12-21';
 
 statement ok
 CREATE VIEW dev_warm.count_by_day AS
@@ -145,8 +145,8 @@ CREATE VIEW dev_warm.count_by_day AS
     FROM dev_warm.stg_data_days
     GROUP BY 1
     HAVING
-        NOT (mz_now() <= date_trunc('day', ts) + CAST('7 days' AS interval)) AND
-        mz_now() <= date_trunc('year', date_trunc('day', ts) + CAST('1 year' AS interval));
+        NOT (TIMESTAMP '2024-12-21' <= date_trunc('day', ts) + CAST('7 days' AS interval)) AND
+        TIMESTAMP '2024-12-21' <= date_trunc('year', date_trunc('day', ts) + CAST('1 year' AS interval));
 
 statement ok
 CREATE VIEW dev_fy2023.stg_data_days AS
@@ -168,51 +168,50 @@ CREATE VIEW dev_fy2023.count_by_day AS
         NOT (CAST('2024-01-01' AS timestamp) <= date_trunc('day', ts)) AND
         CAST('2023-01-01' AS timestamp) <= date_trunc('day', ts);
 
-# TODO(Joe) This broke in 2025 already, please fix ;)
 # This test will break in the year 10000. If you've survived that far then congratulations. Please
 # update the years 10000 and 10001 in the view dev.mock_data_days to a much larger year.
-#query TIT
-#SELECT *, 'fy2023' AS origin FROM dev_fy2023.count_by_day
-#UNION ALL
-#SELECT *, 'warm' AS origin FROM dev_warm.count_by_day
-#ORDER BY day DESC;
-#----
-#2024-01-05␠00:00:00  1  warm
-#2024-01-04␠00:00:00  1  warm
-#2024-01-03␠00:00:00  1  warm
-#2024-01-02␠00:00:00  1  warm
-#2024-01-01␠00:00:00  1  warm
-#2023-12-31␠00:00:00  1  fy2023
-#2023-12-30␠00:00:00  1  fy2023
-#2023-12-29␠00:00:00  1  fy2023
-#2023-12-28␠00:00:00  1  fy2023
-#2023-12-27␠00:00:00  1  fy2023
-#2023-12-26␠00:00:00  1  fy2023
-#2023-12-25␠00:00:00  1  fy2023
-#2023-12-24␠00:00:00  1  fy2023
-#2023-12-23␠00:00:00  1  fy2023
-#2023-12-22␠00:00:00  1  fy2023
-#2023-12-21␠00:00:00  1  fy2023
-#2023-12-20␠00:00:00  1  fy2023
-#2023-12-19␠00:00:00  1  fy2023
-#2023-12-18␠00:00:00  1  fy2023
-#2023-12-17␠00:00:00  1  fy2023
-#2023-12-16␠00:00:00  1  fy2023
-#2023-12-15␠00:00:00  1  fy2023
-#2023-12-14␠00:00:00  1  fy2023
-#2023-12-13␠00:00:00  1  fy2023
-#2023-12-12␠00:00:00  1  fy2023
-#2023-12-11␠00:00:00  1  fy2023
-#2023-12-10␠00:00:00  1  fy2023
-#2023-12-09␠00:00:00  1  fy2023
-#2023-12-08␠00:00:00  1  fy2023
-#2023-12-07␠00:00:00  1  fy2023
-#2023-12-06␠00:00:00  1  fy2023
-#2023-12-05␠00:00:00  1  fy2023
-#2023-12-04␠00:00:00  1  fy2023
-#2023-12-03␠00:00:00  1  fy2023
-#2023-12-02␠00:00:00  1  fy2023
-#2023-12-01␠00:00:00  1  fy2023
+query TIT
+SELECT *, 'fy2023' AS origin FROM dev_fy2023.count_by_day
+UNION ALL
+SELECT *, 'warm' AS origin FROM dev_warm.count_by_day
+ORDER BY day DESC;
+----
+2024-01-05␠00:00:00  1  warm
+2024-01-04␠00:00:00  1  warm
+2024-01-03␠00:00:00  1  warm
+2024-01-02␠00:00:00  1  warm
+2024-01-01␠00:00:00  1  warm
+2023-12-31␠00:00:00  1  fy2023
+2023-12-30␠00:00:00  1  fy2023
+2023-12-29␠00:00:00  1  fy2023
+2023-12-28␠00:00:00  1  fy2023
+2023-12-27␠00:00:00  1  fy2023
+2023-12-26␠00:00:00  1  fy2023
+2023-12-25␠00:00:00  1  fy2023
+2023-12-24␠00:00:00  1  fy2023
+2023-12-23␠00:00:00  1  fy2023
+2023-12-22␠00:00:00  1  fy2023
+2023-12-21␠00:00:00  1  fy2023
+2023-12-20␠00:00:00  1  fy2023
+2023-12-19␠00:00:00  1  fy2023
+2023-12-18␠00:00:00  1  fy2023
+2023-12-17␠00:00:00  1  fy2023
+2023-12-16␠00:00:00  1  fy2023
+2023-12-15␠00:00:00  1  fy2023
+2023-12-14␠00:00:00  1  fy2023
+2023-12-13␠00:00:00  1  fy2023
+2023-12-12␠00:00:00  1  fy2023
+2023-12-11␠00:00:00  1  fy2023
+2023-12-10␠00:00:00  1  fy2023
+2023-12-09␠00:00:00  1  fy2023
+2023-12-08␠00:00:00  1  fy2023
+2023-12-07␠00:00:00  1  fy2023
+2023-12-06␠00:00:00  1  fy2023
+2023-12-05␠00:00:00  1  fy2023
+2023-12-04␠00:00:00  1  fy2023
+2023-12-03␠00:00:00  1  fy2023
+2023-12-02␠00:00:00  1  fy2023
+2023-12-01␠00:00:00  1  fy2023
 
 # Constant queries should have a timestamp near the current time (instead of, e.g., u64::MAX)
 query B


### PR DESCRIPTION
Replace usages of `mz_now` with a hard-coded timestamp to remove flakiness

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
