### PR TITLE
bazel: Always build with full debuginfo

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -116,11 +116,6 @@ build:debuginfo-full --copt=-g2
 build:debuginfo-full --strip=never
 build:debuginfo-full --@rules_rust//:extra_rustc_flag=-Cstrip=none
 
-build:debuginfo-limited --@rules_rust//:extra_rustc_flag=-Cdebuginfo=line-tables-only
-build:debuginfo-limited --copt=-gline-tables-only
-build:debuginfo-limited --strip=never
-build:debuginfo-limited --@rules_rust//:extra_rustc_flag=-Cstrip=none
-
 build:debuginfo-none --@rules_rust//:extra_rustc_flag=-Cdebuginfo=0
 build:debuginfo-none --copt=-g0
 build:debuginfo-none --strip=always
@@ -173,9 +168,7 @@ build:release-lto --@rules_rust//:extra_rustc_flag=-Clto=thin
 # too large and we OOD/OOM.
 build:release-tagged --config=release --config=release-lto --config=release-stamp --config=debuginfo-full
 # PRs in CI.
-#
-# Not doing a full stamp nor omitting full debug info, greatly speeds up compile times.
-build:release-dev --config=release --config=release-lto --config=debuginfo-limited
+build:release-dev --config=release --config=release-lto --config=debuginfo-full
 
 # "Optimized" Build.
 #


### PR DESCRIPTION
This will increase compile time, thus making CI roundtrips slower. We should consider if the better debuggability is worth it though: https://materializeinc.slack.com/archives/CU7ELJ6E9/p1736243826039879

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
