### PR TITLE
bump console image and enable security contexts

### DIFF
--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
         {{- if .Values.operator.features.createConsole }}
         - "--create-console"
         {{- end }}
-        - "--console-image-tag-default=25.1.0-beta.2"
+        - "--console-image-tag-default=25.1.0-beta.3"
         {{- range $key, $value := .Values.operator.features.consoleImageTagMapOverride }}
         - "--console-image-tag-map={{ $key }}={{ $value }}"
         {{- end }}
@@ -148,5 +148,6 @@ spec:
         - "--segment-client-side"
         {{- end }}
         {{- end }}
+        - "--enable-security-context"
         resources:
           {{- toYaml .Values.operator.resources | nindent 10 }}

--- a/misc/images/materialized-base/Dockerfile
+++ b/misc/images/materialized-base/Dockerfile
@@ -15,7 +15,7 @@
 # deployed to production, but the version needs to be bumped whenever features
 # that the console depends upon are removed (to a version of the console that
 # doesn't depend on those features).
-FROM materialize/console:25.1.0-beta.2 AS console
+FROM materialize/console:25.1.0-beta.3 AS console
 
 MZFROM ubuntu-base
 


### PR DESCRIPTION
Bumps console image to one that doesn't run as root, and enables security contexts.

### Motivation

Better security for our users, and is one of the differences between SaaS and self-hosted.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
