### PR TITLE
storage: Correct output index for source exports

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -116,8 +116,8 @@ build:debuginfo-full --copt=-g2
 build:debuginfo-full --strip=never
 build:debuginfo-full --@rules_rust//:extra_rustc_flag=-Cstrip=none
 
-build:debuginfo-limited --@rules_rust//:extra_rustc_flag=-Cdebuginfo=line-tables-only
-build:debuginfo-limited --copt=-gline-tables-only
+build:debuginfo-limited --@rules_rust//:extra_rustc_flag=-Cdebuginfo=1
+build:debuginfo-limited --copt=-g1
 build:debuginfo-limited --strip=never
 build:debuginfo-limited --@rules_rust//:extra_rustc_flag=-Cstrip=none
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4903,6 +4903,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "crossbeam-channel",
+ "derivative",
  "differential-dataflow",
  "futures",
  "http 1.1.0",

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -119,7 +119,7 @@ impl TimestampProvider for Frontiers {
 
         let mock_read_hold = |id, frontier| {
             let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-            ReadHold::new(id, frontier, tx)
+            ReadHold::with_channel(id, frontier, tx)
         };
 
         for (instance_id, ids) in id_bundle.compute_ids.iter() {

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -17,6 +17,7 @@ bytes = "1.3.0"
 bytesize = "1.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.8"
+derivative = "2.2.0"
 differential-dataflow = "0.13.2"
 futures = "0.3.25"
 http = "1.1.0"

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -944,7 +944,7 @@ mod tests {
                     .get(&id)
                     .ok_or(ReadHoldError::CollectionMissing(id))?;
                 let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-                holds.push(ReadHold::new(id, read.clone(), tx));
+                holds.push(ReadHold::with_channel(id, read.clone(), tx));
             }
             Ok(holds)
         }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -1177,7 +1177,7 @@ impl<T: ComputeControllerTimestamp> InstanceState<T> {
             since
         });
 
-        let hold = ReadHold::new(id, since, self.read_holds_tx.clone());
+        let hold = ReadHold::with_channel(id, since, self.read_holds_tx.clone());
         Ok(hold)
     }
 

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -2182,8 +2182,8 @@ impl<T: ComputeControllerTimestamp> CollectionState<T> {
         // Initialize collection read holds.
         // Note that the implied read hold was already added to the `read_capabilities` when
         // `shared` was created, so we only need to add the warmup read hold here.
-        let implied_read_hold = ReadHold::new(collection_id, since.clone(), read_holds_tx.clone());
-        let warmup_read_hold = ReadHold::new(collection_id, since.clone(), read_holds_tx);
+        let implied_read_hold = ReadHold::with_channel(collection_id, since.clone(), read_holds_tx.clone());
+        let warmup_read_hold = ReadHold::with_channel(collection_id, since.clone(), read_holds_tx);
 
         let updates = warmup_read_hold.since().iter().map(|t| (t.clone(), 1));
         shared.lock_read_capabilities(|c| {

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -38,7 +38,7 @@ use mz_repr::adt::interval::Interval;
 use mz_repr::refresh_schedule::RefreshSchedule;
 use mz_repr::{Datum, Diff, GlobalId, Row};
 use mz_storage_client::controller::IntrospectionType;
-use mz_storage_types::read_holds::ReadHold;
+use mz_storage_types::read_holds::{self, ReadHold};
 use mz_storage_types::read_policy::ReadPolicy;
 use serde::Serialize;
 use thiserror::Error;
@@ -130,15 +130,23 @@ impl From<CollectionMissing> for ReadPolicyError {
 pub type Command<T> = Box<dyn FnOnce(&mut Instance<T>) + Send>;
 
 /// A client for an [`Instance`] task.
-#[derive(Debug, Clone)]
+#[derive(Clone, derivative::Derivative)]
+#[derivative(Debug)]
 pub(super) struct Client<T: ComputeControllerTimestamp> {
     /// A sender for commands for the instance.
     command_tx: mpsc::UnboundedSender<Command<T>>,
+    /// A sender for read hold changes for collections installed on the instance.
+    #[derivative(Debug = "ignore")]
+    read_hold_tx: read_holds::ChangeTx<T>,
 }
 
 impl<T: ComputeControllerTimestamp> Client<T> {
     pub fn send(&self, command: Command<T>) -> Result<(), SendError<Command<T>>> {
         self.command_tx.send(command)
+    }
+
+    pub fn read_hold_tx(&self) -> read_holds::ChangeTx<T> {
+        Arc::clone(&self.read_hold_tx)
     }
 }
 
@@ -162,6 +170,17 @@ where
     ) -> Self {
         let (command_tx, command_rx) = mpsc::unbounded_channel();
 
+        let read_hold_tx: read_holds::ChangeTx<_> = {
+            let command_tx = command_tx.clone();
+            Arc::new(move |id, change: ChangeBatch<_>| {
+                let cmd: Command<_> = {
+                    let change = change.clone();
+                    Box::new(move |i| i.apply_read_hold_change(id, change.clone()))
+                };
+                command_tx.send(cmd).map_err(|_| SendError((id, change)))
+            })
+        };
+
         mz_ore::task::spawn(
             || format!("compute-instance-{id}"),
             Instance::new(
@@ -175,12 +194,16 @@ where
                 dyncfg,
                 command_rx,
                 response_tx,
+                Arc::clone(&read_hold_tx),
                 introspection_tx,
             )
             .run(),
         );
 
-        Self { command_tx }
+        Self {
+            command_tx,
+            read_hold_tx,
+        }
     }
 }
 
@@ -273,11 +296,7 @@ pub(super) struct Instance<T: ComputeControllerTimestamp> {
     ///
     /// Copies of this sender are given to [`ReadHold`]s that are created in
     /// [`CollectionState::new`].
-    read_holds_tx: mpsc::UnboundedSender<(GlobalId, ChangeBatch<T>)>,
-    /// Receiver for updates to collection read holds.
-    ///
-    /// Received updates are applied by [`Instance::apply_read_hold_changes`].
-    read_holds_rx: mpsc::UnboundedReceiver<(GlobalId, ChangeBatch<T>)>,
+    read_hold_tx: read_holds::ChangeTx<T>,
     /// A sender for responses from replicas.
     replica_tx: mz_ore::channel::InstrumentedUnboundedSender<ReplicaResponse<T>, IntCounter>,
     /// A receiver for responses from replicas.
@@ -355,7 +374,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
             shared,
             storage_dependencies,
             compute_dependencies,
-            self.read_holds_tx.clone(),
+            Arc::clone(&self.read_hold_tx),
             introspection,
         );
         // If the collection is write-only, clear its read policy to reflect that.
@@ -720,17 +739,6 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
             .expect("Cannot error if target_replica_ids is None")
     }
 
-    /// Report an external read hold change.
-    ///
-    /// Changes to externally held read holds are sequenced through `command_rx`, to ensure that,
-    /// e.g., we don't receive changes for a collection before we have seen its creation command.
-    #[mz_ore::instrument(level = "debug")]
-    pub fn report_read_hold_change(&self, id: GlobalId, changes: ChangeBatch<T>) {
-        self.read_holds_tx
-            .send((id, changes))
-            .expect("rx is held by `self`");
-    }
-
     /// Clean up collection state that is not needed anymore.
     ///
     /// Three conditions need to be true before we can remove state for a collection:
@@ -798,8 +806,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
             now: _,
             wallclock_lag: _,
             wallclock_lag_last_refresh,
-            read_holds_tx: _,
-            read_holds_rx: _,
+            read_hold_tx: _,
             replica_tx: _,
             replica_rx: _,
         } = self;
