### PR TITLE
Extract `Let`s from `LetRec`

### DIFF
--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -122,6 +122,8 @@ optimizer_feature_flags!({
     enable_join_prioritize_arranged: bool,
     // See the feature flag of the same name.
     enable_projection_pushdown_after_relation_cse: bool,
+    // See the feature flag of the same name.
+    enable_let_prefix_extraction: bool,
 });
 
 /// A trait used to implement layered config construction.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4653,6 +4653,7 @@ pub fn unplan_create_cluster(
                 enable_reduce_reduction: _,
                 enable_join_prioritize_arranged,
                 enable_projection_pushdown_after_relation_cse,
+                enable_let_prefix_extraction: _,
             } = optimizer_feature_overrides;
             let features_extracted = ClusterFeatureExtracted {
                 // Seen is ignored when unplanning.

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -434,6 +434,7 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 enable_join_prioritize_arranged: v.enable_join_prioritize_arranged,
                 enable_projection_pushdown_after_relation_cse: v
                     .enable_projection_pushdown_after_relation_cse,
+                enable_let_prefix_extraction: Default::default(),
             },
         })
     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1785,6 +1785,12 @@ macro_rules! feature_flags {
 }
 
 feature_flags!(
+    {
+        name: enable_let_prefix_extraction,
+        desc: "Enables hoisting of loop-invariant CTE bindindgs",
+        default: true,
+        enable_for_item_parsing: false,
+    },
     // Gates for other feature flags
     {
         name: allow_real_time_recency,
@@ -2221,6 +2227,7 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_join_prioritize_arranged: vars.enable_join_prioritize_arranged(),
             enable_projection_pushdown_after_relation_cse: vars
                 .enable_projection_pushdown_after_relation_cse(),
+            enable_let_prefix_extraction: vars.enable_let_prefix_extraction(),
         }
     }
 }

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -132,32 +132,12 @@ impl NormalizeLets {
 
         // A final bottom-up traversal to normalize the shape of nested LetRec blocks
         relation.try_visit_mut_post(&mut |relation| -> Result<(), RecursionLimitError> {
-            // Disassemble `LetRec` into a `Let` stack if possible.
-            // If a `LetRec` remains, return the would-be `Let` bindings to it.
-            // This is to maintain `LetRec`-freedom for `LetRec`-free expressions.
-            let mut bindings = let_motion::harvest_non_recursive(relation);
-            if let MirRelationExpr::LetRec {
-                ids,
-                values,
-                limits,
-                body: _,
-            } = relation
-            {
-                bindings.extend(ids.drain(..).zip(values.drain(..).zip(limits.drain(..))));
-                support::replace_bindings_from_map(bindings, ids, values, limits);
-            } else {
-                for (id, (value, max_iter)) in bindings.into_iter().rev() {
-                    assert_none!(max_iter);
-                    *relation = MirRelationExpr::Let {
-                        id,
-                        value: Box::new(value),
-                        body: Box::new(relation.take_dangerous()),
-                    };
-                }
-            }
-
             // Move a non-recursive suffix of bindings from the end of the LetRec
             // to the LetRec body.
+            // This is unsafe when applied to expressions which contain `ArrangeBy`,
+            // as if the extracted suffixes reference arrangements they will not be
+            // able to access those arrangements from outside the `LetRec` scope.
+            // It happens to work at the moment, so we don't touch it but should fix.
             let bindings = let_motion::harvest_nonrec_suffix(relation)?;
             if let MirRelationExpr::LetRec {
                 ids: _,
@@ -181,6 +161,20 @@ impl NormalizeLets {
                         body: Box::new(relation.take_dangerous()),
                     };
                 }
+            }
+
+            // Extract `Let` prefixes from `LetRec`, to reveal their non-recursive nature.
+            // This assists with hoisting e.g. arrangements out of `LetRec` blocks, a thing
+            // we don't promise to do, but it can be helpful to do. This also exposes more
+            // AST nodes to non-`LetRec` analyses, which don't always have parity with `LetRec`.
+            let bindings = let_motion::harvest_non_recursive(relation);
+            for (id, (value, max_iter)) in bindings.into_iter().rev() {
+                assert_none!(max_iter);
+                *relation = MirRelationExpr::Let {
+                    id,
+                    value: Box::new(value),
+                    body: Box::new(relation.take_dangerous()),
+                };
             }
 
             Ok(())
@@ -596,7 +590,7 @@ mod let_motion {
     }
 
     /// Harvest any safe-to-lower non-recursive suffix of binding from a
-    /// `LetRec` expression.
+    /// `LetRec` expression, potentially wrapped in a stack of `Let`s.
     pub(crate) fn harvest_nonrec_suffix(
         expr: &mut MirRelationExpr,
     ) -> Result<BTreeMap<LocalId, MirRelationExpr>, RecursionLimitError> {

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -132,6 +132,32 @@ impl NormalizeLets {
 
         // A final bottom-up traversal to normalize the shape of nested LetRec blocks
         relation.try_visit_mut_post(&mut |relation| -> Result<(), RecursionLimitError> {
+            if !features.enable_let_prefix_extraction {
+                // Disassemble `LetRec` into a `Let` stack if possible.
+                // If a `LetRec` remains, return the would-be `Let` bindings to it.
+                // This is to maintain `LetRec`-freedom for `LetRec`-free expressions.
+                let mut bindings = let_motion::harvest_non_recursive(relation);
+                if let MirRelationExpr::LetRec {
+                    ids,
+                    values,
+                    limits,
+                    body: _,
+                } = relation
+                {
+                    bindings.extend(ids.drain(..).zip(values.drain(..).zip(limits.drain(..))));
+                    support::replace_bindings_from_map(bindings, ids, values, limits);
+                } else {
+                    for (id, (value, max_iter)) in bindings.into_iter().rev() {
+                        assert_none!(max_iter);
+                        *relation = MirRelationExpr::Let {
+                            id,
+                            value: Box::new(value),
+                            body: Box::new(relation.take_dangerous()),
+                        };
+                    }
+                }
+            }
+
             // Move a non-recursive suffix of bindings from the end of the LetRec
             // to the LetRec body.
             // This is unsafe when applied to expressions which contain `ArrangeBy`,
@@ -163,18 +189,20 @@ impl NormalizeLets {
                 }
             }
 
-            // Extract `Let` prefixes from `LetRec`, to reveal their non-recursive nature.
-            // This assists with hoisting e.g. arrangements out of `LetRec` blocks, a thing
-            // we don't promise to do, but it can be helpful to do. This also exposes more
-            // AST nodes to non-`LetRec` analyses, which don't always have parity with `LetRec`.
-            let bindings = let_motion::harvest_non_recursive(relation);
-            for (id, (value, max_iter)) in bindings.into_iter().rev() {
-                assert_none!(max_iter);
-                *relation = MirRelationExpr::Let {
-                    id,
-                    value: Box::new(value),
-                    body: Box::new(relation.take_dangerous()),
-                };
+            if features.enable_let_prefix_extraction {
+                // Extract `Let` prefixes from `LetRec`, to reveal their non-recursive nature.
+                // This assists with hoisting e.g. arrangements out of `LetRec` blocks, a thing
+                // we don't promise to do, but it can be helpful to do. This also exposes more
+                // AST nodes to non-`LetRec` analyses, which don't always have parity with `LetRec`.
+                let bindings = let_motion::harvest_non_recursive(relation);
+                for (id, (value, max_iter)) in bindings.into_iter().rev() {
+                    assert_none!(max_iter);
+                    *relation = MirRelationExpr::Let {
+                        id,
+                        value: Box::new(value),
+                        body: Box::new(relation.take_dangerous()),
+                    };
+                }
             }
 
             Ok(())
@@ -590,7 +618,7 @@ mod let_motion {
     }
 
     /// Harvest any safe-to-lower non-recursive suffix of binding from a
-    /// `LetRec` expression, potentially wrapped in a stack of `Let`s.
+    /// `LetRec` expression.
     pub(crate) fn harvest_nonrec_suffix(
         expr: &mut MirRelationExpr,
     ) -> Result<BTreeMap<LocalId, MirRelationExpr>, RecursionLimitError> {

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -260,6 +260,7 @@ fn apply_transform<T: mz_transform::Transform>(
     let mut features = mz_repr::optimize::OptimizerFeatures::default();
     // Apply a non-default feature flag to test the right implementation.
     features.enable_letrec_fixpoint_analysis = true;
+    features.enable_let_prefix_extraction = true;
     let typecheck_ctx = mz_transform::typecheck::empty_context();
     let mut df_meta = DataflowMetainfo::default();
     let mut transform_ctx =

--- a/src/transform/tests/test_transforms/normalize_lets.spec
+++ b/src/transform/tests/test_transforms/normalize_lets.spec
@@ -196,21 +196,23 @@ With
     Map (null::bigint)
       Get t0
 ----
-With Mutually Recursive
+With
   cte l0 =
     Map (null)
       Get t0
-  cte l1 =
-    Union
-      Get l0
-      Get l0
-      Get l1
 Return
-  With
-    cte l2 =
-      Filter (#0 > 0)
+  With Mutually Recursive
+    cte l1 =
+      Union
+        Get l0
+        Get l0
         Get l1
   Return
-    Union
-      Get l2
-      Get l2
+    With
+      cte l2 =
+        Filter (#0 > 0)
+          Get l1
+    Return
+      Union
+        Get l2
+        Get l2

--- a/src/transform/tests/test_transforms/relation_cse.spec
+++ b/src/transform/tests/test_transforms/relation_cse.spec
@@ -87,7 +87,7 @@ With
       Project (#0, #1)
         Get t0
 ----
-With Mutually Recursive
+With
   cte l0 =
     Project (#0, #1)
       Get t0
@@ -96,36 +96,38 @@ With Mutually Recursive
       Union
         Get l0
         Get l0
-  cte l2 =
-    Filter (#1 > 7)
-      Get l4
-  cte l3 =
-    Filter (#1 > 7)
-      Get l6
-  cte l4 =
-    Distinct project=[#0, #1]
-      Union
-        Get l1
-        Get l2
-        Get l2
-        Get l3
-        Get l3
-  cte l5 =
-    Filter (#1 > 7)
-      Get l4
-  cte l6 =
-    Distinct project=[#0, #1]
-      Union
-        Get l1
-        Get l5
-        Get l5
-        Get l3
-        Get l3
 Return
-  Union
-    Filter (#1 > 7)
-      Get t0
-    Filter (#1 > 7)
-      Get l6
-    Filter (#1 > 7)
-      Get l4
+  With Mutually Recursive
+    cte l2 =
+      Filter (#1 > 7)
+        Get l4
+    cte l3 =
+      Filter (#1 > 7)
+        Get l6
+    cte l4 =
+      Distinct project=[#0, #1]
+        Union
+          Get l1
+          Get l2
+          Get l2
+          Get l3
+          Get l3
+    cte l5 =
+      Filter (#1 > 7)
+        Get l4
+    cte l6 =
+      Distinct project=[#0, #1]
+        Union
+          Get l1
+          Get l5
+          Get l5
+          Get l3
+          Get l3
+  Return
+    Union
+      Filter (#1 > 7)
+        Get t0
+      Filter (#1 > 7)
+        Get l6
+      Filter (#1 > 7)
+        Get l4

--- a/test/sqllogictest/advent-of-code/2023/aoc_1203.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1203.slt
@@ -229,7 +229,7 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Reduce aggregates=[count(*)] // { arity: 1 }
         Project () // { arity: 0 }
@@ -278,7 +278,7 @@ Explained Query:
       Project (#0..=#2) // { arity: 3 }
         Join on=(#2 = #3) type=differential // { arity: 4 }
           implementation
-            %1:l3[#0]UK » %0:l4[#2]K
+            %1:l3[#0]UKA » %0:l4[#2]K
           Get l4 // { arity: 3 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l3 // { arity: 1 }
@@ -302,169 +302,171 @@ Explained Query:
     cte l8 =
       ArrangeBy keys=[[#0, #1]] // { arity: 3 }
         Get l5 // { arity: 3 }
-    cte l9 =
-      Distinct project=[#0..=#3] // { arity: 4 }
-        Union // { arity: 4 }
-          Distinct project=[#0..=#3] // { arity: 4 }
-            Union // { arity: 4 }
-              Project (#2, #0, #1, #7) // { arity: 4 }
-                Map (1) // { arity: 8 }
-                  Join on=(#0 = (#3 + #5) AND #1 = (#4 + #6)) type=delta // { arity: 7 }
-                    implementation
-                      %0:l5 » %1:l6[×] » %2:l7[×] » %3:l7[×]
-                      %1:l6 » %0:l5[×] » %2:l7[×] » %3:l7[×]
-                      %2:l7 » %0:l5[×] » %1:l6[×] » %3:l7[×]
-                      %3:l7 » %0:l5[×] » %1:l6[×] » %2:l7[×]
-                    ArrangeBy keys=[[]] // { arity: 3 }
-                      Get l5 // { arity: 3 }
-                    ArrangeBy keys=[[]] // { arity: 2 }
-                      Project (#0, #1) // { arity: 2 }
-                        Get l6 // { arity: 3 }
-                    Get l7 // { arity: 1 }
-                    Get l7 // { arity: 1 }
-              Project (#7, #0, #1, #8) // { arity: 4 }
-                Map ((#2 || #3), (#6 + 1)) // { arity: 9 }
-                  Join on=(#0 = #4 AND #1 = (#5 - 1)) type=differential // { arity: 7 }
-                    implementation
-                      %0:l8[#0, #1]KK » %1:l9[#1, (#2 - 1)]KK
-                    Get l8 // { arity: 3 }
-                    ArrangeBy keys=[[#1, (#2 - 1)]] // { arity: 4 }
-                      Get l9 // { arity: 4 }
-          Project (#7, #0, #5, #8) // { arity: 4 }
-            Map ((#3 || #2), (#6 + 1)) // { arity: 9 }
-              Join on=(#0 = #4 AND #1 = (#5 + #6)) type=differential // { arity: 7 }
-                implementation
-                  %0:l8[#0, #1]KK » %1:l9[#1, (#2 + #3)]KK
-                Get l8 // { arity: 3 }
-                ArrangeBy keys=[[#1, (#2 + #3)]] // { arity: 4 }
-                  Get l9 // { arity: 4 }
   Return // { arity: 2 }
-    With
-      cte l10 =
-        Distinct project=[#0, #1] // { arity: 2 }
-          Project (#1, #2) // { arity: 2 }
-            Get l9 // { arity: 4 }
-      cte l11 =
-        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-          Project (#0, #1) // { arity: 2 }
-            Get l5 // { arity: 3 }
-      cte l12 =
-        Project (#0..=#3) // { arity: 4 }
-          Join on=(#1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-            implementation
-              %0:l9[#1, #2]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[#1, #2]] // { arity: 4 }
-              Get l9 // { arity: 4 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-              Union // { arity: 2 }
-                Negate // { arity: 2 }
-                  Distinct project=[#0, #1] // { arity: 2 }
-                    Project (#0, #1) // { arity: 2 }
-                      Join on=(#0 = #2 AND #3 = (#1 - 1)) type=differential // { arity: 4 }
-                        implementation
-                          %0:l10[#0, (#1 - 1)]KK » %1:l11[#0, #1]KK
-                        ArrangeBy keys=[[#0, (#1 - 1)]] // { arity: 2 }
-                          Get l10 // { arity: 2 }
-                        Get l11 // { arity: 2 }
-                Get l10 // { arity: 2 }
-      cte l13 =
-        Distinct project=[#0..=#2] // { arity: 3 }
-          Project (#1..=#3) // { arity: 3 }
-            Get l12 // { arity: 4 }
-      cte l14 =
-        Project (#1..=#3, #7) // { arity: 4 }
-          Map (text_to_integer(#0)) // { arity: 8 }
-            Join on=(#1 = #4 AND #2 = #5 AND #3 = #6) type=differential // { arity: 7 }
-              implementation
-                %0:l12[#1..=#3]KKK » %1[#0..=#2]KKK
-              ArrangeBy keys=[[#1..=#3]] // { arity: 4 }
-                Get l12 // { arity: 4 }
-              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                Union // { arity: 3 }
-                  Negate // { arity: 3 }
-                    Distinct project=[#0..=#2] // { arity: 3 }
-                      Project (#0..=#2) // { arity: 3 }
-                        Join on=(#0 = #3 AND #4 = (#1 + #2)) type=differential // { arity: 5 }
-                          implementation
-                            %0:l13[#0, (#1 + #2)]KK » %1:l11[#0, #1]KK
-                          ArrangeBy keys=[[#0, (#1 + #2)]] // { arity: 3 }
-                            Get l13 // { arity: 3 }
-                          Get l11 // { arity: 2 }
-                  Get l13 // { arity: 3 }
-      cte l15 =
-        Reduce aggregates=[sum(#0)] // { arity: 1 }
-          Project (#3) // { arity: 1 }
-            Get l14 // { arity: 4 }
-      cte l16 =
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Constant // { arity: 1 }
-            - (0)
-            - (-1)
-            - (1)
-      cte l17 =
-        Distinct project=[#0, #1, #4, #2, #3] // { arity: 5 }
-          Project (#0, #1, #3, #4, #6) // { arity: 5 }
-            Filter (#7 = (#1 + #2)) // { arity: 8 }
-              FlatMap generate_series(#4, ((#4 + #5) - 1), 1) // { arity: 8 }
-                Project (#0, #1, #3..=#7) // { arity: 7 }
-                  Join on=(#4 = (#0 + #2)) type=delta // { arity: 8 }
-                    implementation
-                      %0:l6 » %1:l16[×] » %3:l14[#0]K » %2:l16[×]
-                      %1:l16 » %0:l6[×]ef » %3:l14[#0]K » %2:l16[×]
-                      %2:l16 » %0:l6[×]ef » %1:l16[×] » %3:l14[#0]K
-                      %3:l14 » %0:l6[×]ef » %1:l16[×] » %2:l16[×]
-                    ArrangeBy keys=[[]] // { arity: 2 }
-                      Project (#0, #1) // { arity: 2 }
-                        Filter (#2 = "*") // { arity: 3 }
-                          Get l6 // { arity: 3 }
-                    Get l16 // { arity: 1 }
-                    Get l16 // { arity: 1 }
-                    ArrangeBy keys=[[#0]] // { arity: 4 }
-                      Get l14 // { arity: 4 }
-      cte l18 =
-        ArrangeBy keys=[[#0, #1]] // { arity: 5 }
-          Get l17 // { arity: 5 }
-      cte l19 =
-        Reduce aggregates=[sum(#0)] // { arity: 1 }
-          Project (#2) // { arity: 1 }
-            Distinct project=[#0, #1, (#2 * #3)] // { arity: 3 }
-              Project (#0, #1, #5, #10) // { arity: 4 }
-                Filter (#2{count} = 2) AND ((#6 != #11) OR (#7 != #12)) // { arity: 13 }
-                  Join on=(#0 = #3 = #8 AND #1 = #4 = #9) type=delta // { arity: 13 }
-                    implementation
-                      %0 » %1:l18[#0, #1]KK » %2:l18[#0, #1]KK
-                      %1:l18 » %0[#0, #1]UKKAef » %2:l18[#0, #1]KK
-                      %2:l18 » %0[#0, #1]UKKAef » %1:l18[#0, #1]KK
-                    ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-                      Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+    With Mutually Recursive
+      cte l9 =
+        Distinct project=[#0..=#3] // { arity: 4 }
+          Union // { arity: 4 }
+            Distinct project=[#0..=#3] // { arity: 4 }
+              Union // { arity: 4 }
+                Project (#2, #0, #1, #7) // { arity: 4 }
+                  Map (1) // { arity: 8 }
+                    Join on=(#0 = (#3 + #5) AND #1 = (#4 + #6)) type=delta // { arity: 7 }
+                      implementation
+                        %0:l5 » %1:l6[×] » %2:l7[×] » %3:l7[×]
+                        %1:l6 » %0:l5[×] » %2:l7[×] » %3:l7[×]
+                        %2:l7 » %0:l5[×] » %1:l6[×] » %3:l7[×]
+                        %3:l7 » %0:l5[×] » %1:l6[×] » %2:l7[×]
+                      ArrangeBy keys=[[]] // { arity: 3 }
+                        Get l5 // { arity: 3 }
+                      ArrangeBy keys=[[]] // { arity: 2 }
                         Project (#0, #1) // { arity: 2 }
-                          Get l17 // { arity: 5 }
-                    Get l18 // { arity: 5 }
-                    Get l18 // { arity: 5 }
+                          Get l6 // { arity: 3 }
+                      Get l7 // { arity: 1 }
+                      Get l7 // { arity: 1 }
+                Project (#7, #0, #1, #8) // { arity: 4 }
+                  Map ((#2 || #3), (#6 + 1)) // { arity: 9 }
+                    Join on=(#0 = #4 AND #1 = (#5 - 1)) type=differential // { arity: 7 }
+                      implementation
+                        %0:l8[#0, #1]KK » %1:l9[#1, (#2 - 1)]KK
+                      Get l8 // { arity: 3 }
+                      ArrangeBy keys=[[#1, (#2 - 1)]] // { arity: 4 }
+                        Get l9 // { arity: 4 }
+            Project (#7, #0, #5, #8) // { arity: 4 }
+              Map ((#3 || #2), (#6 + 1)) // { arity: 9 }
+                Join on=(#0 = #4 AND #1 = (#5 + #6)) type=differential // { arity: 7 }
+                  implementation
+                    %0:l8[#0, #1]KK » %1:l9[#1, (#2 + #3)]KK
+                  Get l8 // { arity: 3 }
+                  ArrangeBy keys=[[#1, (#2 + #3)]] // { arity: 4 }
+                    Get l9 // { arity: 4 }
     Return // { arity: 2 }
-      CrossJoin type=differential // { arity: 2 }
-        implementation
-          %0[×]U » %1[×]U
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l15 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l15 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l19 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l19 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
+      With
+        cte l10 =
+          Distinct project=[#0, #1] // { arity: 2 }
+            Project (#1, #2) // { arity: 2 }
+              Get l9 // { arity: 4 }
+        cte l11 =
+          ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Get l5 // { arity: 3 }
+        cte l12 =
+          Project (#0..=#3) // { arity: 4 }
+            Join on=(#1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+              implementation
+                %0:l9[#1, #2]KK » %1[#0, #1]KK
+              ArrangeBy keys=[[#1, #2]] // { arity: 4 }
+                Get l9 // { arity: 4 }
+              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                Union // { arity: 2 }
+                  Negate // { arity: 2 }
+                    Distinct project=[#0, #1] // { arity: 2 }
+                      Project (#0, #1) // { arity: 2 }
+                        Join on=(#0 = #2 AND #3 = (#1 - 1)) type=differential // { arity: 4 }
+                          implementation
+                            %0:l10[#0, (#1 - 1)]KK » %1:l11[#0, #1]KK
+                          ArrangeBy keys=[[#0, (#1 - 1)]] // { arity: 2 }
+                            Get l10 // { arity: 2 }
+                          Get l11 // { arity: 2 }
+                  Get l10 // { arity: 2 }
+        cte l13 =
+          Distinct project=[#0..=#2] // { arity: 3 }
+            Project (#1..=#3) // { arity: 3 }
+              Get l12 // { arity: 4 }
+        cte l14 =
+          Project (#1..=#3, #7) // { arity: 4 }
+            Map (text_to_integer(#0)) // { arity: 8 }
+              Join on=(#1 = #4 AND #2 = #5 AND #3 = #6) type=differential // { arity: 7 }
+                implementation
+                  %0:l12[#1..=#3]KKK » %1[#0..=#2]KKK
+                ArrangeBy keys=[[#1..=#3]] // { arity: 4 }
+                  Get l12 // { arity: 4 }
+                ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                  Union // { arity: 3 }
+                    Negate // { arity: 3 }
+                      Distinct project=[#0..=#2] // { arity: 3 }
+                        Project (#0..=#2) // { arity: 3 }
+                          Join on=(#0 = #3 AND #4 = (#1 + #2)) type=differential // { arity: 5 }
+                            implementation
+                              %0:l13[#0, (#1 + #2)]KK » %1:l11[#0, #1]KK
+                            ArrangeBy keys=[[#0, (#1 + #2)]] // { arity: 3 }
+                              Get l13 // { arity: 3 }
+                            Get l11 // { arity: 2 }
+                    Get l13 // { arity: 3 }
+        cte l15 =
+          Reduce aggregates=[sum(#0)] // { arity: 1 }
+            Project (#3) // { arity: 1 }
+              Get l14 // { arity: 4 }
+        cte l16 =
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Constant // { arity: 1 }
+              - (0)
+              - (-1)
+              - (1)
+        cte l17 =
+          Distinct project=[#0, #1, #4, #2, #3] // { arity: 5 }
+            Project (#0, #1, #3, #4, #6) // { arity: 5 }
+              Filter (#7 = (#1 + #2)) // { arity: 8 }
+                FlatMap generate_series(#4, ((#4 + #5) - 1), 1) // { arity: 8 }
+                  Project (#0, #1, #3..=#7) // { arity: 7 }
+                    Join on=(#4 = (#0 + #2)) type=delta // { arity: 8 }
+                      implementation
+                        %0:l6 » %1:l16[×] » %3:l14[#0]K » %2:l16[×]
+                        %1:l16 » %0:l6[×]ef » %3:l14[#0]K » %2:l16[×]
+                        %2:l16 » %0:l6[×]ef » %1:l16[×] » %3:l14[#0]K
+                        %3:l14 » %0:l6[×]ef » %1:l16[×] » %2:l16[×]
+                      ArrangeBy keys=[[]] // { arity: 2 }
+                        Project (#0, #1) // { arity: 2 }
+                          Filter (#2 = "*") // { arity: 3 }
+                            Get l6 // { arity: 3 }
+                      Get l16 // { arity: 1 }
+                      Get l16 // { arity: 1 }
+                      ArrangeBy keys=[[#0]] // { arity: 4 }
+                        Get l14 // { arity: 4 }
+        cte l18 =
+          ArrangeBy keys=[[#0, #1]] // { arity: 5 }
+            Get l17 // { arity: 5 }
+        cte l19 =
+          Reduce aggregates=[sum(#0)] // { arity: 1 }
+            Project (#2) // { arity: 1 }
+              Distinct project=[#0, #1, (#2 * #3)] // { arity: 3 }
+                Project (#0, #1, #5, #10) // { arity: 4 }
+                  Filter (#2{count} = 2) AND ((#6 != #11) OR (#7 != #12)) // { arity: 13 }
+                    Join on=(#0 = #3 = #8 AND #1 = #4 = #9) type=delta // { arity: 13 }
+                      implementation
+                        %0 » %1:l18[#0, #1]KK » %2:l18[#0, #1]KK
+                        %1:l18 » %0[#0, #1]UKKAef » %2:l18[#0, #1]KK
+                        %2:l18 » %0[#0, #1]UKKAef » %1:l18[#0, #1]KK
+                      ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+                        Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+                          Project (#0, #1) // { arity: 2 }
+                            Get l17 // { arity: 5 }
+                      Get l18 // { arity: 5 }
+                      Get l18 // { arity: 5 }
+      Return // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0[×]U » %1[×]U
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l15 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l15 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l19 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l19 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1204.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1204.slt
@@ -282,7 +282,7 @@ FROM
     multipliers;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#3, #4) // { arity: 2 }
         Map (regexp_match["Card +(\d+): (.*)", case_insensitive=false](#1), text_to_integer(array_index(#2, 1)), regexp_split_to_array[" \| ", case_insensitive=false](array_index(#2, 2))) // { arity: 5 }
@@ -336,46 +336,48 @@ Explained Query:
           Project (#2, #0) // { arity: 2 }
             Map (0) // { arity: 3 }
               Get l1 // { arity: 2 }
-    cte l5 =
-      Project (#1, #3) // { arity: 2 }
-        Join on=(#0 = #2) type=differential // { arity: 4 }
-          implementation
-            %1:l6[#0]UK » %0:l4[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              Get l4 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              Get l6 // { arity: 2 }
-    cte l6 =
-      Project (#0, #2) // { arity: 2 }
-        Map (bigint_to_integer(#1{sum})) // { arity: 3 }
-          Reduce group_by=[#0] aggregates=[sum(coalesce(#1, 1))] // { arity: 2 }
-            Union // { arity: 2 }
-              Map (null) // { arity: 2 }
-                Union // { arity: 1 }
-                  Negate // { arity: 1 }
-                    Project (#0) // { arity: 1 }
-                      Get l5 // { arity: 2 }
-                  Project (#1) // { arity: 1 }
-                    Get l4 // { arity: 2 }
-              Get l5 // { arity: 2 }
   Return // { arity: 1 }
-    With
-      cte l7 =
-        Reduce aggregates=[sum(#0)] // { arity: 1 }
-          Project (#1) // { arity: 1 }
-            Get l6 // { arity: 2 }
+    With Mutually Recursive
+      cte l5 =
+        Project (#1, #3) // { arity: 2 }
+          Join on=(#0 = #2) type=differential // { arity: 4 }
+            implementation
+              %1:l6[#0]UK » %0:l4[#0]K
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Filter (#0) IS NOT NULL // { arity: 2 }
+                Get l4 // { arity: 2 }
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Filter (#0) IS NOT NULL // { arity: 2 }
+                Get l6 // { arity: 2 }
+      cte l6 =
+        Project (#0, #2) // { arity: 2 }
+          Map (bigint_to_integer(#1{sum})) // { arity: 3 }
+            Reduce group_by=[#0] aggregates=[sum(coalesce(#1, 1))] // { arity: 2 }
+              Union // { arity: 2 }
+                Map (null) // { arity: 2 }
+                  Union // { arity: 1 }
+                    Negate // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Get l5 // { arity: 2 }
+                    Project (#1) // { arity: 1 }
+                      Get l4 // { arity: 2 }
+                Get l5 // { arity: 2 }
     Return // { arity: 1 }
-      Union // { arity: 1 }
-        Get l7 // { arity: 1 }
-        Map (null) // { arity: 1 }
-          Union // { arity: 0 }
-            Negate // { arity: 0 }
-              Project () // { arity: 0 }
-                Get l7 // { arity: 1 }
-            Constant // { arity: 0 }
-              - ()
+      With
+        cte l7 =
+          Reduce aggregates=[sum(#0)] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Get l6 // { arity: 2 }
+      Return // { arity: 1 }
+        Union // { arity: 1 }
+          Get l7 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l7 // { arity: 1 }
+              Constant // { arity: 0 }
+                - ()
 
 Source materialize.public.aoc_1204
 
@@ -515,141 +517,111 @@ WITH MUTUALLY RECURSIVE
 select * from part1, part2;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#3..=#5) // { arity: 3 }
         Map (regexp_split_to_array["(:|\|)", case_insensitive=false](#1), text_to_integer(array_index(regexp_match["[0-9]+", case_insensitive=false](btrim(array_index(#2, 1))), 1)), regexp_split_to_array[" ", case_insensitive=false](btrim(array_index(#2, 2))), regexp_split_to_array[" ", case_insensitive=false](btrim(array_index(#2, 3)))) // { arity: 6 }
           FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0{input})) // { arity: 2 }
             ReadStorage materialize.public.aoc_1204 // { arity: 1 }
     cte l1 =
-      Distinct project=[#0..=#2] // { arity: 3 }
-        Get l0 // { arity: 3 }
-    cte l2 =
       Distinct project=[#0, #1] // { arity: 2 }
         Project (#1, #2) // { arity: 2 }
-          Get l1 // { arity: 3 }
-    cte l3 =
+          Get l0 // { arity: 3 }
+    cte l2 =
       Filter (#2 != "") // { arity: 3 }
         FlatMap unnest_array(#0) // { arity: 3 }
-          Get l2 // { arity: 2 }
-    cte l4 =
+          Get l1 // { arity: 2 }
+    cte l3 =
       Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
         Project (#0, #1) // { arity: 2 }
           Distinct project=[#0..=#2] // { arity: 3 }
             Union // { arity: 3 }
-              Get l3 // { arity: 3 }
+              Get l2 // { arity: 3 }
               Negate // { arity: 3 }
                 Threshold // { arity: 3 }
                   Union // { arity: 3 }
-                    Get l3 // { arity: 3 }
+                    Get l2 // { arity: 3 }
                     Negate // { arity: 3 }
                       Filter (#2 != "") // { arity: 3 }
                         FlatMap unnest_array(#1) // { arity: 3 }
-                          Get l2 // { arity: 2 }
-    cte l5 =
-      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-        Get l2 // { arity: 2 }
-    cte l6 =
+                          Get l1 // { arity: 2 }
+    cte l4 =
       Union // { arity: 3 }
-        Get l4 // { arity: 3 }
-        Project (#0, #1, #4) // { arity: 3 }
-          Map (0) // { arity: 5 }
-            Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
-              implementation
-                %1:l5[#0, #1]UKK » %0[#0, #1]KK
-              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+        Get l3 // { arity: 3 }
+        Map (0) // { arity: 3 }
+          Union // { arity: 2 }
+            Negate // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Get l3 // { arity: 3 }
+            Get l1 // { arity: 2 }
+    cte l5 =
+      Project (#0, #5{count}) // { arity: 2 }
+        Join on=(#1 = #3 AND #2 = #4) type=differential // { arity: 6 }
+          implementation
+            %1[#0, #1]UKK » %0:l0[#1, #2]KK
+          ArrangeBy keys=[[#1, #2]] // { arity: 3 }
+            Get l0 // { arity: 3 }
+          ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+            Union // { arity: 3 }
+              Get l4 // { arity: 3 }
+              Map (null) // { arity: 3 }
                 Union // { arity: 2 }
                   Negate // { arity: 2 }
                     Project (#0, #1) // { arity: 2 }
                       Get l4 // { arity: 3 }
-                  Get l2 // { arity: 2 }
-              Get l5 // { arity: 2 }
-    cte l7 =
-      Union // { arity: 3 }
-        Get l6 // { arity: 3 }
-        Map (error("more than one record produced in subquery")) // { arity: 3 }
-          Project (#0, #1) // { arity: 2 }
-            Filter (#2{count} > 1) // { arity: 3 }
-              Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
-                Project (#0, #1) // { arity: 2 }
-                  Get l6 // { arity: 3 }
-    cte l8 =
-      Project (#0, #8{count}) // { arity: 2 }
-        Join on=(#0 = #3 AND #1 = #4 = #6 AND #2 = #5 = #7) type=delta // { arity: 9 }
-          implementation
-            %0:l0 » %1:l1[#0..=#2]UKKK » %2[#0, #1]KK
-            %1:l1 » %0:l0[#0..=#2]KKK » %2[#0, #1]KK
-            %2 » %0:l0[#1, #2]KK » %1:l1[#0..=#2]UKKK
-          ArrangeBy keys=[[#0..=#2], [#1, #2]] // { arity: 3 }
-            Get l0 // { arity: 3 }
-          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-            Get l1 // { arity: 3 }
-          ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-            Union // { arity: 3 }
-              Get l7 // { arity: 3 }
-              Project (#0, #1, #4) // { arity: 3 }
-                Map (null) // { arity: 5 }
-                  Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
-                    implementation
-                      %1:l5[#0, #1]UKK » %0[#0, #1]KK
-                    ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                      Union // { arity: 2 }
-                        Negate // { arity: 2 }
-                          Distinct project=[#0, #1] // { arity: 2 }
-                            Project (#0, #1) // { arity: 2 }
-                              Get l7 // { arity: 3 }
-                        Get l2 // { arity: 2 }
-                    Get l5 // { arity: 2 }
-    cte l9 =
+                  Get l1 // { arity: 2 }
+    cte l6 =
       Reduce aggregates=[sum(power(2, bigint_to_double((#0{count} - 1))))] // { arity: 1 }
         Project (#1{count}) // { arity: 1 }
           Filter (#1{count} > 0) // { arity: 2 }
-            Get l8 // { arity: 2 }
-    cte l10 =
-      Union // { arity: 2 }
-        Get l8 // { arity: 2 }
-        Project (#2, #3{count}) // { arity: 2 }
-          Filter (integer_to_bigint(#2) = (integer_to_bigint(#0) + #4)) // { arity: 5 }
-            FlatMap generate_series(1, #1, 1) // { arity: 5 }
-              CrossJoin type=differential // { arity: 4 }
-                implementation
-                  %0:l10[×] » %1:l8[×]
-                ArrangeBy keys=[[]] // { arity: 2 }
-                  Get l10 // { arity: 2 }
-                ArrangeBy keys=[[]] // { arity: 2 }
-                  Get l8 // { arity: 2 }
+            Get l5 // { arity: 2 }
   Return // { arity: 2 }
-    With
-      cte l11 =
-        Reduce aggregates=[count(*)] // { arity: 1 }
-          Project () // { arity: 0 }
-            Get l10 // { arity: 2 }
+    With Mutually Recursive
+      cte l7 =
+        Union // { arity: 2 }
+          Get l5 // { arity: 2 }
+          Project (#2, #3{count}) // { arity: 2 }
+            Filter (integer_to_bigint(#2) = (integer_to_bigint(#0) + #4)) // { arity: 5 }
+              FlatMap generate_series(1, #1, 1) // { arity: 5 }
+                CrossJoin type=differential // { arity: 4 }
+                  implementation
+                    %0:l7[×] » %1:l5[×]
+                  ArrangeBy keys=[[]] // { arity: 2 }
+                    Get l7 // { arity: 2 }
+                  ArrangeBy keys=[[]] // { arity: 2 }
+                    Get l5 // { arity: 2 }
     Return // { arity: 2 }
-      CrossJoin type=differential // { arity: 2 }
-        implementation
-          %0[×]U » %1[×]U
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Project (#1) // { arity: 1 }
-            Map (double_to_numeric(#0{sum})) // { arity: 2 }
-              Union // { arity: 1 }
-                Get l9 // { arity: 1 }
-                Map (null) // { arity: 1 }
-                  Union // { arity: 0 }
-                    Negate // { arity: 0 }
-                      Project () // { arity: 0 }
-                        Get l9 // { arity: 1 }
-                    Constant // { arity: 0 }
-                      - ()
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l11 // { arity: 1 }
-            Map (0) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l11 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
+      With
+        cte l8 =
+          Reduce aggregates=[count(*)] // { arity: 1 }
+            Project () // { arity: 0 }
+              Get l7 // { arity: 2 }
+      Return // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0[×]U » %1[×]U
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Map (double_to_numeric(#0{sum})) // { arity: 2 }
+                Union // { arity: 1 }
+                  Get l6 // { arity: 1 }
+                  Map (null) // { arity: 1 }
+                    Union // { arity: 0 }
+                      Negate // { arity: 0 }
+                        Project () // { arity: 0 }
+                          Get l6 // { arity: 1 }
+                      Constant // { arity: 0 }
+                        - ()
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l8 // { arity: 1 }
+              Map (0) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l8 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
 
 Source materialize.public.aoc_1204
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1205.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1205.slt
@@ -1161,7 +1161,7 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#2, #3) // { arity: 2 }
         Map (split_string(#1, ":", 1), split_string(#1, ":", 2)) // { arity: 4 }
@@ -1178,237 +1178,239 @@ Explained Query:
       ArrangeBy keys=[[#0, #1]] // { arity: 5 }
         Get l1 // { arity: 5 }
     cte l3 =
-      Project (#0..=#2, #5, #6) // { arity: 5 }
-        Filter (#2 >= #5) AND (#2 <= ((#5 + #7) - 1)) // { arity: 8 }
-          Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 8 }
-            implementation
-              %0:l7[#0, #1]KK » %1:l2[#0, #1]KK
-            ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-              Get l7 // { arity: 3 }
-            Get l2 // { arity: 5 }
-    cte l4 =
       Project (#1) // { arity: 1 }
         Filter (#0 = "seeds") // { arity: 2 }
           Get l0 // { arity: 2 }
-    cte l5 =
-      Union // { arity: 2 }
-        Project (#3, #2) // { arity: 2 }
-          Map (text_to_bigint(#1), "seed") // { arity: 4 }
-            FlatMap unnest_array(regexp_split_to_array[" ", case_insensitive=false](btrim(#0))) // { arity: 2 }
-              Get l4 // { arity: 1 }
-        Project (#0, #4) // { arity: 2 }
-          Map (coalesce((#1 + (#3 - #2)), #1)) // { arity: 5 }
-            Union // { arity: 4 }
-              Project (#1..=#4) // { arity: 4 }
-                Get l3 // { arity: 5 }
-              Project (#1, #2, #6, #7) // { arity: 4 }
-                Map (null, null) // { arity: 8 }
-                  Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-                    implementation
-                      %0[#0..=#2]KKK » %1:l7[#0..=#2]KKK
-                    ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                      Union // { arity: 3 }
-                        Negate // { arity: 3 }
-                          Distinct project=[#0..=#2] // { arity: 3 }
-                            Project (#0..=#2) // { arity: 3 }
-                              Get l3 // { arity: 5 }
-                        Get l7 // { arity: 3 }
-                    ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                      Get l7 // { arity: 3 }
-    cte l6 =
+    cte l4 =
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Distinct project=[#0, #1] // { arity: 2 }
           Project (#0, #1) // { arity: 2 }
             Get l1 // { arity: 5 }
-    cte l7 =
-      Project (#0, #3, #1) // { arity: 3 }
-        Join on=(#0 = #2) type=differential // { arity: 4 }
-          implementation
-            %0[#0]K » %1:l6[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Distinct project=[#0, #1] // { arity: 2 }
-              Get l5 // { arity: 2 }
-          Get l6 // { arity: 2 }
-    cte l8 =
-      Reduce aggregates=[min(#0)] // { arity: 1 }
-        Project (#1) // { arity: 1 }
-          Filter (#0 = "location") // { arity: 2 }
-            Get l5 // { arity: 2 }
-    cte l9 =
-      Distinct project=[#0..=#2] // { arity: 3 }
-        Union // { arity: 3 }
-          Project (#6, #4, #5) // { arity: 3 }
-            Map (regexp_split_to_array[" ", case_insensitive=false](btrim(#0)), (2 * #1), text_to_bigint(array_index(#2, integer_to_bigint((#3 - 1)))), (#4 + text_to_bigint(array_index(#2, integer_to_bigint(#3)))), "seed") // { arity: 7 }
-              FlatMap generate_series(1, ((regexp_split_to_array[" ", case_insensitive=false](btrim(#0)) array_length 1) / 2), 1) // { arity: 2 }
-                Get l4 // { arity: 1 }
-          Project (#1, #10, #11) // { arity: 3 }
-            Map ((#8 - #4), (#6 + #9), (#7 + #9)) // { arity: 12 }
-              Get l11 // { arity: 9 }
-          Get l19 // { arity: 3 }
-    cte l10 =
-      Project (#0..=#2, #4) // { arity: 4 }
-        Join on=(#0 = #3) type=differential // { arity: 5 }
-          implementation
-            %0:l9[#0]K » %1:l6[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 3 }
-            Get l9 // { arity: 3 }
-          Get l6 // { arity: 2 }
-    cte l11 =
-      Project (#0, #3, #1, #2, #6, #10, #9, #11, #7) // { arity: 9 }
-        Filter (#9 < #11) // { arity: 12 }
-          Map (greatest(#1, #6), (#6 + #8), least(#2, #10)) // { arity: 12 }
-            Join on=(#0 = #4 AND #3 = #5) type=differential // { arity: 9 }
-              implementation
-                %0:l10[#0, #3]KK » %1:l2[#0, #1]KK
-              ArrangeBy keys=[[#0, #3]] // { arity: 4 }
-                Get l10 // { arity: 4 }
-              Get l2 // { arity: 5 }
-    cte l12 =
-      Distinct project=[#0..=#8] // { arity: 9 }
-        Get l11 // { arity: 9 }
-    cte l13 =
-      Distinct project=[#0..=#4] // { arity: 5 }
-        Project (#0..=#3, #7) // { arity: 5 }
-          Get l12 // { arity: 9 }
-    cte l14 =
-      Reduce group_by=[#0..=#4] aggregates=[min(#5)] // { arity: 6 }
-        Project (#0..=#4, #9) // { arity: 6 }
-          Filter (#9 >= #4) // { arity: 10 }
-            Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8) type=differential // { arity: 10 }
-              implementation
-                %1:l11[#0..=#3]KKKKf » %0:l13[#0..=#3]KKKKf
-              ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
-                Filter (#2) IS NOT NULL AND (#3) IS NOT NULL // { arity: 5 }
-                  Get l13 // { arity: 5 }
-              ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
-                Project (#0..=#3, #6) // { arity: 5 }
-                  Filter (#2) IS NOT NULL AND (#6 < #3) // { arity: 9 }
-                    Get l11 // { arity: 9 }
-    cte l15 =
-      Project (#0..=#4, #6) // { arity: 6 }
-        Map (coalesce(#5{min}, #3)) // { arity: 7 }
-          Union // { arity: 6 }
-            Get l14 // { arity: 6 }
-            Project (#0..=#4, #10) // { arity: 6 }
-              Map (null) // { arity: 11 }
-                Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8 AND #4 = #9) type=differential // { arity: 10 }
-                  implementation
-                    %1:l13[#0..=#4]UKKKKK » %0[#0..=#4]KKKKK
-                  ArrangeBy keys=[[#0..=#4]] // { arity: 5 }
-                    Union // { arity: 5 }
-                      Negate // { arity: 5 }
-                        Project (#0..=#4) // { arity: 5 }
-                          Get l14 // { arity: 6 }
-                      Get l13 // { arity: 5 }
-                  ArrangeBy keys=[[#0..=#4]] // { arity: 5 }
-                    Get l13 // { arity: 5 }
-    cte l16 =
-      Reduce group_by=[#0, #3, #1, #2] aggregates=[min(#4)] // { arity: 5 }
-        Project (#0..=#3, #8) // { arity: 5 }
-          Join on=(#0 = #4 AND #1 = #6 AND #2 = #7 AND #3 = #5) type=differential // { arity: 9 }
-            implementation
-              %1:l11[#0, #2, #3, #1]KKKKf » %0:l10[#0..=#3]KKKKf
-            ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
-              Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 4 }
-                Get l10 // { arity: 4 }
-            ArrangeBy keys=[[#0, #2, #3, #1]] // { arity: 5 }
-              Project (#0..=#3, #6) // { arity: 5 }
-                Filter (#6 < #3) AND (#6 >= #2) // { arity: 9 }
-                  Get l11 // { arity: 9 }
-    cte l17 =
-      ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
-        Get l10 // { arity: 4 }
-    cte l18 =
-      Project (#0..=#3, #5) // { arity: 5 }
-        Map (coalesce(#4{min}, #3)) // { arity: 6 }
-          Union // { arity: 5 }
-            Get l16 // { arity: 5 }
-            Project (#0..=#3, #8) // { arity: 5 }
-              Map (null) // { arity: 9 }
-                Join on=(#0 = #4 AND #1 = #7 AND #2 = #5 AND #3 = #6) type=differential // { arity: 8 }
-                  implementation
-                    %0[#0, #2, #3, #1]KKKK » %1:l17[#0..=#3]KKKK
-                  ArrangeBy keys=[[#0, #2, #3, #1]] // { arity: 4 }
-                    Union // { arity: 4 }
-                      Negate // { arity: 4 }
-                        Project (#0..=#3) // { arity: 4 }
-                          Get l16 // { arity: 5 }
-                      Project (#0, #3, #1, #2) // { arity: 4 }
-                        Get l10 // { arity: 4 }
-                  Get l17 // { arity: 4 }
-    cte l19 =
-      Distinct project=[#0..=#2] // { arity: 3 }
-        Union // { arity: 3 }
-          Project (#1, #7, #23) // { arity: 3 }
-            Join on=(#0 = #9 = #18 AND #1 = #10 = #19 AND #2 = #11 = #20 AND #3 = #12 = #21 AND #4 = #13 AND #5 = #14 AND #6 = #15 AND #7 = #16 = #22 AND #8 = #17) type=delta // { arity: 24 }
-              implementation
-                %0:l11 » %1:l12[#0..=#8]UKKKKKKKKK » %2[#0..=#4]KKKKK
-                %1:l12 » %0:l11[#0..=#8]KKKKKKKKK » %2[#0..=#4]KKKKK
-                %2 » %0:l11[#0..=#3, #7]KKKKK » %1:l12[#0..=#8]UKKKKKKKKK
-              ArrangeBy keys=[[#0..=#8], [#0..=#3, #7]] // { arity: 9 }
-                Get l11 // { arity: 9 }
-              ArrangeBy keys=[[#0..=#8]] // { arity: 9 }
-                Get l12 // { arity: 9 }
-              ArrangeBy keys=[[#0..=#4]] // { arity: 6 }
-                Union // { arity: 6 }
-                  Filter (#4 < #5) // { arity: 6 }
-                    Get l15 // { arity: 6 }
-                  Map (error("more than one record produced in subquery")) // { arity: 6 }
-                    Project (#0..=#4) // { arity: 5 }
-                      Filter error("more than one record produced in subquery") AND (#5{count} > 1) // { arity: 6 }
-                        Reduce group_by=[#0..=#4] aggregates=[count(*)] // { arity: 6 }
-                          Project (#0..=#4) // { arity: 5 }
-                            Get l15 // { arity: 6 }
-          Distinct project=[#1, #0, #2] // { arity: 3 }
-            Project (#1, #3, #12) // { arity: 3 }
-              Join on=(#0 = #4 = #8 AND #1 = #5 = #10 AND #2 = #6 = #11 AND #3 = #7 = #9) type=delta // { arity: 13 }
-                implementation
-                  %0:l17 » %1:l17[#0..=#3]KKKK » %2[#0..=#3]KKKK
-                  %1:l17 » %0:l17[#0..=#3]KKKK » %2[#0..=#3]KKKK
-                  %2 » %0:l17[#0..=#3]KKKK » %1:l17[#0..=#3]KKKK
-                Get l17 // { arity: 4 }
-                Get l17 // { arity: 4 }
-                ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
-                  Union // { arity: 5 }
-                    Filter (#2 < #4) // { arity: 5 }
-                      Get l18 // { arity: 5 }
-                    Map (error("more than one record produced in subquery")) // { arity: 5 }
-                      Project (#0..=#3) // { arity: 4 }
-                        Filter error("more than one record produced in subquery") AND (#4{count} > 1) // { arity: 5 }
-                          Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
-                            Project (#0..=#3) // { arity: 4 }
-                              Get l18 // { arity: 5 }
   Return // { arity: 2 }
-    With
-      cte l20 =
+    With Mutually Recursive
+      cte l5 =
+        Project (#0..=#2, #5, #6) // { arity: 5 }
+          Filter (#2 >= #5) AND (#2 <= ((#5 + #7) - 1)) // { arity: 8 }
+            Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 8 }
+              implementation
+                %0:l7[#0, #1]KK » %1:l2[#0, #1]KK
+              ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+                Get l7 // { arity: 3 }
+              Get l2 // { arity: 5 }
+      cte l6 =
+        Union // { arity: 2 }
+          Project (#3, #2) // { arity: 2 }
+            Map (text_to_bigint(#1), "seed") // { arity: 4 }
+              FlatMap unnest_array(regexp_split_to_array[" ", case_insensitive=false](btrim(#0))) // { arity: 2 }
+                Get l3 // { arity: 1 }
+          Project (#0, #4) // { arity: 2 }
+            Map (coalesce((#1 + (#3 - #2)), #1)) // { arity: 5 }
+              Union // { arity: 4 }
+                Project (#1..=#4) // { arity: 4 }
+                  Get l5 // { arity: 5 }
+                Project (#1, #2, #6, #7) // { arity: 4 }
+                  Map (null, null) // { arity: 8 }
+                    Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                      implementation
+                        %0[#0..=#2]KKK » %1:l7[#0..=#2]KKK
+                      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                        Union // { arity: 3 }
+                          Negate // { arity: 3 }
+                            Distinct project=[#0..=#2] // { arity: 3 }
+                              Project (#0..=#2) // { arity: 3 }
+                                Get l5 // { arity: 5 }
+                          Get l7 // { arity: 3 }
+                      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                        Get l7 // { arity: 3 }
+      cte l7 =
+        Project (#0, #3, #1) // { arity: 3 }
+          Join on=(#0 = #2) type=differential // { arity: 4 }
+            implementation
+              %0[#0]K » %1:l4[#0]K
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Distinct project=[#0, #1] // { arity: 2 }
+                Get l6 // { arity: 2 }
+            Get l4 // { arity: 2 }
+      cte l8 =
         Reduce aggregates=[min(#0)] // { arity: 1 }
           Project (#1) // { arity: 1 }
-            Filter (#0 = "location") // { arity: 3 }
+            Filter (#0 = "location") // { arity: 2 }
+              Get l6 // { arity: 2 }
+      cte l9 =
+        Distinct project=[#0..=#2] // { arity: 3 }
+          Union // { arity: 3 }
+            Project (#6, #4, #5) // { arity: 3 }
+              Map (regexp_split_to_array[" ", case_insensitive=false](btrim(#0)), (2 * #1), text_to_bigint(array_index(#2, integer_to_bigint((#3 - 1)))), (#4 + text_to_bigint(array_index(#2, integer_to_bigint(#3)))), "seed") // { arity: 7 }
+                FlatMap generate_series(1, ((regexp_split_to_array[" ", case_insensitive=false](btrim(#0)) array_length 1) / 2), 1) // { arity: 2 }
+                  Get l3 // { arity: 1 }
+            Project (#1, #10, #11) // { arity: 3 }
+              Map ((#8 - #4), (#6 + #9), (#7 + #9)) // { arity: 12 }
+                Get l11 // { arity: 9 }
+            Get l19 // { arity: 3 }
+      cte l10 =
+        Project (#0..=#2, #4) // { arity: 4 }
+          Join on=(#0 = #3) type=differential // { arity: 5 }
+            implementation
+              %0:l9[#0]K » %1:l4[#0]K
+            ArrangeBy keys=[[#0]] // { arity: 3 }
               Get l9 // { arity: 3 }
+            Get l4 // { arity: 2 }
+      cte l11 =
+        Project (#0, #3, #1, #2, #6, #10, #9, #11, #7) // { arity: 9 }
+          Filter (#9 < #11) // { arity: 12 }
+            Map (greatest(#1, #6), (#6 + #8), least(#2, #10)) // { arity: 12 }
+              Join on=(#0 = #4 AND #3 = #5) type=differential // { arity: 9 }
+                implementation
+                  %0:l10[#0, #3]KK » %1:l2[#0, #1]KK
+                ArrangeBy keys=[[#0, #3]] // { arity: 4 }
+                  Get l10 // { arity: 4 }
+                Get l2 // { arity: 5 }
+      cte l12 =
+        Distinct project=[#0..=#8] // { arity: 9 }
+          Get l11 // { arity: 9 }
+      cte l13 =
+        Distinct project=[#0..=#4] // { arity: 5 }
+          Project (#0..=#3, #7) // { arity: 5 }
+            Get l12 // { arity: 9 }
+      cte l14 =
+        Reduce group_by=[#0..=#4] aggregates=[min(#5)] // { arity: 6 }
+          Project (#0..=#4, #9) // { arity: 6 }
+            Filter (#9 >= #4) // { arity: 10 }
+              Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8) type=differential // { arity: 10 }
+                implementation
+                  %1:l11[#0..=#3]KKKKf » %0:l13[#0..=#3]KKKKf
+                ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
+                  Filter (#2) IS NOT NULL AND (#3) IS NOT NULL // { arity: 5 }
+                    Get l13 // { arity: 5 }
+                ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
+                  Project (#0..=#3, #6) // { arity: 5 }
+                    Filter (#2) IS NOT NULL AND (#6 < #3) // { arity: 9 }
+                      Get l11 // { arity: 9 }
+      cte l15 =
+        Project (#0..=#4, #6) // { arity: 6 }
+          Map (coalesce(#5{min}, #3)) // { arity: 7 }
+            Union // { arity: 6 }
+              Get l14 // { arity: 6 }
+              Project (#0..=#4, #10) // { arity: 6 }
+                Map (null) // { arity: 11 }
+                  Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8 AND #4 = #9) type=differential // { arity: 10 }
+                    implementation
+                      %1:l13[#0..=#4]UKKKKK » %0[#0..=#4]KKKKK
+                    ArrangeBy keys=[[#0..=#4]] // { arity: 5 }
+                      Union // { arity: 5 }
+                        Negate // { arity: 5 }
+                          Project (#0..=#4) // { arity: 5 }
+                            Get l14 // { arity: 6 }
+                        Get l13 // { arity: 5 }
+                    ArrangeBy keys=[[#0..=#4]] // { arity: 5 }
+                      Get l13 // { arity: 5 }
+      cte l16 =
+        Reduce group_by=[#0, #3, #1, #2] aggregates=[min(#4)] // { arity: 5 }
+          Project (#0..=#3, #8) // { arity: 5 }
+            Join on=(#0 = #4 AND #1 = #6 AND #2 = #7 AND #3 = #5) type=differential // { arity: 9 }
+              implementation
+                %1:l11[#0, #2, #3, #1]KKKKf » %0:l10[#0..=#3]KKKKf
+              ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+                Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 4 }
+                  Get l10 // { arity: 4 }
+              ArrangeBy keys=[[#0, #2, #3, #1]] // { arity: 5 }
+                Project (#0..=#3, #6) // { arity: 5 }
+                  Filter (#6 < #3) AND (#6 >= #2) // { arity: 9 }
+                    Get l11 // { arity: 9 }
+      cte l17 =
+        ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+          Get l10 // { arity: 4 }
+      cte l18 =
+        Project (#0..=#3, #5) // { arity: 5 }
+          Map (coalesce(#4{min}, #3)) // { arity: 6 }
+            Union // { arity: 5 }
+              Get l16 // { arity: 5 }
+              Project (#0..=#3, #8) // { arity: 5 }
+                Map (null) // { arity: 9 }
+                  Join on=(#0 = #4 AND #1 = #7 AND #2 = #5 AND #3 = #6) type=differential // { arity: 8 }
+                    implementation
+                      %0[#0, #2, #3, #1]KKKK » %1:l17[#0..=#3]KKKK
+                    ArrangeBy keys=[[#0, #2, #3, #1]] // { arity: 4 }
+                      Union // { arity: 4 }
+                        Negate // { arity: 4 }
+                          Project (#0..=#3) // { arity: 4 }
+                            Get l16 // { arity: 5 }
+                        Project (#0, #3, #1, #2) // { arity: 4 }
+                          Get l10 // { arity: 4 }
+                    Get l17 // { arity: 4 }
+      cte l19 =
+        Distinct project=[#0..=#2] // { arity: 3 }
+          Union // { arity: 3 }
+            Project (#1, #7, #23) // { arity: 3 }
+              Join on=(#0 = #9 = #18 AND #1 = #10 = #19 AND #2 = #11 = #20 AND #3 = #12 = #21 AND #4 = #13 AND #5 = #14 AND #6 = #15 AND #7 = #16 = #22 AND #8 = #17) type=delta // { arity: 24 }
+                implementation
+                  %0:l11 » %1:l12[#0..=#8]UKKKKKKKKK » %2[#0..=#4]KKKKK
+                  %1:l12 » %0:l11[#0..=#8]KKKKKKKKK » %2[#0..=#4]KKKKK
+                  %2 » %0:l11[#0..=#3, #7]KKKKK » %1:l12[#0..=#8]UKKKKKKKKK
+                ArrangeBy keys=[[#0..=#8], [#0..=#3, #7]] // { arity: 9 }
+                  Get l11 // { arity: 9 }
+                ArrangeBy keys=[[#0..=#8]] // { arity: 9 }
+                  Get l12 // { arity: 9 }
+                ArrangeBy keys=[[#0..=#4]] // { arity: 6 }
+                  Union // { arity: 6 }
+                    Filter (#4 < #5) // { arity: 6 }
+                      Get l15 // { arity: 6 }
+                    Map (error("more than one record produced in subquery")) // { arity: 6 }
+                      Project (#0..=#4) // { arity: 5 }
+                        Filter error("more than one record produced in subquery") AND (#5{count} > 1) // { arity: 6 }
+                          Reduce group_by=[#0..=#4] aggregates=[count(*)] // { arity: 6 }
+                            Project (#0..=#4) // { arity: 5 }
+                              Get l15 // { arity: 6 }
+            Distinct project=[#1, #0, #2] // { arity: 3 }
+              Project (#1, #3, #12) // { arity: 3 }
+                Join on=(#0 = #4 = #8 AND #1 = #5 = #10 AND #2 = #6 = #11 AND #3 = #7 = #9) type=delta // { arity: 13 }
+                  implementation
+                    %0:l17 » %1:l17[#0..=#3]KKKK » %2[#0..=#3]KKKK
+                    %1:l17 » %0:l17[#0..=#3]KKKK » %2[#0..=#3]KKKK
+                    %2 » %0:l17[#0..=#3]KKKK » %1:l17[#0..=#3]KKKK
+                  Get l17 // { arity: 4 }
+                  Get l17 // { arity: 4 }
+                  ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
+                    Union // { arity: 5 }
+                      Filter (#2 < #4) // { arity: 5 }
+                        Get l18 // { arity: 5 }
+                      Map (error("more than one record produced in subquery")) // { arity: 5 }
+                        Project (#0..=#3) // { arity: 4 }
+                          Filter error("more than one record produced in subquery") AND (#4{count} > 1) // { arity: 5 }
+                            Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
+                              Project (#0..=#3) // { arity: 4 }
+                                Get l18 // { arity: 5 }
     Return // { arity: 2 }
-      CrossJoin type=differential // { arity: 2 }
-        implementation
-          %0[×]U » %1[×]U
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l8 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l8 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l20 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l20 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
+      With
+        cte l20 =
+          Reduce aggregates=[min(#0)] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Filter (#0 = "location") // { arity: 3 }
+                Get l9 // { arity: 3 }
+      Return // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0[×]U » %1[×]U
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l8 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l8 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l20 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l20 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1210.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1210.slt
@@ -371,7 +371,7 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#0, #2, #3) // { arity: 3 }
         Map (substr(#1, #2, 1)) // { arity: 4 }
@@ -428,197 +428,199 @@ Explained Query:
     cte l5 =
       ArrangeBy keys=[[#0, #1]] // { arity: 4 }
         Get l3 // { arity: 4 }
-    cte l6 =
-      Distinct project=[#0, #1] // { arity: 2 }
-        Union // { arity: 2 }
-          Get l4 // { arity: 2 }
-          Project (#4, #5) // { arity: 2 }
-            Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 6 }
-              implementation
-                %0:l6[#0, #1]UKK » %1:l5[#0, #1]KK
-              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
-                  Get l6 // { arity: 2 }
-              Get l5 // { arity: 4 }
-    cte l7 =
-      Reduce aggregates=[count(*)] // { arity: 1 }
-        Project () // { arity: 0 }
-          Get l6 // { arity: 2 }
-    cte l8 =
-      Distinct project=[#0..=#2] // { arity: 3 }
-        Union // { arity: 3 }
-          Project (#0, #1, #4) // { arity: 3 }
-            Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 5 }
-              implementation
-                %0:l6[#0, #1]UKK » %1:l0[#0, #1]KKf
-              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
-                  Get l6 // { arity: 2 }
-              ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-                Filter (#2 != "S") // { arity: 3 }
-                  Get l0 // { arity: 3 }
-          Project (#0, #1, #8) // { arity: 3 }
-            Map (case when ((#0 = #0) AND (#0 = (#6 + 1)) AND (#1 = #7) AND (#1 = (#1 + 1))) then "J" else case when ((#0 = #0) AND (#0 = #6) AND (#1 = (#1 + 1)) AND (#1 = (#7 - 1))) then "-" else case when ((#0 = #0) AND (#0 = (#6 - 1)) AND (#1 = #7) AND (#1 = (#1 + 1))) then "7" else case when ((#0 = #6) AND (#0 = (#0 + 1)) AND (#1 = #1) AND (#1 = (#7 - 1))) then "L" else case when ((#0 = (#0 + 1)) AND (#0 = (#6 - 1)) AND (#1 = #1) AND (#1 = #7)) then "|" else case when ((#0 = #0) AND (#0 = #6) AND (#1 = (#1 - 1)) AND (#1 = (#7 - 1))) then "F" else "???" end end end end end end) // { arity: 9 }
-              Join on=(#0 = #2 = #4 AND #1 = #3 = #5) type=delta // { arity: 8 }
-                implementation
-                  %0:l4 » %1:l3[#0, #1]KK » %2:l5[#0, #1]KK
-                  %1:l3 » %0:l4[#0, #1]KKef » %2:l5[#0, #1]KK
-                  %2:l5 » %0:l4[#0, #1]KKef » %1:l3[#0, #1]KK
-                ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                  Get l4 // { arity: 2 }
-                ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                  Project (#0, #1) // { arity: 2 }
-                    Get l3 // { arity: 4 }
-                Get l5 // { arity: 4 }
-    cte l9 =
-      ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-        Get l17 // { arity: 3 }
-    cte l10 =
-      Project (#0..=#2, #5) // { arity: 4 }
-        Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 6 }
-          implementation
-            %0:l9[#0, #1]KK » %1:l8[#0, #1]KK
-          Get l9 // { arity: 3 }
-          ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-            Get l8 // { arity: 3 }
-    cte l11 =
-      Project (#2, #3, #6, #7) // { arity: 4 }
-        Map ((#0 + 1), (#1 + 1)) // { arity: 8 }
-          Join on=(#0 = #4 AND #1 = #5) type=differential // { arity: 6 }
-            implementation
-              %0[#0, #1]KK » %1:l0[#0, #1]KK
-            ArrangeBy keys=[[#0, #1]] // { arity: 4 }
-              Union // { arity: 4 }
-                Map (null) // { arity: 4 }
-                  Union // { arity: 3 }
-                    Negate // { arity: 3 }
-                      Project (#0..=#2) // { arity: 3 }
-                        Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 5 }
-                          implementation
-                            %1[#0, #1]UKKA » %0:l9[#0, #1]KK
-                          Get l9 // { arity: 3 }
-                          ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                            Distinct project=[#0, #1] // { arity: 2 }
-                              Project (#0, #1) // { arity: 2 }
-                                Get l10 // { arity: 4 }
-                    Get l17 // { arity: 3 }
-                Get l10 // { arity: 4 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-              Project (#0, #1) // { arity: 2 }
-                Get l0 // { arity: 3 }
-    cte l12 =
-      Distinct project=[#0] // { arity: 1 }
-        Project (#1) // { arity: 1 }
-          Get l11 // { arity: 4 }
-    cte l13 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
-        FlatMap wrap1("J", "-", "|", "F") // { arity: 2 }
-          Get l12 // { arity: 1 }
-    cte l14 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Get l12 // { arity: 1 }
-    cte l15 =
-      Union // { arity: 2 }
-        Get l13 // { arity: 2 }
-        Project (#0, #2) // { arity: 2 }
-          Map (false) // { arity: 3 }
-            Join on=(#0 = #1) type=differential // { arity: 2 }
-              implementation
-                %1:l14[#0]UK » %0[#0]K
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Union // { arity: 1 }
-                  Negate // { arity: 1 }
-                    Project (#0) // { arity: 1 }
-                      Get l13 // { arity: 2 }
-                  Get l12 // { arity: 1 }
-              Get l14 // { arity: 1 }
-    cte l16 =
-      Union // { arity: 2 }
-        Get l15 // { arity: 2 }
-        Map (error("more than one record produced in subquery")) // { arity: 2 }
-          Project (#0) // { arity: 1 }
-            Filter (#1{count} > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                Project (#0) // { arity: 1 }
-                  Get l15 // { arity: 2 }
-    cte l17 =
-      Distinct project=[#0..=#2] // { arity: 3 }
-        Union // { arity: 3 }
-          Project (#0, #1, #3) // { arity: 3 }
-            Filter ((#0 = 1) OR (#1 = 1)) // { arity: 4 }
-              Map (false) // { arity: 4 }
-                Get l0 // { arity: 3 }
-          Project (#2, #3, #6) // { arity: 3 }
-            Map (case when #5{any} then NOT(#0) else #0 end) // { arity: 7 }
-              Join on=(#1 = #4) type=differential // { arity: 6 }
-                implementation
-                  %0:l11[#1]K » %1[#0]K
-                ArrangeBy keys=[[#1]] // { arity: 4 }
-                  Get l11 // { arity: 4 }
-                ArrangeBy keys=[[#0]] // { arity: 2 }
-                  Union // { arity: 2 }
-                    Get l16 // { arity: 2 }
-                    Project (#0, #2) // { arity: 2 }
-                      Map (null) // { arity: 3 }
-                        Join on=(#0 = #1) type=differential // { arity: 2 }
-                          implementation
-                            %1:l14[#0]UK » %0[#0]K
-                          ArrangeBy keys=[[#0]] // { arity: 1 }
-                            Union // { arity: 1 }
-                              Negate // { arity: 1 }
-                                Distinct project=[#0] // { arity: 1 }
-                                  Project (#0) // { arity: 1 }
-                                    Get l16 // { arity: 2 }
-                              Get l12 // { arity: 1 }
-                          Get l14 // { arity: 1 }
   Return // { arity: 2 }
-    With
-      cte l18 =
-        Project (#0, #1) // { arity: 2 }
-          Filter (#2 = true) // { arity: 3 }
-            Get l17 // { arity: 3 }
-      cte l19 =
+    With Mutually Recursive
+      cte l6 =
+        Distinct project=[#0, #1] // { arity: 2 }
+          Union // { arity: 2 }
+            Get l4 // { arity: 2 }
+            Project (#4, #5) // { arity: 2 }
+              Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 6 }
+                implementation
+                  %0:l6[#0, #1]UKK » %1:l5[#0, #1]KK
+                ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                  Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
+                    Get l6 // { arity: 2 }
+                Get l5 // { arity: 4 }
+      cte l7 =
         Reduce aggregates=[count(*)] // { arity: 1 }
-          Union // { arity: 0 }
-            Negate // { arity: 0 }
-              Project () // { arity: 0 }
-                Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+          Project () // { arity: 0 }
+            Get l6 // { arity: 2 }
+      cte l8 =
+        Distinct project=[#0..=#2] // { arity: 3 }
+          Union // { arity: 3 }
+            Project (#0, #1, #4) // { arity: 3 }
+              Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 5 }
+                implementation
+                  %0:l6[#0, #1]UKK » %1:l0[#0, #1]KKf
+                ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                  Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
+                    Get l6 // { arity: 2 }
+                ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+                  Filter (#2 != "S") // { arity: 3 }
+                    Get l0 // { arity: 3 }
+            Project (#0, #1, #8) // { arity: 3 }
+              Map (case when ((#0 = #0) AND (#0 = (#6 + 1)) AND (#1 = #7) AND (#1 = (#1 + 1))) then "J" else case when ((#0 = #0) AND (#0 = #6) AND (#1 = (#1 + 1)) AND (#1 = (#7 - 1))) then "-" else case when ((#0 = #0) AND (#0 = (#6 - 1)) AND (#1 = #7) AND (#1 = (#1 + 1))) then "7" else case when ((#0 = #6) AND (#0 = (#0 + 1)) AND (#1 = #1) AND (#1 = (#7 - 1))) then "L" else case when ((#0 = (#0 + 1)) AND (#0 = (#6 - 1)) AND (#1 = #1) AND (#1 = #7)) then "|" else case when ((#0 = #0) AND (#0 = #6) AND (#1 = (#1 - 1)) AND (#1 = (#7 - 1))) then "F" else "???" end end end end end end) // { arity: 9 }
+                Join on=(#0 = #2 = #4 AND #1 = #3 = #5) type=delta // { arity: 8 }
                   implementation
-                    %1[#0, #1]UKKA » %0:l18[#0, #1]UKKef
+                    %0:l4 » %1:l3[#0, #1]KK » %2:l5[#0, #1]KK
+                    %1:l3 » %0:l4[#0, #1]KKef » %2:l5[#0, #1]KK
+                    %2:l5 » %0:l4[#0, #1]KKef » %1:l3[#0, #1]KK
                   ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                    Get l18 // { arity: 2 }
+                    Get l4 // { arity: 2 }
                   ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                    Distinct project=[#0, #1] // { arity: 2 }
-                      Project (#0, #1) // { arity: 2 }
-                        Get l8 // { arity: 3 }
-            Project () // { arity: 0 }
-              Get l18 // { arity: 2 }
-    Return // { arity: 2 }
-      CrossJoin type=differential // { arity: 2 }
-        implementation
-          %0[×]U » %1[×]U
-        ArrangeBy keys=[[]] // { arity: 1 }
+                    Project (#0, #1) // { arity: 2 }
+                      Get l3 // { arity: 4 }
+                  Get l5 // { arity: 4 }
+      cte l9 =
+        ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+          Get l17 // { arity: 3 }
+      cte l10 =
+        Project (#0..=#2, #5) // { arity: 4 }
+          Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 6 }
+            implementation
+              %0:l9[#0, #1]KK » %1:l8[#0, #1]KK
+            Get l9 // { arity: 3 }
+            ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+              Get l8 // { arity: 3 }
+      cte l11 =
+        Project (#2, #3, #6, #7) // { arity: 4 }
+          Map ((#0 + 1), (#1 + 1)) // { arity: 8 }
+            Join on=(#0 = #4 AND #1 = #5) type=differential // { arity: 6 }
+              implementation
+                %0[#0, #1]KK » %1:l0[#0, #1]KK
+              ArrangeBy keys=[[#0, #1]] // { arity: 4 }
+                Union // { arity: 4 }
+                  Map (null) // { arity: 4 }
+                    Union // { arity: 3 }
+                      Negate // { arity: 3 }
+                        Project (#0..=#2) // { arity: 3 }
+                          Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 5 }
+                            implementation
+                              %1[#0, #1]UKKA » %0:l9[#0, #1]KK
+                            Get l9 // { arity: 3 }
+                            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                              Distinct project=[#0, #1] // { arity: 2 }
+                                Project (#0, #1) // { arity: 2 }
+                                  Get l10 // { arity: 4 }
+                      Get l17 // { arity: 3 }
+                  Get l10 // { arity: 4 }
+              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                Project (#0, #1) // { arity: 2 }
+                  Get l0 // { arity: 3 }
+      cte l12 =
+        Distinct project=[#0] // { arity: 1 }
           Project (#1) // { arity: 1 }
-            Map ((#0{count} / 2)) // { arity: 2 }
-              Union // { arity: 1 }
-                Get l7 // { arity: 1 }
-                Map (0) // { arity: 1 }
-                  Union // { arity: 0 }
-                    Negate // { arity: 0 }
-                      Project () // { arity: 0 }
-                        Get l7 // { arity: 1 }
-                    Constant // { arity: 0 }
-                      - ()
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l19 // { arity: 1 }
-            Map (0) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l19 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
+            Get l11 // { arity: 4 }
+      cte l13 =
+        Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+          FlatMap wrap1("J", "-", "|", "F") // { arity: 2 }
+            Get l12 // { arity: 1 }
+      cte l14 =
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Get l12 // { arity: 1 }
+      cte l15 =
+        Union // { arity: 2 }
+          Get l13 // { arity: 2 }
+          Project (#0, #2) // { arity: 2 }
+            Map (false) // { arity: 3 }
+              Join on=(#0 = #1) type=differential // { arity: 2 }
+                implementation
+                  %1:l14[#0]UK » %0[#0]K
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Union // { arity: 1 }
+                    Negate // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Get l13 // { arity: 2 }
+                    Get l12 // { arity: 1 }
+                Get l14 // { arity: 1 }
+      cte l16 =
+        Union // { arity: 2 }
+          Get l15 // { arity: 2 }
+          Map (error("more than one record produced in subquery")) // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              Filter (#1{count} > 1) // { arity: 2 }
+                Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                  Project (#0) // { arity: 1 }
+                    Get l15 // { arity: 2 }
+      cte l17 =
+        Distinct project=[#0..=#2] // { arity: 3 }
+          Union // { arity: 3 }
+            Project (#0, #1, #3) // { arity: 3 }
+              Filter ((#0 = 1) OR (#1 = 1)) // { arity: 4 }
+                Map (false) // { arity: 4 }
+                  Get l0 // { arity: 3 }
+            Project (#2, #3, #6) // { arity: 3 }
+              Map (case when #5{any} then NOT(#0) else #0 end) // { arity: 7 }
+                Join on=(#1 = #4) type=differential // { arity: 6 }
+                  implementation
+                    %0:l11[#1]K » %1[#0]K
+                  ArrangeBy keys=[[#1]] // { arity: 4 }
+                    Get l11 // { arity: 4 }
+                  ArrangeBy keys=[[#0]] // { arity: 2 }
+                    Union // { arity: 2 }
+                      Get l16 // { arity: 2 }
+                      Project (#0, #2) // { arity: 2 }
+                        Map (null) // { arity: 3 }
+                          Join on=(#0 = #1) type=differential // { arity: 2 }
+                            implementation
+                              %1:l14[#0]UK » %0[#0]K
+                            ArrangeBy keys=[[#0]] // { arity: 1 }
+                              Union // { arity: 1 }
+                                Negate // { arity: 1 }
+                                  Distinct project=[#0] // { arity: 1 }
+                                    Project (#0) // { arity: 1 }
+                                      Get l16 // { arity: 2 }
+                                Get l12 // { arity: 1 }
+                            Get l14 // { arity: 1 }
+    Return // { arity: 2 }
+      With
+        cte l18 =
+          Project (#0, #1) // { arity: 2 }
+            Filter (#2 = true) // { arity: 3 }
+              Get l17 // { arity: 3 }
+        cte l19 =
+          Reduce aggregates=[count(*)] // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                    implementation
+                      %1[#0, #1]UKKA » %0:l18[#0, #1]UKKef
+                    ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                      Get l18 // { arity: 2 }
+                    ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                      Distinct project=[#0, #1] // { arity: 2 }
+                        Project (#0, #1) // { arity: 2 }
+                          Get l8 // { arity: 3 }
+              Project () // { arity: 0 }
+                Get l18 // { arity: 2 }
+      Return // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0[×]U » %1[×]U
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Map ((#0{count} / 2)) // { arity: 2 }
+                Union // { arity: 1 }
+                  Get l7 // { arity: 1 }
+                  Map (0) // { arity: 1 }
+                    Union // { arity: 0 }
+                      Negate // { arity: 0 }
+                        Project () // { arity: 0 }
+                          Get l7 // { arity: 1 }
+                      Constant // { arity: 0 }
+                        - ()
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l19 // { arity: 1 }
+              Map (0) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l19 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1212.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1212.slt
@@ -92,7 +92,7 @@ WITH MUTUALLY RECURSIVE
 SELECT SUM(count) FROM counts;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#1, #3, #4) // { arity: 3 }
         Map (regexp_split_to_array[" ", case_insensitive=false](array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))), (array_index(#2, 1) || "."), array_index(#2, 2)) // { arity: 5 }
@@ -109,80 +109,82 @@ Explained Query:
         Project (#0, #1) // { arity: 2 }
           Filter (#2 != "#") // { arity: 3 }
             Get l1 // { arity: 3 }
-    cte l3 =
-      Project (#0..=#2, #5) // { arity: 4 }
-        Join on=(#0 = #3 = #6 AND #4 = (#2 + 1) AND #7 = ((#1 + #5) + 1)) type=delta // { arity: 8 }
-          implementation
-            %0:l5 » %1[#0, #1]KK » %2:l2[#0, #1]KKf
-            %1 » %0:l5[#0, (#2 + 1)]KK » %2:l2[#0, #1]KKf
-            %2:l2 » %0:l5[#0]K » %1[#0, #1]KK
-          ArrangeBy keys=[[#0], [#0, (#2 + 1)]] // { arity: 3 }
-            Get l5 // { arity: 3 }
-          ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-            Project (#0, #2, #3) // { arity: 3 }
-              Map (text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2)))) // { arity: 4 }
-                FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#1) array_length 1), 1) // { arity: 3 }
-                  Project (#0, #2) // { arity: 2 }
-                    Get l0 // { arity: 3 }
-          Get l2 // { arity: 2 }
-    cte l4 =
-      Distinct project=[#0..=#2] // { arity: 3 }
-        Project (#0, #1, #3) // { arity: 3 }
-          Get l3 // { arity: 4 }
-    cte l5 =
-      Union // { arity: 3 }
-        Project (#0, #3, #4) // { arity: 3 }
-          Map (0, 0) // { arity: 5 }
-            Get l0 // { arity: 3 }
-        Project (#0, #5, #2) // { arity: 3 }
-          Map ((#1 + 1)) // { arity: 6 }
-            Join on=(#0 = #3 AND #4 = (#1 + 1)) type=differential // { arity: 5 }
-              implementation
-                %1:l2[#0, #1]KKf » %0:l5[#0, (#1 + 1)]KKf
-              ArrangeBy keys=[[#0, (#1 + 1)]] // { arity: 3 }
-                Get l5 // { arity: 3 }
-              Get l2 // { arity: 2 }
-        Project (#0, #7, #8) // { arity: 3 }
-          Map (((#1 + #3) + 1), (#2 + 1)) // { arity: 9 }
-            Join on=(#0 = #4 AND #1 = #5 AND #3 = #6) type=differential // { arity: 7 }
-              implementation
-                %0:l3[#0, #1, #3]KKK » %1[#0..=#2]KKK
-              ArrangeBy keys=[[#0, #1, #3]] // { arity: 4 }
-                Get l3 // { arity: 4 }
-              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                Union // { arity: 3 }
-                  Negate // { arity: 3 }
-                    Distinct project=[#0..=#2] // { arity: 3 }
-                      Project (#0..=#2) // { arity: 3 }
-                        Filter (#4 >= (#1 + 1)) AND (#4 <= (#1 + #2)) // { arity: 5 }
-                          Join on=(#0 = #3) type=differential // { arity: 5 }
-                            implementation
-                              %1:l1[#0]Kef » %0:l4[#0]Kef
-                            ArrangeBy keys=[[#0]] // { arity: 3 }
-                              Get l4 // { arity: 3 }
-                            ArrangeBy keys=[[#0]] // { arity: 2 }
-                              Project (#0, #1) // { arity: 2 }
-                                Filter (#2 = ".") // { arity: 3 }
-                                  Get l1 // { arity: 3 }
-                  Get l4 // { arity: 3 }
   Return // { arity: 1 }
-    With
-      cte l6 =
-        Reduce aggregates=[sum(#0{count})] // { arity: 1 }
-          Project (#3{count}) // { arity: 1 }
-            TopK group_by=[#0] order_by=[#1 desc nulls_first, #2 desc nulls_first] limit=1 // { arity: 4 }
-              Reduce group_by=[#0..=#2] aggregates=[count(*)] // { arity: 4 }
-                Get l5 // { arity: 3 }
+    With Mutually Recursive
+      cte l3 =
+        Project (#0..=#2, #5) // { arity: 4 }
+          Join on=(#0 = #3 = #6 AND #4 = (#2 + 1) AND #7 = ((#1 + #5) + 1)) type=delta // { arity: 8 }
+            implementation
+              %0:l5 » %1[#0, #1]KK » %2:l2[#0, #1]KKf
+              %1 » %0:l5[#0, (#2 + 1)]KK » %2:l2[#0, #1]KKf
+              %2:l2 » %0:l5[#0]K » %1[#0, #1]KK
+            ArrangeBy keys=[[#0], [#0, (#2 + 1)]] // { arity: 3 }
+              Get l5 // { arity: 3 }
+            ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+              Project (#0, #2, #3) // { arity: 3 }
+                Map (text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2)))) // { arity: 4 }
+                  FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#1) array_length 1), 1) // { arity: 3 }
+                    Project (#0, #2) // { arity: 2 }
+                      Get l0 // { arity: 3 }
+            Get l2 // { arity: 2 }
+      cte l4 =
+        Distinct project=[#0..=#2] // { arity: 3 }
+          Project (#0, #1, #3) // { arity: 3 }
+            Get l3 // { arity: 4 }
+      cte l5 =
+        Union // { arity: 3 }
+          Project (#0, #3, #4) // { arity: 3 }
+            Map (0, 0) // { arity: 5 }
+              Get l0 // { arity: 3 }
+          Project (#0, #5, #2) // { arity: 3 }
+            Map ((#1 + 1)) // { arity: 6 }
+              Join on=(#0 = #3 AND #4 = (#1 + 1)) type=differential // { arity: 5 }
+                implementation
+                  %1:l2[#0, #1]KKf » %0:l5[#0, (#1 + 1)]KKf
+                ArrangeBy keys=[[#0, (#1 + 1)]] // { arity: 3 }
+                  Get l5 // { arity: 3 }
+                Get l2 // { arity: 2 }
+          Project (#0, #7, #8) // { arity: 3 }
+            Map (((#1 + #3) + 1), (#2 + 1)) // { arity: 9 }
+              Join on=(#0 = #4 AND #1 = #5 AND #3 = #6) type=differential // { arity: 7 }
+                implementation
+                  %0:l3[#0, #1, #3]KKK » %1[#0..=#2]KKK
+                ArrangeBy keys=[[#0, #1, #3]] // { arity: 4 }
+                  Get l3 // { arity: 4 }
+                ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                  Union // { arity: 3 }
+                    Negate // { arity: 3 }
+                      Distinct project=[#0..=#2] // { arity: 3 }
+                        Project (#0..=#2) // { arity: 3 }
+                          Filter (#4 >= (#1 + 1)) AND (#4 <= (#1 + #2)) // { arity: 5 }
+                            Join on=(#0 = #3) type=differential // { arity: 5 }
+                              implementation
+                                %1:l1[#0]Kef » %0:l4[#0]Kef
+                              ArrangeBy keys=[[#0]] // { arity: 3 }
+                                Get l4 // { arity: 3 }
+                              ArrangeBy keys=[[#0]] // { arity: 2 }
+                                Project (#0, #1) // { arity: 2 }
+                                  Filter (#2 = ".") // { arity: 3 }
+                                    Get l1 // { arity: 3 }
+                    Get l4 // { arity: 3 }
     Return // { arity: 1 }
-      Union // { arity: 1 }
-        Get l6 // { arity: 1 }
-        Map (null) // { arity: 1 }
-          Union // { arity: 0 }
-            Negate // { arity: 0 }
-              Project () // { arity: 0 }
-                Get l6 // { arity: 1 }
-            Constant // { arity: 0 }
-              - ()
+      With
+        cte l6 =
+          Reduce aggregates=[sum(#0{count})] // { arity: 1 }
+            Project (#3{count}) // { arity: 1 }
+              TopK group_by=[#0] order_by=[#1 desc nulls_first, #2 desc nulls_first] limit=1 // { arity: 4 }
+                Reduce group_by=[#0..=#2] aggregates=[count(*)] // { arity: 4 }
+                  Get l5 // { arity: 3 }
+      Return // { arity: 1 }
+        Union // { arity: 1 }
+          Get l6 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l6 // { arity: 1 }
+              Constant // { arity: 0 }
+                - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1214.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1214.slt
@@ -128,99 +128,101 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM part1;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#1, #2) // { arity: 2 }
         Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
           FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
             ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Project (#0, #2, #3) // { arity: 3 }
-        Map (substr(#1, #2, 1)) // { arity: 4 }
-          FlatMap generate_series(1, char_length(#1), 1) // { arity: 3 }
-            Get l0 // { arity: 2 }
-    cte l2 =
-      Threshold // { arity: 3 }
-        Union // { arity: 3 }
-          Threshold // { arity: 3 }
-            Union // { arity: 3 }
-              Threshold // { arity: 3 }
-                Union // { arity: 3 }
-                  Get l2 // { arity: 3 }
-                  Project (#2, #1, #3) // { arity: 3 }
-                    Map ((#0 - 1), "O") // { arity: 4 }
-                      Get l4 // { arity: 2 }
-                  Negate // { arity: 3 }
-                    Project (#2, #1, #3) // { arity: 3 }
-                      Map ((#0 - 1), ".") // { arity: 4 }
-                        Get l4 // { arity: 2 }
-              Map (".") // { arity: 3 }
-                Get l4 // { arity: 2 }
-              Negate // { arity: 3 }
-                Map ("O") // { arity: 3 }
-                  Get l4 // { arity: 2 }
-          Get l1 // { arity: 3 }
-          Negate // { arity: 3 }
-            Get l8 // { arity: 3 }
-    cte l3 =
-      Project (#0, #1) // { arity: 2 }
-        Filter (#2 = "O") // { arity: 3 }
-          Get l2 // { arity: 3 }
-    cte l4 =
-      Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = (#2 + 1) AND #1 = #3) type=differential // { arity: 4 }
-          implementation
-            %0:l3[#1, #0]KKef » %1:l2[#1, (#0 + 1)]KKef
-          ArrangeBy keys=[[#1, #0]] // { arity: 2 }
-            Get l3 // { arity: 2 }
-          ArrangeBy keys=[[#1, (#0 + 1)]] // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Filter (#2 = ".") // { arity: 3 }
-                Get l2 // { arity: 3 }
-    cte l5 =
       Reduce aggregates=[max(#0)] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Get l0 // { arity: 2 }
-    cte l6 =
+    cte l2 =
       Union // { arity: 1 }
-        Get l5 // { arity: 1 }
+        Get l1 // { arity: 1 }
         Map (null) // { arity: 1 }
           Union // { arity: 0 }
             Negate // { arity: 0 }
               Project () // { arity: 0 }
-                Get l5 // { arity: 1 }
+                Get l1 // { arity: 1 }
             Constant // { arity: 0 }
               - ()
-    cte l7 =
-      Reduce aggregates=[sum(((1 + #1{max}) - #0))] // { arity: 1 }
-        CrossJoin type=differential // { arity: 2 }
-          implementation
-            %1[×]U » %0:l3[×]ef
-          ArrangeBy keys=[[]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Get l3 // { arity: 2 }
-          ArrangeBy keys=[[]] // { arity: 1 }
-            Union // { arity: 1 }
-              Get l6 // { arity: 1 }
-              Map (null) // { arity: 1 }
-                Union // { arity: 0 }
-                  Negate // { arity: 0 }
-                    Project () // { arity: 0 }
-                      Get l6 // { arity: 1 }
-                  Constant // { arity: 0 }
-                    - ()
-    cte l8 =
-      Get l1 // { arity: 3 }
+    cte l3 =
+      Project (#0, #2, #3) // { arity: 3 }
+        Map (substr(#1, #2, 1)) // { arity: 4 }
+          FlatMap generate_series(1, char_length(#1), 1) // { arity: 3 }
+            Get l0 // { arity: 2 }
   Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l7 // { arity: 1 }
-      Map (null) // { arity: 1 }
-        Union // { arity: 0 }
-          Negate // { arity: 0 }
-            Project () // { arity: 0 }
-              Get l7 // { arity: 1 }
-          Constant // { arity: 0 }
-            - ()
+    With Mutually Recursive
+      cte l4 =
+        Threshold // { arity: 3 }
+          Union // { arity: 3 }
+            Threshold // { arity: 3 }
+              Union // { arity: 3 }
+                Threshold // { arity: 3 }
+                  Union // { arity: 3 }
+                    Get l4 // { arity: 3 }
+                    Project (#2, #1, #3) // { arity: 3 }
+                      Map ((#0 - 1), "O") // { arity: 4 }
+                        Get l6 // { arity: 2 }
+                    Negate // { arity: 3 }
+                      Project (#2, #1, #3) // { arity: 3 }
+                        Map ((#0 - 1), ".") // { arity: 4 }
+                          Get l6 // { arity: 2 }
+                Map (".") // { arity: 3 }
+                  Get l6 // { arity: 2 }
+                Negate // { arity: 3 }
+                  Map ("O") // { arity: 3 }
+                    Get l6 // { arity: 2 }
+            Get l3 // { arity: 3 }
+            Negate // { arity: 3 }
+              Get l8 // { arity: 3 }
+      cte l5 =
+        Project (#0, #1) // { arity: 2 }
+          Filter (#2 = "O") // { arity: 3 }
+            Get l4 // { arity: 3 }
+      cte l6 =
+        Project (#0, #1) // { arity: 2 }
+          Join on=(#0 = (#2 + 1) AND #1 = #3) type=differential // { arity: 4 }
+            implementation
+              %0:l5[#1, #0]KKef » %1:l4[#1, (#0 + 1)]KKef
+            ArrangeBy keys=[[#1, #0]] // { arity: 2 }
+              Get l5 // { arity: 2 }
+            ArrangeBy keys=[[#1, (#0 + 1)]] // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Filter (#2 = ".") // { arity: 3 }
+                  Get l4 // { arity: 3 }
+      cte l7 =
+        Reduce aggregates=[sum(((1 + #1{max}) - #0))] // { arity: 1 }
+          CrossJoin type=differential // { arity: 2 }
+            implementation
+              %1[×]U » %0:l5[×]ef
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l5 // { arity: 2 }
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Union // { arity: 1 }
+                Get l2 // { arity: 1 }
+                Map (null) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l2 // { arity: 1 }
+                    Constant // { arity: 0 }
+                      - ()
+      cte l8 =
+        Get l3 // { arity: 3 }
+    Return // { arity: 1 }
+      Union // { arity: 1 }
+        Get l7 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l7 // { arity: 1 }
+            Constant // { arity: 0 }
+              - ()
 
 Source materialize.public.input
 
@@ -574,237 +576,239 @@ WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 142)
 SELECT * FROM part2;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#1, #2) // { arity: 2 }
         Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
           FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
             ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Project (#0, #2, #3) // { arity: 3 }
-        Map (substr(#1, #2, 1)) // { arity: 4 }
-          FlatMap generate_series(1, char_length(#1), 1) // { arity: 3 }
-            Get l0 // { arity: 2 }
-    cte [recursion_limit=142, return_at_limit] l2 =
-      Threshold // { arity: 3 }
-        Union // { arity: 3 }
-          Get l18 // { arity: 3 }
-          Get l1 // { arity: 3 }
-          Negate // { arity: 3 }
-            Get l22 // { arity: 3 }
-    cte l6 =
-      With Mutually Recursive
-        cte l3 =
-          Threshold // { arity: 3 }
-            Union // { arity: 3 }
-              Threshold // { arity: 3 }
-                Union // { arity: 3 }
-                  Threshold // { arity: 3 }
-                    Union // { arity: 3 }
-                      Get l3 // { arity: 3 }
-                      Project (#2, #1, #3) // { arity: 3 }
-                        Map ((#0 - 1), "O") // { arity: 4 }
-                          Get l4 // { arity: 2 }
-                      Negate // { arity: 3 }
-                        Project (#2, #1, #3) // { arity: 3 }
-                          Map ((#0 - 1), ".") // { arity: 4 }
-                            Get l4 // { arity: 2 }
-                  Map (".") // { arity: 3 }
-                    Get l4 // { arity: 2 }
-                  Negate // { arity: 3 }
-                    Map ("O") // { arity: 3 }
-                      Get l4 // { arity: 2 }
-              Get l2 // { arity: 3 }
-              Negate // { arity: 3 }
-                Get l5 // { arity: 3 }
-        cte l4 =
-          Project (#0, #1) // { arity: 2 }
-            Join on=(#0 = (#2 + 1) AND #1 = #3) type=differential // { arity: 4 }
-              implementation
-                %0:l3[#1, #0]KKef » %1:l3[#1, (#0 + 1)]KKef
-              ArrangeBy keys=[[#1, #0]] // { arity: 2 }
-                Project (#0, #1) // { arity: 2 }
-                  Filter (#2 = "O") // { arity: 3 }
-                    Get l3 // { arity: 3 }
-              ArrangeBy keys=[[#1, (#0 + 1)]] // { arity: 2 }
-                Project (#0, #1) // { arity: 2 }
-                  Filter (#2 = ".") // { arity: 3 }
-                    Get l3 // { arity: 3 }
-        cte l5 =
-          Get l2 // { arity: 3 }
-      Return // { arity: 3 }
-        Get l3 // { arity: 3 }
-    cte l10 =
-      With Mutually Recursive
-        cte l7 =
-          Threshold // { arity: 3 }
-            Union // { arity: 3 }
-              Threshold // { arity: 3 }
-                Union // { arity: 3 }
-                  Threshold // { arity: 3 }
-                    Union // { arity: 3 }
-                      Get l7 // { arity: 3 }
-                      Project (#0, #2, #3) // { arity: 3 }
-                        Map ((#1 - 1), "O") // { arity: 4 }
-                          Get l8 // { arity: 2 }
-                      Negate // { arity: 3 }
-                        Project (#0, #2, #3) // { arity: 3 }
-                          Map ((#1 - 1), ".") // { arity: 4 }
-                            Get l8 // { arity: 2 }
-                  Map (".") // { arity: 3 }
-                    Get l8 // { arity: 2 }
-                  Negate // { arity: 3 }
-                    Map ("O") // { arity: 3 }
-                      Get l8 // { arity: 2 }
-              Get l6 // { arity: 3 }
-              Negate // { arity: 3 }
-                Get l9 // { arity: 3 }
-        cte l8 =
-          Project (#0, #1) // { arity: 2 }
-            Join on=(#0 = #2 AND #1 = (#3 + 1)) type=differential // { arity: 4 }
-              implementation
-                %0:l7[#0, #1]KKef » %1:l7[#0, (#1 + 1)]KKef
-              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                Project (#0, #1) // { arity: 2 }
-                  Filter (#2 = "O") // { arity: 3 }
-                    Get l7 // { arity: 3 }
-              ArrangeBy keys=[[#0, (#1 + 1)]] // { arity: 2 }
-                Project (#0, #1) // { arity: 2 }
-                  Filter (#2 = ".") // { arity: 3 }
-                    Get l7 // { arity: 3 }
-        cte l9 =
-          Get l6 // { arity: 3 }
-      Return // { arity: 3 }
-        Get l7 // { arity: 3 }
-    cte l14 =
-      With Mutually Recursive
-        cte l11 =
-          Threshold // { arity: 3 }
-            Union // { arity: 3 }
-              Threshold // { arity: 3 }
-                Union // { arity: 3 }
-                  Threshold // { arity: 3 }
-                    Union // { arity: 3 }
-                      Get l11 // { arity: 3 }
-                      Project (#2, #1, #3) // { arity: 3 }
-                        Map ((#0 + 1), "O") // { arity: 4 }
-                          Get l12 // { arity: 2 }
-                      Negate // { arity: 3 }
-                        Project (#2, #1, #3) // { arity: 3 }
-                          Map ((#0 + 1), ".") // { arity: 4 }
-                            Get l12 // { arity: 2 }
-                  Map (".") // { arity: 3 }
-                    Get l12 // { arity: 2 }
-                  Negate // { arity: 3 }
-                    Map ("O") // { arity: 3 }
-                      Get l12 // { arity: 2 }
-              Get l10 // { arity: 3 }
-              Negate // { arity: 3 }
-                Get l13 // { arity: 3 }
-        cte l12 =
-          Project (#0, #1) // { arity: 2 }
-            Join on=(#0 = (#2 - 1) AND #1 = #3) type=differential // { arity: 4 }
-              implementation
-                %0:l11[#1, #0]KKef » %1:l11[#1, (#0 - 1)]KKef
-              ArrangeBy keys=[[#1, #0]] // { arity: 2 }
-                Project (#0, #1) // { arity: 2 }
-                  Filter (#2 = "O") // { arity: 3 }
-                    Get l11 // { arity: 3 }
-              ArrangeBy keys=[[#1, (#0 - 1)]] // { arity: 2 }
-                Project (#0, #1) // { arity: 2 }
-                  Filter (#2 = ".") // { arity: 3 }
-                    Get l11 // { arity: 3 }
-        cte l13 =
-          Get l10 // { arity: 3 }
-      Return // { arity: 3 }
-        Get l11 // { arity: 3 }
-    cte [recursion_limit=142, return_at_limit] l18 =
-      With Mutually Recursive
-        cte l15 =
-          Threshold // { arity: 3 }
-            Union // { arity: 3 }
-              Threshold // { arity: 3 }
-                Union // { arity: 3 }
-                  Threshold // { arity: 3 }
-                    Union // { arity: 3 }
-                      Get l15 // { arity: 3 }
-                      Project (#0, #2, #3) // { arity: 3 }
-                        Map ((#1 + 1), "O") // { arity: 4 }
-                          Get l16 // { arity: 2 }
-                      Negate // { arity: 3 }
-                        Project (#0, #2, #3) // { arity: 3 }
-                          Map ((#1 + 1), ".") // { arity: 4 }
-                            Get l16 // { arity: 2 }
-                  Map (".") // { arity: 3 }
-                    Get l16 // { arity: 2 }
-                  Negate // { arity: 3 }
-                    Map ("O") // { arity: 3 }
-                      Get l16 // { arity: 2 }
-              Get l14 // { arity: 3 }
-              Negate // { arity: 3 }
-                Get l17 // { arity: 3 }
-        cte l16 =
-          Project (#0, #1) // { arity: 2 }
-            Join on=(#0 = #2 AND #1 = (#3 - 1)) type=differential // { arity: 4 }
-              implementation
-                %0:l15[#0, #1]KKef » %1:l15[#0, (#1 - 1)]KKef
-              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                Project (#0, #1) // { arity: 2 }
-                  Filter (#2 = "O") // { arity: 3 }
-                    Get l15 // { arity: 3 }
-              ArrangeBy keys=[[#0, (#1 - 1)]] // { arity: 2 }
-                Project (#0, #1) // { arity: 2 }
-                  Filter (#2 = ".") // { arity: 3 }
-                    Get l15 // { arity: 3 }
-        cte l17 =
-          Get l14 // { arity: 3 }
-      Return // { arity: 3 }
-        Get l15 // { arity: 3 }
-    cte l19 =
       Reduce aggregates=[max(#0)] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Get l0 // { arity: 2 }
-    cte l20 =
+    cte l2 =
       Union // { arity: 1 }
-        Get l19 // { arity: 1 }
+        Get l1 // { arity: 1 }
         Map (null) // { arity: 1 }
           Union // { arity: 0 }
             Negate // { arity: 0 }
               Project () // { arity: 0 }
-                Get l19 // { arity: 1 }
+                Get l1 // { arity: 1 }
             Constant // { arity: 0 }
               - ()
-    cte l21 =
-      Reduce aggregates=[sum(((1 + #1{max}) - #0))] // { arity: 1 }
-        CrossJoin type=differential // { arity: 2 }
-          implementation
-            %1[×]U » %0:l18[×]ef
-          ArrangeBy keys=[[]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#2 = "O") // { arity: 3 }
-                Get l18 // { arity: 3 }
-          ArrangeBy keys=[[]] // { arity: 1 }
-            Union // { arity: 1 }
-              Get l20 // { arity: 1 }
-              Map (null) // { arity: 1 }
-                Union // { arity: 0 }
-                  Negate // { arity: 0 }
-                    Project () // { arity: 0 }
-                      Get l20 // { arity: 1 }
-                  Constant // { arity: 0 }
-                    - ()
-    cte [recursion_limit=142, return_at_limit] l22 =
-      Get l1 // { arity: 3 }
+    cte l3 =
+      Project (#0, #2, #3) // { arity: 3 }
+        Map (substr(#1, #2, 1)) // { arity: 4 }
+          FlatMap generate_series(1, char_length(#1), 1) // { arity: 3 }
+            Get l0 // { arity: 2 }
   Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l21 // { arity: 1 }
-      Map (null) // { arity: 1 }
-        Union // { arity: 0 }
-          Negate // { arity: 0 }
-            Project () // { arity: 0 }
-              Get l21 // { arity: 1 }
-          Constant // { arity: 0 }
-            - ()
+    With Mutually Recursive
+      cte [recursion_limit=142, return_at_limit] l4 =
+        Threshold // { arity: 3 }
+          Union // { arity: 3 }
+            Get l20 // { arity: 3 }
+            Get l3 // { arity: 3 }
+            Negate // { arity: 3 }
+              Get l22 // { arity: 3 }
+      cte l8 =
+        With Mutually Recursive
+          cte l5 =
+            Threshold // { arity: 3 }
+              Union // { arity: 3 }
+                Threshold // { arity: 3 }
+                  Union // { arity: 3 }
+                    Threshold // { arity: 3 }
+                      Union // { arity: 3 }
+                        Get l5 // { arity: 3 }
+                        Project (#2, #1, #3) // { arity: 3 }
+                          Map ((#0 - 1), "O") // { arity: 4 }
+                            Get l6 // { arity: 2 }
+                        Negate // { arity: 3 }
+                          Project (#2, #1, #3) // { arity: 3 }
+                            Map ((#0 - 1), ".") // { arity: 4 }
+                              Get l6 // { arity: 2 }
+                    Map (".") // { arity: 3 }
+                      Get l6 // { arity: 2 }
+                    Negate // { arity: 3 }
+                      Map ("O") // { arity: 3 }
+                        Get l6 // { arity: 2 }
+                Get l4 // { arity: 3 }
+                Negate // { arity: 3 }
+                  Get l7 // { arity: 3 }
+          cte l6 =
+            Project (#0, #1) // { arity: 2 }
+              Join on=(#0 = (#2 + 1) AND #1 = #3) type=differential // { arity: 4 }
+                implementation
+                  %0:l5[#1, #0]KKef » %1:l5[#1, (#0 + 1)]KKef
+                ArrangeBy keys=[[#1, #0]] // { arity: 2 }
+                  Project (#0, #1) // { arity: 2 }
+                    Filter (#2 = "O") // { arity: 3 }
+                      Get l5 // { arity: 3 }
+                ArrangeBy keys=[[#1, (#0 + 1)]] // { arity: 2 }
+                  Project (#0, #1) // { arity: 2 }
+                    Filter (#2 = ".") // { arity: 3 }
+                      Get l5 // { arity: 3 }
+          cte l7 =
+            Get l4 // { arity: 3 }
+        Return // { arity: 3 }
+          Get l5 // { arity: 3 }
+      cte l12 =
+        With Mutually Recursive
+          cte l9 =
+            Threshold // { arity: 3 }
+              Union // { arity: 3 }
+                Threshold // { arity: 3 }
+                  Union // { arity: 3 }
+                    Threshold // { arity: 3 }
+                      Union // { arity: 3 }
+                        Get l9 // { arity: 3 }
+                        Project (#0, #2, #3) // { arity: 3 }
+                          Map ((#1 - 1), "O") // { arity: 4 }
+                            Get l10 // { arity: 2 }
+                        Negate // { arity: 3 }
+                          Project (#0, #2, #3) // { arity: 3 }
+                            Map ((#1 - 1), ".") // { arity: 4 }
+                              Get l10 // { arity: 2 }
+                    Map (".") // { arity: 3 }
+                      Get l10 // { arity: 2 }
+                    Negate // { arity: 3 }
+                      Map ("O") // { arity: 3 }
+                        Get l10 // { arity: 2 }
+                Get l8 // { arity: 3 }
+                Negate // { arity: 3 }
+                  Get l11 // { arity: 3 }
+          cte l10 =
+            Project (#0, #1) // { arity: 2 }
+              Join on=(#0 = #2 AND #1 = (#3 + 1)) type=differential // { arity: 4 }
+                implementation
+                  %0:l9[#0, #1]KKef » %1:l9[#0, (#1 + 1)]KKef
+                ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                  Project (#0, #1) // { arity: 2 }
+                    Filter (#2 = "O") // { arity: 3 }
+                      Get l9 // { arity: 3 }
+                ArrangeBy keys=[[#0, (#1 + 1)]] // { arity: 2 }
+                  Project (#0, #1) // { arity: 2 }
+                    Filter (#2 = ".") // { arity: 3 }
+                      Get l9 // { arity: 3 }
+          cte l11 =
+            Get l8 // { arity: 3 }
+        Return // { arity: 3 }
+          Get l9 // { arity: 3 }
+      cte l16 =
+        With Mutually Recursive
+          cte l13 =
+            Threshold // { arity: 3 }
+              Union // { arity: 3 }
+                Threshold // { arity: 3 }
+                  Union // { arity: 3 }
+                    Threshold // { arity: 3 }
+                      Union // { arity: 3 }
+                        Get l13 // { arity: 3 }
+                        Project (#2, #1, #3) // { arity: 3 }
+                          Map ((#0 + 1), "O") // { arity: 4 }
+                            Get l14 // { arity: 2 }
+                        Negate // { arity: 3 }
+                          Project (#2, #1, #3) // { arity: 3 }
+                            Map ((#0 + 1), ".") // { arity: 4 }
+                              Get l14 // { arity: 2 }
+                    Map (".") // { arity: 3 }
+                      Get l14 // { arity: 2 }
+                    Negate // { arity: 3 }
+                      Map ("O") // { arity: 3 }
+                        Get l14 // { arity: 2 }
+                Get l12 // { arity: 3 }
+                Negate // { arity: 3 }
+                  Get l15 // { arity: 3 }
+          cte l14 =
+            Project (#0, #1) // { arity: 2 }
+              Join on=(#0 = (#2 - 1) AND #1 = #3) type=differential // { arity: 4 }
+                implementation
+                  %0:l13[#1, #0]KKef » %1:l13[#1, (#0 - 1)]KKef
+                ArrangeBy keys=[[#1, #0]] // { arity: 2 }
+                  Project (#0, #1) // { arity: 2 }
+                    Filter (#2 = "O") // { arity: 3 }
+                      Get l13 // { arity: 3 }
+                ArrangeBy keys=[[#1, (#0 - 1)]] // { arity: 2 }
+                  Project (#0, #1) // { arity: 2 }
+                    Filter (#2 = ".") // { arity: 3 }
+                      Get l13 // { arity: 3 }
+          cte l15 =
+            Get l12 // { arity: 3 }
+        Return // { arity: 3 }
+          Get l13 // { arity: 3 }
+      cte [recursion_limit=142, return_at_limit] l20 =
+        With Mutually Recursive
+          cte l17 =
+            Threshold // { arity: 3 }
+              Union // { arity: 3 }
+                Threshold // { arity: 3 }
+                  Union // { arity: 3 }
+                    Threshold // { arity: 3 }
+                      Union // { arity: 3 }
+                        Get l17 // { arity: 3 }
+                        Project (#0, #2, #3) // { arity: 3 }
+                          Map ((#1 + 1), "O") // { arity: 4 }
+                            Get l18 // { arity: 2 }
+                        Negate // { arity: 3 }
+                          Project (#0, #2, #3) // { arity: 3 }
+                            Map ((#1 + 1), ".") // { arity: 4 }
+                              Get l18 // { arity: 2 }
+                    Map (".") // { arity: 3 }
+                      Get l18 // { arity: 2 }
+                    Negate // { arity: 3 }
+                      Map ("O") // { arity: 3 }
+                        Get l18 // { arity: 2 }
+                Get l16 // { arity: 3 }
+                Negate // { arity: 3 }
+                  Get l19 // { arity: 3 }
+          cte l18 =
+            Project (#0, #1) // { arity: 2 }
+              Join on=(#0 = #2 AND #1 = (#3 - 1)) type=differential // { arity: 4 }
+                implementation
+                  %0:l17[#0, #1]KKef » %1:l17[#0, (#1 - 1)]KKef
+                ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                  Project (#0, #1) // { arity: 2 }
+                    Filter (#2 = "O") // { arity: 3 }
+                      Get l17 // { arity: 3 }
+                ArrangeBy keys=[[#0, (#1 - 1)]] // { arity: 2 }
+                  Project (#0, #1) // { arity: 2 }
+                    Filter (#2 = ".") // { arity: 3 }
+                      Get l17 // { arity: 3 }
+          cte l19 =
+            Get l16 // { arity: 3 }
+        Return // { arity: 3 }
+          Get l17 // { arity: 3 }
+      cte l21 =
+        Reduce aggregates=[sum(((1 + #1{max}) - #0))] // { arity: 1 }
+          CrossJoin type=differential // { arity: 2 }
+            implementation
+              %1[×]U » %0:l20[×]ef
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Filter (#2 = "O") // { arity: 3 }
+                  Get l20 // { arity: 3 }
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Union // { arity: 1 }
+                Get l2 // { arity: 1 }
+                Map (null) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l2 // { arity: 1 }
+                    Constant // { arity: 0 }
+                      - ()
+      cte [recursion_limit=142, return_at_limit] l22 =
+        Get l3 // { arity: 3 }
+    Return // { arity: 1 }
+      Union // { arity: 1 }
+        Get l21 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l21 // { arity: 1 }
+            Constant // { arity: 0 }
+              - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1215.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1215.slt
@@ -198,270 +198,213 @@ WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 10)
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#1, #2) // { arity: 2 }
         Map (array_index(regexp_split_to_array[",", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
           FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
             ReadStorage materialize.public.input // { arity: 1 }
-    cte [recursion_limit=10, return_at_limit] l1 =
-      Union // { arity: 2 }
-        Project (#1, #2) // { arity: 2 }
-          Map (0) // { arity: 3 }
-            Get l0 // { arity: 2 }
-        Project (#2, #3) // { arity: 2 }
-          Filter (char_length(#0) > 0) // { arity: 4 }
-            Map (substr(#0, 2), (((#1 + integer_to_bigint(ascii(substr(#0, 1, 1)))) * 17) % 256)) // { arity: 4 }
-              Get l1 // { arity: 2 }
-    cte l2 =
-      Reduce aggregates=[sum(#0)] // { arity: 1 }
-        Project (#1) // { arity: 1 }
-          Filter (#0 = "") // { arity: 2 }
-            Get l1 // { arity: 2 }
-    cte l3 =
+    cte l1 =
       Distinct project=[#0] // { arity: 1 }
         Project (#2) // { arity: 1 }
           Map (case when ("-" = substr(#1, char_length(#1))) then substr(#1, 1, (char_length(#1) - 1)) else substr(#1, 1, (char_length(#1) - 2)) end) // { arity: 3 }
             Get l0 // { arity: 2 }
-    cte l4 =
+    cte l2 =
       Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
           Join on=(#0 = #2) type=differential // { arity: 3 }
             implementation
-              %0:l3[#0]UK » %1:l0[#1]Kef
+              %0:l1[#0]UKA » %1:l0[#1]Kef
             ArrangeBy keys=[[#0]] // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 1 }
-                Get l3 // { arity: 1 }
+              Get l1 // { arity: 1 }
             ArrangeBy keys=[[#1]] // { arity: 2 }
               Project (#0, #3) // { arity: 2 }
                 Filter (#3) IS NOT NULL AND (0 = case when #2 then 0 else text_to_integer(substr(#1, char_length(#1))) end) // { arity: 4 }
                   Map (("-" = substr(#1, char_length(#1))), case when #2 then substr(#1, 1, (char_length(#1) - 1)) else substr(#1, 1, (char_length(#1) - 2)) end) // { arity: 4 }
                     Get l0 // { arity: 2 }
-    cte l5 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Get l3 // { arity: 1 }
-    cte l6 =
+    cte l3 =
       Union // { arity: 2 }
-        Get l4 // { arity: 2 }
-        Project (#0, #2) // { arity: 2 }
-          Map (null) // { arity: 3 }
-            Join on=(#0 = #1) type=differential // { arity: 2 }
-              implementation
-                %1:l5[#0]UK » %0[#0]K
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Union // { arity: 1 }
-                  Negate // { arity: 1 }
-                    Project (#0) // { arity: 1 }
-                      Get l4 // { arity: 2 }
-                  Get l3 // { arity: 1 }
-              Get l5 // { arity: 1 }
-    cte l7 =
-      Union // { arity: 2 }
-        Get l6 // { arity: 2 }
-        Map (error("more than one record produced in subquery")) // { arity: 2 }
-          Project (#0) // { arity: 1 }
-            Filter (#1{count} > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                Project (#0) // { arity: 1 }
-                  Get l6 // { arity: 2 }
-    cte l8 =
+        Get l2 // { arity: 2 }
+        Map (null) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l2 // { arity: 2 }
+            Get l1 // { arity: 1 }
+    cte l4 =
       Project (#0..=#2) // { arity: 3 }
         Filter (#0 > coalesce(#4{max}, 0)) // { arity: 5 }
           Join on=(#1 = #3) type=differential // { arity: 5 }
             implementation
-              %0:l0[#1]K » %1[#0]K
+              %1[#0]UK » %0:l0[#1]K
             ArrangeBy keys=[[#1]] // { arity: 3 }
               Project (#0, #3, #4) // { arity: 3 }
                 Map (("-" = substr(#1, char_length(#1))), case when #2 then substr(#1, 1, (char_length(#1) - 1)) else substr(#1, 1, (char_length(#1) - 2)) end, case when #2 then 0 else text_to_integer(substr(#1, char_length(#1))) end) // { arity: 5 }
                   Get l0 // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 2 }
               Union // { arity: 2 }
-                Get l7 // { arity: 2 }
-                Project (#0, #2) // { arity: 2 }
-                  Map (null) // { arity: 3 }
-                    Join on=(#0 = #1) type=differential // { arity: 2 }
-                      implementation
-                        %1:l5[#0]UK » %0[#0]K
-                      ArrangeBy keys=[[#0]] // { arity: 1 }
-                        Union // { arity: 1 }
-                          Negate // { arity: 1 }
-                            Distinct project=[#0] // { arity: 1 }
-                              Project (#0) // { arity: 1 }
-                                Get l7 // { arity: 2 }
-                          Get l3 // { arity: 1 }
-                      Get l5 // { arity: 1 }
-    cte l9 =
-      Distinct project=[#0..=#2] // { arity: 3 }
-        Get l8 // { arity: 3 }
-    cte l10 =
+                Get l3 // { arity: 2 }
+                Map (null) // { arity: 2 }
+                  Union // { arity: 1 }
+                    Negate // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Get l3 // { arity: 2 }
+                    Get l1 // { arity: 1 }
+    cte l5 =
       Distinct project=[#0] // { arity: 1 }
         Project (#1) // { arity: 1 }
-          Get l9 // { arity: 3 }
-    cte l11 =
+          Get l4 // { arity: 3 }
+    cte l6 =
       Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
           Join on=(#0 = #2) type=differential // { arity: 3 }
             implementation
-              %0:l10[#0]UK » %1:l8[#1]K
+              %0:l5[#0]UKA » %1:l4[#1]K
             ArrangeBy keys=[[#0]] // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 1 }
-                Get l10 // { arity: 1 }
+              Get l5 // { arity: 1 }
             ArrangeBy keys=[[#1]] // { arity: 2 }
               Project (#0, #1) // { arity: 2 }
                 Filter (#1) IS NOT NULL // { arity: 3 }
-                  Get l8 // { arity: 3 }
-    cte l12 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Get l10 // { arity: 1 }
-    cte l13 =
+                  Get l4 // { arity: 3 }
+    cte l7 =
       Union // { arity: 2 }
-        Get l11 // { arity: 2 }
-        Project (#0, #2) // { arity: 2 }
-          Map (null) // { arity: 3 }
-            Join on=(#0 = #1) type=differential // { arity: 2 }
-              implementation
-                %1:l12[#0]UK » %0[#0]K
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Union // { arity: 1 }
-                  Negate // { arity: 1 }
-                    Project (#0) // { arity: 1 }
-                      Get l11 // { arity: 2 }
-                  Get l10 // { arity: 1 }
-              Get l12 // { arity: 1 }
-    cte l14 =
-      Union // { arity: 2 }
-        Get l13 // { arity: 2 }
-        Map (error("more than one record produced in subquery")) // { arity: 2 }
-          Project (#0) // { arity: 1 }
-            Filter (#1{count} > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                Project (#0) // { arity: 1 }
-                  Get l13 // { arity: 2 }
-    cte l15 =
+        Get l6 // { arity: 2 }
+        Map (null) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l6 // { arity: 2 }
+            Get l5 // { arity: 1 }
+    cte l8 =
       Project (#1..=#4) // { arity: 4 }
         TopK group_by=[#1] order_by=[#0 desc nulls_first, #2 asc nulls_last] limit=1 // { arity: 5 }
-          Project (#0..=#2, #7{min}, #8) // { arity: 5 }
-            Map ((#1) IS NULL) // { arity: 9 }
-              Join on=(#0 = #3 AND #1 = #4 = #6 AND #2 = #5) type=delta // { arity: 8 }
+          Project (#0..=#2, #4{min}, #5) // { arity: 5 }
+            Map ((#1) IS NULL) // { arity: 6 }
+              Join on=(#1 = #3) type=differential // { arity: 5 }
                 implementation
-                  %0:l8 » %1:l9[#0..=#2]UKKK » %2[#0]K
-                  %1:l9 » %0:l8[#0..=#2]KKK » %2[#0]K
-                  %2 » %0:l8[#1]K » %1:l9[#0..=#2]UKKK
-                ArrangeBy keys=[[#0..=#2], [#1]] // { arity: 3 }
-                  Get l8 // { arity: 3 }
-                ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                  Get l9 // { arity: 3 }
+                  %1[#0]UK » %0:l4[#1]K
+                ArrangeBy keys=[[#1]] // { arity: 3 }
+                  Get l4 // { arity: 3 }
                 ArrangeBy keys=[[#0]] // { arity: 2 }
                   Union // { arity: 2 }
-                    Get l14 // { arity: 2 }
-                    Project (#0, #2) // { arity: 2 }
-                      Map (null) // { arity: 3 }
-                        Join on=(#0 = #1) type=differential // { arity: 2 }
-                          implementation
-                            %1:l12[#0]UK » %0[#0]K
-                          ArrangeBy keys=[[#0]] // { arity: 1 }
-                            Union // { arity: 1 }
-                              Negate // { arity: 1 }
-                                Distinct project=[#0] // { arity: 1 }
-                                  Project (#0) // { arity: 1 }
-                                    Get l14 // { arity: 2 }
-                              Get l10 // { arity: 1 }
-                          Get l12 // { arity: 1 }
-    cte [recursion_limit=10, return_at_limit] l16 =
-      Union // { arity: 3 }
-        Project (#0, #0, #4) // { arity: 3 }
-          Map (0) // { arity: 5 }
-            Get l15 // { arity: 4 }
-        Project (#0, #3, #4) // { arity: 3 }
-          Filter (char_length(#1) > 0) // { arity: 5 }
-            Map (substr(#1, 2), (((#2 + integer_to_bigint(ascii(substr(#1, 1, 1)))) * 17) % 256)) // { arity: 5 }
-              Get l16 // { arity: 3 }
+                    Get l7 // { arity: 2 }
+                    Map (null) // { arity: 2 }
+                      Union // { arity: 1 }
+                        Negate // { arity: 1 }
+                          Project (#0) // { arity: 1 }
+                            Get l7 // { arity: 2 }
+                        Get l5 // { arity: 1 }
   Return // { arity: 2 }
-    With
-      cte l17 =
-        Project (#1, #3, #4{min}) // { arity: 3 }
-          Join on=(#0 = #2) type=differential // { arity: 5 }
-            implementation
-              %1:l15[#0]UKf » %0:l16[#0]Kef
-            ArrangeBy keys=[[#0]] // { arity: 2 }
-              Project (#0, #2) // { arity: 2 }
-                Filter (#1 = "") AND (#0) IS NOT NULL // { arity: 3 }
-                  Get l16 // { arity: 3 }
-            ArrangeBy keys=[[#0]] // { arity: 3 }
-              Project (#0..=#2{min}) // { arity: 3 }
-                Filter NOT(#3) // { arity: 4 }
-                  Get l15 // { arity: 4 }
-      cte l18 =
-        Project (#0, #2{min}) // { arity: 2 }
-          Get l17 // { arity: 3 }
-      cte l19 =
-        Distinct project=[#0, #1{min}] // { arity: 2 }
-          Get l18 // { arity: 2 }
-      cte l20 =
-        Reduce group_by=[#0, #1{min}] aggregates=[count(*)] // { arity: 3 }
-          Project (#0, #1{min}) // { arity: 2 }
-            Filter (#1{min} >= #3{min}) // { arity: 4 }
-              Join on=(#0 = #2) type=differential // { arity: 4 }
-                implementation
-                  %0:l19[#0]K » %1:l18[#0]K
-                ArrangeBy keys=[[#0]] // { arity: 2 }
-                  Get l19 // { arity: 2 }
-                ArrangeBy keys=[[#0]] // { arity: 2 }
-                  Get l18 // { arity: 2 }
-      cte l21 =
+    With Mutually Recursive
+      cte [recursion_limit=10, return_at_limit] l9 =
+        Union // { arity: 2 }
+          Project (#1, #2) // { arity: 2 }
+            Map (0) // { arity: 3 }
+              Get l0 // { arity: 2 }
+          Project (#2, #3) // { arity: 2 }
+            Filter (char_length(#0) > 0) // { arity: 4 }
+              Map (substr(#0, 2), (((#1 + integer_to_bigint(ascii(substr(#0, 1, 1)))) * 17) % 256)) // { arity: 4 }
+                Get l9 // { arity: 2 }
+      cte l10 =
+        Reduce aggregates=[sum(#0)] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = "") // { arity: 2 }
+              Get l9 // { arity: 2 }
+      cte [recursion_limit=10, return_at_limit] l11 =
         Union // { arity: 3 }
-          Get l20 // { arity: 3 }
-          Map (0) // { arity: 3 }
-            Union // { arity: 2 }
-              Negate // { arity: 2 }
-                Project (#0, #1{min}) // { arity: 2 }
-                  Get l20 // { arity: 3 }
-              Get l19 // { arity: 2 }
-      cte l22 =
-        Reduce aggregates=[sum((((1 + #0) * #2{count}) * integer_to_bigint(#1)))] // { arity: 1 }
-          Project (#0, #1, #5{count}) // { arity: 3 }
-            Join on=(#0 = #3 AND #2{min} = #4{min}) type=differential // { arity: 6 }
-              implementation
-                %1[#0, #1]UKK » %0:l17[#0, #2]KK
-              ArrangeBy keys=[[#0, #2{min}]] // { arity: 3 }
-                Get l17 // { arity: 3 }
-              ArrangeBy keys=[[#0, #1{min}]] // { arity: 3 }
-                Union // { arity: 3 }
-                  Get l21 // { arity: 3 }
-                  Map (null) // { arity: 3 }
-                    Union // { arity: 2 }
-                      Negate // { arity: 2 }
-                        Project (#0, #1{min}) // { arity: 2 }
-                          Get l21 // { arity: 3 }
-                      Get l19 // { arity: 2 }
+          Project (#0, #0, #4) // { arity: 3 }
+            Map (0) // { arity: 5 }
+              Get l8 // { arity: 4 }
+          Project (#0, #3, #4) // { arity: 3 }
+            Filter (char_length(#1) > 0) // { arity: 5 }
+              Map (substr(#1, 2), (((#2 + integer_to_bigint(ascii(substr(#1, 1, 1)))) * 17) % 256)) // { arity: 5 }
+                Get l11 // { arity: 3 }
     Return // { arity: 2 }
-      CrossJoin type=differential // { arity: 2 }
-        implementation
-          %0[×]U » %1[×]U
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Project (#1) // { arity: 1 }
-            Map (numeric_to_bigint(#0{sum})) // { arity: 2 }
-              Union // { arity: 1 }
-                Get l2 // { arity: 1 }
-                Map (null) // { arity: 1 }
-                  Union // { arity: 0 }
-                    Negate // { arity: 0 }
-                      Project () // { arity: 0 }
-                        Get l2 // { arity: 1 }
-                    Constant // { arity: 0 }
-                      - ()
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Project (#1) // { arity: 1 }
-            Map (numeric_to_bigint(#0{sum})) // { arity: 2 }
-              Union // { arity: 1 }
-                Get l22 // { arity: 1 }
-                Map (null) // { arity: 1 }
-                  Union // { arity: 0 }
-                    Negate // { arity: 0 }
-                      Project () // { arity: 0 }
-                        Get l22 // { arity: 1 }
-                    Constant // { arity: 0 }
-                      - ()
+      With
+        cte l12 =
+          Project (#1, #3, #4{min}) // { arity: 3 }
+            Join on=(#0 = #2) type=differential // { arity: 5 }
+              implementation
+                %1:l8[#0]UKf » %0:l11[#0]Kef
+              ArrangeBy keys=[[#0]] // { arity: 2 }
+                Project (#0, #2) // { arity: 2 }
+                  Filter (#1 = "") AND (#0) IS NOT NULL // { arity: 3 }
+                    Get l11 // { arity: 3 }
+              ArrangeBy keys=[[#0]] // { arity: 3 }
+                Project (#0..=#2{min}) // { arity: 3 }
+                  Filter NOT(#3) // { arity: 4 }
+                    Get l8 // { arity: 4 }
+        cte l13 =
+          Project (#0, #2{min}) // { arity: 2 }
+            Get l12 // { arity: 3 }
+        cte l14 =
+          Distinct project=[#0, #1{min}] // { arity: 2 }
+            Get l13 // { arity: 2 }
+        cte l15 =
+          Reduce group_by=[#0, #1{min}] aggregates=[count(*)] // { arity: 3 }
+            Project (#0, #1{min}) // { arity: 2 }
+              Filter (#1{min} >= #3{min}) // { arity: 4 }
+                Join on=(#0 = #2) type=differential // { arity: 4 }
+                  implementation
+                    %0:l14[#0]K » %1:l13[#0]K
+                  ArrangeBy keys=[[#0]] // { arity: 2 }
+                    Get l14 // { arity: 2 }
+                  ArrangeBy keys=[[#0]] // { arity: 2 }
+                    Get l13 // { arity: 2 }
+        cte l16 =
+          Union // { arity: 3 }
+            Get l15 // { arity: 3 }
+            Map (0) // { arity: 3 }
+              Union // { arity: 2 }
+                Negate // { arity: 2 }
+                  Project (#0, #1{min}) // { arity: 2 }
+                    Get l15 // { arity: 3 }
+                Get l14 // { arity: 2 }
+        cte l17 =
+          Reduce aggregates=[sum((((1 + #0) * #2{count}) * integer_to_bigint(#1)))] // { arity: 1 }
+            Project (#0, #1, #5{count}) // { arity: 3 }
+              Join on=(#0 = #3 AND #2{min} = #4{min}) type=differential // { arity: 6 }
+                implementation
+                  %1[#0, #1]UKK » %0:l12[#0, #2]KK
+                ArrangeBy keys=[[#0, #2{min}]] // { arity: 3 }
+                  Get l12 // { arity: 3 }
+                ArrangeBy keys=[[#0, #1{min}]] // { arity: 3 }
+                  Union // { arity: 3 }
+                    Get l16 // { arity: 3 }
+                    Map (null) // { arity: 3 }
+                      Union // { arity: 2 }
+                        Negate // { arity: 2 }
+                          Project (#0, #1{min}) // { arity: 2 }
+                            Get l16 // { arity: 3 }
+                        Get l14 // { arity: 2 }
+      Return // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0[×]U » %1[×]U
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Map (numeric_to_bigint(#0{sum})) // { arity: 2 }
+                Union // { arity: 1 }
+                  Get l10 // { arity: 1 }
+                  Map (null) // { arity: 1 }
+                    Union // { arity: 0 }
+                      Negate // { arity: 0 }
+                        Project () // { arity: 0 }
+                          Get l10 // { arity: 1 }
+                      Constant // { arity: 0 }
+                        - ()
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Map (numeric_to_bigint(#0{sum})) // { arity: 2 }
+                Union // { arity: 1 }
+                  Get l17 // { arity: 1 }
+                  Map (null) // { arity: 1 }
+                    Union // { arity: 0 }
+                      Negate // { arity: 0 }
+                        Project () // { arity: 0 }
+                          Get l17 // { arity: 1 }
+                      Constant // { arity: 0 }
+                        - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1216.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1216.slt
@@ -224,7 +224,7 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#0, #2, #3) // { arity: 3 }
         Map (substr(#1, #2, 1)) // { arity: 4 }
@@ -234,10 +234,74 @@ Explained Query:
                 FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
                   ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
+      Project (#1) // { arity: 1 }
+        Get l0 // { arity: 3 }
+    cte l2 =
+      Reduce aggregates=[min(#0)] // { arity: 1 }
+        Get l1 // { arity: 1 }
+    cte l3 =
+      Union // { arity: 1 }
+        Get l2 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l2 // { arity: 1 }
+            Constant // { arity: 0 }
+              - ()
+    cte l4 =
+      Reduce aggregates=[max(#0)] // { arity: 1 }
+        Get l1 // { arity: 1 }
+    cte l5 =
+      Union // { arity: 1 }
+        Get l4 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l4 // { arity: 1 }
+            Constant // { arity: 0 }
+              - ()
+    cte l6 =
+      Project (#0) // { arity: 1 }
+        Get l0 // { arity: 3 }
+    cte l7 =
+      Reduce aggregates=[min(#0)] // { arity: 1 }
+        Get l6 // { arity: 1 }
+    cte l8 =
+      Union // { arity: 1 }
+        Get l7 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l7 // { arity: 1 }
+            Constant // { arity: 0 }
+              - ()
+    cte l9 =
+      Project (#0, #1) // { arity: 2 }
+        Get l0 // { arity: 3 }
+    cte l10 =
+      CrossJoin type=differential // { arity: 3 }
+        implementation
+          %1[×]U » %0:l9[×]
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Get l9 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l5 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l5 // { arity: 1 }
+                Constant // { arity: 0 }
+                  - ()
+    cte l11 =
       ArrangeBy keys=[[#0, #1]] // { arity: 3 }
         Filter (#2) IS NOT NULL // { arity: 3 }
           Get l0 // { arity: 3 }
-    cte l2 =
+    cte l12 =
       ArrangeBy keys=[[#0, #1]] // { arity: 5 }
         Constant // { arity: 5 }
           total_rows (diffs absed): 24
@@ -262,193 +326,131 @@ Explained Query:
             - ("l", "|", 1, 0, "d")
             - ("r", "-", 0, 1, "r")
             - ("r", ".", 0, 1, "r")
-    cte l3 =
-      Distinct project=[#0..=#2] // { arity: 3 }
-        Union // { arity: 3 }
-          Project (#11, #12, #10) // { arity: 3 }
-            Map ((#0 + #8), (#1 + #9)) // { arity: 13 }
-              Join on=(#0 = #3 AND #1 = #4 AND #2 = #6 AND #5 = #7) type=differential // { arity: 11 }
-                implementation
-                  %0:l3[#0, #1]KK » %1:l1[#0, #1]KK » %2:l2[#0, #1]KK
-                ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-                  Get l3 // { arity: 3 }
-                Get l1 // { arity: 3 }
-                Get l2 // { arity: 5 }
-          Constant // { arity: 3 }
-            - (1, 1, "r")
-    cte l4 =
-      Project (#0, #1) // { arity: 2 }
-        Get l0 // { arity: 3 }
-    cte l5 =
-      Reduce aggregates=[count(*)] // { arity: 1 }
-        Project () // { arity: 0 }
-          Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
-            implementation
-              %0[#0, #1]UKKA » %1[#0, #1]UKKA
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-              Distinct project=[#0, #1] // { arity: 2 }
-                Project (#0, #1) // { arity: 2 }
-                  Get l3 // { arity: 3 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-              Distinct project=[#0, #1] // { arity: 2 }
-                Get l4 // { arity: 2 }
-    cte l6 =
-      Project (#1) // { arity: 1 }
-        Get l0 // { arity: 3 }
-    cte l7 =
-      Reduce aggregates=[min(#0)] // { arity: 1 }
-        Get l6 // { arity: 1 }
-    cte l8 =
-      Union // { arity: 1 }
-        Get l7 // { arity: 1 }
-        Map (null) // { arity: 1 }
-          Union // { arity: 0 }
-            Negate // { arity: 0 }
-              Project () // { arity: 0 }
-                Get l7 // { arity: 1 }
-            Constant // { arity: 0 }
-              - ()
-    cte l9 =
-      Reduce aggregates=[max(#0)] // { arity: 1 }
-        Get l6 // { arity: 1 }
-    cte l10 =
-      Union // { arity: 1 }
-        Get l9 // { arity: 1 }
-        Map (null) // { arity: 1 }
-          Union // { arity: 0 }
-            Negate // { arity: 0 }
-              Project () // { arity: 0 }
-                Get l9 // { arity: 1 }
-            Constant // { arity: 0 }
-              - ()
-    cte l11 =
-      Project (#0) // { arity: 1 }
-        Get l0 // { arity: 3 }
-    cte l12 =
-      Reduce aggregates=[min(#0)] // { arity: 1 }
-        Get l11 // { arity: 1 }
-    cte l13 =
-      Union // { arity: 1 }
-        Get l12 // { arity: 1 }
-        Map (null) // { arity: 1 }
-          Union // { arity: 0 }
-            Negate // { arity: 0 }
-              Project () // { arity: 0 }
-                Get l12 // { arity: 1 }
-            Constant // { arity: 0 }
-              - ()
-    cte l14 =
-      CrossJoin type=differential // { arity: 3 }
-        implementation
-          %1[×]U » %0:l4[×]
-        ArrangeBy keys=[[]] // { arity: 2 }
-          Get l4 // { arity: 2 }
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l10 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l10 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
-    cte l15 =
-      Distinct project=[#0{min}..=#3] // { arity: 4 }
-        Union // { arity: 4 }
-          Project (#0, #1{min}, #3, #2) // { arity: 4 }
-            Map (("r" || integer_to_text(#0)), "r") // { arity: 4 }
-              CrossJoin type=differential // { arity: 2 }
-                implementation
-                  %1[×]U » %0:l11[×]
-                ArrangeBy keys=[[]] // { arity: 1 }
-                  Get l11 // { arity: 1 }
-                ArrangeBy keys=[[]] // { arity: 1 }
-                  Union // { arity: 1 }
-                    Get l8 // { arity: 1 }
-                    Map (null) // { arity: 1 }
-                      Union // { arity: 0 }
-                        Negate // { arity: 0 }
-                          Project () // { arity: 0 }
-                            Get l8 // { arity: 1 }
-                        Constant // { arity: 0 }
-                          - ()
-          Project (#0, #2{max}, #4, #3) // { arity: 4 }
-            Map (("l" || integer_to_text(#0)), "l") // { arity: 5 }
-              Get l14 // { arity: 3 }
-          Project (#1{min}, #0, #3, #2) // { arity: 4 }
-            Map (("d" || integer_to_text(#0)), "d") // { arity: 4 }
-              CrossJoin type=differential // { arity: 2 }
-                implementation
-                  %1[×]U » %0:l6[×]
-                ArrangeBy keys=[[]] // { arity: 1 }
-                  Get l6 // { arity: 1 }
-                ArrangeBy keys=[[]] // { arity: 1 }
-                  Union // { arity: 1 }
-                    Get l13 // { arity: 1 }
-                    Map (null) // { arity: 1 }
-                      Union // { arity: 0 }
-                        Negate // { arity: 0 }
-                          Project () // { arity: 0 }
-                            Get l13 // { arity: 1 }
-                        Constant // { arity: 0 }
-                          - ()
-          Project (#2{max}, #1, #4, #3) // { arity: 4 }
-            Map (("u" || integer_to_text(#1)), "u") // { arity: 5 }
-              Get l14 // { arity: 3 }
-          Project (#12, #13, #11, #3) // { arity: 4 }
-            Map ((#0 + #9), (#1 + #10)) // { arity: 14 }
-              Join on=(#0 = #4 AND #1 = #5 AND #2 = #7 AND #6 = #8) type=differential // { arity: 12 }
-                implementation
-                  %0:l15[#0, #1]KK » %1:l1[#0, #1]KK » %2:l2[#0, #1]KK
-                ArrangeBy keys=[[#0{min}, #1{min}]] // { arity: 4 }
-                  Filter (#0{min}) IS NOT NULL AND (#1{min}) IS NOT NULL // { arity: 4 }
-                    Get l15 // { arity: 4 }
-                Get l1 // { arity: 3 }
-                Get l2 // { arity: 5 }
   Return // { arity: 2 }
-    With
-      cte l16 =
-        Reduce aggregates=[max(#0{count})] // { arity: 1 }
-          Project (#1{count}) // { arity: 1 }
-            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-              Project (#2) // { arity: 1 }
-                Join on=(#0{min} = #3 AND #1{min} = #4) type=differential // { arity: 5 }
+    With Mutually Recursive
+      cte l13 =
+        Distinct project=[#0..=#2] // { arity: 3 }
+          Union // { arity: 3 }
+            Project (#11, #12, #10) // { arity: 3 }
+              Map ((#0 + #8), (#1 + #9)) // { arity: 13 }
+                Join on=(#0 = #3 AND #1 = #4 AND #2 = #6 AND #5 = #7) type=differential // { arity: 11 }
                   implementation
-                    %1[#0, #1]UKKA » %0[#0, #1]KK
-                  ArrangeBy keys=[[#0{min}, #1{min}]] // { arity: 3 }
-                    Distinct project=[#0{min}..=#2] // { arity: 3 }
-                      Project (#0{min}, #1{min}, #3) // { arity: 3 }
-                        Filter (#0{min}) IS NOT NULL AND (#1{min}) IS NOT NULL // { arity: 4 }
-                          Get l15 // { arity: 4 }
-                  ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                    Distinct project=[#0, #1] // { arity: 2 }
-                      Project (#0, #1) // { arity: 2 }
-                        Get l0 // { arity: 3 }
+                    %0:l13[#0, #1]KK » %1:l11[#0, #1]KK » %2:l12[#0, #1]KK
+                  ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+                    Get l13 // { arity: 3 }
+                  Get l11 // { arity: 3 }
+                  Get l12 // { arity: 5 }
+            Constant // { arity: 3 }
+              - (1, 1, "r")
+      cte l14 =
+        Reduce aggregates=[count(*)] // { arity: 1 }
+          Project () // { arity: 0 }
+            Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+              implementation
+                %0[#0, #1]UKKA » %1[#0, #1]UKKA
+              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                Distinct project=[#0, #1] // { arity: 2 }
+                  Project (#0, #1) // { arity: 2 }
+                    Get l13 // { arity: 3 }
+              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                Distinct project=[#0, #1] // { arity: 2 }
+                  Get l9 // { arity: 2 }
+      cte l15 =
+        Distinct project=[#0{min}..=#3] // { arity: 4 }
+          Union // { arity: 4 }
+            Project (#0, #1{min}, #3, #2) // { arity: 4 }
+              Map (("r" || integer_to_text(#0)), "r") // { arity: 4 }
+                CrossJoin type=differential // { arity: 2 }
+                  implementation
+                    %1[×]U » %0:l6[×]
+                  ArrangeBy keys=[[]] // { arity: 1 }
+                    Get l6 // { arity: 1 }
+                  ArrangeBy keys=[[]] // { arity: 1 }
+                    Union // { arity: 1 }
+                      Get l3 // { arity: 1 }
+                      Map (null) // { arity: 1 }
+                        Union // { arity: 0 }
+                          Negate // { arity: 0 }
+                            Project () // { arity: 0 }
+                              Get l3 // { arity: 1 }
+                          Constant // { arity: 0 }
+                            - ()
+            Project (#0, #2{max}, #4, #3) // { arity: 4 }
+              Map (("l" || integer_to_text(#0)), "l") // { arity: 5 }
+                Get l10 // { arity: 3 }
+            Project (#1{min}, #0, #3, #2) // { arity: 4 }
+              Map (("d" || integer_to_text(#0)), "d") // { arity: 4 }
+                CrossJoin type=differential // { arity: 2 }
+                  implementation
+                    %1[×]U » %0:l1[×]
+                  ArrangeBy keys=[[]] // { arity: 1 }
+                    Get l1 // { arity: 1 }
+                  ArrangeBy keys=[[]] // { arity: 1 }
+                    Union // { arity: 1 }
+                      Get l8 // { arity: 1 }
+                      Map (null) // { arity: 1 }
+                        Union // { arity: 0 }
+                          Negate // { arity: 0 }
+                            Project () // { arity: 0 }
+                              Get l8 // { arity: 1 }
+                          Constant // { arity: 0 }
+                            - ()
+            Project (#2{max}, #1, #4, #3) // { arity: 4 }
+              Map (("u" || integer_to_text(#1)), "u") // { arity: 5 }
+                Get l10 // { arity: 3 }
+            Project (#12, #13, #11, #3) // { arity: 4 }
+              Map ((#0 + #9), (#1 + #10)) // { arity: 14 }
+                Join on=(#0 = #4 AND #1 = #5 AND #2 = #7 AND #6 = #8) type=differential // { arity: 12 }
+                  implementation
+                    %0:l15[#0, #1]KK » %1:l11[#0, #1]KK » %2:l12[#0, #1]KK
+                  ArrangeBy keys=[[#0{min}, #1{min}]] // { arity: 4 }
+                    Filter (#0{min}) IS NOT NULL AND (#1{min}) IS NOT NULL // { arity: 4 }
+                      Get l15 // { arity: 4 }
+                  Get l11 // { arity: 3 }
+                  Get l12 // { arity: 5 }
     Return // { arity: 2 }
-      CrossJoin type=differential // { arity: 2 }
-        implementation
-          %0[×]U » %1[×]U
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l5 // { arity: 1 }
-            Map (0) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l5 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l16 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l16 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
+      With
+        cte l16 =
+          Reduce aggregates=[max(#0{count})] // { arity: 1 }
+            Project (#1{count}) // { arity: 1 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                Project (#2) // { arity: 1 }
+                  Join on=(#0{min} = #3 AND #1{min} = #4) type=differential // { arity: 5 }
+                    implementation
+                      %1[#0, #1]UKKA » %0[#0, #1]KK
+                    ArrangeBy keys=[[#0{min}, #1{min}]] // { arity: 3 }
+                      Distinct project=[#0{min}..=#2] // { arity: 3 }
+                        Project (#0{min}, #1{min}, #3) // { arity: 3 }
+                          Filter (#0{min}) IS NOT NULL AND (#1{min}) IS NOT NULL // { arity: 4 }
+                            Get l15 // { arity: 4 }
+                    ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                      Distinct project=[#0, #1] // { arity: 2 }
+                        Project (#0, #1) // { arity: 2 }
+                          Get l0 // { arity: 3 }
+      Return // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0[×]U » %1[×]U
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l14 // { arity: 1 }
+              Map (0) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l14 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l16 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l16 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1217.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1217.slt
@@ -224,7 +224,7 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#0, #2, #3) // { arity: 3 }
         Map (text_to_integer(substr(#1, #2, 1))) // { arity: 4 }
@@ -236,104 +236,51 @@ Explained Query:
     cte l1 =
       ArrangeBy keys=[[#0, #1]] // { arity: 3 }
         Get l0 // { arity: 3 }
-    cte l2 =
-      Project (#0..=#3, #5{min}) // { arity: 5 }
-        Get l3 // { arity: 6 }
-    cte l3 =
-      Reduce group_by=[#0..=#4] aggregates=[min(#5)] // { arity: 6 }
-        Union // { arity: 6 }
-          Project (#6, #7, #2, #3, #9, #10) // { arity: 6 }
-            Map ((#4 + 1), (#5 + #8)) // { arity: 11 }
-              Join on=(#6 = (#0 + #2) AND #7 = (#1 + #3)) type=differential // { arity: 9 }
-                implementation
-                  %0:l3[(#0 + #2), (#1 + #3)]KKif » %1:l1[#0, #1]KKif
-                ArrangeBy keys=[[(#0 + #2), (#1 + #3)]] // { arity: 6 }
-                  Filter (#4 < 3) // { arity: 6 }
-                    Get l3 // { arity: 6 }
-                Get l1 // { arity: 3 }
-          Project (#5, #6, #3, #2, #9, #8) // { arity: 6 }
-            Map ((#4 + #7), 1) // { arity: 10 }
-              Join on=(#5 = (#0 + #3) AND #6 = (#1 + #2)) type=differential // { arity: 8 }
-                implementation
-                  %0:l2[(#0 + #3), (#1 + #2)]KK » %1:l1[#0, #1]KK
-                ArrangeBy keys=[[(#0 + #3), (#1 + #2)]] // { arity: 5 }
-                  Get l2 // { arity: 5 }
-                Get l1 // { arity: 3 }
-          Project (#5, #6, #8, #9, #11, #10) // { arity: 6 }
-            Map (-(#3), -(#2), (#4 + #7), 1) // { arity: 12 }
-              Join on=(#5 = (#0 - #3) AND #6 = (#1 - #2)) type=differential // { arity: 8 }
-                implementation
-                  %0:l2[(#0 - #3), (#1 - #2)]KK » %1:l1[#0, #1]KK
-                ArrangeBy keys=[[(#0 - #3), (#1 - #2)]] // { arity: 5 }
-                  Get l2 // { arity: 5 }
-                Get l1 // { arity: 3 }
-          Constant // { arity: 6 }
-            - (1, 1, 0, 1, 0, 0)
-            - (1, 1, 1, 0, 0, 0)
-    cte l4 =
-      Reduce aggregates=[min(#0{min})] // { arity: 1 }
-        Project (#2{min}) // { arity: 1 }
-          Join on=(#0 = #3{max} AND #1 = #4{max}) type=differential // { arity: 5 }
-            implementation
-              %1[×]UA » %2[×]UA » %0:l3[#0, #1]KK
-            ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-              Project (#0, #1, #5{min}) // { arity: 3 }
-                Get l3 // { arity: 6 }
-            ArrangeBy keys=[[]] // { arity: 1 }
-              Reduce aggregates=[max(#0)] // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Get l0 // { arity: 3 }
-            ArrangeBy keys=[[]] // { arity: 1 }
-              Reduce aggregates=[max(#0)] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Get l0 // { arity: 3 }
-    cte l5 =
-      Project (#0..=#3, #5{min}) // { arity: 5 }
-        Filter (#4 >= 4) // { arity: 6 }
-          Get l6 // { arity: 6 }
-    cte l6 =
-      Reduce group_by=[#0..=#4] aggregates=[min(#5)] // { arity: 6 }
-        Union // { arity: 6 }
-          Project (#6, #7, #2, #3, #9, #10) // { arity: 6 }
-            Map ((#4 + 1), (#5 + #8)) // { arity: 11 }
-              Join on=(#6 = (#0 + #2) AND #7 = (#1 + #3)) type=differential // { arity: 9 }
-                implementation
-                  %0:l6[(#0 + #2), (#1 + #3)]KKif » %1:l1[#0, #1]KKif
-                ArrangeBy keys=[[(#0 + #2), (#1 + #3)]] // { arity: 6 }
-                  Filter (#4 < 10) // { arity: 6 }
-                    Get l6 // { arity: 6 }
-                Get l1 // { arity: 3 }
-          Project (#5, #6, #3, #2, #9, #8) // { arity: 6 }
-            Map ((#4 + #7), 1) // { arity: 10 }
-              Join on=(#5 = (#0 + #3) AND #6 = (#1 + #2)) type=differential // { arity: 8 }
-                implementation
-                  %0:l5[(#0 + #3), (#1 + #2)]KKif » %1:l1[#0, #1]KKif
-                ArrangeBy keys=[[(#0 + #3), (#1 + #2)]] // { arity: 5 }
-                  Get l5 // { arity: 5 }
-                Get l1 // { arity: 3 }
-          Project (#5, #6, #8, #9, #11, #10) // { arity: 6 }
-            Map (-(#3), -(#2), (#4 + #7), 1) // { arity: 12 }
-              Join on=(#5 = (#0 - #3) AND #6 = (#1 - #2)) type=differential // { arity: 8 }
-                implementation
-                  %0:l5[(#0 - #3), (#1 - #2)]KKif » %1:l1[#0, #1]KKif
-                ArrangeBy keys=[[(#0 - #3), (#1 - #2)]] // { arity: 5 }
-                  Get l5 // { arity: 5 }
-                Get l1 // { arity: 3 }
-          Constant // { arity: 6 }
-            - (1, 1, 0, 1, 0, 0)
-            - (1, 1, 1, 0, 0, 0)
   Return // { arity: 2 }
-    With
-      cte l7 =
+    With Mutually Recursive
+      cte l2 =
+        Project (#0..=#3, #5{min}) // { arity: 5 }
+          Get l3 // { arity: 6 }
+      cte l3 =
+        Reduce group_by=[#0..=#4] aggregates=[min(#5)] // { arity: 6 }
+          Union // { arity: 6 }
+            Project (#6, #7, #2, #3, #9, #10) // { arity: 6 }
+              Map ((#4 + 1), (#5 + #8)) // { arity: 11 }
+                Join on=(#6 = (#0 + #2) AND #7 = (#1 + #3)) type=differential // { arity: 9 }
+                  implementation
+                    %0:l3[(#0 + #2), (#1 + #3)]KKif » %1:l1[#0, #1]KKif
+                  ArrangeBy keys=[[(#0 + #2), (#1 + #3)]] // { arity: 6 }
+                    Filter (#4 < 3) // { arity: 6 }
+                      Get l3 // { arity: 6 }
+                  Get l1 // { arity: 3 }
+            Project (#5, #6, #3, #2, #9, #8) // { arity: 6 }
+              Map ((#4 + #7), 1) // { arity: 10 }
+                Join on=(#5 = (#0 + #3) AND #6 = (#1 + #2)) type=differential // { arity: 8 }
+                  implementation
+                    %0:l2[(#0 + #3), (#1 + #2)]KK » %1:l1[#0, #1]KK
+                  ArrangeBy keys=[[(#0 + #3), (#1 + #2)]] // { arity: 5 }
+                    Get l2 // { arity: 5 }
+                  Get l1 // { arity: 3 }
+            Project (#5, #6, #8, #9, #11, #10) // { arity: 6 }
+              Map (-(#3), -(#2), (#4 + #7), 1) // { arity: 12 }
+                Join on=(#5 = (#0 - #3) AND #6 = (#1 - #2)) type=differential // { arity: 8 }
+                  implementation
+                    %0:l2[(#0 - #3), (#1 - #2)]KK » %1:l1[#0, #1]KK
+                  ArrangeBy keys=[[(#0 - #3), (#1 - #2)]] // { arity: 5 }
+                    Get l2 // { arity: 5 }
+                  Get l1 // { arity: 3 }
+            Constant // { arity: 6 }
+              - (1, 1, 0, 1, 0, 0)
+              - (1, 1, 1, 0, 0, 0)
+      cte l4 =
         Reduce aggregates=[min(#0{min})] // { arity: 1 }
           Project (#2{min}) // { arity: 1 }
             Join on=(#0 = #3{max} AND #1 = #4{max}) type=differential // { arity: 5 }
               implementation
-                %1[×]UA » %2[×]UA » %0:l6[#0, #1]KKif
+                %1[×]UA » %2[×]UA » %0:l3[#0, #1]KK
               ArrangeBy keys=[[#0, #1]] // { arity: 3 }
                 Project (#0, #1, #5{min}) // { arity: 3 }
-                  Filter (#4 >= 4) // { arity: 6 }
-                    Get l6 // { arity: 6 }
+                  Get l3 // { arity: 6 }
               ArrangeBy keys=[[]] // { arity: 1 }
                 Reduce aggregates=[max(#0)] // { arity: 1 }
                   Project (#0) // { arity: 1 }
@@ -342,30 +289,85 @@ Explained Query:
                 Reduce aggregates=[max(#0)] // { arity: 1 }
                   Project (#1) // { arity: 1 }
                     Get l0 // { arity: 3 }
+      cte l5 =
+        Project (#0..=#3, #5{min}) // { arity: 5 }
+          Filter (#4 >= 4) // { arity: 6 }
+            Get l6 // { arity: 6 }
+      cte l6 =
+        Reduce group_by=[#0..=#4] aggregates=[min(#5)] // { arity: 6 }
+          Union // { arity: 6 }
+            Project (#6, #7, #2, #3, #9, #10) // { arity: 6 }
+              Map ((#4 + 1), (#5 + #8)) // { arity: 11 }
+                Join on=(#6 = (#0 + #2) AND #7 = (#1 + #3)) type=differential // { arity: 9 }
+                  implementation
+                    %0:l6[(#0 + #2), (#1 + #3)]KKif » %1:l1[#0, #1]KKif
+                  ArrangeBy keys=[[(#0 + #2), (#1 + #3)]] // { arity: 6 }
+                    Filter (#4 < 10) // { arity: 6 }
+                      Get l6 // { arity: 6 }
+                  Get l1 // { arity: 3 }
+            Project (#5, #6, #3, #2, #9, #8) // { arity: 6 }
+              Map ((#4 + #7), 1) // { arity: 10 }
+                Join on=(#5 = (#0 + #3) AND #6 = (#1 + #2)) type=differential // { arity: 8 }
+                  implementation
+                    %0:l5[(#0 + #3), (#1 + #2)]KKif » %1:l1[#0, #1]KKif
+                  ArrangeBy keys=[[(#0 + #3), (#1 + #2)]] // { arity: 5 }
+                    Get l5 // { arity: 5 }
+                  Get l1 // { arity: 3 }
+            Project (#5, #6, #8, #9, #11, #10) // { arity: 6 }
+              Map (-(#3), -(#2), (#4 + #7), 1) // { arity: 12 }
+                Join on=(#5 = (#0 - #3) AND #6 = (#1 - #2)) type=differential // { arity: 8 }
+                  implementation
+                    %0:l5[(#0 - #3), (#1 - #2)]KKif » %1:l1[#0, #1]KKif
+                  ArrangeBy keys=[[(#0 - #3), (#1 - #2)]] // { arity: 5 }
+                    Get l5 // { arity: 5 }
+                  Get l1 // { arity: 3 }
+            Constant // { arity: 6 }
+              - (1, 1, 0, 1, 0, 0)
+              - (1, 1, 1, 0, 0, 0)
     Return // { arity: 2 }
-      CrossJoin type=differential // { arity: 2 }
-        implementation
-          %0[×]U » %1[×]U
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l4 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l4 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l7 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l7 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
+      With
+        cte l7 =
+          Reduce aggregates=[min(#0{min})] // { arity: 1 }
+            Project (#2{min}) // { arity: 1 }
+              Join on=(#0 = #3{max} AND #1 = #4{max}) type=differential // { arity: 5 }
+                implementation
+                  %1[×]UA » %2[×]UA » %0:l6[#0, #1]KKif
+                ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+                  Project (#0, #1, #5{min}) // { arity: 3 }
+                    Filter (#4 >= 4) // { arity: 6 }
+                      Get l6 // { arity: 6 }
+                ArrangeBy keys=[[]] // { arity: 1 }
+                  Reduce aggregates=[max(#0)] // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l0 // { arity: 3 }
+                ArrangeBy keys=[[]] // { arity: 1 }
+                  Reduce aggregates=[max(#0)] // { arity: 1 }
+                    Project (#1) // { arity: 1 }
+                      Get l0 // { arity: 3 }
+      Return // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0[×]U » %1[×]U
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l4 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l4 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l7 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l7 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1218.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1218.slt
@@ -218,155 +218,157 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#1, #2) // { arity: 2 }
         Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
           FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
             ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Distinct project=[#0..=#4] // { arity: 5 }
-        Union // { arity: 5 }
-          Project (#0, #1, #7..=#9) // { arity: 5 }
-            Map ((#0 + (#4 * #6)), (#1 + (#5 * #6)), (#2 + 1)) // { arity: 10 }
-              Join on=(#2 = #3) type=differential // { arity: 7 }
-                implementation
-                  %0:l1[#2]K » %1:l0[#0]K
-                ArrangeBy keys=[[#2]] // { arity: 3 }
-                  Project (#2..=#4) // { arity: 3 }
-                    Get l1 // { arity: 5 }
-                ArrangeBy keys=[[#0]] // { arity: 4 }
-                  Project (#0, #4..=#6) // { arity: 4 }
-                    Map (regexp_split_to_array[" ", case_insensitive=false](#1), array_index(#2, 1), case when (#3 = "U") then -1 else case when ("D" = array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 1)) then 1 else 0 end end, case when (#3 = "L") then -1 else case when ("R" = array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 1)) then 1 else 0 end end, text_to_integer(array_index(#2, 2))) // { arity: 7 }
-                      Get l0 // { arity: 2 }
-          Constant // { arity: 5 }
-            - (0, 0, 0, 0, 1)
-    cte l2 =
-      Reduce aggregates=[sum(((#0 + #2) * (#1 - #3)))] // { arity: 1 }
-        Project (#0..=#3) // { arity: 4 }
-          Get l1 // { arity: 5 }
-    cte l3 =
-      Union // { arity: 1 }
-        Get l2 // { arity: 1 }
-        Map (null) // { arity: 1 }
-          Union // { arity: 0 }
-            Negate // { arity: 0 }
-              Project () // { arity: 0 }
-                Get l2 // { arity: 1 }
-            Constant // { arity: 0 }
-              - ()
-    cte l4 =
       Reduce aggregates=[sum(#0)] // { arity: 1 }
         Project (#2) // { arity: 1 }
           Map (text_to_integer(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 2))) // { arity: 3 }
             Get l0 // { arity: 2 }
-    cte l5 =
+    cte l2 =
       Union // { arity: 1 }
-        Get l4 // { arity: 1 }
+        Get l1 // { arity: 1 }
         Map (null) // { arity: 1 }
           Union // { arity: 0 }
             Negate // { arity: 0 }
               Project () // { arity: 0 }
-                Get l4 // { arity: 1 }
+                Get l1 // { arity: 1 }
             Constant // { arity: 0 }
               - ()
-    cte l6 =
-      Distinct project=[#0..=#4] // { arity: 5 }
-        Union // { arity: 5 }
-          Project (#0, #1, #7..=#9) // { arity: 5 }
-            Map ((#0 + integer_to_bigint((#4 * #6))), (#1 + integer_to_bigint((#5 * #6))), (#2 + 1)) // { arity: 10 }
-              Join on=(#2 = #3) type=differential // { arity: 7 }
-                implementation
-                  %0:l6[#2]K » %1:l0[#0]K
-                ArrangeBy keys=[[#2]] // { arity: 3 }
-                  Project (#2..=#4) // { arity: 3 }
-                    Get l6 // { arity: 5 }
-                ArrangeBy keys=[[#0]] // { arity: 4 }
-                  Project (#0, #4, #5, #7) // { arity: 4 }
-                    Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), substr(#2, 8, 1), case when (#3 = "3") then -1 else case when ("1" = substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 8, 1)) then 1 else 0 end end, case when (#3 = "2") then -1 else case when ("0" = substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 8, 1)) then 1 else 0 end end, decode(("0" || substr(#2, 3, 5)), "hex"), (((65536 * get_byte(#6, 0)) + (256 * get_byte(#6, 1))) + get_byte(#6, 2))) // { arity: 8 }
-                      Get l0 // { arity: 2 }
-          Constant // { arity: 5 }
-            - (0, 0, 0, 0, 1)
   Return // { arity: 2 }
-    With
-      cte l7 =
+    With Mutually Recursive
+      cte l3 =
+        Distinct project=[#0..=#4] // { arity: 5 }
+          Union // { arity: 5 }
+            Project (#0, #1, #7..=#9) // { arity: 5 }
+              Map ((#0 + (#4 * #6)), (#1 + (#5 * #6)), (#2 + 1)) // { arity: 10 }
+                Join on=(#2 = #3) type=differential // { arity: 7 }
+                  implementation
+                    %0:l3[#2]K » %1:l0[#0]K
+                  ArrangeBy keys=[[#2]] // { arity: 3 }
+                    Project (#2..=#4) // { arity: 3 }
+                      Get l3 // { arity: 5 }
+                  ArrangeBy keys=[[#0]] // { arity: 4 }
+                    Project (#0, #4..=#6) // { arity: 4 }
+                      Map (regexp_split_to_array[" ", case_insensitive=false](#1), array_index(#2, 1), case when (#3 = "U") then -1 else case when ("D" = array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 1)) then 1 else 0 end end, case when (#3 = "L") then -1 else case when ("R" = array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 1)) then 1 else 0 end end, text_to_integer(array_index(#2, 2))) // { arity: 7 }
+                        Get l0 // { arity: 2 }
+            Constant // { arity: 5 }
+              - (0, 0, 0, 0, 1)
+      cte l4 =
         Reduce aggregates=[sum(((#0 + #2) * (#1 - #3)))] // { arity: 1 }
           Project (#0..=#3) // { arity: 4 }
-            Get l6 // { arity: 5 }
-      cte l8 =
+            Get l3 // { arity: 5 }
+      cte l5 =
         Union // { arity: 1 }
-          Get l7 // { arity: 1 }
+          Get l4 // { arity: 1 }
           Map (null) // { arity: 1 }
             Union // { arity: 0 }
               Negate // { arity: 0 }
                 Project () // { arity: 0 }
-                  Get l7 // { arity: 1 }
+                  Get l4 // { arity: 1 }
               Constant // { arity: 0 }
                 - ()
-      cte l9 =
-        Reduce aggregates=[sum(#0)] // { arity: 1 }
-          Project (#3) // { arity: 1 }
-            Map (decode(("0" || substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 3, 5)), "hex"), (((65536 * get_byte(#2, 0)) + (256 * get_byte(#2, 1))) + get_byte(#2, 2))) // { arity: 4 }
-              Get l0 // { arity: 2 }
-      cte l10 =
-        Union // { arity: 1 }
-          Get l9 // { arity: 1 }
-          Map (null) // { arity: 1 }
-            Union // { arity: 0 }
-              Negate // { arity: 0 }
-                Project () // { arity: 0 }
-                  Get l9 // { arity: 1 }
-              Constant // { arity: 0 }
-                - ()
+      cte l6 =
+        Distinct project=[#0..=#4] // { arity: 5 }
+          Union // { arity: 5 }
+            Project (#0, #1, #7..=#9) // { arity: 5 }
+              Map ((#0 + integer_to_bigint((#4 * #6))), (#1 + integer_to_bigint((#5 * #6))), (#2 + 1)) // { arity: 10 }
+                Join on=(#2 = #3) type=differential // { arity: 7 }
+                  implementation
+                    %0:l6[#2]K » %1:l0[#0]K
+                  ArrangeBy keys=[[#2]] // { arity: 3 }
+                    Project (#2..=#4) // { arity: 3 }
+                      Get l6 // { arity: 5 }
+                  ArrangeBy keys=[[#0]] // { arity: 4 }
+                    Project (#0, #4, #5, #7) // { arity: 4 }
+                      Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), substr(#2, 8, 1), case when (#3 = "3") then -1 else case when ("1" = substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 8, 1)) then 1 else 0 end end, case when (#3 = "2") then -1 else case when ("0" = substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 8, 1)) then 1 else 0 end end, decode(("0" || substr(#2, 3, 5)), "hex"), (((65536 * get_byte(#6, 0)) + (256 * get_byte(#6, 1))) + get_byte(#6, 2))) // { arity: 8 }
+                        Get l0 // { arity: 2 }
+            Constant // { arity: 5 }
+              - (0, 0, 0, 0, 1)
     Return // { arity: 2 }
-      Project (#4, #5) // { arity: 2 }
-        Map ((((abs(#0{sum}) / 2) + (#1{sum} / 2)) + 1), numeric_to_bigint((((abs(#2{sum}) / 2) + bigint_to_numeric((#3{sum} / 2))) + 1))) // { arity: 6 }
-          CrossJoin type=delta // { arity: 4 }
-            implementation
-              %0 » %1[×]U » %2[×]U » %3[×]U
-              %1 » %0[×]U » %2[×]U » %3[×]U
-              %2 » %0[×]U » %1[×]U » %3[×]U
-              %3 » %0[×]U » %1[×]U » %2[×]U
-            ArrangeBy keys=[[]] // { arity: 1 }
-              Union // { arity: 1 }
-                Get l3 // { arity: 1 }
-                Map (null) // { arity: 1 }
-                  Union // { arity: 0 }
-                    Negate // { arity: 0 }
-                      Project () // { arity: 0 }
-                        Get l3 // { arity: 1 }
-                    Constant // { arity: 0 }
-                      - ()
-            ArrangeBy keys=[[]] // { arity: 1 }
-              Union // { arity: 1 }
-                Get l5 // { arity: 1 }
-                Map (null) // { arity: 1 }
-                  Union // { arity: 0 }
-                    Negate // { arity: 0 }
-                      Project () // { arity: 0 }
-                        Get l5 // { arity: 1 }
-                    Constant // { arity: 0 }
-                      - ()
-            ArrangeBy keys=[[]] // { arity: 1 }
-              Union // { arity: 1 }
-                Get l8 // { arity: 1 }
-                Map (null) // { arity: 1 }
-                  Union // { arity: 0 }
-                    Negate // { arity: 0 }
-                      Project () // { arity: 0 }
-                        Get l8 // { arity: 1 }
-                    Constant // { arity: 0 }
-                      - ()
-            ArrangeBy keys=[[]] // { arity: 1 }
-              Union // { arity: 1 }
-                Get l10 // { arity: 1 }
-                Map (null) // { arity: 1 }
-                  Union // { arity: 0 }
-                    Negate // { arity: 0 }
-                      Project () // { arity: 0 }
-                        Get l10 // { arity: 1 }
-                    Constant // { arity: 0 }
-                      - ()
+      With
+        cte l7 =
+          Reduce aggregates=[sum(((#0 + #2) * (#1 - #3)))] // { arity: 1 }
+            Project (#0..=#3) // { arity: 4 }
+              Get l6 // { arity: 5 }
+        cte l8 =
+          Union // { arity: 1 }
+            Get l7 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l7 // { arity: 1 }
+                Constant // { arity: 0 }
+                  - ()
+        cte l9 =
+          Reduce aggregates=[sum(#0)] // { arity: 1 }
+            Project (#3) // { arity: 1 }
+              Map (decode(("0" || substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 3, 5)), "hex"), (((65536 * get_byte(#2, 0)) + (256 * get_byte(#2, 1))) + get_byte(#2, 2))) // { arity: 4 }
+                Get l0 // { arity: 2 }
+        cte l10 =
+          Union // { arity: 1 }
+            Get l9 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l9 // { arity: 1 }
+                Constant // { arity: 0 }
+                  - ()
+      Return // { arity: 2 }
+        Project (#4, #5) // { arity: 2 }
+          Map ((((abs(#0{sum}) / 2) + (#1{sum} / 2)) + 1), numeric_to_bigint((((abs(#2{sum}) / 2) + bigint_to_numeric((#3{sum} / 2))) + 1))) // { arity: 6 }
+            CrossJoin type=delta // { arity: 4 }
+              implementation
+                %0 » %1[×]U » %2[×]U » %3[×]U
+                %1 » %0[×]U » %2[×]U » %3[×]U
+                %2 » %0[×]U » %1[×]U » %3[×]U
+                %3 » %0[×]U » %1[×]U » %2[×]U
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Get l5 // { arity: 1 }
+                  Map (null) // { arity: 1 }
+                    Union // { arity: 0 }
+                      Negate // { arity: 0 }
+                        Project () // { arity: 0 }
+                          Get l5 // { arity: 1 }
+                      Constant // { arity: 0 }
+                        - ()
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Get l2 // { arity: 1 }
+                  Map (null) // { arity: 1 }
+                    Union // { arity: 0 }
+                      Negate // { arity: 0 }
+                        Project () // { arity: 0 }
+                          Get l2 // { arity: 1 }
+                      Constant // { arity: 0 }
+                        - ()
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Get l8 // { arity: 1 }
+                  Map (null) // { arity: 1 }
+                    Union // { arity: 0 }
+                      Negate // { arity: 0 }
+                        Project () // { arity: 0 }
+                          Get l8 // { arity: 1 }
+                      Constant // { arity: 0 }
+                        - ()
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Get l10 // { arity: 1 }
+                  Map (null) // { arity: 1 }
+                    Union // { arity: 0 }
+                      Negate // { arity: 0 }
+                        Project () // { arity: 0 }
+                          Get l10 // { arity: 1 }
+                      Constant // { arity: 0 }
+                        - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1219.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1219.slt
@@ -322,7 +322,7 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#0, #2, #6..=#9) // { arity: 6 }
         Map (array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2)), substr(#3, 2, 1), ((#4 = "<") OR (#4 = ">")), case when #5 then substr(#3, 1, 1) else "x" end, case when #5 then #4 else ">" end, case when #5 then text_to_integer(array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 1)) else 0 end, case when #5 then array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 2) else #3 end) // { arity: 10 }
@@ -334,82 +334,84 @@ Explained Query:
                     Project (#1) // { arity: 1 }
                       Map (array_index(regexp_split_to_array["\n\n", case_insensitive=false](#0{input}), 1)) // { arity: 2 }
                         ReadStorage materialize.public.input // { arity: 1 }
-    cte l1 =
-      Union // { arity: 5 }
-        Project (#7, #3..=#6) // { arity: 5 }
-          Map (regexp_split_to_array[",", case_insensitive=false](btrim(btrim(#1, "\}"), "\{")), text_to_integer(substr(array_index(#2, 1), 3)), text_to_integer(substr(array_index(#2, 2), 3)), text_to_integer(substr(array_index(#2, 3), 3)), text_to_integer(substr(array_index(#2, 4), 3)), "in") // { arity: 8 }
-            FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0)) // { arity: 2 }
-              Project (#1) // { arity: 1 }
-                Map (array_index(regexp_split_to_array["\n\n", case_insensitive=false](#0{input}), 2)) // { arity: 2 }
-                  ReadStorage materialize.public.input // { arity: 1 }
-        Project (#6, #1..=#4) // { arity: 5 }
-          TopK group_by=[#0, #1, #2, #3, #4] order_by=[#5 asc nulls_last] limit=1 // { arity: 7 }
-            Project (#0..=#4, #6, #10) // { arity: 7 }
-              Filter case when (#8 = "<") then case when (#7 = "x") then (#1 < #9) else case when (#7 = "m") then (#2 < #9) else case when (#7 = "a") then (#3 < #9) else case when (#7 = "s") then (#4 < #9) else false end end end end else case when (#8 = ">") then case when (#7 = "x") then (#1 > #9) else case when (#7 = "m") then (#2 > #9) else case when (#7 = "a") then (#3 > #9) else case when (#7 = "s") then (#4 > #9) else false end end end end else false end end // { arity: 11 }
-                Join on=(#0 = #5) type=differential // { arity: 11 }
-                  implementation
-                    %0:l1[#0]K » %1:l0[#0]K
-                  ArrangeBy keys=[[#0]] // { arity: 5 }
-                    Filter (#0) IS NOT NULL // { arity: 5 }
-                      Get l1 // { arity: 5 }
-                  ArrangeBy keys=[[#0]] // { arity: 6 }
-                    Get l0 // { arity: 6 }
-    cte l2 =
-      Reduce aggregates=[sum((((#0 + #1) + #2) + #3))] // { arity: 1 }
-        Project (#1..=#4) // { arity: 4 }
-          Filter (#0 = "A") // { arity: 5 }
-            Get l1 // { arity: 5 }
-    cte l3 =
-      Project (#0..=#9, #12..=#15) // { arity: 14 }
-        Join on=(#0 = #10 AND #1 = #11) type=differential // { arity: 16 }
-          implementation
-            %0:l4[#0, #1]KK » %1:l0[#0, #1]KK
-          ArrangeBy keys=[[#0, #1]] // { arity: 10 }
-            Filter (#0) IS NOT NULL // { arity: 10 }
-              Get l4 // { arity: 10 }
-          ArrangeBy keys=[[#0, #1]] // { arity: 6 }
-            Get l0 // { arity: 6 }
-    cte l4 =
-      Union // { arity: 10 }
-        Project (#13, #28, #16, #18, #20, #21, #23, #24, #26, #27) // { arity: 10 }
-          Map ((#10 = "x"), (#11 = ">"), case when (#14 AND #15) then greatest((#12 + 1), #2) else #2 end, (#11 = "<"), case when (#14 AND #17) then least((#12 - 1), #3) else #3 end, (#10 = "m"), case when (#15 AND #19) then greatest((#12 + 1), #4) else #4 end, case when (#17 AND #19) then least((#12 - 1), #5) else #5 end, (#10 = "a"), case when (#15 AND #22) then greatest((#12 + 1), #6) else #6 end, case when (#17 AND #22) then least((#12 - 1), #7) else #7 end, (#10 = "s"), case when (#15 AND #25) then greatest((#12 + 1), #8) else #8 end, case when (#17 AND #25) then least((#12 - 1), #9) else #9 end, 1) // { arity: 29 }
-            Get l3 // { arity: 14 }
-        Project (#0, #14, #17, #19, #21, #22, #24, #25, #27, #28) // { arity: 10 }
-          Map ((#1 + 1), (#10 = "x"), (#11 = "<"), case when (#15 AND #16) then greatest(#12, #2) else #2 end, (#11 = ">"), case when (#15 AND #18) then least(#12, #3) else #3 end, (#10 = "m"), case when (#16 AND #20) then greatest(#12, #4) else #4 end, case when (#18 AND #20) then least(#12, #5) else #5 end, (#10 = "a"), case when (#16 AND #23) then greatest(#12, #6) else #6 end, case when (#18 AND #23) then least(#12, #7) else #7 end, (#10 = "s"), case when (#16 AND #26) then greatest(#12, #8) else #8 end, case when (#18 AND #26) then least(#12, #9) else #9 end) // { arity: 29 }
-            Get l3 // { arity: 14 }
-        Constant // { arity: 10 }
-          - ("in", 1, 1, 4000, 1, 4000, 1, 4000, 1, 4000)
   Return // { arity: 2 }
-    With
-      cte l5 =
-        Reduce aggregates=[sum((((integer_to_bigint(((1 + #1) - #0)) * integer_to_bigint(((1 + #3) - #2))) * integer_to_bigint(((1 + #5) - #4))) * integer_to_bigint(((1 + #7) - #6))))] // { arity: 1 }
-          Project (#2..=#9) // { arity: 8 }
-            Filter (#0 = "A") // { arity: 10 }
-              Get l4 // { arity: 10 }
+    With Mutually Recursive
+      cte l1 =
+        Union // { arity: 5 }
+          Project (#7, #3..=#6) // { arity: 5 }
+            Map (regexp_split_to_array[",", case_insensitive=false](btrim(btrim(#1, "\}"), "\{")), text_to_integer(substr(array_index(#2, 1), 3)), text_to_integer(substr(array_index(#2, 2), 3)), text_to_integer(substr(array_index(#2, 3), 3)), text_to_integer(substr(array_index(#2, 4), 3)), "in") // { arity: 8 }
+              FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0)) // { arity: 2 }
+                Project (#1) // { arity: 1 }
+                  Map (array_index(regexp_split_to_array["\n\n", case_insensitive=false](#0{input}), 2)) // { arity: 2 }
+                    ReadStorage materialize.public.input // { arity: 1 }
+          Project (#6, #1..=#4) // { arity: 5 }
+            TopK group_by=[#0, #1, #2, #3, #4] order_by=[#5 asc nulls_last] limit=1 // { arity: 7 }
+              Project (#0..=#4, #6, #10) // { arity: 7 }
+                Filter case when (#8 = "<") then case when (#7 = "x") then (#1 < #9) else case when (#7 = "m") then (#2 < #9) else case when (#7 = "a") then (#3 < #9) else case when (#7 = "s") then (#4 < #9) else false end end end end else case when (#8 = ">") then case when (#7 = "x") then (#1 > #9) else case when (#7 = "m") then (#2 > #9) else case when (#7 = "a") then (#3 > #9) else case when (#7 = "s") then (#4 > #9) else false end end end end else false end end // { arity: 11 }
+                  Join on=(#0 = #5) type=differential // { arity: 11 }
+                    implementation
+                      %0:l1[#0]K » %1:l0[#0]K
+                    ArrangeBy keys=[[#0]] // { arity: 5 }
+                      Filter (#0) IS NOT NULL // { arity: 5 }
+                        Get l1 // { arity: 5 }
+                    ArrangeBy keys=[[#0]] // { arity: 6 }
+                      Get l0 // { arity: 6 }
+      cte l2 =
+        Reduce aggregates=[sum((((#0 + #1) + #2) + #3))] // { arity: 1 }
+          Project (#1..=#4) // { arity: 4 }
+            Filter (#0 = "A") // { arity: 5 }
+              Get l1 // { arity: 5 }
+      cte l3 =
+        Project (#0..=#9, #12..=#15) // { arity: 14 }
+          Join on=(#0 = #10 AND #1 = #11) type=differential // { arity: 16 }
+            implementation
+              %0:l4[#0, #1]KK » %1:l0[#0, #1]KK
+            ArrangeBy keys=[[#0, #1]] // { arity: 10 }
+              Filter (#0) IS NOT NULL // { arity: 10 }
+                Get l4 // { arity: 10 }
+            ArrangeBy keys=[[#0, #1]] // { arity: 6 }
+              Get l0 // { arity: 6 }
+      cte l4 =
+        Union // { arity: 10 }
+          Project (#13, #28, #16, #18, #20, #21, #23, #24, #26, #27) // { arity: 10 }
+            Map ((#10 = "x"), (#11 = ">"), case when (#14 AND #15) then greatest((#12 + 1), #2) else #2 end, (#11 = "<"), case when (#14 AND #17) then least((#12 - 1), #3) else #3 end, (#10 = "m"), case when (#15 AND #19) then greatest((#12 + 1), #4) else #4 end, case when (#17 AND #19) then least((#12 - 1), #5) else #5 end, (#10 = "a"), case when (#15 AND #22) then greatest((#12 + 1), #6) else #6 end, case when (#17 AND #22) then least((#12 - 1), #7) else #7 end, (#10 = "s"), case when (#15 AND #25) then greatest((#12 + 1), #8) else #8 end, case when (#17 AND #25) then least((#12 - 1), #9) else #9 end, 1) // { arity: 29 }
+              Get l3 // { arity: 14 }
+          Project (#0, #14, #17, #19, #21, #22, #24, #25, #27, #28) // { arity: 10 }
+            Map ((#1 + 1), (#10 = "x"), (#11 = "<"), case when (#15 AND #16) then greatest(#12, #2) else #2 end, (#11 = ">"), case when (#15 AND #18) then least(#12, #3) else #3 end, (#10 = "m"), case when (#16 AND #20) then greatest(#12, #4) else #4 end, case when (#18 AND #20) then least(#12, #5) else #5 end, (#10 = "a"), case when (#16 AND #23) then greatest(#12, #6) else #6 end, case when (#18 AND #23) then least(#12, #7) else #7 end, (#10 = "s"), case when (#16 AND #26) then greatest(#12, #8) else #8 end, case when (#18 AND #26) then least(#12, #9) else #9 end) // { arity: 29 }
+              Get l3 // { arity: 14 }
+          Constant // { arity: 10 }
+            - ("in", 1, 1, 4000, 1, 4000, 1, 4000, 1, 4000)
     Return // { arity: 2 }
-      CrossJoin type=differential // { arity: 2 }
-        implementation
-          %0[×]U » %1[×]U
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l2 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l2 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l5 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l5 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
+      With
+        cte l5 =
+          Reduce aggregates=[sum((((integer_to_bigint(((1 + #1) - #0)) * integer_to_bigint(((1 + #3) - #2))) * integer_to_bigint(((1 + #5) - #4))) * integer_to_bigint(((1 + #7) - #6))))] // { arity: 1 }
+            Project (#2..=#9) // { arity: 8 }
+              Filter (#0 = "A") // { arity: 10 }
+                Get l4 // { arity: 10 }
+      Return // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0[×]U » %1[×]U
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l2 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l2 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l5 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l5 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1220.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1220.slt
@@ -138,7 +138,7 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM signal WHERE target = 'cn' AND pulse = 'hi';
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#1) // { arity: 1 }
         FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0{input})) // { arity: 2 }
@@ -149,276 +149,278 @@ Explained Query:
           FlatMap generate_series(3, (regexp_split_to_array[" ", case_insensitive=false](#0) array_length 1), 1) // { arity: 2 }
             Get l0 // { arity: 1 }
     cte l2 =
-      Distinct project=[#0, #1] monotonic // { arity: 2 }
-        Union // { arity: 2 }
-          Project (#0, #2) // { arity: 2 }
-            Filter (#1 > 0) // { arity: 3 }
-              Map ((#1 - 1)) // { arity: 3 }
-                Get l2 // { arity: 2 }
-          Project (#2, #3) // { arity: 2 }
-            Filter (#1 = 0) AND (#0 < 4100) // { arity: 4 }
-              Map ((#0 + 1), 20) // { arity: 4 }
-                Get l2 // { arity: 2 }
-          Constant // { arity: 2 }
-            - (1, 1)
-    cte l3 =
-      Union // { arity: 4 }
-        Project (#2, #0, #3, #4) // { arity: 4 }
-          Filter (#1 = 0) // { arity: 5 }
-            Map ("roadcaster", 1, "lo") // { arity: 5 }
-              Get l2 // { arity: 2 }
-        Filter (#2 > 0) // { arity: 4 }
-          Get l12 // { arity: 4 }
-        Filter (#2 > 0) // { arity: 4 }
-          Get l26 // { arity: 4 }
-    cte l4 =
-      ArrangeBy keys=[[#1]] // { arity: 4 }
-        Project (#0..=#3) // { arity: 4 }
-          Filter (#4 = "lo") AND (#1) IS NOT NULL // { arity: 5 }
-            Get l27 // { arity: 5 }
-    cte l5 =
       Project (#1, #2) // { arity: 2 }
         Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#0), 1), substr(#1, 2)) // { arity: 3 }
           Get l0 // { arity: 1 }
-    cte l6 =
-      Project (#0..=#3, #5) // { arity: 5 }
-        Map ((#3 + 1)) // { arity: 6 }
-          Join on=(#1 = #4) type=differential // { arity: 5 }
-            implementation
-              %0:l4[#1]Kef » %1:l5[#0]Kef
-            Get l4 // { arity: 4 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Project (#1) // { arity: 1 }
-                Filter ("%" = substr(#0, 1, 1)) // { arity: 2 }
-                  Get l5 // { arity: 2 }
-    cte l7 =
-      Distinct project=[#0, #2, #3, #1] // { arity: 4 }
-        Project (#0..=#3) // { arity: 4 }
-          Get l6 // { arity: 5 }
-    cte l8 =
-      Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
-        Project (#0..=#3) // { arity: 4 }
-          Filter ((#6 < #1) OR ((#1 = #6) AND ((#7 < #2) OR ((#2 = #7) AND (#4 < #0))))) // { arity: 8 }
-            Join on=(#3 = #5) type=differential // { arity: 8 }
-              implementation
-                %1:l4[#1]Kef » %0:l7[#3]Kef
-              ArrangeBy keys=[[#3]] // { arity: 4 }
-                Get l7 // { arity: 4 }
-              Get l4 // { arity: 4 }
-    cte l9 =
-      ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
-        Get l7 // { arity: 4 }
-    cte l10 =
-      Union // { arity: 5 }
-        Get l8 // { arity: 5 }
-        Project (#0..=#3, #8) // { arity: 5 }
-          Map (0) // { arity: 9 }
-            Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential // { arity: 8 }
-              implementation
-                %1:l9[#0..=#3]UKKKK » %0[#0..=#3]KKKK
-              ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
-                Union // { arity: 4 }
-                  Negate // { arity: 4 }
-                    Project (#0..=#3) // { arity: 4 }
-                      Get l8 // { arity: 5 }
-                  Get l7 // { arity: 4 }
-              Get l9 // { arity: 4 }
-    cte l11 =
-      Union // { arity: 5 }
-        Get l10 // { arity: 5 }
-        Map (error("more than one record produced in subquery")) // { arity: 5 }
+  Return // { arity: 5 }
+    With Mutually Recursive
+      cte l3 =
+        Distinct project=[#0, #1] monotonic // { arity: 2 }
+          Union // { arity: 2 }
+            Project (#0, #2) // { arity: 2 }
+              Filter (#1 > 0) // { arity: 3 }
+                Map ((#1 - 1)) // { arity: 3 }
+                  Get l3 // { arity: 2 }
+            Project (#2, #3) // { arity: 2 }
+              Filter (#1 = 0) AND (#0 < 4100) // { arity: 4 }
+                Map ((#0 + 1), 20) // { arity: 4 }
+                  Get l3 // { arity: 2 }
+            Constant // { arity: 2 }
+              - (1, 1)
+      cte l4 =
+        Union // { arity: 4 }
+          Project (#2, #0, #3, #4) // { arity: 4 }
+            Filter (#1 = 0) // { arity: 5 }
+              Map ("roadcaster", 1, "lo") // { arity: 5 }
+                Get l3 // { arity: 2 }
+          Filter (#2 > 0) // { arity: 4 }
+            Get l12 // { arity: 4 }
+          Filter (#2 > 0) // { arity: 4 }
+            Get l26 // { arity: 4 }
+      cte l5 =
+        ArrangeBy keys=[[#1]] // { arity: 4 }
           Project (#0..=#3) // { arity: 4 }
-            Filter (#4{count} > 1) // { arity: 5 }
-              Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
+            Filter (#4 = "lo") AND (#1) IS NOT NULL // { arity: 5 }
+              Get l27 // { arity: 5 }
+      cte l6 =
+        Project (#0..=#3, #5) // { arity: 5 }
+          Map ((#3 + 1)) // { arity: 6 }
+            Join on=(#1 = #4) type=differential // { arity: 5 }
+              implementation
+                %0:l5[#1]Kef » %1:l2[#0]Kef
+              Get l5 // { arity: 4 }
+              ArrangeBy keys=[[#0]] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Filter ("%" = substr(#0, 1, 1)) // { arity: 2 }
+                    Get l2 // { arity: 2 }
+      cte l7 =
+        Distinct project=[#0, #2, #3, #1] // { arity: 4 }
+          Project (#0..=#3) // { arity: 4 }
+            Get l6 // { arity: 5 }
+      cte l8 =
+        Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
+          Project (#0..=#3) // { arity: 4 }
+            Filter ((#6 < #1) OR ((#1 = #6) AND ((#7 < #2) OR ((#2 = #7) AND (#4 < #0))))) // { arity: 8 }
+              Join on=(#3 = #5) type=differential // { arity: 8 }
+                implementation
+                  %1:l5[#1]Kef » %0:l7[#3]Kef
+                ArrangeBy keys=[[#3]] // { arity: 4 }
+                  Get l7 // { arity: 4 }
+                Get l5 // { arity: 4 }
+      cte l9 =
+        ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+          Get l7 // { arity: 4 }
+      cte l10 =
+        Union // { arity: 5 }
+          Get l8 // { arity: 5 }
+          Project (#0..=#3, #8) // { arity: 5 }
+            Map (0) // { arity: 9 }
+              Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential // { arity: 8 }
+                implementation
+                  %1:l9[#0..=#3]UKKKK » %0[#0..=#3]KKKK
+                ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+                  Union // { arity: 4 }
+                    Negate // { arity: 4 }
+                      Project (#0..=#3) // { arity: 4 }
+                        Get l8 // { arity: 5 }
+                    Get l7 // { arity: 4 }
+                Get l9 // { arity: 4 }
+      cte l11 =
+        Union // { arity: 5 }
+          Get l10 // { arity: 5 }
+          Map (error("more than one record produced in subquery")) // { arity: 5 }
+            Project (#0..=#3) // { arity: 4 }
+              Filter (#4{count} > 1) // { arity: 5 }
+                Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
+                  Project (#0..=#3) // { arity: 4 }
+                    Get l10 // { arity: 5 }
+      cte l12 =
+        Project (#1, #2, #4, #10) // { arity: 4 }
+          Map (case when (0 = (#9{count} % 2)) then "hi" else "lo" end) // { arity: 11 }
+            Join on=(#0 = #5 AND #1 = #8 AND #2 = #6 AND #3 = #7) type=differential // { arity: 10 }
+              implementation
+                %0:l6[#0, #2, #3, #1]KKKK » %1[#0..=#3]KKKK
+              ArrangeBy keys=[[#0, #2, #3, #1]] // { arity: 5 }
+                Get l6 // { arity: 5 }
+              ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
+                Union // { arity: 5 }
+                  Get l11 // { arity: 5 }
+                  Project (#0..=#3, #8) // { arity: 5 }
+                    Map (null) // { arity: 9 }
+                      Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential // { arity: 8 }
+                        implementation
+                          %1:l9[#0..=#3]UKKKK » %0[#0..=#3]KKKK
+                        ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+                          Union // { arity: 4 }
+                            Negate // { arity: 4 }
+                              Distinct project=[#0..=#3] // { arity: 4 }
+                                Project (#0..=#3) // { arity: 4 }
+                                  Get l11 // { arity: 5 }
+                            Get l7 // { arity: 4 }
+                        Get l9 // { arity: 4 }
+      cte l13 =
+        Filter (#1) IS NOT NULL // { arity: 5 }
+          Get l27 // { arity: 5 }
+      cte l14 =
+        Project (#0..=#3, #5) // { arity: 5 }
+          Map ((#3 + 1)) // { arity: 6 }
+            Join on=(#1 = #4) type=differential // { arity: 5 }
+              implementation
+                %1:l2[#0]Kef » %0:l13[#1]Kef
+              ArrangeBy keys=[[#1]] // { arity: 4 }
                 Project (#0..=#3) // { arity: 4 }
-                  Get l10 // { arity: 5 }
-    cte l12 =
-      Project (#1, #2, #4, #10) // { arity: 4 }
-        Map (case when (0 = (#9{count} % 2)) then "hi" else "lo" end) // { arity: 11 }
-          Join on=(#0 = #5 AND #1 = #8 AND #2 = #6 AND #3 = #7) type=differential // { arity: 10 }
-            implementation
-              %0:l6[#0, #2, #3, #1]KKKK » %1[#0..=#3]KKKK
-            ArrangeBy keys=[[#0, #2, #3, #1]] // { arity: 5 }
-              Get l6 // { arity: 5 }
-            ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
-              Union // { arity: 5 }
-                Get l11 // { arity: 5 }
-                Project (#0..=#3, #8) // { arity: 5 }
-                  Map (null) // { arity: 9 }
-                    Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential // { arity: 8 }
-                      implementation
-                        %1:l9[#0..=#3]UKKKK » %0[#0..=#3]KKKK
-                      ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
-                        Union // { arity: 4 }
-                          Negate // { arity: 4 }
-                            Distinct project=[#0..=#3] // { arity: 4 }
-                              Project (#0..=#3) // { arity: 4 }
-                                Get l11 // { arity: 5 }
-                          Get l7 // { arity: 4 }
-                      Get l9 // { arity: 4 }
-    cte l13 =
-      Filter (#1) IS NOT NULL // { arity: 5 }
-        Get l27 // { arity: 5 }
-    cte l14 =
-      Project (#0..=#3, #5) // { arity: 5 }
-        Map ((#3 + 1)) // { arity: 6 }
-          Join on=(#1 = #4) type=differential // { arity: 5 }
-            implementation
-              %1:l5[#0]Kef » %0:l13[#1]Kef
-            ArrangeBy keys=[[#1]] // { arity: 4 }
-              Project (#0..=#3) // { arity: 4 }
-                Get l13 // { arity: 5 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Project (#1) // { arity: 1 }
-                Filter ("&" = substr(#0, 1, 1)) // { arity: 2 }
-                  Get l5 // { arity: 2 }
-    cte l15 =
-      Distinct project=[#0] // { arity: 1 }
-        Project (#1) // { arity: 1 }
-          Get l14 // { arity: 5 }
-    cte l16 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Get l15 // { arity: 1 }
-    cte l17 =
-      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-        Project (#0) // { arity: 1 }
-          Join on=(#0 = #1) type=differential // { arity: 2 }
-            implementation
-              %0:l16[#0]UK » %1:l1[#0]K
-            Get l16 // { arity: 1 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Project (#1) // { arity: 1 }
-                Filter (#1) IS NOT NULL // { arity: 2 }
-                  Get l1 // { arity: 2 }
-    cte l18 =
-      Union // { arity: 2 }
-        Get l17 // { arity: 2 }
-        Project (#0, #2) // { arity: 2 }
-          Map (0) // { arity: 3 }
+                  Get l13 // { arity: 5 }
+              ArrangeBy keys=[[#0]] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Filter ("&" = substr(#0, 1, 1)) // { arity: 2 }
+                    Get l2 // { arity: 2 }
+      cte l15 =
+        Distinct project=[#0] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Get l14 // { arity: 5 }
+      cte l16 =
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Get l15 // { arity: 1 }
+      cte l17 =
+        Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+          Project (#0) // { arity: 1 }
             Join on=(#0 = #1) type=differential // { arity: 2 }
               implementation
-                %1:l16[#0]UK » %0[#0]K
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Union // { arity: 1 }
-                  Negate // { arity: 1 }
-                    Project (#0) // { arity: 1 }
-                      Get l17 // { arity: 2 }
-                  Get l15 // { arity: 1 }
+                %0:l16[#0]UK » %1:l1[#0]K
               Get l16 // { arity: 1 }
-    cte l19 =
-      Union // { arity: 2 }
-        Get l18 // { arity: 2 }
-        Map (error("more than one record produced in subquery")) // { arity: 2 }
-          Project (#0) // { arity: 1 }
-            Filter (#1{count} > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                Project (#0) // { arity: 1 }
-                  Get l18 // { arity: 2 }
-    cte l20 =
-      Project (#0..=#4, #6{count}) // { arity: 6 }
-        Join on=(#1 = #5) type=differential // { arity: 7 }
-          implementation
-            %0:l14[#1]K » %1[#0]K
-          ArrangeBy keys=[[#1]] // { arity: 5 }
-            Get l14 // { arity: 5 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Union // { arity: 2 }
-              Get l19 // { arity: 2 }
-              Project (#0, #2) // { arity: 2 }
-                Map (null) // { arity: 3 }
-                  Join on=(#0 = #1) type=differential // { arity: 2 }
-                    implementation
-                      %1:l16[#0]UK » %0[#0]K
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Union // { arity: 1 }
-                        Negate // { arity: 1 }
-                          Distinct project=[#0] // { arity: 1 }
-                            Project (#0) // { arity: 1 }
-                              Get l19 // { arity: 2 }
-                        Get l15 // { arity: 1 }
-                    Get l16 // { arity: 1 }
-    cte l21 =
-      Distinct project=[#0, #2, #3, #1] // { arity: 4 }
-        Project (#0..=#3) // { arity: 4 }
-          Get l20 // { arity: 6 }
-    cte l22 =
-      Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
-        Project (#0..=#3) // { arity: 4 }
-          Filter (#7 = "hi") // { arity: 8 }
-            TopK group_by=[#0, #1, #2, #3, #4] order_by=[#5 desc nulls_first, #6 desc nulls_first] limit=1 exp_group_size=1000 // { arity: 8 }
-              Project (#0..=#4, #6..=#8) // { arity: 8 }
-                Filter ((#6 < #1) OR ((#1 = #6) AND ((#7 < #2) OR ((#2 = #7) AND (#4 <= #0))))) // { arity: 9 }
-                  Join on=(#3 = #5) type=differential // { arity: 9 }
-                    implementation
-                      %0:l21[#3]K » %1:l13[#1]K
-                    ArrangeBy keys=[[#3]] // { arity: 4 }
-                      Get l21 // { arity: 4 }
-                    ArrangeBy keys=[[#1]] // { arity: 5 }
-                      Get l13 // { arity: 5 }
-    cte l23 =
-      ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
-        Get l21 // { arity: 4 }
-    cte l24 =
-      Union // { arity: 5 }
-        Get l22 // { arity: 5 }
-        Project (#0..=#3, #8) // { arity: 5 }
-          Map (0) // { arity: 9 }
-            Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential // { arity: 8 }
-              implementation
-                %1:l23[#0..=#3]UKKKK » %0[#0..=#3]KKKK
-              ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
-                Union // { arity: 4 }
-                  Negate // { arity: 4 }
-                    Project (#0..=#3) // { arity: 4 }
-                      Get l22 // { arity: 5 }
-                  Get l21 // { arity: 4 }
-              Get l23 // { arity: 4 }
-    cte l25 =
-      Union // { arity: 5 }
-        Get l24 // { arity: 5 }
-        Map (error("more than one record produced in subquery")) // { arity: 5 }
-          Project (#0..=#3) // { arity: 4 }
-            Filter (#4{count} > 1) // { arity: 5 }
-              Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
-                Project (#0..=#3) // { arity: 4 }
-                  Get l24 // { arity: 5 }
-    cte l26 =
-      Project (#1, #2, #4, #11) // { arity: 4 }
-        Map (case when (#5{count} = #10{count}) then "lo" else "hi" end) // { arity: 12 }
-          Join on=(#0 = #6 AND #1 = #9 AND #2 = #7 AND #3 = #8) type=differential // { arity: 11 }
+              ArrangeBy keys=[[#0]] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Filter (#1) IS NOT NULL // { arity: 2 }
+                    Get l1 // { arity: 2 }
+      cte l18 =
+        Union // { arity: 2 }
+          Get l17 // { arity: 2 }
+          Project (#0, #2) // { arity: 2 }
+            Map (0) // { arity: 3 }
+              Join on=(#0 = #1) type=differential // { arity: 2 }
+                implementation
+                  %1:l16[#0]UK » %0[#0]K
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Union // { arity: 1 }
+                    Negate // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Get l17 // { arity: 2 }
+                    Get l15 // { arity: 1 }
+                Get l16 // { arity: 1 }
+      cte l19 =
+        Union // { arity: 2 }
+          Get l18 // { arity: 2 }
+          Map (error("more than one record produced in subquery")) // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              Filter (#1{count} > 1) // { arity: 2 }
+                Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                  Project (#0) // { arity: 1 }
+                    Get l18 // { arity: 2 }
+      cte l20 =
+        Project (#0..=#4, #6{count}) // { arity: 6 }
+          Join on=(#1 = #5) type=differential // { arity: 7 }
             implementation
-              %0:l20[#0, #2, #3, #1]KKKK » %1[#0..=#3]KKKK
-            ArrangeBy keys=[[#0, #2, #3, #1]] // { arity: 6 }
-              Get l20 // { arity: 6 }
-            ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
-              Union // { arity: 5 }
-                Get l25 // { arity: 5 }
-                Project (#0..=#3, #8) // { arity: 5 }
-                  Map (null) // { arity: 9 }
-                    Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential // { arity: 8 }
+              %0:l14[#1]K » %1[#0]K
+            ArrangeBy keys=[[#1]] // { arity: 5 }
+              Get l14 // { arity: 5 }
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Union // { arity: 2 }
+                Get l19 // { arity: 2 }
+                Project (#0, #2) // { arity: 2 }
+                  Map (null) // { arity: 3 }
+                    Join on=(#0 = #1) type=differential // { arity: 2 }
                       implementation
-                        %1:l23[#0..=#3]UKKKK » %0[#0..=#3]KKKK
-                      ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
-                        Union // { arity: 4 }
-                          Negate // { arity: 4 }
-                            Distinct project=[#0..=#3] // { arity: 4 }
-                              Project (#0..=#3) // { arity: 4 }
-                                Get l25 // { arity: 5 }
-                          Get l21 // { arity: 4 }
-                      Get l23 // { arity: 4 }
-    cte l27 =
-      Project (#0, #5, #1..=#3) // { arity: 5 }
-        Join on=(#0 = #4) type=differential // { arity: 6 }
-          implementation
-            %0:l3[#0]K » %1:l1[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 4 }
-            Get l3 // { arity: 4 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              Get l1 // { arity: 2 }
-  Return // { arity: 5 }
-    Filter (#1 = "cn") AND (#4 = "hi") // { arity: 5 }
-      Get l27 // { arity: 5 }
+                        %1:l16[#0]UK » %0[#0]K
+                      ArrangeBy keys=[[#0]] // { arity: 1 }
+                        Union // { arity: 1 }
+                          Negate // { arity: 1 }
+                            Distinct project=[#0] // { arity: 1 }
+                              Project (#0) // { arity: 1 }
+                                Get l19 // { arity: 2 }
+                          Get l15 // { arity: 1 }
+                      Get l16 // { arity: 1 }
+      cte l21 =
+        Distinct project=[#0, #2, #3, #1] // { arity: 4 }
+          Project (#0..=#3) // { arity: 4 }
+            Get l20 // { arity: 6 }
+      cte l22 =
+        Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
+          Project (#0..=#3) // { arity: 4 }
+            Filter (#7 = "hi") // { arity: 8 }
+              TopK group_by=[#0, #1, #2, #3, #4] order_by=[#5 desc nulls_first, #6 desc nulls_first] limit=1 exp_group_size=1000 // { arity: 8 }
+                Project (#0..=#4, #6..=#8) // { arity: 8 }
+                  Filter ((#6 < #1) OR ((#1 = #6) AND ((#7 < #2) OR ((#2 = #7) AND (#4 <= #0))))) // { arity: 9 }
+                    Join on=(#3 = #5) type=differential // { arity: 9 }
+                      implementation
+                        %0:l21[#3]K » %1:l13[#1]K
+                      ArrangeBy keys=[[#3]] // { arity: 4 }
+                        Get l21 // { arity: 4 }
+                      ArrangeBy keys=[[#1]] // { arity: 5 }
+                        Get l13 // { arity: 5 }
+      cte l23 =
+        ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+          Get l21 // { arity: 4 }
+      cte l24 =
+        Union // { arity: 5 }
+          Get l22 // { arity: 5 }
+          Project (#0..=#3, #8) // { arity: 5 }
+            Map (0) // { arity: 9 }
+              Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential // { arity: 8 }
+                implementation
+                  %1:l23[#0..=#3]UKKKK » %0[#0..=#3]KKKK
+                ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+                  Union // { arity: 4 }
+                    Negate // { arity: 4 }
+                      Project (#0..=#3) // { arity: 4 }
+                        Get l22 // { arity: 5 }
+                    Get l21 // { arity: 4 }
+                Get l23 // { arity: 4 }
+      cte l25 =
+        Union // { arity: 5 }
+          Get l24 // { arity: 5 }
+          Map (error("more than one record produced in subquery")) // { arity: 5 }
+            Project (#0..=#3) // { arity: 4 }
+              Filter (#4{count} > 1) // { arity: 5 }
+                Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
+                  Project (#0..=#3) // { arity: 4 }
+                    Get l24 // { arity: 5 }
+      cte l26 =
+        Project (#1, #2, #4, #11) // { arity: 4 }
+          Map (case when (#5{count} = #10{count}) then "lo" else "hi" end) // { arity: 12 }
+            Join on=(#0 = #6 AND #1 = #9 AND #2 = #7 AND #3 = #8) type=differential // { arity: 11 }
+              implementation
+                %0:l20[#0, #2, #3, #1]KKKK » %1[#0..=#3]KKKK
+              ArrangeBy keys=[[#0, #2, #3, #1]] // { arity: 6 }
+                Get l20 // { arity: 6 }
+              ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
+                Union // { arity: 5 }
+                  Get l25 // { arity: 5 }
+                  Project (#0..=#3, #8) // { arity: 5 }
+                    Map (null) // { arity: 9 }
+                      Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential // { arity: 8 }
+                        implementation
+                          %1:l23[#0..=#3]UKKKK » %0[#0..=#3]KKKK
+                        ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+                          Union // { arity: 4 }
+                            Negate // { arity: 4 }
+                              Distinct project=[#0..=#3] // { arity: 4 }
+                                Project (#0..=#3) // { arity: 4 }
+                                  Get l25 // { arity: 5 }
+                            Get l21 // { arity: 4 }
+                        Get l23 // { arity: 4 }
+      cte l27 =
+        Project (#0, #5, #1..=#3) // { arity: 5 }
+          Join on=(#0 = #4) type=differential // { arity: 6 }
+            implementation
+              %0:l4[#0]K » %1:l1[#0]K
+            ArrangeBy keys=[[#0]] // { arity: 4 }
+              Get l4 // { arity: 4 }
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Filter (#0) IS NOT NULL // { arity: 2 }
+                Get l1 // { arity: 2 }
+    Return // { arity: 5 }
+      Filter (#1 = "cn") AND (#4 = "hi") // { arity: 5 }
+        Get l27 // { arity: 5 }
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1222.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1222.slt
@@ -206,53 +206,19 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#1, #2) // { arity: 2 }
         Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
           FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
             ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Distinct project=[#0] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l7 // { arity: 4 }
+      Project (#0) // { arity: 1 }
+        Get l0 // { arity: 2 }
     cte l2 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
-        CrossJoin type=differential // { arity: 2 }
-          implementation
-            %0:l1[×] » %1:l10[×]
-          ArrangeBy keys=[[]] // { arity: 1 }
-            Get l1 // { arity: 1 }
-          ArrangeBy keys=[[]] // { arity: 1 }
-            Get l10 // { arity: 1 }
-    cte l3 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         Get l1 // { arity: 1 }
-    cte l4 =
-      Union // { arity: 2 }
-        Get l2 // { arity: 2 }
-        Project (#0, #2) // { arity: 2 }
-          Map (false) // { arity: 3 }
-            Join on=(#0 = #1) type=differential // { arity: 2 }
-              implementation
-                %1:l3[#0]UK » %0[#0]K
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Union // { arity: 1 }
-                  Negate // { arity: 1 }
-                    Project (#0) // { arity: 1 }
-                      Get l2 // { arity: 2 }
-                  Get l1 // { arity: 1 }
-              Get l3 // { arity: 1 }
-    cte l5 =
-      Union // { arity: 2 }
-        Get l4 // { arity: 2 }
-        Map (error("more than one record produced in subquery")) // { arity: 2 }
-          Project (#0) // { arity: 1 }
-            Filter (#1{count} > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                Project (#0) // { arity: 1 }
-                  Get l4 // { arity: 2 }
-    cte l6 =
+    cte l3 =
       Project (#0, #1, #3, #5) // { arity: 4 }
         Join on=(#0 = #2 = #4) type=delta // { arity: 6 }
           implementation
@@ -271,211 +237,243 @@ Explained Query:
             Project (#0, #2) // { arity: 2 }
               FlatMap generate_series(text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 1)), 3)), text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 2)), 3)), 1) // { arity: 3 }
                 Get l0 // { arity: 2 }
-    cte l7 =
-      Union // { arity: 4 }
-        Threshold // { arity: 4 }
-          Union // { arity: 4 }
-            Get l6 // { arity: 4 }
-            Negate // { arity: 4 }
-              Get l16 // { arity: 4 }
-        Project (#0..=#2, #6) // { arity: 4 }
-          Map (case when #5{any} then #3 else (#3 - 1) end) // { arity: 7 }
-            Join on=(#0 = #4) type=differential // { arity: 6 }
-              implementation
-                %0:l7[#0]K » %1[#0]K
-              ArrangeBy keys=[[#0]] // { arity: 4 }
-                Get l7 // { arity: 4 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Union // { arity: 2 }
-                  Get l5 // { arity: 2 }
-                  Project (#0, #2) // { arity: 2 }
-                    Map (null) // { arity: 3 }
-                      Join on=(#0 = #1) type=differential // { arity: 2 }
-                        implementation
-                          %1:l3[#0]UK » %0[#0]K
-                        ArrangeBy keys=[[#0]] // { arity: 1 }
-                          Union // { arity: 1 }
-                            Negate // { arity: 1 }
-                              Distinct project=[#0] // { arity: 1 }
-                                Project (#0) // { arity: 1 }
-                                  Get l5 // { arity: 2 }
-                            Get l1 // { arity: 1 }
-                        Get l3 // { arity: 1 }
-    cte l8 =
-      Distinct project=[#0, #1] // { arity: 2 }
-        Project (#0, #4) // { arity: 2 }
-          Filter (#0 != #4) // { arity: 8 }
-            Join on=(#1 = #5 AND #2 = #6 AND #7 = (#3 + 1)) type=differential // { arity: 8 }
-              implementation
-                %0:l7[#1, #2, (#3 + 1)]KKK » %1:l7[#1..=#3]KKK
-              ArrangeBy keys=[[#1, #2, (#3 + 1)]] // { arity: 4 }
-                Get l7 // { arity: 4 }
-              ArrangeBy keys=[[#1..=#3]] // { arity: 4 }
-                Get l7 // { arity: 4 }
-    cte l9 =
-      Project (#1) // { arity: 1 }
-        Get l8 // { arity: 2 }
-    cte l10 =
-      Distinct project=[#0] // { arity: 1 }
-        Union // { arity: 1 }
+  Return // { arity: 2 }
+    With Mutually Recursive
+      cte l4 =
+        Distinct project=[#0] // { arity: 1 }
           Project (#0) // { arity: 1 }
-            Filter (#3 = 1) // { arity: 4 }
-              Get l7 // { arity: 4 }
-          Get l9 // { arity: 1 }
-    cte l11 =
-      Project (#0) // { arity: 1 }
-        Get l0 // { arity: 2 }
-    cte l12 =
-      Distinct project=[#0] // { arity: 1 }
-        Get l11 // { arity: 1 }
-    cte l13 =
-      CrossJoin type=differential // { arity: 3 }
-        implementation
-          %0:l12[×] » %1:l8[×]
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Get l12 // { arity: 1 }
-        ArrangeBy keys=[[]] // { arity: 2 }
-          Get l8 // { arity: 2 }
-    cte l14 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Get l9 // { arity: 1 }
-    cte l15 =
-      Reduce aggregates=[count(distinct #0)] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Join on=(#0 = #1 = #2) type=delta // { arity: 3 }
+            Get l9 // { arity: 4 }
+      cte l5 =
+        Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+          CrossJoin type=differential // { arity: 2 }
             implementation
-              %0:l11 » %2:l12[#0]UK » %1[#0]K
-              %1 » %2:l12[#0]UK » %0:l11[#0]K
-              %2:l12 » %0:l11[#0]K » %1[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Get l11 // { arity: 1 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Union // { arity: 1 }
-                Negate // { arity: 1 }
-                  Distinct project=[#0] // { arity: 1 }
-                    Project (#0) // { arity: 1 }
-                      Filter (#3{count} = 1) // { arity: 4 }
-                        Join on=(#1 = #2) type=differential // { arity: 4 }
-                          implementation
-                            %1[#0]UKAef » %0:l13[#1]Kef
-                          ArrangeBy keys=[[#1]] // { arity: 2 }
-                            Project (#0, #2) // { arity: 2 }
-                              Filter (#0 = #1) // { arity: 3 }
-                                Get l13 // { arity: 3 }
-                          ArrangeBy keys=[[#0]] // { arity: 2 }
-                            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                              Project (#0) // { arity: 1 }
-                                Join on=(#0 = #1) type=differential // { arity: 2 }
-                                  implementation
-                                    %0[#0]UKA » %1:l14[#0]K
-                                  ArrangeBy keys=[[#0]] // { arity: 1 }
-                                    Distinct project=[#0] // { arity: 1 }
-                                      Project (#2) // { arity: 1 }
-                                        Get l13 // { arity: 3 }
-                                  Get l14 // { arity: 1 }
-                Get l12 // { arity: 1 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
+              %0:l4[×] » %1:l12[×]
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Get l4 // { arity: 1 }
+            ArrangeBy keys=[[]] // { arity: 1 }
               Get l12 // { arity: 1 }
-    cte l16 =
-      Get l6 // { arity: 4 }
-    cte l17 =
-      Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
-        Project (#0, #3) // { arity: 2 }
-          Join on=(#1 = #2) type=differential // { arity: 4 }
-            implementation
-              %0:l22[#1]K » %1:l8[#0]K
-            ArrangeBy keys=[[#1]] // { arity: 2 }
-              Get l22 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
-              Get l8 // { arity: 2 }
-    cte l18 =
-      Distinct project=[#0] // { arity: 1 }
+      cte l6 =
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Get l4 // { arity: 1 }
+      cte l7 =
+        Union // { arity: 2 }
+          Get l5 // { arity: 2 }
+          Project (#0, #2) // { arity: 2 }
+            Map (false) // { arity: 3 }
+              Join on=(#0 = #1) type=differential // { arity: 2 }
+                implementation
+                  %1:l6[#0]UK » %0[#0]K
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Union // { arity: 1 }
+                    Negate // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Get l5 // { arity: 2 }
+                    Get l4 // { arity: 1 }
+                Get l6 // { arity: 1 }
+      cte l8 =
+        Union // { arity: 2 }
+          Get l7 // { arity: 2 }
+          Map (error("more than one record produced in subquery")) // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              Filter (#1{count} > 1) // { arity: 2 }
+                Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                  Project (#0) // { arity: 1 }
+                    Get l7 // { arity: 2 }
+      cte l9 =
+        Union // { arity: 4 }
+          Threshold // { arity: 4 }
+            Union // { arity: 4 }
+              Get l3 // { arity: 4 }
+              Negate // { arity: 4 }
+                Get l16 // { arity: 4 }
+          Project (#0..=#2, #6) // { arity: 4 }
+            Map (case when #5{any} then #3 else (#3 - 1) end) // { arity: 7 }
+              Join on=(#0 = #4) type=differential // { arity: 6 }
+                implementation
+                  %0:l9[#0]K » %1[#0]K
+                ArrangeBy keys=[[#0]] // { arity: 4 }
+                  Get l9 // { arity: 4 }
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Union // { arity: 2 }
+                    Get l8 // { arity: 2 }
+                    Project (#0, #2) // { arity: 2 }
+                      Map (null) // { arity: 3 }
+                        Join on=(#0 = #1) type=differential // { arity: 2 }
+                          implementation
+                            %1:l6[#0]UK » %0[#0]K
+                          ArrangeBy keys=[[#0]] // { arity: 1 }
+                            Union // { arity: 1 }
+                              Negate // { arity: 1 }
+                                Distinct project=[#0] // { arity: 1 }
+                                  Project (#0) // { arity: 1 }
+                                    Get l8 // { arity: 2 }
+                              Get l4 // { arity: 1 }
+                          Get l6 // { arity: 1 }
+      cte l10 =
+        Distinct project=[#0, #1] // { arity: 2 }
+          Project (#0, #4) // { arity: 2 }
+            Filter (#0 != #4) // { arity: 8 }
+              Join on=(#1 = #5 AND #2 = #6 AND #7 = (#3 + 1)) type=differential // { arity: 8 }
+                implementation
+                  %0:l9[#1, #2, (#3 + 1)]KKK » %1:l9[#1..=#3]KKK
+                ArrangeBy keys=[[#1, #2, (#3 + 1)]] // { arity: 4 }
+                  Get l9 // { arity: 4 }
+                ArrangeBy keys=[[#1..=#3]] // { arity: 4 }
+                  Get l9 // { arity: 4 }
+      cte l11 =
         Project (#1) // { arity: 1 }
-          Get l17 // { arity: 3 }
-    cte l19 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Get l18 // { arity: 1 }
-    cte l20 =
-      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-        Project (#0) // { arity: 1 }
-          Join on=(#0 = #1) type=differential // { arity: 2 }
-            implementation
-              %0:l19[#0]UK » %1:l14[#0]K
-            Get l19 // { arity: 1 }
-            Get l14 // { arity: 1 }
-    cte l21 =
-      Union // { arity: 2 }
-        Get l20 // { arity: 2 }
-        Project (#0, #2) // { arity: 2 }
-          Map (0) // { arity: 3 }
+          Get l10 // { arity: 2 }
+      cte l12 =
+        Distinct project=[#0] // { arity: 1 }
+          Union // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#3 = 1) // { arity: 4 }
+                Get l9 // { arity: 4 }
+            Get l11 // { arity: 1 }
+      cte l13 =
+        CrossJoin type=differential // { arity: 3 }
+          implementation
+            %0:l2[×] » %1:l10[×]
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l2 // { arity: 1 }
+          ArrangeBy keys=[[]] // { arity: 2 }
+            Get l10 // { arity: 2 }
+      cte l14 =
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Get l11 // { arity: 1 }
+      cte l15 =
+        Reduce aggregates=[count(distinct #0)] // { arity: 1 }
+          Project (#0) // { arity: 1 }
             Join on=(#0 = #1) type=differential // { arity: 2 }
               implementation
-                %1:l19[#0]UK » %0[#0]K
+                %0:l1[#0]K » %1[#0]K
+              ArrangeBy keys=[[#0]] // { arity: 1 }
+                Get l1 // { arity: 1 }
               ArrangeBy keys=[[#0]] // { arity: 1 }
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
-                    Project (#0) // { arity: 1 }
-                      Get l20 // { arity: 2 }
-                  Get l18 // { arity: 1 }
-              Get l19 // { arity: 1 }
-    cte l22 =
-      Distinct project=[#0, #1] // { arity: 2 }
-        Union // { arity: 2 }
-          Project (#0, #1) // { arity: 2 }
-            Filter (#3{count} = 1) // { arity: 4 }
-              Join on=(#1 = #2) type=differential // { arity: 4 }
-                implementation
-                  %1[#0]UKAef » %0:l8[#1]Kef
-                ArrangeBy keys=[[#1]] // { arity: 2 }
-                  Get l8 // { arity: 2 }
-                ArrangeBy keys=[[#0]] // { arity: 2 }
-                  Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                    Get l9 // { arity: 1 }
-          Project (#0, #1) // { arity: 2 }
-            Join on=(#1 = #3 AND #2{count} = #4{count}) type=differential // { arity: 5 }
+                    Distinct project=[#0] // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Filter (#3{count} = 1) // { arity: 4 }
+                          Join on=(#1 = #2) type=differential // { arity: 4 }
+                            implementation
+                              %1[#0]UKAef » %0:l13[#1]Kef
+                            ArrangeBy keys=[[#1]] // { arity: 2 }
+                              Project (#0, #2) // { arity: 2 }
+                                Filter (#0 = #1) // { arity: 3 }
+                                  Get l13 // { arity: 3 }
+                            ArrangeBy keys=[[#0]] // { arity: 2 }
+                              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                                Project (#0) // { arity: 1 }
+                                  Join on=(#0 = #1) type=differential // { arity: 2 }
+                                    implementation
+                                      %0[#0]UKA » %1:l14[#0]K
+                                    ArrangeBy keys=[[#0]] // { arity: 1 }
+                                      Distinct project=[#0] // { arity: 1 }
+                                        Project (#2) // { arity: 1 }
+                                          Get l13 // { arity: 3 }
+                                    Get l14 // { arity: 1 }
+                  Get l2 // { arity: 1 }
+      cte l16 =
+        Get l3 // { arity: 4 }
+      cte l17 =
+        Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+          Project (#0, #3) // { arity: 2 }
+            Join on=(#1 = #2) type=differential // { arity: 4 }
               implementation
-                %0:l17[#1, #2]KK » %1[#0, #1]KK
-              ArrangeBy keys=[[#1, #2{count}]] // { arity: 3 }
-                Get l17 // { arity: 3 }
-              ArrangeBy keys=[[#0, #1{count}]] // { arity: 2 }
-                Union // { arity: 2 }
-                  Get l21 // { arity: 2 }
-                  Map (error("more than one record produced in subquery")) // { arity: 2 }
-                    Project (#0) // { arity: 1 }
-                      Filter (#1{count} > 1) // { arity: 2 }
-                        Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                          Project (#0) // { arity: 1 }
-                            Get l21 // { arity: 2 }
-  Return // { arity: 2 }
-    With
-      cte l23 =
-        Reduce aggregates=[count(*)] // { arity: 1 }
-          Project () // { arity: 0 }
-            Get l22 // { arity: 2 }
+                %0:l22[#1]K » %1:l10[#0]K
+              ArrangeBy keys=[[#1]] // { arity: 2 }
+                Get l22 // { arity: 2 }
+              ArrangeBy keys=[[#0]] // { arity: 2 }
+                Get l10 // { arity: 2 }
+      cte l18 =
+        Distinct project=[#0] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Get l17 // { arity: 3 }
+      cte l19 =
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Get l18 // { arity: 1 }
+      cte l20 =
+        Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Join on=(#0 = #1) type=differential // { arity: 2 }
+              implementation
+                %0:l19[#0]UK » %1:l14[#0]K
+              Get l19 // { arity: 1 }
+              Get l14 // { arity: 1 }
+      cte l21 =
+        Union // { arity: 2 }
+          Get l20 // { arity: 2 }
+          Project (#0, #2) // { arity: 2 }
+            Map (0) // { arity: 3 }
+              Join on=(#0 = #1) type=differential // { arity: 2 }
+                implementation
+                  %1:l19[#0]UK » %0[#0]K
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Union // { arity: 1 }
+                    Negate // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Get l20 // { arity: 2 }
+                    Get l18 // { arity: 1 }
+                Get l19 // { arity: 1 }
+      cte l22 =
+        Distinct project=[#0, #1] // { arity: 2 }
+          Union // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Filter (#3{count} = 1) // { arity: 4 }
+                Join on=(#1 = #2) type=differential // { arity: 4 }
+                  implementation
+                    %1[#0]UKAef » %0:l10[#1]Kef
+                  ArrangeBy keys=[[#1]] // { arity: 2 }
+                    Get l10 // { arity: 2 }
+                  ArrangeBy keys=[[#0]] // { arity: 2 }
+                    Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                      Get l11 // { arity: 1 }
+            Project (#0, #1) // { arity: 2 }
+              Join on=(#1 = #3 AND #2{count} = #4{count}) type=differential // { arity: 5 }
+                implementation
+                  %0:l17[#1, #2]KK » %1[#0, #1]KK
+                ArrangeBy keys=[[#1, #2{count}]] // { arity: 3 }
+                  Get l17 // { arity: 3 }
+                ArrangeBy keys=[[#0, #1{count}]] // { arity: 2 }
+                  Union // { arity: 2 }
+                    Get l21 // { arity: 2 }
+                    Map (error("more than one record produced in subquery")) // { arity: 2 }
+                      Project (#0) // { arity: 1 }
+                        Filter (#1{count} > 1) // { arity: 2 }
+                          Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                            Project (#0) // { arity: 1 }
+                              Get l21 // { arity: 2 }
     Return // { arity: 2 }
-      CrossJoin type=differential // { arity: 2 }
-        implementation
-          %0[×]U » %1[×]U
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l15 // { arity: 1 }
-            Map (0) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l15 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l23 // { arity: 1 }
-            Map (0) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l23 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
+      With
+        cte l23 =
+          Reduce aggregates=[count(*)] // { arity: 1 }
+            Project () // { arity: 0 }
+              Get l22 // { arity: 2 }
+      Return // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0[×]U » %1[×]U
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l15 // { arity: 1 }
+              Map (0) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l15 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l23 // { arity: 1 }
+              Map (0) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l23 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1223.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1223.slt
@@ -292,7 +292,7 @@ SELECT * FROM longest ORDER BY d DESC;
 ----
 Explained Query:
   Finish order_by=[#2{max} desc nulls_first] output=[#0..=#3]
-    With Mutually Recursive
+    With
       cte l0 =
         Project (#0, #2) // { arity: 2 }
           Filter ("#" != substr(#1, #2, 1)) // { arity: 3 }
@@ -380,54 +380,6 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Get l3 // { arity: 4 }
       cte l5 =
-        ArrangeBy keys=[[#0, #1]] // { arity: 4 }
-          Get l3 // { arity: 4 }
-      cte l6 =
-        Project (#0..=#4, #7, #8) // { arity: 7 }
-          Filter ((#0 != #7) OR (#1 != #8)) // { arity: 9 }
-            Join on=(#3 = #5 AND #4 = #6) type=differential // { arity: 9 }
-              implementation
-                %0:l9[#3, #4]KK » %1:l5[#0, #1]KK
-              ArrangeBy keys=[[#3, #4]] // { arity: 5 }
-                Get l9 // { arity: 5 }
-              Get l5 // { arity: 4 }
-      cte l7 =
-        Distinct project=[#0, #1] // { arity: 2 }
-          Project (#3, #4) // { arity: 2 }
-            Get l6 // { arity: 7 }
-      cte l8 =
-        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-          Get l4 // { arity: 2 }
-      cte l9 =
-        Project (#0, #1, #4{min}, #2, #3) // { arity: 5 }
-          Reduce group_by=[#0, #1, #3, #4] aggregates=[min(#2)] // { arity: 5 }
-            Union // { arity: 5 }
-              Project (#0, #1, #6, #2, #3) // { arity: 5 }
-                Map (1) // { arity: 7 }
-                  Join on=(#0 = #4 AND #1 = #5) type=differential // { arity: 6 }
-                    implementation
-                      %1:l8[#0, #1]UKK » %0:l5[#0, #1]KK
-                    Get l5 // { arity: 4 }
-                    Get l8 // { arity: 2 }
-              Project (#0, #1, #9, #5, #6) // { arity: 5 }
-                Map ((#2 + 1)) // { arity: 10 }
-                  Join on=(#3 = #7 AND #4 = #8) type=differential // { arity: 9 }
-                    implementation
-                      %0:l6[#3, #4]KK » %1[#0, #1]KK
-                    ArrangeBy keys=[[#3, #4]] // { arity: 7 }
-                      Get l6 // { arity: 7 }
-                    ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                      Union // { arity: 2 }
-                        Negate // { arity: 2 }
-                          Project (#0, #1) // { arity: 2 }
-                            Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
-                              implementation
-                                %0:l7[#0, #1]UKK » %1:l8[#0, #1]UKK
-                              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                                Get l7 // { arity: 2 }
-                              Get l8 // { arity: 2 }
-                        Get l7 // { arity: 2 }
-      cte l10 =
         Union // { arity: 2 }
           Negate // { arity: 2 }
             Distinct project=[#0, #1] // { arity: 2 }
@@ -436,30 +388,30 @@ Explained Query:
                   FlatMap wrap2(1, 2, 12, 20, 130, 126, 141, 140) // { arity: 4 }
                     Get l4 // { arity: 2 }
           Get l4 // { arity: 2 }
-      cte l11 =
+      cte l6 =
         Distinct project=[#0, #1] // { arity: 2 }
-          Get l10 // { arity: 2 }
-      cte l12 =
+          Get l5 // { arity: 2 }
+      cte l7 =
         Filter ((#2 < #0) OR ((#0 = #2) AND (#3 < #1))) // { arity: 4 }
           CrossJoin type=differential // { arity: 4 }
             implementation
-              %0:l11[×] » %1:l4[×]
+              %0:l6[×] » %1:l4[×]
             ArrangeBy keys=[[]] // { arity: 2 }
-              Get l11 // { arity: 2 }
+              Get l6 // { arity: 2 }
             ArrangeBy keys=[[]] // { arity: 2 }
               Get l4 // { arity: 2 }
-      cte l13 =
+      cte l8 =
         Distinct project=[#0, #1] // { arity: 2 }
           Project (#2, #3) // { arity: 2 }
-            Get l12 // { arity: 4 }
-      cte l14 =
+            Get l7 // { arity: 4 }
+      cte l9 =
         Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
           Project (#0, #1) // { arity: 2 }
             Join on=(#2 = #4 AND #3 = #5) type=differential // { arity: 6 }
               implementation
-                %0:l12[#2, #3]KK » %1[#0, #1]KK
+                %0:l7[#2, #3]KK » %1[#0, #1]KK
               ArrangeBy keys=[[#2, #3]] // { arity: 4 }
-                Get l12 // { arity: 4 }
+                Get l7 // { arity: 4 }
               ArrangeBy keys=[[#0, #1]] // { arity: 2 }
                 Union // { arity: 2 }
                   Negate // { arity: 2 }
@@ -467,62 +419,90 @@ Explained Query:
                       Project (#0, #1) // { arity: 2 }
                         Filter (#0 = #2) AND (#1 = #3) // { arity: 4 }
                           FlatMap wrap2(1, 2, 12, 20, 130, 126, 141, 140) // { arity: 4 }
-                            Get l13 // { arity: 2 }
-                  Get l13 // { arity: 2 }
-      cte l15 =
+                            Get l8 // { arity: 2 }
+                  Get l8 // { arity: 2 }
+      cte l10 =
+        ArrangeBy keys=[[#0, #1]] // { arity: 4 }
+          Get l3 // { arity: 4 }
+      cte l11 =
         ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-          Get l11 // { arity: 2 }
-      cte l16 =
-        Union // { arity: 3 }
-          Get l14 // { arity: 3 }
-          Project (#0, #1, #4) // { arity: 3 }
-            Map (0) // { arity: 5 }
-              Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
-                implementation
-                  %1:l15[#0, #1]UKK » %0[#0, #1]KK
-                ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                  Union // { arity: 2 }
-                    Negate // { arity: 2 }
-                      Project (#0, #1) // { arity: 2 }
-                        Get l14 // { arity: 3 }
-                    Get l11 // { arity: 2 }
-                Get l15 // { arity: 2 }
-      cte l17 =
-        Project (#0, #1, #3{max}, #2) // { arity: 4 }
-          Reduce group_by=[#0, #1, #3] aggregates=[max(#2)] // { arity: 4 }
-            Union // { arity: 4 }
-              Project (#7, #8, #19, #20) // { arity: 4 }
-                Filter (1 != ((#3 >> #18) % 2)) // { arity: 21 }
-                  Map (bigint_to_integer(#17{count}), (#2 + #6{min}), (#3 + (1 << #18))) // { arity: 21 }
-                    Join on=(#0 = #4 AND #1 = #5 AND #7 = #9 = #11 = #13 = #15 AND #8 = #10 = #12 = #14 = #16) type=delta // { arity: 18 }
-                      implementation
-                        %0:l17 » %1:l9[#0, #1]KK » %2:l8[#0, #1]UKK » %4:l15[#0, #1]UKK » %3:l10[#0, #1]KK » %5[#0, #1]KK
-                        %1:l9 » %2:l8[#0, #1]UKK » %4:l15[#0, #1]UKK » %0:l17[#0, #1]KK » %3:l10[#0, #1]KK » %5[#0, #1]KK
-                        %2:l8 » %4:l15[#0, #1]UKK » %1:l9[#3, #4]KK » %0:l17[#0, #1]KK » %3:l10[#0, #1]KK » %5[#0, #1]KK
-                        %3:l10 » %2:l8[#0, #1]UKK » %4:l15[#0, #1]UKK » %1:l9[#3, #4]KK » %0:l17[#0, #1]KK » %5[#0, #1]KK
-                        %4:l15 » %2:l8[#0, #1]UKK » %1:l9[#3, #4]KK » %0:l17[#0, #1]KK » %3:l10[#0, #1]KK » %5[#0, #1]KK
-                        %5 » %2:l8[#0, #1]UKK » %4:l15[#0, #1]UKK » %1:l9[#3, #4]KK » %0:l17[#0, #1]KK » %3:l10[#0, #1]KK
-                      ArrangeBy keys=[[#0, #1]] // { arity: 4 }
-                        Get l17 // { arity: 4 }
-                      ArrangeBy keys=[[#0, #1], [#3, #4]] // { arity: 5 }
-                        Get l9 // { arity: 5 }
-                      Get l8 // { arity: 2 }
-                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                        Get l10 // { arity: 2 }
-                      Get l15 // { arity: 2 }
-                      ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-                        Union // { arity: 3 }
-                          Get l16 // { arity: 3 }
-                          Map (error("more than one record produced in subquery")) // { arity: 3 }
-                            Project (#0, #1) // { arity: 2 }
-                              Filter (#2{count} > 1) // { arity: 3 }
-                                Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
-                                  Project (#0, #1) // { arity: 2 }
-                                    Get l16 // { arity: 3 }
-              Constant // { arity: 4 }
-                - (12, 20, 0, 0)
+          Get l4 // { arity: 2 }
     Return // { arity: 4 }
-      Get l17 // { arity: 4 }
+      With Mutually Recursive
+        cte l12 =
+          Project (#0..=#4, #7, #8) // { arity: 7 }
+            Filter ((#0 != #7) OR (#1 != #8)) // { arity: 9 }
+              Join on=(#3 = #5 AND #4 = #6) type=differential // { arity: 9 }
+                implementation
+                  %0:l14[#3, #4]KK » %1:l10[#0, #1]KK
+                ArrangeBy keys=[[#3, #4]] // { arity: 5 }
+                  Get l14 // { arity: 5 }
+                Get l10 // { arity: 4 }
+        cte l13 =
+          Distinct project=[#0, #1] // { arity: 2 }
+            Project (#3, #4) // { arity: 2 }
+              Get l12 // { arity: 7 }
+        cte l14 =
+          Project (#0, #1, #4{min}, #2, #3) // { arity: 5 }
+            Reduce group_by=[#0, #1, #3, #4] aggregates=[min(#2)] // { arity: 5 }
+              Union // { arity: 5 }
+                Project (#0, #1, #6, #2, #3) // { arity: 5 }
+                  Map (1) // { arity: 7 }
+                    Join on=(#0 = #4 AND #1 = #5) type=differential // { arity: 6 }
+                      implementation
+                        %1:l11[#0, #1]UKK » %0:l10[#0, #1]KK
+                      Get l10 // { arity: 4 }
+                      Get l11 // { arity: 2 }
+                Project (#0, #1, #9, #5, #6) // { arity: 5 }
+                  Map ((#2 + 1)) // { arity: 10 }
+                    Join on=(#3 = #7 AND #4 = #8) type=differential // { arity: 9 }
+                      implementation
+                        %0:l12[#3, #4]KK » %1[#0, #1]KK
+                      ArrangeBy keys=[[#3, #4]] // { arity: 7 }
+                        Get l12 // { arity: 7 }
+                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                        Union // { arity: 2 }
+                          Negate // { arity: 2 }
+                            Project (#0, #1) // { arity: 2 }
+                              Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                                implementation
+                                  %0:l13[#0, #1]UKK » %1:l11[#0, #1]UKK
+                                ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                                  Get l13 // { arity: 2 }
+                                Get l11 // { arity: 2 }
+                          Get l13 // { arity: 2 }
+        cte l15 =
+          Project (#0, #1, #3{max}, #2) // { arity: 4 }
+            Reduce group_by=[#0, #1, #3] aggregates=[max(#2)] // { arity: 4 }
+              Union // { arity: 4 }
+                Project (#7, #8, #15, #16) // { arity: 4 }
+                  Filter (1 != ((#3 >> #14) % 2)) // { arity: 17 }
+                    Map (bigint_to_integer(#13{count}), (#2 + #6{min}), (#3 + (1 << #14))) // { arity: 17 }
+                      Join on=(#0 = #4 AND #1 = #5 AND #7 = #9 = #11 AND #8 = #10 = #12) type=delta // { arity: 14 }
+                        implementation
+                          %0:l15 » %1:l14[#0, #1]KK » %3[#0, #1]UKK » %2:l5[#0, #1]KK
+                          %1:l14 » %3[#0, #1]UKK » %0:l15[#0, #1]KK » %2:l5[#0, #1]KK
+                          %2:l5 » %3[#0, #1]UKK » %1:l14[#3, #4]KK » %0:l15[#0, #1]KK
+                          %3 » %1:l14[#3, #4]KK » %0:l15[#0, #1]KK » %2:l5[#0, #1]KK
+                        ArrangeBy keys=[[#0, #1]] // { arity: 4 }
+                          Get l15 // { arity: 4 }
+                        ArrangeBy keys=[[#0, #1], [#3, #4]] // { arity: 5 }
+                          Get l14 // { arity: 5 }
+                        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                          Get l5 // { arity: 2 }
+                        ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+                          Union // { arity: 3 }
+                            Get l9 // { arity: 3 }
+                            Map (0) // { arity: 3 }
+                              Union // { arity: 2 }
+                                Negate // { arity: 2 }
+                                  Project (#0, #1) // { arity: 2 }
+                                    Get l9 // { arity: 3 }
+                                Get l6 // { arity: 2 }
+                Constant // { arity: 4 }
+                  - (12, 20, 0, 0)
+      Return // { arity: 4 }
+        Get l15 // { arity: 4 }
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1225.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1225.slt
@@ -129,7 +129,7 @@ WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 50)
 SELECT * FROM part1;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#3, #4) // { arity: 2 }
         Map (regexp_split_to_array[" ", case_insensitive=false](#0), btrim(array_index(#2, 1), ":"), btrim(array_index(#2, integer_to_bigint(#1)), ",")) // { arity: 5 }
@@ -145,144 +145,146 @@ Explained Query:
             Get l0 // { arity: 2 }
           Project (#1) // { arity: 1 }
             Get l0 // { arity: 2 }
-    cte l2 =
-      Project (#1{sum}) // { arity: 1 }
-        Get l7 // { arity: 2 }
-    cte l3 =
-      Reduce aggregates=[sum(#0), count(#0)] // { arity: 2 }
-        Get l2 // { arity: 1 }
-    cte l4 =
-      Project (#2) // { arity: 1 }
-        Map ((#0{sum} / bigint_to_numeric(case when (#1{count} = 0) then null else #1{count} end))) // { arity: 3 }
-          Union // { arity: 2 }
-            Get l3 // { arity: 2 }
-            Map (null, 0) // { arity: 2 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l3 // { arity: 2 }
-                Constant // { arity: 0 }
-                  - ()
-    cte l5 =
-      Reduce aggregates=[sum((#0 * #0)), sum(#0), count(#0)] // { arity: 3 }
-        Get l2 // { arity: 1 }
-    cte l6 =
-      Project (#3) // { arity: 1 }
-        Map (sqrtnumeric(case when ((#0{sum}) IS NULL OR (#1{sum}) IS NULL OR (case when (#2{count} = 0) then null else #2{count} end) IS NULL OR (case when (0 = (#2{count} - 1)) then null else (#2{count} - 1) end) IS NULL) then null else greatest(((#0{sum} - ((#1{sum} * #1{sum}) / bigint_to_numeric(case when (#2{count} = 0) then null else #2{count} end))) / bigint_to_numeric(case when (0 = (#2{count} - 1)) then null else (#2{count} - 1) end)), 0) end)) // { arity: 4 }
-          Union // { arity: 3 }
-            Get l5 // { arity: 3 }
-            Map (null, null, 0) // { arity: 3 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l5 // { arity: 3 }
-                Constant // { arity: 0 }
-                  - ()
-    cte [recursion_limit=50, return_at_limit] l7 =
-      Union // { arity: 2 }
-        Threshold // { arity: 2 }
-          Union // { arity: 2 }
-            Get l1 // { arity: 2 }
-            Negate // { arity: 2 }
-              Get l8 // { arity: 2 }
-        Reduce group_by=[#0] aggregates=[sum(((#1 - #2) / #3))] // { arity: 2 }
-          Project (#0, #3..=#5) // { arity: 4 }
-            Join on=(#1 = #2) type=delta // { arity: 6 }
-              implementation
-                %0 » %2[×]U » %3[×]U » %1:l7[#0]K
-                %1:l7 » %2[×]U » %3[×]U » %0[#1]K
-                %2 » %3[×]U » %0[×] » %1:l7[#0]K
-                %3 » %2[×]U » %0[×] » %1:l7[#0]K
-              ArrangeBy keys=[[], [#1]] // { arity: 2 }
-                Union // { arity: 2 }
-                  Filter (#1) IS NOT NULL // { arity: 2 }
-                    Get l0 // { arity: 2 }
-                  Project (#1, #0) // { arity: 2 }
-                    Filter (#0) IS NOT NULL // { arity: 2 }
-                      Get l0 // { arity: 2 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Filter (#0) IS NOT NULL // { arity: 2 }
-                  Get l7 // { arity: 2 }
-              ArrangeBy keys=[[]] // { arity: 1 }
-                Union // { arity: 1 }
-                  Get l4 // { arity: 1 }
-                  Map (null) // { arity: 1 }
-                    Union // { arity: 0 }
-                      Negate // { arity: 0 }
-                        Project () // { arity: 0 }
-                          Get l4 // { arity: 1 }
-                      Constant // { arity: 0 }
-                        - ()
-              ArrangeBy keys=[[]] // { arity: 1 }
-                Union // { arity: 1 }
-                  Get l6 // { arity: 1 }
-                  Map (null) // { arity: 1 }
-                    Union // { arity: 0 }
-                      Negate // { arity: 0 }
-                        Project () // { arity: 0 }
-                          Get l6 // { arity: 1 }
-                      Constant // { arity: 0 }
-                        - ()
-    cte [recursion_limit=50, return_at_limit] l8 =
-      Get l1 // { arity: 2 }
   Return // { arity: 1 }
-    With
-      cte l9 =
-        Reduce aggregates=[count(*)] // { arity: 1 }
-          Project () // { arity: 0 }
-            Filter (#1{sum} < 0) // { arity: 2 }
-              Get l7 // { arity: 2 }
-      cte l10 =
-        Union // { arity: 1 }
-          Get l9 // { arity: 1 }
-          Map (0) // { arity: 1 }
-            Union // { arity: 0 }
-              Negate // { arity: 0 }
-                Project () // { arity: 0 }
-                  Get l9 // { arity: 1 }
-              Constant // { arity: 0 }
-                - ()
-      cte l11 =
-        Reduce aggregates=[count(*)] // { arity: 1 }
-          Project () // { arity: 0 }
-            Filter (#1{sum} > 0) // { arity: 2 }
-              Get l7 // { arity: 2 }
-      cte l12 =
-        Union // { arity: 1 }
-          Get l11 // { arity: 1 }
-          Map (0) // { arity: 1 }
-            Union // { arity: 0 }
-              Negate // { arity: 0 }
-                Project () // { arity: 0 }
-                  Get l11 // { arity: 1 }
-              Constant // { arity: 0 }
-                - ()
+    With Mutually Recursive
+      cte l2 =
+        Project (#1{sum}) // { arity: 1 }
+          Get l7 // { arity: 2 }
+      cte l3 =
+        Reduce aggregates=[sum(#0), count(#0)] // { arity: 2 }
+          Get l2 // { arity: 1 }
+      cte l4 =
+        Project (#2) // { arity: 1 }
+          Map ((#0{sum} / bigint_to_numeric(case when (#1{count} = 0) then null else #1{count} end))) // { arity: 3 }
+            Union // { arity: 2 }
+              Get l3 // { arity: 2 }
+              Map (null, 0) // { arity: 2 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l3 // { arity: 2 }
+                  Constant // { arity: 0 }
+                    - ()
+      cte l5 =
+        Reduce aggregates=[sum((#0 * #0)), sum(#0), count(#0)] // { arity: 3 }
+          Get l2 // { arity: 1 }
+      cte l6 =
+        Project (#3) // { arity: 1 }
+          Map (sqrtnumeric(case when ((#0{sum}) IS NULL OR (#1{sum}) IS NULL OR (case when (#2{count} = 0) then null else #2{count} end) IS NULL OR (case when (0 = (#2{count} - 1)) then null else (#2{count} - 1) end) IS NULL) then null else greatest(((#0{sum} - ((#1{sum} * #1{sum}) / bigint_to_numeric(case when (#2{count} = 0) then null else #2{count} end))) / bigint_to_numeric(case when (0 = (#2{count} - 1)) then null else (#2{count} - 1) end)), 0) end)) // { arity: 4 }
+            Union // { arity: 3 }
+              Get l5 // { arity: 3 }
+              Map (null, null, 0) // { arity: 3 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l5 // { arity: 3 }
+                  Constant // { arity: 0 }
+                    - ()
+      cte [recursion_limit=50, return_at_limit] l7 =
+        Union // { arity: 2 }
+          Threshold // { arity: 2 }
+            Union // { arity: 2 }
+              Get l1 // { arity: 2 }
+              Negate // { arity: 2 }
+                Get l8 // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[sum(((#1 - #2) / #3))] // { arity: 2 }
+            Project (#0, #3..=#5) // { arity: 4 }
+              Join on=(#1 = #2) type=delta // { arity: 6 }
+                implementation
+                  %0 » %2[×]U » %3[×]U » %1:l7[#0]K
+                  %1:l7 » %2[×]U » %3[×]U » %0[#1]K
+                  %2 » %3[×]U » %0[×] » %1:l7[#0]K
+                  %3 » %2[×]U » %0[×] » %1:l7[#0]K
+                ArrangeBy keys=[[], [#1]] // { arity: 2 }
+                  Union // { arity: 2 }
+                    Filter (#1) IS NOT NULL // { arity: 2 }
+                      Get l0 // { arity: 2 }
+                    Project (#1, #0) // { arity: 2 }
+                      Filter (#0) IS NOT NULL // { arity: 2 }
+                        Get l0 // { arity: 2 }
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Filter (#0) IS NOT NULL // { arity: 2 }
+                    Get l7 // { arity: 2 }
+                ArrangeBy keys=[[]] // { arity: 1 }
+                  Union // { arity: 1 }
+                    Get l4 // { arity: 1 }
+                    Map (null) // { arity: 1 }
+                      Union // { arity: 0 }
+                        Negate // { arity: 0 }
+                          Project () // { arity: 0 }
+                            Get l4 // { arity: 1 }
+                        Constant // { arity: 0 }
+                          - ()
+                ArrangeBy keys=[[]] // { arity: 1 }
+                  Union // { arity: 1 }
+                    Get l6 // { arity: 1 }
+                    Map (null) // { arity: 1 }
+                      Union // { arity: 0 }
+                        Negate // { arity: 0 }
+                          Project () // { arity: 0 }
+                            Get l6 // { arity: 1 }
+                        Constant // { arity: 0 }
+                          - ()
+      cte [recursion_limit=50, return_at_limit] l8 =
+        Get l1 // { arity: 2 }
     Return // { arity: 1 }
-      Project (#2) // { arity: 1 }
-        Map ((#0{count} * #1{count})) // { arity: 3 }
-          CrossJoin type=differential // { arity: 2 }
-            implementation
-              %0[×]U » %1[×]U
-            ArrangeBy keys=[[]] // { arity: 1 }
-              Union // { arity: 1 }
-                Get l10 // { arity: 1 }
-                Map (null) // { arity: 1 }
-                  Union // { arity: 0 }
-                    Negate // { arity: 0 }
-                      Project () // { arity: 0 }
-                        Get l10 // { arity: 1 }
-                    Constant // { arity: 0 }
-                      - ()
-            ArrangeBy keys=[[]] // { arity: 1 }
-              Union // { arity: 1 }
-                Get l12 // { arity: 1 }
-                Map (null) // { arity: 1 }
-                  Union // { arity: 0 }
-                    Negate // { arity: 0 }
-                      Project () // { arity: 0 }
-                        Get l12 // { arity: 1 }
-                    Constant // { arity: 0 }
-                      - ()
+      With
+        cte l9 =
+          Reduce aggregates=[count(*)] // { arity: 1 }
+            Project () // { arity: 0 }
+              Filter (#1{sum} < 0) // { arity: 2 }
+                Get l7 // { arity: 2 }
+        cte l10 =
+          Union // { arity: 1 }
+            Get l9 // { arity: 1 }
+            Map (0) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l9 // { arity: 1 }
+                Constant // { arity: 0 }
+                  - ()
+        cte l11 =
+          Reduce aggregates=[count(*)] // { arity: 1 }
+            Project () // { arity: 0 }
+              Filter (#1{sum} > 0) // { arity: 2 }
+                Get l7 // { arity: 2 }
+        cte l12 =
+          Union // { arity: 1 }
+            Get l11 // { arity: 1 }
+            Map (0) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l11 // { arity: 1 }
+                Constant // { arity: 0 }
+                  - ()
+      Return // { arity: 1 }
+        Project (#2) // { arity: 1 }
+          Map ((#0{count} * #1{count})) // { arity: 3 }
+            CrossJoin type=differential // { arity: 2 }
+              implementation
+                %0[×]U » %1[×]U
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Get l10 // { arity: 1 }
+                  Map (null) // { arity: 1 }
+                    Union // { arity: 0 }
+                      Negate // { arity: 0 }
+                        Project () // { arity: 0 }
+                          Get l10 // { arity: 1 }
+                      Constant // { arity: 0 }
+                        - ()
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Get l12 // { arity: 1 }
+                  Map (null) // { arity: 1 }
+                    Union // { arity: 0 }
+                      Negate // { arity: 0 }
+                        Project () // { arity: 0 }
+                          Get l12 // { arity: 1 }
+                      Constant // { arity: 0 }
+                        - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/distinct_arrangements.slt
+++ b/test/sqllogictest/distinct_arrangements.slt
@@ -379,7 +379,6 @@ Arrange ReduceMinsMaxes
 Arrange ReduceMinsMaxes
 Arrange ReduceMinsMaxes
 Arrange recursive err
-Arrange recursive err
 ArrangeAccumulable [val: empty]
 ArrangeBy[[Column(0)]]
 ArrangeBy[[Column(0)]]
@@ -407,7 +406,6 @@ Arranged MinsMaxesHierarchical input
 Arranged MinsMaxesHierarchical input
 Arranged MinsMaxesHierarchical input
 Arranged MinsMaxesHierarchical input
-Distinct recursive err
 Distinct recursive err
 DistinctBy
 DistinctByErrorCheck
@@ -984,7 +982,7 @@ AccumulableErrorCheck  10
 Arrange␠ReduceMinsMaxes  3
 Arrange␠export␠iterative  2
 Arrange␠export␠iterative␠err  2
-Arrange␠recursive␠err  4
+Arrange␠recursive␠err  3
 ArrangeAccumulable␠[val:␠empty]  10
 ArrangeBy[[CallBinary␠{␠func:␠JsonbGetString␠{␠stringify:␠true␠},␠expr1:␠Column(1),␠expr2:␠Literal(Ok(Row{[String("id")]}),␠ColumnType␠{␠scalar_type:␠String,␠nullable:␠false␠})␠}]]  2
 ArrangeBy[[CallBinary␠{␠func:␠JsonbGetString␠{␠stringify:␠true␠},␠expr1:␠Column(2),␠expr2:␠Literal(Ok(Row{[String("id")]}),␠ColumnType␠{␠scalar_type:␠String,␠nullable:␠false␠})␠}]]  1
@@ -1031,7 +1029,7 @@ Arranged␠DistinctBy  47
 Arranged␠MinsMaxesHierarchical␠input  14
 Arranged␠ReduceInaccumulable  3
 Arranged␠TopK␠input  92
-Distinct␠recursive␠err  4
+Distinct␠recursive␠err  3
 DistinctBy  47
 DistinctByErrorCheck  47
 ReduceAccumulable  10

--- a/test/sqllogictest/freshmart.slt
+++ b/test/sqllogictest/freshmart.slt
@@ -674,7 +674,7 @@ JOIN categories c USING (category_id)
 JOIN has_subcategories s USING (category_id);
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#0{category_id})
         ReadStorage materialize.public.categories
@@ -688,80 +688,82 @@ Explained Query:
           ArrangeBy keys=[[#0{category_id}]]
             Project (#2{category_id}, #4{price})
               ReadIndex on=dynamic_price_shopping_cart dynamic_price_shopping_cart_idx=[*** full scan ***]
-    cte l3 =
-      Project (#0{category_id}, #1, #3)
-        Map (bigint_to_integer(#2{count_price}))
-          Union
-            Project (#0{category_id}, #3, #2{count_price})
-              Map (adjust_numeric_scale(coalesce(#1{sum_price}, 0)))
-                Reduce group_by=[#0{category_id}] aggregates=[sum(#1{price}), count(#1{price})]
-                  Union
-                    Map (null)
-                      Union
-                        Negate
-                          Project (#0{category_id})
-                            Join on=(#0{category_id} = #1{category_id}) type=differential
-                              Get l1
-                              ArrangeBy keys=[[#0{category_id}]]
-                                Distinct project=[#0{category_id}]
-                                  Project (#0{category_id})
-                                    Get l2
-                        Get l0
-                    Get l2
-            Project (#4{parent_id}, #1, #5)
-              Map (integer_to_bigint(#2))
-                Join on=(#0 = #3{category_id}) type=differential
-                  ArrangeBy keys=[[#0{category_id}]]
-                    Get l3
-                  ArrangeBy keys=[[#0{category_id}]]
-                    Project (#0{category_id}, #2{parent_id})
-                      Filter (#2{parent_id}) IS NOT NULL
-                        ReadStorage materialize.public.categories
   Return
-    With
-      cte l4 =
-        Project (#0{category_id})
-          ReadStorage materialize.public.categories
-      cte l5 =
-        ArrangeBy keys=[[#0{category_id}]]
-          Get l4
-      cte l6 =
-        Project (#0{category_id})
-          Join on=(#0{category_id} = #1{parent_id}) type=differential
-            Get l5
-            ArrangeBy keys=[[#0{parent_id}]]
-              Project (#2{parent_id})
-                Filter (#2{parent_id}) IS NOT NULL
-                  ReadStorage materialize.public.categories
+    With Mutually Recursive
+      cte l3 =
+        Project (#0{category_id}, #1, #3)
+          Map (bigint_to_integer(#2{count_price}))
+            Union
+              Project (#0{category_id}, #3, #2{count_price})
+                Map (adjust_numeric_scale(coalesce(#1{sum_price}, 0)))
+                  Reduce group_by=[#0{category_id}] aggregates=[sum(#1{price}), count(#1{price})]
+                    Union
+                      Map (null)
+                        Union
+                          Negate
+                            Project (#0{category_id})
+                              Join on=(#0{category_id} = #1{category_id}) type=differential
+                                Get l1
+                                ArrangeBy keys=[[#0{category_id}]]
+                                  Distinct project=[#0{category_id}]
+                                    Project (#0{category_id})
+                                      Get l2
+                          Get l0
+                      Get l2
+              Project (#4{parent_id}, #1, #5)
+                Map (integer_to_bigint(#2))
+                  Join on=(#0 = #3{category_id}) type=differential
+                    ArrangeBy keys=[[#0{category_id}]]
+                      Get l3
+                    ArrangeBy keys=[[#0{category_id}]]
+                      Project (#0{category_id}, #2{parent_id})
+                        Filter (#2{parent_id}) IS NOT NULL
+                          ReadStorage materialize.public.categories
     Return
-      Project (#0{category_id}, #5{parent_id}, #9, #4{category_name}, #1{sum}, #8)
-        Filter (#2{sum} > 0)
-          Map (bigint_to_integer(#2{sum}), (#7{count} > 0))
-            Join on=(#0{category_id} = #3{category_id} = #6{category_id}) type=delta
-              ArrangeBy keys=[[#0{category_id}]]
-                Reduce group_by=[#0{category_id}] aggregates=[sum(#1), sum(#2)]
-                  Project (#0{category_id}, #2, #3)
-                    Join on=(#0{category_id} = #1{category_id}) type=differential
-                      Get l5
-                      ArrangeBy keys=[[#0{category_id}]]
-                        Get l3
-              ArrangeBy keys=[[#0{category_id}]]
-                ReadStorage materialize.public.categories
-              ArrangeBy keys=[[#0{category_id}]]
-                Reduce group_by=[#0{category_id}] aggregates=[count((null OR (#1{category_id}) IS NOT NULL))]
-                  Union
-                    Map (null)
-                      Union
-                        Negate
-                          Project (#0{category_id})
-                            Join on=(#0{category_id} = #1{category_id}) type=differential
-                              Get l5
-                              ArrangeBy keys=[[#0{category_id}]]
-                                Distinct project=[#0{category_id}]
-                                  Get l6
-                        Get l4
-                    Project (#0{category_id}, #0{category_id})
-                      Get l6
+      With
+        cte l4 =
+          Project (#0{category_id})
+            ReadStorage materialize.public.categories
+        cte l5 =
+          ArrangeBy keys=[[#0{category_id}]]
+            Get l4
+        cte l6 =
+          Project (#0{category_id})
+            Join on=(#0{category_id} = #1{parent_id}) type=differential
+              Get l5
+              ArrangeBy keys=[[#0{parent_id}]]
+                Project (#2{parent_id})
+                  Filter (#2{parent_id}) IS NOT NULL
+                    ReadStorage materialize.public.categories
+      Return
+        Project (#0{category_id}, #5{parent_id}, #9, #4{category_name}, #1{sum}, #8)
+          Filter (#2{sum} > 0)
+            Map (bigint_to_integer(#2{sum}), (#7{count} > 0))
+              Join on=(#0{category_id} = #3{category_id} = #6{category_id}) type=delta
+                ArrangeBy keys=[[#0{category_id}]]
+                  Reduce group_by=[#0{category_id}] aggregates=[sum(#1), sum(#2)]
+                    Project (#0{category_id}, #2, #3)
+                      Join on=(#0{category_id} = #1{category_id}) type=differential
+                        Get l5
+                        ArrangeBy keys=[[#0{category_id}]]
+                          Get l3
+                ArrangeBy keys=[[#0{category_id}]]
+                  ReadStorage materialize.public.categories
+                ArrangeBy keys=[[#0{category_id}]]
+                  Reduce group_by=[#0{category_id}] aggregates=[count((null OR (#1{category_id}) IS NOT NULL))]
+                    Union
+                      Map (null)
+                        Union
+                          Negate
+                            Project (#0{category_id})
+                              Join on=(#0{category_id} = #1{category_id}) type=differential
+                                Get l5
+                                ArrangeBy keys=[[#0{category_id}]]
+                                  Distinct project=[#0{category_id}]
+                                    Get l6
+                          Get l4
+                      Project (#0{category_id}, #0{category_id})
+                        Get l6
 
 Source materialize.public.categories
 

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -2518,7 +2518,7 @@ SELECT coalesce(w, -1) FROM results ORDER BY w ASC LIMIT 20
 ----
 Explained Query:
   Finish order_by=[#1{min} asc nulls_last] limit=20 output=[#2]
-    With Mutually Recursive
+    With
       cte l0 =
         Project (#1{person1id}, #2{person2id}) // { arity: 2 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
@@ -2541,11 +2541,11 @@ Explained Query:
               Project (#1{person1id}, #2{person2id}, #15{parentmessageid}) // { arity: 3 }
                 Join on=(#1{person1id} = #12{creatorpersonid} AND #2{person2id} = #25{creatorpersonid} AND #4{messageid} = #28{parentmessageid} AND #13{containerforumid} = #29{id} AND #26{containerforumid} = #30{id}) type=delta // { arity: 31 }
                   implementation
-                    %0:person_knows_person » %1:message[#9]KA » %3:l2[#0]UK » %2:message[#12]KA » %4:l2[#0]UK
-                    %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UK
-                    %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UK
-                    %3:l2 » %1:message[#10]KA » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UK
-                    %4:l2 » %2:message[#10]KA » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UK
+                    %0:person_knows_person » %1:message[#9]KA » %3:l2[#0]UKA » %2:message[#12]KA » %4:l2[#0]UKA
+                    %1:message » %3:l2[#0]UKA » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UKA
+                    %2:message » %4:l2[#0]UKA » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UKA
+                    %3:l2 » %1:message[#10]KA » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UKA
+                    %4:l2 » %2:message[#10]KA » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UKA
                   ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
                     ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                   ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
@@ -2554,45 +2554,47 @@ Explained Query:
                     ReadIndex on=message message_containerforumid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
                   Get l2 // { arity: 1 }
                   Get l2 // { arity: 1 }
-      cte l4 =
-        Project (#2, #0{person2id}, #1{min}) // { arity: 3 }
-          Map (1450) // { arity: 3 }
-            Reduce group_by=[#0{person2id}] aggregates=[min(#1)] // { arity: 2 }
-              Distinct project=[#0{person2id}, #1] // { arity: 2 }
-                Union // { arity: 2 }
-                  Project (#3{person2id}, #5) // { arity: 2 }
-                    Map ((#1 + #4)) // { arity: 6 }
-                      Join on=(#0 = #2{person1id}) type=differential // { arity: 5 }
-                        implementation
-                          %0:l4[#0]UK » %1[#0]K
-                        ArrangeBy keys=[[#0]] // { arity: 2 }
-                          Project (#1{person2id}, #2{min}) // { arity: 2 }
-                            Get l4 // { arity: 3 }
-                        ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
-                          Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
-                            Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
-                              Union // { arity: 3 }
-                                Map (null) // { arity: 3 }
-                                  Union // { arity: 2 }
-                                    Negate // { arity: 2 }
-                                      Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-                                        Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
-                                          implementation
-                                            %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
-                                          Get l1 // { arity: 2 }
-                                          ArrangeBy keys=[[#1, #0]] // { arity: 2 }
-                                            Distinct project=[#0, #1] // { arity: 2 }
-                                              Project (#2, #3) // { arity: 2 }
-                                                Get l3 // { arity: 5 }
-                                    Get l0 // { arity: 2 }
-                                Project (#0{person1id}, #1{person2id}, #4{sum}) // { arity: 3 }
-                                  Get l3 // { arity: 5 }
-                  Constant // { arity: 2 }
-                    - (1450, 0)
     Return // { arity: 3 }
-      Project (#1{person2id}, #2{min}, #2{min}) // { arity: 3 }
-        Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
-          Get l4 // { arity: 3 }
+      With Mutually Recursive
+        cte l4 =
+          Project (#2, #0{person2id}, #1{min}) // { arity: 3 }
+            Map (1450) // { arity: 3 }
+              Reduce group_by=[#0{person2id}] aggregates=[min(#1)] // { arity: 2 }
+                Distinct project=[#0{person2id}, #1] // { arity: 2 }
+                  Union // { arity: 2 }
+                    Project (#3{person2id}, #5) // { arity: 2 }
+                      Map ((#1 + #4)) // { arity: 6 }
+                        Join on=(#0 = #2{person1id}) type=differential // { arity: 5 }
+                          implementation
+                            %0:l4[#0]UK » %1[#0]K
+                          ArrangeBy keys=[[#0]] // { arity: 2 }
+                            Project (#1{person2id}, #2{min}) // { arity: 2 }
+                              Get l4 // { arity: 3 }
+                          ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
+                            Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
+                              Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
+                                Union // { arity: 3 }
+                                  Map (null) // { arity: 3 }
+                                    Union // { arity: 2 }
+                                      Negate // { arity: 2 }
+                                        Project (#0{person1id}, #1{person2id}) // { arity: 2 }
+                                          Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
+                                            implementation
+                                              %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+                                            Get l1 // { arity: 2 }
+                                            ArrangeBy keys=[[#1, #0]] // { arity: 2 }
+                                              Distinct project=[#0, #1] // { arity: 2 }
+                                                Project (#2, #3) // { arity: 2 }
+                                                  Get l3 // { arity: 5 }
+                                      Get l0 // { arity: 2 }
+                                  Project (#0{person1id}, #1{person2id}, #4{sum}) // { arity: 3 }
+                                    Get l3 // { arity: 5 }
+                    Constant // { arity: 2 }
+                      - (1450, 0)
+      Return // { arity: 3 }
+        Project (#1{person2id}, #2{min}, #2{min}) // { arity: 3 }
+          Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
+            Get l4 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -2713,7 +2715,7 @@ EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) 
 SELECT coalesce(min(w), -1) FROM results
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#1{person1id}, #2{person2id}) // { arity: 2 }
         ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
@@ -2736,11 +2738,11 @@ Explained Query:
             Project (#1{person1id}, #2{person2id}, #15{parentmessageid}) // { arity: 3 }
               Join on=(#1{person1id} = #12{creatorpersonid} AND #2{person2id} = #25{creatorpersonid} AND #4{messageid} = #28{parentmessageid} AND #13{containerforumid} = #29{id} AND #26{containerforumid} = #30{id}) type=delta // { arity: 31 }
                 implementation
-                  %0:person_knows_person » %1:message[#9]KA » %3:l2[#0]UK » %2:message[#12]KA » %4:l2[#0]UK
-                  %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UK
-                  %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UK
-                  %3:l2 » %1:message[#10]KA » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UK
-                  %4:l2 » %2:message[#10]KA » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UK
+                  %0:person_knows_person » %1:message[#9]KA » %3:l2[#0]UKA » %2:message[#12]KA » %4:l2[#0]UKA
+                  %1:message » %3:l2[#0]UKA » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UKA
+                  %2:message » %4:l2[#0]UKA » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UKA
+                  %3:l2 » %1:message[#10]KA » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UKA
+                  %4:l2 » %2:message[#10]KA » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UKA
                 ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
                   ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                 ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
@@ -2768,220 +2770,222 @@ Explained Query:
                 Get l0 // { arity: 2 }
             Project (#0{person1id}, #1{person2id}, #4{sum}) // { arity: 3 }
               Get l3 // { arity: 5 }
-    cte l5 =
-      Project (#1, #3{person2id}) // { arity: 2 }
-        Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
-          implementation
-            %0:l8[#0]K » %1:l4[#0]K
-          ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-            Get l8 // { arity: 2 }
-          ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
-            Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-              Get l4 // { arity: 3 }
-    cte l6 =
-      Union // { arity: 2 }
-        Project (#1{person2id}, #0) // { arity: 2 }
-          Get l5 // { arity: 2 }
-        Get l8 // { arity: 2 }
-    cte l7 =
-      Distinct project=[] // { arity: 0 }
-        Project () // { arity: 0 }
-          Join on=(#0{person2id} = #1{person2id}) type=differential // { arity: 2 }
+  Return // { arity: 1 }
+    With Mutually Recursive
+      cte l5 =
+        Project (#1, #3{person2id}) // { arity: 2 }
+          Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
             implementation
-              %0:l6[#0]Kf » %1:l6[#0]Kf
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-              Project (#0{person2id}) // { arity: 1 }
-                Filter #1 // { arity: 2 }
-                  Get l6 // { arity: 2 }
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-              Project (#0{person2id}) // { arity: 1 }
-                Filter NOT(#1) // { arity: 2 }
-                  Get l6 // { arity: 2 }
-    cte l8 =
-      Distinct project=[#0{person2id}, #1] // { arity: 2 }
+              %0:l8[#0]K » %1:l4[#0]K
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+              Get l8 // { arity: 2 }
+            ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
+              Project (#0{person1id}, #1{person2id}) // { arity: 2 }
+                Get l4 // { arity: 3 }
+      cte l6 =
         Union // { arity: 2 }
           Project (#1{person2id}, #0) // { arity: 2 }
-            CrossJoin type=differential // { arity: 2 }
+            Get l5 // { arity: 2 }
+          Get l8 // { arity: 2 }
+      cte l7 =
+        Distinct project=[] // { arity: 0 }
+          Project () // { arity: 0 }
+            Join on=(#0{person2id} = #1{person2id}) type=differential // { arity: 2 }
               implementation
-                %0:l5[×] » %1[×]
-              ArrangeBy keys=[[]] // { arity: 2 }
-                Get l5 // { arity: 2 }
-              ArrangeBy keys=[[]] // { arity: 0 }
+                %0:l6[#0]Kf » %1:l6[#0]Kf
+              ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+                Project (#0{person2id}) // { arity: 1 }
+                  Filter #1 // { arity: 2 }
+                    Get l6 // { arity: 2 }
+              ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+                Project (#0{person2id}) // { arity: 1 }
+                  Filter NOT(#1) // { arity: 2 }
+                    Get l6 // { arity: 2 }
+      cte l8 =
+        Distinct project=[#0{person2id}, #1] // { arity: 2 }
+          Union // { arity: 2 }
+            Project (#1{person2id}, #0) // { arity: 2 }
+              CrossJoin type=differential // { arity: 2 }
+                implementation
+                  %0:l5[×] » %1[×]
+                ArrangeBy keys=[[]] // { arity: 2 }
+                  Get l5 // { arity: 2 }
+                ArrangeBy keys=[[]] // { arity: 0 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Get l7 // { arity: 0 }
+                    Constant // { arity: 0 }
+                      - ()
+            Project (#1, #0) // { arity: 2 }
+              Map (true, -1) // { arity: 2 }
+                Get l7 // { arity: 0 }
+            Constant // { arity: 2 }
+              - (1450, true)
+              - (15393162796819, false)
+      cte l9 =
+        TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
+          Project (#0..=#3, #5) // { arity: 5 }
+            Filter (#4 = false) // { arity: 6 }
+              Get l17 // { arity: 6 }
+      cte l10 =
+        Distinct project=[#0..=#2] // { arity: 3 }
+          Project (#0..=#2{person2id}) // { arity: 3 }
+            Get l17 // { arity: 6 }
+      cte l11 =
+        ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+          Get l10 // { arity: 3 }
+      cte l12 =
+        Project (#0..=#2) // { arity: 3 }
+          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+            implementation
+              %1[#0..=#2]UKKKA » %0:l11[#0..=#2]UKKK
+            Get l11 // { arity: 3 }
+            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+              Distinct project=[#0..=#2] // { arity: 3 }
+                Project (#0..=#2) // { arity: 3 }
+                  Get l9 // { arity: 5 }
+      cte l13 =
+        TopK group_by=[#0, #1, #2{person2id}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
+          Union // { arity: 5 }
+            Project (#3, #4, #1{person2id}, #7, #8) // { arity: 5 }
+              Map ((#6 + #2), false) // { arity: 9 }
+                Join on=(#0{person1id} = #5) type=differential // { arity: 7 }
+                  implementation
+                    %0:l4[#0]K » %1:l9[#2]K
+                  ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
+                    Get l4 // { arity: 3 }
+                  ArrangeBy keys=[[#2]] // { arity: 4 }
+                    Project (#0..=#3) // { arity: 4 }
+                      Get l9 // { arity: 5 }
+            Project (#0..=#3, #9) // { arity: 5 }
+              Map ((#4 OR #8)) // { arity: 10 }
+                Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
+                  implementation
+                    %0:l17[#0..=#2]KKK » %1[#0..=#2]KKK
+                  ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
+                    Project (#0..=#4) // { arity: 5 }
+                      Get l17 // { arity: 6 }
+                  ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                    Union // { arity: 4 }
+                      Map (true) // { arity: 4 }
+                        Get l12 // { arity: 3 }
+                      Project (#0..=#2, #6) // { arity: 4 }
+                        Map (false) // { arity: 7 }
+                          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                            implementation
+                              %1:l11[#0..=#2]UKKK » %0[#0..=#2]KKK
+                            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                              Union // { arity: 3 }
+                                Negate // { arity: 3 }
+                                  Get l12 // { arity: 3 }
+                                Get l10 // { arity: 3 }
+                            Get l11 // { arity: 3 }
+      cte l14 =
+        Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
+          Project (#1, #3) // { arity: 2 }
+            Join on=(#0{person2id} = #2{person2id}) type=differential // { arity: 4 }
+              implementation
+                %0:l13[#0]Kef » %1:l13[#0]Kef
+              ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+                Project (#2{person2id}, #3) // { arity: 2 }
+                  Filter (#0 = false) // { arity: 5 }
+                    Get l13 // { arity: 5 }
+              ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+                Project (#2{person2id}, #3) // { arity: 2 }
+                  Filter (#0 = true) // { arity: 5 }
+                    Get l13 // { arity: 5 }
+      cte l15 =
+        Project (#1) // { arity: 1 }
+          Map ((#0{min} / 2)) // { arity: 2 }
+            Union // { arity: 1 }
+              Get l14 // { arity: 1 }
+              Map (null) // { arity: 1 }
                 Union // { arity: 0 }
                   Negate // { arity: 0 }
-                    Get l7 // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l14 // { arity: 1 }
                   Constant // { arity: 0 }
                     - ()
-          Project (#1, #0) // { arity: 2 }
-            Map (true, -1) // { arity: 2 }
-              Get l7 // { arity: 0 }
-          Constant // { arity: 2 }
-            - (1450, true)
-            - (15393162796819, false)
-    cte l9 =
-      TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
-        Project (#0..=#3, #5) // { arity: 5 }
-          Filter (#4 = false) // { arity: 6 }
-            Get l17 // { arity: 6 }
-    cte l10 =
-      Distinct project=[#0..=#2] // { arity: 3 }
-        Project (#0..=#2{person2id}) // { arity: 3 }
-          Get l17 // { arity: 6 }
-    cte l11 =
-      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-        Get l10 // { arity: 3 }
-    cte l12 =
-      Project (#0..=#2) // { arity: 3 }
-        Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-          implementation
-            %1[#0..=#2]UKKKA » %0:l11[#0..=#2]UKKK
-          Get l11 // { arity: 3 }
-          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-            Distinct project=[#0..=#2] // { arity: 3 }
-              Project (#0..=#2) // { arity: 3 }
-                Get l9 // { arity: 5 }
-    cte l13 =
-      TopK group_by=[#0, #1, #2{person2id}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
-        Union // { arity: 5 }
-          Project (#3, #4, #1{person2id}, #7, #8) // { arity: 5 }
-            Map ((#6 + #2), false) // { arity: 9 }
-              Join on=(#0{person1id} = #5) type=differential // { arity: 7 }
-                implementation
-                  %0:l4[#0]K » %1:l9[#2]K
-                ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
-                  Get l4 // { arity: 3 }
-                ArrangeBy keys=[[#2]] // { arity: 4 }
-                  Project (#0..=#3) // { arity: 4 }
-                    Get l9 // { arity: 5 }
-          Project (#0..=#3, #9) // { arity: 5 }
-            Map ((#4 OR #8)) // { arity: 10 }
-              Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
-                implementation
-                  %0:l17[#0..=#2]KKK » %1[#0..=#2]KKK
-                ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-                  Project (#0..=#4) // { arity: 5 }
-                    Get l17 // { arity: 6 }
-                ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-                  Union // { arity: 4 }
-                    Map (true) // { arity: 4 }
-                      Get l12 // { arity: 3 }
-                    Project (#0..=#2, #6) // { arity: 4 }
-                      Map (false) // { arity: 7 }
-                        Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-                          implementation
-                            %1:l11[#0..=#2]UKKK » %0[#0..=#2]KKK
-                          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                            Union // { arity: 3 }
-                              Negate // { arity: 3 }
-                                Get l12 // { arity: 3 }
-                              Get l10 // { arity: 3 }
-                          Get l11 // { arity: 3 }
-    cte l14 =
-      Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
-        Project (#1, #3) // { arity: 2 }
-          Join on=(#0{person2id} = #2{person2id}) type=differential // { arity: 4 }
-            implementation
-              %0:l13[#0]Kef » %1:l13[#0]Kef
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              Project (#2{person2id}, #3) // { arity: 2 }
-                Filter (#0 = false) // { arity: 5 }
-                  Get l13 // { arity: 5 }
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              Project (#2{person2id}, #3) // { arity: 2 }
-                Filter (#0 = true) // { arity: 5 }
-                  Get l13 // { arity: 5 }
-    cte l15 =
-      Project (#1) // { arity: 1 }
-        Map ((#0{min} / 2)) // { arity: 2 }
-          Union // { arity: 1 }
-            Get l14 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l14 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
-    cte l16 =
-      Distinct project=[] // { arity: 0 }
-        Project () // { arity: 0 }
-          Filter #1 AND (#0{person2id} = -1) // { arity: 2 }
-            Get l8 // { arity: 2 }
-    cte l17 =
-      Distinct project=[#0..=#5] // { arity: 6 }
-        Union // { arity: 6 }
-          Project (#1, #0, #0, #2..=#4) // { arity: 6 }
-            Map (0, false, 0) // { arity: 5 }
-              Union // { arity: 2 }
-                Map (1450, false) // { arity: 2 }
-                  Get l16 // { arity: 0 }
-                Map (15393162796819, true) // { arity: 2 }
-                  Get l16 // { arity: 0 }
-          Project (#0..=#3, #7, #8) // { arity: 6 }
-            Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
-              CrossJoin type=delta // { arity: 7 }
-                implementation
-                  %0:l13 » %1[×]U » %2[×]U
-                  %1 » %2[×]U » %0:l13[×]
-                  %2 » %1[×]U » %0:l13[×]
-                ArrangeBy keys=[[]] // { arity: 5 }
-                  Get l13 // { arity: 5 }
-                ArrangeBy keys=[[]] // { arity: 1 }
-                  TopK limit=1 // { arity: 1 }
-                    Project (#4) // { arity: 1 }
-                      Get l9 // { arity: 5 }
-                ArrangeBy keys=[[]] // { arity: 1 }
-                  Union // { arity: 1 }
-                    Get l15 // { arity: 1 }
-                    Map (null) // { arity: 1 }
-                      Union // { arity: 0 }
-                        Negate // { arity: 0 }
-                          Project () // { arity: 0 }
-                            Get l15 // { arity: 1 }
-                        Constant // { arity: 0 }
-                          - ()
-  Return // { arity: 1 }
-    With
-      cte l18 =
-        Project (#0..=#3) // { arity: 4 }
-          Join on=(#4 = #5{max}) type=differential // { arity: 6 }
-            implementation
-              %1[#0]UK » %0:l17[#4]K
-            ArrangeBy keys=[[#4]] // { arity: 5 }
-              Project (#0..=#3, #5) // { arity: 5 }
-                Get l17 // { arity: 6 }
-            ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-              Reduce aggregates=[max(#0)] // { arity: 1 }
-                Project (#5) // { arity: 1 }
-                  Get l17 // { arity: 6 }
-      cte l19 =
-        Reduce aggregates=[min(#0{min})] // { arity: 1 }
-          Project (#2{min}) // { arity: 1 }
-            Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
-              Project (#0, #2, #3, #5) // { arity: 4 }
-                Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
+      cte l16 =
+        Distinct project=[] // { arity: 0 }
+          Project () // { arity: 0 }
+            Filter #1 AND (#0{person2id} = -1) // { arity: 2 }
+              Get l8 // { arity: 2 }
+      cte l17 =
+        Distinct project=[#0..=#5] // { arity: 6 }
+          Union // { arity: 6 }
+            Project (#1, #0, #0, #2..=#4) // { arity: 6 }
+              Map (0, false, 0) // { arity: 5 }
+                Union // { arity: 2 }
+                  Map (1450, false) // { arity: 2 }
+                    Get l16 // { arity: 0 }
+                  Map (15393162796819, true) // { arity: 2 }
+                    Get l16 // { arity: 0 }
+            Project (#0..=#3, #7, #8) // { arity: 6 }
+              Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
+                CrossJoin type=delta // { arity: 7 }
                   implementation
-                    %0:l18[#1]Kef » %1:l18[#1]Kef
-                  ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1..=#3) // { arity: 3 }
-                      Filter (#0 = false) // { arity: 4 }
-                        Get l18 // { arity: 4 }
-                  ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1..=#3) // { arity: 3 }
-                      Filter (#0 = true) // { arity: 4 }
-                        Get l18 // { arity: 4 }
+                    %0:l13 » %1[×]U » %2[×]U
+                    %1 » %2[×]U » %0:l13[×]
+                    %2 » %1[×]U » %0:l13[×]
+                  ArrangeBy keys=[[]] // { arity: 5 }
+                    Get l13 // { arity: 5 }
+                  ArrangeBy keys=[[]] // { arity: 1 }
+                    TopK limit=1 // { arity: 1 }
+                      Project (#4) // { arity: 1 }
+                        Get l9 // { arity: 5 }
+                  ArrangeBy keys=[[]] // { arity: 1 }
+                    Union // { arity: 1 }
+                      Get l15 // { arity: 1 }
+                      Map (null) // { arity: 1 }
+                        Union // { arity: 0 }
+                          Negate // { arity: 0 }
+                            Project () // { arity: 0 }
+                              Get l15 // { arity: 1 }
+                          Constant // { arity: 0 }
+                            - ()
     Return // { arity: 1 }
-      Project (#1) // { arity: 1 }
-        Map (coalesce(#0{min_min}, -1)) // { arity: 2 }
-          Union // { arity: 1 }
-            Get l19 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l19 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
+      With
+        cte l18 =
+          Project (#0..=#3) // { arity: 4 }
+            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
+              implementation
+                %1[#0]UK » %0:l17[#4]K
+              ArrangeBy keys=[[#4]] // { arity: 5 }
+                Project (#0..=#3, #5) // { arity: 5 }
+                  Get l17 // { arity: 6 }
+              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+                Reduce aggregates=[max(#0)] // { arity: 1 }
+                  Project (#5) // { arity: 1 }
+                    Get l17 // { arity: 6 }
+        cte l19 =
+          Reduce aggregates=[min(#0{min})] // { arity: 1 }
+            Project (#2{min}) // { arity: 1 }
+              Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
+                Project (#0, #2, #3, #5) // { arity: 4 }
+                  Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
+                    implementation
+                      %0:l18[#1]Kef » %1:l18[#1]Kef
+                    ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
+                      Project (#1..=#3) // { arity: 3 }
+                        Filter (#0 = false) // { arity: 4 }
+                          Get l18 // { arity: 4 }
+                    ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
+                      Project (#1..=#3) // { arity: 3 }
+                        Filter (#0 = true) // { arity: 4 }
+                          Get l18 // { arity: 4 }
+      Return // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Map (coalesce(#0{min_min}, -1)) // { arity: 2 }
+            Union // { arity: 1 }
+              Get l19 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l19 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -3669,101 +3673,103 @@ FROM paths
 WHERE w = (SELECT MIN(w) FROM paths)
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
         ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
     cte l1 =
-      ArrangeBy keys=[[]] // { arity: 1 }
+      ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+        ReadIndex on=pathq19 pathq19_src=[delta join lookup] // { arity: 3 }
+  Return // { arity: 3 }
+    With Mutually Recursive
+      cte l2 =
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Map ((#0 / 2)) // { arity: 2 }
+                Get l7 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l7 // { arity: 1 }
+                Constant // { arity: 0 }
+                  - ()
+      cte l3 =
+        TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
+          Union // { arity: 3 }
+            Project (#1{id}, #1{id}, #12) // { arity: 3 }
+              Map (0) // { arity: 13 }
+                ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
+            Project (#0, #5{dst}, #7) // { arity: 3 }
+              Filter coalesce((#2 < #3), true) // { arity: 8 }
+                Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
+                  Join on=(#1 = #4{src}) type=delta // { arity: 7 }
+                    implementation
+                      %0:l3 » %2:l1[#0]KA » %1:l2[×]
+                      %1:l2 » %0:l3[×] » %2:l1[#0]KA
+                      %2:l1 » %0:l3[#1]K » %1:l2[×]
+                    ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
+                      Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                        Get l3 // { arity: 3 }
+                    Get l2 // { arity: 1 }
+                    Get l1 // { arity: 3 }
+      cte l4 =
+        TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
+          Union // { arity: 3 }
+            Project (#1{id}, #1{id}, #12) // { arity: 3 }
+              Map (0) // { arity: 13 }
+                ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
+            Project (#0, #5{dst}, #7) // { arity: 3 }
+              Filter coalesce((#2 < #3), true) // { arity: 8 }
+                Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
+                  Join on=(#1 = #4{src}) type=delta // { arity: 7 }
+                    implementation
+                      %0:l4 » %2:l1[#0]KA » %1:l2[×]
+                      %1:l2 » %0:l4[×] » %2:l1[#0]KA
+                      %2:l1 » %0:l4[#1]K » %1:l2[×]
+                    ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
+                      Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                        Get l4 // { arity: 3 }
+                    Get l2 // { arity: 1 }
+                    Get l1 // { arity: 3 }
+      cte l5 =
+        Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
+          Project (#0{id}, #2, #3{id}, #5) // { arity: 4 }
+            Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
+              implementation
+                %0:l3[#1]K » %1:l4[#1]K
+              ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+                Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                  Get l3 // { arity: 3 }
+              ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+                Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                  Get l4 // { arity: 3 }
+      cte l6 =
+        Reduce aggregates=[min(#0{min})] // { arity: 1 }
+          Project (#2{min}) // { arity: 1 }
+            Get l5 // { arity: 3 }
+      cte l7 =
         Union // { arity: 1 }
-          Project (#1) // { arity: 1 }
-            Map ((#0 / 2)) // { arity: 2 }
-              Get l7 // { arity: 1 }
+          Get l6 // { arity: 1 }
           Map (null) // { arity: 1 }
             Union // { arity: 0 }
               Negate // { arity: 0 }
                 Project () // { arity: 0 }
-                  Get l7 // { arity: 1 }
+                  Get l6 // { arity: 1 }
               Constant // { arity: 0 }
                 - ()
-    cte l2 =
-      ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-        ReadIndex on=pathq19 pathq19_src=[delta join lookup] // { arity: 3 }
-    cte l3 =
-      TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
-        Union // { arity: 3 }
-          Project (#1{id}, #1{id}, #12) // { arity: 3 }
-            Map (0) // { arity: 13 }
-              ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
-          Project (#0, #5{dst}, #7) // { arity: 3 }
-            Filter coalesce((#2 < #3), true) // { arity: 8 }
-              Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
-                Join on=(#1 = #4{src}) type=delta // { arity: 7 }
-                  implementation
-                    %0:l3 » %2:l2[#0]KA » %1:l1[×]
-                    %1:l1 » %0:l3[×] » %2:l2[#0]KA
-                    %2:l2 » %0:l3[#1]K » %1:l1[×]
-                  ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
-                    Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                      Get l3 // { arity: 3 }
-                  Get l1 // { arity: 1 }
-                  Get l2 // { arity: 3 }
-    cte l4 =
-      TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
-        Union // { arity: 3 }
-          Project (#1{id}, #1{id}, #12) // { arity: 3 }
-            Map (0) // { arity: 13 }
-              ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
-          Project (#0, #5{dst}, #7) // { arity: 3 }
-            Filter coalesce((#2 < #3), true) // { arity: 8 }
-              Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
-                Join on=(#1 = #4{src}) type=delta // { arity: 7 }
-                  implementation
-                    %0:l4 » %2:l2[#0]KA » %1:l1[×]
-                    %1:l1 » %0:l4[×] » %2:l2[#0]KA
-                    %2:l2 » %0:l4[#1]K » %1:l1[×]
-                  ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
-                    Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                      Get l4 // { arity: 3 }
-                  Get l1 // { arity: 1 }
-                  Get l2 // { arity: 3 }
-    cte l5 =
-      Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-        Project (#0{id}, #2, #3{id}, #5) // { arity: 4 }
-          Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
-            implementation
-              %0:l3[#1]K » %1:l4[#1]K
-            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                Get l3 // { arity: 3 }
-            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                Get l4 // { arity: 3 }
-    cte l6 =
-      Reduce aggregates=[min(#0{min})] // { arity: 1 }
-        Project (#2{min}) // { arity: 1 }
-          Get l5 // { arity: 3 }
-    cte l7 =
-      Union // { arity: 1 }
-        Get l6 // { arity: 1 }
-        Map (null) // { arity: 1 }
-          Union // { arity: 0 }
-            Negate // { arity: 0 }
-              Project () // { arity: 0 }
-                Get l6 // { arity: 1 }
-            Constant // { arity: 0 }
-              - ()
-  Return // { arity: 3 }
-    Project (#0{id}..=#2{min}) // { arity: 3 }
-      Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
-        implementation
-          %1[#0]UK » %0:l5[#2]K
-        ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-          Get l5 // { arity: 3 }
-        ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-          Reduce aggregates=[min(#0{min})] // { arity: 1 }
-            Project (#2{min}) // { arity: 1 }
-              Get l5 // { arity: 3 }
+    Return // { arity: 3 }
+      Project (#0{id}..=#2{min}) // { arity: 3 }
+        Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UK » %0:l5[#2]K
+          ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+            Get l5 // { arity: 3 }
+          ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+            Reduce aggregates=[min(#0{min})] // { arity: 1 }
+              Project (#2{min}) // { arity: 1 }
+                Get l5 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -3828,172 +3834,174 @@ SELECT * FROM results WHERE w = (SELECT min(w) FROM results) ORDER BY f, t
 ----
 Explained Query:
   Finish order_by=[#0{id} asc nulls_last, #1{id} asc nulls_last] output=[#0..=#2]
-    With Mutually Recursive
+    With
       cte l0 =
-        TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
-          Project (#0..=#3, #5) // { arity: 5 }
-            Filter (#4 = false) // { arity: 6 }
-              Get l7 // { arity: 6 }
-      cte l1 =
-        Distinct project=[#0..=#2] // { arity: 3 }
-          Project (#0..=#2{id}) // { arity: 3 }
-            Get l7 // { arity: 6 }
-      cte l2 =
-        Project (#0..=#2) // { arity: 3 }
-          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-            implementation
-              %1[#0..=#2]UKKKA » %0:l1[#0..=#2]UKKK
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 3 }
-                Get l1 // { arity: 3 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Distinct project=[#0..=#2] // { arity: 3 }
-                Project (#0..=#2) // { arity: 3 }
-                  Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 5 }
-                    Get l0 // { arity: 5 }
-      cte l3 =
-        TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
-          Distinct project=[#0..=#4] // { arity: 5 }
-            Union // { arity: 5 }
-              Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
-                Map ((#6 + bigint_to_double(#2{w})), false) // { arity: 9 }
-                  Join on=(#0{src} = #5) type=differential // { arity: 7 }
-                    implementation
-                      %0:pathq19[#0]KA » %1:l0[#2]K
-                    ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-                      ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
-                    ArrangeBy keys=[[#2]] // { arity: 4 }
-                      Project (#0..=#3) // { arity: 4 }
-                        Filter (#2) IS NOT NULL // { arity: 5 }
-                          Get l0 // { arity: 5 }
-              Project (#0..=#3, #9) // { arity: 5 }
-                Map ((#4 OR #8)) // { arity: 10 }
-                  Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
-                    implementation
-                      %0:l7[#0..=#2]KKK » %1[#0..=#2]KKK
-                    ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-                      Project (#0..=#4) // { arity: 5 }
-                        Get l7 // { arity: 6 }
-                    ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-                      Union // { arity: 4 }
-                        Map (true) // { arity: 4 }
-                          Get l2 // { arity: 3 }
-                        Project (#0..=#2, #6) // { arity: 4 }
-                          Map (false) // { arity: 7 }
-                            Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-                              implementation
-                                %1:l1[#0..=#2]UKKK » %0[#0..=#2]KKK
-                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                                Union // { arity: 3 }
-                                  Negate // { arity: 3 }
-                                    Get l2 // { arity: 3 }
-                                  Get l1 // { arity: 3 }
-                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                                Get l1 // { arity: 3 }
-      cte l4 =
-        Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
-          Project (#1, #3) // { arity: 2 }
-            Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
-              implementation
-                %0:l3[#0]Kef » %1:l3[#0]Kef
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2{dst}, #3) // { arity: 2 }
-                  Filter (#0 = false) AND (#2{dst}) IS NOT NULL // { arity: 5 }
-                    Get l3 // { arity: 5 }
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2{dst}, #3) // { arity: 2 }
-                  Filter (#0 = true) AND (#2{dst}) IS NOT NULL // { arity: 5 }
-                    Get l3 // { arity: 5 }
-      cte l5 =
-        Project (#1) // { arity: 1 }
-          Map ((#0{min} / 2)) // { arity: 2 }
-            Union // { arity: 1 }
-              Get l4 // { arity: 1 }
-              Map (null) // { arity: 1 }
-                Union // { arity: 0 }
-                  Negate // { arity: 0 }
-                    Project () // { arity: 0 }
-                      Get l4 // { arity: 1 }
-                  Constant // { arity: 0 }
-                    - ()
-      cte l6 =
         ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
           ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
-      cte l7 =
-        Distinct project=[#0..=#5] // { arity: 6 }
-          Union // { arity: 6 }
-            Project (#1, #0{id}, #0{id}, #2..=#4) // { arity: 6 }
-              Map (0, false, 0) // { arity: 5 }
-                Union // { arity: 2 }
-                  Project (#1{id}, #12) // { arity: 2 }
-                    Map (false) // { arity: 13 }
-                      ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
-                  Project (#1{id}, #12) // { arity: 2 }
-                    Map (true) // { arity: 13 }
-                      ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
-            Project (#0..=#3, #7, #8) // { arity: 6 }
-              Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
-                CrossJoin type=delta // { arity: 7 }
-                  implementation
-                    %0:l3 » %1[×]U » %2[×]U
-                    %1 » %2[×]U » %0:l3[×]
-                    %2 » %1[×]U » %0:l3[×]
-                  ArrangeBy keys=[[]] // { arity: 5 }
-                    Get l3 // { arity: 5 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    TopK limit=1 // { arity: 1 }
-                      Project (#4) // { arity: 1 }
-                        Get l0 // { arity: 5 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    Union // { arity: 1 }
-                      Get l5 // { arity: 1 }
-                      Map (null) // { arity: 1 }
-                        Union // { arity: 0 }
-                          Negate // { arity: 0 }
-                            Project () // { arity: 0 }
-                              Get l5 // { arity: 1 }
-                          Constant // { arity: 0 }
-                            - ()
     Return // { arity: 3 }
-      With
-        cte l8 =
-          Project (#0..=#3) // { arity: 4 }
-            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
+      With Mutually Recursive
+        cte l1 =
+          TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
+            Project (#0..=#3, #5) // { arity: 5 }
+              Filter (#4 = false) // { arity: 6 }
+                Get l7 // { arity: 6 }
+        cte l2 =
+          Distinct project=[#0..=#2] // { arity: 3 }
+            Project (#0..=#2{id}) // { arity: 3 }
+              Get l7 // { arity: 6 }
+        cte l3 =
+          Project (#0..=#2) // { arity: 3 }
+            Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
               implementation
-                %1[#0]UK » %0:l7[#4]K
-              ArrangeBy keys=[[#4]] // { arity: 5 }
-                Project (#0..=#3, #5) // { arity: 5 }
-                  Filter (#2{id}) IS NOT NULL // { arity: 6 }
-                    Get l7 // { arity: 6 }
-              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-                Reduce aggregates=[max(#0)] // { arity: 1 }
-                  Project (#5) // { arity: 1 }
-                    Get l7 // { arity: 6 }
-        cte l9 =
-          Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-            Project (#0{id}, #2, #3{id}, #5) // { arity: 4 }
-              Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
+                %1[#0..=#2]UKKKA » %0:l2[#0..=#2]UKKK
+              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 3 }
+                  Get l2 // { arity: 3 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                Distinct project=[#0..=#2] // { arity: 3 }
+                  Project (#0..=#2) // { arity: 3 }
+                    Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 5 }
+                      Get l1 // { arity: 5 }
+        cte l4 =
+          TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
+            Distinct project=[#0..=#4] // { arity: 5 }
+              Union // { arity: 5 }
+                Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
+                  Map ((#6 + bigint_to_double(#2{w})), false) // { arity: 9 }
+                    Join on=(#0{src} = #5) type=differential // { arity: 7 }
+                      implementation
+                        %0:pathq19[#0]KA » %1:l1[#2]K
+                      ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+                        ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
+                      ArrangeBy keys=[[#2]] // { arity: 4 }
+                        Project (#0..=#3) // { arity: 4 }
+                          Filter (#2) IS NOT NULL // { arity: 5 }
+                            Get l1 // { arity: 5 }
+                Project (#0..=#3, #9) // { arity: 5 }
+                  Map ((#4 OR #8)) // { arity: 10 }
+                    Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
+                      implementation
+                        %0:l7[#0..=#2]KKK » %1[#0..=#2]KKK
+                      ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
+                        Project (#0..=#4) // { arity: 5 }
+                          Get l7 // { arity: 6 }
+                      ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                        Union // { arity: 4 }
+                          Map (true) // { arity: 4 }
+                            Get l3 // { arity: 3 }
+                          Project (#0..=#2, #6) // { arity: 4 }
+                            Map (false) // { arity: 7 }
+                              Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                                implementation
+                                  %1:l2[#0..=#2]UKKK » %0[#0..=#2]KKK
+                                ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                                  Union // { arity: 3 }
+                                    Negate // { arity: 3 }
+                                      Get l3 // { arity: 3 }
+                                    Get l2 // { arity: 3 }
+                                ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                                  Get l2 // { arity: 3 }
+        cte l5 =
+          Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
+            Project (#1, #3) // { arity: 2 }
+              Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
                 implementation
-                  %0:l8[#1]Kef » %1:l8[#1]Kef
-                ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-                  Project (#1{id}..=#3) // { arity: 3 }
-                    Filter (#0 = false) // { arity: 4 }
-                      Get l8 // { arity: 4 }
-                ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-                  Project (#1{id}..=#3) // { arity: 3 }
-                    Filter (#0 = true) // { arity: 4 }
-                      Get l8 // { arity: 4 }
+                  %0:l4[#0]Kef » %1:l4[#0]Kef
+                ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                  Project (#2{dst}, #3) // { arity: 2 }
+                    Filter (#0 = false) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                      Get l4 // { arity: 5 }
+                ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                  Project (#2{dst}, #3) // { arity: 2 }
+                    Filter (#0 = true) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                      Get l4 // { arity: 5 }
+        cte l6 =
+          Project (#1) // { arity: 1 }
+            Map ((#0{min} / 2)) // { arity: 2 }
+              Union // { arity: 1 }
+                Get l5 // { arity: 1 }
+                Map (null) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l5 // { arity: 1 }
+                    Constant // { arity: 0 }
+                      - ()
+        cte l7 =
+          Distinct project=[#0..=#5] // { arity: 6 }
+            Union // { arity: 6 }
+              Project (#1, #0{id}, #0{id}, #2..=#4) // { arity: 6 }
+                Map (0, false, 0) // { arity: 5 }
+                  Union // { arity: 2 }
+                    Project (#1{id}, #12) // { arity: 2 }
+                      Map (false) // { arity: 13 }
+                        ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
+                    Project (#1{id}, #12) // { arity: 2 }
+                      Map (true) // { arity: 13 }
+                        ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
+              Project (#0..=#3, #7, #8) // { arity: 6 }
+                Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
+                  CrossJoin type=delta // { arity: 7 }
+                    implementation
+                      %0:l4 » %1[×]U » %2[×]U
+                      %1 » %2[×]U » %0:l4[×]
+                      %2 » %1[×]U » %0:l4[×]
+                    ArrangeBy keys=[[]] // { arity: 5 }
+                      Get l4 // { arity: 5 }
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      TopK limit=1 // { arity: 1 }
+                        Project (#4) // { arity: 1 }
+                          Get l1 // { arity: 5 }
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Union // { arity: 1 }
+                        Get l6 // { arity: 1 }
+                        Map (null) // { arity: 1 }
+                          Union // { arity: 0 }
+                            Negate // { arity: 0 }
+                              Project () // { arity: 0 }
+                                Get l6 // { arity: 1 }
+                            Constant // { arity: 0 }
+                              - ()
       Return // { arity: 3 }
-        Project (#0{id}..=#2{min}) // { arity: 3 }
-          Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
-            implementation
-              %1[#0]UK » %0:l9[#2]K
-            ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-              Get l9 // { arity: 3 }
-            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-              Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                Project (#2{min}) // { arity: 1 }
-                  Get l9 // { arity: 3 }
+        With
+          cte l8 =
+            Project (#0..=#3) // { arity: 4 }
+              Join on=(#4 = #5{max}) type=differential // { arity: 6 }
+                implementation
+                  %1[#0]UK » %0:l7[#4]K
+                ArrangeBy keys=[[#4]] // { arity: 5 }
+                  Project (#0..=#3, #5) // { arity: 5 }
+                    Filter (#2{id}) IS NOT NULL // { arity: 6 }
+                      Get l7 // { arity: 6 }
+                ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+                  Reduce aggregates=[max(#0)] // { arity: 1 }
+                    Project (#5) // { arity: 1 }
+                      Get l7 // { arity: 6 }
+          cte l9 =
+            Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
+              Project (#0{id}, #2, #3{id}, #5) // { arity: 4 }
+                Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
+                  implementation
+                    %0:l8[#1]Kef » %1:l8[#1]Kef
+                  ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+                    Project (#1{id}..=#3) // { arity: 3 }
+                      Filter (#0 = false) // { arity: 4 }
+                        Get l8 // { arity: 4 }
+                  ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+                    Project (#1{id}..=#3) // { arity: 3 }
+                      Filter (#0 = true) // { arity: 4 }
+                        Get l8 // { arity: 4 }
+        Return // { arity: 3 }
+          Project (#0{id}..=#2{min}) // { arity: 3 }
+            Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
+              implementation
+                %1[#0]UK » %0:l9[#2]K
+              ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+                Get l9 // { arity: 3 }
+              ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+                Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                  Project (#2{min}) // { arity: 1 }
+                    Get l9 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -4426,7 +4434,7 @@ SELECT t, w FROM results WHERE w = (SELECT min(w) FROM results) ORDER BY t LIMIT
 ----
 Explained Query:
   Finish order_by=[#0{personid} asc nulls_last] limit=20 output=[#0, #1]
-    With Mutually Recursive
+    With
       cte l0 =
         Project (#1{personid}) // { arity: 1 }
           Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
@@ -4443,207 +4451,209 @@ Explained Query:
       cte l2 =
         ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
           Get l0 // { arity: 1 }
-      cte l3 =
-        Distinct project=[#0{dst}] // { arity: 1 }
-          Union // { arity: 1 }
-            Project (#2{dst}) // { arity: 1 }
-              Join on=(#0 = #1{src}) type=delta // { arity: 4 }
+    Return // { arity: 2 }
+      With Mutually Recursive
+        cte l3 =
+          Distinct project=[#0{dst}] // { arity: 1 }
+            Union // { arity: 1 }
+              Project (#2{dst}) // { arity: 1 }
+                Join on=(#0 = #1{src}) type=delta // { arity: 4 }
+                  implementation
+                    %0:l3 » %1:l1[#0]KA » %2[×]
+                    %1:l1 » %0:l3[#0]UK » %2[×]
+                    %2 » %0:l3[×] » %1:l1[#0]KA
+                  ArrangeBy keys=[[], [#0{dst}]] // { arity: 1 }
+                    Get l3 // { arity: 1 }
+                  Get l1 // { arity: 3 }
+                  ArrangeBy keys=[[]] // { arity: 0 }
+                    Union // { arity: 0 }
+                      Negate // { arity: 0 }
+                        Distinct project=[] // { arity: 0 }
+                          Project () // { arity: 0 }
+                            Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
+                              implementation
+                                %0:l3[#0]UK » %1:l2[#0]K
+                              ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
+                                Get l3 // { arity: 1 }
+                              Get l2 // { arity: 1 }
+                      Constant // { arity: 0 }
+                        - ()
+              Constant // { arity: 1 }
+                - (10995116285979)
+        cte l4 =
+          TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
+            Project (#0..=#3, #5) // { arity: 5 }
+              Filter (#4 = false) // { arity: 6 }
+                Get l12 // { arity: 6 }
+        cte l5 =
+          Distinct project=[#0..=#2] // { arity: 3 }
+            Project (#0..=#2{personid}) // { arity: 3 }
+              Get l12 // { arity: 6 }
+        cte l6 =
+          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+            Get l5 // { arity: 3 }
+        cte l7 =
+          Project (#0..=#2) // { arity: 3 }
+            Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+              implementation
+                %1[#0..=#2]UKKKA » %0:l6[#0..=#2]UKKK
+              Get l6 // { arity: 3 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                Distinct project=[#0..=#2] // { arity: 3 }
+                  Project (#0..=#2) // { arity: 3 }
+                    Get l4 // { arity: 5 }
+        cte l8 =
+          TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
+            Union // { arity: 5 }
+              Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
+                Map ((#6 + integer_to_bigint(#2{w})), false) // { arity: 9 }
+                  Join on=(#0{src} = #5) type=differential // { arity: 7 }
+                    implementation
+                      %0:l1[#0]KA » %1:l4[#2]K
+                    Get l1 // { arity: 3 }
+                    ArrangeBy keys=[[#2]] // { arity: 4 }
+                      Project (#0..=#3) // { arity: 4 }
+                        Get l4 // { arity: 5 }
+              Project (#0..=#3, #9) // { arity: 5 }
+                Map ((#4 OR #8)) // { arity: 10 }
+                  Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
+                    implementation
+                      %0:l12[#0..=#2]KKK » %1[#0..=#2]KKK
+                    ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
+                      Project (#0..=#4) // { arity: 5 }
+                        Get l12 // { arity: 6 }
+                    ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                      Union // { arity: 4 }
+                        Map (true) // { arity: 4 }
+                          Get l7 // { arity: 3 }
+                        Project (#0..=#2, #6) // { arity: 4 }
+                          Map (false) // { arity: 7 }
+                            Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                              implementation
+                                %1:l6[#0..=#2]UKKK » %0[#0..=#2]KKK
+                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                                Union // { arity: 3 }
+                                  Negate // { arity: 3 }
+                                    Get l7 // { arity: 3 }
+                                  Get l5 // { arity: 3 }
+                              Get l6 // { arity: 3 }
+        cte l9 =
+          Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
+            Project (#1, #3) // { arity: 2 }
+              Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
                 implementation
-                  %0:l3 » %1:l1[#0]KA » %2[×]
-                  %1:l1 » %0:l3[#0]UK » %2[×]
-                  %2 » %0:l3[×] » %1:l1[#0]KA
-                ArrangeBy keys=[[], [#0{dst}]] // { arity: 1 }
-                  Get l3 // { arity: 1 }
-                Get l1 // { arity: 3 }
-                ArrangeBy keys=[[]] // { arity: 0 }
+                  %0:l8[#0]Kef » %1:l8[#0]Kef
+                ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                  Project (#2{dst}, #3) // { arity: 2 }
+                    Filter (#0 = false) // { arity: 5 }
+                      Get l8 // { arity: 5 }
+                ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                  Project (#2{dst}, #3) // { arity: 2 }
+                    Filter (#0 = true) // { arity: 5 }
+                      Get l8 // { arity: 5 }
+        cte l10 =
+          Project (#1) // { arity: 1 }
+            Map ((#0{min} / 2)) // { arity: 2 }
+              Union // { arity: 1 }
+                Get l9 // { arity: 1 }
+                Map (null) // { arity: 1 }
                   Union // { arity: 0 }
                     Negate // { arity: 0 }
-                      Distinct project=[] // { arity: 0 }
-                        Project () // { arity: 0 }
-                          Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
-                            implementation
-                              %0:l3[#0]UK » %1:l2[#0]K
-                            ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                              Get l3 // { arity: 1 }
-                            Get l2 // { arity: 1 }
+                      Project () // { arity: 0 }
+                        Get l9 // { arity: 1 }
                     Constant // { arity: 0 }
                       - ()
-            Constant // { arity: 1 }
-              - (10995116285979)
-      cte l4 =
-        TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
-          Project (#0..=#3, #5) // { arity: 5 }
-            Filter (#4 = false) // { arity: 6 }
-              Get l12 // { arity: 6 }
-      cte l5 =
-        Distinct project=[#0..=#2] // { arity: 3 }
-          Project (#0..=#2{personid}) // { arity: 3 }
-            Get l12 // { arity: 6 }
-      cte l6 =
-        ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-          Get l5 // { arity: 3 }
-      cte l7 =
-        Project (#0..=#2) // { arity: 3 }
-          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-            implementation
-              %1[#0..=#2]UKKKA » %0:l6[#0..=#2]UKKK
-            Get l6 // { arity: 3 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Distinct project=[#0..=#2] // { arity: 3 }
-                Project (#0..=#2) // { arity: 3 }
-                  Get l4 // { arity: 5 }
-      cte l8 =
-        TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
-          Union // { arity: 5 }
-            Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
-              Map ((#6 + integer_to_bigint(#2{w})), false) // { arity: 9 }
-                Join on=(#0{src} = #5) type=differential // { arity: 7 }
-                  implementation
-                    %0:l1[#0]KA » %1:l4[#2]K
-                  Get l1 // { arity: 3 }
-                  ArrangeBy keys=[[#2]] // { arity: 4 }
-                    Project (#0..=#3) // { arity: 4 }
-                      Get l4 // { arity: 5 }
-            Project (#0..=#3, #9) // { arity: 5 }
-              Map ((#4 OR #8)) // { arity: 10 }
-                Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
-                  implementation
-                    %0:l12[#0..=#2]KKK » %1[#0..=#2]KKK
-                  ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-                    Project (#0..=#4) // { arity: 5 }
-                      Get l12 // { arity: 6 }
-                  ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-                    Union // { arity: 4 }
-                      Map (true) // { arity: 4 }
-                        Get l7 // { arity: 3 }
-                      Project (#0..=#2, #6) // { arity: 4 }
-                        Map (false) // { arity: 7 }
-                          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+        cte l11 =
+          Distinct project=[] // { arity: 0 }
+            Project () // { arity: 0 }
+              Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
+                implementation
+                  %0:l3[#0]UK » %1:l2[#0]K
+                ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
+                  Get l3 // { arity: 1 }
+                Get l2 // { arity: 1 }
+        cte l12 =
+          Distinct project=[#0..=#5] // { arity: 6 }
+            Union // { arity: 6 }
+              Project (#0..=#2{personid}, #4, #3, #5) // { arity: 6 }
+                Map (false, 0, 0) // { arity: 6 }
+                  Distinct project=[#0..=#2{personid}] // { arity: 3 }
+                    Union // { arity: 3 }
+                      Project (#1, #0, #0) // { arity: 3 }
+                        Map (10995116285979, false) // { arity: 2 }
+                          Get l11 // { arity: 0 }
+                      Project (#1, #0{personid}, #0{personid}) // { arity: 3 }
+                        Map (true) // { arity: 2 }
+                          CrossJoin type=differential // { arity: 1 }
                             implementation
-                              %1:l6[#0..=#2]UKKK » %0[#0..=#2]KKK
-                            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                              Union // { arity: 3 }
-                                Negate // { arity: 3 }
-                                  Get l7 // { arity: 3 }
-                                Get l5 // { arity: 3 }
-                            Get l6 // { arity: 3 }
-      cte l9 =
-        Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
-          Project (#1, #3) // { arity: 2 }
-            Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
-              implementation
-                %0:l8[#0]Kef » %1:l8[#0]Kef
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2{dst}, #3) // { arity: 2 }
-                  Filter (#0 = false) // { arity: 5 }
-                    Get l8 // { arity: 5 }
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2{dst}, #3) // { arity: 2 }
-                  Filter (#0 = true) // { arity: 5 }
-                    Get l8 // { arity: 5 }
-      cte l10 =
-        Project (#1) // { arity: 1 }
-          Map ((#0{min} / 2)) // { arity: 2 }
-            Union // { arity: 1 }
-              Get l9 // { arity: 1 }
-              Map (null) // { arity: 1 }
-                Union // { arity: 0 }
-                  Negate // { arity: 0 }
-                    Project () // { arity: 0 }
-                      Get l9 // { arity: 1 }
-                  Constant // { arity: 0 }
-                    - ()
-      cte l11 =
-        Distinct project=[] // { arity: 0 }
-          Project () // { arity: 0 }
-            Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
-              implementation
-                %0:l3[#0]UK » %1:l2[#0]K
-              ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                Get l3 // { arity: 1 }
-              Get l2 // { arity: 1 }
-      cte l12 =
-        Distinct project=[#0..=#5] // { arity: 6 }
-          Union // { arity: 6 }
-            Project (#0..=#2{personid}, #4, #3, #5) // { arity: 6 }
-              Map (false, 0, 0) // { arity: 6 }
-                Distinct project=[#0..=#2{personid}] // { arity: 3 }
-                  Union // { arity: 3 }
-                    Project (#1, #0, #0) // { arity: 3 }
-                      Map (10995116285979, false) // { arity: 2 }
-                        Get l11 // { arity: 0 }
-                    Project (#1, #0{personid}, #0{personid}) // { arity: 3 }
-                      Map (true) // { arity: 2 }
-                        CrossJoin type=differential // { arity: 1 }
-                          implementation
-                            %1:l11[×]U » %0:l0[×]
-                          ArrangeBy keys=[[]] // { arity: 1 }
-                            Get l0 // { arity: 1 }
-                          ArrangeBy keys=[[]] // { arity: 0 }
-                            Get l11 // { arity: 0 }
-            Project (#0..=#3, #7, #8) // { arity: 6 }
-              Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
-                CrossJoin type=delta // { arity: 7 }
-                  implementation
-                    %0:l8 » %1[×]U » %2[×]U
-                    %1 » %2[×]U » %0:l8[×]
-                    %2 » %1[×]U » %0:l8[×]
-                  ArrangeBy keys=[[]] // { arity: 5 }
-                    Get l8 // { arity: 5 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    TopK limit=1 // { arity: 1 }
-                      Project (#4) // { arity: 1 }
-                        Get l4 // { arity: 5 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    Union // { arity: 1 }
-                      Get l10 // { arity: 1 }
-                      Map (null) // { arity: 1 }
-                        Union // { arity: 0 }
-                          Negate // { arity: 0 }
-                            Project () // { arity: 0 }
-                              Get l10 // { arity: 1 }
-                          Constant // { arity: 0 }
-                            - ()
-    Return // { arity: 2 }
-      With
-        cte l13 =
-          Project (#0..=#3) // { arity: 4 }
-            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
-              implementation
-                %1[#0]UK » %0:l12[#4]K
-              ArrangeBy keys=[[#4]] // { arity: 5 }
-                Project (#0..=#3, #5) // { arity: 5 }
-                  Get l12 // { arity: 6 }
-              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-                Reduce aggregates=[max(#0)] // { arity: 1 }
-                  Project (#5) // { arity: 1 }
-                    Get l12 // { arity: 6 }
-        cte l14 =
-          Project (#1{personid}, #2{min}) // { arity: 2 }
-            Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1 + #3))] // { arity: 3 }
-              Project (#0{personid}, #2, #3{personid}, #5) // { arity: 4 }
-                Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
-                  implementation
-                    %0:l13[#1]Kef » %1:l13[#1]Kef
-                  ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
-                    Project (#1{personid}..=#3) // { arity: 3 }
-                      Filter (#0 = false) // { arity: 4 }
-                        Get l13 // { arity: 4 }
-                  ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
-                    Project (#1{personid}..=#3) // { arity: 3 }
-                      Filter (#0 = true) // { arity: 4 }
-                        Get l13 // { arity: 4 }
+                              %1:l11[×]U » %0:l0[×]
+                            ArrangeBy keys=[[]] // { arity: 1 }
+                              Get l0 // { arity: 1 }
+                            ArrangeBy keys=[[]] // { arity: 0 }
+                              Get l11 // { arity: 0 }
+              Project (#0..=#3, #7, #8) // { arity: 6 }
+                Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
+                  CrossJoin type=delta // { arity: 7 }
+                    implementation
+                      %0:l8 » %1[×]U » %2[×]U
+                      %1 » %2[×]U » %0:l8[×]
+                      %2 » %1[×]U » %0:l8[×]
+                    ArrangeBy keys=[[]] // { arity: 5 }
+                      Get l8 // { arity: 5 }
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      TopK limit=1 // { arity: 1 }
+                        Project (#4) // { arity: 1 }
+                          Get l4 // { arity: 5 }
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Union // { arity: 1 }
+                        Get l10 // { arity: 1 }
+                        Map (null) // { arity: 1 }
+                          Union // { arity: 0 }
+                            Negate // { arity: 0 }
+                              Project () // { arity: 0 }
+                                Get l10 // { arity: 1 }
+                            Constant // { arity: 0 }
+                              - ()
       Return // { arity: 2 }
-        Project (#0{personid}, #1{min}) // { arity: 2 }
-          Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
-            implementation
-              %1[#0]UK » %0:l14[#1]K
-            ArrangeBy keys=[[#1{min}]] // { arity: 2 }
-              Get l14 // { arity: 2 }
-            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-              Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                Project (#1{min}) // { arity: 1 }
-                  Get l14 // { arity: 2 }
+        With
+          cte l13 =
+            Project (#0..=#3) // { arity: 4 }
+              Join on=(#4 = #5{max}) type=differential // { arity: 6 }
+                implementation
+                  %1[#0]UK » %0:l12[#4]K
+                ArrangeBy keys=[[#4]] // { arity: 5 }
+                  Project (#0..=#3, #5) // { arity: 5 }
+                    Get l12 // { arity: 6 }
+                ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+                  Reduce aggregates=[max(#0)] // { arity: 1 }
+                    Project (#5) // { arity: 1 }
+                      Get l12 // { arity: 6 }
+          cte l14 =
+            Project (#1{personid}, #2{min}) // { arity: 2 }
+              Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1 + #3))] // { arity: 3 }
+                Project (#0{personid}, #2, #3{personid}, #5) // { arity: 4 }
+                  Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
+                    implementation
+                      %0:l13[#1]Kef » %1:l13[#1]Kef
+                    ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
+                      Project (#1{personid}..=#3) // { arity: 3 }
+                        Filter (#0 = false) // { arity: 4 }
+                          Get l13 // { arity: 4 }
+                    ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
+                      Project (#1{personid}..=#3) // { arity: 3 }
+                        Filter (#0 = true) // { arity: 4 }
+                          Get l13 // { arity: 4 }
+        Return // { arity: 2 }
+          Project (#0{personid}, #1{min}) // { arity: 2 }
+            Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
+              implementation
+                %1[#0]UK » %0:l14[#1]K
+              ArrangeBy keys=[[#1{min}]] // { arity: 2 }
+                Get l14 // { arity: 2 }
+              ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+                Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                  Project (#1{min}) // { arity: 1 }
+                    Get l14 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.person_workat_company_companyid (differential join)

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -2525,7 +2525,7 @@ SELECT coalesce(w, -1) FROM results ORDER BY w ASC LIMIT 20
 ----
 Explained Query:
   Finish order_by=[#1{min} asc nulls_last] limit=20 output=[#2]
-    With Mutually Recursive
+    With
       cte l0 =
         Project (#1{person1id}, #2{person2id}) // { arity: 2 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
@@ -2548,11 +2548,11 @@ Explained Query:
               Project (#1{person1id}, #2{person2id}, #15{parentmessageid}) // { arity: 3 }
                 Join on=(#1{person1id} = #12{creatorpersonid} AND #2{person2id} = #25{creatorpersonid} AND #4{messageid} = #28{parentmessageid} AND #13{containerforumid} = #29{id} AND #26{containerforumid} = #30{id}) type=delta // { arity: 31 }
                   implementation
-                    %0:person_knows_person » %1:message[#9]KA » %3:l2[#0]UK » %2:message[#12]KA » %4:l2[#0]UK
-                    %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UK
-                    %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UK
-                    %3:l2 » %1:message[#10]KA » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UK
-                    %4:l2 » %2:message[#10]KA » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UK
+                    %0:person_knows_person » %1:message[#9]KA » %3:l2[#0]UKA » %2:message[#12]KA » %4:l2[#0]UKA
+                    %1:message » %3:l2[#0]UKA » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UKA
+                    %2:message » %4:l2[#0]UKA » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UKA
+                    %3:l2 » %1:message[#10]KA » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UKA
+                    %4:l2 » %2:message[#10]KA » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UKA
                   ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
                     ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                   ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
@@ -2561,45 +2561,47 @@ Explained Query:
                     ReadIndex on=message message_containerforumid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
                   Get l2 // { arity: 1 }
                   Get l2 // { arity: 1 }
-      cte l4 =
-        Project (#2, #0{person2id}, #1{min}) // { arity: 3 }
-          Map (1450) // { arity: 3 }
-            Reduce group_by=[#0{person2id}] aggregates=[min(#1)] // { arity: 2 }
-              Distinct project=[#0{person2id}, #1] // { arity: 2 }
-                Union // { arity: 2 }
-                  Project (#3{person2id}, #5) // { arity: 2 }
-                    Map ((#1 + #4)) // { arity: 6 }
-                      Join on=(#0 = #2{person1id}) type=differential // { arity: 5 }
-                        implementation
-                          %0:l4[#0]UK » %1[#0]K
-                        ArrangeBy keys=[[#0]] // { arity: 2 }
-                          Project (#1{person2id}, #2{min}) // { arity: 2 }
-                            Get l4 // { arity: 3 }
-                        ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
-                          Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
-                            Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
-                              Union // { arity: 3 }
-                                Map (null) // { arity: 3 }
-                                  Union // { arity: 2 }
-                                    Negate // { arity: 2 }
-                                      Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-                                        Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
-                                          implementation
-                                            %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
-                                          Get l1 // { arity: 2 }
-                                          ArrangeBy keys=[[#1, #0]] // { arity: 2 }
-                                            Distinct project=[#0, #1] // { arity: 2 }
-                                              Project (#2, #3) // { arity: 2 }
-                                                Get l3 // { arity: 5 }
-                                    Get l0 // { arity: 2 }
-                                Project (#0{person1id}, #1{person2id}, #4{sum}) // { arity: 3 }
-                                  Get l3 // { arity: 5 }
-                  Constant // { arity: 2 }
-                    - (1450, 0)
     Return // { arity: 3 }
-      Project (#1{person2id}, #2{min}, #2{min}) // { arity: 3 }
-        Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
-          Get l4 // { arity: 3 }
+      With Mutually Recursive
+        cte l4 =
+          Project (#2, #0{person2id}, #1{min}) // { arity: 3 }
+            Map (1450) // { arity: 3 }
+              Reduce group_by=[#0{person2id}] aggregates=[min(#1)] // { arity: 2 }
+                Distinct project=[#0{person2id}, #1] // { arity: 2 }
+                  Union // { arity: 2 }
+                    Project (#3{person2id}, #5) // { arity: 2 }
+                      Map ((#1 + #4)) // { arity: 6 }
+                        Join on=(#0 = #2{person1id}) type=differential // { arity: 5 }
+                          implementation
+                            %0:l4[#0]UK » %1[#0]K
+                          ArrangeBy keys=[[#0]] // { arity: 2 }
+                            Project (#1{person2id}, #2{min}) // { arity: 2 }
+                              Get l4 // { arity: 3 }
+                          ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
+                            Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
+                              Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
+                                Union // { arity: 3 }
+                                  Map (null) // { arity: 3 }
+                                    Union // { arity: 2 }
+                                      Negate // { arity: 2 }
+                                        Project (#0{person1id}, #1{person2id}) // { arity: 2 }
+                                          Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
+                                            implementation
+                                              %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+                                            Get l1 // { arity: 2 }
+                                            ArrangeBy keys=[[#1, #0]] // { arity: 2 }
+                                              Distinct project=[#0, #1] // { arity: 2 }
+                                                Project (#2, #3) // { arity: 2 }
+                                                  Get l3 // { arity: 5 }
+                                      Get l0 // { arity: 2 }
+                                  Project (#0{person1id}, #1{person2id}, #4{sum}) // { arity: 3 }
+                                    Get l3 // { arity: 5 }
+                    Constant // { arity: 2 }
+                      - (1450, 0)
+      Return // { arity: 3 }
+        Project (#1{person2id}, #2{min}, #2{min}) // { arity: 3 }
+          Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
+            Get l4 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -2720,7 +2722,7 @@ EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) 
 SELECT coalesce(min(w), -1) FROM results
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#1{person1id}, #2{person2id}) // { arity: 2 }
         ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
@@ -2743,11 +2745,11 @@ Explained Query:
             Project (#1{person1id}, #2{person2id}, #15{parentmessageid}) // { arity: 3 }
               Join on=(#1{person1id} = #12{creatorpersonid} AND #2{person2id} = #25{creatorpersonid} AND #4{messageid} = #28{parentmessageid} AND #13{containerforumid} = #29{id} AND #26{containerforumid} = #30{id}) type=delta // { arity: 31 }
                 implementation
-                  %0:person_knows_person » %1:message[#9]KA » %3:l2[#0]UK » %2:message[#12]KA » %4:l2[#0]UK
-                  %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UK
-                  %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UK
-                  %3:l2 » %1:message[#10]KA » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UK
-                  %4:l2 » %2:message[#10]KA » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UK
+                  %0:person_knows_person » %1:message[#9]KA » %3:l2[#0]UKA » %2:message[#12]KA » %4:l2[#0]UKA
+                  %1:message » %3:l2[#0]UKA » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UKA
+                  %2:message » %4:l2[#0]UKA » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UKA
+                  %3:l2 » %1:message[#10]KA » %0:person_knows_person[#1]KA » %2:message[#12]KA » %4:l2[#0]UKA
+                  %4:l2 » %2:message[#10]KA » %0:person_knows_person[#2]KA » %1:message[#9]KA » %3:l2[#0]UKA
                 ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
                   ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                 ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
@@ -2775,220 +2777,222 @@ Explained Query:
                 Get l0 // { arity: 2 }
             Project (#0{person1id}, #1{person2id}, #4{sum}) // { arity: 3 }
               Get l3 // { arity: 5 }
-    cte l5 =
-      Project (#1, #3{person2id}) // { arity: 2 }
-        Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
-          implementation
-            %0:l8[#0]K » %1:l4[#0]K
-          ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-            Get l8 // { arity: 2 }
-          ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
-            Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-              Get l4 // { arity: 3 }
-    cte l6 =
-      Union // { arity: 2 }
-        Project (#1{person2id}, #0) // { arity: 2 }
-          Get l5 // { arity: 2 }
-        Get l8 // { arity: 2 }
-    cte l7 =
-      Distinct project=[] // { arity: 0 }
-        Project () // { arity: 0 }
-          Join on=(#0{person2id} = #1{person2id}) type=differential // { arity: 2 }
+  Return // { arity: 1 }
+    With Mutually Recursive
+      cte l5 =
+        Project (#1, #3{person2id}) // { arity: 2 }
+          Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
             implementation
-              %0:l6[#0]Kf » %1:l6[#0]Kf
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-              Project (#0{person2id}) // { arity: 1 }
-                Filter #1 // { arity: 2 }
-                  Get l6 // { arity: 2 }
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-              Project (#0{person2id}) // { arity: 1 }
-                Filter NOT(#1) // { arity: 2 }
-                  Get l6 // { arity: 2 }
-    cte l8 =
-      Distinct project=[#0{person2id}, #1] // { arity: 2 }
+              %0:l8[#0]K » %1:l4[#0]K
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+              Get l8 // { arity: 2 }
+            ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
+              Project (#0{person1id}, #1{person2id}) // { arity: 2 }
+                Get l4 // { arity: 3 }
+      cte l6 =
         Union // { arity: 2 }
           Project (#1{person2id}, #0) // { arity: 2 }
-            CrossJoin type=differential // { arity: 2 }
+            Get l5 // { arity: 2 }
+          Get l8 // { arity: 2 }
+      cte l7 =
+        Distinct project=[] // { arity: 0 }
+          Project () // { arity: 0 }
+            Join on=(#0{person2id} = #1{person2id}) type=differential // { arity: 2 }
               implementation
-                %0:l5[×] » %1[×]
-              ArrangeBy keys=[[]] // { arity: 2 }
-                Get l5 // { arity: 2 }
-              ArrangeBy keys=[[]] // { arity: 0 }
+                %0:l6[#0]Kf » %1:l6[#0]Kf
+              ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+                Project (#0{person2id}) // { arity: 1 }
+                  Filter #1 // { arity: 2 }
+                    Get l6 // { arity: 2 }
+              ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+                Project (#0{person2id}) // { arity: 1 }
+                  Filter NOT(#1) // { arity: 2 }
+                    Get l6 // { arity: 2 }
+      cte l8 =
+        Distinct project=[#0{person2id}, #1] // { arity: 2 }
+          Union // { arity: 2 }
+            Project (#1{person2id}, #0) // { arity: 2 }
+              CrossJoin type=differential // { arity: 2 }
+                implementation
+                  %0:l5[×] » %1[×]
+                ArrangeBy keys=[[]] // { arity: 2 }
+                  Get l5 // { arity: 2 }
+                ArrangeBy keys=[[]] // { arity: 0 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Get l7 // { arity: 0 }
+                    Constant // { arity: 0 }
+                      - ()
+            Project (#1, #0) // { arity: 2 }
+              Map (true, -1) // { arity: 2 }
+                Get l7 // { arity: 0 }
+            Constant // { arity: 2 }
+              - (1450, true)
+              - (15393162796819, false)
+      cte l9 =
+        TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
+          Project (#0..=#3, #5) // { arity: 5 }
+            Filter (#4 = false) // { arity: 6 }
+              Get l17 // { arity: 6 }
+      cte l10 =
+        Distinct project=[#0..=#2] // { arity: 3 }
+          Project (#0..=#2{person2id}) // { arity: 3 }
+            Get l17 // { arity: 6 }
+      cte l11 =
+        ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+          Get l10 // { arity: 3 }
+      cte l12 =
+        Project (#0..=#2) // { arity: 3 }
+          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+            implementation
+              %1[#0..=#2]UKKKA » %0:l11[#0..=#2]UKKK
+            Get l11 // { arity: 3 }
+            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+              Distinct project=[#0..=#2] // { arity: 3 }
+                Project (#0..=#2) // { arity: 3 }
+                  Get l9 // { arity: 5 }
+      cte l13 =
+        TopK group_by=[#0, #1, #2{person2id}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
+          Union // { arity: 5 }
+            Project (#3, #4, #1{person2id}, #7, #8) // { arity: 5 }
+              Map ((#6 + #2), false) // { arity: 9 }
+                Join on=(#0{person1id} = #5) type=differential // { arity: 7 }
+                  implementation
+                    %0:l4[#0]K » %1:l9[#2]K
+                  ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
+                    Get l4 // { arity: 3 }
+                  ArrangeBy keys=[[#2]] // { arity: 4 }
+                    Project (#0..=#3) // { arity: 4 }
+                      Get l9 // { arity: 5 }
+            Project (#0..=#3, #9) // { arity: 5 }
+              Map ((#4 OR #8)) // { arity: 10 }
+                Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
+                  implementation
+                    %0:l17[#0..=#2]KKK » %1[#0..=#2]KKK
+                  ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
+                    Project (#0..=#4) // { arity: 5 }
+                      Get l17 // { arity: 6 }
+                  ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                    Union // { arity: 4 }
+                      Map (true) // { arity: 4 }
+                        Get l12 // { arity: 3 }
+                      Project (#0..=#2, #6) // { arity: 4 }
+                        Map (false) // { arity: 7 }
+                          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                            implementation
+                              %1:l11[#0..=#2]UKKK » %0[#0..=#2]KKK
+                            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                              Union // { arity: 3 }
+                                Negate // { arity: 3 }
+                                  Get l12 // { arity: 3 }
+                                Get l10 // { arity: 3 }
+                            Get l11 // { arity: 3 }
+      cte l14 =
+        Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
+          Project (#1, #3) // { arity: 2 }
+            Join on=(#0{person2id} = #2{person2id}) type=differential // { arity: 4 }
+              implementation
+                %0:l13[#0]Kef » %1:l13[#0]Kef
+              ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+                Project (#2{person2id}, #3) // { arity: 2 }
+                  Filter (#0 = false) // { arity: 5 }
+                    Get l13 // { arity: 5 }
+              ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+                Project (#2{person2id}, #3) // { arity: 2 }
+                  Filter (#0 = true) // { arity: 5 }
+                    Get l13 // { arity: 5 }
+      cte l15 =
+        Project (#1) // { arity: 1 }
+          Map ((#0{min} / 2)) // { arity: 2 }
+            Union // { arity: 1 }
+              Get l14 // { arity: 1 }
+              Map (null) // { arity: 1 }
                 Union // { arity: 0 }
                   Negate // { arity: 0 }
-                    Get l7 // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l14 // { arity: 1 }
                   Constant // { arity: 0 }
                     - ()
-          Project (#1, #0) // { arity: 2 }
-            Map (true, -1) // { arity: 2 }
-              Get l7 // { arity: 0 }
-          Constant // { arity: 2 }
-            - (1450, true)
-            - (15393162796819, false)
-    cte l9 =
-      TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
-        Project (#0..=#3, #5) // { arity: 5 }
-          Filter (#4 = false) // { arity: 6 }
-            Get l17 // { arity: 6 }
-    cte l10 =
-      Distinct project=[#0..=#2] // { arity: 3 }
-        Project (#0..=#2{person2id}) // { arity: 3 }
-          Get l17 // { arity: 6 }
-    cte l11 =
-      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-        Get l10 // { arity: 3 }
-    cte l12 =
-      Project (#0..=#2) // { arity: 3 }
-        Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-          implementation
-            %1[#0..=#2]UKKKA » %0:l11[#0..=#2]UKKK
-          Get l11 // { arity: 3 }
-          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-            Distinct project=[#0..=#2] // { arity: 3 }
-              Project (#0..=#2) // { arity: 3 }
-                Get l9 // { arity: 5 }
-    cte l13 =
-      TopK group_by=[#0, #1, #2{person2id}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
-        Union // { arity: 5 }
-          Project (#3, #4, #1{person2id}, #7, #8) // { arity: 5 }
-            Map ((#6 + #2), false) // { arity: 9 }
-              Join on=(#0{person1id} = #5) type=differential // { arity: 7 }
-                implementation
-                  %0:l4[#0]K » %1:l9[#2]K
-                ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
-                  Get l4 // { arity: 3 }
-                ArrangeBy keys=[[#2]] // { arity: 4 }
-                  Project (#0..=#3) // { arity: 4 }
-                    Get l9 // { arity: 5 }
-          Project (#0..=#3, #9) // { arity: 5 }
-            Map ((#4 OR #8)) // { arity: 10 }
-              Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
-                implementation
-                  %0:l17[#0..=#2]KKK » %1[#0..=#2]KKK
-                ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-                  Project (#0..=#4) // { arity: 5 }
-                    Get l17 // { arity: 6 }
-                ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-                  Union // { arity: 4 }
-                    Map (true) // { arity: 4 }
-                      Get l12 // { arity: 3 }
-                    Project (#0..=#2, #6) // { arity: 4 }
-                      Map (false) // { arity: 7 }
-                        Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-                          implementation
-                            %1:l11[#0..=#2]UKKK » %0[#0..=#2]KKK
-                          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                            Union // { arity: 3 }
-                              Negate // { arity: 3 }
-                                Get l12 // { arity: 3 }
-                              Get l10 // { arity: 3 }
-                          Get l11 // { arity: 3 }
-    cte l14 =
-      Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
-        Project (#1, #3) // { arity: 2 }
-          Join on=(#0{person2id} = #2{person2id}) type=differential // { arity: 4 }
-            implementation
-              %0:l13[#0]Kef » %1:l13[#0]Kef
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              Project (#2{person2id}, #3) // { arity: 2 }
-                Filter (#0 = false) // { arity: 5 }
-                  Get l13 // { arity: 5 }
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              Project (#2{person2id}, #3) // { arity: 2 }
-                Filter (#0 = true) // { arity: 5 }
-                  Get l13 // { arity: 5 }
-    cte l15 =
-      Project (#1) // { arity: 1 }
-        Map ((#0{min} / 2)) // { arity: 2 }
-          Union // { arity: 1 }
-            Get l14 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l14 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
-    cte l16 =
-      Distinct project=[] // { arity: 0 }
-        Project () // { arity: 0 }
-          Filter #1 AND (#0{person2id} = -1) // { arity: 2 }
-            Get l8 // { arity: 2 }
-    cte l17 =
-      Distinct project=[#0..=#5] // { arity: 6 }
-        Union // { arity: 6 }
-          Project (#1, #0, #0, #2..=#4) // { arity: 6 }
-            Map (0, false, 0) // { arity: 5 }
-              Union // { arity: 2 }
-                Map (1450, false) // { arity: 2 }
-                  Get l16 // { arity: 0 }
-                Map (15393162796819, true) // { arity: 2 }
-                  Get l16 // { arity: 0 }
-          Project (#0..=#3, #7, #8) // { arity: 6 }
-            Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
-              CrossJoin type=delta // { arity: 7 }
-                implementation
-                  %0:l13 » %1[×]U » %2[×]U
-                  %1 » %2[×]U » %0:l13[×]
-                  %2 » %1[×]U » %0:l13[×]
-                ArrangeBy keys=[[]] // { arity: 5 }
-                  Get l13 // { arity: 5 }
-                ArrangeBy keys=[[]] // { arity: 1 }
-                  TopK limit=1 // { arity: 1 }
-                    Project (#4) // { arity: 1 }
-                      Get l9 // { arity: 5 }
-                ArrangeBy keys=[[]] // { arity: 1 }
-                  Union // { arity: 1 }
-                    Get l15 // { arity: 1 }
-                    Map (null) // { arity: 1 }
-                      Union // { arity: 0 }
-                        Negate // { arity: 0 }
-                          Project () // { arity: 0 }
-                            Get l15 // { arity: 1 }
-                        Constant // { arity: 0 }
-                          - ()
-  Return // { arity: 1 }
-    With
-      cte l18 =
-        Project (#0..=#3) // { arity: 4 }
-          Join on=(#4 = #5{max}) type=differential // { arity: 6 }
-            implementation
-              %1[#0]UK » %0:l17[#4]K
-            ArrangeBy keys=[[#4]] // { arity: 5 }
-              Project (#0..=#3, #5) // { arity: 5 }
-                Get l17 // { arity: 6 }
-            ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-              Reduce aggregates=[max(#0)] // { arity: 1 }
-                Project (#5) // { arity: 1 }
-                  Get l17 // { arity: 6 }
-      cte l19 =
-        Reduce aggregates=[min(#0{min})] // { arity: 1 }
-          Project (#2{min}) // { arity: 1 }
-            Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
-              Project (#0, #2, #3, #5) // { arity: 4 }
-                Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
+      cte l16 =
+        Distinct project=[] // { arity: 0 }
+          Project () // { arity: 0 }
+            Filter #1 AND (#0{person2id} = -1) // { arity: 2 }
+              Get l8 // { arity: 2 }
+      cte l17 =
+        Distinct project=[#0..=#5] // { arity: 6 }
+          Union // { arity: 6 }
+            Project (#1, #0, #0, #2..=#4) // { arity: 6 }
+              Map (0, false, 0) // { arity: 5 }
+                Union // { arity: 2 }
+                  Map (1450, false) // { arity: 2 }
+                    Get l16 // { arity: 0 }
+                  Map (15393162796819, true) // { arity: 2 }
+                    Get l16 // { arity: 0 }
+            Project (#0..=#3, #7, #8) // { arity: 6 }
+              Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
+                CrossJoin type=delta // { arity: 7 }
                   implementation
-                    %0:l18[#1]Kef » %1:l18[#1]Kef
-                  ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1..=#3) // { arity: 3 }
-                      Filter (#0 = false) // { arity: 4 }
-                        Get l18 // { arity: 4 }
-                  ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1..=#3) // { arity: 3 }
-                      Filter (#0 = true) // { arity: 4 }
-                        Get l18 // { arity: 4 }
+                    %0:l13 » %1[×]U » %2[×]U
+                    %1 » %2[×]U » %0:l13[×]
+                    %2 » %1[×]U » %0:l13[×]
+                  ArrangeBy keys=[[]] // { arity: 5 }
+                    Get l13 // { arity: 5 }
+                  ArrangeBy keys=[[]] // { arity: 1 }
+                    TopK limit=1 // { arity: 1 }
+                      Project (#4) // { arity: 1 }
+                        Get l9 // { arity: 5 }
+                  ArrangeBy keys=[[]] // { arity: 1 }
+                    Union // { arity: 1 }
+                      Get l15 // { arity: 1 }
+                      Map (null) // { arity: 1 }
+                        Union // { arity: 0 }
+                          Negate // { arity: 0 }
+                            Project () // { arity: 0 }
+                              Get l15 // { arity: 1 }
+                          Constant // { arity: 0 }
+                            - ()
     Return // { arity: 1 }
-      Project (#1) // { arity: 1 }
-        Map (coalesce(#0{min_min}, -1)) // { arity: 2 }
-          Union // { arity: 1 }
-            Get l19 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l19 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
+      With
+        cte l18 =
+          Project (#0..=#3) // { arity: 4 }
+            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
+              implementation
+                %1[#0]UK » %0:l17[#4]K
+              ArrangeBy keys=[[#4]] // { arity: 5 }
+                Project (#0..=#3, #5) // { arity: 5 }
+                  Get l17 // { arity: 6 }
+              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+                Reduce aggregates=[max(#0)] // { arity: 1 }
+                  Project (#5) // { arity: 1 }
+                    Get l17 // { arity: 6 }
+        cte l19 =
+          Reduce aggregates=[min(#0{min})] // { arity: 1 }
+            Project (#2{min}) // { arity: 1 }
+              Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
+                Project (#0, #2, #3, #5) // { arity: 4 }
+                  Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
+                    implementation
+                      %0:l18[#1]Kef » %1:l18[#1]Kef
+                    ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
+                      Project (#1..=#3) // { arity: 3 }
+                        Filter (#0 = false) // { arity: 4 }
+                          Get l18 // { arity: 4 }
+                    ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
+                      Project (#1..=#3) // { arity: 3 }
+                        Filter (#0 = true) // { arity: 4 }
+                          Get l18 // { arity: 4 }
+      Return // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Map (coalesce(#0{min_min}, -1)) // { arity: 2 }
+            Union // { arity: 1 }
+              Get l19 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l19 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -3676,101 +3680,103 @@ FROM paths
 WHERE w = (SELECT MIN(w) FROM paths)
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
         ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
     cte l1 =
-      ArrangeBy keys=[[]] // { arity: 1 }
+      ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+        ReadIndex on=pathq19 pathq19_src=[delta join lookup] // { arity: 3 }
+  Return // { arity: 3 }
+    With Mutually Recursive
+      cte l2 =
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Map ((#0 / 2)) // { arity: 2 }
+                Get l7 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l7 // { arity: 1 }
+                Constant // { arity: 0 }
+                  - ()
+      cte l3 =
+        TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
+          Union // { arity: 3 }
+            Project (#1{id}, #1{id}, #12) // { arity: 3 }
+              Map (0) // { arity: 13 }
+                ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
+            Project (#0, #5{dst}, #7) // { arity: 3 }
+              Filter coalesce((#2 < #3), true) // { arity: 8 }
+                Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
+                  Join on=(#1 = #4{src}) type=delta // { arity: 7 }
+                    implementation
+                      %0:l3 » %2:l1[#0]KA » %1:l2[×]
+                      %1:l2 » %0:l3[×] » %2:l1[#0]KA
+                      %2:l1 » %0:l3[#1]K » %1:l2[×]
+                    ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
+                      Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                        Get l3 // { arity: 3 }
+                    Get l2 // { arity: 1 }
+                    Get l1 // { arity: 3 }
+      cte l4 =
+        TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
+          Union // { arity: 3 }
+            Project (#1{id}, #1{id}, #12) // { arity: 3 }
+              Map (0) // { arity: 13 }
+                ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
+            Project (#0, #5{dst}, #7) // { arity: 3 }
+              Filter coalesce((#2 < #3), true) // { arity: 8 }
+                Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
+                  Join on=(#1 = #4{src}) type=delta // { arity: 7 }
+                    implementation
+                      %0:l4 » %2:l1[#0]KA » %1:l2[×]
+                      %1:l2 » %0:l4[×] » %2:l1[#0]KA
+                      %2:l1 » %0:l4[#1]K » %1:l2[×]
+                    ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
+                      Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                        Get l4 // { arity: 3 }
+                    Get l2 // { arity: 1 }
+                    Get l1 // { arity: 3 }
+      cte l5 =
+        Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
+          Project (#0{id}, #2, #3{id}, #5) // { arity: 4 }
+            Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
+              implementation
+                %0:l3[#1]K » %1:l4[#1]K
+              ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+                Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                  Get l3 // { arity: 3 }
+              ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+                Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                  Get l4 // { arity: 3 }
+      cte l6 =
+        Reduce aggregates=[min(#0{min})] // { arity: 1 }
+          Project (#2{min}) // { arity: 1 }
+            Get l5 // { arity: 3 }
+      cte l7 =
         Union // { arity: 1 }
-          Project (#1) // { arity: 1 }
-            Map ((#0 / 2)) // { arity: 2 }
-              Get l7 // { arity: 1 }
+          Get l6 // { arity: 1 }
           Map (null) // { arity: 1 }
             Union // { arity: 0 }
               Negate // { arity: 0 }
                 Project () // { arity: 0 }
-                  Get l7 // { arity: 1 }
+                  Get l6 // { arity: 1 }
               Constant // { arity: 0 }
                 - ()
-    cte l2 =
-      ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-        ReadIndex on=pathq19 pathq19_src=[delta join lookup] // { arity: 3 }
-    cte l3 =
-      TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
-        Union // { arity: 3 }
-          Project (#1{id}, #1{id}, #12) // { arity: 3 }
-            Map (0) // { arity: 13 }
-              ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
-          Project (#0, #5{dst}, #7) // { arity: 3 }
-            Filter coalesce((#2 < #3), true) // { arity: 8 }
-              Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
-                Join on=(#1 = #4{src}) type=delta // { arity: 7 }
-                  implementation
-                    %0:l3 » %2:l2[#0]KA » %1:l1[×]
-                    %1:l1 » %0:l3[×] » %2:l2[#0]KA
-                    %2:l2 » %0:l3[#1]K » %1:l1[×]
-                  ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
-                    Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                      Get l3 // { arity: 3 }
-                  Get l1 // { arity: 1 }
-                  Get l2 // { arity: 3 }
-    cte l4 =
-      TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
-        Union // { arity: 3 }
-          Project (#1{id}, #1{id}, #12) // { arity: 3 }
-            Map (0) // { arity: 13 }
-              ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
-          Project (#0, #5{dst}, #7) // { arity: 3 }
-            Filter coalesce((#2 < #3), true) // { arity: 8 }
-              Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
-                Join on=(#1 = #4{src}) type=delta // { arity: 7 }
-                  implementation
-                    %0:l4 » %2:l2[#0]KA » %1:l1[×]
-                    %1:l1 » %0:l4[×] » %2:l2[#0]KA
-                    %2:l2 » %0:l4[#1]K » %1:l1[×]
-                  ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
-                    Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                      Get l4 // { arity: 3 }
-                  Get l1 // { arity: 1 }
-                  Get l2 // { arity: 3 }
-    cte l5 =
-      Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-        Project (#0{id}, #2, #3{id}, #5) // { arity: 4 }
-          Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
-            implementation
-              %0:l3[#1]K » %1:l4[#1]K
-            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                Get l3 // { arity: 3 }
-            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                Get l4 // { arity: 3 }
-    cte l6 =
-      Reduce aggregates=[min(#0{min})] // { arity: 1 }
-        Project (#2{min}) // { arity: 1 }
-          Get l5 // { arity: 3 }
-    cte l7 =
-      Union // { arity: 1 }
-        Get l6 // { arity: 1 }
-        Map (null) // { arity: 1 }
-          Union // { arity: 0 }
-            Negate // { arity: 0 }
-              Project () // { arity: 0 }
-                Get l6 // { arity: 1 }
-            Constant // { arity: 0 }
-              - ()
-  Return // { arity: 3 }
-    Project (#0{id}..=#2{min}) // { arity: 3 }
-      Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
-        implementation
-          %1[#0]UK » %0:l5[#2]K
-        ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-          Get l5 // { arity: 3 }
-        ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-          Reduce aggregates=[min(#0{min})] // { arity: 1 }
-            Project (#2{min}) // { arity: 1 }
-              Get l5 // { arity: 3 }
+    Return // { arity: 3 }
+      Project (#0{id}..=#2{min}) // { arity: 3 }
+        Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UK » %0:l5[#2]K
+          ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+            Get l5 // { arity: 3 }
+          ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+            Reduce aggregates=[min(#0{min})] // { arity: 1 }
+              Project (#2{min}) // { arity: 1 }
+                Get l5 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -3835,172 +3841,174 @@ SELECT * FROM results WHERE w = (SELECT min(w) FROM results) ORDER BY f, t
 ----
 Explained Query:
   Finish order_by=[#0{id} asc nulls_last, #1{id} asc nulls_last] output=[#0..=#2]
-    With Mutually Recursive
+    With
       cte l0 =
-        TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
-          Project (#0..=#3, #5) // { arity: 5 }
-            Filter (#4 = false) // { arity: 6 }
-              Get l7 // { arity: 6 }
-      cte l1 =
-        Distinct project=[#0..=#2] // { arity: 3 }
-          Project (#0..=#2{id}) // { arity: 3 }
-            Get l7 // { arity: 6 }
-      cte l2 =
-        Project (#0..=#2) // { arity: 3 }
-          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-            implementation
-              %1[#0..=#2]UKKKA » %0:l1[#0..=#2]UKKK
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 3 }
-                Get l1 // { arity: 3 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Distinct project=[#0..=#2] // { arity: 3 }
-                Project (#0..=#2) // { arity: 3 }
-                  Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 5 }
-                    Get l0 // { arity: 5 }
-      cte l3 =
-        TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
-          Distinct project=[#0..=#4] // { arity: 5 }
-            Union // { arity: 5 }
-              Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
-                Map ((#6 + bigint_to_double(#2{w})), false) // { arity: 9 }
-                  Join on=(#0{src} = #5) type=differential // { arity: 7 }
-                    implementation
-                      %0:pathq19[#0]KA » %1:l0[#2]K
-                    ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-                      ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
-                    ArrangeBy keys=[[#2]] // { arity: 4 }
-                      Project (#0..=#3) // { arity: 4 }
-                        Filter (#2) IS NOT NULL // { arity: 5 }
-                          Get l0 // { arity: 5 }
-              Project (#0..=#3, #9) // { arity: 5 }
-                Map ((#4 OR #8)) // { arity: 10 }
-                  Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
-                    implementation
-                      %0:l7[#0..=#2]KKK » %1[#0..=#2]KKK
-                    ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-                      Project (#0..=#4) // { arity: 5 }
-                        Get l7 // { arity: 6 }
-                    ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-                      Union // { arity: 4 }
-                        Map (true) // { arity: 4 }
-                          Get l2 // { arity: 3 }
-                        Project (#0..=#2, #6) // { arity: 4 }
-                          Map (false) // { arity: 7 }
-                            Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-                              implementation
-                                %1:l1[#0..=#2]UKKK » %0[#0..=#2]KKK
-                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                                Union // { arity: 3 }
-                                  Negate // { arity: 3 }
-                                    Get l2 // { arity: 3 }
-                                  Get l1 // { arity: 3 }
-                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                                Get l1 // { arity: 3 }
-      cte l4 =
-        Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
-          Project (#1, #3) // { arity: 2 }
-            Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
-              implementation
-                %0:l3[#0]Kef » %1:l3[#0]Kef
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2{dst}, #3) // { arity: 2 }
-                  Filter (#0 = false) AND (#2{dst}) IS NOT NULL // { arity: 5 }
-                    Get l3 // { arity: 5 }
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2{dst}, #3) // { arity: 2 }
-                  Filter (#0 = true) AND (#2{dst}) IS NOT NULL // { arity: 5 }
-                    Get l3 // { arity: 5 }
-      cte l5 =
-        Project (#1) // { arity: 1 }
-          Map ((#0{min} / 2)) // { arity: 2 }
-            Union // { arity: 1 }
-              Get l4 // { arity: 1 }
-              Map (null) // { arity: 1 }
-                Union // { arity: 0 }
-                  Negate // { arity: 0 }
-                    Project () // { arity: 0 }
-                      Get l4 // { arity: 1 }
-                  Constant // { arity: 0 }
-                    - ()
-      cte l6 =
         ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
           ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
-      cte l7 =
-        Distinct project=[#0..=#5] // { arity: 6 }
-          Union // { arity: 6 }
-            Project (#1, #0{id}, #0{id}, #2..=#4) // { arity: 6 }
-              Map (0, false, 0) // { arity: 5 }
-                Union // { arity: 2 }
-                  Project (#1{id}, #12) // { arity: 2 }
-                    Map (false) // { arity: 13 }
-                      ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
-                  Project (#1{id}, #12) // { arity: 2 }
-                    Map (true) // { arity: 13 }
-                      ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
-            Project (#0..=#3, #7, #8) // { arity: 6 }
-              Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
-                CrossJoin type=delta // { arity: 7 }
-                  implementation
-                    %0:l3 » %1[×]U » %2[×]U
-                    %1 » %2[×]U » %0:l3[×]
-                    %2 » %1[×]U » %0:l3[×]
-                  ArrangeBy keys=[[]] // { arity: 5 }
-                    Get l3 // { arity: 5 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    TopK limit=1 // { arity: 1 }
-                      Project (#4) // { arity: 1 }
-                        Get l0 // { arity: 5 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    Union // { arity: 1 }
-                      Get l5 // { arity: 1 }
-                      Map (null) // { arity: 1 }
-                        Union // { arity: 0 }
-                          Negate // { arity: 0 }
-                            Project () // { arity: 0 }
-                              Get l5 // { arity: 1 }
-                          Constant // { arity: 0 }
-                            - ()
     Return // { arity: 3 }
-      With
-        cte l8 =
-          Project (#0..=#3) // { arity: 4 }
-            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
+      With Mutually Recursive
+        cte l1 =
+          TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
+            Project (#0..=#3, #5) // { arity: 5 }
+              Filter (#4 = false) // { arity: 6 }
+                Get l7 // { arity: 6 }
+        cte l2 =
+          Distinct project=[#0..=#2] // { arity: 3 }
+            Project (#0..=#2{id}) // { arity: 3 }
+              Get l7 // { arity: 6 }
+        cte l3 =
+          Project (#0..=#2) // { arity: 3 }
+            Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
               implementation
-                %1[#0]UK » %0:l7[#4]K
-              ArrangeBy keys=[[#4]] // { arity: 5 }
-                Project (#0..=#3, #5) // { arity: 5 }
-                  Filter (#2{id}) IS NOT NULL // { arity: 6 }
-                    Get l7 // { arity: 6 }
-              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-                Reduce aggregates=[max(#0)] // { arity: 1 }
-                  Project (#5) // { arity: 1 }
-                    Get l7 // { arity: 6 }
-        cte l9 =
-          Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-            Project (#0{id}, #2, #3{id}, #5) // { arity: 4 }
-              Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
+                %1[#0..=#2]UKKKA » %0:l2[#0..=#2]UKKK
+              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 3 }
+                  Get l2 // { arity: 3 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                Distinct project=[#0..=#2] // { arity: 3 }
+                  Project (#0..=#2) // { arity: 3 }
+                    Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 5 }
+                      Get l1 // { arity: 5 }
+        cte l4 =
+          TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
+            Distinct project=[#0..=#4] // { arity: 5 }
+              Union // { arity: 5 }
+                Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
+                  Map ((#6 + bigint_to_double(#2{w})), false) // { arity: 9 }
+                    Join on=(#0{src} = #5) type=differential // { arity: 7 }
+                      implementation
+                        %0:pathq19[#0]KA » %1:l1[#2]K
+                      ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+                        ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
+                      ArrangeBy keys=[[#2]] // { arity: 4 }
+                        Project (#0..=#3) // { arity: 4 }
+                          Filter (#2) IS NOT NULL // { arity: 5 }
+                            Get l1 // { arity: 5 }
+                Project (#0..=#3, #9) // { arity: 5 }
+                  Map ((#4 OR #8)) // { arity: 10 }
+                    Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
+                      implementation
+                        %0:l7[#0..=#2]KKK » %1[#0..=#2]KKK
+                      ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
+                        Project (#0..=#4) // { arity: 5 }
+                          Get l7 // { arity: 6 }
+                      ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                        Union // { arity: 4 }
+                          Map (true) // { arity: 4 }
+                            Get l3 // { arity: 3 }
+                          Project (#0..=#2, #6) // { arity: 4 }
+                            Map (false) // { arity: 7 }
+                              Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                                implementation
+                                  %1:l2[#0..=#2]UKKK » %0[#0..=#2]KKK
+                                ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                                  Union // { arity: 3 }
+                                    Negate // { arity: 3 }
+                                      Get l3 // { arity: 3 }
+                                    Get l2 // { arity: 3 }
+                                ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                                  Get l2 // { arity: 3 }
+        cte l5 =
+          Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
+            Project (#1, #3) // { arity: 2 }
+              Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
                 implementation
-                  %0:l8[#1]Kef » %1:l8[#1]Kef
-                ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-                  Project (#1{id}..=#3) // { arity: 3 }
-                    Filter (#0 = false) // { arity: 4 }
-                      Get l8 // { arity: 4 }
-                ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-                  Project (#1{id}..=#3) // { arity: 3 }
-                    Filter (#0 = true) // { arity: 4 }
-                      Get l8 // { arity: 4 }
+                  %0:l4[#0]Kef » %1:l4[#0]Kef
+                ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                  Project (#2{dst}, #3) // { arity: 2 }
+                    Filter (#0 = false) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                      Get l4 // { arity: 5 }
+                ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                  Project (#2{dst}, #3) // { arity: 2 }
+                    Filter (#0 = true) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                      Get l4 // { arity: 5 }
+        cte l6 =
+          Project (#1) // { arity: 1 }
+            Map ((#0{min} / 2)) // { arity: 2 }
+              Union // { arity: 1 }
+                Get l5 // { arity: 1 }
+                Map (null) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l5 // { arity: 1 }
+                    Constant // { arity: 0 }
+                      - ()
+        cte l7 =
+          Distinct project=[#0..=#5] // { arity: 6 }
+            Union // { arity: 6 }
+              Project (#1, #0{id}, #0{id}, #2..=#4) // { arity: 6 }
+                Map (0, false, 0) // { arity: 5 }
+                  Union // { arity: 2 }
+                    Project (#1{id}, #12) // { arity: 2 }
+                      Map (false) // { arity: 13 }
+                        ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
+                    Project (#1{id}, #12) // { arity: 2 }
+                      Map (true) // { arity: 13 }
+                        ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
+              Project (#0..=#3, #7, #8) // { arity: 6 }
+                Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
+                  CrossJoin type=delta // { arity: 7 }
+                    implementation
+                      %0:l4 » %1[×]U » %2[×]U
+                      %1 » %2[×]U » %0:l4[×]
+                      %2 » %1[×]U » %0:l4[×]
+                    ArrangeBy keys=[[]] // { arity: 5 }
+                      Get l4 // { arity: 5 }
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      TopK limit=1 // { arity: 1 }
+                        Project (#4) // { arity: 1 }
+                          Get l1 // { arity: 5 }
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Union // { arity: 1 }
+                        Get l6 // { arity: 1 }
+                        Map (null) // { arity: 1 }
+                          Union // { arity: 0 }
+                            Negate // { arity: 0 }
+                              Project () // { arity: 0 }
+                                Get l6 // { arity: 1 }
+                            Constant // { arity: 0 }
+                              - ()
       Return // { arity: 3 }
-        Project (#0{id}..=#2{min}) // { arity: 3 }
-          Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
-            implementation
-              %1[#0]UK » %0:l9[#2]K
-            ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-              Get l9 // { arity: 3 }
-            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-              Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                Project (#2{min}) // { arity: 1 }
-                  Get l9 // { arity: 3 }
+        With
+          cte l8 =
+            Project (#0..=#3) // { arity: 4 }
+              Join on=(#4 = #5{max}) type=differential // { arity: 6 }
+                implementation
+                  %1[#0]UK » %0:l7[#4]K
+                ArrangeBy keys=[[#4]] // { arity: 5 }
+                  Project (#0..=#3, #5) // { arity: 5 }
+                    Filter (#2{id}) IS NOT NULL // { arity: 6 }
+                      Get l7 // { arity: 6 }
+                ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+                  Reduce aggregates=[max(#0)] // { arity: 1 }
+                    Project (#5) // { arity: 1 }
+                      Get l7 // { arity: 6 }
+          cte l9 =
+            Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
+              Project (#0{id}, #2, #3{id}, #5) // { arity: 4 }
+                Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
+                  implementation
+                    %0:l8[#1]Kef » %1:l8[#1]Kef
+                  ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+                    Project (#1{id}..=#3) // { arity: 3 }
+                      Filter (#0 = false) // { arity: 4 }
+                        Get l8 // { arity: 4 }
+                  ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+                    Project (#1{id}..=#3) // { arity: 3 }
+                      Filter (#0 = true) // { arity: 4 }
+                        Get l8 // { arity: 4 }
+        Return // { arity: 3 }
+          Project (#0{id}..=#2{min}) // { arity: 3 }
+            Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
+              implementation
+                %1[#0]UK » %0:l9[#2]K
+              ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+                Get l9 // { arity: 3 }
+              ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+                Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                  Project (#2{min}) // { arity: 1 }
+                    Get l9 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -4433,7 +4441,7 @@ SELECT t, w FROM results WHERE w = (SELECT min(w) FROM results) ORDER BY t LIMIT
 ----
 Explained Query:
   Finish order_by=[#0{personid} asc nulls_last] limit=20 output=[#0, #1]
-    With Mutually Recursive
+    With
       cte l0 =
         Project (#1{personid}) // { arity: 1 }
           Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
@@ -4450,207 +4458,209 @@ Explained Query:
       cte l2 =
         ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
           Get l0 // { arity: 1 }
-      cte l3 =
-        Distinct project=[#0{dst}] // { arity: 1 }
-          Union // { arity: 1 }
-            Project (#2{dst}) // { arity: 1 }
-              Join on=(#0 = #1{src}) type=delta // { arity: 4 }
+    Return // { arity: 2 }
+      With Mutually Recursive
+        cte l3 =
+          Distinct project=[#0{dst}] // { arity: 1 }
+            Union // { arity: 1 }
+              Project (#2{dst}) // { arity: 1 }
+                Join on=(#0 = #1{src}) type=delta // { arity: 4 }
+                  implementation
+                    %0:l3 » %1:l1[#0]KA » %2[×]
+                    %1:l1 » %0:l3[#0]UK » %2[×]
+                    %2 » %0:l3[×] » %1:l1[#0]KA
+                  ArrangeBy keys=[[], [#0{dst}]] // { arity: 1 }
+                    Get l3 // { arity: 1 }
+                  Get l1 // { arity: 3 }
+                  ArrangeBy keys=[[]] // { arity: 0 }
+                    Union // { arity: 0 }
+                      Negate // { arity: 0 }
+                        Distinct project=[] // { arity: 0 }
+                          Project () // { arity: 0 }
+                            Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
+                              implementation
+                                %0:l3[#0]UK » %1:l2[#0]K
+                              ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
+                                Get l3 // { arity: 1 }
+                              Get l2 // { arity: 1 }
+                      Constant // { arity: 0 }
+                        - ()
+              Constant // { arity: 1 }
+                - (10995116285979)
+        cte l4 =
+          TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
+            Project (#0..=#3, #5) // { arity: 5 }
+              Filter (#4 = false) // { arity: 6 }
+                Get l12 // { arity: 6 }
+        cte l5 =
+          Distinct project=[#0..=#2] // { arity: 3 }
+            Project (#0..=#2{personid}) // { arity: 3 }
+              Get l12 // { arity: 6 }
+        cte l6 =
+          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+            Get l5 // { arity: 3 }
+        cte l7 =
+          Project (#0..=#2) // { arity: 3 }
+            Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+              implementation
+                %1[#0..=#2]UKKKA » %0:l6[#0..=#2]UKKK
+              Get l6 // { arity: 3 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                Distinct project=[#0..=#2] // { arity: 3 }
+                  Project (#0..=#2) // { arity: 3 }
+                    Get l4 // { arity: 5 }
+        cte l8 =
+          TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
+            Union // { arity: 5 }
+              Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
+                Map ((#6 + integer_to_bigint(#2{w})), false) // { arity: 9 }
+                  Join on=(#0{src} = #5) type=differential // { arity: 7 }
+                    implementation
+                      %0:l1[#0]KA » %1:l4[#2]K
+                    Get l1 // { arity: 3 }
+                    ArrangeBy keys=[[#2]] // { arity: 4 }
+                      Project (#0..=#3) // { arity: 4 }
+                        Get l4 // { arity: 5 }
+              Project (#0..=#3, #9) // { arity: 5 }
+                Map ((#4 OR #8)) // { arity: 10 }
+                  Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
+                    implementation
+                      %0:l12[#0..=#2]KKK » %1[#0..=#2]KKK
+                    ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
+                      Project (#0..=#4) // { arity: 5 }
+                        Get l12 // { arity: 6 }
+                    ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                      Union // { arity: 4 }
+                        Map (true) // { arity: 4 }
+                          Get l7 // { arity: 3 }
+                        Project (#0..=#2, #6) // { arity: 4 }
+                          Map (false) // { arity: 7 }
+                            Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                              implementation
+                                %1:l6[#0..=#2]UKKK » %0[#0..=#2]KKK
+                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                                Union // { arity: 3 }
+                                  Negate // { arity: 3 }
+                                    Get l7 // { arity: 3 }
+                                  Get l5 // { arity: 3 }
+                              Get l6 // { arity: 3 }
+        cte l9 =
+          Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
+            Project (#1, #3) // { arity: 2 }
+              Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
                 implementation
-                  %0:l3 » %1:l1[#0]KA » %2[×]
-                  %1:l1 » %0:l3[#0]UK » %2[×]
-                  %2 » %0:l3[×] » %1:l1[#0]KA
-                ArrangeBy keys=[[], [#0{dst}]] // { arity: 1 }
-                  Get l3 // { arity: 1 }
-                Get l1 // { arity: 3 }
-                ArrangeBy keys=[[]] // { arity: 0 }
+                  %0:l8[#0]Kef » %1:l8[#0]Kef
+                ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                  Project (#2{dst}, #3) // { arity: 2 }
+                    Filter (#0 = false) // { arity: 5 }
+                      Get l8 // { arity: 5 }
+                ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                  Project (#2{dst}, #3) // { arity: 2 }
+                    Filter (#0 = true) // { arity: 5 }
+                      Get l8 // { arity: 5 }
+        cte l10 =
+          Project (#1) // { arity: 1 }
+            Map ((#0{min} / 2)) // { arity: 2 }
+              Union // { arity: 1 }
+                Get l9 // { arity: 1 }
+                Map (null) // { arity: 1 }
                   Union // { arity: 0 }
                     Negate // { arity: 0 }
-                      Distinct project=[] // { arity: 0 }
-                        Project () // { arity: 0 }
-                          Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
-                            implementation
-                              %0:l3[#0]UK » %1:l2[#0]K
-                            ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                              Get l3 // { arity: 1 }
-                            Get l2 // { arity: 1 }
+                      Project () // { arity: 0 }
+                        Get l9 // { arity: 1 }
                     Constant // { arity: 0 }
                       - ()
-            Constant // { arity: 1 }
-              - (10995116285979)
-      cte l4 =
-        TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
-          Project (#0..=#3, #5) // { arity: 5 }
-            Filter (#4 = false) // { arity: 6 }
-              Get l12 // { arity: 6 }
-      cte l5 =
-        Distinct project=[#0..=#2] // { arity: 3 }
-          Project (#0..=#2{personid}) // { arity: 3 }
-            Get l12 // { arity: 6 }
-      cte l6 =
-        ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-          Get l5 // { arity: 3 }
-      cte l7 =
-        Project (#0..=#2) // { arity: 3 }
-          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-            implementation
-              %1[#0..=#2]UKKKA » %0:l6[#0..=#2]UKKK
-            Get l6 // { arity: 3 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Distinct project=[#0..=#2] // { arity: 3 }
-                Project (#0..=#2) // { arity: 3 }
-                  Get l4 // { arity: 5 }
-      cte l8 =
-        TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
-          Union // { arity: 5 }
-            Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
-              Map ((#6 + integer_to_bigint(#2{w})), false) // { arity: 9 }
-                Join on=(#0{src} = #5) type=differential // { arity: 7 }
-                  implementation
-                    %0:l1[#0]KA » %1:l4[#2]K
-                  Get l1 // { arity: 3 }
-                  ArrangeBy keys=[[#2]] // { arity: 4 }
-                    Project (#0..=#3) // { arity: 4 }
-                      Get l4 // { arity: 5 }
-            Project (#0..=#3, #9) // { arity: 5 }
-              Map ((#4 OR #8)) // { arity: 10 }
-                Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
-                  implementation
-                    %0:l12[#0..=#2]KKK » %1[#0..=#2]KKK
-                  ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-                    Project (#0..=#4) // { arity: 5 }
-                      Get l12 // { arity: 6 }
-                  ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-                    Union // { arity: 4 }
-                      Map (true) // { arity: 4 }
-                        Get l7 // { arity: 3 }
-                      Project (#0..=#2, #6) // { arity: 4 }
-                        Map (false) // { arity: 7 }
-                          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+        cte l11 =
+          Distinct project=[] // { arity: 0 }
+            Project () // { arity: 0 }
+              Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
+                implementation
+                  %0:l3[#0]UK » %1:l2[#0]K
+                ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
+                  Get l3 // { arity: 1 }
+                Get l2 // { arity: 1 }
+        cte l12 =
+          Distinct project=[#0..=#5] // { arity: 6 }
+            Union // { arity: 6 }
+              Project (#0..=#2{personid}, #4, #3, #5) // { arity: 6 }
+                Map (false, 0, 0) // { arity: 6 }
+                  Distinct project=[#0..=#2{personid}] // { arity: 3 }
+                    Union // { arity: 3 }
+                      Project (#1, #0, #0) // { arity: 3 }
+                        Map (10995116285979, false) // { arity: 2 }
+                          Get l11 // { arity: 0 }
+                      Project (#1, #0{personid}, #0{personid}) // { arity: 3 }
+                        Map (true) // { arity: 2 }
+                          CrossJoin type=differential // { arity: 1 }
                             implementation
-                              %1:l6[#0..=#2]UKKK » %0[#0..=#2]KKK
-                            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                              Union // { arity: 3 }
-                                Negate // { arity: 3 }
-                                  Get l7 // { arity: 3 }
-                                Get l5 // { arity: 3 }
-                            Get l6 // { arity: 3 }
-      cte l9 =
-        Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
-          Project (#1, #3) // { arity: 2 }
-            Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
-              implementation
-                %0:l8[#0]Kef » %1:l8[#0]Kef
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2{dst}, #3) // { arity: 2 }
-                  Filter (#0 = false) // { arity: 5 }
-                    Get l8 // { arity: 5 }
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2{dst}, #3) // { arity: 2 }
-                  Filter (#0 = true) // { arity: 5 }
-                    Get l8 // { arity: 5 }
-      cte l10 =
-        Project (#1) // { arity: 1 }
-          Map ((#0{min} / 2)) // { arity: 2 }
-            Union // { arity: 1 }
-              Get l9 // { arity: 1 }
-              Map (null) // { arity: 1 }
-                Union // { arity: 0 }
-                  Negate // { arity: 0 }
-                    Project () // { arity: 0 }
-                      Get l9 // { arity: 1 }
-                  Constant // { arity: 0 }
-                    - ()
-      cte l11 =
-        Distinct project=[] // { arity: 0 }
-          Project () // { arity: 0 }
-            Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
-              implementation
-                %0:l3[#0]UK » %1:l2[#0]K
-              ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                Get l3 // { arity: 1 }
-              Get l2 // { arity: 1 }
-      cte l12 =
-        Distinct project=[#0..=#5] // { arity: 6 }
-          Union // { arity: 6 }
-            Project (#0..=#2{personid}, #4, #3, #5) // { arity: 6 }
-              Map (false, 0, 0) // { arity: 6 }
-                Distinct project=[#0..=#2{personid}] // { arity: 3 }
-                  Union // { arity: 3 }
-                    Project (#1, #0, #0) // { arity: 3 }
-                      Map (10995116285979, false) // { arity: 2 }
-                        Get l11 // { arity: 0 }
-                    Project (#1, #0{personid}, #0{personid}) // { arity: 3 }
-                      Map (true) // { arity: 2 }
-                        CrossJoin type=differential // { arity: 1 }
-                          implementation
-                            %1:l11[×]U » %0:l0[×]
-                          ArrangeBy keys=[[]] // { arity: 1 }
-                            Get l0 // { arity: 1 }
-                          ArrangeBy keys=[[]] // { arity: 0 }
-                            Get l11 // { arity: 0 }
-            Project (#0..=#3, #7, #8) // { arity: 6 }
-              Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
-                CrossJoin type=delta // { arity: 7 }
-                  implementation
-                    %0:l8 » %1[×]U » %2[×]U
-                    %1 » %2[×]U » %0:l8[×]
-                    %2 » %1[×]U » %0:l8[×]
-                  ArrangeBy keys=[[]] // { arity: 5 }
-                    Get l8 // { arity: 5 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    TopK limit=1 // { arity: 1 }
-                      Project (#4) // { arity: 1 }
-                        Get l4 // { arity: 5 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    Union // { arity: 1 }
-                      Get l10 // { arity: 1 }
-                      Map (null) // { arity: 1 }
-                        Union // { arity: 0 }
-                          Negate // { arity: 0 }
-                            Project () // { arity: 0 }
-                              Get l10 // { arity: 1 }
-                          Constant // { arity: 0 }
-                            - ()
-    Return // { arity: 2 }
-      With
-        cte l13 =
-          Project (#0..=#3) // { arity: 4 }
-            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
-              implementation
-                %1[#0]UK » %0:l12[#4]K
-              ArrangeBy keys=[[#4]] // { arity: 5 }
-                Project (#0..=#3, #5) // { arity: 5 }
-                  Get l12 // { arity: 6 }
-              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-                Reduce aggregates=[max(#0)] // { arity: 1 }
-                  Project (#5) // { arity: 1 }
-                    Get l12 // { arity: 6 }
-        cte l14 =
-          Project (#1{personid}, #2{min}) // { arity: 2 }
-            Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1 + #3))] // { arity: 3 }
-              Project (#0{personid}, #2, #3{personid}, #5) // { arity: 4 }
-                Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
-                  implementation
-                    %0:l13[#1]Kef » %1:l13[#1]Kef
-                  ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
-                    Project (#1{personid}..=#3) // { arity: 3 }
-                      Filter (#0 = false) // { arity: 4 }
-                        Get l13 // { arity: 4 }
-                  ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
-                    Project (#1{personid}..=#3) // { arity: 3 }
-                      Filter (#0 = true) // { arity: 4 }
-                        Get l13 // { arity: 4 }
+                              %1:l11[×]U » %0:l0[×]
+                            ArrangeBy keys=[[]] // { arity: 1 }
+                              Get l0 // { arity: 1 }
+                            ArrangeBy keys=[[]] // { arity: 0 }
+                              Get l11 // { arity: 0 }
+              Project (#0..=#3, #7, #8) // { arity: 6 }
+                Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
+                  CrossJoin type=delta // { arity: 7 }
+                    implementation
+                      %0:l8 » %1[×]U » %2[×]U
+                      %1 » %2[×]U » %0:l8[×]
+                      %2 » %1[×]U » %0:l8[×]
+                    ArrangeBy keys=[[]] // { arity: 5 }
+                      Get l8 // { arity: 5 }
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      TopK limit=1 // { arity: 1 }
+                        Project (#4) // { arity: 1 }
+                          Get l4 // { arity: 5 }
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Union // { arity: 1 }
+                        Get l10 // { arity: 1 }
+                        Map (null) // { arity: 1 }
+                          Union // { arity: 0 }
+                            Negate // { arity: 0 }
+                              Project () // { arity: 0 }
+                                Get l10 // { arity: 1 }
+                            Constant // { arity: 0 }
+                              - ()
       Return // { arity: 2 }
-        Project (#0{personid}, #1{min}) // { arity: 2 }
-          Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
-            implementation
-              %1[#0]UK » %0:l14[#1]K
-            ArrangeBy keys=[[#1{min}]] // { arity: 2 }
-              Get l14 // { arity: 2 }
-            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-              Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                Project (#1{min}) // { arity: 1 }
-                  Get l14 // { arity: 2 }
+        With
+          cte l13 =
+            Project (#0..=#3) // { arity: 4 }
+              Join on=(#4 = #5{max}) type=differential // { arity: 6 }
+                implementation
+                  %1[#0]UK » %0:l12[#4]K
+                ArrangeBy keys=[[#4]] // { arity: 5 }
+                  Project (#0..=#3, #5) // { arity: 5 }
+                    Get l12 // { arity: 6 }
+                ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+                  Reduce aggregates=[max(#0)] // { arity: 1 }
+                    Project (#5) // { arity: 1 }
+                      Get l12 // { arity: 6 }
+          cte l14 =
+            Project (#1{personid}, #2{min}) // { arity: 2 }
+              Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1 + #3))] // { arity: 3 }
+                Project (#0{personid}, #2, #3{personid}, #5) // { arity: 4 }
+                  Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
+                    implementation
+                      %0:l13[#1]Kef » %1:l13[#1]Kef
+                    ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
+                      Project (#1{personid}..=#3) // { arity: 3 }
+                        Filter (#0 = false) // { arity: 4 }
+                          Get l13 // { arity: 4 }
+                    ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
+                      Project (#1{personid}..=#3) // { arity: 3 }
+                        Filter (#0 = true) // { arity: 4 }
+                          Get l13 // { arity: 4 }
+        Return // { arity: 2 }
+          Project (#0{personid}, #1{min}) // { arity: 2 }
+            Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
+              implementation
+                %1[#0]UK » %0:l14[#1]K
+              ArrangeBy keys=[[#1{min}]] // { arity: 2 }
+                Get l14 // { arity: 2 }
+              ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+                Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                  Project (#1{min}) // { arity: 1 }
+                    Get l14 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.person_workat_company_companyid (differential join)

--- a/test/sqllogictest/outer_join_simplification.slt
+++ b/test/sqllogictest/outer_join_simplification.slt
@@ -692,7 +692,7 @@ with mutually recursive
 select * from c0
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#0{a}..=#2{u}, #4{v})
         Join on=(#0{a} = #3{a}) type=differential
@@ -702,20 +702,22 @@ Explained Query:
           ArrangeBy keys=[[#0{a}]]
             Filter (#0{a}) IS NOT NULL
               ReadStorage materialize.public.bar
-    cte l1 =
-      Distinct project=[#0{a}..=#4{v}]
-        Union
-          Map (null, null)
-            Union
-              Negate
-                Project (#0{a}..=#2{u})
-                  Get l0
-              ReadStorage materialize.public.foo_raw
-          Project (#0{a}..=#2{u}, #0{a}, #3{v})
-            Get l0
-          Get l1
   Return
-    Get l1
+    With Mutually Recursive
+      cte l1 =
+        Distinct project=[#0{a}..=#4{v}]
+          Union
+            Map (null, null)
+              Union
+                Negate
+                  Project (#0{a}..=#2{u})
+                    Get l0
+                ReadStorage materialize.public.foo_raw
+            Project (#0{a}..=#2{u}, #0{a}, #3{v})
+              Get l0
+            Get l1
+    Return
+      Get l1
 
 Source materialize.public.foo_raw
 Source materialize.public.bar
@@ -837,7 +839,7 @@ with mutually recursive
 select * from c0;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Project (#0{a}) // { arity: 1 }
         Filter (#0{a}) IS NOT NULL // { arity: 2 }
@@ -845,53 +847,55 @@ Explained Query:
     cte l1 =
       Project (#0{c}) // { arity: 1 }
         ReadStorage materialize.public.quux // { arity: 2 }
-    cte l2 =
-      Distinct project=[#0{a}..=#2{u}] // { arity: 3 }
-        Union // { arity: 3 }
-          Project (#0..=#2) // { arity: 3 }
-            Join on=(#0 = #3{a} AND #1 = #4{b} AND #7{c} = case when (#6) IS NULL then null else #5{c} end) type=delta // { arity: 8 }
-              ArrangeBy keys=[[#0{a}], [#1{b}]] // { arity: 3 }
-                Get l2 // { arity: 3 }
-              ArrangeBy keys=[[#0{a}]] // { arity: 1 }
-                Union // { arity: 1 }
-                  Get l0 // { arity: 1 }
-                  Threshold // { arity: 1 }
-                    Union // { arity: 1 }
-                      Negate // { arity: 1 }
-                        Get l0 // { arity: 1 }
-                      Distinct project=[#0] // { arity: 1 }
-                        Project (#0{a}) // { arity: 1 }
-                          Get l2 // { arity: 3 }
-              ArrangeBy keys=[[#0{b}], [case when (#2) IS NULL then null else #1{c} end]] // { arity: 3 }
-                Union // { arity: 3 }
-                  Project (#0{b}, #1{c}, #3) // { arity: 3 }
-                    Map (true) // { arity: 4 }
-                      ReadStorage materialize.public.baz // { arity: 3 }
-                  Map (null, null) // { arity: 3 }
+  Return // { arity: 3 }
+    With Mutually Recursive
+      cte l2 =
+        Distinct project=[#0{a}..=#2{u}] // { arity: 3 }
+          Union // { arity: 3 }
+            Project (#0..=#2) // { arity: 3 }
+              Join on=(#0 = #3{a} AND #1 = #4{b} AND #7{c} = case when (#6) IS NULL then null else #5{c} end) type=delta // { arity: 8 }
+                ArrangeBy keys=[[#0{a}], [#1{b}]] // { arity: 3 }
+                  Get l2 // { arity: 3 }
+                ArrangeBy keys=[[#0{a}]] // { arity: 1 }
+                  Union // { arity: 1 }
+                    Get l0 // { arity: 1 }
                     Threshold // { arity: 1 }
                       Union // { arity: 1 }
                         Negate // { arity: 1 }
-                          Project (#0{b}) // { arity: 1 }
-                            ReadStorage materialize.public.baz // { arity: 3 }
+                          Get l0 // { arity: 1 }
                         Distinct project=[#0] // { arity: 1 }
-                          Project (#1{b}) // { arity: 1 }
+                          Project (#0{a}) // { arity: 1 }
                             Get l2 // { arity: 3 }
-              ArrangeBy keys=[[#0{c}]] // { arity: 1 }
-                Union // { arity: 1 }
-                  Get l1 // { arity: 1 }
-                  Threshold // { arity: 1 }
-                    Union // { arity: 1 }
-                      Negate // { arity: 1 }
-                        Get l1 // { arity: 1 }
-                      Distinct project=[#0{c}] // { arity: 1 }
+                ArrangeBy keys=[[#0{b}], [case when (#2) IS NULL then null else #1{c} end]] // { arity: 3 }
+                  Union // { arity: 3 }
+                    Project (#0{b}, #1{c}, #3) // { arity: 3 }
+                      Map (true) // { arity: 4 }
+                        ReadStorage materialize.public.baz // { arity: 3 }
+                    Map (null, null) // { arity: 3 }
+                      Threshold // { arity: 1 }
                         Union // { arity: 1 }
-                          Project (#1{c}) // { arity: 1 }
-                            ReadStorage materialize.public.baz // { arity: 3 }
-                          Constant // { arity: 1 }
-                            - (null)
-          ReadStorage materialize.public.foo // { arity: 3 }
-  Return // { arity: 3 }
-    Get l2 // { arity: 3 }
+                          Negate // { arity: 1 }
+                            Project (#0{b}) // { arity: 1 }
+                              ReadStorage materialize.public.baz // { arity: 3 }
+                          Distinct project=[#0] // { arity: 1 }
+                            Project (#1{b}) // { arity: 1 }
+                              Get l2 // { arity: 3 }
+                ArrangeBy keys=[[#0{c}]] // { arity: 1 }
+                  Union // { arity: 1 }
+                    Get l1 // { arity: 1 }
+                    Threshold // { arity: 1 }
+                      Union // { arity: 1 }
+                        Negate // { arity: 1 }
+                          Get l1 // { arity: 1 }
+                        Distinct project=[#0{c}] // { arity: 1 }
+                          Union // { arity: 1 }
+                            Project (#1{c}) // { arity: 1 }
+                              ReadStorage materialize.public.baz // { arity: 3 }
+                            Constant // { arity: 1 }
+                              - (null)
+            ReadStorage materialize.public.foo // { arity: 3 }
+    Return // { arity: 3 }
+      Get l2 // { arity: 3 }
 
 Source materialize.public.foo
 Source materialize.public.bar

--- a/test/sqllogictest/transform/literal_lifting.slt
+++ b/test/sqllogictest/transform/literal_lifting.slt
@@ -1012,7 +1012,7 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0 UNION ALL SELECT * FROM c1
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Distinct project=[#0{f1}] // { arity: 1 }
         Union // { arity: 1 }
@@ -1020,18 +1020,20 @@ Explained Query:
             ReadStorage materialize.public.t1 // { arity: 2 }
           Project (#1{f2}) // { arity: 1 }
             ReadStorage materialize.public.t1 // { arity: 2 }
-    cte l1 =
-      Map (42) // { arity: 2 }
-        Distinct project=[#0{f1}] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l0 // { arity: 1 }
-            Project (#0{f1}) // { arity: 1 }
-              Get l1 // { arity: 2 }
   Return // { arity: 2 }
-    Union // { arity: 2 }
-      Map (42) // { arity: 2 }
-        Get l0 // { arity: 1 }
-      Get l1 // { arity: 2 }
+    With Mutually Recursive
+      cte l1 =
+        Map (42) // { arity: 2 }
+          Distinct project=[#0{f1}] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l0 // { arity: 1 }
+              Project (#0{f1}) // { arity: 1 }
+                Get l1 // { arity: 2 }
+    Return // { arity: 2 }
+      Union // { arity: 2 }
+        Map (42) // { arity: 2 }
+          Get l0 // { arity: 1 }
+        Get l1 // { arity: 2 }
 
 Source materialize.public.t1
 

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -542,3 +542,91 @@ where (~ (select "replication_factor" from mz_catalog.mz_clusters limit 1 offset
          end
       )
 limit 117;
+
+## Ensure that we hoist WMR-invariant Let bindings, to avoid a `raw` modifier on arrangements
+## that can be accessed through keys (and which do not otherwise require linear work).
+
+statement ok
+create table potato (a TEXT, b TEXT);
+
+statement ok
+create index on potato(a);
+
+## The only thing that needs to stay true about what follows is that `potato` is used only
+## as indexed access, and has `raw = false` to avoid decanting its contents.
+query T multiline
+EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR WITH MUTUALLY RECURSIVE
+walk(a TEXT, b TEXT) AS (
+    SELECT a, b
+    FROM potato
+    WHERE a = 'russet'
+
+    UNION
+
+    SELECT potato.a, potato.b
+    FROM potato
+    INNER JOIN walk
+    ON potato.a = walk.b 
+)
+select * from walk;
+----
+Explained Query:
+  With
+    cte l0 =
+      Get::PassArrangements materialize.public.potato
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[text?, text?]
+  Return
+    With Mutually Recursive
+      cte l1 =
+        ArrangeBy
+          input_key=[#0, #1]
+          raw=true
+          Reduce::Distinct
+            val_plan
+              project=()
+            key_plan=id
+            Union
+              Join::Linear
+                linear_stage[0]
+                  lookup={ relation=0, key=[#0] }
+                  stream={ key=[#0], thinning=() }
+                source={ relation=1, key=[#0] }
+                Get::PassArrangements l0
+                  raw=false
+                  arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+                  types=[text?, text?]
+                ArrangeBy
+                  raw=true
+                  arrangements[0]={ key=[#0], permutation=id, thinning=() }
+                  types=[text]
+                  Constant
+                    - ("russet")
+              Join::Linear
+                linear_stage[0]
+                  lookup={ relation=1, key=[#0] }
+                  stream={ key=[#0], thinning=(#1) }
+                source={ relation=0, key=[#0] }
+                Get::PassArrangements l0
+                  raw=false
+                  arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+                  types=[text?, text?]
+                ArrangeBy
+                  raw=true
+                  arrangements[0]={ key=[#0], permutation=id, thinning=() }
+                  types=[text]
+                  Get::Collection l1
+                    project=(#1)
+                    filter=((#1) IS NOT NULL)
+                    raw=true
+    Return
+      Get::PassArrangements l1
+        raw=true
+
+Used Indexes:
+  - materialize.public.potato_a_idx (differential join, lookup)
+
+Target cluster: quickstart
+
+EOF

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -566,7 +566,7 @@ walk(a TEXT, b TEXT) AS (
     SELECT potato.a, potato.b
     FROM potato
     INNER JOIN walk
-    ON potato.a = walk.b 
+    ON potato.a = walk.b
 )
 select * from walk;
 ----

--- a/test/sqllogictest/transform/projection_lifting.slt
+++ b/test/sqllogictest/transform/projection_lifting.slt
@@ -92,25 +92,27 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM triangle_cycles;
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Filter (#0{src}) IS NOT NULL AND (#1{dst}) IS NOT NULL
         ReadStorage materialize.public.edges
-    cte l1 =
-      Distinct project=[#0{dst}..=#2{src}]
-        Union
-          Project (#1{dst}, #3{dst}, #0{src})
-            Join on=(#0{src} = #5{dst} AND #1{dst} = #2{src} AND #3{dst} = #4{src}) type=differential
-              ArrangeBy keys=[[#1{dst}]]
-                Get l0
-              ArrangeBy keys=[[#0{src}]]
-                Get l0
-              ArrangeBy keys=[[#0{src}, #1{dst}]]
-                Get l0
-          Project (#2{src}, #0{dst}, #1{dst})
-            Get l1
   Return
-    Get l1
+    With Mutually Recursive
+      cte l1 =
+        Distinct project=[#0{dst}..=#2{src}]
+          Union
+            Project (#1{dst}, #3{dst}, #0{src})
+              Join on=(#0{src} = #5{dst} AND #1{dst} = #2{src} AND #3{dst} = #4{src}) type=differential
+                ArrangeBy keys=[[#1{dst}]]
+                  Get l0
+                ArrangeBy keys=[[#0{src}]]
+                  Get l0
+                ArrangeBy keys=[[#0{src}, #1{dst}]]
+                  Get l0
+            Project (#2{src}, #0{dst}, #1{dst})
+              Get l1
+    Return
+      Get l1
 
 Source materialize.public.edges
   filter=((#0{src}) IS NOT NULL AND (#1{dst}) IS NOT NULL)

--- a/test/sqllogictest/transform/redundant_join.slt
+++ b/test/sqllogictest/transform/redundant_join.slt
@@ -140,31 +140,28 @@ SELECT * FROM (
 );
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Distinct project=[(#0{f1} % 2)] // { arity: 1 }
         Project (#0{f1}) // { arity: 1 }
           ReadStorage materialize.public.t2 // { arity: 2 }
-    cte l1 =
-      Distinct project=[#0{f1}..=#2] // { arity: 3 }
-        Union // { arity: 3 }
-          Get l1 // { arity: 3 }
-          Project (#0, #0, #0) // { arity: 3 }
-            Get l0 // { arity: 1 }
-          Join on=(#2 = (#0{f1} % 2)) type=differential // { arity: 3 }
-            implementation
-              %1:l0[#0]UK » %0:t2[(#0 % 2)]K
-            ArrangeBy keys=[[(#0{f1} % 2)]] // { arity: 2 }
-              ReadStorage materialize.public.t2 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Get l0 // { arity: 1 }
   Return // { arity: 1 }
-    Union // { arity: 1 }
-      Project (#2) // { arity: 1 }
-        Get l1 // { arity: 3 }
-      Project (#1) // { arity: 1 }
-        Map (42) // { arity: 2 }
-          Get l0 // { arity: 1 }
+    With Mutually Recursive
+      cte l1 =
+        Distinct project=[#0{f1}..=#2] // { arity: 3 }
+          Union // { arity: 3 }
+            Get l1 // { arity: 3 }
+            Project (#0, #0, #0) // { arity: 3 }
+              Get l0 // { arity: 1 }
+            Map ((#0{f1} % 2)) // { arity: 3 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
+    Return // { arity: 1 }
+      Union // { arity: 1 }
+        Project (#2) // { arity: 1 }
+          Get l1 // { arity: 3 }
+        Project (#1) // { arity: 1 }
+          Map (42) // { arity: 2 }
+            Get l0 // { arity: 1 }
 
 Source materialize.public.t2
 

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -1578,7 +1578,7 @@ UNION ALL
 SELECT * FROM c2 WHERE f1 > 7
 ----
 Explained Query:
-  With Mutually Recursive
+  With
     cte l0 =
       Union // { arity: 2 }
         ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
@@ -1586,28 +1586,30 @@ Explained Query:
     cte l1 =
       Filter (#1{f2} > 7) // { arity: 2 }
         Get l0 // { arity: 2 }
-    cte l2 =
-      Union // { arity: 2 }
-        Get l1 // { arity: 2 }
-        Get l2 // { arity: 2 }
-        Get l2 // { arity: 2 }
-        Get l3 // { arity: 2 }
-        Get l3 // { arity: 2 }
-    cte l3 =
-      Union // { arity: 2 }
-        Get l1 // { arity: 2 }
-        Get l2 // { arity: 2 }
-        Get l2 // { arity: 2 }
-        Get l3 // { arity: 2 }
-        Get l3 // { arity: 2 }
   Return // { arity: 2 }
-    Union // { arity: 2 }
-      Filter (#0{f1} > 7) // { arity: 2 }
-        Get l0 // { arity: 2 }
-      Filter (#0{f1} > 7) // { arity: 2 }
-        Get l2 // { arity: 2 }
-      Filter (#0{f1} > 7) // { arity: 2 }
-        Get l3 // { arity: 2 }
+    With Mutually Recursive
+      cte l2 =
+        Union // { arity: 2 }
+          Get l1 // { arity: 2 }
+          Get l2 // { arity: 2 }
+          Get l2 // { arity: 2 }
+          Get l3 // { arity: 2 }
+          Get l3 // { arity: 2 }
+      cte l3 =
+        Union // { arity: 2 }
+          Get l1 // { arity: 2 }
+          Get l2 // { arity: 2 }
+          Get l2 // { arity: 2 }
+          Get l3 // { arity: 2 }
+          Get l3 // { arity: 2 }
+    Return // { arity: 2 }
+      Union // { arity: 2 }
+        Filter (#0{f1} > 7) // { arity: 2 }
+          Get l0 // { arity: 2 }
+        Filter (#0{f1} > 7) // { arity: 2 }
+          Get l2 // { arity: 2 }
+        Filter (#0{f1} > 7) // { arity: 2 }
+          Get l3 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)


### PR DESCRIPTION
Our let normalization consolidates let and letrec stages, partly on account of tracking the same thing two different ways is annoying and makes the code complicated. At the same time, other parts of the code prefer to have as much extracted from letrec stages as possible, both because transforms can be less effective with letrec stages, and because once we have `ArrangeBy` stages they should be hoisted as high out of letrec stages as is possible, to maximize their availability.

Both of these feel like glitches that we should solve closer to the problems (e.g. improving the transforms to achieve parity, and hoisting arrangements in lowering to renderable plans). This PR is first to see what the plan changes are and whether we like them, and if we are lucky to address some complaints we have around arrangements not being found come render time.

cc: @ggevay 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
