### PR TITLE
tests: Add simplest possible emulator test

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1698,6 +1698,16 @@ steps:
     agents:
       queue: hetzner-aarch64-8cpu-16gb
 
+  - id: emulator
+    label: Materialize Emulator
+    depends_on: build-aarch64
+    timeout_in_minutes: 20
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: emulator
+    agents:
+      queue: hetzner-aarch64-4cpu-8gb
+
   - id: sqllogictest
     label: ":bulb: SQL logic tests"
     depends_on: build-aarch64

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -31,6 +31,26 @@ from materialize.mzcompose.services.minio import minio_blob_uri
 from materialize.mzcompose.services.postgres import METADATA_STORE
 
 
+class MaterializeEmulator(Service):
+    """Just the Materialize Emulator with its defaults unchanged"""
+
+    def __init__(self, image: str | None = None):
+        name = "materialized"
+
+        config: ServiceConfig = {
+            "mzbuild": name,
+            "ports": [6875, 6876, 6877, 6878, 6880, 6881, 26257],
+            "healthcheck": {
+                "test": ["CMD", "curl", "-f", "localhost:6878/api/readyz"],
+                "interval": "1s",
+                # A fully loaded Materialize can take a long time to start.
+                "start_period": "600s",
+            },
+        }
+
+        super().__init__(name=name, config=config)
+
+
 class Materialized(Service):
     class Size:
         DEFAULT_SIZE = 4

--- a/test/emulator/mzcompose
+++ b/test/emulator/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/emulator/mzcompose.py
+++ b/test/emulator/mzcompose.py
@@ -1,0 +1,27 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""
+For now only tests that the Materialize emulator can start up with its
+defaults, regression test for https://github.com/MaterializeInc/materialize/pull/30964
+"""
+
+
+from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.services.materialized import (
+    MaterializeEmulator,
+)
+
+SERVICES = [MaterializeEmulator()]
+
+
+def workflow_default(c: Composition) -> None:
+    c.up("materialized")
+    result = c.sql_query("SELECT 1")
+    assert result == [(1,)]


### PR DESCRIPTION
Regression test for https://github.com/MaterializeInc/materialize/pull/30964

This is only to make sure we don't shoot ourselves into the foot by setting non-functional defaults.

Green test run: https://buildkite.com/materialize/nightly/builds/10806

This has the side effect that every nightly run will upload telemetry now. Disabling telemetry is not an option, because it was exactly the telemetry default that was breaking the emulator.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
