### PR TITLE
bazel: Refactor `run.py` so `bin/environmentd` uses Bazel remote caching

### DIFF
--- a/misc/python/materialize/cli/bazel.py
+++ b/misc/python/materialize/cli/bazel.py
@@ -13,12 +13,11 @@ import argparse
 import os
 import pathlib
 import subprocess
-from enum import Enum
 from pathlib import Path
 
 from materialize import MZ_ROOT, bazel, ui
+from materialize.bazel import remote_cache_arg
 from materialize.build_config import BuildConfig
-from materialize.teleport import TeleportProxy
 
 
 def main() -> int:
@@ -187,60 +186,6 @@ def output_path(target) -> list[pathlib.Path]:
         cmd_args, text=True, stderr=subprocess.DEVNULL
     ).splitlines()
     return [pathlib.Path(path) for path in paths]
-
-
-def remote_cache_arg(config: BuildConfig) -> list[str]:
-    """List of arguments that could possibly enable use of a remote cache."""
-
-    ci_remote = os.getenv("CI_BAZEL_REMOTE_CACHE")
-    config_remote = config.bazel.remote_cache
-
-    if ci_remote:
-        remote_cache = ci_remote
-    elif config_remote:
-        bazel_remote = RemoteCache(config_remote)
-        remote_cache = bazel_remote.address()
-    else:
-        remote_cache = None
-
-    if remote_cache:
-        return [f"--remote_cache={remote_cache}"]
-    else:
-        return []
-
-
-class RemoteCache:
-    """The remote cache we're conecting to."""
-
-    def __init__(self, value: str):
-        if value.startswith("teleport"):
-            app_name = value.split(":")[1]
-            self.kind = RemoteCacheKind.teleport
-            self.data = app_name
-        else:
-            self.kind = RemoteCacheKind.normal
-            self.data = value
-
-    def address(self) -> str:
-        """Address for connecting to this remote cache."""
-        if self.kind == RemoteCacheKind.normal:
-            return self.data
-        else:
-            TeleportProxy.spawn(self.data, "6889")
-            return "http://localhost:6889"
-
-
-class RemoteCacheKind(Enum):
-    """Kind of remote cache we're connecting to."""
-
-    teleport = "teleport"
-    """Connecting to a remote cache through a teleport proxy."""
-
-    normal = "normal"
-    """An HTTP address for the cache."""
-
-    def __str__(self):
-        return self.value
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR refactors the `run.py` script to use Bazel remote caching. FWIW `run.py` was the first thing adapted to use Bazel, so this is catching it up to other advances we've made more recently.

It also changes the `bin/environmentd --release` flag to use the Bazel "optimized" config which is better for local development.

### Motivation

Improve developer experience

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
