### PR TITLE
storage: in upsert StateValue allow converting finalized tombstones

### DIFF
--- a/src/storage/src/upsert/types.rs
+++ b/src/storage/src/upsert/types.rs
@@ -391,16 +391,10 @@ impl<T: Eq, O> StateValue<T, O> {
                     provisional_value: (Some(provisional_value), provisional_ts, provisional_order),
                 })
             }
-            StateValue::Value(Value::Tombstone(_)) => {
-                // This cannot happen with how the new feedback UPSERT uses
-                // state. There are only ever provisional tombstones, and all
-                // updates that are merged/consolidated into upsert state come
-                // from the persist input, which doesn't need tombstones.
-                //
-                // Regular, finalized tombstones are only used by the classic
-                // UPSERT operator when doing partial processing.
-                panic!("cannot turn a finalized tombstone into a provisional value")
-            }
+            StateValue::Value(Value::Tombstone(_)) => StateValue::Value(Value::ProvisionalValue {
+                finalized_value: None,
+                provisional_value: (Some(provisional_value), provisional_ts, provisional_order),
+            }),
             StateValue::Value(Value::ProvisionalValue {
                 finalized_value,
                 provisional_value: _,


### PR DESCRIPTION
Before, we were using the wrong assumption that the new feedback UPSERT operator could not yield finalized tombstone values, because it only writes finalized values that "exist". But it can happen that `ensure_decoded` puts in place a finalized tombstone when state values consolidate to a diff of zero.

We say "can happen" above, because `merge_update` returns whether or not a merged value can be deleted, and this returns true when the diff_sum is zero. So in most cases the finalized tombstone would be cleaned up right away. However, not all callers immediately (or at all) act on this "can delete" information, which leads to finalized tombstones actually existing in state.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8864

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
