### PR TITLE
build: Use "limited" debug info instead of "line-tables"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -116,8 +116,8 @@ build:debuginfo-full --copt=-g2
 build:debuginfo-full --strip=never
 build:debuginfo-full --@rules_rust//:extra_rustc_flag=-Cstrip=none
 
-build:debuginfo-limited --@rules_rust//:extra_rustc_flag=-Cdebuginfo=line-tables-only
-build:debuginfo-limited --copt=-gline-tables-only
+build:debuginfo-limited --@rules_rust//:extra_rustc_flag=-Cdebuginfo=1
+build:debuginfo-limited --copt=-g1
 build:debuginfo-limited --strip=never
 build:debuginfo-limited --@rules_rust//:extra_rustc_flag=-Cstrip=none
 


### PR DESCRIPTION
Chatted about this in [Slack](https://materializeinc.slack.com/archives/CU7ELJ6E9/p1736243826039879), as-is we only see non-inlined functions which makes it hard to follow timely operators. This PR bumps our debuginfo from line-tables to limited, let's see if it helps.

### Motivation

Better debug info

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
