### PR TITLE
docs: upgrade Rust instructions

### DIFF
--- a/doc/developer/upgrade-rust.md
+++ b/doc/developer/upgrade-rust.md
@@ -34,5 +34,9 @@ Anyone is welcome to upgrade the version of Rust! Below is the list of things yo
     * The [Releases](https://github.com/rust-lang/rust/releases) page for the Rust repository
       should mention if it's been changed. But the only way to know for sure it to
       [git blame the `UNICODE_VERSION` const](https://github.com/rust-lang/rust/blame/master/library/core/src/unicode/unicode_data.rs).
-6. When the upgrade PR finally merges, post in `#eng-general` to give everyone a heads up and let
+6. **Before merging the PR**, run [Nightly](https://buildkite.com/materialize/nightly) to catch any performance
+   regressions that may be caused by the upgrade. If there are minor regressions, it's most likely
+   okay to proceed, but in general it's easier to make that decision while the PR is still open as
+   opposed to merged on `main`.
+7. When the upgrade PR finally merges, post in `#eng-general` to give everyone a heads up and let
    them know they can upgrade by running `rustup upgrade stable`.

--- a/doc/developer/upgrade-rust.md
+++ b/doc/developer/upgrade-rust.md
@@ -35,7 +35,7 @@ Anyone is welcome to upgrade the version of Rust! Below is the list of things yo
       should mention if it's been changed. But the only way to know for sure it to
       [git blame the `UNICODE_VERSION` const](https://github.com/rust-lang/rust/blame/master/library/core/src/unicode/unicode_data.rs).
 6. **Before merging the PR**, run [Nightly](https://buildkite.com/materialize/nightly) to catch any performance
-   regressions that may be caused by the upgrade. If there are minor regressions, it's most likely
+   regressions that may be caused by the upgrade. If there are minor performance regressions, it's most likely
    okay to proceed, but in general it's easier to make that decision while the PR is still open as
    opposed to merged on `main`.
 7. When the upgrade PR finally merges, post in `#eng-general` to give everyone a heads up and let


### PR DESCRIPTION
Update the instructions to include running Nightly

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
