### PR TITLE
[persist] Add a structured-only update set type, and use it in the builder

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -124,7 +124,6 @@ def get_default_system_parameters(
             "true" if version > MzVersion.parse_mz("v0.127.0-dev") else "false"
         ),
         "persist_batch_columnar_format": "both_v2",
-        "persist_batch_columnar_format_percent": "100",
         "persist_batch_delete_enabled": "true",
         "persist_batch_structured_order": "true",
         "persist_batch_structured_key_lower_len": "256",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1019,6 +1019,7 @@ class FlipFlagsAction(Action):
         self.flags_with_values["persist_batch_columnar_format"] = ["row", "both_v2"]
         self.flags_with_values["persist_record_schema_id"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_order"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["persist_batch_builder_structured"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [
             "0",
             "1",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1017,13 +1017,6 @@ class FlipFlagsAction(Action):
         )
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_columnar_format"] = ["row", "both_v2"]
-        self.flags_with_values["persist_batch_columnar_format_percent"] = [
-            "0",
-            "25",
-            "50",
-            "75",
-            "100",
-        ]
         self.flags_with_values["persist_record_schema_id"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_order"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -1249,8 +1249,8 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
         let metrics_ = Arc::clone(&metrics);
         let schema_id = write_schemas.id;
 
-        let key_lower = {
-            let key_bytes = updates.updates.records().keys();
+        let key_lower = if let Some(records) = updates.updates.records() {
+            let key_bytes = records.keys();
             if key_bytes.is_empty() {
                 &[]
             } else if run_order == RunOrder::Codec {
@@ -1258,6 +1258,8 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
             } else {
                 ::arrow::compute::min_binary(key_bytes).expect("min of nonempty array")
             }
+        } else {
+            &[]
         };
         let key_lower = truncate_bytes(key_lower, TRUNCATE_LEN, TruncateBound::Lower)
             .expect("lower bound always exists");

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -30,7 +30,7 @@ use futures_util::{stream, FutureExt};
 use mz_dyncfg::Config;
 use mz_ore::cast::CastFrom;
 use mz_ore::{instrument, soft_panic_or_log};
-use mz_persist::indexed::columnar::{ColumnarRecords, ColumnarRecordsBuilder};
+use mz_persist::indexed::columnar::ColumnarRecordsBuilder;
 use mz_persist::indexed::encoding::{BatchColumnarFormat, BlobTraceBatchPart, BlobTraceUpdates};
 use mz_persist::location::Blob;
 use mz_persist_types::arrow::{ArrayBound, ArrayOrd};

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -310,6 +310,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::batch::BATCH_DELETE_ENABLED)
         .add(&crate::batch::BATCH_COLUMNAR_FORMAT)
         .add(&crate::batch::BLOB_TARGET_SIZE)
+        .add(&crate::batch::BUILDER_STRUCTURED)
         .add(&crate::batch::INLINE_WRITES_TOTAL_MAX_BYTES)
         .add(&crate::batch::INLINE_WRITES_SINGLE_MAX_BYTES)
         .add(&crate::batch::ENCODING_ENABLE_DICTIONARY)

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -309,7 +309,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     mz_persist::cfg::all_dyn_configs(configs)
         .add(&crate::batch::BATCH_DELETE_ENABLED)
         .add(&crate::batch::BATCH_COLUMNAR_FORMAT)
-        .add(&crate::batch::BATCH_COLUMNAR_FORMAT_PERCENT)
         .add(&crate::batch::BLOB_TARGET_SIZE)
         .add(&crate::batch::INLINE_WRITES_TOTAL_MAX_BYTES)
         .add(&crate::batch::INLINE_WRITES_SINGLE_MAX_BYTES)

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -1260,32 +1260,23 @@ where
             return updates;
         }
 
-        let (records, ext) = match updates {
-            BlobTraceUpdates::Row(r) => (r, None),
-            BlobTraceUpdates::Both(r, e) => (r, Some(e)),
-        };
+        let mut codec = updates
+            .records()
+            .map(|r| (r.keys().clone(), r.vals().clone()));
+        let mut structured = updates.structured().cloned();
+        let mut timestamps = updates.timestamps().clone();
+        let mut diffs = updates.diffs().clone();
 
