### PR TITLE
adapter/docs: Add TODO doc for the `AsAny` trait

### DIFF
--- a/src/sql/src/session/vars/value.rs
+++ b/src/sql/src/session/vars/value.rs
@@ -75,9 +75,14 @@ impl<'a> PartialEq for &'a dyn Value {
 }
 impl<'a> Eq for &'a dyn Value {}
 
-/// Helper trait ...
+/// Helper trait to cast a `&dyn T` to a `&dyn Any`.
 ///
-/// TODO(parkmycar): Document why this exists
+/// In Rust all types that are `'static` implement [`std::any::Any`] and thus can be casted to a
+/// `&dyn Any`. But once you create a trait object, the type is erased and thus so is the
+/// implementation for [`Any`]. This trait essentially adds a types' [`Any`] impl to the vtable
+/// created when casted to trait object, if [`AsAny`] is a supertrait.
+///
+/// See [`Value`] for an example of using [`AsAny`].
 pub trait AsAny {
     fn as_any(&self) -> &dyn Any;
 }


### PR DESCRIPTION
@frankmcsherry I was reminded of this while we were chatting about box clone.

### Motivation

Fix TODO

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