@@ -867,17 +874,16 @@ where
         dyncfg: Arc<ConfigSet>,
         command_rx: mpsc::UnboundedReceiver<Command<T>>,
         response_tx: mpsc::UnboundedSender<ComputeControllerResponse<T>>,
+        read_hold_tx: read_holds::ChangeTx<T>,
         introspection_tx: crossbeam_channel::Sender<IntrospectionUpdates>,
     ) -> Self {
-        let (read_holds_tx, read_holds_rx) = mpsc::unbounded_channel();
-
         let mut collections = BTreeMap::new();
         let mut log_sources = BTreeMap::new();
         for (log, id, shared) in arranged_logs {
             let collection = CollectionState::new_log_collection(
                 id,
                 shared,
-                read_holds_tx.clone(),
+                Arc::clone(&read_hold_tx),
                 introspection_tx.clone(),
             );
             collections.insert(id, collection);
@@ -912,8 +918,7 @@ where
             now,
             wallclock_lag,
             wallclock_lag_last_refresh: Instant::now(),
-            read_holds_tx,
-            read_holds_rx,
+            read_hold_tx,
             replica_tx,
             replica_rx,
         }
@@ -994,14 +999,11 @@ where
 
         // Apply all outstanding read hold changes. This might cause read hold downgrades to be
         // added to `command_tx`, so we need to apply those in a loop.
-        while !self.read_holds_rx.is_empty() {
-            self.apply_read_hold_changes();
-
-            // TODO(teskje): Make `Command` an enum and assert that all received commands are read
-            // hold downgrades.
-            while let Ok(cmd) = command_rx.try_recv() {
-                cmd(self);
-            }
+        //
+        // TODO(teskje): Make `Command` an enum and assert that all received commands are read
+        // hold downgrades.
+        while let Ok(cmd) = command_rx.try_recv() {
+            cmd(self);
         }
 
         // Collections might have been dropped but not cleaned up yet.
@@ -1670,86 +1672,62 @@ where
         });
     }
 
