### PR TITLE
only consider user clusters when validating max_credit_consumption_rate

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1284,7 +1284,8 @@ impl Catalog {
     }
 
     pub fn user_cluster_replicas(&self) -> impl Iterator<Item = &ClusterReplica> {
-        self.user_clusters().flat_map(|cluster| cluster.replicas())
+        self.user_clusters()
+            .flat_map(|cluster| cluster.user_replicas())
     }
 
     pub fn databases(&self) -> impl Iterator<Item = &Database> {

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1398,14 +1398,18 @@ impl Coordinator {
                     cluster_id, config, ..
                 } => {
                     *new_replicas_per_cluster.entry(*cluster_id).or_insert(0) += 1;
-                    if let ReplicaLocation::Managed(location) = &config.location {
-                        let replica_allocation = self
-                            .catalog()
-                            .cluster_replica_sizes()
-                            .0
-                            .get(location.size_for_billing())
-                            .expect("location size is validated against the cluster replica sizes");
-                        new_credit_consumption_rate += replica_allocation.credits_per_hour
+                    if cluster_id.is_user() {
+                        if let ReplicaLocation::Managed(location) = &config.location {
+                            let replica_allocation = self
+                                .catalog()
+                                .cluster_replica_sizes()
+                                .0
+                                .get(location.size_for_billing())
+                                .expect(
+                                    "location size is validated against the cluster replica sizes",
+                                );
+                            new_credit_consumption_rate += replica_allocation.credits_per_hour
+                        }
                     }
                 }
                 Op::CreateItem { name, item, .. } => {
@@ -1460,18 +1464,21 @@ impl Coordinator {
                                 *new_replicas_per_cluster.entry(*cluster_id).or_insert(0) -= 1;
                                 let cluster =
                                     self.catalog().get_cluster_replica(*cluster_id, *replica_id);
-                                if let ReplicaLocation::Managed(location) = &cluster.config.location
-                                {
-                                    let replica_allocation = self
-                                .catalog()
-                                .cluster_replica_sizes()
-                                .0
-                                .get(location.size_for_billing())
-                                .expect(
-                                    "location size is validated against the cluster replica sizes",
-                                );
-                                    new_credit_consumption_rate -=
-                                        replica_allocation.credits_per_hour
+                                if cluster_id.is_user() {
+                                    if let ReplicaLocation::Managed(location) =
+                                        &cluster.config.location
+                                    {
+                                        let replica_allocation = self
+                                            .catalog()
+                                            .cluster_replica_sizes()
+                                            .0
+                                            .get(location.size_for_billing())
+                                            .expect(
+                                                "location size is validated against the cluster replica sizes",
+                                            );
+                                        new_credit_consumption_rate -=
+                                            replica_allocation.credits_per_hour
+                                    }
                                 }
                             }
                             DropObjectInfo::Database(_) => {

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1397,8 +1397,8 @@ impl Coordinator {
                 Op::CreateClusterReplica {
                     cluster_id, config, ..
                 } => {
-                    *new_replicas_per_cluster.entry(*cluster_id).or_insert(0) += 1;
                     if cluster_id.is_user() {
+                        *new_replicas_per_cluster.entry(*cluster_id).or_insert(0) += 1;
                         if let ReplicaLocation::Managed(location) = &config.location {
                             let replica_allocation = self
                                 .catalog()
@@ -1461,10 +1461,11 @@ impl Coordinator {
                                 new_clusters -= 1;
                             }
                             DropObjectInfo::ClusterReplica((cluster_id, replica_id, _reason)) => {
-                                *new_replicas_per_cluster.entry(*cluster_id).or_insert(0) -= 1;
-                                let cluster =
-                                    self.catalog().get_cluster_replica(*cluster_id, *replica_id);
                                 if cluster_id.is_user() {
+                                    *new_replicas_per_cluster.entry(*cluster_id).or_insert(0) -= 1;
+                                    let cluster = self
+                                        .catalog()
+                                        .get_cluster_replica(*cluster_id, *replica_id);
                                     if let ReplicaLocation::Managed(location) =
                                         &cluster.config.location
                                     {
@@ -1691,7 +1692,7 @@ impl Coordinator {
             let current_amount = self
                 .catalog()
                 .try_get_cluster(cluster_id)
-                .map(|instance| instance.replicas().count())
+                .map(|instance| instance.user_replicas().count())
                 .unwrap_or(0);
             self.validate_resource_limit(
                 current_amount,

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -681,13 +681,15 @@ impl Coordinator {
         // `catalog_transact` will do this validation too, but allocating
         // replica IDs is expensive enough that we need to do this validation
         // before allocating replica IDs. See database-issues#6046.
-        self.validate_resource_limit(
-            0,
-            i64::from(replication_factor),
-            SystemVars::max_replicas_per_cluster,
-            "cluster replica",
-            MAX_REPLICAS_PER_CLUSTER.name(),
-        )?;
+        if cluster_id.is_user() {
+            self.validate_resource_limit(
+                0,
+                i64::from(replication_factor),
+                SystemVars::max_replicas_per_cluster,
+                "cluster replica",
+                MAX_REPLICAS_PER_CLUSTER.name(),
+            )?;
+        }
 
         for replica_name in (0..replication_factor).map(managed_cluster_replica_name) {
             self.create_managed_cluster_replica_op(
@@ -809,13 +811,15 @@ impl Coordinator {
         // `catalog_transact` will do this validation too, but allocating
         // replica IDs is expensive enough that we need to do this validation
         // before allocating replica IDs. See database-issues#6046.
-        self.validate_resource_limit(
-            0,
-            i64::try_from(replicas.len()).unwrap_or(i64::MAX),
-            SystemVars::max_replicas_per_cluster,
-            "cluster replica",
-            MAX_REPLICAS_PER_CLUSTER.name(),
-        )?;
+        if id.is_user() {
+            self.validate_resource_limit(
+                0,
+                i64::try_from(replicas.len()).unwrap_or(i64::MAX),
+                SystemVars::max_replicas_per_cluster,
+                "cluster replica",
+                MAX_REPLICAS_PER_CLUSTER.name(),
+            )?;
+        }
 
         for (replica_name, replica_config) in replicas {
             // If the AZ was not specified, choose one, round-robin, from the ones with
@@ -1163,13 +1167,15 @@ impl Coordinator {
         // replica IDs is expensive enough that we need to do this validation
         // before allocating replica IDs. See database-issues#6046.
         if new_replication_factor > replication_factor {
-            self.validate_resource_limit(
-                usize::cast_from(*replication_factor),
-                i64::from(*new_replication_factor) - i64::from(*replication_factor),
-                SystemVars::max_replicas_per_cluster,
-                "cluster replica",
-                MAX_REPLICAS_PER_CLUSTER.name(),
-            )?;
+            if cluster_id.is_user() {
+                self.validate_resource_limit(
+                    usize::cast_from(*replication_factor),
+                    i64::from(*new_replication_factor) - i64::from(*replication_factor),
+                    SystemVars::max_replicas_per_cluster,
+                    "cluster replica",
+                    MAX_REPLICAS_PER_CLUSTER.name(),
+                )?;
+            }
         }
 
         if new_size != size

--- a/test/cluster/resources/resource-limits.td
+++ b/test/cluster/resources/resource-limits.td
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+$ postgres-connect name=mz_analytics url=postgres://mz_analytics:materialize@${testdrive.materialize-internal-sql-addr}
 
 ! ALTER SYSTEM SET max_tables TO 42
 contains:permission denied to alter system
@@ -108,6 +109,21 @@ ALTER SYSTEM SET max_replicas_per_cluster = 1
 
 ! CREATE CLUSTER REPLICA c1.r2 SIZE '1'
 contains:creating cluster replica would violate max_replicas_per_cluster limit (desired: 2, limit: 1, current: 1)
+
+> SELECT COUNT(*) FROM mz_cluster_replicas JOIN mz_clusters ON mz_cluster_replicas.cluster_id = mz_clusters.id WHERE mz_clusters.name = 'mz_analytics'
+0
+
+$ postgres-execute connection=mz_analytics
+ALTER CLUSTER mz_analytics SET (REPLICATION FACTOR = 2)
+
+> SELECT COUNT(*) FROM mz_cluster_replicas JOIN mz_clusters ON mz_cluster_replicas.cluster_id = mz_clusters.id WHERE mz_clusters.name = 'mz_analytics'
+2
+
+$ postgres-execute connection=mz_analytics
+ALTER CLUSTER mz_analytics SET (REPLICATION FACTOR = 0)
+
+> SELECT COUNT(*) FROM mz_cluster_replicas JOIN mz_clusters ON mz_cluster_replicas.cluster_id = mz_clusters.id WHERE mz_clusters.name = 'mz_analytics'
+0
 
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET max_replicas_per_cluster = 100
@@ -435,6 +451,21 @@ ALTER SYSTEM SET max_credit_consumption_rate = 3
 
 ! CREATE CLUSTER REPLICA c1.r3 SIZE '1'
 contains:creating cluster replica would violate max_credit_consumption_rate limit (desired: 4, limit: 3, current: 3)
+
+> SELECT COUNT(*) FROM mz_cluster_replicas JOIN mz_clusters ON mz_cluster_replicas.cluster_id = mz_clusters.id WHERE mz_clusters.name = 'mz_analytics'
+0
+
+$ postgres-execute connection=mz_analytics
+ALTER CLUSTER mz_analytics SET (REPLICATION FACTOR = 1)
+
+> SELECT COUNT(*) FROM mz_cluster_replicas JOIN mz_clusters ON mz_cluster_replicas.cluster_id = mz_clusters.id WHERE mz_clusters.name = 'mz_analytics'
+1
+
+$ postgres-execute connection=mz_analytics
+ALTER CLUSTER mz_analytics SET (REPLICATION FACTOR = 0)
+
+> SELECT COUNT(*) FROM mz_cluster_replicas JOIN mz_clusters ON mz_cluster_replicas.cluster_id = mz_clusters.id WHERE mz_clusters.name = 'mz_analytics'
+0
 
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET max_credit_consumption_rate = 4.0


### PR DESCRIPTION
### Motivation

we already only look at user clusters when determining the current consumption rate, so this just makes the logic consistent when looking at newly created clusters

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
