### PR TITLE
ci: Turn off output consistency for now

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1150,6 +1150,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: output-consistency
               args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200"]
+        skip: "too flaky currently, find better way to ignore known issues"
 
       - id: output-consistency-postgres
         label: "Output consistency (Postgres)"
@@ -1161,6 +1162,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: postgres-consistency
               args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200"]
+        skip: "too flaky currently, find better way to ignore known issues"
 
       - id: output-consistency-version-dfr
         label: "Output consistency (version for DFR)"
@@ -1172,6 +1174,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: version-consistency
               args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200", "--evaluation-strategy=dataflow_rendering", "--other-tag=common-ancestor"]
+        skip: "too flaky currently, find better way to ignore known issues"
 
       - id: output-consistency-version-ctf
         label: "Output consistency (version for CTF)"
@@ -1183,6 +1186,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: version-consistency
               args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200", "--evaluation-strategy=constant_folding", "--other-tag=common-ancestor"]
+        skip: "too flaky currently, find better way to ignore known issues"
 
       - id: output-consistency-feature-flags-dfr
         label: "Output consistency (feature-flags for DFR)"
@@ -1194,6 +1198,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: feature-flag-consistency
               args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200", "--evaluation-strategy=dataflow_rendering"]
+        skip: "too flaky currently, find better way to ignore known issues"
 
 
   - group: SQLsmith


### PR DESCRIPTION
In the last few months it only had false positives and known issues, my attempts to fix them were successful, but more and more keep popping up. Recent one: https://materializeinc.slack.com/archives/C01LKF361MZ/p1736269975845669

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
