### PR TITLE
[persist] Don't discard parts that should be deleted

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -162,13 +162,13 @@ where
     /// marks them as deleted.
     #[instrument(level = "debug", fields(shard = %self.shard_id()))]
     pub async fn delete(mut self) {
-        self.mark_consumed();
         if !self.batch_delete_enabled {
+            self.mark_consumed();
             return;
         }
         let mut deletes = PartDeletes::default();
-        for part in self.batch.parts.iter() {
-            deletes.add(part);
+        for part in self.batch.parts.drain(..) {
+            deletes.add(&part);
         }
         let () = deletes
             .delete(


### PR DESCRIPTION
Calling `mark_consumed` drops all the parts in the batch, so the rest of this method's logic didn't do anything.

### Motivation

Bug! First reported [in Slack](https://materializeinc.slack.com/archives/C06V70RE7SN/p1727361839440419).

### Tips for reviewer

The slack thread also suggests that `compare_and_append_batch` should take ownership of the data. I've taken a look at this, but it's going to be a more substantial change... still seems worth doing, but better as a followup.

This also includes a simple regression test.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
