### PR TITLE
[copy_from]: Arrow/Parquet Reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,12 +2302,14 @@ dependencies = [
 
 [[package]]
 name = "dec"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdeb628adfc427c3f926528cf76daf4418453e103151739d48f79b8182cb41f"
+checksum = "a8aed775093963adbd1821f88d7934c839330b05f41c9877bdbc7b385e498b9c"
 dependencies = [
  "decnumber-sys",
  "libc",
+ "num-traits",
+ "paste",
  "serde",
  "static_assertions",
 ]
@@ -4686,9 +4688,11 @@ dependencies = [
  "anyhow",
  "arrow",
  "chrono",
+ "dec",
  "half 2.4.1",
  "mz-ore",
  "mz-repr",
+ "num-traits",
  "ordered-float 4.2.0",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4686,10 +4686,13 @@ dependencies = [
  "anyhow",
  "arrow",
  "chrono",
+ "half 2.4.1",
  "mz-ore",
  "mz-repr",
+ "ordered-float 4.2.0",
  "serde",
  "serde_json",
+ "uuid",
  "workspace-hack",
 ]
 
@@ -11730,6 +11733,7 @@ dependencies = [
  "futures-task",
  "futures-util",
  "getrandom 0.2.10",
+ "half 2.4.1",
  "hashbrown 0.14.5",
  "hyper 0.14.27",
  "hyper 1.4.1",

--- a/src/arrow-util/Cargo.toml
+++ b/src/arrow-util/Cargo.toml
@@ -13,10 +13,13 @@ workspace = true
 anyhow = "1.0.66"
 arrow = { version = "53.3.0", default-features = false }
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
+half = "2"
 mz-repr = { path = "../repr" }
 mz-ore = { path = "../ore" }
+ordered-float = { version = "4.2.0" }
 serde = { version = "1.0.152" }
 serde_json = "1.0.125"
+uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/arrow-util/Cargo.toml
+++ b/src/arrow-util/Cargo.toml
@@ -13,9 +13,11 @@ workspace = true
 anyhow = "1.0.66"
 arrow = { version = "53.3.0", default-features = false }
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
+dec = { version = "0.4.9", features = ["num-traits"] }
 half = "2"
 mz-repr = { path = "../repr" }
 mz-ore = { path = "../ore" }
+num-traits = "0.2"
 ordered-float = { version = "4.2.0" }
 serde = { version = "1.0.152" }
 serde_json = "1.0.125"

--- a/src/arrow-util/src/lib.rs
+++ b/src/arrow-util/src/lib.rs
@@ -7,4 +7,26 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
+
+use arrow::array::{make_array, ArrayRef};
+use arrow::buffer::NullBuffer;
+
 pub mod builder;
+pub mod reader;
+
+/// Merge the provided null buffer with the existing array's null buffer, if any.
+pub fn mask_nulls(column: &ArrayRef, null_mask: Option<&NullBuffer>) -> ArrayRef {
+    if null_mask.is_none() {
+        Arc::clone(column)
+    } else {
+        let nulls = NullBuffer::union(null_mask, column.nulls());
+        let data = column
+            .to_data()
+            .into_builder()
+            .nulls(nulls)
+            .build()
+            .expect("changed only null mask");
+        make_array(data)
+    }
+}

--- a/src/arrow-util/src/reader.rs
+++ b/src/arrow-util/src/reader.rs
@@ -217,7 +217,7 @@ fn scalar_type_and_array_to_reader(
             // Don't use the context here, but make sure the precision is valid.
             let mut ctx = dec::Context::<Numeric>::default();
             ctx.set_precision(precision).map_err(|e| {
-                anyhow::anyhow!("invalid precision from Decimal128, {precision}, {e}")
+                anyhow::anyhow!("invalid precision from Decimal256, {precision}, {e}")
             })?;
 
             let array = downcast_array::<Decimal256Array>(array);

--- a/src/arrow-util/src/reader.rs
+++ b/src/arrow-util/src/reader.rs
@@ -509,7 +509,7 @@ impl ColReader {
                 let mut num = ctx.from_i128(x);
 
                 // Scale the number.
-                ctx.div(&mut num, &scale_factor);
+                ctx.div(&mut num, scale_factor);
 
                 Datum::Numeric(OrderedDecimal(num))
             }),
@@ -533,7 +533,7 @@ impl ColReader {
                         .map_err(|e| anyhow::anyhow!("decimal out of range: {e}"))?;
 
                     // Scale the number.
-                    ctx.div(&mut num, &scale_factor);
+                    ctx.div(&mut num, scale_factor);
 
                     Ok::<_, anyhow::Error>(Datum::Numeric(OrderedDecimal(num)))
                 })
@@ -868,6 +868,7 @@ mod tests {
         dec128.append_value(100000000009);
 
         let dec128 = dec128.finish();
+        #[allow(clippy::as_conversions)]
         let batch = StructArray::from(vec![(
             Arc::new(Field::new("a", dec128.data_type().clone(), true)),
             Arc::new(dec128) as arrow::array::ArrayRef,
@@ -912,6 +913,7 @@ mod tests {
         dec256.append_value(arrow::datatypes::i256::from(100000000009i64));
 
         let dec256 = dec256.finish();
+        #[allow(clippy::as_conversions)]
         let batch = StructArray::from(vec![(
             Arc::new(Field::new("a", dec256.data_type().clone(), true)),
             Arc::new(dec256) as arrow::array::ArrayRef,

--- a/src/arrow-util/src/reader.rs
+++ b/src/arrow-util/src/reader.rs
@@ -78,7 +78,7 @@ impl ArrowReader {
             let column = array
                 .column_by_name(col_name.as_str())
                 .ok_or_else(|| anyhow::anyhow!("'{col_name}' not found"))?;
-            let reader = scalar_type_and_array_to_reader(&col_type.scalar_type, column.clone())
+            let reader = scalar_type_and_array_to_reader(&col_type.scalar_type, Arc::clone(column))
                 .context(col_name.clone())?;
 
             readers.push(reader);
@@ -258,7 +258,7 @@ fn scalar_type_and_array_to_reader(
         ) => {
             let array = downcast_array::<ListArray>(array);
             let inner_decoder =
-                scalar_type_and_array_to_reader(&element_type, Arc::clone(array.values()))
+                scalar_type_and_array_to_reader(element_type, Arc::clone(array.values()))
                     .context("list")?;
             Ok(ColReader::List {
                 offsets: array.offsets().clone(),
@@ -275,7 +275,7 @@ fn scalar_type_and_array_to_reader(
         ) => {
             let array = downcast_array::<LargeListArray>(array);
             let inner_decoder =
-                scalar_type_and_array_to_reader(&element_type, Arc::clone(array.values()))
+                scalar_type_and_array_to_reader(element_type, Arc::clone(array.values()))
                     .context("large list")?;
             Ok(ColReader::LargeList {
                 offsets: array.offsets().clone(),

--- a/src/arrow-util/src/reader.rs
+++ b/src/arrow-util/src/reader.rs
@@ -1,0 +1,734 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Reader for [`arrow`] data that outputs [`Row`]s.
+
+use std::sync::Arc;
+
+use anyhow::Context;
+use arrow::array::{
+    Array, BinaryArray, BinaryViewArray, BooleanArray, Date32Array, Date64Array,
+    FixedSizeBinaryArray, Float16Array, Float32Array, Float64Array, Int16Array, Int32Array,
+    Int64Array, Int8Array, LargeBinaryArray, LargeListArray, LargeStringArray, ListArray,
+    StringArray, StringViewArray, StructArray, Time32SecondArray, TimestampMicrosecondArray,
+    TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt16Array,
+    UInt32Array, UInt64Array, UInt8Array,
+};
+use arrow::buffer::{NullBuffer, OffsetBuffer};
+use arrow::datatypes::{DataType, TimeUnit};
+use chrono::{DateTime, NaiveTime};
+use mz_ore::cast::CastFrom;
+use mz_repr::adt::date::Date;
+use mz_repr::adt::jsonb::JsonbPacker;
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::{Datum, RelationDesc, Row, RowPacker, ScalarType, SharedRow};
+use ordered_float::OrderedFloat;
+use uuid::Uuid;
+
+use crate::mask_nulls;
+
+/// Type that can read out of an [`arrow::array::StructArray`] and into a [`Row`], given a
+/// [`RelationDesc`].
+///
+/// The inverse of a [`crate::builder::ArrowBuilder`].
+///
+/// Note: When creating an [`ArrowReader`] we perform a "one-time downcast" of the children Arrays
+/// from the [`StructArray`], into `enum ColReader`s. This is a much more verbose approach than the
+/// alternative of downcasting from a `dyn arrow::array::Array` every time we read a [`Row`], but
+/// it is _much_ more performant.
+pub struct ArrowReader {
+    len: usize,
+    readers: Vec<ColReader>,
+}
+
+impl ArrowReader {
+    /// Create an [`ArrowReader`] validating that the provided [`RelationDesc`] and [`StructArray`]
+    /// have a matching schema.
+    ///
+    /// The [`RelationDesc`] and [`StructArray`] need to uphold the following to be a valid pair:
+    ///
+    /// * Same number of columns.
+    /// * Columns of all the same name.
+    /// * Columns of compatible types.
+    ///
+    /// TODO(cf2): Relax some of these restrictions by allowing users to map column names, omit
+    /// columns, perform some lightweight casting, and matching not on column name but column
+    /// position.
+    /// TODO(cf2): Allow specifying an optional `arrow::Schema` for extra metadata.
+    pub fn new(desc: &RelationDesc, array: StructArray) -> Result<Self, anyhow::Error> {
+        let inner_columns = array.columns();
+        let desc_columns = desc.typ().columns();
+
+        if inner_columns.len() != desc_columns.len() {
+            return Err(anyhow::anyhow!(
+                "wrong number of columns {} vs {}",
+                inner_columns.len(),
+                desc_columns.len()
+            ));
+        }
+
+        let mut readers = Vec::with_capacity(desc_columns.len());
+        for (col_name, col_type) in desc.iter() {
+            let column = array
+                .column_by_name(col_name.as_str())
+                .ok_or_else(|| anyhow::anyhow!("'{col_name}' not found"))?;
+            let reader = scalar_type_and_array_to_reader(&col_type.scalar_type, column.clone())
+                .context(col_name.clone())?;
+
+            readers.push(reader);
+        }
+
+        Ok(ArrowReader {
+            len: array.len(),
+            readers,
+        })
+    }
+
+    /// Read the value at `idx` into the provided `Row`.
+    pub fn read(&self, idx: usize, row: &mut Row) -> Result<(), anyhow::Error> {
+        let mut packer = row.packer();
+        for reader in &self.readers {
+            reader.read(idx, &mut packer).context(idx)?;
+        }
+        Ok(())
+    }
+
+    /// Read all of the values in this [`ArrowReader`] into `rows`.
+    pub fn read_all(&self, rows: &mut Vec<Row>) -> Result<usize, anyhow::Error> {
+        for idx in 0..self.len {
+            let mut row = Row::default();
+            self.read(idx, &mut row).context(idx)?;
+            rows.push(row);
+        }
+        Ok(self.len)
+    }
+}
+
+fn scalar_type_and_array_to_reader(
+    scalar_type: &ScalarType,
+    array: Arc<dyn Array>,
+) -> Result<ColReader, anyhow::Error> {
+    fn downcast_array<T: arrow::array::Array + Clone + 'static>(array: Arc<dyn Array>) -> T {
+        array
+            .as_any()
+            .downcast_ref::<T>()
+            .expect("checked DataType")
+            .clone()
+    }
+
+    match (scalar_type, array.data_type()) {
+        (ScalarType::Bool, DataType::Boolean) => {
+            Ok(ColReader::Boolean(downcast_array::<BooleanArray>(array)))
+        }
+        (ScalarType::Int16 | ScalarType::Int32 | ScalarType::Int64, DataType::Int8) => {
+            let array = downcast_array::<Int8Array>(array);
+            let cast: fn(i8) -> Datum<'static> = match scalar_type {
+                ScalarType::Int16 => |x| Datum::Int16(i16::cast_from(x)),
+                ScalarType::Int32 => |x| Datum::Int32(i32::cast_from(x)),
+                ScalarType::Int64 => |x| Datum::Int64(i64::cast_from(x)),
+                _ => unreachable!("checked above"),
+            };
+            Ok(ColReader::Int8 { array, cast })
+        }
+        (ScalarType::Int16, DataType::Int16) => {
+            Ok(ColReader::Int16(downcast_array::<Int16Array>(array)))
+        }
+        (ScalarType::Int32, DataType::Int32) => {
+            Ok(ColReader::Int32(downcast_array::<Int32Array>(array)))
+        }
+        (ScalarType::Int64, DataType::Int64) => {
+            Ok(ColReader::Int64(downcast_array::<Int64Array>(array)))
+        }
+        (ScalarType::UInt16 | ScalarType::UInt32 | ScalarType::UInt64, DataType::UInt8) => {
+            let array = downcast_array::<UInt8Array>(array);
+            let cast: fn(u8) -> Datum<'static> = match scalar_type {
+                ScalarType::UInt16 => |x| Datum::UInt16(u16::cast_from(x)),
+                ScalarType::UInt32 => |x| Datum::UInt32(u32::cast_from(x)),
+                ScalarType::UInt64 => |x| Datum::UInt64(u64::cast_from(x)),
+                _ => unreachable!("checked above"),
+            };
+            Ok(ColReader::UInt8 { array, cast })
+        }
+        (ScalarType::UInt16, DataType::UInt16) => {
+            Ok(ColReader::UInt16(downcast_array::<UInt16Array>(array)))
+        }
+        (ScalarType::UInt32, DataType::UInt32) => {
+            Ok(ColReader::UInt32(downcast_array::<UInt32Array>(array)))
+        }
+        (ScalarType::UInt64, DataType::UInt64) => {
+            Ok(ColReader::UInt64(downcast_array::<UInt64Array>(array)))
+        }
+        (ScalarType::Float32 | ScalarType::Float64, DataType::Float16) => {
+            let array = downcast_array::<Float16Array>(array);
+            let cast: fn(half::f16) -> Datum<'static> = match scalar_type {
+                ScalarType::Float32 => |x| Datum::Float32(OrderedFloat::from(x.to_f32())),
+                ScalarType::Float64 => |x| Datum::Float64(OrderedFloat::from(x.to_f64())),
+                _ => unreachable!("checked above"),
+            };
+            Ok(ColReader::Float16 { array, cast })
+        }
+        (ScalarType::Float32, DataType::Float32) => {
+            Ok(ColReader::Float32(downcast_array::<Float32Array>(array)))
+        }
+        (ScalarType::Float64, DataType::Float64) => {
+            Ok(ColReader::Float64(downcast_array::<Float64Array>(array)))
+        }
+        (ScalarType::Bytes, DataType::Binary) => {
+            Ok(ColReader::Binary(downcast_array::<BinaryArray>(array)))
+        }
+        (ScalarType::Bytes, DataType::LargeBinary) => {
+            let array = downcast_array::<LargeBinaryArray>(array);
+            Ok(ColReader::LargeBinary(array))
+        }
+        (ScalarType::Bytes, DataType::FixedSizeBinary(_)) => {
+            let array = downcast_array::<FixedSizeBinaryArray>(array);
+            Ok(ColReader::FixedSizeBinary(array))
+        }
+        (ScalarType::Bytes, DataType::BinaryView) => {
+            let array = downcast_array::<BinaryViewArray>(array);
+            Ok(ColReader::BinaryView(array))
+        }
+        (
+            ScalarType::Uuid,
+            DataType::Binary
+            | DataType::BinaryView
+            | DataType::LargeBinary
+            | DataType::FixedSizeBinary(_),
+        ) => {
+            let reader = scalar_type_and_array_to_reader(&ScalarType::Bytes, array)
+                .context("uuid reader")?;
+            Ok(ColReader::Uuid(Box::new(reader)))
+        }
+        (ScalarType::String, DataType::Utf8) => {
+            Ok(ColReader::String(downcast_array::<StringArray>(array)))
+        }
+        (ScalarType::String, DataType::LargeUtf8) => {
+            let array = downcast_array::<LargeStringArray>(array);
+            Ok(ColReader::LargeString(array))
+        }
+        (ScalarType::String, DataType::Utf8View) => {
+            let array = downcast_array::<StringViewArray>(array);
+            Ok(ColReader::StringView(array))
+        }
+        (ScalarType::Jsonb, DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View) => {
+            let reader = scalar_type_and_array_to_reader(&ScalarType::String, array)
+                .context("json reader")?;
+            Ok(ColReader::Jsonb(Box::new(reader)))
+        }
+        (ScalarType::Timestamp { .. }, DataType::Timestamp(TimeUnit::Second, None)) => {
+            let array = downcast_array::<TimestampSecondArray>(array);
+            Ok(ColReader::TimestampSecond(array))
+        }
+        (ScalarType::Timestamp { .. }, DataType::Timestamp(TimeUnit::Millisecond, None)) => {
+            let array = downcast_array::<TimestampMillisecondArray>(array);
+            Ok(ColReader::TimestampMillisecond(array))
+        }
+        (ScalarType::Timestamp { .. }, DataType::Timestamp(TimeUnit::Microsecond, None)) => {
+            let array = downcast_array::<TimestampMicrosecondArray>(array);
+            Ok(ColReader::TimestampMicrosecond(array))
+        }
+        (ScalarType::Timestamp { .. }, DataType::Timestamp(TimeUnit::Nanosecond, None)) => {
+            let array = downcast_array::<TimestampNanosecondArray>(array);
+            Ok(ColReader::TimestampNanosecond(array))
+        }
+        (ScalarType::Date, DataType::Date32) => {
+            let array = downcast_array::<Date32Array>(array);
+            Ok(ColReader::Date32(array))
+        }
+        (ScalarType::Date, DataType::Date64) => {
+            let array = downcast_array::<Date64Array>(array);
+            Ok(ColReader::Date64(array))
+        }
+        (ScalarType::Time, DataType::Time32(TimeUnit::Second)) => {
+            let array = downcast_array::<Time32SecondArray>(array);
+            Ok(ColReader::Time32Seconds(array))
+        }
+        (
+            ScalarType::List {
+                element_type,
+                custom_id: _,
+            },
+            DataType::List(_),
+        ) => {
+            let array = downcast_array::<ListArray>(array);
+            let inner_decoder =
+                scalar_type_and_array_to_reader(&element_type, Arc::clone(array.values()))
+                    .context("list")?;
+            Ok(ColReader::List {
+                offsets: array.offsets().clone(),
+                values: Box::new(inner_decoder),
+                nulls: array.nulls().cloned(),
+            })
+        }
+        (
+            ScalarType::List {
+                element_type,
+                custom_id: _,
+            },
+            DataType::LargeList(_),
+        ) => {
+            let array = downcast_array::<LargeListArray>(array);
+            let inner_decoder =
+                scalar_type_and_array_to_reader(&element_type, Arc::clone(array.values()))
+                    .context("large list")?;
+            Ok(ColReader::LargeList {
+                offsets: array.offsets().clone(),
+                values: Box::new(inner_decoder),
+                nulls: array.nulls().cloned(),
+            })
+        }
+        (
+            ScalarType::Record {
+                fields,
+                custom_id: _,
+            },
+            DataType::Struct(_),
+        ) => {
+            let record_array = downcast_array::<StructArray>(array);
+            let null_mask = record_array.nulls();
+
+            let mut decoders = Vec::with_capacity(fields.len());
+            for (name, typ) in fields.iter() {
+                let inner_array = record_array
+                    .column_by_name(name.as_str())
+                    .ok_or_else(|| anyhow::anyhow!("missing name '{name}'"))?;
+                let inner_array = mask_nulls(inner_array, null_mask);
+                let inner_decoder = scalar_type_and_array_to_reader(&typ.scalar_type, inner_array)
+                    .context(name.clone())?;
+
+                decoders.push(Box::new(inner_decoder));
+            }
+
+            Ok(ColReader::Record {
+                fields: decoders,
+                nulls: null_mask.cloned(),
+            })
+        }
+        other => anyhow::bail!("unsupported: {other:?}"),
+    }
+}
+
+/// A "downcasted" version of [`arrow::array::Array`] that supports reading [`Datum`]s.
+///
+/// Note: While this is fairly verbose, one-time "downcasting" to an enum is _much_ more performant
+/// than downcasting every time we read a [`Datum`].
+enum ColReader {
+    Boolean(arrow::array::BooleanArray),
+
+    Int8 {
+        array: arrow::array::Int8Array,
+        cast: fn(i8) -> Datum<'static>,
+    },
+    Int16(arrow::array::Int16Array),
+    Int32(arrow::array::Int32Array),
+    Int64(arrow::array::Int64Array),
+
+    UInt8 {
+        array: arrow::array::UInt8Array,
+        cast: fn(u8) -> Datum<'static>,
+    },
+    UInt16(arrow::array::UInt16Array),
+    UInt32(arrow::array::UInt32Array),
+    UInt64(arrow::array::UInt64Array),
+
+    Float16 {
+        array: arrow::array::Float16Array,
+        cast: fn(half::f16) -> Datum<'static>,
+    },
+    Float32(arrow::array::Float32Array),
+    Float64(arrow::array::Float64Array),
+
+    Binary(arrow::array::BinaryArray),
+    LargeBinary(arrow::array::LargeBinaryArray),
+    FixedSizeBinary(arrow::array::FixedSizeBinaryArray),
+    BinaryView(arrow::array::BinaryViewArray),
+    Uuid(Box<ColReader>),
+
+    String(arrow::array::StringArray),
+    LargeString(arrow::array::LargeStringArray),
+    StringView(arrow::array::StringViewArray),
+    Jsonb(Box<ColReader>),
+
+    TimestampSecond(arrow::array::TimestampSecondArray),
+    TimestampMillisecond(arrow::array::TimestampMillisecondArray),
+    TimestampMicrosecond(arrow::array::TimestampMicrosecondArray),
+    TimestampNanosecond(arrow::array::TimestampNanosecondArray),
+
+    Date32(Date32Array),
+    Date64(Date64Array),
+
+    Time32Seconds(Time32SecondArray),
+
+    List {
+        offsets: OffsetBuffer<i32>,
+        values: Box<ColReader>,
+        nulls: Option<NullBuffer>,
+    },
+    LargeList {
+        offsets: OffsetBuffer<i64>,
+        values: Box<ColReader>,
+        nulls: Option<NullBuffer>,
+    },
+
+    Record {
+        fields: Vec<Box<ColReader>>,
+        nulls: Option<NullBuffer>,
+    },
+}
+
+impl ColReader {
+    fn read(&self, idx: usize, packer: &mut RowPacker) -> Result<(), anyhow::Error> {
+        let datum = match self {
+            ColReader::Boolean(array) => array.is_valid(idx).then(|| array.value(idx)).map(|x| {
+                if x {
+                    Datum::True
+                } else {
+                    Datum::False
+                }
+            }),
+            ColReader::Int8 { array, cast } => {
+                array.is_valid(idx).then(|| array.value(idx)).map(cast)
+            }
+            ColReader::Int16(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(Datum::Int16),
+            ColReader::Int32(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(Datum::Int32),
+            ColReader::Int64(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(Datum::Int64),
+            ColReader::UInt8 { array, cast } => {
+                array.is_valid(idx).then(|| array.value(idx)).map(cast)
+            }
+            ColReader::UInt16(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(Datum::UInt16),
+            ColReader::UInt32(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(Datum::UInt32),
+            ColReader::UInt64(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(Datum::UInt64),
+            ColReader::Float16 { array, cast } => {
+                array.is_valid(idx).then(|| array.value(idx)).map(cast)
+            }
+            ColReader::Float32(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(|x| Datum::Float32(OrderedFloat(x))),
+            ColReader::Float64(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(|x| Datum::Float64(OrderedFloat(x))),
+            ColReader::Binary(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(Datum::Bytes),
+            ColReader::LargeBinary(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(Datum::Bytes),
+            ColReader::FixedSizeBinary(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(Datum::Bytes),
+            ColReader::BinaryView(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(Datum::Bytes),
+            ColReader::Uuid(reader) => {
+                // First read a binary value into a temp row, and later parse that as UUID into our
+                // actual Row Packer.
+                let mut temp_row = SharedRow::get();
+                temp_row
+                    .pack_with(|temp_packer| reader.read(idx, temp_packer))
+                    .context("uuid")?;
+                let temp_row = temp_row.borrow();
+                let slice = match temp_row.unpack_first() {
+                    Datum::Bytes(slice) => slice,
+                    Datum::Null => {
+                        packer.push(Datum::Null);
+                        return Ok(());
+                    }
+                    other => anyhow::bail!("expected String, found {other:?}"),
+                };
+
+                let uuid = Uuid::from_slice(slice).context("parsing uuid")?;
+                Some(Datum::Uuid(uuid))
+            }
+            ColReader::String(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(Datum::String),
+            ColReader::LargeString(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(Datum::String),
+            ColReader::StringView(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(Datum::String),
+            ColReader::Jsonb(reader) => {
+                // First read a string value into a temp row, and later parse that as JSON into our
+                // actual Row Packer.
+                let mut temp_row = SharedRow::get();
+                temp_row
+                    .pack_with(|temp_packer| reader.read(idx, temp_packer))
+                    .context("jsonb")?;
+                let temp_row = temp_row.borrow();
+                let value = match temp_row.unpack_first() {
+                    Datum::String(value) => value,
+                    Datum::Null => {
+                        packer.push(Datum::Null);
+                        return Ok(());
+                    }
+                    other => anyhow::bail!("expected String, found {other:?}"),
+                };
+
+                JsonbPacker::new(packer)
+                    .pack_str(value)
+                    .context("roundtrip json")?;
+
+                // Return early because we've already packed the necessasry Datums.
+                return Ok(());
+            }
+            ColReader::TimestampSecond(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(|secs| {
+                    let dt = DateTime::from_timestamp(secs, 0)
+                        .ok_or_else(|| anyhow::anyhow!("invalid timestamp seconds {secs}"))?;
+                    let dt = CheckedTimestamp::from_timestamplike(dt.naive_utc())
+                        .context("TimestampSeconds")?;
+                    Ok::<_, anyhow::Error>(Datum::Timestamp(dt))
+                })
+                .transpose()?,
+            ColReader::TimestampMillisecond(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(|millis| {
+                    let dt = DateTime::from_timestamp_millis(millis).ok_or_else(|| {
+                        anyhow::anyhow!("invalid timestamp milliseconds {millis}")
+                    })?;
+                    let dt = CheckedTimestamp::from_timestamplike(dt.naive_utc())
+                        .context("TimestampMillis")?;
+                    Ok::<_, anyhow::Error>(Datum::Timestamp(dt))
+                })
+                .transpose()?,
+            ColReader::TimestampMicrosecond(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(|micros| {
+                    let dt = DateTime::from_timestamp_micros(micros).ok_or_else(|| {
+                        anyhow::anyhow!("invalid timestamp microseconds {micros}")
+                    })?;
+                    let dt = CheckedTimestamp::from_timestamplike(dt.naive_utc())
+                        .context("TimestampMicros")?;
+                    Ok::<_, anyhow::Error>(Datum::Timestamp(dt))
+                })
+                .transpose()?,
+            ColReader::TimestampNanosecond(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(|nanos| {
+                    let dt = DateTime::from_timestamp_nanos(nanos);
+                    let dt = CheckedTimestamp::from_timestamplike(dt.naive_utc())
+                        .context("TimestampNanos")?;
+                    Ok::<_, anyhow::Error>(Datum::Timestamp(dt))
+                })
+                .transpose()?,
+            ColReader::Date32(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(|unix_days| {
+                    let date = Date::from_unix_epoch(unix_days).context("date32")?;
+                    Ok::<_, anyhow::Error>(Datum::Date(date))
+                })
+                .transpose()?,
+            ColReader::Date64(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(|unix_millis| {
+                    let date = DateTime::from_timestamp_millis(unix_millis)
+                        .ok_or_else(|| anyhow::anyhow!("invalid Date64 {unix_millis}"))?;
+                    let unix_epoch = DateTime::from_timestamp(0, 0)
+                        .expect("UNIX epoch")
+                        .date_naive();
+                    let delta = date.date_naive().signed_duration_since(unix_epoch);
+                    let days: i32 = delta.num_days().try_into().context("date64")?;
+                    let date = Date::from_unix_epoch(days).context("date64")?;
+                    Ok::<_, anyhow::Error>(Datum::Date(date))
+                })
+                .transpose()?,
+            ColReader::Time32Seconds(array) => array
+                .is_valid(idx)
+                .then(|| array.value(idx))
+                .map(|secs| {
+                    let usecs: u32 = secs.try_into().context("time32 seconds")?;
+                    let time = NaiveTime::from_num_seconds_from_midnight_opt(usecs, 0)
+                        .ok_or_else(|| anyhow::anyhow!("invalid Time32 Seconds {secs}"))?;
+                    Ok::<_, anyhow::Error>(Datum::Time(time))
+                })
+                .transpose()?,
+            ColReader::List {
+                offsets,
+                values,
+                nulls,
+            } => {
+                let is_valid = nulls.as_ref().map(|n| n.is_valid(idx)).unwrap_or(true);
+                if !is_valid {
+                    packer.push(Datum::Null);
+                    return Ok(());
+                }
+
+                let start: usize = offsets[idx].try_into().context("list start offset")?;
+                let end: usize = offsets[idx + 1].try_into().context("list end offset")?;
+
+                packer
+                    .push_list_with(|packer| {
+                        for idx in start..end {
+                            values.read(idx, packer)?;
+                        }
+                        Ok::<_, anyhow::Error>(())
+                    })
+                    .context("pack list")?;
+
+                // Return early because we've already packed the necessasry Datums.
+                return Ok(());
+            }
+            ColReader::LargeList {
+                offsets,
+                values,
+                nulls,
+            } => {
+                let is_valid = nulls.as_ref().map(|n| n.is_valid(idx)).unwrap_or(true);
+                if !is_valid {
+                    packer.push(Datum::Null);
+                    return Ok(());
+                }
+
+                let start: usize = offsets[idx].try_into().context("list start offset")?;
+                let end: usize = offsets[idx + 1].try_into().context("list end offset")?;
+
+                packer
+                    .push_list_with(|packer| {
+                        for idx in start..end {
+                            values.read(idx, packer)?;
+                        }
+                        Ok::<_, anyhow::Error>(())
+                    })
+                    .context("pack list")?;
+
+                // Return early because we've already packed the necessasry Datums.
+                return Ok(());
+            }
+            ColReader::Record { fields, nulls } => {
+                let is_valid = nulls.as_ref().map(|n| n.is_valid(idx)).unwrap_or(true);
+                if !is_valid {
+                    packer.push(Datum::Null);
+                    return Ok(());
+                }
+
+                packer
+                    .push_list_with(|packer| {
+                        for field in fields {
+                            field.read(idx, packer)?;
+                        }
+                        Ok::<_, anyhow::Error>(())
+                    })
+                    .context("pack record")?;
+
+                // Return early because we've already packed the necessasry Datums.
+                return Ok(());
+            }
+        };
+
+        match datum {
+            Some(d) => packer.push(d),
+            None => packer.push(Datum::Null),
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn smoketest_reader() {
+        let desc = RelationDesc::builder()
+            .with_column("bool", ScalarType::Bool.nullable(true))
+            .with_column("int4", ScalarType::Int32.nullable(true))
+            .with_column("uint8", ScalarType::UInt64.nullable(true))
+            .with_column("float32", ScalarType::Float32.nullable(true))
+            .with_column("string", ScalarType::String.nullable(true))
+            .with_column("bytes", ScalarType::Bytes.nullable(true))
+            .with_column("uuid", ScalarType::Uuid.nullable(true))
+            .with_column("json", ScalarType::Jsonb.nullable(true))
+            .with_column(
+                "list",
+                ScalarType::List {
+                    element_type: Box::new(ScalarType::UInt32),
+                    custom_id: None,
+                }
+                .nullable(true),
+            )
+            .finish();
+
+        let mut og_row = Row::default();
+        let mut packer = og_row.packer();
+
+        packer.extend([
+            Datum::True,
+            Datum::Int32(42),
+            Datum::UInt64(10000),
+            Datum::Float32(OrderedFloat::from(-1.1f32)),
+            Datum::String("hello world"),
+            Datum::Bytes(b"1010101"),
+            Datum::Uuid(uuid::Uuid::new_v4()),
+        ]);
+        JsonbPacker::new(&mut packer)
+            .pack_serde_json(
+                serde_json::json!({"code": 200, "email": "space_monkey@materialize.com"}),
+            )
+            .expect("failed to pack JSON");
+        packer.push_list([Datum::UInt32(200), Datum::UInt32(300)]);
+
+        let null_row = Row::pack(vec![Datum::Null; 9]);
+
+        // Encode our data with our ArrowBuilder.
+        let mut builder = crate::builder::ArrowBuilder::new(&desc, 2, 46).unwrap();
+        builder.add_row(&og_row).unwrap();
+        builder.add_row(&null_row).unwrap();
+        let record_batch = builder.to_record_batch().unwrap();
+
+        // Decode our data!
+        let reader =
+            ArrowReader::new(&desc, arrow::array::StructArray::from(record_batch)).unwrap();
+        let mut rnd_row = Row::default();
+
+        reader.read(0, &mut rnd_row).unwrap();
+        assert_eq!(&og_row, &rnd_row);
+
+        // Create a packer to clear the row alloc.
+        rnd_row.packer();
+
+        reader.read(1, &mut rnd_row).unwrap();
+        assert_eq!(&null_row, &rnd_row);
+    }
+}

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -2850,6 +2850,20 @@ impl SharedRow {
         row_packer.extend(iter);
         row_builder.clone()
     }
+
+    /// Calls the provided closure with a [`RowPacker`] writing the shared row.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the row is already borrowed elsewhere.
+    pub fn pack_with<F, R>(&mut self, f: F) -> R
+    where
+        for<'a> F: FnOnce(&'a mut RowPacker<'a>) -> R,
+    {
+        let mut borrow = self.borrow_mut();
+        let mut packer = borrow.packer();
+        (f)(&mut packer)
+    }
 }
 
 impl std::ops::Deref for SharedRow {

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -44,7 +44,7 @@ crossbeam-utils = { version = "0.8.20" }
 crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
 csv-async = { version = "1.3.0", features = ["tokio"] }
 debugid = { version = "0.8.0", default-features = false, features = ["serde"] }
-dec = { version = "0.4.8", default-features = false, features = ["serde"] }
+dec = { version = "0.4.9", default-features = false, features = ["num-traits", "serde"] }
 digest = { version = "0.10.6", features = ["mac", "std"] }
 either = { version = "1.8.0" }
 event-listener = { version = "5.3.1" }
@@ -179,7 +179,7 @@ crossbeam-utils = { version = "0.8.20" }
 crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
 csv-async = { version = "1.3.0", features = ["tokio"] }
 debugid = { version = "0.8.0", default-features = false, features = ["serde"] }
-dec = { version = "0.4.8", default-features = false, features = ["serde"] }
+dec = { version = "0.4.9", default-features = false, features = ["num-traits", "serde"] }
 digest = { version = "0.10.6", features = ["mac", "std"] }
 either = { version = "1.8.0" }
 event-listener = { version = "5.3.1" }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -59,6 +59,7 @@ futures-sink = { version = "0.3.30" }
 futures-task = { version = "0.3.30" }
 futures-util = { version = "0.3.30", features = ["channel", "io", "sink"] }
 getrandom = { version = "0.2.10", default-features = false, features = ["std"] }
+half = { version = "2.4.1", features = ["num-traits"] }
 hashbrown = { version = "0.14.5", features = ["raw"] }
 hyper-582f2526e08bb6a0 = { package = "hyper", version = "0.14.27", features = ["client", "http1", "http2", "stream", "tcp"] }
 hyper-dff4ba8e3ae991db = { package = "hyper", version = "1.4.1", features = ["client", "http1", "http2", "server"] }
@@ -193,6 +194,7 @@ futures-sink = { version = "0.3.30" }
 futures-task = { version = "0.3.30" }
 futures-util = { version = "0.3.30", features = ["channel", "io", "sink"] }
 getrandom = { version = "0.2.10", default-features = false, features = ["std"] }
+half = { version = "2.4.1", features = ["num-traits"] }
 hashbrown = { version = "0.14.5", features = ["raw"] }
 hyper-582f2526e08bb6a0 = { package = "hyper", version = "0.14.27", features = ["client", "http1", "http2", "stream", "tcp"] }
 hyper-dff4ba8e3ae991db = { package = "hyper", version = "1.4.1", features = ["client", "http1", "http2", "server"] }


### PR DESCRIPTION
This PR implements an `ArrowReader` in the `mz_arrow_util` crate. It's intended to be used with `COPY ... FROM ... (FORMAT PARQUET)`.

We don't currently support all Arrow Types, but so far this has been sufficient for testing and I figured with how large the change already is this was a good place to start.

### Motivation

Progress towards https://github.com/MaterializeInc/database-issues/issues/6575

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
