### PR TITLE
catalog: Clean up old objects in migrations

### DIFF
--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -1423,7 +1423,7 @@ impl Catalog {
                 }
 
                 // Drop any roles.
-                tx.remove_roles(&delta.roles)?;
+                tx.remove_user_roles(&delta.roles)?;
 
                 for role_id in delta.roles {
                     let role = state


### PR DESCRIPTION
Previously, only a subset of the catalog object migrations would delete system catalog objects from the durable catalog after they've been removed from `builtin.rs`. The rest of the catalog object migrations would leak the objects in the durable catalog and never use them. This commit updates all catalog object migrations so that system catalog objects are removed from the durable catalog once they've been removed from `builtin.rs`.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