-    /// Apply collection read hold changes pending in `read_holds_rx`.
-    fn apply_read_hold_changes(&mut self) {
-        let mut allowed_compaction = BTreeMap::new();
-
-        // It's more efficient to apply updates for greater IDs before updates for smaller IDs,
-        // since ID order usually matches dependency order and downgrading read holds on a
-        // collection can cause downgrades on its dependencies. So instead of processing changes as
-        // they come in, we batch them up as much as we can and process them in reverse ID order.
-        let mut recv_batch = || {
-            let mut batch = BTreeMap::<_, ChangeBatch<_>>::new();
-            while let Ok((id, mut update)) = self.read_holds_rx.try_recv() {
-                batch
-                    .entry(id)
-                    .and_modify(|e| e.extend(update.drain()))
-                    .or_insert(update);
-            }
-
-            let has_updates = !batch.is_empty();
-            has_updates.then_some(batch)
+    /// Apply a collection read hold change.
+    fn apply_read_hold_change(&mut self, id: GlobalId, mut update: ChangeBatch<T>) {
+        let Some(collection) = self.collections.get_mut(&id) else {
+            soft_panic_or_log!(
+                "read hold change for absent collection (id={id}, changes={update:?})"
+            );
+            return;
         };
 
-        while let Some(batch) = recv_batch() {
-            for (id, mut update) in batch.into_iter().rev() {
-                let Some(collection) = self.collections.get_mut(&id) else {
-                    soft_panic_or_log!(
-                        "read hold change for absent collection (id={id}, changes={update:?})"
-                    );
-                    continue;
-                };
-
-                let new_since = collection.shared.lock_read_capabilities(|caps| {
-                    // Sanity check to prevent corrupted `read_capabilities`, which can cause hard-to-debug
-                    // issues (usually stuck read frontiers).
-                    let read_frontier = caps.frontier();
-                    for (time, diff) in update.iter() {
-                        let count = caps.count_for(time) + diff;
-                        assert!(
-                            count >= 0,
-                            "invalid read capabilities update: negative capability \
-                     (id={id:?}, read_capabilities={caps:?}, update={update:?})",
-                        );
-                        assert!(
-                            count == 0 || read_frontier.less_equal(time),
-                            "invalid read capabilities update: frontier regression \
-                     (id={id:?}, read_capabilities={caps:?}, update={update:?})",
-                        );
-                    }
-
-                    // Apply read capability updates and learn about resulting changes to the read
-                    // frontier.
-                    let changes = caps.update_iter(update.drain());
-
-                    let changed = changes.count() > 0;
-                    changed.then(|| caps.frontier().to_owned())
-                });
-
-                let Some(new_since) = new_since else {
-                    continue; // read frontier did not change
-                };
-
-                // Propagate read frontier update to dependencies.
-                for read_hold in collection.compute_dependencies.values_mut() {
-                    read_hold
-                        .try_downgrade(new_since.clone())
-                        .expect("frontiers don't regress");
-                }
-                for read_hold in collection.storage_dependencies.values_mut() {
-                    read_hold
-                        .try_downgrade(new_since.clone())
-                        .expect("frontiers don't regress");
-                }
-
-                allowed_compaction.insert(id, new_since);
+        let new_since = collection.shared.lock_read_capabilities(|caps| {
+            // Sanity check to prevent corrupted `read_capabilities`, which can cause hard-to-debug
+            // issues (usually stuck read frontiers).
+            let read_frontier = caps.frontier();
+            for (time, diff) in update.iter() {
+                let count = caps.count_for(time) + diff;
+                assert!(
+                    count >= 0,
+                    "invalid read capabilities update: negative capability \
+             (id={id:?}, read_capabilities={caps:?}, update={update:?})",
+                );
+                assert!(
+                    count == 0 || read_frontier.less_equal(time),
+                    "invalid read capabilities update: frontier regression \
+             (id={id:?}, read_capabilities={caps:?}, update={update:?})",
+                );
             }
+
+            // Apply read capability updates and learn about resulting changes to the read
+            // frontier.
+            let changes = caps.update_iter(update.drain());
+
+            let changed = changes.count() > 0;
+            changed.then(|| caps.frontier().to_owned())
+        });
+
+        let Some(new_since) = new_since else {
+            return; // read frontier did not change
+        };
+
+        // Propagate read frontier update to dependencies.
+        for read_hold in collection.compute_dependencies.values_mut() {
+            read_hold
+                .try_downgrade(new_since.clone())
+                .expect("frontiers don't regress");
+        }
+        for read_hold in collection.storage_dependencies.values_mut() {
+            read_hold
+                .try_downgrade(new_since.clone())
+                .expect("frontiers don't regress");
         }
 
-        // Produce `AllowCompaction` commands.
-        for (id, frontier) in allowed_compaction {
-            self.send(ComputeCommand::AllowCompaction { id, frontier });
-        }
+        // Produce `AllowCompaction` command.
+        self.send(ComputeCommand::AllowCompaction {
+            id,
+            frontier: new_since,
+        });
     }
 
     /// Fulfills a registered peek and cleans up associated state.
@@ -2098,7 +2076,6 @@ where
     pub fn maintain(&mut self) {
         self.rehydrate_failed_replicas();
         self.downgrade_warmup_capabilities();
-        self.apply_read_hold_changes();
         self.schedule_collections();
         self.cleanup_collections();
         self.update_frontier_introspection();
@@ -2171,7 +2148,7 @@ impl<T: ComputeControllerTimestamp> CollectionState<T> {
         shared: SharedCollectionState<T>,
         storage_dependencies: BTreeMap<GlobalId, ReadHold<T>>,
         compute_dependencies: BTreeMap<GlobalId, ReadHold<T>>,
-        read_holds_tx: mpsc::UnboundedSender<(GlobalId, ChangeBatch<T>)>,
+        read_hold_tx: read_holds::ChangeTx<T>,
         introspection: CollectionIntrospection<T>,
     ) -> Self {
         // A collection is not readable before the `as_of`.
@@ -2187,8 +2164,8 @@ impl<T: ComputeControllerTimestamp> CollectionState<T> {
         // Note that the implied read hold was already added to the `read_capabilities` when
         // `shared` was created, so we only need to add the warmup read hold here.
         let implied_read_hold =
-            ReadHold::with_channel(collection_id, since.clone(), read_holds_tx.clone());
-        let warmup_read_hold = ReadHold::with_channel(collection_id, since.clone(), read_holds_tx);
+            ReadHold::new(collection_id, since.clone(), Arc::clone(&read_hold_tx));
+        let warmup_read_hold = ReadHold::new(collection_id, since.clone(), read_hold_tx);
 
         let updates = warmup_read_hold.since().iter().map(|t| (t.clone(), 1));
         shared.lock_read_capabilities(|c| {
@@ -2213,7 +2190,7 @@ impl<T: ComputeControllerTimestamp> CollectionState<T> {
     fn new_log_collection(
         id: GlobalId,
         shared: SharedCollectionState<T>,
-        read_holds_tx: mpsc::UnboundedSender<(GlobalId, ChangeBatch<T>)>,
+        read_hold_tx: read_holds::ChangeTx<T>,
         introspection_tx: crossbeam_channel::Sender<IntrospectionUpdates>,
     ) -> Self {
         let since = Antichain::from_elem(T::minimum());
@@ -2225,7 +2202,7 @@ impl<T: ComputeControllerTimestamp> CollectionState<T> {
             shared,
             Default::default(),
             Default::default(),
-            read_holds_tx,
+            read_hold_tx,
             introspection,
         );
         state.log_collection = true;
@@ -2277,7 +2254,7 @@ pub(super) struct SharedCollectionState<T> {
     /// This accumulation contains the capabilities held by all [`ReadHold`]s given out for the
     /// collection, including `implied_read_hold` and `warmup_read_hold`.
     ///
-    /// NOTE: This field may only be modified by [`Instance::apply_read_hold_changes`] and
+    /// NOTE: This field may only be modified by [`Instance::apply_read_hold_change`] and
     /// `ComputeController::acquire_read_hold`. Nobody else should modify read capabilities
     /// directly. Instead, collection users should manage read holds through [`ReadHold`] objects
     /// acquired through `ComputeController::acquire_read_hold`.

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1996,7 +1996,7 @@ where
 
         let acquired_holds = advanced_holds
             .into_iter()
-            .map(|(id, since)| ReadHold::new(id, since, self.holds_tx.clone()))
+            .map(|(id, since)| ReadHold::with_channel(id, since, self.holds_tx.clone()))
             .collect_vec();
 
         trace!(?desired_holds, ?acquired_holds, "acquire_read_holds");

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -81,6 +81,8 @@ pub enum InternalStorageCommand {
         /// A frontier in the source time domain with the property that all updates not beyond it
         /// have already been durably ingested.
         source_resume_uppers: BTreeMap<GlobalId, Vec<Row>>,
+        /// The upper of the ingestion collection's shard.
+        ingestion_upper: Antichain<mz_repr::Timestamp>,
     },
     /// Render a sink dataflow.
     RunSinkDataflow(

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -15,12 +15,14 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
-use anyhow::bail;
+use anyhow::anyhow;
 use chrono::{DateTime, NaiveDateTime};
 use differential_dataflow::{AsCollection, Hashable};
 use futures::StreamExt;
 use maplit::btreemap;
-use mz_kafka_util::client::{get_partitions, MzClientContext, PartitionId, TunnelingClientContext};
+use mz_kafka_util::client::{
+    get_partitions, GetPartitionsError, MzClientContext, PartitionId, TunnelingClientContext,
+};
 use mz_ore::assert_none;
 use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;
@@ -215,7 +217,7 @@ fn render_reader<G: Scope<Timestamp = KafkaTimestamp>>(
     connection: KafkaSourceConnection,
     config: RawSourceCreationConfig,
     resume_uppers: impl futures::Stream<Item = Antichain<KafkaTimestamp>> + 'static,
-    metadata_stream: Stream<G, MetadataUpdate>,
+    metadata_stream: Stream<G, (mz_repr::Timestamp, MetadataUpdate)>,
     start_signal: impl std::future::Future<Output = ()> + 'static,
 ) -> (
     StackedCollection<G, (usize, Result<SourceMessage, DataflowError>)>,
@@ -517,7 +519,6 @@ fn render_reader<G: Scope<Timestamp = KafkaTimestamp>>(
 
             let mut prev_offset_known = None;
             let mut prev_offset_committed = None;
-            let mut prev_pid_info: Option<BTreeMap<PartitionId, HighWatermark>> = None;
             let mut metadata_update: Option<MetadataUpdate> = None;
             let mut snapshot_total = None;
 
@@ -539,7 +540,10 @@ fn render_reader<G: Scope<Timestamp = KafkaTimestamp>>(
                                 updates.append(&mut data);
                             }
                         }
-                        metadata_update = updates.into_iter().max_by_key(|u| u.timestamp);
+                        metadata_update = updates
+                            .into_iter()
+                            .max_by_key(|(ts, _)| *ts)
+                            .map(|(_, update)| update);
                     }
 
                     // This future is not cancel safe but we are only passing a reference to it in
@@ -548,8 +552,8 @@ fn render_reader<G: Scope<Timestamp = KafkaTimestamp>>(
                     _ = resume_uppers_process_loop.as_mut() => {},
                 }
 
-                match metadata_update.take().map(|m| m.info) {
-                    Some(Ok(partitions)) => {
+                match metadata_update.take() {
+                    Some(MetadataUpdate::Partitions(partitions)) => {
                         let max_pid = partitions.keys().last().cloned();
                         let lower = max_pid
                             .map(RangeBound::after)
@@ -559,66 +563,6 @@ fn render_reader<G: Scope<Timestamp = KafkaTimestamp>>(
                             RangeBound::PosInfinity,
                             MzOffset::from(0),
                         );
-
-                        // Topics are identified by name but it's possible that a user recreates a
-                        // topic with the same name but different configuration. Ideally we'd want to
-                        // catch all of these cases and immediately error out the source, since the
-                        // data is effectively gone. Unfortunately this is not possible without
-                        // something like KIP-516 so we're left with heuristics.
-                        //
-                        // The first heuristic is whether the reported number of partitions went down
-                        if !PartialOrder::less_equal(data_cap.time(), &future_ts) {
-                            let prev_pid_count = prev_pid_info.map(|info| info.len()).unwrap_or(0);
-                            let pid_count = partitions.len();
-                            let err = DataflowError::SourceError(Box::new(SourceError {
-                                error: SourceErrorDetails::Other(
-                                    format!(
-                                        "topic was recreated: partition count regressed from \
-                                         {prev_pid_count} to {pid_count}"
-                                    )
-                                    .into(),
-                                ),
-                            }));
-                            let time = data_cap.time().clone();
-                            let err = Err(err);
-                            for (output, err) in
-                                outputs.iter().map(|o| o.output_index).repeat_clone(err)
-                            {
-                                data_output
-                                    .give_fueled(&data_cap, ((output, err), time, 1))
-                                    .await;
-                            }
-                            return;
-                        }
-
-                        // The second heuristic is whether the high watermark regressed
-                        if let Some(prev_pid_info) = prev_pid_info {
-                            for (pid, prev_high_watermark) in prev_pid_info {
-                                let high_watermark = partitions[&pid];
-                                if !(prev_high_watermark <= high_watermark) {
-                                    let err = DataflowError::SourceError(Box::new(SourceError {
-                                        error: SourceErrorDetails::Other(
-                                            format!(
-                                                "topic was recreated: high watermark of \
-                                                 partition {pid} regressed from {} to {}",
-                                                prev_high_watermark, high_watermark
-                                            )
-                                            .into(),
-                                        ),
-                                    }));
-                                    let time = data_cap.time().clone();
-                                    let err = Err(err);
-                                    for (output, err) in
-                                        outputs.iter().map(|o| o.output_index).repeat_clone(err)
-                                    {
-                                        data_output
-                                            .give_fueled(&data_cap, ((output, err), time, 1))
-                                            .await;
-                                    }
-                                    return;
-                                }
-                            }
-                        }
 
                         let mut upstream_stat = 0;
                         for (&pid, &high_watermark) in &partitions {
@@ -688,9 +632,8 @@ fn render_reader<G: Scope<Timestamp = KafkaTimestamp>>(
                         progress_statistics.offset_known = Some(upstream_stat);
                         data_cap.downgrade(&future_ts);
                         progress_cap.downgrade(&future_ts);
-                        prev_pid_info = Some(partitions);
                     }
-                    Some(Err(status)) => {
+                    Some(MetadataUpdate::TransientError(status)) => {
                         if let Some(update) = status.kafka {
                             for (output, update) in outputs.iter().repeat_clone(update) {
                                 health_output.give(
@@ -715,6 +658,19 @@ fn render_reader<G: Scope<Timestamp = KafkaTimestamp>>(
                                 );
                             }
                         }
+                    }
+                    Some(MetadataUpdate::DefiniteError(error)) => {
+                        let error = Err(error.into());
+                        let time = data_cap.time().clone();
+                        for (output, error) in
+                            outputs.iter().map(|o| o.output_index).repeat_clone(error)
+                        {
+                            data_output
+                                .give_fueled(&data_cap, ((output, error), time, 1))
+                                .await;
+                        }
+
+                        return;
                     }
                     None => {}
                 }
@@ -1460,7 +1416,7 @@ fn fetch_partition_info<C: ConsumerContext>(
     consumer: &BaseConsumer<C>,
     topic: &str,
     fetch_timeout: Duration,
-) -> Result<BTreeMap<PartitionId, HighWatermark>, anyhow::Error> {
+) -> Result<BTreeMap<PartitionId, HighWatermark>, GetPartitionsError> {
     let pids = get_partitions(consumer.client(), topic, fetch_timeout)?;
 
     let mut offset_requests = TopicPartitionList::with_capacity(pids.len());
@@ -1474,7 +1430,7 @@ fn fetch_partition_info<C: ConsumerContext>(
     for entry in offset_responses.elements() {
         let offset = match entry.offset() {
             Offset::Offset(offset) => offset,
-            offset => bail!("unexpected high watermark offset: {offset:?}"),
+            offset => Err(anyhow!("unexpected high watermark offset: {offset:?}"))?,
         };
 
         let pid = entry.partition();
@@ -1486,39 +1442,45 @@ fn fetch_partition_info<C: ConsumerContext>(
 }
 
 /// An update produced by the metadata fetcher.
-///
-/// Either the IDs and high watermarks of the topic partitions as of `timestamp`, or a health
-/// status describing a fetch error.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-struct MetadataUpdate {
-    timestamp: mz_repr::Timestamp,
-    info: Result<BTreeMap<PartitionId, HighWatermark>, HealthStatus>,
+enum MetadataUpdate {
+    /// The current IDs and high watermarks of all topic partitions.
+    Partitions(BTreeMap<PartitionId, HighWatermark>),
+    /// A transient error.
+    ///
+    /// Transient errors stall the source until their cause has been resolved.
+    TransientError(HealthStatus),
+    /// A definite error.
+    ///
+    /// Definite errors cannot be recovered from. They poison the source until the end of time.
+    DefiniteError(SourceError),
 }
 
 impl MetadataUpdate {
-    fn to_probe(&self) -> Option<Probe<KafkaTimestamp>> {
-        let Ok(partitions) = &self.info else {
-            return None;
-        };
+    /// Return the upstream frontier resulting from the metadata update, if any.
+    fn upstream_frontier(&self) -> Option<Antichain<KafkaTimestamp>> {
+        match self {
+            Self::Partitions(partitions) => {
+                let max_pid = partitions.keys().last().copied();
+                let lower = max_pid
+                    .map(RangeBound::after)
+                    .unwrap_or(RangeBound::NegInfinity);
+                let future_ts =
+                    Partitioned::new_range(lower, RangeBound::PosInfinity, MzOffset::from(0));
 
-        let max_pid = partitions.keys().last().copied();
-        let lower = max_pid
-            .map(RangeBound::after)
-            .unwrap_or(RangeBound::NegInfinity);
-        let future_ts = Partitioned::new_range(lower, RangeBound::PosInfinity, MzOffset::from(0));
+                let mut frontier = Antichain::from_elem(future_ts);
+                for (pid, high_watermark) in partitions {
+                    frontier.insert(Partitioned::new_singleton(
+                        RangeBound::exact(*pid),
+                        MzOffset::from(*high_watermark),
+                    ));
+                }
 
-        let mut upstream_frontier = Antichain::from_elem(future_ts);
-        for (pid, high_watermark) in partitions {
-            upstream_frontier.insert(Partitioned::new_singleton(
-                RangeBound::exact(*pid),
-                MzOffset::from(*high_watermark),
-            ));
+                Some(frontier)
+            }
+            Self::DefiniteError(_) => Some(Antichain::new()),
+            Self::TransientError(_) => None,
         }
-
-        Some(Probe {
-            probe_ts: self.timestamp,
-            upstream_frontier,
-        })
     }
 }
 
@@ -1540,12 +1502,20 @@ fn render_metadata_fetcher<G: Scope<Timestamp = KafkaTimestamp>>(
     connection: KafkaSourceConnection,
     config: RawSourceCreationConfig,
 ) -> (
-    Stream<G, MetadataUpdate>,
+    Stream<G, (mz_repr::Timestamp, MetadataUpdate)>,
     Stream<G, Probe<KafkaTimestamp>>,
     PressOnDropButton,
 ) {
     let active_worker_id = usize::cast_from(config.id.hashed());
     let is_active_worker = active_worker_id % scope.peers() == scope.index();
+
+    let resume_upper = Antichain::from_iter(
+        config
+            .source_resume_uppers
+            .values()
+            .map(|uppers| uppers.iter().map(KafkaTimestamp::decode_row))
+            .flatten(),
+    );
 
     let name = format!("KafkaMetadataFetcher({})", config.id);
     let mut builder = AsyncOperatorBuilder::new(name, scope.clone());
@@ -1603,11 +1573,9 @@ fn render_metadata_fetcher<G: Scope<Timestamp = KafkaTimestamp>>(
                     ContextCreationError::Ssh(_) => HealthStatus::ssh(status_update),
                     _ => HealthStatus::kafka(status_update),
                 };
-                let update = MetadataUpdate {
-                    timestamp: 0.into(),
-                    info: Err(status),
-                };
-                metadata_output.give(&metadata_cap, update);
+                let error = MetadataUpdate::TransientError(status);
+                let timestamp = (config.now_fn)().into();
+                metadata_output.give(&metadata_cap, (timestamp, error));
                 return;
             }
         };
@@ -1625,11 +1593,42 @@ fn render_metadata_fetcher<G: Scope<Timestamp = KafkaTimestamp>>(
         let (tx, mut rx) = mpsc::unbounded_channel();
         spawn_metadata_thread(config, consumer, topic, poll_interval, tx);
 
-        while let Some(update) = rx.recv().await {
-            if let Some(probe) = update.to_probe() {
+        let mut prev_upstream_frontier = resume_upper;
+
+        while let Some((timestamp, mut update)) = rx.recv().await {
+            if prev_upstream_frontier.is_empty() {
+                return;
+            }
+
+            if let Some(upstream_frontier) = update.upstream_frontier() {
+                // Topics are identified by name but it's possible that a user recreates a topic
+                // with the same name. Ideally we'd want to catch all of these cases and
+                // immediately error out the source, since the data is effectively gone.
+                // Unfortunately this is not possible without something like KIP-516.
+                //
+                // The best we can do is check whether the upstream frontier regressed. This tells
+                // us thet the topic was recreated and now contains fewer offsets and/or fewer
+                // partitions. Note that we are not able to detect topic recreation if neither of
+                // the two are true.
+                if !PartialOrder::less_equal(&prev_upstream_frontier, &upstream_frontier) {
+                    let error = SourceError {
+                        error: SourceErrorDetails::Other("topic was recreated".into()),
+                    };
+                    update = MetadataUpdate::DefiniteError(error);
+                }
+            }
+
+            if let Some(upstream_frontier) = update.upstream_frontier() {
+                prev_upstream_frontier = upstream_frontier.clone();
+
+                let probe = Probe {
+                    probe_ts: timestamp,
+                    upstream_frontier,
+                };
                 probe_output.give(&probe_cap, probe);
             }
-            metadata_output.give(&metadata_cap, update);
+
+            metadata_output.give(&metadata_cap, (timestamp, update));
         }
     });
 
@@ -1641,7 +1640,7 @@ fn spawn_metadata_thread<C: ConsumerContext>(
     consumer: BaseConsumer<TunnelingClientContext<C>>,
     topic: String,
     poll_interval: Duration,
-    tx: mpsc::UnboundedSender<MetadataUpdate>,
+    tx: mpsc::UnboundedSender<(mz_repr::Timestamp, MetadataUpdate)>,
 ) {
     thread::Builder::new()
         .name(format!("kafka-metadata-{}", config.id))
@@ -1680,10 +1679,13 @@ fn spawn_metadata_thread<C: ConsumerContext>(
                             "kafka metadata thread: fetched partition metadata info",
                         );
 
-                        MetadataUpdate {
-                            timestamp: probe_ts,
-                            info: Ok(partitions),
-                        }
+                        MetadataUpdate::Partitions(partitions)
+                    }
+                    Err(GetPartitionsError::TopicDoesNotExist) => {
+                        let error = SourceError {
+                            error: SourceErrorDetails::Other("topic was deleted".into()),
+                        };
+                        MetadataUpdate::DefiniteError(error)
                     }
                     Err(e) => {
                         let kafka_status = Some(HealthStatusUpdate::stalled(
@@ -1699,17 +1701,14 @@ fn spawn_metadata_thread<C: ConsumerContext>(
                             }
                         };
 
-                        MetadataUpdate {
-                            timestamp: probe_ts,
-                            info: Err(HealthStatus {
-                                kafka: kafka_status,
-                                ssh: ssh_status,
-                            }),
-                        }
+                        MetadataUpdate::TransientError(HealthStatus {
+                            kafka: kafka_status,
+                            ssh: ssh_status,
+                        })
                     }
                 };
 
-                if tx.send(update).is_err() {
+                if tx.send((probe_ts, update)).is_err() {
                     break;
                 }
 

--- a/src/storage/src/upsert/types.rs
+++ b/src/storage/src/upsert/types.rs
@@ -391,16 +391,10 @@ impl<T: Eq, O> StateValue<T, O> {
                     provisional_value: (Some(provisional_value), provisional_ts, provisional_order),
                 })
             }
-            StateValue::Value(Value::Tombstone(_)) => {
-                // This cannot happen with how the new feedback UPSERT uses
-                // state. There are only ever provisional tombstones, and all
-                // updates that are merged/consolidated into upsert state come
-                // from the persist input, which doesn't need tombstones.
-                //
-                // Regular, finalized tombstones are only used by the classic
-                // UPSERT operator when doing partial processing.
-                panic!("cannot turn a finalized tombstone into a provisional value")
-            }
+            StateValue::Value(Value::Tombstone(_)) => StateValue::Value(Value::ProvisionalValue {
+                finalized_value: None,
+                provisional_value: (Some(provisional_value), provisional_ts, provisional_order),
+            }),
             StateValue::Value(Value::ProvisionalValue {
                 finalized_value,
                 provisional_value: _,

--- a/test/testdrive-old-kafka-src-syntax/kafka-recreate-topic.td
+++ b/test/testdrive-old-kafka-src-syntax/kafka-recreate-topic.td
@@ -7,74 +7,54 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)
+
+> CREATE CLUSTER to_recreate SIZE '1'
+
+# Test detection of topic deletion.
+
 $ kafka-create-topic topic=topic0 partitions=4
 
-$ kafka-ingest key-format=bytes format=bytes key-terminator=: topic=topic0 repeat=1
-1:1
-
-> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
-    URL '${testdrive.schema-registry-url}'
-  );
-
-> CREATE CONNECTION kafka_conn
-  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
-
-> CREATE CLUSTER to_recreate SIZE '1', REPLICATION FACTOR 1;
-
-> CREATE SOURCE source0
-  IN CLUSTER to_recreate
+> CREATE SOURCE source0 IN CLUSTER to_recreate
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic0-${testdrive.seed}')
-  KEY FORMAT TEXT
-  VALUE FORMAT TEXT
-  ENVELOPE UPSERT
+  FORMAT TEXT ENVELOPE NONE
 
 > SELECT * FROM source0
-key   text
-----------
-1     1
-
-# Now recreate the topic with fewer partitions and observe the error
 
 $ kafka-delete-topic-flaky topic=topic0
 
-# Even though `kafka-delete-topic` ensures that the topic no longer exists in
-# the broker metadata there is still work to be done asychnronously before it's
-# truly gone that must complete before we attempt to recreate it. There is no
-# way to observe this work completing so the only option left is sleeping for a
-# while. This is the sad state of Kafka. If this test ever becomes flaky let's
-# just delete it.
-# See: https://github.com/confluentinc/confluent-kafka-python/issues/541
-$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
-
-$ kafka-create-topic topic=topic0 partitions=2
-
 ! SELECT * FROM source0
-contains:topic was recreated: partition count regressed from 4 to 2
+contains:topic was deleted
 
-# We can also detect that a topic got recreated by observing the high watermark regressing
+# Test detection of topic recreation.
+#
+# The Kafka source detects topic recreation based on regression of the upstream
+# frontier. For the upstream frontier to regress, the new topic must have:
+#  (1) fewer partitions than the old topic, or
+#  (2) a lower watermark for at least one of its partitions.
+# We test both cases below.
 
-$ kafka-create-topic topic=topic1 partitions=1
+# (1) topic recreation with fewer partitions.
 
-$ kafka-ingest format=bytes topic=topic1 repeat=1
-1
+$ kafka-create-topic topic=topic1 partitions=4
 
-> CREATE SOURCE source1
-  IN CLUSTER to_recreate
+> CREATE SOURCE source1 IN CLUSTER to_recreate
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic1-${testdrive.seed}')
-  FORMAT TEXT
-  ENVELOPE NONE
+  FORMAT TEXT ENVELOPE NONE
 
 > SELECT * FROM source1
-text
-----
-1
 
-# Now recreate the topic with the same number of partitions and observe the error
+# Spin down the cluster, to prevent the source from observing the topic
+# deletion before the new topic was created.
+> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR 0)
+
+# Recreate the topic with fewer partitions.
 
 $ kafka-delete-topic-flaky topic=topic1
 
 # Even though `kafka-delete-topic` ensures that the topic no longer exists in
-# the broker metadata there is still work to be done asychnronously before it's
+# the broker metadata there is still work to be done asynchronously before it's
 # truly gone that must complete before we attempt to recreate it. There is no
 # way to observe this work completing so the only option left is sleeping for a
 # while. This is the sad state of Kafka. If this test ever becomes flaky let's
@@ -82,65 +62,50 @@ $ kafka-delete-topic-flaky topic=topic1
 # See: https://github.com/confluentinc/confluent-kafka-python/issues/541
 $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
 
-$ kafka-create-topic topic=topic1 partitions=1
+$ kafka-create-topic topic=topic1 partitions=2
+
+> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR 1)
 
 ! SELECT * FROM source1
-contains:topic was recreated: high watermark of partition 0 regressed from 1 to 0
+contains:topic was recreated
 
-# Test a pathological topic recreation observed in the wild.
-# See incidents-and-escalations#98.
+# (2) topic recreation with a lower watermark.
 
-# First we create a topic and successfully ingest some data.
-$ kafka-create-topic topic=topic2 partitions=1
-$ kafka-ingest format=bytes topic=topic2 repeat=100
-one
-> CREATE SOURCE source2
-  IN CLUSTER to_recreate
+$ kafka-create-topic topic=topic2 partitions=4
+
+$ kafka-ingest format=bytes topic=topic2
+1
+
+> CREATE SOURCE source2 IN CLUSTER to_recreate
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic2-${testdrive.seed}')
-  FORMAT TEXT
-  ENVELOPE NONE
-> SELECT count(*) FROM source2
-100
+  FORMAT TEXT ENVELOPE NONE
 
-# Then we turn off the source cluster, so that we lose our record of what the
-# high water mark used to be.
-> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR = 0)
+> SELECT * FROM source2
+1
 
-# Then we delete the topic and recreate it...
-# See comment above about needing to sleep after deleting Kafka topics.
+# Spin down the cluster, to prevent the source from observing the topic
+# deletion before the new topic was created.
+> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR 0)
+
+# Recreate the topic with the same number of partitions but a lower watermark.
+
 $ kafka-delete-topic-flaky topic=topic2
+
+# Even though `kafka-delete-topic` ensures that the topic no longer exists in
+# the broker metadata there is still work to be done asynchronously before it's
+# truly gone that must complete before we attempt to recreate it. There is no
+# way to observe this work completing so the only option left is sleeping for a
+# while. This is the sad state of Kafka. If this test ever becomes flaky let's
+# just delete it.
+# See: https://github.com/confluentinc/confluent-kafka-python/issues/541
 $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
-$ kafka-create-topic topic=topic2 partitions=1
 
-# ...crucially, with *fewer* offsets than we had previously.
-$ kafka-ingest format=bytes topic=topic2 repeat=50
-one
+$ kafka-create-topic topic=topic2 partitions=4
 
-# Finally, we turn the source cluster back on. This would previously cause
-# Materialize to panic because we'd attempt to regress the data shard's
-# capability to offset 2 (the max offset in the new topic) when it was
-# already at offset 3 (the max offset in the old topic).
-> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR = 1)
+> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR 1)
 
-# Give the source a few seconds to reconnect to the Kafka partitions and
-# possibly read bad data. This is what actually reproduces the panic we saw in
-# incidents-and-escalations#98. Unfortunately there is no signal we can wait
-# for, so the best we can do is sleep.
-$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=10s
-
-# Ensure the source reports the previous data.
-> SELECT count(*) FROM source2
-100
-
-# Check whether the source is still lumbering along. Correctness has gone out
-# the window here. Data in the new topic will be ignored up until the first new
-# offset, at which point it will start being ingested. In this case, 7 and 8 are
-# the two new data rows.
-$ kafka-ingest format=bytes topic=topic2 repeat=53
-one
-
-> SELECT count(*) FROM source2
-103
+! SELECT * FROM source2
+contains:topic was recreated
 
 # Ensure we don't panic after we restart due to the above finished ingestions.
 $ kafka-create-topic topic=good-topic
@@ -169,10 +134,7 @@ name            status    error
 good_source     running   <null>
 source0         paused    <null>
 source1         paused    <null>
-# Ideally source 2 would be permanently stalled because the topic was recreated,
-# but we can't easily distingiush that situation from a temporary ingestion
-# hiccup, and so at the moment we consider source2 to be fully healthy.
-source2         running   <null>
+source2         paused    <null>
 
 # Testdrive expects all sources to end in a healthy state, so manufacture that
 # by dropping sources.

--- a/test/testdrive/kafka-recreate-topic.td
+++ b/test/testdrive/kafka-recreate-topic.td
@@ -7,37 +7,53 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)
+
+> CREATE CLUSTER to_recreate SIZE '1'
+
+# Test detection of topic deletion.
+
 $ kafka-create-topic topic=topic0 partitions=4
 
-$ kafka-ingest key-format=bytes format=bytes key-terminator=: topic=topic0 repeat=1
-1:1
-
-> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
-    URL '${testdrive.schema-registry-url}'
-  );
-
-> CREATE CONNECTION kafka_conn
-  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
-
-> CREATE CLUSTER to_recreate SIZE '1', REPLICATION FACTOR 1;
-
-> CREATE SOURCE source0
-  IN CLUSTER to_recreate
+> CREATE SOURCE source0 IN CLUSTER to_recreate
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic0-${testdrive.seed}')
-
 > CREATE TABLE source0_tbl FROM SOURCE source0 (REFERENCE "testdrive-topic0-${testdrive.seed}")
-  KEY FORMAT TEXT
-  VALUE FORMAT TEXT
-  ENVELOPE UPSERT
+  FORMAT TEXT ENVELOPE NONE
 
 > SELECT * FROM source0_tbl
-key   text
-----------
-1     1
-
-# Now recreate the topic with fewer partitions and observe the error
 
 $ kafka-delete-topic-flaky topic=topic0
+
+! SELECT * FROM source0_tbl
+contains:topic was deleted
+
+# Test detection of topic recreation.
+#
+# The Kafka source detects topic recreation based on regression of the upstream
+# frontier. For the upstream frontier to regress, the new topic must have:
+#  (1) fewer partitions than the old topic, or
+#  (2) a lower watermark for at least one of its partitions.
+# We test both cases below.
+
+# (1) topic recreation with fewer partitions.
+
+$ kafka-create-topic topic=topic1 partitions=4
+
+> CREATE SOURCE source1 IN CLUSTER to_recreate
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic1-${testdrive.seed}')
+> CREATE TABLE source1_tbl FROM SOURCE source1 (REFERENCE "testdrive-topic1-${testdrive.seed}")
+  FORMAT TEXT ENVELOPE NONE
+
+> SELECT * FROM source1_tbl
+
+# Spin down the cluster, to prevent the source from observing the topic
+# deletion before the new topic was created.
+> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR 0)
+
+# Recreate the topic with fewer partitions.
+
+$ kafka-delete-topic-flaky topic=topic1
 
 # Even though `kafka-delete-topic` ensures that the topic no longer exists in
 # the broker metadata there is still work to be done asynchronously before it's
@@ -48,37 +64,38 @@ $ kafka-delete-topic-flaky topic=topic0
 # See: https://github.com/confluentinc/confluent-kafka-python/issues/541
 $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
 
-$ kafka-create-topic topic=topic0 partitions=2
+$ kafka-create-topic topic=topic1 partitions=2
 
-! SELECT * FROM source0_tbl
-contains:topic was recreated: partition count regressed from 4 to 2
+> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR 1)
 
-# We can also detect that a topic got recreated by observing the high watermark regressing
+! SELECT * FROM source1_tbl
+contains:topic was recreated
 
-$ kafka-create-topic topic=topic1 partitions=1
+# (2) topic recreation with a lower watermark.
 
-$ kafka-ingest format=bytes topic=topic1 repeat=1
+$ kafka-create-topic topic=topic2 partitions=4
+
+$ kafka-ingest format=bytes topic=topic2
 1
 
-> CREATE SOURCE source1
-  IN CLUSTER to_recreate
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic1-${testdrive.seed}')
+> CREATE SOURCE source2 IN CLUSTER to_recreate
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic2-${testdrive.seed}')
+> CREATE TABLE source2_tbl FROM SOURCE source2 (REFERENCE "testdrive-topic2-${testdrive.seed}")
+  FORMAT TEXT ENVELOPE NONE
 
-> CREATE TABLE source1_tbl FROM SOURCE source1 (REFERENCE "testdrive-topic1-${testdrive.seed}")
-  FORMAT TEXT
-  ENVELOPE NONE
-
-> SELECT * FROM source1_tbl
-text
-----
+> SELECT * FROM source2_tbl
 1
 
-# Now recreate the topic with the same number of partitions and observe the error
+# Spin down the cluster, to prevent the source from observing the topic
+# deletion before the new topic was created.
+> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR 0)
 
-$ kafka-delete-topic-flaky topic=topic1
+# Recreate the topic with the same number of partitions but a lower watermark.
+
+$ kafka-delete-topic-flaky topic=topic2
 
 # Even though `kafka-delete-topic` ensures that the topic no longer exists in
-# the broker metadata there is still work to be done asychnronously before it's
+# the broker metadata there is still work to be done asynchronously before it's
 # truly gone that must complete before we attempt to recreate it. There is no
 # way to observe this work completing so the only option left is sleeping for a
 # while. This is the sad state of Kafka. If this test ever becomes flaky let's
@@ -86,70 +103,12 @@ $ kafka-delete-topic-flaky topic=topic1
 # See: https://github.com/confluentinc/confluent-kafka-python/issues/541
 $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
 
-$ kafka-create-topic topic=topic1 partitions=1
+$ kafka-create-topic topic=topic2 partitions=4
 
-! SELECT * FROM source1_tbl
-contains:topic was recreated: high watermark of partition 0 regressed from 1 to 0
+> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR 1)
 
-# Test a pathological topic recreation observed in the wild.
-# See incidents-and-escalations#98.
-
-# First we create a topic and successfully ingest some data.
-$ kafka-create-topic topic=topic2 partitions=1
-$ kafka-ingest format=bytes topic=topic2 repeat=100
-one
-
-> CREATE SOURCE source2
-  IN CLUSTER to_recreate
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic2-${testdrive.seed}')
-
-> CREATE TABLE source2_tbl
-  FROM SOURCE source2 (REFERENCE "testdrive-topic2-${testdrive.seed}")
-  FORMAT TEXT
-  ENVELOPE NONE
-
-> SELECT count(*) FROM source2_tbl
-100
-
-# Then we turn off the source cluster, so that we lose our record of what the
-# high water mark used to be.
-> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR = 0)
-
-# Then we delete the topic and recreate it...
-# See comment above about needing to sleep after deleting Kafka topics.
-$ kafka-delete-topic-flaky topic=topic2
-$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
-$ kafka-create-topic topic=topic2 partitions=1
-
-# ...crucially, with *fewer* offsets than we had previously.
-$ kafka-ingest format=bytes topic=topic2 repeat=50
-one
-
-# Finally, we turn the source cluster back on. This would previously cause
-# Materialize to panic because we'd attempt to regress the data shard's
-# capability to offset 2 (the max offset in the new topic) when it was
-# already at offset 3 (the max offset in the old topic).
-> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR = 1)
-
-# Give the source a few seconds to reconnect to the Kafka partitions and
-# possibly read bad data. This is what actually reproduces the panic we saw in
-# incidents-and-escalations#98. Unfortunately there is no signal we can wait
-# for, so the best we can do is sleep.
-$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=10s
-
-# Ensure the source reports the previous data.
-> SELECT count(*) FROM source2_tbl
-100
-
-# Check whether the source is still lumbering along. Correctness has gone out
-# the window here. Data in the new topic will be ignored up until the first new
-# offset, at which point it will start being ingested. In this case, 7 and 8 are
-# the two new data rows.
-$ kafka-ingest format=bytes topic=topic2 repeat=53
-one
-
-> SELECT count(*) FROM source2_tbl
-103
+! SELECT * FROM source2_tbl
+contains:topic was recreated
 
 # Ensure we don't panic after we restart due to the above finished ingestions.
 $ kafka-create-topic topic=good-topic
@@ -176,14 +135,14 @@ text
 > SELECT name, status, error FROM mz_internal.mz_source_statuses WHERE type != 'progress'
 name            status    error
 -------------------------------
-good_source_tbl running <null>
-source0_tbl stalled "kafka: Source error: source must be dropped and recreated due to failure: topic was recreated: partition count regressed from 4 to 2"
-source1 paused <null>
-source1_tbl stalled "kafka: Source error: source must be dropped and recreated due to failure: topic was recreated: high watermark of partition 0 regressed from 1 to 0"
-source2_tbl running <null>
-good_source running <null>
-source0 paused <null>
-source2 running <null>
+good_source     running   <null>
+good_source_tbl running   <null>
+source0         paused    <null>
+source0_tbl     stalled   "kafka: Source error: source must be dropped and recreated due to failure: topic was deleted"
+source1         paused    <null>
+source1_tbl     stalled   "kafka: Source error: source must be dropped and recreated due to failure: topic was recreated"
+source2         paused    <null>
+source2_tbl     stalled   "kafka: Source error: source must be dropped and recreated due to failure: topic was recreated"
 
 # Testdrive expects all sources to end in a healthy state, so manufacture that
 # by dropping sources.


### PR DESCRIPTION
Previously, the output index of each ingestion export was calculated
assuming that index 0 was reserved for the primary source relation.
When `force_source_table_syntax` is enabled, the primary source
relation is not included in the exports, and therefore caused all
export indexes to be off by one.

This commit fixes the issue by decrementing all export indexes by 1 if
the primary source relation was not included in the exports.

It's unclear to the author how errors are being handled when the
primary relation is not included in the exports.

Works towards resolving #MaterializeInc/database-issues/issues/8620

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
