### PR TITLE
storage: in feedback upsert, fix handling of existing state values

### DIFF
--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -39,6 +39,7 @@ use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::{Capability, InputCapability, Operator};
 use timely::dataflow::{Scope, ScopeParent, Stream};
 use timely::order::{PartialOrder, TotalOrder};
+use timely::progress::timestamp::Refines;
 use timely::progress::{Antichain, Timestamp};
 
 use crate::healthcheck::HealthStatusUpdate;
@@ -221,6 +222,7 @@ pub(crate) fn upsert<G: Scope, FromTime>(
 )
 where
     G::Timestamp: TotalOrder + Sync,
+    G::Timestamp: Refines<mz_repr::Timestamp> + TotalOrder + Sync,
     FromTime: Timestamp + Sync,
 {
     let upsert_metrics = source_config.metrics.get_upsert_metrics(
@@ -407,6 +409,7 @@ fn upsert_operator<G: Scope, FromTime, F, Fut, US>(
 )
 where
     G::Timestamp: TotalOrder + Sync,
+    G::Timestamp: Refines<mz_repr::Timestamp> + TotalOrder + Sync,
     F: FnOnce() -> Fut + 'static,
     Fut: std::future::Future<Output = US>,
     US: UpsertStateBackend<G::Timestamp, Option<FromTime>>,

--- a/src/storage/src/upsert_continual_feedback.rs
+++ b/src/storage/src/upsert_continual_feedback.rs
@@ -739,9 +739,9 @@ where
 
         match value {
             Some(value) => {
-                let existing_value = existing_state_cell.take();
+                let existing_value = existing_state_cell.as_ref();
 
-                let old_value = if let Some(old_value) = existing_value.as_ref() {
+                let old_value = if let Some(old_value) = existing_value {
                     old_value.provisional_value_ref(&ts)
                 } else {
                     None
@@ -754,7 +754,7 @@ where
                 match &drain_style {
                     DrainStyle::AtTime { .. } => {
                         let new_value = match existing_value {
-                            Some(existing_value) => existing_value.into_provisional_value(
+                            Some(existing_value) => existing_value.clone().into_provisional_value(
                                 value.clone(),
                                 ts.clone(),
                                 Some(from_time.0.clone()),

--- a/src/storage/src/upsert_continual_feedback.rs
+++ b/src/storage/src/upsert_continual_feedback.rs
@@ -267,6 +267,7 @@ where
                         worker_id = %source_config.worker_id,
                         source_id = %source_config.id,
                         persist_stash = %persist_stash.len(),
+                        %hydrating,
                         %last_rehydration_chunk,
                         ?resume_upper,
                         ?persist_upper,

--- a/src/storage/src/upsert_continual_feedback.rs
+++ b/src/storage/src/upsert_continual_feedback.rs
@@ -739,20 +739,16 @@ where
 
         match value {
             Some(value) => {
-                let existing_value = existing_state_cell.as_ref();
-
-                let old_value = if let Some(old_value) = existing_value {
-                    old_value.provisional_value_ref(&ts)
-                } else {
-                    None
-                };
-
-                if let Some(old_value) = old_value {
-                    output_updates.push((old_value.clone(), ts.clone(), -1));
+                if let Some(old_value) = existing_state_cell.as_ref() {
+                    if let Some(old_value) = old_value.provisional_value_ref(&ts) {
+                        output_updates.push((old_value.clone(), ts.clone(), -1));
+                    }
                 }
 
                 match &drain_style {
                     DrainStyle::AtTime { .. } => {
+                        let existing_value = existing_state_cell.take();
+
                         let new_value = match existing_value {
                             Some(existing_value) => existing_value.clone().into_provisional_value(
                                 value.clone(),
@@ -765,6 +761,7 @@ where
                                 Some(from_time.0.clone()),
                             ),
                         };
+
                         existing_state_cell.replace(new_value);
                     }
                     DrainStyle::ToUpper { .. } => {
@@ -775,19 +772,16 @@ where
                 output_updates.push((value, ts, 1));
             }
             None => {
-                let existing_value = existing_state_cell.take();
-
-                let old_value = if let Some(old_value) = existing_value.as_ref() {
-                    old_value.provisional_value_ref(&ts)
-                } else {
-                    None
-                };
-                if let Some(old_value) = old_value {
-                    output_updates.push((old_value.clone(), ts.clone(), -1));
+                if let Some(old_value) = existing_state_cell.as_ref() {
+                    if let Some(old_value) = old_value.provisional_value_ref(&ts) {
+                        output_updates.push((old_value.clone(), ts.clone(), -1));
+                    }
                 }
 
                 match &drain_style {
                     DrainStyle::AtTime { .. } => {
+                        let existing_value = existing_state_cell.take();
+
                         let new_value = match existing_value {
                             Some(existing_value) => existing_value
                                 .into_provisional_tombstone(ts.clone(), Some(from_time.0.clone())),
@@ -796,6 +790,7 @@ where
                                 Some(from_time.0.clone()),
                             ),
                         };
+
                         existing_state_cell.replace(new_value);
                     }
                     DrainStyle::ToUpper { .. } => {


### PR DESCRIPTION
Before, while working off the "upsert commands" (aka. input) we were
taking the existing value out of `command_state` when processing and we
were only putting in a new value when processing commands with
`DrainStyle::AtTime`. This is problematic when processing commands of
multiple timestamps in one invocation of `drain_staged_input`:
processing the first update for a key `k` at timestamp `t` takes away
any value that we might have retrieved from state, then when processing
another update for key `k` at timestamp `t+1`, we think there is no
previous value and don't emit a retraction. Meaning we suddely have
multiple values for the same key in our collection, which is not legal.

Now, we just don't take away the state value without putting something
back.

The astute reader might now wonder how this can be correct. Say our
upsert state contains:

```
k1 -> v2
```

The input frontier is at at a time that allows processing and the
persist input frontier is at `[11]`.

We're processing these upsert commands, tuples of `(key, timestamp,
value)`:

```
(k1, 10, v2)
(k1, 11, v3)
```

Naively (and somewhat correctly), you would assume the correct updates
to emit when processing this, one timestamp after another, would be (now
additionally with diffs):

```
((k1, 10, v2), -1)
((k1, 10, v2), 1)
((k1, 11, v2), -1)
((k1, 11, v3), 1)
```
(Those first two updates might seem nonsensical, but the code doesn't
actually check to see if the values differ, it simply retracts and
updates.)

The answer lies in the fact that we're _only_ allowed to process updates
with timestamp `11` when they are not beyond the persist frontier
anymore, that is the frontier is at say `11`. Meaning what we have in
state is the _global view_ of upsert state as of that persist frontier,
meaning it is correct to emit updates at `11`. And anything we emit at
"lower" timestamps (timestamps that are not beyond the persist frontier,
for sticklers) will not be written down because the output shards upper
is already past that. All that will be written down is:

```
((k1, 11, v2), -1)
((k1, 11, v3), 1)
```

Which is the correct updates to write down given the current contents of
the shard at upper `11`. This _is_ subtle, and I'm note sure I like it,
but I also think it's correct.

As a follow-up, we could say that we don't process updates that are not
beyond the persist frontier, because we know that they won't be written
down anymore. But this is not needed to fix this bug.

### Tips for reviewer

I threw in another fix. I first thought that was the problem but it wasn't for the thing that @def- and @benesch were debugging. It might have been the cause of other flakes.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
