### PR TITLE
Add additional prometheus scrape annotations for envronmentd.

### DIFF
--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -1198,6 +1198,22 @@ fn create_environmentd_statefulset_object(
         );
         pod_template_annotations.insert("prometheus.io/path".to_owned(), "/metrics".to_string());
         pod_template_annotations.insert("prometheus.io/scheme".to_owned(), "http".to_string());
+        pod_template_annotations.insert(
+            "materialize.prometheus.io/mz_usage_path".to_owned(),
+            "/metrics/mz_usage".to_string(),
+        );
+        pod_template_annotations.insert(
+            "materialize.prometheus.io/mz_frontier_path".to_owned(),
+            "/metrics/mz_frontier".to_string(),
+        );
+        pod_template_annotations.insert(
+            "materialize.prometheus.io/mz_compute_path".to_owned(),
+            "/metrics/mz_compute".to_string(),
+        );
+        pod_template_annotations.insert(
+            "materialize.prometheus.io/mz_storage_path".to_owned(),
+            "/metrics/mz_storage".to_string(),
+        );
     }
 
     let tolerations = Some(vec![


### PR DESCRIPTION
Add additional prometheus scrape annotations for secondary metrics paths on envronmentd.
```
materialize.prometheus.io/mz_usage_path
materialize.prometheus.io/mz_frontier_path
materialize.prometheus.io/mz_compute_path
materialize.prometheus.io/mz_storage_path
```

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


  * This PR adds a known-desirable feature.
Resolves https://github.com/MaterializeInc/cloud/issues/10608

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
