### PR TITLE
[optimizer] Reduce MRE::typ() calls in SemijoinIdempotence

### DIFF
--- a/src/transform/src/semijoin_idempotence.rs
+++ b/src/transform/src/semijoin_idempotence.rs
@@ -230,6 +230,10 @@ fn attempt_join_simplification(
                         // TODO: Discover the transform that would not require this code.
                         let mut is_not_nulls = Vec::new();
                         for (col0, col1) in ltr.iter() {
+                            // We are using the pre-computed types; recomputing the types here
+                            // might alter nullability. As of 2025-01-09, Gábor has not found that
+                            // happening. But for the future, notice that this could be a source of
+                            // inaccurate or inconsistent nullability information.
                             if !typ1.column_types[*col1].nullable
                                 && typ0.column_types[*col0].nullable
                             {

--- a/src/transform/src/semijoin_idempotence.rs
+++ b/src/transform/src/semijoin_idempotence.rs
@@ -198,6 +198,9 @@ fn attempt_join_simplification(
     let input_mapper = JoinInputMapper::new(inputs);
 
     if let Some((ltr, rtl)) = semijoin_bijection(inputs, equivalences) {
+        // If semijoin_bijection returns `Some(...)`, then `inputs.len() == 2`.
+        assert_eq!(inputs.len(), 2);
+
         // Collect the `Get` identifiers each input might present as.
         let ids0 = as_filtered_get(&inputs[0], gets_behind_gets)
             .iter()
@@ -207,6 +210,10 @@ fn attempt_join_simplification(
             .iter()
             .map(|(id, _)| *id)
             .collect::<Vec<_>>();
+
+        // Record the types of the inputs, for use in both loops below.
+        let typ0 = inputs[0].typ().column_types;
+        let typ1 = inputs[1].typ().column_types;
 
         // Consider replacing the second input for the benefit of the first.
         if distinct_on_keys_of(&inputs[1], &rtl)
@@ -222,8 +229,6 @@ fn attempt_join_simplification(
                         // The pushdown is for the benefit of CSE on the `A` expressions,
                         // in the not uncommon case of nullable foreign keys in outer joins.
                         // TODO: Discover the transform that would not require this code.
-                        let typ0 = inputs[0].typ().column_types;
-                        let typ1 = inputs[1].typ().column_types;
                         let mut is_not_nulls = Vec::new();
                         for (col0, col1) in ltr.iter() {
                             if !typ1[*col1].nullable && typ0[*col0].nullable {
@@ -256,8 +261,6 @@ fn attempt_join_simplification(
                         // The pushdown is for the benefit of CSE on the `A` expressions,
                         // in the not uncommon case of nullable foreign keys in outer joins.
                         // TODO: Discover the transform that would not require this code.
-                        let typ0 = inputs[0].typ().column_types;
-                        let typ1 = inputs[1].typ().column_types;
                         let mut is_not_nulls = Vec::new();
                         for (col1, col0) in rtl.iter() {
                             if !typ0[*col0].nullable && typ1[*col1].nullable {

--- a/src/transform/src/semijoin_idempotence.rs
+++ b/src/transform/src/semijoin_idempotence.rs
@@ -26,6 +26,7 @@
 //! which we will transfer to the columns of `D` thereby forming `C`.
 
 use itertools::Itertools;
+use mz_repr::RelationType;
 use std::collections::BTreeMap;
 
 use mz_expr::{Id, JoinInputMapper, LocalId, MirRelationExpr, MirScalarExpr, RECURSION_LIMIT};
@@ -212,13 +213,11 @@ fn attempt_join_simplification(
             .collect::<Vec<_>>();
 
         // Record the types of the inputs, for use in both loops below.
-        let typ0 = inputs[0].typ().column_types;
-        let typ1 = inputs[1].typ().column_types;
+        let typ0 = inputs[0].typ();
+        let typ1 = inputs[1].typ();
 
         // Consider replacing the second input for the benefit of the first.
-        if distinct_on_keys_of(&inputs[1], &rtl)
-            && input_mapper.input_arity(1) == equivalences.len()
-        {
+        if distinct_on_keys_of(&typ1, &rtl) && input_mapper.input_arity(1) == equivalences.len() {
             for mut candidate in list_replacements(&inputs[1], let_replacements, gets_behind_gets) {
                 if ids0.contains(&candidate.id) {
                     if let Some(permutation) = validate_replacement(&ltr, &mut candidate) {
@@ -231,7 +230,9 @@ fn attempt_join_simplification(
                         // TODO: Discover the transform that would not require this code.
                         let mut is_not_nulls = Vec::new();
                         for (col0, col1) in ltr.iter() {
-                            if !typ1[*col1].nullable && typ0[*col0].nullable {
+                            if !typ1.column_types[*col1].nullable
+                                && typ0.column_types[*col0].nullable
+                            {
                                 is_not_nulls.push(MirScalarExpr::Column(*col0).call_is_null().not())
                             }
                         }
@@ -248,9 +249,7 @@ fn attempt_join_simplification(
             }
         }
         // Consider replacing the first input for the benefit of the second.
-        if distinct_on_keys_of(&inputs[0], &ltr)
-            && input_mapper.input_arity(0) == equivalences.len()
-        {
+        if distinct_on_keys_of(&typ0, &ltr) && input_mapper.input_arity(0) == equivalences.len() {
             for mut candidate in list_replacements(&inputs[0], let_replacements, gets_behind_gets) {
                 if ids1.contains(&candidate.id) {
                     if let Some(permutation) = validate_replacement(&rtl, &mut candidate) {
@@ -263,7 +262,9 @@ fn attempt_join_simplification(
                         // TODO: Discover the transform that would not require this code.
                         let mut is_not_nulls = Vec::new();
                         for (col1, col0) in rtl.iter() {
-                            if !typ0[*col0].nullable && typ1[*col1].nullable {
+                            if !typ0.column_types[*col0].nullable
+                                && typ1.column_types[*col1].nullable
+                            {
                                 is_not_nulls.push(MirScalarExpr::Column(*col1).call_is_null().not())
                             }
                         }
@@ -425,7 +426,7 @@ fn list_replacements_join(
         // Each unique key could be a semijoin candidate.
         // We want to check that the join equivalences exactly match the key,
         // and then transcribe the corresponding columns in the other input.
-        if distinct_on_keys_of(&inputs[1], &rtl) {
+        if distinct_on_keys_of(&inputs[1].typ(), &rtl) {
             let columns = ltr
                 .iter()
                 .map(|(k0, k1)| (*k0, *k0, *k1))
@@ -455,7 +456,7 @@ fn list_replacements_join(
         // Each unique key could be a semijoin candidate.
         // We want to check that the join equivalences exactly match the key,
         // and then transcribe the corresponding columns in the other input.
-        if distinct_on_keys_of(&inputs[0], &ltr) {
+        if distinct_on_keys_of(&inputs[0].typ(), &ltr) {
             let columns = ltr
                 .iter()
                 .map(|(k0, k1)| (*k1, *k0, *k0))
@@ -487,10 +488,9 @@ fn list_replacements_join(
     results
 }
 
-/// True iff some unique key of `input` is contained in the keys of `map`.
-fn distinct_on_keys_of(expr: &MirRelationExpr, map: &BTreeMap<usize, usize>) -> bool {
-    expr.typ()
-        .keys
+/// True iff some unique key of `typ` is contained in the keys of `map`.
+fn distinct_on_keys_of(typ: &RelationType, map: &BTreeMap<usize, usize>) -> bool {
+    typ.keys
         .iter()
         .any(|key| key.iter().all(|k| map.contains_key(k)))
 }


### PR DESCRIPTION
Ensures we only call `MRE::typ()` twice, rather than six times, in `attempt_join_simplification`. Changes the interface of `distinct_on_keys_of` to just take a `RelationType`, which should offer some additional savings.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
