### PR TITLE
lint: Fix lint from new Rust version

### DIFF
--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -197,7 +197,7 @@ impl Coordinator {
     pub(crate) async fn ensure_timeline_state<'a>(
         &'a mut self,
         timeline: &'a Timeline,
-    ) -> &mut TimelineState<Timestamp> {
+    ) -> &'a mut TimelineState<Timestamp> {
         Self::ensure_timeline_state_with_initial_time(
             timeline,
             Timestamp::minimum(),

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -134,7 +134,7 @@ impl<'a> Transaction<'a> {
             txn_wal_shard,
         }: Snapshot,
         upper: mz_repr::Timestamp,
-    ) -> Result<Transaction, CatalogError> {
+    ) -> Result<Transaction<'a>, CatalogError> {
         Ok(Transaction {
             durable_catalog,
             databases: TableTransaction::new_with_uniqueness_fn(

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -877,7 +877,7 @@ impl MirRelationExpr {
     fn column_names<'a>(
         &'a self,
         ctx: &'a PlanRenderingContext<'_, MirRelationExpr>,
-    ) -> Option<&Vec<String>> {
+    ) -> Option<&'a Vec<String>> {
         if !ctx.config.humanized_exprs {
             None
         } else if let Some(analyses) = ctx.annotations.get(self) {

--- a/src/pgwire-common/src/codec.rs
+++ b/src/pgwire-common/src/codec.rs
@@ -242,7 +242,7 @@ pub struct Cursor<'a> {
 impl<'a> Cursor<'a> {
     /// Constructs a new `Cursor` from a byte slice. The cursor will begin
     /// decoding from the beginning of the slice.
-    pub fn new(buf: &'a [u8]) -> Cursor {
+    pub fn new(buf: &'a [u8]) -> Cursor<'a> {
         Cursor { buf }
     }
 

--- a/src/repr/src/explain.rs
+++ b/src/repr/src/explain.rs
@@ -368,7 +368,7 @@ pub struct RenderingContext<'a> {
 }
 
 impl<'a> RenderingContext<'a> {
-    pub fn new(indent: Indent, humanizer: &'a dyn ExprHumanizer) -> RenderingContext {
+    pub fn new(indent: Indent, humanizer: &'a dyn ExprHumanizer) -> RenderingContext<'a> {
         RenderingContext { indent, humanizer }
     }
 }

--- a/src/sql-pretty/src/util.rs
+++ b/src/sql-pretty/src/util.rs
@@ -33,7 +33,7 @@ where
 
 pub(crate) fn title_comma_separate<'a, F, T, S>(title: S, f: F, v: &'a [T]) -> RcDoc<'a, ()>
 where
-    F: Fn(&'a T) -> RcDoc,
+    F: Fn(&'a T) -> RcDoc<'a>,
     S: Into<String>,
 {
     let title = RcDoc::text(title.into());
@@ -50,7 +50,7 @@ pub(crate) fn nest_comma_separate<'a, F, T: 'a, I>(
     v: I,
 ) -> RcDoc<'a, ()>
 where
-    F: Fn(&'a T) -> RcDoc,
+    F: Fn(&'a T) -> RcDoc<'a>,
     I: IntoIterator<Item = &'a T>,
 {
     nest(title, comma_separate(f, v))
@@ -58,7 +58,7 @@ where
 
 pub(crate) fn comma_separate<'a, F, T: 'a, I>(f: F, v: I) -> RcDoc<'a, ()>
 where
-    F: Fn(&'a T) -> RcDoc,
+    F: Fn(&'a T) -> RcDoc<'a>,
     I: IntoIterator<Item = &'a T>,
 {
     let docs = v.into_iter().map(f);

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -199,13 +199,13 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync + ConnectionR
     fn resolve_cluster<'a, 'b>(
         &'a self,
         cluster_name: Option<&'b str>,
-    ) -> Result<&dyn CatalogCluster<'a>, CatalogError>;
+    ) -> Result<&'a dyn CatalogCluster<'a>, CatalogError>;
 
     /// Resolves the named cluster replica.
     fn resolve_cluster_replica<'a, 'b>(
         &'a self,
         cluster_replica_name: &'b QualifiedReplica,
-    ) -> Result<&dyn CatalogClusterReplica<'a>, CatalogError>;
+    ) -> Result<&'a dyn CatalogClusterReplica<'a>, CatalogError>;
 
     /// Resolves a partially-specified item name, that is NOT a function or
     /// type. (For resolving functions or types, please use

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1276,7 +1276,7 @@ pub struct NameResolver<'a> {
 }
 
 impl<'a> NameResolver<'a> {
-    fn new(catalog: &'a dyn SessionCatalog) -> NameResolver {
+    fn new(catalog: &'a dyn SessionCatalog) -> NameResolver<'a> {
         NameResolver {
             catalog,
             ctes: BTreeMap::new(),

--- a/src/sql/src/pure/references.rs
+++ b/src/sql/src/pure/references.rs
@@ -309,7 +309,7 @@ impl RetrievedSourceReferences {
         &'a self,
         requested: Option<&ExternalReferences>,
         source_name: &UnresolvedItemName,
-    ) -> Result<Vec<RequestedSourceExport<&ReferenceMetadata>>, PlanError> {
+    ) -> Result<Vec<RequestedSourceExport<&'a ReferenceMetadata>>, PlanError> {
         // Filter all available references to those requested by the `ExternalReferences`
         // specification and include any alias that the user has specified.
         // TODO(database-issues#8620): The alias handling can be removed once subsources are removed.

--- a/src/storage-types/src/stats.rs
+++ b/src/storage-types/src/stats.rs
@@ -185,7 +185,7 @@ impl RelationPartStats<'_> {
         num_oks.map(|num_oks| num_results - num_oks)
     }
 
-    fn col_values<'a>(&'a self, idx: usize, arena: &'a RowArena) -> Option<ResultSpec> {
+    fn col_values<'a>(&'a self, idx: usize, arena: &'a RowArena) -> Option<ResultSpec<'a>> {
         let name = self.desc.get_name(idx);
         let typ = &self.desc.typ().column_types[idx];
 

--- a/src/walkabout/src/ir.rs
+++ b/src/walkabout/src/ir.rs
@@ -40,7 +40,7 @@ pub enum Item {
 }
 
 impl Item {
-    pub fn fields<'a>(&'a self) -> Box<dyn Iterator<Item = &Field> + 'a> {
+    pub fn fields<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Field> + 'a> {
         match self {
             Item::Struct(s) => Box::new(s.fields.iter()),
             Item::Enum(e) => Box::new(e.variants.iter().flat_map(|v| &v.fields)),


### PR DESCRIPTION
After the upgrade to the new Rust version, a lot of warnings of the
form "warning: elided lifetime has a name" were appearing. This commit
resolves those warnings by adding explicit lifetime names.


### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
