### PR TITLE
test: unflake source statistics tests more

### DIFF
--- a/test/testdrive/source-statistics.td
+++ b/test/testdrive/source-statistics.td
@@ -104,8 +104,8 @@ mammalmore    moosemoose   2
       s.name,
       bool_and(u.snapshot_committed),
       SUM(u.messages_received) >= 4,
-      SUM(u.updates_staged),
-      SUM(u.updates_committed),
+      SUM(u.updates_staged) > 0,
+      SUM(u.updates_committed) > 0,
       SUM(u.bytes_received) > 0,
       bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
@@ -113,7 +113,7 @@ mammalmore    moosemoose   2
   WHERE s.name IN ('metrics_test_source')
   GROUP BY s.name
   ORDER BY s.name
-metrics_test_source true true 2 2 true true
+metrics_test_source true true true true true true
 
 > DROP SOURCE metrics_test_source CASCADE
 

--- a/test/testdrive/statistics-deletion.td
+++ b/test/testdrive/statistics-deletion.td
@@ -66,6 +66,12 @@ one:two
   VALUE FORMAT BYTES
   ENVELOPE UPSERT
 
+> SELECT * FROM upsert_size_tbl
+one two
+
+> SELECT * FROM upsert_cluster_tbl
+one two
+
 > CREATE SCHEMA subsources_size;
 > CREATE SCHEMA subsources_cluster;
 > CREATE CLUSTER subsource_size_s_cluster SIZE '2';

--- a/test/testdrive/statistics-maintenance.td
+++ b/test/testdrive/statistics-maintenance.td
@@ -46,6 +46,9 @@ one:two
   VALUE FORMAT BYTES
   ENVELOPE UPSERT
 
+> SELECT * FROM upsert1_tbl
+one two
+
 # The `CREATE TABLE ... FROM SOURCE` commands caused a recreation of the
 # respective source dataflows, during which we might have lost the statistics
 # about committed updates from the snapshot. Ingest some more data to ensure we


### PR DESCRIPTION
Fixes source statistics test flakes observed https://buildkite.com/materialize/nightly/builds/10798.

In particular, when we ingest extra updates to work around `CREATE TABLE ... FROM SOURCE` recreating the dataflow and dropping statistics on the floor while doing so, that ingest races with the dataflow recreation and it's possible that the old dataflow is alive long enough to commit the data, which is the opposite of what we want. To fix this, we can select from the created table once, making sure that the table dataflow exists.

### Motivation

  * This PR fixes a previously unreported bug.

Fixes more source statistics test flakes.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
