### PR TITLE
testdrive: Remove further source stats flakiness

### DIFF
--- a/test/testdrive-old-kafka-src-syntax/statistics-maintenance.td
+++ b/test/testdrive-old-kafka-src-syntax/statistics-maintenance.td
@@ -53,13 +53,12 @@ one:two
 sink1 1 1 true true
 
 > SELECT s.name,
-  SUM(u.updates_committed) > 0,
   SUM(u.messages_received)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
-upsert1 true 1
+upsert1 1
 
 # Shut down the cluster
 > ALTER CLUSTER cluster1 SET (REPLICATION FACTOR = 0)
@@ -73,13 +72,12 @@ upsert1 true 1
 sink1 1 1 true true
 
 > SELECT s.name,
-  SUM(u.updates_committed) > 0,
   SUM(u.messages_received)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
-upsert1 true 1
+upsert1 1
 
 # Ingest some more data, and ensure counters are maintained
 
@@ -97,10 +95,9 @@ two:three
 sink1 2 2 true true
 
 > SELECT s.name,
-  SUM(u.updates_committed) > 0,
   SUM(u.messages_received)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
-upsert1 true 2
+upsert1 2


### PR DESCRIPTION
See https://github.com/MaterializeInc/database-issues/issues/8848

Noticed in https://buildkite.com/materialize/nightly/builds/10760#0194246d-b7de-4481-a6bb-aab5f27f40c4

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
