### PR TITLE
test: unflake source statistics tests

### DIFF
--- a/test/cluster/storage/01-create-sources.td
+++ b/test/cluster/storage/01-create-sources.td
@@ -59,6 +59,7 @@ one
 one
 
 > SELECT s.name,
+  SUM(u.updates_committed) > 0,
   SUM(u.messages_received) >= 2,
   SUM(u.offset_known),
   SUM(u.offset_committed)
@@ -66,5 +67,13 @@ one
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
-remote1 true 1 1
-remote2 true 1 1
+remote1 true true 1 1
+remote2 true true 1 1
+
+> SELECT s.name,
+  SUM(u.updates_committed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('webhook_text')
+  GROUP BY s.id, s.name
+webhook_text 1

--- a/test/cluster/storage/01-create-sources.td
+++ b/test/cluster/storage/01-create-sources.td
@@ -58,6 +58,16 @@ one
 > SELECT * from remote2_tbl
 one
 
+# The `CREATE TABLE ... FROM SOURCE` commands caused a recreation of the
+# respective source dataflows, during which we might have lost the
+# statistics about committed updates from the snapshot. Ingest some more data
+# to ensure we see some `updates_committed`.
+
+$ kafka-ingest format=bytes topic=remote1
+two
+$ kafka-ingest format=bytes topic=remote2
+two
+
 > SELECT s.name,
   SUM(u.updates_committed) > 0,
   SUM(u.messages_received) >= 2,
@@ -67,8 +77,8 @@ one
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
-remote1 true true 1 1
-remote2 true true 1 1
+remote1 true true 2 2
+remote2 true true 2 2
 
 > SELECT s.name,
   SUM(u.updates_committed)

--- a/test/cluster/storage/02-after-environmentd-restart.td
+++ b/test/cluster/storage/02-after-environmentd-restart.td
@@ -15,8 +15,10 @@ $ set-sql-timeout duration=180s
 
 > SELECT * from remote1
 one
+two
 > SELECT * from remote2
 one
+two
 
 # ensure after envd has restarted, we have maintained statistics.
 > SELECT s.name,
@@ -28,8 +30,8 @@ one
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
-remote1 true true 1 1
-remote2 true true 1 1
+remote1 true true 2 2
+remote2 true true 2 2
 
 > SELECT s.name,
   SUM(u.updates_committed)
@@ -40,18 +42,20 @@ remote2 true true 1 1
 webhook_text 1
 
 $ kafka-ingest format=bytes topic=remote1
-two
+three
 $ kafka-ingest format=bytes topic=remote2
-two
+three
 $ webhook-append database=materialize schema=public name=webhook_text
 b
 
 > SELECT * from remote1
 one
 two
+three
 > SELECT * from remote2
 one
 two
+three
 
 # Ensure that offsets/counters can be updated correctly.
 > SELECT s.name,
@@ -63,8 +67,8 @@ two
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
-remote1 true true 2 2
-remote2 true true 2 2
+remote1 true true 3 3
+remote2 true true 3 3
 
 > SELECT s.name,
   SUM(u.updates_committed)

--- a/test/cluster/storage/02-after-environmentd-restart.td
+++ b/test/cluster/storage/02-after-environmentd-restart.td
@@ -20,6 +20,7 @@ one
 
 # ensure after envd has restarted, we have maintained statistics.
 > SELECT s.name,
+  SUM(u.updates_committed) > 0,
   SUM(u.messages_received) >= 2,
   SUM(u.offset_known),
   SUM(u.offset_committed)
@@ -27,8 +28,16 @@ one
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
-remote1 true 1 1
-remote2 true 1 1
+remote1 true true 1 1
+remote2 true true 1 1
+
+> SELECT s.name,
+  SUM(u.updates_committed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('webhook_text')
+  GROUP BY s.id, s.name
+webhook_text 1
 
 $ kafka-ingest format=bytes topic=remote1
 two
@@ -46,6 +55,7 @@ two
 
 # Ensure that offsets/counters can be updated correctly.
 > SELECT s.name,
+  SUM(u.updates_committed) > 0,
   SUM(u.messages_received) >= 4,
   SUM(u.offset_known),
   SUM(u.offset_committed)
@@ -53,5 +63,13 @@ two
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
-remote1 true 2 2
-remote2 true 2 2
+remote1 true true 2 2
+remote2 true true 2 2
+
+> SELECT s.name,
+  SUM(u.updates_committed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('webhook_text')
+  GROUP BY s.id, s.name
+webhook_text 2

--- a/test/cluster/storage/03-while-clusterd-down.td
+++ b/test/cluster/storage/03-while-clusterd-down.td
@@ -20,20 +20,24 @@ $ set-sql-timeout duration=180s
 > SELECT * from remote1
 one
 two
+three
 > SELECT * from remote2
 one
 two
+three
 
 $ kafka-ingest format=bytes topic=remote1
-three
+four
 $ kafka-ingest format=bytes topic=remote2
-three
+four
 
 > SELECT * from remote1
 one
 two
+three
 > SELECT * from remote2
 one
 two
+three
 
 > SET transaction_isolation = 'strict serializable'

--- a/test/cluster/storage/04-after-clusterd-restart.td
+++ b/test/cluster/storage/04-after-clusterd-restart.td
@@ -17,26 +17,30 @@ $ set-sql-timeout duration=180s
 one
 two
 three
+four
 > SELECT * from remote2
 one
 two
 three
+four
 
 $ kafka-ingest format=bytes topic=remote1
-four
+five
 $ kafka-ingest format=bytes topic=remote2
-four
+five
 
 > SELECT * from remote1
 one
 two
 three
 four
+five
 > SELECT * from remote2
 one
 two
 three
 four
+five
 
 > SELECT s.name,
   SUM(u.offset_known),
@@ -45,5 +49,5 @@ four
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
-remote1 4 4
-remote2 4 4
+remote1 5 5
+remote2 5 5

--- a/test/testdrive-old-kafka-src-syntax/statistics-deletion.td
+++ b/test/testdrive-old-kafka-src-syntax/statistics-deletion.td
@@ -89,6 +89,17 @@ one:two
 sink_size 1 1 true true
 sink_cluster 1 1 true true
 
+> SELECT s.name,
+  SUM(u.updates_committed) > 0
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('upsert_size', 'upsert_cluster', 's', 'bids')
+  GROUP BY s.id, s.name
+upsert_size true
+upsert_cluster true
+s false
+s false
+
 # We have to obtain these before we delete the sink.
 $ set-from-sql var=sink-size-id
 SELECT s.id

--- a/test/testdrive-old-kafka-src-syntax/statistics-maintenance.td
+++ b/test/testdrive-old-kafka-src-syntax/statistics-maintenance.td
@@ -53,12 +53,13 @@ one:two
 sink1 1 1 true true
 
 > SELECT s.name,
+  SUM(u.updates_committed) > 0,
   SUM(u.messages_received)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
-upsert1 1
+upsert1 true 1
 
 # Shut down the cluster
 > ALTER CLUSTER cluster1 SET (REPLICATION FACTOR = 0)
@@ -72,12 +73,13 @@ upsert1 1
 sink1 1 1 true true
 
 > SELECT s.name,
+  SUM(u.updates_committed) > 0,
   SUM(u.messages_received)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
-upsert1 1
+upsert1 true 1
 
 # Ingest some more data, and ensure counters are maintained
 
@@ -95,9 +97,10 @@ two:three
 sink1 2 2 true true
 
 > SELECT s.name,
+  SUM(u.updates_committed) > 0,
   SUM(u.messages_received)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
-upsert1 2
+upsert1 true 2

--- a/test/testdrive/statistics-deletion.td
+++ b/test/testdrive/statistics-deletion.td
@@ -9,6 +9,8 @@
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000
+ALTER SYSTEM SET storage_statistics_interval = 1000
 
 > CREATE CLUSTER cluster1 REPLICAS (r1 (SIZE '2'))
 
@@ -82,8 +84,12 @@ one:two
 > CREATE TABLE subsources_cluster.organizations FROM SOURCE subsources_cluster.s (REFERENCE organizations);
 > CREATE TABLE subsources_cluster.users FROM SOURCE subsources_cluster.s (REFERENCE users);
 
-# NOTE: These queries are slow to succeed because the default metrics scraping
-# interval is 30 seconds. Here we are just ensuring metrics were populated.
+# The `CREATE TABLE ... FROM SOURCE` commands caused a recreation of the
+# respective source dataflows, during which we might have lost the statistics
+# about committed updates from the snapshot. Ingest some more data to ensure we
+# see some `updates_committed`.
+$ kafka-ingest format=bytes topic=upsert key-format=bytes key-terminator=:
+two:three
 
 > SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed)
   FROM mz_sinks s

--- a/test/testdrive/statistics-deletion.td
+++ b/test/testdrive/statistics-deletion.td
@@ -93,6 +93,17 @@ one:two
 sink_size 1 1 true true
 sink_cluster 1 1 true true
 
+> SELECT s.name,
+  SUM(u.updates_committed) > 0
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('upsert_size', 'upsert_cluster', 's', 'bids')
+  GROUP BY s.id, s.name
+upsert_size true
+upsert_cluster true
+s false
+s false
+
 # We have to obtain these before we delete the sink.
 $ set-from-sql var=sink-size-id
 SELECT s.id

--- a/test/testdrive/statistics-maintenance.td
+++ b/test/testdrive/statistics-maintenance.td
@@ -55,12 +55,13 @@ one:two
 sink1 1 1 true true
 
 > SELECT s.name,
+  SUM(u.updates_committed) > 0,
   SUM(u.messages_received) >= 2
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
-upsert1 true
+upsert1 true true
 
 # Shut down the cluster
 > ALTER CLUSTER cluster1 SET (REPLICATION FACTOR = 0)
@@ -74,12 +75,13 @@ upsert1 true
 sink1 1 1 true true
 
 > SELECT s.name,
+  SUM(u.updates_committed) > 0,
   SUM(u.messages_received) >= 2
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
-upsert1 true
+upsert1 true true
 
 # Ingest some more data, and ensure counters are maintained
 
@@ -97,9 +99,10 @@ two:three
 sink1 2 2 true true
 
 > SELECT s.name,
+  SUM(u.updates_committed) > 0,
   SUM(u.messages_received) >= 4
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
-upsert1 true
+upsert1 true true

--- a/test/testdrive/statistics-maintenance.td
+++ b/test/testdrive/statistics-maintenance.td
@@ -46,6 +46,13 @@ one:two
   VALUE FORMAT BYTES
   ENVELOPE UPSERT
 
+# The `CREATE TABLE ... FROM SOURCE` commands caused a recreation of the
+# respective source dataflows, during which we might have lost the statistics
+# about committed updates from the snapshot. Ingest some more data to ensure we
+# see some `updates_committed`.
+$ kafka-ingest format=bytes topic=upsert key-format=bytes key-terminator=:
+two:three
+
 # Ensure we produce statistics
 > SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed)
   FROM mz_sinks s
@@ -88,7 +95,7 @@ upsert1 true true
 > ALTER CLUSTER cluster1 SET (REPLICATION FACTOR = 1)
 > INSERT INTO t VALUES ('key1', 'value')
 $ kafka-ingest format=bytes topic=upsert key-format=bytes key-terminator=:
-two:three
+three:four
 
 # Statistics should remain the same
 > SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed)


### PR DESCRIPTION
This PR restores and fixes storage statistics tests that use the new `CREATE TABLE ... FROM SOURCE` syntax. This syntax recreates the source dataflow, which can lead to the loss of `updates_committed` counts. Tests checking for `updates_committed > 0` need to insert new updates after the dataflow was recreated, to avoid flakes.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8848

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
