### PR TITLE
[copy_from] support an optional `INTO` keyword, i.e. `COPY (INTO)? <table> FROM`

### DIFF
--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -170,3 +170,17 @@ COPY (select * from t order by 1) TO 's3://path/' || repeat('1', 2)
 COPY (SELECT * FROM t ORDER BY 1) TO 's3://path/' || repeat('1', 2)
 =>
 Copy(CopyStatement { relation: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [OrderByExpr { expr: Value(Number("1")), asc: None, nulls_last: None }], limit: None, offset: None }, as_of: None }), direction: To, target: Expr(Op { op: Op { namespace: None, op: "||" }, expr1: Value(String("s3://path/")), expr2: Some(Function(Function { name: Name(UnresolvedItemName([Ident("repeat")])), args: Args { args: [Value(String("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false })) }), options: [] })
+
+parse-statement
+COPY INTO t1 FROM STDIN
+----
+COPY t1 FROM STDIN
+=>
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t1")])), columns: [] }, direction: From, target: Stdin, options: [] })
+
+parse-statement
+COPY INTO t(a, b) TO '/any/path'
+----
+error: Expected identifier, found INTO
+COPY INTO t(a, b) TO '/any/path'
+     ^


### PR DESCRIPTION
Chatted about this in the [rnd-sql-council](https://materializeinc.slack.com/archives/C063H5S7NKE/p1736187285810109). This PR adds support for an optional `INTO` keyword for `COPY ... FROM`.

### Motivation

Other databases use the syntax of `COPY INTO <table> FROM ...` and IMO makes the statement easier to understand for folks that are unfamiliar.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
