### PR TITLE
orchestratord support alternative schedulers

### DIFF
--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -143,6 +143,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.resources.requests` | Resources requested by the operator for CPU and memory | ``{"cpu":"100m","memory":"512Mi"}`` |
 | `operator.secretsController` | Which secrets controller to use for storing secrets. Valid values are 'kubernetes' and 'aws-secrets-manager'. Setting 'aws-secrets-manager' requires a configured AWS cloud provider and IAM role for the environment with Secrets Manager permissions. | ``"kubernetes"`` |
 | `rbac.create` | Whether to create necessary RBAC roles and bindings | ``true`` |
+| `schedulerName` | Optionally use a non-default kubernetes scheduler. | ``nil`` |
 | `serviceAccount.create` | Whether to create a new service account for the operator | ``true`` |
 | `serviceAccount.name` | The name of the service account to be created | ``"orchestratord"`` |
 | `storage.storageClass.allowVolumeExpansion` |  | ``false`` |

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -150,5 +150,8 @@ spec:
         {{- end }}
         {{- end }}
         - "--enable-security-context"
+        {{- if .Values.schedulerName }}
+        - "--scheduler-name={{ .Values.schedulerName }}"
+        {{- end }}
         resources:
           {{- toYaml .Values.operator.resources | nindent 10 }}

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -178,3 +178,17 @@ tests:
   - contains:
       path: spec.template.spec.containers[0].args
       content: "--secrets-controller=aws-secrets-manager"
+
+- it: should not pass the scheduler when not configured
+  asserts:
+  - notContains:
+      path: spec.template.spec.containers[0].args
+      content: "--scheduler-name"
+
+- it: should pass the scheduler when configured
+  set:
+    schedulerName: my-scheduler
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: "--scheduler-name=my-scheduler"

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -230,6 +230,9 @@ rbac:
   # -- Whether to create necessary RBAC roles and bindings
   create: true
 
+# -- Optionally use a non-default kubernetes scheduler.
+schedulerName: null
+
 # Service account settings
 serviceAccount:
   # -- Whether to create a new service account for the operator


### PR DESCRIPTION
Add support to the helm chart for alternative kubernetes schedulers.

### Motivation

Part of the migration to using orchestratord in SaaS. We use a custom scheduler there.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