-        let records = match self.ts_rewrite.as_ref() {
-            Some(rewrite) => {
-                let timestamps = records.timestamps().clone();
-                let rewrite = |i: i64| {
-                    let mut t = T::decode(i.to_le_bytes());
-                    t.advance_by(rewrite.borrow());
-                    i64::from_le_bytes(T::encode(&t))
-                };
-                let timestamps = arrow::compute::unary_mut(timestamps, rewrite)
-                    .unwrap_or_else(|i| arrow::compute::unary(&i, rewrite));
-                ColumnarRecords::new(
-                    records.keys().clone(),
-                    records.vals().clone(),
-                    realloc_array(&timestamps, metrics),
-                    records.diffs().clone(),
-                )
-            }
-            None => records,
-        };
-        let (records, ext) = if self.needs_truncation {
-            let filter = BooleanArray::from_unary(records.timestamps(), |i| {
+        if let Some(rewrite) = self.ts_rewrite.as_ref() {
+            timestamps = arrow::compute::unary(&timestamps, |i: i64| {
+                let mut t = T::decode(i.to_le_bytes());
+                t.advance_by(rewrite.borrow());
+                i64::from_le_bytes(T::encode(&t))
+            });
+        }
+
+        let reallocated = if self.needs_truncation {
+            let filter = BooleanArray::from_unary(&timestamps, |i| {
                 let t = T::decode(i.to_le_bytes());
                 let truncate_t = {
                     !self.registered_desc.lower().less_equal(&t)
@@ -1295,29 +1286,47 @@ where
             });
             if filter.false_count() == 0 {
                 // If we're not filtering anything in practice, skip filtering and reallocating.
-                (records, ext)
+                false
             } else {
                 let filter = FilterBuilder::new(&filter).optimize().build();
                 let do_filter = |array: &dyn Array| filter.filter(array).expect("valid filter len");
-                let keys = realloc_array(do_filter(records.keys()).as_binary(), metrics);
-                let values = realloc_array(do_filter(records.vals()).as_binary(), metrics);
-                let timestamps =
-                    realloc_array(do_filter(records.timestamps()).as_primitive(), metrics);
-                let diffs = realloc_array(do_filter(records.diffs()).as_primitive(), metrics);
-                let records = ColumnarRecords::new(keys, values, timestamps, diffs);
-                let ext = ext.map(|ext| ColumnarRecordsStructuredExt {
-                    key: realloc_any(do_filter(&ext.key), metrics),
-                    val: realloc_any(do_filter(&ext.val), metrics),
-                });
-                (records, ext)
+                if let Some((keys, vals)) = codec {
+                    codec = Some((
+                        realloc_array(do_filter(&keys).as_binary(), metrics),
+                        realloc_array(do_filter(&vals).as_binary(), metrics),
+                    ));
+                }
+                if let Some(ext) = structured {
+                    structured = Some(ColumnarRecordsStructuredExt {
+                        key: realloc_any(do_filter(&*ext.key), metrics),
+                        val: realloc_any(do_filter(&*ext.val), metrics),
+                    });
+                }
+                timestamps = realloc_array(do_filter(&timestamps).as_primitive(), metrics);
+                diffs = realloc_array(do_filter(&diffs).as_primitive(), metrics);
+                true
             }
         } else {
-            (records, ext)
+            false
         };
 
-        match ext {
-            Some(ext) => BlobTraceUpdates::Both(records, ext),
-            None => BlobTraceUpdates::Row(records),
+        if self.ts_rewrite.is_some() && !reallocated {
+            timestamps = realloc_array(&timestamps, metrics);
+        }
+
+        match (codec, structured) {
+            (Some((key, value)), None) => {
+                BlobTraceUpdates::Row(ColumnarRecords::new(key, value, timestamps, diffs))
+            }
+            (Some((key, value)), Some(ext)) => {
+                BlobTraceUpdates::Both(ColumnarRecords::new(key, value, timestamps, diffs), ext)
+            }
+            (None, Some(ext)) => BlobTraceUpdates::Structured {
+                key_values: ext,
+                timestamps,
+                diffs,
+            },
+            (None, None) => unreachable!(),
         }
     }
 }
@@ -1341,7 +1350,12 @@ impl Cursor {
         &self,
         encoded: &'a EncodedPart<T>,
     ) -> Option<(&'a [u8], &'a [u8], T, [u8; 8])> {
-        let part = encoded.part.updates.records();
+        // TODO(structured): replace before allowing structured-only parts
+        let part = encoded
+            .part
+            .updates
+            .records()
+            .expect("created cursor for non-codec data");
         let ((k, v), t, d) = part.get(self.idx)?;
 
         let mut t = T::decode(t);

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -436,7 +436,7 @@ where
             .expect("internal error: invalid encoded state");
         read_metrics
             .part_goodbytes
-            .inc_by(u64::cast_from(parsed.updates.records().goodbytes()));
+            .inc_by(u64::cast_from(parsed.updates.goodbytes()));
         EncodedPart::from_hollow(read_metrics.clone(), registered_desc, part, parsed)
     })
 }
@@ -776,7 +776,7 @@ impl<K: Codec, V: Codec, T: Timestamp + Lattice + Codec64, D> FetchedPart<K, V, 
         part_decode_format: PartDecodeFormat,
         stats: Option<&LazyPartStats>,
     ) -> Self {
-        let part_len = u64::cast_from(part.part.updates.records().len());
+        let part_len = u64::cast_from(part.part.updates.len());
         match &migration {
             PartMigration::SameSchema { .. } => metrics.schema.migration_count_same.inc(),
             PartMigration::Codec { .. } => {
@@ -1105,7 +1105,7 @@ where
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         // We don't know in advance how restrictive the filter will be.
-        let max_len = self.part.part.updates.records().len();
+        let max_len = self.part.part.updates.len();
         (0, Some(max_len))
     }
 }
@@ -1403,7 +1403,7 @@ impl Cursor {
 
     /// Returns true if the cursor is past the end of the part data.
     pub fn is_exhausted<T: Timestamp + Codec64>(&self, part: &EncodedPart<T>) -> bool {
-        self.idx >= part.part.updates.records().len()
+        self.idx >= part.part.updates.len()
     }
 
     /// Advance the cursor just past the end of the most recent update, if there is one.

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -19,7 +19,6 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
 use mz_ore::cast::CastInto;
 use mz_ore::{assert_none, halt};
-use mz_persist::indexed::columnar::ColumnarRecords;
 use mz_persist::indexed::encoding::{BatchColumnarFormat, BlobTraceBatchPart, BlobTraceUpdates};
 use mz_persist::location::{SeqNo, VersionedData};
 use mz_persist::metrics::ColumnarMetrics;
@@ -1608,11 +1607,7 @@ impl ProtoInlineBatchPart {
         let updates = proto
             .updates
             .ok_or_else(|| TryFromProtoError::missing_field("ProtoInlineBatchPart::updates"))?;
-        let (updates, ext) = ColumnarRecords::from_proto(lgbytes, updates)?;
-        let updates = match ext {
-            None => BlobTraceUpdates::Row(updates),
-            Some(ext) => BlobTraceUpdates::Both(updates, ext),
-        };
+        let updates = BlobTraceUpdates::from_proto(lgbytes, updates)?;
 
         Ok(BlobTraceBatchPart {
             desc: proto.desc.into_rust_if_some("ProtoInlineBatchPart::desc")?,

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1419,7 +1419,7 @@ pub mod datadriven {
 
     use crate::batch::{
         validate_truncate_batch, Batch, BatchBuilder, BatchBuilderConfig, BatchBuilderInternal,
-        BatchParts, BLOB_TARGET_SIZE, STRUCTURED_ORDER,
+        BatchParts, BLOB_TARGET_SIZE, BUILDER_STRUCTURED, STRUCTURED_ORDER,
     };
     use crate::cfg::COMPACTION_MEMORY_BOUND_BYTES;
     use crate::fetch::{Cursor, EncodedPart};
@@ -1466,6 +1466,7 @@ pub mod datadriven {
             client
                 .cfg
                 .set_config(&STRUCTURED_ORDER, *STRUCTURED_ORDER.default());
+            client.cfg.set_config(&BUILDER_STRUCTURED, true);
             let state_versions = Arc::new(StateVersions::new(
                 client.cfg.clone(),
                 Arc::clone(&client.consensus),

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -10,7 +10,7 @@
 //! Code for iterating through one or more parts, including streaming consolidation.
 
 use anyhow::anyhow;
-use arrow::array::{Array, AsArray};
+use arrow::array::{Array, AsArray, Int64Array};
 use std::cmp::{Ordering, Reverse};
 use std::collections::binary_heap::PeekMut;
 use std::collections::{BinaryHeap, VecDeque};
@@ -25,7 +25,6 @@ use differential_dataflow::trace::Description;
 use futures_util::stream::FuturesUnordered;
 use futures_util::StreamExt;
 use itertools::Itertools;
-use mz_ore::iter::IteratorExt;
 use mz_ore::task::JoinHandle;
 use mz_persist::indexed::columnar::{ColumnarRecords, ColumnarRecordsStructuredExt};
 use mz_persist::indexed::encoding::BlobTraceUpdates;
@@ -89,8 +88,7 @@ fn interleave_updates<T: Codec64, D: Codec64>(
     updates: &[&BlobTraceUpdates],
     elements: impl IntoIterator<Item = (Indices, T, D)>,
 ) -> BlobTraceUpdates {
-    let mut arrays: Vec<&dyn Array> = Vec::with_capacity(updates.len());
-    let (indices, timestamps, diffs) = elements
+    let (indices, timestamps, diffs): (Vec<_>, Vec<_>, Vec<_>) = elements
         .into_iter()
         .map(|(idx, t, d)| {
             (
@@ -99,34 +97,43 @@ fn interleave_updates<T: Codec64, D: Codec64>(
                 i64::from_le_bytes(D::encode(&d)),
             )
         })
-        .multiunzip::<(Vec<_>, Vec<_>, Vec<_>)>();
-    let mut interleave = |get_array: fn(&BlobTraceUpdates) -> &dyn Array| {
+        .multiunzip();
+
+    let mut arrays: Vec<&dyn Array> = Vec::with_capacity(updates.len());
+    let mut interleave = |get_array: fn(&BlobTraceUpdates) -> Option<&dyn Array>| {
         for part in updates {
-            arrays.push(get_array(part));
+            arrays.push(get_array(part)?);
         }
-        let out =
-            ::arrow::compute::interleave(arrays.as_slice(), &indices).expect("valid references");
+        let out = ::arrow::compute::interleave(arrays.as_slice(), &indices).ok();
         arrays.clear();
         out
     };
-    let keys = interleave(|u| u.records().keys()).as_binary().clone();
-    let vals = interleave(|u| u.records().vals()).as_binary().clone();
-    let records = ColumnarRecords::new(keys, vals, timestamps.into(), diffs.into());
-    let has_ext = updates.iter().all(|e| e.structured().is_some());
-    // The structured impl will migrate structured data using the write schemas, but we don't have
-    // those available here. Instead, drop the structured data on the floor; if we need it, it will
-    // be re-created from our codec data later in the pipeline.
-    let types_match = updates
-        .iter()
-        .flat_map(|e| e.structured())
-        .map(|e| (e.key.data_type(), e.val.data_type()))
-        .all_equal();
-    if has_ext && types_match {
-        let key = interleave(|u| &u.structured().unwrap().key);
-        let val = interleave(|u| &u.structured().unwrap().val);
-        BlobTraceUpdates::Both(records, ColumnarRecordsStructuredExt { key, val })
-    } else {
-        BlobTraceUpdates::Row(records)
+
+    let codec_keys =
+        interleave(|u| Some(u.records()?.keys())).and_then(|k| k.as_binary_opt().cloned());
+    let codec_vals =
+        interleave(|u| Some(u.records()?.vals())).and_then(|v| v.as_binary_opt().cloned());
+    let structured_keys = interleave(|u| Some(u.structured()?.key.as_ref()));
+    let structured_vals = interleave(|u| Some(u.structured()?.val.as_ref()));
+    let timestamps = Int64Array::from(timestamps);
+    let diffs = Int64Array::from(diffs);
+
+    match (codec_keys, codec_vals, structured_keys, structured_vals) {
+        (Some(c_k), Some(c_v), Some(s_k), Some(s_v)) => BlobTraceUpdates::Both(
+            ColumnarRecords::new(c_k, c_v, timestamps, diffs),
+            ColumnarRecordsStructuredExt { key: s_k, val: s_v },
+        ),
+        (Some(c_k), Some(c_v), _, _) => {
+            BlobTraceUpdates::Row(ColumnarRecords::new(c_k, c_v, timestamps, diffs))
+        }
+        (_, _, Some(s_k), Some(s_v)) => BlobTraceUpdates::Structured {
+            key_values: ColumnarRecordsStructuredExt { key: s_k, val: s_v },
+            timestamps,
+            diffs,
+        },
+        _ => {
+            panic!("unable to generate either codec or structured data for updates; invalid types?")
+        }
     }
 }
 
@@ -173,7 +180,7 @@ impl<T: Codec64, D: Codec64> RowSort<T, D> for CodecSort<T, D> {
     }
 
     fn len(updates: &Self::Updates) -> usize {
-        updates.records().len()
+        updates.len()
     }
 
     fn kv_size((key, value): Self::KV<'_>) -> usize {
@@ -182,7 +189,12 @@ impl<T: Codec64, D: Codec64> RowSort<T, D> for CodecSort<T, D> {
     }
 
     fn get(updates: &Self::Updates, index: usize) -> Option<(Self::KV<'_>, T, D)> {
-        let ((k, v), t, d) = updates.records().get(index)?;
+        // TODO(structured): replace before allowing structured-only parts
+        // (pass in schemas and get_or_make_codec?)
+        let ((k, v), t, d) = updates
+            .records()
+            .expect("codec data is present")
+            .get(index)?;
         Some(((k, v), T::decode(t), D::decode(d)))
     }
 
@@ -253,7 +265,7 @@ impl<K: Codec, V: Codec, T: Codec64, D: Codec64> RowSort<T, D> for StructuredSor
     }
 
     fn len(updates: &Self::Updates) -> usize {
-        updates.data.records().len()
+        updates.data.len()
     }
 
     fn kv_size((key, value): Self::KV<'_>) -> usize {

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -261,7 +261,8 @@ impl<K: Codec, V: Codec, T: Codec64, D: Codec64> RowSort<T, D> for StructuredSor
     }
 
     fn get(updates: &Self::Updates, index: usize) -> Option<(Self::KV<'_>, T, D)> {
-        let (_, t, d) = updates.data.records().get(index)?;
+        let t = updates.data.timestamps().values().get(index)?.to_le_bytes();
+        let d = updates.data.diffs().values().get(index)?.to_le_bytes();
         Some((
             (updates.key_ord.at(index), Some(updates.val_ord.at(index))),
             T::decode(t),

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -829,7 +829,8 @@ mod tests {
         let part =
             BlobTraceBatchPart::decode(&value, &metrics.columnar).expect("failed to decode part");
         let mut updates = Vec::new();
-        for ((k, v), t, d) in part.updates.records().iter() {
+        // TODO(bkirwi): switch to structured data in tests
+        for ((k, v), t, d) in part.updates.records().expect("codec data").iter() {
             updates.push((
                 (
                     K::decode(k, &read_schemas.key),

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -974,8 +974,8 @@ where
                     let mut v = V::default();
                     key_decoder.decode(i, &mut k);
                     val_decoder.decode(i, &mut v);
-                    let t = T::decode(iter.records().timestamps().value(i).to_le_bytes());
-                    let d = D::decode(iter.records().diffs().value(i).to_le_bytes());
+                    let t = T::decode(iter.timestamps().value(i).to_le_bytes());
+                    let d = D::decode(iter.diffs().value(i).to_le_bytes());
                     ((Ok(k), Ok(v)), t, d)
                 });
 

--- a/src/persist-client/tests/machine/batch
+++ b/src/persist-client/tests/machine/batch
@@ -57,7 +57,7 @@ fetch-batch input=b0 stats=lower
 <empty>
 
 # write a batch that doesn't cleanly divide into target part size (each update is 25 bytes)
-write-batch output=b0 lower=0 upper=2 target_size=50
+write-batch output=b0 lower=0 upper=2 target_size=30
 a 0 1
 b 0 1
 d 0 1
@@ -78,7 +78,7 @@ part 0
 part 1
 
 # write a batch that exactly divides into target part size (each update is 25 bytes)
-write-batch output=b0 lower=0 upper=2 target_size=50
+write-batch output=b0 lower=0 upper=2 target_size=30
 a 0 1
 b 0 1
 c 0 1
@@ -101,7 +101,7 @@ part 0
 part 1
 
 # write an empty batch. should contain no parts.
-write-batch output=b0 lower=0 upper=2 target_size=50
+write-batch output=b0 lower=0 upper=2 target_size=30
 ----
 parts=0 len=0
 
@@ -142,7 +142,7 @@ c 0 1
 part 0
 
 # unsorted batches record each part in their own run
-write-batch output=b0 lower=0 upper=2 consolidate=false target_size=50
+write-batch output=b0 lower=0 upper=2 consolidate=false target_size=30
 y 0 1
 z 0 1
 n 0 1

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -103,20 +103,17 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                 {
                     let mut x = ::mz_dyncfg::ConfigUpdates::default();
                     x.add_dynamic("persist_batch_columnar_format", ::mz_dyncfg::ConfigVal::String("both_v2".into()));
-                    x.add_dynamic("persist_batch_columnar_format_percent", ::mz_dyncfg::ConfigVal::Usize(100));
                     x.add_dynamic("persist_part_decode_format", ::mz_dyncfg::ConfigVal::String("arrow".into()));
                     x
                 },
                 {
                     let mut x = ::mz_dyncfg::ConfigUpdates::default();
                     x.add_dynamic("persist_batch_columnar_format", ::mz_dyncfg::ConfigVal::String("both_v2".into()));
-                    x.add_dynamic("persist_batch_columnar_format_percent", ::mz_dyncfg::ConfigVal::Usize(100));
                     x
                 },
                 {
                     let mut x = ::mz_dyncfg::ConfigUpdates::default();
                     x.add_dynamic("persist_batch_columnar_format", ::mz_dyncfg::ConfigVal::String("both_v2".into()));
-                    x.add_dynamic("persist_batch_columnar_format_percent", ::mz_dyncfg::ConfigVal::Usize(100));
                     x.add_dynamic("persist_batch_structured_key_lower_len", ::mz_dyncfg::ConfigVal::Usize(256));
                     x.add_dynamic("persist_batch_structured_order", ::mz_dyncfg::ConfigVal::Bool(true));
                     x

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -115,7 +115,7 @@ pub trait Schema2<T>: Debug + Send + Sync {
     /// Type that is able to decode values of `T` from [`Self::ArrowColumn`].
     type Decoder: ColumnDecoder<T> + Debug + Send + Sync;
     /// Type that is able to encoder values of `T`.
-    type Encoder: ColumnEncoder<T, FinishedColumn = Self::ArrowColumn> + Debug;
+    type Encoder: ColumnEncoder<T, FinishedColumn = Self::ArrowColumn> + Debug + Send + Sync;
 
     /// Returns a type that is able to decode instances of `T` from the provider column.
     fn decoder(&self, col: Self::ArrowColumn) -> Result<Self::Decoder, anyhow::Error>;

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -189,14 +189,12 @@ pub fn schema2_to_codec<A: Codec + Default>(
     let mut buffer = vec![];
 
     for i in 0..len {
-        if decoder.is_null(i) {
-            builder.append_null();
-        } else {
-            decoder.decode(i, &mut value);
-            Codec::encode(&value, &mut buffer);
-            builder.append_value(&buffer);
-            buffer.clear()
-        }
+        // The binary encoding of key/value types can never be null.
+        // Defer to the implementation-defined behaviour for null entries in that case.
+        decoder.decode(i, &mut value);
+        Codec::encode(&value, &mut buffer);
+        builder.append_value(&buffer);
+        buffer.clear()
     }
 
     Ok(BinaryBuilder::finish(&mut builder))

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -11,8 +11,7 @@
 
 use std::sync::Arc;
 
-use arrow::array::Array;
-use arrow::buffer::ScalarBuffer;
+use arrow::array::{Array, Int64Array};
 
 use crate::columnar::{ColumnEncoder, Schema2};
 use crate::Codec64;
@@ -24,9 +23,9 @@ pub struct Part2 {
     /// The 'v' values from a Part, generally `()`.
     pub val: Arc<dyn Array>,
     /// The `ts` values from a Part.
-    pub time: ScalarBuffer<i64>,
+    pub time: Int64Array,
     /// The `diff` values from a Part.
-    pub diff: ScalarBuffer<i64>,
+    pub diff: Int64Array,
 }
 
 /// A builder for [`Part2`].
@@ -77,8 +76,8 @@ impl<K, KS: Schema2<K>, V, VS: Schema2<V>> PartBuilder2<K, KS, V, VS> {
 
         let key_col = key.finish();
         let val_col = val.finish();
-        let time = ScalarBuffer::from(time.0);
-        let diff = ScalarBuffer::from(diff.0);
+        let time = Int64Array::from(time.0);
+        let diff = Int64Array::from(diff.0);
 
         Part2 {
             key: Arc::new(key_col),

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -9,6 +9,7 @@
 
 //! A columnar representation of one blob's worth of data
 
+use std::mem;
 use std::sync::Arc;
 
 use arrow::array::{Array, Int64Array};
@@ -29,6 +30,7 @@ pub struct Part2 {
 }
 
 /// A builder for [`Part2`].
+#[derive(Debug)]
 pub struct PartBuilder2<K, KS: Schema2<K>, V, VS: Schema2<V>> {
     key: KS::Encoder,
     val: VS::Encoder,
@@ -85,6 +87,12 @@ impl<K, KS: Schema2<K>, V, VS: Schema2<V>> PartBuilder2<K, KS, V, VS> {
             time,
             diff,
         }
+    }
+
+    /// Finish the builder and replace it with an empty one.
+    pub fn finish_and_replace(&mut self, key_schema: &KS, val_schema: &VS) -> Part2 {
+        let builder = mem::replace(self, PartBuilder2::new(key_schema, val_schema));
+        builder.finish()
     }
 }
 

--- a/src/persist/src/indexed/columnar/arrow.rs
+++ b/src/persist/src/indexed/columnar/arrow.rs
@@ -243,7 +243,7 @@ pub fn decode_arrow_batch_kvtd(
         timestamps: realloc_array(time, metrics),
         diffs: realloc_array(diff, metrics),
     };
-    ret.borrow().validate()?;
+    ret.validate()?;
 
     Ok(ret)
 }

--- a/src/persist/src/indexed/columnar/parquet.rs
+++ b/src/persist/src/indexed/columnar/parquet.rs
@@ -139,6 +139,9 @@ pub fn encode_parquet_kvtd<W: Write + Send>(
             let schema = Schema::new(fields);
             (arrays, Arc::new(schema), "k,v,t,d,k_s,v_s")
         }
+        BlobTraceUpdates::Structured { .. } => {
+            unimplemented!("codec data should exist before reaching parquet encoding")
+        }
     };
 
     let mut writer = ArrowWriter::try_new(w, Arc::clone(&schema), Some(properties))?;

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -13,7 +13,7 @@
 // Ditto for Log* and the Log. The others are used internally in these top-level
 // structs.
 
-use arrow::array::{Array, ArrayRef};
+use arrow::array::{Array, ArrayRef, Int64Array};
 use arrow::datatypes::DataType;
 use std::fmt::{self, Debug};
 use std::marker::PhantomData;
@@ -207,6 +207,16 @@ impl BlobTraceUpdates {
     /// The number of updates.
     pub fn len(&self) -> usize {
         self.records().len()
+    }
+
+    /// The updates' timestamps as an integer array.
+    pub fn timestamps(&self) -> &Int64Array {
+        self.records().timestamps()
+    }
+
+    /// The updates' diffs as an integer array.
+    pub fn diffs(&self) -> &Int64Array {
+        self.records().diffs()
     }
 
     /// Return the [`ColumnarRecords`] of the blob.

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -15,14 +15,14 @@
 
 use arrow::array::{Array, ArrayRef, BinaryArray, Int64Array};
 use arrow::buffer::OffsetBuffer;
-use arrow::datatypes::DataType;
+use arrow::datatypes::{DataType, ToByteSlice};
 use bytes::{BufMut, Bytes};
 use differential_dataflow::trace::Description;
 use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::soft_panic_or_log;
-use mz_persist_types::columnar::{codec_to_schema2, data_type};
+use mz_persist_types::columnar::{codec_to_schema2, data_type, schema2_to_codec};
 use mz_persist_types::parquet::EncodingConfig;
 use mz_persist_types::schema::backward_compatible;
 use mz_persist_types::{Codec, Codec64};
@@ -31,8 +31,8 @@ use proptest::arbitrary::Arbitrary;
 use proptest::prelude::*;
 use proptest::strategy::{BoxedStrategy, Just};
 use prost::Message;
+use serde::Serialize;
 use std::fmt::{self, Debug};
-use std::marker::PhantomData;
 use std::sync::Arc;
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
@@ -200,30 +200,52 @@ pub enum BlobTraceUpdates {
     ///
     /// [`Codec`]: mz_persist_types::Codec
     Both(ColumnarRecords, ColumnarRecordsStructuredExt),
-    // TODO(parkmycar): Write only columnar/Arrow data.
+    /// New-style structured format, including structured representations of the K/V columns and
+    /// the usual timestamp / diff encoding.
+    Structured {
+        /// Key-value data.
+        key_values: ColumnarRecordsStructuredExt,
+        /// Timestamp data.
+        timestamps: Int64Array,
+        /// Diffs.
+        diffs: Int64Array,
+    },
 }
 
 impl BlobTraceUpdates {
     /// The number of updates.
     pub fn len(&self) -> usize {
-        self.records().len()
+        match self {
+            BlobTraceUpdates::Row(c) => c.len(),
+            BlobTraceUpdates::Both(c, _structured) => c.len(),
+            BlobTraceUpdates::Structured { timestamps, .. } => timestamps.len(),
+        }
     }
 
     /// The updates' timestamps as an integer array.
     pub fn timestamps(&self) -> &Int64Array {
-        self.records().timestamps()
+        match self {
+            BlobTraceUpdates::Row(c) => c.timestamps(),
+            BlobTraceUpdates::Both(c, _structured) => c.timestamps(),
+            BlobTraceUpdates::Structured { timestamps, .. } => timestamps,
+        }
     }
 
     /// The updates' diffs as an integer array.
     pub fn diffs(&self) -> &Int64Array {
-        self.records().diffs()
+        match self {
+            BlobTraceUpdates::Row(c) => c.diffs(),
+            BlobTraceUpdates::Both(c, _structured) => c.diffs(),
+            BlobTraceUpdates::Structured { diffs, .. } => diffs,
+        }
     }
 
     /// Return the [`ColumnarRecords`] of the blob.
-    pub fn records(&self) -> &ColumnarRecords {
+    pub fn records(&self) -> Option<&ColumnarRecords> {
         match self {
-            BlobTraceUpdates::Row(c) => c,
-            BlobTraceUpdates::Both(c, _structured) => c,
+            BlobTraceUpdates::Row(c) => Some(c),
+            BlobTraceUpdates::Both(c, _structured) => Some(c),
+            BlobTraceUpdates::Structured { .. } => None,
         }
     }
 
@@ -231,13 +253,57 @@ impl BlobTraceUpdates {
     pub fn structured(&self) -> Option<&ColumnarRecordsStructuredExt> {
         match self {
             BlobTraceUpdates::Row(_) => None,
-            BlobTraceUpdates::Both(_, structured) => Some(structured),
+            BlobTraceUpdates::Both(_, s) => Some(s),
+            BlobTraceUpdates::Structured { key_values, .. } => Some(key_values),
         }
     }
 
     /// Return the estimated memory usage of the raw data.
     pub fn goodbytes(&self) -> usize {
-        self.records().goodbytes() + self.structured().map_or(0, |e| e.goodbytes())
+        match self {
+            BlobTraceUpdates::Row(c) => c.goodbytes(),
+            // NB: we only report goodbytes for columnar records here, to avoid
+            // dual-counting the same records. (This means that our goodput % is much lower
+            // during the migration, which is an accurate reflection of reality.)
+            BlobTraceUpdates::Both(c, _) => c.goodbytes(),
+            BlobTraceUpdates::Structured {
+                key_values,
+                timestamps,
+                diffs,
+            } => {
+                key_values.goodbytes()
+                    + timestamps.values().to_byte_slice().len()
+                    + diffs.values().to_byte_slice().len()
+            }
+        }
+    }
+
+    /// Return the [ColumnarRecords] of the blob, generating it if it does not exist.
+    pub fn get_or_make_codec<K: Codec, V: Codec>(
+        &mut self,
+        key_schema: &K::Schema,
+        val_schema: &V::Schema,
+    ) -> &ColumnarRecords {
+        match self {
+            BlobTraceUpdates::Row(records) => records,
+            BlobTraceUpdates::Both(records, _) => records,
+            BlobTraceUpdates::Structured {
+                key_values,
+                timestamps,
+                diffs,
+            } => {
+                let key = schema2_to_codec::<K>(key_schema, &*key_values.key).expect("valid keys");
+                let val =
+                    schema2_to_codec::<V>(val_schema, &*key_values.val).expect("valid values");
+                let records = ColumnarRecords::new(key, val, timestamps.clone(), diffs.clone());
+
+                *self = BlobTraceUpdates::Both(records, key_values.clone());
+                let BlobTraceUpdates::Both(records, _) = self else {
+                    unreachable!("set to BlobTraceUpdates::Both in previous line")
+                };
+                records
+            }
+        }
     }
 
     /// Return the [`ColumnarRecordsStructuredExt`] of the blob.
@@ -246,49 +312,53 @@ impl BlobTraceUpdates {
         key_schema: &K::Schema,
         val_schema: &V::Schema,
     ) -> &ColumnarRecordsStructuredExt {
-        match self {
+        let structured = match self {
             BlobTraceUpdates::Row(records) => {
                 let key = codec_to_schema2::<K>(key_schema, records.keys()).expect("valid keys");
                 let val = codec_to_schema2::<V>(val_schema, records.vals()).expect("valid values");
+
                 *self = BlobTraceUpdates::Both(
                     records.clone(),
                     ColumnarRecordsStructuredExt { key, val },
                 );
-                // Recurse at most once, since this data is now structured.
-                self.get_or_make_structured::<K, V>(key_schema, val_schema)
-            }
-            BlobTraceUpdates::Both(_, structured) => {
-                // If the types don't match, attempt to migrate the array to the new type.
-                // We expect this to succeed, since this should only be called with backwards-
-                // compatible schemas... but if it fails we only log, and let some higher-level
-                // code signal the error if it cares.
-                let migrate = |array: &mut ArrayRef, to_type: DataType| {
-                    // TODO: Plumb down the SchemaCache and use it here for the array migrations.
-                    let from_type = array.data_type().clone();
-                    if from_type != to_type {
-                        if let Some(migration) = backward_compatible(&from_type, &to_type) {
-                            *array = migration.migrate(Arc::clone(array));
-                        } else {
-                            error!(
-                                ?from_type,
-                                ?to_type,
-                                "failed to migrate array type; backwards-incompatible schema migration?"
-                            );
-                        }
-                    }
+                let BlobTraceUpdates::Both(_, structured) = self else {
+                    unreachable!("set to BlobTraceUpdates::Both in previous line")
                 };
-                migrate(
-                    &mut structured.key,
-                    data_type::<K>(key_schema).expect("valid key schema"),
-                );
-                migrate(
-                    &mut structured.val,
-                    data_type::<V>(val_schema).expect("valid value schema"),
-                );
-
                 structured
             }
-        }
+            BlobTraceUpdates::Both(_, structured) => structured,
+            BlobTraceUpdates::Structured { key_values, .. } => key_values,
+        };
+
+        // If the types don't match, attempt to migrate the array to the new type.
+        // We expect this to succeed, since this should only be called with backwards-
+        // compatible schemas... but if it fails we only log, and let some higher-level
+        // code signal the error if it cares.
+        let migrate = |array: &mut ArrayRef, to_type: DataType| {
+            // TODO: Plumb down the SchemaCache and use it here for the array migrations.
+            let from_type = array.data_type().clone();
+            if from_type != to_type {
+                if let Some(migration) = backward_compatible(&from_type, &to_type) {
+                    *array = migration.migrate(Arc::clone(array));
+                } else {
+                    error!(
+                        ?from_type,
+                        ?to_type,
+                        "failed to migrate array type; backwards-incompatible schema migration?"
+                    );
+                }
+            }
+        };
+        migrate(
+            &mut structured.key,
+            data_type::<K>(key_schema).expect("valid key schema"),
+        );
+        migrate(
+            &mut structured.val,
+            data_type::<V>(val_schema).expect("valid value schema"),
+        );
+
+        structured
     }
 
     /// Concatenate the given records together, column-by-column.
@@ -304,7 +374,11 @@ impl BlobTraceUpdates {
             _ => {}
         }
 
-        let columnar: Vec<_> = updates.iter().map(|u| u.records().clone()).collect();
+        // TODO: skip this when we no longer require codec data.
+        let columnar: Vec<_> = updates
+            .iter_mut()
+            .map(|u| u.get_or_make_codec::<K, V>(key_schema, val_schema).clone())
+            .collect();
         let records = ColumnarRecords::concat(&columnar, metrics);
 
         let mut keys = Vec::with_capacity(records.len());
@@ -362,20 +436,28 @@ impl BlobTraceUpdates {
 
     /// See [RustType::into_proto].
     pub fn into_proto(&self) -> ProtoColumnarRecords {
-        let records = self.records();
+        let (key_offsets, key_data, val_offsets, val_data) = match self.records() {
+            None => (vec![], Bytes::new(), vec![], Bytes::new()),
+            Some(records) => (
+                records.keys().offsets().to_vec(),
+                Bytes::copy_from_slice(records.keys().value_data()),
+                records.vals().offsets().to_vec(),
+                Bytes::copy_from_slice(records.vals().value_data()),
+            ),
+        };
         let (k_struct, v_struct) = match self.structured().map(|x| x.into_proto()) {
             None => (None, None),
             Some((k, v)) => (Some(k), Some(v)),
         };
 
         ProtoColumnarRecords {
-            len: records.len().into_proto(),
-            key_offsets: records.keys().offsets().to_vec(),
-            key_data: Bytes::copy_from_slice(records.keys().value_data()),
-            val_offsets: records.vals().offsets().to_vec(),
-            val_data: Bytes::copy_from_slice(records.vals().value_data()),
-            timestamps: records.timestamps().values().to_vec(),
-            diffs: records.diffs().values().to_vec(),
+            len: self.len().into_proto(),
+            key_offsets,
+            key_data,
+            val_offsets,
+            val_data,
+            timestamps: self.timestamps().values().to_vec(),
+            diffs: self.diffs().values().to_vec(),
             key_structured: k_struct,
             val_structured: v_struct,
         }
@@ -390,11 +472,18 @@ impl BlobTraceUpdates {
         val_schema: &V::Schema,
     ) -> Self {
         match format {
-            BatchColumnarFormat::Row => Self::Row(self.records().clone()),
+            BatchColumnarFormat::Row => {
+                let mut this = self.clone();
+                Self::Row(
+                    this.get_or_make_codec::<K, V>(key_schema, val_schema)
+                        .clone(),
+                )
+            }
             BatchColumnarFormat::Both(_) => {
                 let mut this = self.clone();
                 Self::Both(
-                    this.records().clone(),
+                    this.get_or_make_codec::<K, V>(key_schema, val_schema)
+                        .clone(),
                     this.get_or_make_structured::<K, V>(key_schema, val_schema)
                         .clone(),
                 )
@@ -450,22 +539,18 @@ impl TraceBatchMeta {
             batches.push(batch);
         }
 
-        for update in batches
-            .iter()
-            .flat_map(|batch| batch.updates.records().iter())
-        {
-            let ((_key, _val), _ts, diff) = update;
+        for (batch_idx, batch) in batches.iter().enumerate() {
+            for (row_idx, diff) in batch.updates.diffs().values().iter().enumerate() {
+                // TODO: Don't assume diff is an i64, take a D type param instead.
+                let diff: u64 = Codec64::decode(diff.to_le_bytes());
 
-            // TODO: Don't assume diff is an i64, take a D type param instead.
-            let diff: u64 = Codec64::decode(diff);
-
-            // Check data invariants.
-            if diff == 0 {
-                return Err(format!(
-                    "update with 0 diff: {:?}",
-                    PrettyRecord::<u64, i64>(update, PhantomData)
-                )
-                .into());
+                // Check data invariants.
+                if diff == 0 {
+                    return Err(format!(
+                        "update with 0 diff in batch {batch_idx} at row {row_idx}",
+                    )
+                    .into());
+                }
             }
         }
 
@@ -486,12 +571,8 @@ impl<T: Timestamp + Codec64> BlobTraceBatchPart<T> {
 
         let uncompacted = PartialOrder::less_equal(self.desc.since(), self.desc.lower());
 
-        for update in self.updates.records().iter() {
-            let ((_key, _val), ts, diff) = update;
-            // TODO: Don't assume diff is an i64, take a D type param instead.
-            let ts = T::decode(ts);
-            let diff: i64 = Codec64::decode(diff);
-
+        for time in self.updates.timestamps().values() {
+            let ts = T::decode(time.to_le_bytes());
             // Check ts against desc.
             if !self.desc.lower().less_equal(&ts) {
                 return Err(format!(
@@ -512,16 +593,18 @@ impl<T: Timestamp + Codec64> BlobTraceBatchPart<T> {
                 )
                 .into());
             }
+        }
+
+        for (row_idx, diff) in self.updates.diffs().values().iter().enumerate() {
+            // TODO: Don't assume diff is an i64, take a D type param instead.
+            let diff: u64 = Codec64::decode(diff.to_le_bytes());
 
             // Check data invariants.
             if diff == 0 {
-                return Err(format!(
-                    "update with 0 diff: {:?}",
-                    PrettyRecord::<u64, i64>(update, PhantomData)
-                )
-                .into());
+                return Err(format!("update with 0 diff at row {row_idx}",).into());
             }
         }
+
         Ok(())
     }
 
@@ -542,45 +625,8 @@ impl<T: Timestamp + Codec64> BlobTraceBatchPart<T> {
     pub fn key_lower(&self) -> &[u8] {
         self.updates
             .records()
-            .iter()
-            .map(|((key, _), _, _)| key)
-            .min()
+            .and_then(|r| r.keys().iter().flatten().min())
             .unwrap_or(&[])
-    }
-}
-
-#[derive(PartialOrd, Ord, PartialEq, Eq)]
-struct PrettyBytes<'a>(&'a [u8]);
-
-impl fmt::Debug for PrettyBytes<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match std::str::from_utf8(self.0) {
-            Ok(x) => fmt::Debug::fmt(x, f),
-            Err(_) => fmt::Debug::fmt(self.0, f),
-        }
-    }
-}
-
-struct PrettyRecord<'a, T, D>(
-    ((&'a [u8], &'a [u8]), [u8; 8], [u8; 8]),
-    PhantomData<(T, D)>,
-);
-
-impl<T, D> fmt::Debug for PrettyRecord<'_, T, D>
-where
-    T: Debug + Codec64,
-    D: Debug + Codec64,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let ((k, v), ts, diff) = &self.0;
-        fmt::Debug::fmt(
-            &(
-                (PrettyBytes(k), PrettyBytes(v)),
-                T::decode(*ts),
-                D::decode(*diff),
-            ),
-            f,
-        )
     }
 }
 
@@ -639,6 +685,10 @@ pub fn encode_trace_inline_meta<T: Timestamp + Codec64>(batch: &BlobTraceBatchPa
         BlobTraceUpdates::Both { .. } => {
             let metadata = ProtoFormatMetadata::StructuredMigration(2);
             (ProtoBatchFormat::ParquetStructured, Some(metadata))
+        }
+
+        BlobTraceUpdates::Structured { .. } => {
+            unimplemented!("codec data should exist before reaching parquet encoding")
         }
     };
 
@@ -809,7 +859,7 @@ mod tests {
         };
         assert_eq!(
             b.validate(),
-            Err(Error::from("update with 0 diff: ((\"0\", \"0\"), 0, 0)"))
+            Err(Error::from("update with 0 diff at row 0"))
         );
     }
 

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -380,6 +380,27 @@ impl BlobTraceUpdates {
             val_structured: v_struct,
         }
     }
+
+    /// Convert these updates into the specified batch format, re-encoding or discarding key-value
+    /// data as necessary.
+    pub fn as_format<K: Codec, V: Codec>(
+        &self,
+        format: BatchColumnarFormat,
+        key_schema: &K::Schema,
+        val_schema: &V::Schema,
+    ) -> Self {
+        match format {
+            BatchColumnarFormat::Row => Self::Row(self.records().clone()),
+            BatchColumnarFormat::Both(_) => {
+                let mut this = self.clone();
+                Self::Both(
+                    this.records().clone(),
+                    this.get_or_make_structured::<K, V>(key_schema, val_schema)
+                        .clone(),
+                )
+            }
+        }
+    }
 }
 
 impl TraceBatchMeta {

--- a/test/sqllogictest/persist-fast-path.slt
+++ b/test/sqllogictest/persist-fast-path.slt
@@ -18,11 +18,6 @@ ALTER SYSTEM SET persist_batch_columnar_format = 'both_v2'
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET persist_batch_columnar_format_percent = 100
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET persist_batch_structured_order = true
 ----
 COMPLETE 0


### PR DESCRIPTION
What it says on the tin.

Notably: this does _not_ allow writing structured-only data to disk: we will always generate the codec-encoded columns before writing the part. I've left a couple `expect`ations in the code that would panic if this was ever not true: to be cleaned up in the next PR.

### Motivation

Part of the work that we need to do to allow writing _only_ structured data.

### Tips for reviewer

This is a somewhat ugly interstitial state. I'm trying to resist doing too much cleanup of code that we don't expect to live for too long... but however if you think anything's too sketchy to live in main for even a short time I can try and tackle that up front!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
