### PR TITLE
Change CTE order in EXPLAIN output

### DIFF
--- a/doc/user/content/sql/explain-plan.md
+++ b/doc/user/content/sql/explain-plan.md
@@ -171,15 +171,15 @@ In the example below, the CTE `l0` represents a linear sub-plan (a chain of `Get
 `Filter`, and `Project` operators) which is used in both inputs of a self-join.
 
 ```text
-Return
-  Join on=(#1 = #2)
-    Get l0
-    Get l0
 With
   cte l0 =
     Project (#0, #1)
       Filter (#0 > #2)
         ReadStorage materialize.public.t
+Return
+  Join on=(#1 = #2)
+    Get l0
+    Get l0
 ```
 
 <a name="explain-plan-columns"></a>

--- a/src/expr-parser/tests/test_mir_parser/with_ctes.spec
+++ b/src/expr-parser/tests/test_mir_parser/with_ctes.spec
@@ -20,64 +20,64 @@ Source defined as t0
 
 # One CTE
 roundtrip
-Return
-  Filter #0 AND #1
-    Get l0
 With
   cte l0 =
     Constant <empty> // { types: "(boolean, boolean)" }
+Return
+  Filter #0 AND #1
+    Get l0
 ----
 roundtrip OK
 
 # Many CTEs
 roundtrip
+With
+  cte l0 =
+    Constant <empty> // { types: "(boolean, boolean?)" }
+  cte l1 =
+    Filter #0 AND #1
+      Constant <empty> // { types: "(boolean?, boolean)" }
+  cte l2 =
+    Filter (NOT(#0) OR NOT(#1))
+      Constant <empty> // { types: "(boolean?, boolean)" }
 Return
   Union
     Get l0
     Get l2
     Get l1
-With
-  cte l2 =
-    Filter (NOT(#0) OR NOT(#1))
-      Constant <empty> // { types: "(boolean?, boolean)" }
-  cte l1 =
-    Filter #0 AND #1
-      Constant <empty> // { types: "(boolean?, boolean)" }
-  cte l0 =
-    Constant <empty> // { types: "(boolean, boolean?)" }
 ----
 roundtrip OK
 
 # With mutually recursive (simple).
 roundtrip
-Return
-  Filter #0 AND #1
-    Get l0
 With Mutually Recursive
   cte l0 = // { types: "(boolean?, boolean)" }
     Get l1
   cte l1 = // { types: "(boolean, boolean?)" }
+    Get l0
+Return
+  Filter #0 AND #1
     Get l0
 ----
 roundtrip OK
 
 # With mutually recursive (nested).
 roundtrip
-Return
-  Map ("return_inner")
-    Get l1
 With Mutually Recursive
   cte l1 = // { types: "(bigint, bigint)" }
-    Return
-      Union
-        Get l1
-        Filter (#0 > 1)
-          Get l0
     With Mutually Recursive
       cte l0 = // { types: "(bigint, bigint)" }
         Union
           Get l0
           Filter (#0 > 42)
             Get t0
+    Return
+      Union
+        Get l1
+        Filter (#0 > 1)
+          Get l0
+Return
+  Map ("return_outer")
+    Get l1
 ----
 roundtrip OK

--- a/src/expr-test-util/tests/testdata/rel
+++ b/src/expr-test-util/tests/testdata/rel
@@ -88,13 +88,13 @@ build
    (get x))
 ----
 ----
-Return
-  Get l0
 With
   cte l0 =
     Constant
       - (1, 2, 3)
       - (4, 5, 6)
+Return
+  Get l0
 
 ----
 ----

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -345,17 +345,17 @@ impl MirRelationExpr {
                     self.fmt_analyses(f, ctx)?;
                     ctx.indented(|ctx| head.fmt_text(f, ctx))?;
                 } else {
-                    write!(f, "{}Return", ctx.indent)?;
-                    self.fmt_analyses(f, ctx)?;
-                    ctx.indented(|ctx| head.fmt_text(f, ctx))?;
                     writeln!(f, "{}With", ctx.indent)?;
                     ctx.indented(|ctx| {
-                        for (id, value) in bindings.iter().rev() {
+                        for (id, value) in bindings.iter() {
                             writeln!(f, "{}cte {} =", ctx.indent, *id)?;
                             ctx.indented(|ctx| value.fmt_text(f, ctx))?;
                         }
                         Ok(())
                     })?;
+                    write!(f, "{}Return", ctx.indent)?;
+                    self.fmt_analyses(f, ctx)?;
+                    ctx.indented(|ctx| head.fmt_text(f, ctx))?;
                 }
             }
             LetRec {
@@ -382,16 +382,13 @@ impl MirRelationExpr {
                 if ctx.config.linear_chains {
                     unreachable!(); // We exclude this case in `as_explain_single_plan`.
                 } else {
-                    write!(f, "{}Return", ctx.indent)?;
-                    self.fmt_analyses(f, ctx)?;
-                    ctx.indented(|ctx| head.fmt_text(f, ctx))?;
                     write!(f, "{}With Mutually Recursive", ctx.indent)?;
                     if let Some(limit) = all_limits_same {
                         write!(f, " {}", limit)?;
                     }
                     writeln!(f)?;
                     ctx.indented(|ctx| {
-                        for (id, value, limit) in bindings.iter().rev() {
+                        for (id, value, limit) in bindings.iter() {
                             write!(f, "{}cte", ctx.indent)?;
                             if all_limits_same.is_none() {
                                 if let Some(limit) = limit {
@@ -403,6 +400,9 @@ impl MirRelationExpr {
                         }
                         Ok(())
                     })?;
+                    write!(f, "{}Return", ctx.indent)?;
+                    self.fmt_analyses(f, ctx)?;
+                    ctx.indented(|ctx| head.fmt_text(f, ctx))?;
                 }
             }
             Get {

--- a/src/transform/tests/test_transforms/anf.spec
+++ b/src/transform/tests/test_transforms/anf.spec
@@ -31,35 +31,35 @@ TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=3
               Map (null::bigint)
                 Get t0
 ----
-Return
-  Get l8
 With
-  cte l8 =
-    TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=3
-      Get l7
-  cte l7 =
-    Reduce group_by=[#0] aggregates=[min(#1), max(#2)]
-      Get l6
-  cte l6 =
-    ArrangeBy keys=[[#1], [#2, #3]]
-      Get l5
-  cte l5 =
-    Threshold
-      Get l4
-  cte l4 =
-    Negate
-      Get l3
-  cte l3 =
-    Project (#2, #0, #1)
-      Get l2
-  cte l2 =
-    Filter (#0 > 0)
-      Get l1
+  cte l0 =
+    Get t0
   cte l1 =
     Map (null)
       Get l0
-  cte l0 =
-    Get t0
+  cte l2 =
+    Filter (#0 > 0)
+      Get l1
+  cte l3 =
+    Project (#2, #0, #1)
+      Get l2
+  cte l4 =
+    Negate
+      Get l3
+  cte l5 =
+    Threshold
+      Get l4
+  cte l6 =
+    ArrangeBy keys=[[#1], [#2, #3]]
+      Get l5
+  cte l7 =
+    Reduce group_by=[#0] aggregates=[min(#1), max(#2)]
+      Get l6
+  cte l8 =
+    TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=3
+      Get l7
+Return
+  Get l8
 
 # Joins.
 apply pipeline=anf
@@ -68,18 +68,18 @@ Join on=(#0 = #2 = #4)
   Constant <empty> // { types: "(bigint, bigint)" }
   Get t0
 ----
-Return
-  Get l2
 With
+  cte l0 =
+    Get t0
+  cte l1 =
+    Constant <empty>
   cte l2 =
     Join on=(#0 = #2 = #4)
       Get l0
       Get l1
       Get l0
-  cte l1 =
-    Constant <empty>
-  cte l0 =
-    Get t0
+Return
+  Get l2
 
 # Union.
 apply pipeline=anf
@@ -88,18 +88,18 @@ Union
   Constant <empty> // { types: "(bigint, bigint)" }
   Get t0
 ----
-Return
-  Get l2
 With
+  cte l0 =
+    Get t0
+  cte l1 =
+    Constant <empty>
   cte l2 =
     Union
       Get l0
       Get l1
       Get l0
-  cte l1 =
-    Constant <empty>
-  cte l0 =
-    Get t0
+Return
+  Get l2
 
 
 ## LetRec cases
@@ -154,51 +154,27 @@ With
       Project (#0, #1)
         Get t0
 ----
-Return
-  Get l21
 With
+  cte l0 =
+    Get t0
+  cte l1 =
+    Project (#0, #1)
+      Get l0
+  cte l2 =
+    Union
+      Get l1
+      Get l1
   cte l21 =
-    Return
-      Return
-        Get l20
-      With
-        cte l20 =
-          Union
-            Get l17
-            Get l18
-            Get l19
-        cte l19 =
-          Filter (#1 > 7)
-            Get l11
-        cte l18 =
-          Filter (#1 > 7)
-            Get l15
-        cte l17 =
-          Filter (#1 > 7)
-            Get l16
-        cte l16 =
-          Get t0
     With Mutually Recursive
-      cte l15 =
-        Get l14
-      cte l14 =
-        Distinct project=[#0, #1]
-          Get l13
-      cte l13 =
-        Union
-          Get l6
-          Get l12
-          Get l12
-          Get l8
-          Get l8
-      cte l12 =
+      cte l6 =
+        Filter (#1 > 7)
+          Get l2
+      cte l7 =
         Filter (#1 > 7)
           Get l11
-      cte l11 =
-        Get l10
-      cte l10 =
-        Distinct project=[#0, #1]
-          Get l9
+      cte l8 =
+        Filter (#1 > 7)
+          Get l15
       cte l9 =
         Union
           Get l6
@@ -206,24 +182,48 @@ With
           Get l7
           Get l8
           Get l8
-      cte l8 =
-        Filter (#1 > 7)
-          Get l15
-      cte l7 =
+      cte l10 =
+        Distinct project=[#0, #1]
+          Get l9
+      cte l11 =
+        Get l10
+      cte l12 =
         Filter (#1 > 7)
           Get l11
-      cte l6 =
-        Filter (#1 > 7)
-          Get l2
-  cte l2 =
-    Union
-      Get l1
-      Get l1
-  cte l1 =
-    Project (#0, #1)
-      Get l0
-  cte l0 =
-    Get t0
+      cte l13 =
+        Union
+          Get l6
+          Get l12
+          Get l12
+          Get l8
+          Get l8
+      cte l14 =
+        Distinct project=[#0, #1]
+          Get l13
+      cte l15 =
+        Get l14
+    Return
+      With
+        cte l16 =
+          Get t0
+        cte l17 =
+          Filter (#1 > 7)
+            Get l16
+        cte l18 =
+          Filter (#1 > 7)
+            Get l15
+        cte l19 =
+          Filter (#1 > 7)
+            Get l11
+        cte l20 =
+          Union
+            Get l17
+            Get l18
+            Get l19
+      Return
+        Get l20
+Return
+  Get l21
 
 # From a failing test
 # See https://github.com/MaterializeInc/materialize/pull/19287#issuecomment-1555923422.
@@ -251,48 +251,48 @@ With Mutually Recursive
         Get t0
       Get l1
 ----
-Return
-  Get l15
 With
   cte l15 =
-    Return
-      Return
-        Get l14
-      With
-        cte l14 =
-          Project (#1)
-            Get l13
-        cte l13 =
-          Filter (#1 > 7)
-            Get l12
-        cte l12 =
-          Map ((#0 + #0))
-            Get l6
     With Mutually Recursive
-      cte l11 =
-        Get l10
+      cte l3 =
+        Get t0
+      cte l4 =
+        Project (#0)
+          Get l3
+      cte l5 =
+        Union
+          Get l4
+          Get l11
+      cte l6 =
+        Get l5
+      cte l7 =
+        Map ((#0 + #0))
+          Get l6
+      cte l8 =
+        Filter (#1 > 7)
+          Get l7
+      cte l9 =
+        Project (#1)
+          Get l8
       cte l10 =
         Union
           Get l6
           Get l9
           Get l9
-      cte l9 =
-        Project (#1)
-          Get l8
-      cte l8 =
-        Filter (#1 > 7)
-          Get l7
-      cte l7 =
-        Map ((#0 + #0))
-          Get l6
-      cte l6 =
-        Get l5
-      cte l5 =
-        Union
-          Get l4
-          Get l11
-      cte l4 =
-        Project (#0)
-          Get l3
-      cte l3 =
-        Get t0
+      cte l11 =
+        Get l10
+    Return
+      With
+        cte l12 =
+          Map ((#0 + #0))
+            Get l6
+        cte l13 =
+          Filter (#1 > 7)
+            Get l12
+        cte l14 =
+          Project (#1)
+            Get l13
+      Return
+        Get l14
+Return
+  Get l15

--- a/src/transform/tests/test_transforms/anf.spec
+++ b/src/transform/tests/test_transforms/anf.spec
@@ -108,32 +108,15 @@ Return
 
 # Recursive queries.
 apply pipeline=anf
-Return
-  Get l3
 With
+  cte l0 =
+    Union
+      Project (#0, #1)
+        Get t0
+      Project (#0, #1)
+        Get t0
   cte l3 =
-    Return
-      Union
-        Filter #1 > 7
-          Get t0
-        Filter #1 > 7
-          Get l2
-        Filter #1 > 7
-          Get l1
     With Mutually Recursive
-      cte l2 = // { types: "(bigint, bigint?)" }
-        Distinct project=[#0, #1]
-          Union
-            Filter #1 > 7
-              Get l0
-            Filter #1 > 7
-              Get l1
-            Filter #1 > 7
-              Get l1
-            Filter #1 > 7
-              Get l2
-            Filter #1 > 7
-              Get l2
       cte l1 = // { types: "(bigint, bigint?)" }
         Distinct project=[#0, #1]
           Union
@@ -147,12 +130,29 @@ With
               Get l2
             Filter #1 > 7
               Get l2
-  cte l0 =
-    Union
-      Project (#0, #1)
-        Get t0
-      Project (#0, #1)
-        Get t0
+      cte l2 = // { types: "(bigint, bigint?)" }
+        Distinct project=[#0, #1]
+          Union
+            Filter #1 > 7
+              Get l0
+            Filter #1 > 7
+              Get l1
+            Filter #1 > 7
+              Get l1
+            Filter #1 > 7
+              Get l2
+            Filter #1 > 7
+              Get l2
+    Return
+      Union
+        Filter #1 > 7
+          Get t0
+        Filter #1 > 7
+          Get l2
+        Filter #1 > 7
+          Get l1
+Return
+  Get l3
 ----
 With
   cte l0 =

--- a/src/transform/tests/test_transforms/arity.spec
+++ b/src/transform/tests/test_transforms/arity.spec
@@ -42,11 +42,11 @@ With
   cte l0 =
     Get t0
 ----
-Return // { arity: 2 }
-  Get l0 // { arity: 2 }
 With
   cte l0 =
     Get t0 // { arity: 2 }
+Return // { arity: 2 }
+  Get l0 // { arity: 2 }
 
 # Local Get in a LetRec block
 explain with=arity
@@ -56,11 +56,11 @@ With Mutually Recursive
   cte l0 = // { types: "(bigint, bigint)" }
     Get t0
 ----
-Return // { arity: 2 }
-  Get l0 // { arity: 2 }
 With Mutually Recursive
   cte l0 =
     Get t0 // { arity: 2 }
+Return // { arity: 2 }
+  Get l0 // { arity: 2 }
 
 # Project
 explain with=arity

--- a/src/transform/tests/test_transforms/column_knowledge.spec
+++ b/src/transform/tests/test_transforms/column_knowledge.spec
@@ -60,16 +60,16 @@ With
             Filter #0 = 1 AND #1 = 2
               Get t0
 ----
-Return
-  FlatMap generate_series(2, 7, 1)
-    Project (#2, #0)
-      Get l0
 With
   cte l0 =
     Filter false
       Reduce group_by=[2] aggregates=[sum(3), max(4)]
         Filter true AND false
           Constant <empty>
+Return
+  FlatMap generate_series(2, 7, 1)
+    Project (#2, #0)
+      Get l0
 
 
 # Infer and apply nullability knowledge.
@@ -88,16 +88,16 @@ With
         Filter (#0) IS NULL AND (#1) IS NULL
           Get t0
 ----
-Return
-  Filter false
-    Project (#2)
-      Get l0
 With
   cte l0 =
     Reduce group_by=[false, false] aggregates=[count(false)]
       Map (false, false)
         Filter false AND (#1) IS NULL
           Constant <empty>
+Return
+  Filter false
+    Project (#2)
+      Get l0
 
 
 # Infer and apply constant value knowledge.
@@ -118,18 +118,18 @@ With
       Filter (#0 = 1) AND (#1 = 2)
         Get t0
 ----
-Return
-  Filter true AND false
-    Constant <empty>
 With
-  cte l1 =
-    Project (#0, #0, #1)
-      Filter (#0 = 2) AND (#1 = 3)
-        Get t0
   cte l0 =
     Project (#0, #1, #1)
       Filter (#0 = 1) AND (#1 = 2)
         Get t0
+  cte l1 =
+    Project (#0, #0, #1)
+      Filter (#0 = 2) AND (#1 = 3)
+        Get t0
+Return
+  Filter true AND false
+    Constant <empty>
 
 
 # Infer and apply constant value knowledge.
@@ -145,14 +145,14 @@ With
     Filter ((#0 = 1) AND (#1 = 2))
       Get t0
 ----
+With
+  cte l0 =
+    Filter (#0 = 1) AND (#1 = 2)
+      Get t0
 Return
   Map (6, (3 * #3))
     Join on=(3 = #2)
       Get l0
-      Get t0
-With
-  cte l0 =
-    Filter (#0 = 1) AND (#1 = 2)
       Get t0
 
 
@@ -196,6 +196,13 @@ With
       Filter (#0) IS NOT NULL
         Get t3
 ----
+With
+  cte l0 =
+    Join on=(#0 = #2)
+      Filter (#0) IS NOT NULL
+        Get t2
+      Filter (#0) IS NOT NULL
+        Get t3
 Return
   Project (#0, #1, #3..=#6)
     Map ((#0) IS NULL, #4, (#2) IS NULL)
@@ -210,13 +217,6 @@ Return
                     Get l0
             Get t2
         Get l0
-With
-  cte l0 =
-    Join on=(#0 = #2)
-      Filter (#0) IS NOT NULL
-        Get t2
-      Filter (#0) IS NOT NULL
-        Get t3
 
 
 ## LetRec cases
@@ -235,8 +235,6 @@ With Mutually Recursive
         Filter (#0 = 1)
           Get l0
 ----
-Return
-  Get l0
 With Mutually Recursive
   cte l0 =
     Distinct project=[1]
@@ -245,6 +243,8 @@ With Mutually Recursive
           - (1)
         Filter true
           Get l0
+Return
+  Get l0
 
 
 # Single binding, value knowledge
@@ -260,9 +260,6 @@ With Mutually Recursive
           Get t0
           Get l0
 ----
-Return
-  Map (8)
-    Get l0
 With Mutually Recursive
   cte l0 =
     Filter (#0 = 3) AND (#1 = 5)
@@ -270,6 +267,9 @@ With Mutually Recursive
         Union
           Get t0
           Get l0
+Return
+  Map (8)
+    Get l0
 
 
 # Single binding, NOT NULL knowledge
@@ -285,9 +285,6 @@ With Mutually Recursive
           Get t0
           Get l0
 ----
-Return
-  Map (true)
-    Get l0
 With Mutually Recursive
   cte l0 =
     Filter (#1) IS NOT NULL
@@ -295,6 +292,9 @@ With Mutually Recursive
         Union
           Get t0
           Get l0
+Return
+  Map (true)
+    Get l0
 
 
 # Multiple bindings, value knowledge
@@ -319,9 +319,14 @@ With Mutually Recursive
         Filter (#0 = 1)
           Get l0
 ----
-Return
-  Get l1
 With Mutually Recursive
+  cte l0 =
+    Distinct project=[1]
+      Union
+        Constant
+          - (1)
+        Filter true
+          Get l0
   cte l1 =
     Distinct project=[2, #1, #2]
       Union
@@ -331,13 +336,8 @@ With Mutually Recursive
               Get l0
               Get t0
         Get l1
-  cte l0 =
-    Distinct project=[1]
-      Union
-        Constant
-          - (1)
-        Filter true
-          Get l0
+Return
+  Get l1
 
 
 
@@ -366,9 +366,14 @@ With Mutually Recursive
         Filter (#0 IS NOT NULL)
           Get l0
 ----
-Return
-  Get l1
 With Mutually Recursive
+  cte l0 =
+    Distinct project=[1]
+      Union
+        Constant
+          - (1)
+        Filter true
+          Get l0
   cte l1 =
     Distinct project=[false, #1, #2]
       Union
@@ -378,13 +383,8 @@ With Mutually Recursive
               Get l0
               Get t0
         Get l1
-  cte l0 =
-    Distinct project=[1]
-      Union
-        Constant
-          - (1)
-        Filter true
-          Get l0
+Return
+  Get l1
 
 
 

--- a/src/transform/tests/test_transforms/column_names.spec
+++ b/src/transform/tests/test_transforms/column_names.spec
@@ -50,11 +50,11 @@ With
   cte l0 =
     Get t0
 ----
-Return // { column_names: "(c0, c1)" }
-  Get l0 // { column_names: "(c0, c1)" }
 With
   cte l0 =
     Get t0 // { column_names: "(c0, c1)" }
+Return // { column_names: "(c0, c1)" }
+  Get l0 // { column_names: "(c0, c1)" }
 
 # Local Get in a LetRec block
 explain with=column_names
@@ -64,11 +64,11 @@ With Mutually Recursive
   cte l0 = // { types: "(bigint, bigint)" }
     Get t0
 ----
-Return // { column_names: "(c0, c1)" }
-  Get l0 // { column_names: "(c0, c1)" }
 With Mutually Recursive
   cte l0 =
     Get t0 // { column_names: "(c0, c1)" }
+Return // { column_names: "(c0, c1)" }
+  Get l0 // { column_names: "(c0, c1)" }
 
 # Project
 explain with=column_names

--- a/src/transform/tests/test_transforms/humanized_exprs.spec
+++ b/src/transform/tests/test_transforms/humanized_exprs.spec
@@ -42,11 +42,11 @@ With
   cte l0 =
     Get t0
 ----
-Return
-  Get l0
 With
   cte l0 =
     Get t0
+Return
+  Get l0
 
 # Local Get in a LetRec block
 explain with=humanized_exprs
@@ -56,11 +56,11 @@ With Mutually Recursive
   cte l0 = // { types: "(bigint, bigint)" }
     Get t0
 ----
-Return
-  Get l0
 With Mutually Recursive
   cte l0 =
     Get t0
+Return
+  Get l0
 
 # Project
 explain with=humanized_exprs

--- a/src/transform/tests/test_transforms/literal_lifting.spec
+++ b/src/transform/tests/test_transforms/literal_lifting.spec
@@ -134,10 +134,6 @@ With Mutually Recursive
           - (1, 42)
           - (2, 42)
 ----
-Return
-  Project (#0, #2, #1)
-    Map ((#0 + 42), 42)
-      Get l0
 With Mutually Recursive
   cte l0 =
     Distinct project=[#0]
@@ -147,6 +143,10 @@ With Mutually Recursive
         Constant
           - (1)
           - (2)
+Return
+  Project (#0, #2, #1)
+    Map ((#0 + 42), 42)
+      Get l0
 
 
 # Multiple bindings, value knowledge
@@ -173,9 +173,13 @@ With Mutually Recursive
         Map (17)
           Constant <empty> // { types: "()" }
 ----
-Return
-  Get l1
 With Mutually Recursive
+  cte l0 =
+    Distinct project=[]
+      Union
+        Constant
+          - ()
+        Constant <empty>
   cte l1 =
     Map (17)
       Distinct project=[#0, #1]
@@ -185,9 +189,5 @@ With Mutually Recursive
             Get l0
           Project (#0, #1)
             Get l1
-  cte l0 =
-    Distinct project=[]
-      Union
-        Constant
-          - ()
-        Constant <empty>
+Return
+  Get l1

--- a/src/transform/tests/test_transforms/non_null_requirements.spec
+++ b/src/transform/tests/test_transforms/non_null_requirements.spec
@@ -91,16 +91,16 @@ With
     Map (null::bigint)
       Get t0
 ----
-Return
-  Filter (#2 > 0)
-    Get l1
 With
+  cte l0 =
+    Constant <empty>
   cte l1 =
     ArrangeBy keys=[[#0]]
       Threshold
         Get l0
-  cte l0 =
-    Constant <empty>
+Return
+  Filter (#2 > 0)
+    Get l1
 
 
 # Regression test for database-issues#1700
@@ -146,21 +146,21 @@ With Mutually Recursive
     Map (null::bigint)
       Get t0
 ----
-Return
-  Filter (#0 < 7) AND (#2 > 0)
-    Union
-      Get l2
-      Get l1
 With Mutually Recursive
-  cte l2 =
-    ArrangeBy keys=[[#0]]
-      Threshold
-        Get l0
+  cte l0 =
+    Constant <empty>
   cte l1 =
     Distinct project=[#0..=#2]
       Union
         Get l1
         Filter (#2 > 0)
           Get l0
-  cte l0 =
-    Constant <empty>
+  cte l2 =
+    ArrangeBy keys=[[#0]]
+      Threshold
+        Get l0
+Return
+  Filter (#0 < 7) AND (#2 > 0)
+    Union
+      Get l2
+      Get l1

--- a/src/transform/tests/test_transforms/normalize_lets.spec
+++ b/src/transform/tests/test_transforms/normalize_lets.spec
@@ -60,14 +60,14 @@ With Mutually Recursive
     Filter #0 > 0
       Get t0
 ----
-Return
-  Union
-    Get l0
-    Get l0
 With
   cte l0 =
     Filter (#0 > 0)
       Get t0
+Return
+  Union
+    Get l0
+    Get l0
 
 # Promote non-recursive Let bindings up the tree.
 apply pipeline=normalize_lets
@@ -94,24 +94,24 @@ Project (#0, #2)
           Project (#1, #0)
             Get t0
 ----
-Return
-  Project (#0, #2)
-    CrossJoin
-      Get l2
-      Get l2
 With
-  cte l2 =
-    Union
-      Get l1
-      Get l1
+  cte l0 =
+    Project (#1, #0)
+      Get t0
   cte l1 =
     Project (#0, #3)
       CrossJoin
         Get l0
         Get l0
-  cte l0 =
-    Project (#1, #0)
-      Get t0
+  cte l2 =
+    Union
+      Get l1
+      Get l1
+Return
+  Project (#0, #2)
+    CrossJoin
+      Get l2
+      Get l2
 
 # Promote LetRec nodes up the tree.
 apply pipeline=normalize_lets
@@ -133,23 +133,23 @@ Map ("return_inner")
                 Get l0
               Get t0
 ----
-Return
-  Map ("return_inner")
-    Get l1
 With Mutually Recursive
   cte l1 =
-    Return
-      Filter (#0 < 100)
-        Union
-          Filter (#0 < 20)
-            Get l1
-          Get l0
     With Mutually Recursive
       cte l0 =
         Union
           Filter (#0 < 10)
             Get l0
           Get t0
+    Return
+      Filter (#0 < 100)
+        Union
+          Filter (#0 < 20)
+            Get l1
+          Get l0
+Return
+  Map ("return_inner")
+    Get l1
 
 # Don't inline Let bindings with multiple references.
 apply pipeline=normalize_lets
@@ -164,16 +164,16 @@ With
     Filter #0 > 0
       Get t0
 ----
+With
+  cte l0 =
+    Filter (#0 > 0)
+      Get t0
 Return
   Union
     Project (#1)
       Get l0
     Project (#0)
       Get l0
-With
-  cte l0 =
-    Filter (#0 > 0)
-      Get t0
 
 # Fuse an outer Let into an inner LetRec.
 apply pipeline=normalize_lets
@@ -196,21 +196,21 @@ With
     Map (null::bigint)
       Get t0
 ----
-Return
-  Return
-    Union
-      Get l2
-      Get l2
-  With
-    cte l2 =
-      Filter (#0 > 0)
-        Get l1
 With Mutually Recursive
+  cte l0 =
+    Map (null)
+      Get t0
   cte l1 =
     Union
       Get l0
       Get l0
       Get l1
-  cte l0 =
-    Map (null)
-      Get t0
+Return
+  With
+    cte l2 =
+      Filter (#0 > 0)
+        Get l1
+  Return
+    Union
+      Get l2
+      Get l2

--- a/src/transform/tests/test_transforms/predicate_pushdown.spec
+++ b/src/transform/tests/test_transforms/predicate_pushdown.spec
@@ -47,10 +47,12 @@ With
       - ("a", 1, 2)
       - ("b", 3, 4)
 ----
-Return
-  Filter
-    Get l1
 With
+  cte l0 =
+    Filter (#0 = "a")
+      Constant
+        - ("a", 1, 2)
+        - ("b", 3, 4)
   cte l1 =
     Distinct project=[#0..=#2]
       Union
@@ -62,11 +64,9 @@ With
               Get t1
         Filter (#0 = "a")
           Get t1
-  cte l0 =
-    Filter (#0 = "a")
-      Constant
-        - ("a", 1, 2)
-        - ("b", 3, 4)
+Return
+  Filter
+    Get l1
 
 
 ## LetRec cases
@@ -88,9 +88,6 @@ With Mutually Recursive
             Get l0
             Get l0
 ----
-Return
-  Filter (#0 = "foo")
-    Get l0
 With Mutually Recursive
   cte l0 =
     Distinct project=[#0, #1]
@@ -101,3 +98,6 @@ With Mutually Recursive
           Join on=(#1 = #2)
             Get l0
             Get l0
+Return
+  Filter (#0 = "foo")
+    Get l0

--- a/src/transform/tests/test_transforms/projection_lifting.spec
+++ b/src/transform/tests/test_transforms/projection_lifting.spec
@@ -162,14 +162,8 @@ With Mutually Recursive
       Project (#1, #1)
         Get t1
 ----
-Return
-  Project (#1, #1, #3, #4, #6, #6)
-    Join on=(#1 = #3)
-      Get l2
-      Get l1
-      Get l0
 With Mutually Recursive
-  cte l2 =
+  cte l0 =
     Filter (#1) IS NOT NULL
       Get t1
   cte l1 =
@@ -178,6 +172,12 @@ With Mutually Recursive
         Get t0
         Project (#1, #1)
           Get l0
-  cte l0 =
+  cte l2 =
     Filter (#1) IS NOT NULL
       Get t1
+Return
+  Project (#1, #1, #3, #4, #6, #6)
+    Join on=(#1 = #3)
+      Get l2
+      Get l1
+      Get l0

--- a/src/transform/tests/test_transforms/projection_pushdown.spec
+++ b/src/transform/tests/test_transforms/projection_pushdown.spec
@@ -351,13 +351,6 @@ With
       Get x
       Get y
 ----
-Return
-  Project (#1)
-    Join on=(#0 = #2)
-      Project (#0, #2)
-        Get l0
-      Project (#1)
-        Get l0
 With
   cte l0 =
     Project (#0, #1, #3)
@@ -366,6 +359,13 @@ With
           Get x
         Project (#0, #2)
           Get y
+Return
+  Project (#1)
+    Join on=(#0 = #2)
+      Project (#0, #2)
+        Get l0
+      Project (#1)
+        Get l0
 
 # Project around a Let (2)
 apply pipeline=projection_pushdown
@@ -380,12 +380,6 @@ With
       Get x
       Get y
 ----
-Return
-  Project (#1)
-    Join on=(#0 = #2)
-      Get l0
-      Project (#1)
-        Get l0
 With
   cte l0 =
     Project (#0, #1)
@@ -394,6 +388,12 @@ With
           Get x
         Project (#0)
           Get y
+Return
+  Project (#1)
+    Join on=(#0 = #2)
+      Get l0
+      Project (#1)
+        Get l0
 
 # Project around a Let (3)
 apply pipeline=projection_pushdown
@@ -410,6 +410,11 @@ With
     Map (1)
       Get x
 ----
+With
+  cte l0 =
+    Map (1)
+      Project (#0, #1)
+        Get x
 Return
   Union
     Join on=(#0 = #1)
@@ -418,11 +423,6 @@ Return
       Get y
     Project (#0, #1, #0, #2)
       Get l0
-With
-  cte l0 =
-    Map (1)
-      Project (#0, #1)
-        Get x
 
 
 ## LetRec cases
@@ -442,13 +442,6 @@ With Mutually Recursive
       Get x
       Get y
 ----
-Return
-  Project (#1)
-    Join on=(#0 = #2)
-      Project (#0, #2)
-        Get l0
-      Project (#1)
-        Get l0
 With Mutually Recursive
   cte l0 =
     Project (#0, #1, #3)
@@ -457,6 +450,13 @@ With Mutually Recursive
           Get x
         Project (#0, #2)
           Get y
+Return
+  Project (#1)
+    Join on=(#0 = #2)
+      Project (#0, #2)
+        Get l0
+      Project (#1)
+        Get l0
 
 # Project around a LetRec (2)
 apply pipeline=projection_pushdown
@@ -471,12 +471,6 @@ With Mutually Recursive
       Get x
       Get y
 ----
-Return
-  Project (#1)
-    Join on=(#0 = #2)
-      Get l0
-      Project (#1)
-        Get l0
 With Mutually Recursive
   cte l0 =
     Project (#0, #1)
@@ -485,6 +479,12 @@ With Mutually Recursive
           Get x
         Project (#0)
           Get y
+Return
+  Project (#1)
+    Join on=(#0 = #2)
+      Get l0
+      Project (#1)
+        Get l0
 
 # Project around a LetRec (3)
 apply pipeline=projection_pushdown
@@ -501,6 +501,11 @@ With Mutually Recursive
     Map (1)
       Get x
 ----
+With Mutually Recursive
+  cte l0 =
+    Map (1)
+      Project (#0, #1)
+        Get x
 Return
   Union
     Join on=(#0 = #1)
@@ -509,11 +514,6 @@ Return
       Get y
     Project (#0, #1, #0, #2)
       Get l0
-With Mutually Recursive
-  cte l0 =
-    Map (1)
-      Project (#0, #1)
-        Get x
 
 
 # Three bindings, l0 and l2 are not recursive
@@ -537,14 +537,10 @@ With Mutually Recursive
   cte l0 = // { types: "(bigint, bigint, bigint)" }
     Get x
 ----
-Return
-  Join on=(#0 = #1)
-    Get l2
-    Project (#0)
-      Get l1
 With Mutually Recursive
-  cte l2 =
-    Get l0
+  cte l0 =
+    Project (#0)
+      Get x
   cte l1 =
     Project (#0, #0, #0)
       Distinct project=[#0]
@@ -553,6 +549,10 @@ With Mutually Recursive
             Get l1
           Project (#0)
             Get x
-  cte l0 =
+  cte l2 =
+    Get l0
+Return
+  Join on=(#0 = #1)
+    Get l2
     Project (#0)
-      Get x
+      Get l1

--- a/src/transform/tests/test_transforms/redundant_join.spec
+++ b/src/transform/tests/test_transforms/redundant_join.spec
@@ -105,14 +105,14 @@ With
     Map (3)
       Get x
 ----
-Return
-  Map (#1, (#2 > #1))
-    Project (#2, #1, #0)
-      Get l0
 With
   cte l0 =
     Map (3)
       Get x
+Return
+  Map (#1, (#2 > #1))
+    Project (#2, #1, #0)
+      Get l0
 
 
 
@@ -142,15 +142,15 @@ With
     Distinct project=[#0]
       Get x
 ----
+With
+  cte l0 =
+    Distinct project=[#0]
+      Get x
 Return
   Project (#0..=#2)
     Map (#0)
       CrossJoin
         Get x
-With
-  cte l0 =
-    Distinct project=[#0]
-      Get x
 
 
 # Distinct handling.
@@ -193,8 +193,6 @@ With Mutually Recursive
             Project (#0)
               Get x
 ----
-Return
-  Get l0
 With Mutually Recursive
   cte l0 =
     Distinct project=[#0..=#2]
@@ -204,6 +202,8 @@ With Mutually Recursive
           Map ((#0 % 2))
             CrossJoin
               Get x
+Return
+  Get l0
 
 
 # Ensure that we're not double-counting in `remove_uses`.
@@ -224,18 +224,18 @@ With Mutually Recursive
           Get l1
           Get l0
 ----
-Return
-  Get l1
 With Mutually Recursive
   cte l1 =
+    With Mutually Recursive
+      cte l0 =
+        Union
+          Get l1
+          Get l0
     Return
       Threshold
         Union
           Get l1
           Negate
             Get l0
-    With Mutually Recursive
-      cte l0 =
-        Union
-          Get l1
-          Get l0
+Return
+  Get l1

--- a/src/transform/tests/test_transforms/relation_cse.spec
+++ b/src/transform/tests/test_transforms/relation_cse.spec
@@ -27,14 +27,14 @@ Union
   Map (null::bigint)
     Get t0
 ----
-Return
-  Union
-    Get l0
-    Get l0
 With
   cte l0 =
     Map (null)
       Get t0
+Return
+  Union
+    Get l0
+    Get l0
 
 
 ## LetRec cases
@@ -87,26 +87,21 @@ With
       Project (#0, #1)
         Get t0
 ----
-Return
-  Union
-    Filter (#1 > 7)
+With Mutually Recursive
+  cte l0 =
+    Project (#0, #1)
       Get t0
+  cte l1 =
+    Filter (#1 > 7)
+      Union
+        Get l0
+        Get l0
+  cte l2 =
+    Filter (#1 > 7)
+      Get l4
+  cte l3 =
     Filter (#1 > 7)
       Get l6
-    Filter (#1 > 7)
-      Get l4
-With Mutually Recursive
-  cte l6 =
-    Distinct project=[#0, #1]
-      Union
-        Get l1
-        Get l5
-        Get l5
-        Get l3
-        Get l3
-  cte l5 =
-    Filter (#1 > 7)
-      Get l4
   cte l4 =
     Distinct project=[#0, #1]
       Union
@@ -115,17 +110,22 @@ With Mutually Recursive
         Get l2
         Get l3
         Get l3
-  cte l3 =
-    Filter (#1 > 7)
-      Get l6
-  cte l2 =
+  cte l5 =
     Filter (#1 > 7)
       Get l4
-  cte l1 =
-    Filter (#1 > 7)
+  cte l6 =
+    Distinct project=[#0, #1]
       Union
-        Get l0
-        Get l0
-  cte l0 =
-    Project (#0, #1)
+        Get l1
+        Get l5
+        Get l5
+        Get l3
+        Get l3
+Return
+  Union
+    Filter (#1 > 7)
       Get t0
+    Filter (#1 > 7)
+      Get l6
+    Filter (#1 > 7)
+      Get l4

--- a/src/transform/tests/test_transforms/semijoin_idempotence.spec
+++ b/src/transform/tests/test_transforms/semijoin_idempotence.spec
@@ -49,6 +49,11 @@ With
       Get t0
       Get t1
 ----
+With
+  cte l0 =
+    Join on=(#0 = #3)
+      Get t0
+      Get t1
 Return
   Union
     Map (null, null)
@@ -62,11 +67,6 @@ Return
         Get t0
     Project (#0..=#2, #0, #4)
       Get l0
-With
-  cte l0 =
-    Join on=(#0 = #3)
-      Get t0
-      Get t1
 
 
 ## LetRec cases

--- a/src/transform/tests/test_transforms/threshold_elision.spec
+++ b/src/transform/tests/test_transforms/threshold_elision.spec
@@ -138,12 +138,6 @@ With
           Filter #0 < 7
             Get x
 ----
-Return
-  Union
-    Get l0
-    Negate
-      Filter (#0 > 9)
-        Get l0
 With
   cte l0 =
     Union
@@ -151,3 +145,9 @@ With
       Negate
         Filter (#0 < 7)
           Get x
+Return
+  Union
+    Get l0
+    Negate
+      Filter (#0 > 9)
+        Get l0

--- a/src/transform/tests/test_transforms/typecheck.spec
+++ b/src/transform/tests/test_transforms/typecheck.spec
@@ -125,11 +125,11 @@ With
 ----
 ----
 In the MIR term:
-Return
-  Get l0
 With
   cte l0 =
     Get t0
+Return
+  Get l0
 
 
 id l0 is shadowed
@@ -180,17 +180,17 @@ With Mutually Recursive
 ----
 ----
 In the MIR term:
-Return
-  Union
-    Get l0
-    Filter (#0 > 1)
-      Get l0
 With Mutually Recursive
   cte l0 =
     Union
       Get l0
       Filter (#0 > 42)
         Get t0
+Return
+  Union
+    Get l0
+    Filter (#0 > 1)
+      Get l0
 
 
 id l0 is shadowed
@@ -211,15 +211,15 @@ With Mutually Recursive
 ----
 ----
 In the MIR term:
-Return
-  Filter #0 AND #1
-    Get l0
 With Mutually Recursive
+  cte l1 =
+    Get l1
   cte l0 =
     Constant
       - (1, 3)
-  cte l1 =
-    Get l1
+Return
+  Filter #0 AND #1
+    Get l0
 
 
 mismatched column types: couldn't compute union of column types in let rec: Can't union types: Bool and Int64

--- a/src/transform/tests/test_transforms/typecheck.spec
+++ b/src/transform/tests/test_transforms/typecheck.spec
@@ -201,25 +201,25 @@ id l0 is shadowed
 typecheck
 Return
   Filter #0 AND #1
-    Get l0
+    Get l1
 With Mutually Recursive
-  cte l0 = // { types: "(boolean?, boolean)" }
+  cte l1 = // { types: "(boolean?, boolean)" }
     Constant // { types: "(bigint, bigint)" }
       - (1, 3)
-  cte l1 = // { types: "(boolean, boolean?)" }
-    Get l1
+  cte l0 = // { types: "(boolean, boolean?)" }
+    Get l0
 ----
 ----
 In the MIR term:
 With Mutually Recursive
-  cte l1 =
-    Get l1
   cte l0 =
+    Get l0
+  cte l1 =
     Constant
       - (1, 3)
 Return
   Filter #0 AND #1
-    Get l0
+    Get l1
 
 
 mismatched column types: couldn't compute union of column types in let rec: Can't union types: Bool and Int64

--- a/src/transform/tests/test_transforms/types.spec
+++ b/src/transform/tests/test_transforms/types.spec
@@ -42,11 +42,11 @@ With
   cte l0 =
     Get t0
 ----
-Return // { types: "(Int64, Int16)" }
-  Get l0 // { types: "(Int64, Int16)" }
 With
   cte l0 =
     Get t0 // { types: "(Int64, Int16)" }
+Return // { types: "(Int64, Int16)" }
+  Get l0 // { types: "(Int64, Int16)" }
 
 # Local Get in a LetRec block
 explain with=types
@@ -56,11 +56,11 @@ With Mutually Recursive
   cte l0 = // { types: "(bigint, smallint)" }
     Get t0
 ----
-Return // { types: "(Int64, Int16)" }
-  Get l0 // { types: "(Int64, Int16)" }
 With Mutually Recursive
   cte l0 =
     Get t0 // { types: "(Int64, Int16)" }
+Return // { types: "(Int64, Int16)" }
+  Get l0 // { types: "(Int64, Int16)" }
 
 # Project
 explain with=types

--- a/src/transform/tests/test_transforms/union_branch_cancellation.spec
+++ b/src/transform/tests/test_transforms/union_branch_cancellation.spec
@@ -71,7 +71,7 @@ Union
     Get x
 ----
 parse error at 1:0:
-expected one of: `Constant`, `Get`, `Return`, `Project`, `Map`, `FlatMap`, `Filter`, `CrossJoin`, `Join`, `Distinct`, `Reduce`, `TopK`, `Negate`, `Threshold`, `Union`, `ArrangeBy`
+expected one of: `Constant`, `Get`, `Return`, `With`, `Project`, `Map`, `FlatMap`, `Filter`, `CrossJoin`, `Join`, `Distinct`, `Reduce`, `TopK`, `Negate`, `Threshold`, `Union`, `ArrangeBy`
 
 
 apply pipeline=union_branch_cancellation

--- a/src/transform/tests/testdata/join-implementation
+++ b/src/transform/tests/testdata/join-implementation
@@ -15,6 +15,10 @@ ok
 opt
 (join [(get x) (get x)] [[#0 #3]])
 ----
+With
+  cte l0 =
+    ArrangeBy keys=[[#0]]
+      Get x
 Return
   Project (#0..=#2, #0, #4, #5)
     Join on=(#0 = #3) type=differential
@@ -22,10 +26,6 @@ Return
         %0:l0[#0]K » %1:l0[#0]K
       Get l0
       Get l0
-With
-  cte l0 =
-    ArrangeBy keys=[[#0]]
-      Get x
 
 # tests single-input predicates properly get pushed out of join equivalences
 # using different combinations of literals and non-literals with different multiplicities
@@ -61,17 +61,17 @@ Filter (#0 = 5) AND (#1 = 5)
 opt
 (join [(get x) (get x)] [[5 #0 5 #3]])
 ----
+With
+  cte l0 =
+    ArrangeBy keys=[[]]
+      Filter (#0 = 5)
+        Get x
 Return
   CrossJoin type=differential
     implementation
       %0:l0[×]ef » %1:l0[×]ef
     Get l0
     Get l0
-With
-  cte l0 =
-    ArrangeBy keys=[[]]
-      Filter (#0 = 5)
-        Get x
 
 opt
 (join [(get x) (get x)] [[5 9 #0 #3]])

--- a/src/transform/tests/testdata/lifting
+++ b/src/transform/tests/testdata/lifting
@@ -292,16 +292,16 @@ opt
      (map (get y) [1])
      [#2 #1])])
 ----
+With
+  cte l0 =
+    Map (1)
+      Get y
 Return
   Union
     Project (#2, #0)
       Get l0
     Project (#2, #1)
       Get l0
-With
-  cte l0 =
-    Map (1)
-      Get y
 
 build format=types apply=LiteralLifting
 (constant [[1 2 3] [1 4 3]] ([int64 int64 int64] [[1 2]]))

--- a/src/transform/tests/testdata/projection-pushdown
+++ b/src/transform/tests/testdata/projection-pushdown
@@ -349,13 +349,6 @@ build apply=ProjectionPushdown
     )
 )
 ----
-Return
-  Project (#1)
-    Join on=(#0 = #2)
-      Project (#0, #2)
-        Get l0
-      Project (#1)
-        Get l0
 With
   cte l0 =
     Project (#0, #1, #3)
@@ -364,6 +357,13 @@ With
           Get x
         Project (#0, #2)
           Get y
+Return
+  Project (#1)
+    Join on=(#0 = #2)
+      Project (#0, #2)
+        Get l0
+      Project (#1)
+        Get l0
 
 build apply=ProjectionPushdown
 (let z
@@ -377,12 +377,6 @@ build apply=ProjectionPushdown
     )
 )
 ----
-Return
-  Project (#1)
-    Join on=(#0 = #2)
-      Get l0
-      Project (#1)
-        Get l0
 With
   cte l0 =
     Project (#0, #1)
@@ -391,6 +385,12 @@ With
           Get x
         Project (#0)
           Get y
+Return
+  Project (#1)
+    Join on=(#0 = #2)
+      Get l0
+      Project (#1)
+        Get l0
 
 build apply=ProjectionPushdown
 (let z
@@ -403,6 +403,11 @@ build apply=ProjectionPushdown
     )
 )
 ----
+With
+  cte l0 =
+    Map (1)
+      Project (#0, #1)
+        Get x
 Return
   Union
     Join on=(#0 = #1)
@@ -411,8 +416,3 @@ Return
       Get y
     Project (#0, #1, #0, #2)
       Get l0
-With
-  cte l0 =
-    Map (1)
-      Project (#0, #1)
-        Get x

--- a/src/transform/tests/testdata/typ
+++ b/src/transform/tests/testdata/typ
@@ -53,14 +53,14 @@ build format=types
 (let z (project (get y) [#1 #0 #2])
     (union [(get z) (get z)]))
 ----
-Return // { types: "(Int32?, Int64?, Int32?)", keys: "()" }
-  Union // { types: "(Int32?, Int64?, Int32?)", keys: "()" }
-    Get l0 // { types: "(Int32?, Int64?, Int32?)", keys: "()" }
-    Get l0 // { types: "(Int32?, Int64?, Int32?)", keys: "()" }
 With
   cte l0 =
     Project (#1, #0, #2) // { types: "(Int32?, Int64?, Int32?)", keys: "()" }
       Get y // { types: "(Int64?, Int32?, Int32?)", keys: "()" }
+Return // { types: "(Int32?, Int64?, Int32?)", keys: "()" }
+  Union // { types: "(Int32?, Int64?, Int32?)", keys: "()" }
+    Get l0 // { types: "(Int32?, Int64?, Int32?)", keys: "()" }
+    Get l0 // { types: "(Int32?, Int64?, Int32?)", keys: "()" }
 
 build format=types
 (join [(get x) (get y)] [])

--- a/test/sqllogictest/advent-of-code/2023/aoc_1201.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1201.slt
@@ -45,6 +45,10 @@ FROM (
 );
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[sum(((text_to_integer(left(regexp_replace["[^\d]", case_insensitive=false, limit=0](#0, ""), 1)) * 10) + text_to_integer(right(regexp_replace["[^\d]", case_insensitive=false, limit=0](#0, ""), 1))))]
+        ReadStorage materialize.public.aoc_1201
   Return
     Union
       Get l0
@@ -55,10 +59,6 @@ Explained Query:
               Get l0
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum(((text_to_integer(left(regexp_replace["[^\d]", case_insensitive=false, limit=0](#0, ""), 1)) * 10) + text_to_integer(right(regexp_replace["[^\d]", case_insensitive=false, limit=0](#0, ""), 1))))]
-        ReadStorage materialize.public.aoc_1201
 
 Source materialize.public.aoc_1201
 
@@ -125,29 +125,7 @@ FROM first, last
 WHERE first.line = last.line
 ----
 Explained Query:
-  Return
-    Union
-      Get l1
-      Map (null)
-        Union
-          Negate
-            Project ()
-              Get l1
-          Constant
-            - ()
   With
-    cte l1 =
-      Reduce aggregates=[sum(((#0 * 10) + #1))]
-        Project (#1, #3)
-          Join on=(#0 = #2) type=differential
-            ArrangeBy keys=[[#0]]
-              Project (#0, #2)
-                TopK group_by=[#0] order_by=[#1 asc nulls_last] limit=1
-                  Get l0
-            ArrangeBy keys=[[#0]]
-              Project (#0, #2)
-                TopK group_by=[#0] order_by=[#1 desc nulls_first] limit=1
-                  Get l0
     cte l0 =
       Project (#0, #1, #4)
         Join on=(#3 = substr(#0, #1, #2)) type=delta
@@ -186,6 +164,28 @@ Explained Query:
               - ("eight", 8)
               - ("seven", 7)
               - ("three", 3)
+    cte l1 =
+      Reduce aggregates=[sum(((#0 * 10) + #1))]
+        Project (#1, #3)
+          Join on=(#0 = #2) type=differential
+            ArrangeBy keys=[[#0]]
+              Project (#0, #2)
+                TopK group_by=[#0] order_by=[#1 asc nulls_last] limit=1
+                  Get l0
+            ArrangeBy keys=[[#0]]
+              Project (#0, #2)
+                TopK group_by=[#0] order_by=[#1 desc nulls_first] limit=1
+                  Get l0
+  Return
+    Union
+      Get l1
+      Map (null)
+        Union
+          Negate
+            Project ()
+              Get l1
+          Constant
+            - ()
 
 Source materialize.public.aoc_1201
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1202.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1202.slt
@@ -70,6 +70,13 @@ EXPLAIN WITH game_cnt AS (
         SELECT SUM(game_id) FROM game_cnt WHERE total_set_cnt = possible_set_cnt;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[sum(text_to_integer(split_string(#0, " ", 2)))]
+        Project (#0)
+          Filter (#1 = #2)
+            Reduce group_by=[#0] aggregates=[count(#1), count(case when ((#2 <= 13) AND (#3 <= 12) AND (#4 <= 14)) then #1 else null end)]
+              ReadStorage materialize.public.aoc_1202
   Return
     Union
       Get l0
@@ -80,13 +87,6 @@ Explained Query:
               Get l0
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum(text_to_integer(split_string(#0, " ", 2)))]
-        Project (#0)
-          Filter (#1 = #2)
-            Reduce group_by=[#0] aggregates=[count(#1), count(case when ((#2 <= 13) AND (#3 <= 12) AND (#4 <= 14)) then #1 else null end)]
-              ReadStorage materialize.public.aoc_1202
 
 Source materialize.public.aoc_1202
 
@@ -119,6 +119,13 @@ GROUP BY split_part(game_id,' ', 2)::int
 SELECT SUM(green_min*red_min*blue_min) FROM game_min;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[sum(((#0 * #1) * #2))]
+        Project (#1..=#3)
+          Reduce group_by=[text_to_integer(split_string(#0, " ", 2))] aggregates=[max(#1), max(#2), max(#3)]
+            Project (#0, #2..=#4)
+              ReadStorage materialize.public.aoc_1202
   Return
     Union
       Get l0
@@ -129,13 +136,6 @@ Explained Query:
               Get l0
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum(((#0 * #1) * #2))]
-        Project (#1..=#3)
-          Reduce group_by=[text_to_integer(split_string(#0, " ", 2))] aggregates=[max(#1), max(#2), max(#3)]
-            Project (#0, #2..=#4)
-              ReadStorage materialize.public.aoc_1202
 
 Source materialize.public.aoc_1202
 
@@ -212,58 +212,24 @@ EXPLAIN with mutually recursive
 select * from part1, part2;
 ----
 Explained Query:
-  Return
-    CrossJoin type=differential
-      ArrangeBy keys=[[]]
-        Union
-          Get l3
-          Map (null)
-            Union
-              Negate
-                Project ()
-                  Get l3
-              Constant
-                - ()
-      ArrangeBy keys=[[]]
-        Project (#1)
-          Map (numeric_to_bigint(#0))
-            Union
-              Get l5
-              Map (null)
-                Union
-                  Negate
-                    Project ()
-                      Get l5
-                  Constant
-                    - ()
   With
-    cte l5 =
-      Reduce aggregates=[sum(#0)]
-        Project (#1)
-          Reduce group_by=[#0] aggregates=[count(*)]
-            Project (#0)
-              Join on=(#0 = #1 = #2) type=delta
-                ArrangeBy keys=[[#0]]
-                  Project (#0)
-                    FlatMap generate_series(1, #1, 1)
-                      Project (#0, #2)
-                        Filter (#1 = "red")
-                          Get l4
-                ArrangeBy keys=[[#0]]
-                  Project (#0)
-                    FlatMap generate_series(1, #1, 1)
-                      Project (#0, #2)
-                        Filter (#1 = "blue")
-                          Get l4
-                ArrangeBy keys=[[#0]]
-                  Project (#0)
-                    FlatMap generate_series(1, #1, 1)
-                      Project (#0, #2)
-                        Filter (#1 = "green")
-                          Get l4
-    cte l4 =
-      Reduce group_by=[#0, #1] aggregates=[max(#2)]
-        Get l1
+    cte l0 =
+      Project (#3, #5, #6)
+        Map (text_to_integer(substr(#0, 5)), regexp_split_to_array[" ", case_insensitive=false](#2), array_index(#4, 3), text_to_integer(array_index(#4, 2)))
+          FlatMap unnest_array(regexp_split_to_array[",", case_insensitive=false](#1))
+            Project (#0, #2)
+              FlatMap unnest_array(regexp_split_to_array[";", case_insensitive=false](#1))
+                Project (#3, #4)
+                  Map (regexp_split_to_array[":", case_insensitive=false](#1), array_index(#2, 1), array_index(#2, 2))
+                    FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
+                      ReadStorage materialize.public.input
+    cte l1 =
+      Filter (#0) IS NOT NULL
+        Get l0
+    cte l2 =
+      ArrangeBy keys=[[#0]]
+        Project (#0)
+          Get l1
     cte l3 =
       Reduce aggregates=[sum(#0)]
         Distinct project=[#0]
@@ -288,23 +254,57 @@ Explained Query:
                                 - ("green", 13)
             Project (#0)
               Get l0
-    cte l2 =
-      ArrangeBy keys=[[#0]]
-        Project (#0)
-          Get l1
-    cte l1 =
-      Filter (#0) IS NOT NULL
-        Get l0
-    cte l0 =
-      Project (#3, #5, #6)
-        Map (text_to_integer(substr(#0, 5)), regexp_split_to_array[" ", case_insensitive=false](#2), array_index(#4, 3), text_to_integer(array_index(#4, 2)))
-          FlatMap unnest_array(regexp_split_to_array[",", case_insensitive=false](#1))
-            Project (#0, #2)
-              FlatMap unnest_array(regexp_split_to_array[";", case_insensitive=false](#1))
-                Project (#3, #4)
-                  Map (regexp_split_to_array[":", case_insensitive=false](#1), array_index(#2, 1), array_index(#2, 2))
-                    FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-                      ReadStorage materialize.public.input
+    cte l4 =
+      Reduce group_by=[#0, #1] aggregates=[max(#2)]
+        Get l1
+    cte l5 =
+      Reduce aggregates=[sum(#0)]
+        Project (#1)
+          Reduce group_by=[#0] aggregates=[count(*)]
+            Project (#0)
+              Join on=(#0 = #1 = #2) type=delta
+                ArrangeBy keys=[[#0]]
+                  Project (#0)
+                    FlatMap generate_series(1, #1, 1)
+                      Project (#0, #2)
+                        Filter (#1 = "red")
+                          Get l4
+                ArrangeBy keys=[[#0]]
+                  Project (#0)
+                    FlatMap generate_series(1, #1, 1)
+                      Project (#0, #2)
+                        Filter (#1 = "blue")
+                          Get l4
+                ArrangeBy keys=[[#0]]
+                  Project (#0)
+                    FlatMap generate_series(1, #1, 1)
+                      Project (#0, #2)
+                        Filter (#1 = "green")
+                          Get l4
+  Return
+    CrossJoin type=differential
+      ArrangeBy keys=[[]]
+        Union
+          Get l3
+          Map (null)
+            Union
+              Negate
+                Project ()
+                  Get l3
+              Constant
+                - ()
+      ArrangeBy keys=[[]]
+        Project (#1)
+          Map (numeric_to_bigint(#0))
+            Union
+              Get l5
+              Map (null)
+                Union
+                  Negate
+                    Project ()
+                      Get l5
+                  Constant
+                    - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1203.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1203.slt
@@ -228,115 +228,73 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  Return
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Union
-            Get l15
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l15
-                Constant
-                  - ()
-        ArrangeBy keys=[[]]
-          Union
-            Get l19
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l19
-                Constant
-                  - ()
-    With
-      cte l19 =
-        Reduce aggregates=[sum(#0)]
-          Project (#2)
-            Distinct project=[#0, #1, (#2 * #3)]
-              Project (#0, #1, #5, #10)
-                Filter (#2 = 2) AND ((#6 != #11) OR (#7 != #12))
-                  Join on=(#0 = #3 = #8 AND #1 = #4 = #9) type=delta
-                    ArrangeBy keys=[[#0, #1]]
-                      Reduce group_by=[#0, #1] aggregates=[count(*)]
-                        Project (#0, #1)
-                          Get l17
-                    Get l18
-                    Get l18
-      cte l18 =
-        ArrangeBy keys=[[#0, #1]]
-          Get l17
-      cte l17 =
-        Distinct project=[#0, #1, #4, #2, #3]
-          Project (#0, #1, #3, #4, #6)
-            Filter (#7 = (#1 + #2))
-              FlatMap generate_series(#4, ((#4 + #5) - 1), 1)
-                Project (#0, #1, #3..=#7)
-                  Join on=(#4 = (#0 + #2)) type=delta
-                    ArrangeBy keys=[[]]
-                      Project (#0, #1)
-                        Filter (#2 = "*")
-                          Get l6
-                    Get l16
-                    Get l16
-                    ArrangeBy keys=[[#0]]
-                      Get l14
-      cte l16 =
-        ArrangeBy keys=[[]]
-          Constant
-            - (0)
-            - (-1)
-            - (1)
-      cte l15 =
-        Reduce aggregates=[sum(#0)]
-          Project (#3)
-            Get l14
-      cte l14 =
-        Project (#1..=#3, #7)
-          Map (text_to_integer(#0))
-            Join on=(#1 = #4 AND #2 = #5 AND #3 = #6) type=differential
-              ArrangeBy keys=[[#1..=#3]]
-                Get l12
-              ArrangeBy keys=[[#0..=#2]]
-                Union
-                  Negate
-                    Distinct project=[#0..=#2]
-                      Project (#0..=#2)
-                        Join on=(#0 = #3 AND #4 = (#1 + #2)) type=differential
-                          ArrangeBy keys=[[#0, (#1 + #2)]]
-                            Get l13
-                          Get l11
-                  Get l13
-      cte l13 =
-        Distinct project=[#0..=#2]
-          Project (#1..=#3)
-            Get l12
-      cte l12 =
-        Project (#0..=#3)
-          Join on=(#1 = #4 AND #2 = #5) type=differential
-            ArrangeBy keys=[[#1, #2]]
-              Get l9
-            ArrangeBy keys=[[#0, #1]]
-              Union
-                Negate
-                  Distinct project=[#0, #1]
-                    Project (#0, #1)
-                      Join on=(#0 = #2 AND #3 = (#1 - 1)) type=differential
-                        ArrangeBy keys=[[#0, (#1 - 1)]]
-                          Get l10
-                        Get l11
-                Get l10
-      cte l11 =
-        ArrangeBy keys=[[#0, #1]]
-          Project (#0, #1)
-            Get l5
-      cte l10 =
-        Distinct project=[#0, #1]
-          Project (#1, #2)
-            Get l9
   With Mutually Recursive
+    cte l0 =
+      Reduce aggregates=[count(*)]
+        Project ()
+          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
+            ReadStorage materialize.public.input
+    cte l1 =
+      Project (#0, #2, #3)
+        Filter (#3 != ".")
+          Map (substr(#1, #2, 1))
+            FlatMap generate_series(1, char_length(#1), 1)
+              Project (#1, #2)
+                Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
+                  CrossJoin type=differential
+                    ArrangeBy keys=[[]]
+                      ReadStorage materialize.public.input
+                    ArrangeBy keys=[[]]
+                      Project (#1)
+                        FlatMap generate_series(1, #0, 1)
+                          Project (#1)
+                            Map (bigint_to_integer(#0))
+                              Union
+                                Get l0
+                                Map (0)
+                                  Union
+                                    Negate
+                                      Project ()
+                                        Get l0
+                                    Constant
+                                      - ()
+    cte l2 =
+      Distinct project=[#0]
+        Project (#2)
+          Get l1
+    cte l3 =
+      Distinct project=[#0]
+        Project (#0)
+          Filter (#0 = #1)
+            FlatMap wrap1("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
+              Get l2
+    cte l4 =
+      ArrangeBy keys=[[#2]]
+        Get l1
+    cte l5 =
+      Project (#0..=#2)
+        Join on=(#2 = #3) type=differential
+          Get l4
+          ArrangeBy keys=[[#0]]
+            Get l3
+    cte l6 =
+      Project (#0..=#2)
+        Join on=(#2 = #3) type=differential
+          Get l4
+          ArrangeBy keys=[[#0]]
+            Union
+              Negate
+                Get l3
+              Get l2
+    cte l7 =
+      ArrangeBy keys=[[]]
+        Constant
+          - (0)
+          - (-1)
+          - (1)
+    cte l8 =
+      ArrangeBy keys=[[#0, #1]]
+        Get l5
     cte l9 =
       Distinct project=[#0..=#3]
         Union
@@ -364,72 +322,114 @@ Explained Query:
                 Get l8
                 ArrangeBy keys=[[#1, (#2 + #3)]]
                   Get l9
-    cte l8 =
-      ArrangeBy keys=[[#0, #1]]
-        Get l5
-    cte l7 =
-      ArrangeBy keys=[[]]
-        Constant
-          - (0)
-          - (-1)
-          - (1)
-    cte l6 =
-      Project (#0..=#2)
-        Join on=(#2 = #3) type=differential
-          Get l4
-          ArrangeBy keys=[[#0]]
-            Union
-              Negate
-                Get l3
-              Get l2
-    cte l5 =
-      Project (#0..=#2)
-        Join on=(#2 = #3) type=differential
-          Get l4
-          ArrangeBy keys=[[#0]]
-            Get l3
-    cte l4 =
-      ArrangeBy keys=[[#2]]
-        Get l1
-    cte l3 =
-      Distinct project=[#0]
-        Project (#0)
-          Filter (#0 = #1)
-            FlatMap wrap1("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
-              Get l2
-    cte l2 =
-      Distinct project=[#0]
-        Project (#2)
-          Get l1
-    cte l1 =
-      Project (#0, #2, #3)
-        Filter (#3 != ".")
-          Map (substr(#1, #2, 1))
-            FlatMap generate_series(1, char_length(#1), 1)
-              Project (#1, #2)
-                Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                  CrossJoin type=differential
+  Return
+    With
+      cte l10 =
+        Distinct project=[#0, #1]
+          Project (#1, #2)
+            Get l9
+      cte l11 =
+        ArrangeBy keys=[[#0, #1]]
+          Project (#0, #1)
+            Get l5
+      cte l12 =
+        Project (#0..=#3)
+          Join on=(#1 = #4 AND #2 = #5) type=differential
+            ArrangeBy keys=[[#1, #2]]
+              Get l9
+            ArrangeBy keys=[[#0, #1]]
+              Union
+                Negate
+                  Distinct project=[#0, #1]
+                    Project (#0, #1)
+                      Join on=(#0 = #2 AND #3 = (#1 - 1)) type=differential
+                        ArrangeBy keys=[[#0, (#1 - 1)]]
+                          Get l10
+                        Get l11
+                Get l10
+      cte l13 =
+        Distinct project=[#0..=#2]
+          Project (#1..=#3)
+            Get l12
+      cte l14 =
+        Project (#1..=#3, #7)
+          Map (text_to_integer(#0))
+            Join on=(#1 = #4 AND #2 = #5 AND #3 = #6) type=differential
+              ArrangeBy keys=[[#1..=#3]]
+                Get l12
+              ArrangeBy keys=[[#0..=#2]]
+                Union
+                  Negate
+                    Distinct project=[#0..=#2]
+                      Project (#0..=#2)
+                        Join on=(#0 = #3 AND #4 = (#1 + #2)) type=differential
+                          ArrangeBy keys=[[#0, (#1 + #2)]]
+                            Get l13
+                          Get l11
+                  Get l13
+      cte l15 =
+        Reduce aggregates=[sum(#0)]
+          Project (#3)
+            Get l14
+      cte l16 =
+        ArrangeBy keys=[[]]
+          Constant
+            - (0)
+            - (-1)
+            - (1)
+      cte l17 =
+        Distinct project=[#0, #1, #4, #2, #3]
+          Project (#0, #1, #3, #4, #6)
+            Filter (#7 = (#1 + #2))
+              FlatMap generate_series(#4, ((#4 + #5) - 1), 1)
+                Project (#0, #1, #3..=#7)
+                  Join on=(#4 = (#0 + #2)) type=delta
                     ArrangeBy keys=[[]]
-                      ReadStorage materialize.public.input
-                    ArrangeBy keys=[[]]
-                      Project (#1)
-                        FlatMap generate_series(1, #0, 1)
-                          Project (#1)
-                            Map (bigint_to_integer(#0))
-                              Union
-                                Get l0
-                                Map (0)
-                                  Union
-                                    Negate
-                                      Project ()
-                                        Get l0
-                                    Constant
-                                      - ()
-    cte l0 =
-      Reduce aggregates=[count(*)]
-        Project ()
-          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-            ReadStorage materialize.public.input
+                      Project (#0, #1)
+                        Filter (#2 = "*")
+                          Get l6
+                    Get l16
+                    Get l16
+                    ArrangeBy keys=[[#0]]
+                      Get l14
+      cte l18 =
+        ArrangeBy keys=[[#0, #1]]
+          Get l17
+      cte l19 =
+        Reduce aggregates=[sum(#0)]
+          Project (#2)
+            Distinct project=[#0, #1, (#2 * #3)]
+              Project (#0, #1, #5, #10)
+                Filter (#2 = 2) AND ((#6 != #11) OR (#7 != #12))
+                  Join on=(#0 = #3 = #8 AND #1 = #4 = #9) type=delta
+                    ArrangeBy keys=[[#0, #1]]
+                      Reduce group_by=[#0, #1] aggregates=[count(*)]
+                        Project (#0, #1)
+                          Get l17
+                    Get l18
+                    Get l18
+    Return
+      CrossJoin type=differential
+        ArrangeBy keys=[[]]
+          Union
+            Get l15
+            Map (null)
+              Union
+                Negate
+                  Project ()
+                    Get l15
+                Constant
+                  - ()
+        ArrangeBy keys=[[]]
+          Union
+            Get l19
+            Map (null)
+              Union
+                Negate
+                  Project ()
+                    Get l19
+                Constant
+                  - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1204.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1204.slt
@@ -95,16 +95,6 @@ SELECT SUM(points)
 FROM winning_points;
 ----
 Explained Query:
-  Return
-    Union
-      Get l0
-      Map (null)
-        Union
-          Negate
-            Project ()
-              Get l0
-          Constant
-            - ()
   With
     cte l0 =
       Reduce aggregates=[sum(roundf64(expf64(#0)))]
@@ -122,6 +112,16 @@ Explained Query:
                               Map (split_string(#1, ":", 1), regexp_split_to_array["\s", case_insensitive=false](ltrim(rtrim(replace(split_string(#1, ":", 2), "|", "")))))
                                 FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
                                   ReadStorage materialize.public.aoc_1204
+  Return
+    Union
+      Get l0
+      Map (null)
+        Union
+          Negate
+            Project ()
+              Get l0
+          Constant
+            - ()
 
 Source materialize.public.aoc_1204
 
@@ -280,45 +280,32 @@ FROM
     multipliers;
 ----
 Explained Query:
-  Return
-    Return
-      Union
-        Get l7
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l7
-            Constant
-              - ()
-    With
-      cte l7 =
-        Reduce aggregates=[sum(#0)]
-          Project (#1)
-            Get l6
   With Mutually Recursive
-    cte l6 =
-      Project (#0, #2)
-        Map (bigint_to_integer(#1))
-          Reduce group_by=[#0] aggregates=[sum(coalesce(#1, 1))]
-            Union
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l5
-                  Project (#1)
-                    Get l4
-              Get l5
-    cte l5 =
-      Project (#1, #3)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Filter (#0) IS NOT NULL
-              Get l4
-          ArrangeBy keys=[[#0]]
-            Filter (#0) IS NOT NULL
-              Get l6
+    cte l0 =
+      Project (#3, #4)
+        Map (regexp_match["Card +(\d+): (.*)", case_insensitive=false](#1), text_to_integer(array_index(#2, 1)), regexp_split_to_array[" \| ", case_insensitive=false](array_index(#2, 2)))
+          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
+            ReadStorage materialize.public.aoc_1204
+    cte l1 =
+      Project (#0, #3)
+        Map (text_to_integer(#2))
+          FlatMap unnest_array(regexp_split_to_array["\s+", case_insensitive=false](btrim(array_index(#1, 2))))
+            Get l0
+    cte l2 =
+      ArrangeBy keys=[[#0, #1]]
+        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+          Get l1
+    cte l3 =
+      Project (#0, #1)
+        Join on=(#0 = #2 AND #1 = #3) type=differential
+          Get l2
+          ArrangeBy keys=[[#0, #1]]
+            Project (#0, #3)
+              Filter (#2) IS NOT NULL
+                Map (text_to_integer(#2))
+                  FlatMap unnest_array(regexp_split_to_array["\s+", case_insensitive=false](btrim(array_index(#1, 1))))
+                    Filter (#0) IS NOT NULL
+                      Get l0
     cte l4 =
       Distinct project=[#0, #1]
         Union
@@ -343,31 +330,44 @@ Explained Query:
           Project (#2, #0)
             Map (0)
               Get l1
-    cte l3 =
-      Project (#0, #1)
-        Join on=(#0 = #2 AND #1 = #3) type=differential
-          Get l2
-          ArrangeBy keys=[[#0, #1]]
-            Project (#0, #3)
-              Filter (#2) IS NOT NULL
-                Map (text_to_integer(#2))
-                  FlatMap unnest_array(regexp_split_to_array["\s+", case_insensitive=false](btrim(array_index(#1, 1))))
-                    Filter (#0) IS NOT NULL
-                      Get l0
-    cte l2 =
-      ArrangeBy keys=[[#0, #1]]
-        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-          Get l1
-    cte l1 =
-      Project (#0, #3)
-        Map (text_to_integer(#2))
-          FlatMap unnest_array(regexp_split_to_array["\s+", case_insensitive=false](btrim(array_index(#1, 2))))
-            Get l0
-    cte l0 =
-      Project (#3, #4)
-        Map (regexp_match["Card +(\d+): (.*)", case_insensitive=false](#1), text_to_integer(array_index(#2, 1)), regexp_split_to_array[" \| ", case_insensitive=false](array_index(#2, 2)))
-          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-            ReadStorage materialize.public.aoc_1204
+    cte l5 =
+      Project (#1, #3)
+        Join on=(#0 = #2) type=differential
+          ArrangeBy keys=[[#0]]
+            Filter (#0) IS NOT NULL
+              Get l4
+          ArrangeBy keys=[[#0]]
+            Filter (#0) IS NOT NULL
+              Get l6
+    cte l6 =
+      Project (#0, #2)
+        Map (bigint_to_integer(#1))
+          Reduce group_by=[#0] aggregates=[sum(coalesce(#1, 1))]
+            Union
+              Map (null)
+                Union
+                  Negate
+                    Project (#0)
+                      Get l5
+                  Project (#1)
+                    Get l4
+              Get l5
+  Return
+    With
+      cte l7 =
+        Reduce aggregates=[sum(#0)]
+          Project (#1)
+            Get l6
+    Return
+      Union
+        Get l7
+        Map (null)
+          Union
+            Negate
+              Project ()
+                Get l7
+            Constant
+              - ()
 
 Source materialize.public.aoc_1204
 
@@ -506,7 +506,105 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 select * from part1, part2;
 ----
 Explained Query:
+  With Mutually Recursive
+    cte l0 =
+      Project (#3..=#5)
+        Map (regexp_split_to_array["(:|\|)", case_insensitive=false](#1), text_to_integer(array_index(regexp_match["[0-9]+", case_insensitive=false](btrim(array_index(#2, 1))), 1)), regexp_split_to_array[" ", case_insensitive=false](btrim(array_index(#2, 2))), regexp_split_to_array[" ", case_insensitive=false](btrim(array_index(#2, 3))))
+          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
+            ReadStorage materialize.public.aoc_1204
+    cte l1 =
+      Distinct project=[#0..=#2]
+        Get l0
+    cte l2 =
+      Distinct project=[#0, #1]
+        Project (#1, #2)
+          Get l1
+    cte l3 =
+      Filter (#2 != "")
+        FlatMap unnest_array(#0)
+          Get l2
+    cte l4 =
+      Reduce group_by=[#0, #1] aggregates=[count(*)]
+        Project (#0, #1)
+          Distinct project=[#0..=#2]
+            Union
+              Get l3
+              Negate
+                Threshold
+                  Union
+                    Get l3
+                    Negate
+                      Filter (#2 != "")
+                        FlatMap unnest_array(#1)
+                          Get l2
+    cte l5 =
+      ArrangeBy keys=[[#0, #1]]
+        Get l2
+    cte l6 =
+      Union
+        Get l4
+        Project (#0, #1, #4)
+          Map (0)
+            Join on=(#0 = #2 AND #1 = #3) type=differential
+              ArrangeBy keys=[[#0, #1]]
+                Union
+                  Negate
+                    Project (#0, #1)
+                      Get l4
+                  Get l2
+              Get l5
+    cte l7 =
+      Union
+        Get l6
+        Map (error("more than one record produced in subquery"))
+          Project (#0, #1)
+            Filter (#2 > 1)
+              Reduce group_by=[#0, #1] aggregates=[count(*)]
+                Project (#0, #1)
+                  Get l6
+    cte l8 =
+      Project (#0, #8)
+        Join on=(#0 = #3 AND #1 = #4 = #6 AND #2 = #5 = #7) type=delta
+          ArrangeBy keys=[[#0..=#2], [#1, #2]]
+            Get l0
+          ArrangeBy keys=[[#0..=#2]]
+            Get l1
+          ArrangeBy keys=[[#0, #1]]
+            Union
+              Get l7
+              Project (#0, #1, #4)
+                Map (null)
+                  Join on=(#0 = #2 AND #1 = #3) type=differential
+                    ArrangeBy keys=[[#0, #1]]
+                      Union
+                        Negate
+                          Distinct project=[#0, #1]
+                            Project (#0, #1)
+                              Get l7
+                        Get l2
+                    Get l5
+    cte l9 =
+      Reduce aggregates=[sum(power(2, bigint_to_double((#0 - 1))))]
+        Project (#1)
+          Filter (#1 > 0)
+            Get l8
+    cte l10 =
+      Union
+        Get l8
+        Project (#2, #3)
+          Filter (integer_to_bigint(#2) = (integer_to_bigint(#0) + #4))
+            FlatMap generate_series(1, #1, 1)
+              CrossJoin type=differential
+                ArrangeBy keys=[[]]
+                  Get l10
+                ArrangeBy keys=[[]]
+                  Get l8
   Return
+    With
+      cte l11 =
+        Reduce aggregates=[count(*)]
+          Project ()
+            Get l10
     Return
       CrossJoin type=differential
         ArrangeBy keys=[[]]
@@ -531,104 +629,6 @@ Explained Query:
                     Get l11
                 Constant
                   - ()
-    With
-      cte l11 =
-        Reduce aggregates=[count(*)]
-          Project ()
-            Get l10
-  With Mutually Recursive
-    cte l10 =
-      Union
-        Get l8
-        Project (#2, #3)
-          Filter (integer_to_bigint(#2) = (integer_to_bigint(#0) + #4))
-            FlatMap generate_series(1, #1, 1)
-              CrossJoin type=differential
-                ArrangeBy keys=[[]]
-                  Get l10
-                ArrangeBy keys=[[]]
-                  Get l8
-    cte l9 =
-      Reduce aggregates=[sum(power(2, bigint_to_double((#0 - 1))))]
-        Project (#1)
-          Filter (#1 > 0)
-            Get l8
-    cte l8 =
-      Project (#0, #8)
-        Join on=(#0 = #3 AND #1 = #4 = #6 AND #2 = #5 = #7) type=delta
-          ArrangeBy keys=[[#0..=#2], [#1, #2]]
-            Get l0
-          ArrangeBy keys=[[#0..=#2]]
-            Get l1
-          ArrangeBy keys=[[#0, #1]]
-            Union
-              Get l7
-              Project (#0, #1, #4)
-                Map (null)
-                  Join on=(#0 = #2 AND #1 = #3) type=differential
-                    ArrangeBy keys=[[#0, #1]]
-                      Union
-                        Negate
-                          Distinct project=[#0, #1]
-                            Project (#0, #1)
-                              Get l7
-                        Get l2
-                    Get l5
-    cte l7 =
-      Union
-        Get l6
-        Map (error("more than one record produced in subquery"))
-          Project (#0, #1)
-            Filter (#2 > 1)
-              Reduce group_by=[#0, #1] aggregates=[count(*)]
-                Project (#0, #1)
-                  Get l6
-    cte l6 =
-      Union
-        Get l4
-        Project (#0, #1, #4)
-          Map (0)
-            Join on=(#0 = #2 AND #1 = #3) type=differential
-              ArrangeBy keys=[[#0, #1]]
-                Union
-                  Negate
-                    Project (#0, #1)
-                      Get l4
-                  Get l2
-              Get l5
-    cte l5 =
-      ArrangeBy keys=[[#0, #1]]
-        Get l2
-    cte l4 =
-      Reduce group_by=[#0, #1] aggregates=[count(*)]
-        Project (#0, #1)
-          Distinct project=[#0..=#2]
-            Union
-              Get l3
-              Negate
-                Threshold
-                  Union
-                    Get l3
-                    Negate
-                      Filter (#2 != "")
-                        FlatMap unnest_array(#1)
-                          Get l2
-    cte l3 =
-      Filter (#2 != "")
-        FlatMap unnest_array(#0)
-          Get l2
-    cte l2 =
-      Distinct project=[#0, #1]
-        Project (#1, #2)
-          Get l1
-    cte l1 =
-      Distinct project=[#0..=#2]
-        Get l0
-    cte l0 =
-      Project (#3..=#5)
-        Map (regexp_split_to_array["(:|\|)", case_insensitive=false](#1), text_to_integer(array_index(regexp_match["[0-9]+", case_insensitive=false](btrim(array_index(#2, 1))), 1)), regexp_split_to_array[" ", case_insensitive=false](btrim(array_index(#2, 2))), regexp_split_to_array[" ", case_insensitive=false](btrim(array_index(#2, 3))))
-          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-            ReadStorage materialize.public.aoc_1204
 
 Source materialize.public.aoc_1204
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1205.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1205.slt
@@ -742,16 +742,6 @@ EXPLAIN WITH seeds AS (
             location;
 ----
 Explained Query:
-  Return
-    Union
-      Get l0
-      Map (null)
-        Union
-          Negate
-            Project ()
-              Get l0
-          Constant
-            - ()
   With
     cte l0 =
       Reduce aggregates=[min(coalesce(#1, #0))]
@@ -827,6 +817,16 @@ Explained Query:
                 Map (arraytoarray(regexp_split_to_array[" ", case_insensitive=false](#1)), array_index(#2, 1), array_index(#2, 2), array_index(#2, 3))
                   FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](array_index(regexp_match["humidity-to-location map:\n([0-9 \n]*)", case_insensitive=false](#0), 1)))
                     ReadStorage materialize.public.input
+  Return
+    Union
+      Get l0
+      Map (null)
+        Union
+          Negate
+            Project ()
+              Get l0
+          Constant
+            - ()
 
 Source materialize.public.input
 
@@ -1145,36 +1145,163 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  Return
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Union
-            Get l8
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l8
-                Constant
-                  - ()
-        ArrangeBy keys=[[]]
-          Union
-            Get l20
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l20
-                Constant
-                  - ()
-    With
-      cte l20 =
-        Reduce aggregates=[min(#0)]
-          Project (#1)
-            Filter (#0 = "location")
-              Get l9
   With Mutually Recursive
+    cte l0 =
+      Project (#2, #3)
+        Map (split_string(#1, ":", 1), split_string(#1, ":", 2))
+          FlatMap unnest_array(regexp_split_to_array["\n\n", case_insensitive=false](#0))
+            ReadStorage materialize.public.input
+    cte l1 =
+      Project (#5..=#9)
+        Filter (#3 != "")
+          Map (split_string(#2, " ", 2), split_string(#0, " ", 1), split_string(#4, "-", 1), split_string(#4, "-", 3), text_to_bigint(#3), text_to_bigint(split_string(#2, " ", 1)), text_to_bigint(split_string(#2, " ", 3)))
+            FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#1))
+              Filter (#0 != "seeds")
+                Get l0
+    cte l2 =
+      ArrangeBy keys=[[#0, #1]]
+        Get l1
+    cte l3 =
+      Project (#0..=#2, #5, #6)
+        Filter (#2 >= #5) AND (#2 <= ((#5 + #7) - 1))
+          Join on=(#0 = #3 AND #1 = #4) type=differential
+            ArrangeBy keys=[[#0, #1]]
+              Get l7
+            Get l2
+    cte l4 =
+      Project (#1)
+        Filter (#0 = "seeds")
+          Get l0
+    cte l5 =
+      Union
+        Project (#3, #2)
+          Map (text_to_bigint(#1), "seed")
+            FlatMap unnest_array(regexp_split_to_array[" ", case_insensitive=false](btrim(#0)))
+              Get l4
+        Project (#0, #4)
+          Map (coalesce((#1 + (#3 - #2)), #1))
+            Union
+              Project (#1..=#4)
+                Get l3
+              Project (#1, #2, #6, #7)
+                Map (null, null)
+                  Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential
+                    ArrangeBy keys=[[#0..=#2]]
+                      Union
+                        Negate
+                          Distinct project=[#0..=#2]
+                            Project (#0..=#2)
+                              Get l3
+                        Get l7
+                    ArrangeBy keys=[[#0..=#2]]
+                      Get l7
+    cte l6 =
+      ArrangeBy keys=[[#0]]
+        Distinct project=[#0, #1]
+          Project (#0, #1)
+            Get l1
+    cte l7 =
+      Project (#0, #3, #1)
+        Join on=(#0 = #2) type=differential
+          ArrangeBy keys=[[#0]]
+            Distinct project=[#0, #1]
+              Get l5
+          Get l6
+    cte l8 =
+      Reduce aggregates=[min(#0)]
+        Project (#1)
+          Filter (#0 = "location")
+            Get l5
+    cte l9 =
+      Distinct project=[#0..=#2]
+        Union
+          Project (#6, #4, #5)
+            Map (regexp_split_to_array[" ", case_insensitive=false](btrim(#0)), (2 * #1), text_to_bigint(array_index(#2, integer_to_bigint((#3 - 1)))), (#4 + text_to_bigint(array_index(#2, integer_to_bigint(#3)))), "seed")
+              FlatMap generate_series(1, ((regexp_split_to_array[" ", case_insensitive=false](btrim(#0)) array_length 1) / 2), 1)
+                Get l4
+          Project (#1, #10, #11)
+            Map ((#8 - #4), (#6 + #9), (#7 + #9))
+              Get l11
+          Get l19
+    cte l10 =
+      Project (#0..=#2, #4)
+        Join on=(#0 = #3) type=differential
+          ArrangeBy keys=[[#0]]
+            Get l9
+          Get l6
+    cte l11 =
+      Project (#0, #3, #1, #2, #6, #10, #9, #11, #7)
+        Filter (#9 < #11)
+          Map (greatest(#1, #6), (#6 + #8), least(#2, #10))
+            Join on=(#0 = #4 AND #3 = #5) type=differential
+              ArrangeBy keys=[[#0, #3]]
+                Get l10
+              Get l2
+    cte l12 =
+      Distinct project=[#0..=#8]
+        Get l11
+    cte l13 =
+      Distinct project=[#0..=#4]
+        Project (#0..=#3, #7)
+          Get l12
+    cte l14 =
+      Reduce group_by=[#0..=#4] aggregates=[min(#5)]
+        Project (#0..=#4, #9)
+          Filter (#9 >= #4)
+            Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8) type=differential
+              ArrangeBy keys=[[#0..=#3]]
+                Filter (#2) IS NOT NULL AND (#3) IS NOT NULL
+                  Get l13
+              ArrangeBy keys=[[#0..=#3]]
+                Project (#0..=#3, #6)
+                  Filter (#2) IS NOT NULL AND (#6 < #3)
+                    Get l11
+    cte l15 =
+      Project (#0..=#4, #6)
+        Map (coalesce(#5, #3))
+          Union
+            Get l14
+            Project (#0..=#4, #10)
+              Map (null)
+                Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8 AND #4 = #9) type=differential
+                  ArrangeBy keys=[[#0..=#4]]
+                    Union
+                      Negate
+                        Project (#0..=#4)
+                          Get l14
+                      Get l13
+                  ArrangeBy keys=[[#0..=#4]]
+                    Get l13
+    cte l16 =
+      Reduce group_by=[#0, #3, #1, #2] aggregates=[min(#4)]
+        Project (#0..=#3, #8)
+          Join on=(#0 = #4 AND #1 = #6 AND #2 = #7 AND #3 = #5) type=differential
+            ArrangeBy keys=[[#0..=#3]]
+              Filter (#1) IS NOT NULL AND (#2) IS NOT NULL
+                Get l10
+            ArrangeBy keys=[[#0, #2, #3, #1]]
+              Project (#0..=#3, #6)
+                Filter (#6 < #3) AND (#6 >= #2)
+                  Get l11
+    cte l17 =
+      ArrangeBy keys=[[#0..=#3]]
+        Get l10
+    cte l18 =
+      Project (#0..=#3, #5)
+        Map (coalesce(#4, #3))
+          Union
+            Get l16
+            Project (#0..=#3, #8)
+              Map (null)
+                Join on=(#0 = #4 AND #1 = #7 AND #2 = #5 AND #3 = #6) type=differential
+                  ArrangeBy keys=[[#0, #2, #3, #1]]
+                    Union
+                      Negate
+                        Project (#0..=#3)
+                          Get l16
+                      Project (#0, #3, #1, #2)
+                        Get l10
+                  Get l17
     cte l19 =
       Distinct project=[#0..=#2]
         Union
@@ -1209,162 +1336,35 @@ Explained Query:
                           Reduce group_by=[#0..=#3] aggregates=[count(*)]
                             Project (#0..=#3)
                               Get l18
-    cte l18 =
-      Project (#0..=#3, #5)
-        Map (coalesce(#4, #3))
+  Return
+    With
+      cte l20 =
+        Reduce aggregates=[min(#0)]
+          Project (#1)
+            Filter (#0 = "location")
+              Get l9
+    Return
+      CrossJoin type=differential
+        ArrangeBy keys=[[]]
           Union
-            Get l16
-            Project (#0..=#3, #8)
-              Map (null)
-                Join on=(#0 = #4 AND #1 = #7 AND #2 = #5 AND #3 = #6) type=differential
-                  ArrangeBy keys=[[#0, #2, #3, #1]]
-                    Union
-                      Negate
-                        Project (#0..=#3)
-                          Get l16
-                      Project (#0, #3, #1, #2)
-                        Get l10
-                  Get l17
-    cte l17 =
-      ArrangeBy keys=[[#0..=#3]]
-        Get l10
-    cte l16 =
-      Reduce group_by=[#0, #3, #1, #2] aggregates=[min(#4)]
-        Project (#0..=#3, #8)
-          Join on=(#0 = #4 AND #1 = #6 AND #2 = #7 AND #3 = #5) type=differential
-            ArrangeBy keys=[[#0..=#3]]
-              Filter (#1) IS NOT NULL AND (#2) IS NOT NULL
-                Get l10
-            ArrangeBy keys=[[#0, #2, #3, #1]]
-              Project (#0..=#3, #6)
-                Filter (#6 < #3) AND (#6 >= #2)
-                  Get l11
-    cte l15 =
-      Project (#0..=#4, #6)
-        Map (coalesce(#5, #3))
+            Get l8
+            Map (null)
+              Union
+                Negate
+                  Project ()
+                    Get l8
+                Constant
+                  - ()
+        ArrangeBy keys=[[]]
           Union
-            Get l14
-            Project (#0..=#4, #10)
-              Map (null)
-                Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8 AND #4 = #9) type=differential
-                  ArrangeBy keys=[[#0..=#4]]
-                    Union
-                      Negate
-                        Project (#0..=#4)
-                          Get l14
-                      Get l13
-                  ArrangeBy keys=[[#0..=#4]]
-                    Get l13
-    cte l14 =
-      Reduce group_by=[#0..=#4] aggregates=[min(#5)]
-        Project (#0..=#4, #9)
-          Filter (#9 >= #4)
-            Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8) type=differential
-              ArrangeBy keys=[[#0..=#3]]
-                Filter (#2) IS NOT NULL AND (#3) IS NOT NULL
-                  Get l13
-              ArrangeBy keys=[[#0..=#3]]
-                Project (#0..=#3, #6)
-                  Filter (#2) IS NOT NULL AND (#6 < #3)
-                    Get l11
-    cte l13 =
-      Distinct project=[#0..=#4]
-        Project (#0..=#3, #7)
-          Get l12
-    cte l12 =
-      Distinct project=[#0..=#8]
-        Get l11
-    cte l11 =
-      Project (#0, #3, #1, #2, #6, #10, #9, #11, #7)
-        Filter (#9 < #11)
-          Map (greatest(#1, #6), (#6 + #8), least(#2, #10))
-            Join on=(#0 = #4 AND #3 = #5) type=differential
-              ArrangeBy keys=[[#0, #3]]
-                Get l10
-              Get l2
-    cte l10 =
-      Project (#0..=#2, #4)
-        Join on=(#0 = #3) type=differential
-          ArrangeBy keys=[[#0]]
-            Get l9
-          Get l6
-    cte l9 =
-      Distinct project=[#0..=#2]
-        Union
-          Project (#6, #4, #5)
-            Map (regexp_split_to_array[" ", case_insensitive=false](btrim(#0)), (2 * #1), text_to_bigint(array_index(#2, integer_to_bigint((#3 - 1)))), (#4 + text_to_bigint(array_index(#2, integer_to_bigint(#3)))), "seed")
-              FlatMap generate_series(1, ((regexp_split_to_array[" ", case_insensitive=false](btrim(#0)) array_length 1) / 2), 1)
-                Get l4
-          Project (#1, #10, #11)
-            Map ((#8 - #4), (#6 + #9), (#7 + #9))
-              Get l11
-          Get l19
-    cte l8 =
-      Reduce aggregates=[min(#0)]
-        Project (#1)
-          Filter (#0 = "location")
-            Get l5
-    cte l7 =
-      Project (#0, #3, #1)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Distinct project=[#0, #1]
-              Get l5
-          Get l6
-    cte l6 =
-      ArrangeBy keys=[[#0]]
-        Distinct project=[#0, #1]
-          Project (#0, #1)
-            Get l1
-    cte l5 =
-      Union
-        Project (#3, #2)
-          Map (text_to_bigint(#1), "seed")
-            FlatMap unnest_array(regexp_split_to_array[" ", case_insensitive=false](btrim(#0)))
-              Get l4
-        Project (#0, #4)
-          Map (coalesce((#1 + (#3 - #2)), #1))
-            Union
-              Project (#1..=#4)
-                Get l3
-              Project (#1, #2, #6, #7)
-                Map (null, null)
-                  Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential
-                    ArrangeBy keys=[[#0..=#2]]
-                      Union
-                        Negate
-                          Distinct project=[#0..=#2]
-                            Project (#0..=#2)
-                              Get l3
-                        Get l7
-                    ArrangeBy keys=[[#0..=#2]]
-                      Get l7
-    cte l4 =
-      Project (#1)
-        Filter (#0 = "seeds")
-          Get l0
-    cte l3 =
-      Project (#0..=#2, #5, #6)
-        Filter (#2 >= #5) AND (#2 <= ((#5 + #7) - 1))
-          Join on=(#0 = #3 AND #1 = #4) type=differential
-            ArrangeBy keys=[[#0, #1]]
-              Get l7
-            Get l2
-    cte l2 =
-      ArrangeBy keys=[[#0, #1]]
-        Get l1
-    cte l1 =
-      Project (#5..=#9)
-        Filter (#3 != "")
-          Map (split_string(#2, " ", 2), split_string(#0, " ", 1), split_string(#4, "-", 1), split_string(#4, "-", 3), text_to_bigint(#3), text_to_bigint(split_string(#2, " ", 1)), text_to_bigint(split_string(#2, " ", 3)))
-            FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#1))
-              Filter (#0 != "seeds")
-                Get l0
-    cte l0 =
-      Project (#2, #3)
-        Map (split_string(#1, ":", 1), split_string(#1, ":", 2))
-          FlatMap unnest_array(regexp_split_to_array["\n\n", case_insensitive=false](#0))
-            ReadStorage materialize.public.input
+            Get l20
+            Map (null)
+              Union
+                Negate
+                  Project ()
+                    Get l20
+                Constant
+                  - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1206.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1206.slt
@@ -57,6 +57,10 @@ SELECT exp(sum(ln(hi - low + 1)))::int
 FROM options;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[sum(lnf64(integer_to_double(((double_to_integer((ceilf64(((integer_to_double(#0) + sqrtf64(integer_to_double(((#0 * #0) - (4 * #1))))) / 2)) - 1)) - double_to_integer((floorf64(((integer_to_double(#0) - sqrtf64(integer_to_double(((#0 * #0) - (4 * #1))))) / 2)) + 1))) + 1))))]
+        ReadStorage materialize.public.input
   Return
     Project (#1)
       Map (double_to_integer(expf64(#0)))
@@ -69,10 +73,6 @@ Explained Query:
                   Get l0
               Constant
                 - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum(lnf64(integer_to_double(((double_to_integer((ceilf64(((integer_to_double(#0) + sqrtf64(integer_to_double(((#0 * #0) - (4 * #1))))) / 2)) - 1)) - double_to_integer((floorf64(((integer_to_double(#0) - sqrtf64(integer_to_double(((#0 * #0) - (4 * #1))))) / 2)) + 1))) + 1))))]
-        ReadStorage materialize.public.input
 
 Source materialize.public.input
 
@@ -116,6 +116,10 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM part12;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[sum(log10numeric(((1 + floornumeric(double_to_numeric(((integer_to_double(#0) + sqrtf64(integer_to_double(((#0 * #0) - (4 * #1))))) / 2)))) - ceilnumeric(double_to_numeric(((integer_to_double(#0) - sqrtf64(integer_to_double(((#0 * #0) - (4 * #1))))) / 2))))))]
+        ReadStorage materialize.public.input
   Return
     Project (#1)
       Map (power_numeric(10, #0))
@@ -128,10 +132,6 @@ Explained Query:
                   Get l0
               Constant
                 - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum(log10numeric(((1 + floornumeric(double_to_numeric(((integer_to_double(#0) + sqrtf64(integer_to_double(((#0 * #0) - (4 * #1))))) / 2)))) - ceilnumeric(double_to_numeric(((integer_to_double(#0) - sqrtf64(integer_to_double(((#0 * #0) - (4 * #1))))) / 2))))))]
-        ReadStorage materialize.public.input
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1207.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1207.slt
@@ -268,43 +268,648 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  Return
-    CrossJoin type=differential
-      ArrangeBy keys=[[]]
-        Project (#1)
-          Map (bigint_to_integer(#0))
-            Union
-              Get l40
-              Map (null)
-                Union
-                  Negate
-                    Project ()
-                      Get l40
-                  Constant
-                    - ()
-      ArrangeBy keys=[[]]
-        Project (#1)
-          Map (bigint_to_integer(#0))
-            Union
-              Get l81
-              Map (null)
-                Union
-                  Negate
-                    Project ()
-                      Get l81
-                  Constant
-                    - ()
   With
-    cte l81 =
+    cte l0 =
+      Project (#3, #4)
+        Map (regexp_split_to_array[" ", case_insensitive=false](#1), array_index(#2, 1), text_to_integer(array_index(#2, 2)))
+          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
+            ReadStorage materialize.public.input
+    cte l1 =
+      Project (#0)
+        Get l0
+    cte l2 =
+      ArrangeBy keys=[[]]
+        Constant
+          - (1)
+          - (2)
+          - (3)
+          - (4)
+          - (5)
+    cte l3 =
+      Map (substr(#0, #1, 1))
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Get l1
+          Get l2
+    cte l4 =
+      Project (#0, #3)
+        Map (bigint_to_integer(#2))
+          Reduce group_by=[#0, #1] aggregates=[count(*)]
+            Project (#0, #2)
+              Get l3
+    cte l5 =
+      Distinct project=[#0]
+        Get l1
+    cte l6 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Get l5
+          ArrangeBy keys=[[]]
+            Project (#0)
+              Filter (#1 = 5)
+                Get l4
+    cte l7 =
+      Union
+        Get l6
+        Map (false)
+          Union
+            Negate
+              Project (#0)
+                Get l6
+            Get l5
+    cte l8 =
+      Project (#0, #1, #3)
+        Join on=(#0 = #2) type=differential
+          ArrangeBy keys=[[#0]]
+            Get l0
+          ArrangeBy keys=[[#0]]
+            Union
+              Get l7
+              Map (null)
+                Union
+                  Negate
+                    Project (#0)
+                      Get l7
+                  Get l5
+    cte l9 =
+      Filter ((#2) IS NULL OR (#2 = false))
+        Get l8
+    cte l10 =
+      Distinct project=[#0]
+        Project (#0)
+          Get l9
+    cte l11 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Get l10
+          ArrangeBy keys=[[]]
+            Project (#0)
+              Filter (#1 = 4)
+                Get l4
+    cte l12 =
+      Union
+        Get l11
+        Map (false)
+          Union
+            Negate
+              Project (#0)
+                Get l11
+            Get l10
+    cte l13 =
+      Project (#0, #1, #3)
+        Join on=(#0 = #2) type=differential
+          ArrangeBy keys=[[#0]]
+            Project (#0, #1)
+              Get l9
+          ArrangeBy keys=[[#0]]
+            Union
+              Get l12
+              Map (null)
+                Union
+                  Negate
+                    Project (#0)
+                      Get l12
+                  Get l10
+    cte l14 =
+      Filter ((#2) IS NULL OR (#2 = false))
+        Get l13
+    cte l15 =
+      Distinct project=[#0]
+        Project (#0)
+          Get l14
+    cte l16 =
+      ArrangeBy keys=[[]]
+        Project (#0)
+          Filter (#1 = 3)
+            Get l4
+    cte l17 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Get l15
+          Get l16
+    cte l18 =
+      Union
+        Get l17
+        Map (false)
+          Union
+            Negate
+              Project (#0)
+                Get l17
+            Get l15
+    cte l19 =
+      Project (#0, #1, #3)
+        Join on=(#0 = #2) type=differential
+          ArrangeBy keys=[[#0]]
+            Project (#0, #1)
+              Get l14
+          ArrangeBy keys=[[#0]]
+            Union
+              Get l18
+              Map (null)
+                Union
+                  Negate
+                    Project (#0)
+                      Get l18
+                  Get l15
+    cte l20 =
+      Distinct project=[#0]
+        Project (#0)
+          Get l19
+    cte l21 =
+      ArrangeBy keys=[[]]
+        Project (#0)
+          Filter (#1 = 2)
+            Get l4
+    cte l22 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Get l20
+          Get l21
+    cte l23 =
+      Union
+        Get l22
+        Map (false)
+          Union
+            Negate
+              Project (#0)
+                Get l22
+            Get l20
+    cte l24 =
+      Project (#0..=#2, #4)
+        Join on=(#0 = #3) type=differential
+          ArrangeBy keys=[[#0]]
+            Get l19
+          ArrangeBy keys=[[#0]]
+            Union
+              Get l23
+              Map (null)
+                Union
+                  Negate
+                    Project (#0)
+                      Get l23
+                  Get l20
+    cte l25 =
+      Filter ((#4) IS NULL OR (#4 = false))
+        Map ((#2 AND #3))
+          Get l24
+    cte l26 =
+      Distinct project=[#0]
+        Project (#0)
+          Get l25
+    cte l27 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Get l26
+          Get l16
+    cte l28 =
+      Union
+        Get l27
+        Map (false)
+          Union
+            Negate
+              Project (#0)
+                Get l27
+            Get l26
+    cte l29 =
+      Project (#0, #1, #3)
+        Join on=(#0 = #2) type=differential
+          ArrangeBy keys=[[#0]]
+            Project (#0, #1)
+              Get l25
+          ArrangeBy keys=[[#0]]
+            Union
+              Get l28
+              Map (null)
+                Union
+                  Negate
+                    Project (#0)
+                      Get l28
+                  Get l26
+    cte l30 =
+      Filter ((#2) IS NULL OR (#2 = false))
+        Get l29
+    cte l31 =
+      Distinct project=[#0]
+        Project (#0)
+          Get l30
+    cte l32 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        Project (#0, #1)
+          Filter (#2 = 2)
+            Reduce group_by=[#0, #1] aggregates=[count(*)]
+              CrossJoin type=differential
+                ArrangeBy keys=[[]]
+                  Get l31
+                Get l21
+    cte l33 =
+      Union
+        Get l32
+        Map (false)
+          Union
+            Negate
+              Project (#0)
+                Get l32
+            Get l31
+    cte l34 =
+      Project (#0, #1, #3)
+        Join on=(#0 = #2) type=differential
+          ArrangeBy keys=[[#0]]
+            Project (#0, #1)
+              Get l30
+          ArrangeBy keys=[[#0]]
+            Union
+              Get l33
+              Map (null)
+                Union
+                  Negate
+                    Project (#0)
+                      Get l33
+                  Get l31
+    cte l35 =
+      Filter ((#2) IS NULL OR (#2 = false))
+        Get l34
+    cte l36 =
+      Distinct project=[#0]
+        Project (#0)
+          Get l35
+    cte l37 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Get l36
+          Get l21
+    cte l38 =
+      Union
+        Get l37
+        Map (false)
+          Union
+            Negate
+              Project (#0)
+                Get l37
+            Get l36
+    cte l39 =
+      Project (#1..=#3)
+        Map (translate(#0, "AKQJT98765432", "ABCDEFGHIJKLM"))
+          Union
+            Project (#0, #1, #3)
+              Filter #2
+                Map (1)
+                  Get l8
+            Project (#0, #1, #3)
+              Filter #2
+                Map (2)
+                  Get l13
+            Project (#0, #1, #4)
+              Filter #2 AND #3
+                Map (3)
+                  Get l24
+            Project (#0, #1, #3)
+              Filter #2
+                Map (4)
+                  Get l29
+            Project (#0, #1, #3)
+              Filter #2
+                Map (5)
+                  Get l34
+            Project (#0, #1, #4)
+              Map (case when #3 then 6 else 7 end)
+                Join on=(#0 = #2) type=differential
+                  ArrangeBy keys=[[#0]]
+                    Project (#0, #1)
+                      Get l35
+                  ArrangeBy keys=[[#0]]
+                    Union
+                      Get l38
+                      Map (null)
+                        Union
+                          Negate
+                            Project (#0)
+                              Get l38
+                          Get l36
+    cte l40 =
       Reduce aggregates=[sum(#0)]
         Project (#0)
           Filter ((#1 < #3) OR ((#1 = #3) AND (#2 <= #4)))
             CrossJoin type=differential
               ArrangeBy keys=[[]]
-                Get l80
+                Get l39
               ArrangeBy keys=[[]]
                 Project (#1, #2)
-                  Get l80
+                  Get l39
+    cte l41 =
+      Filter (#0) IS NOT NULL
+        Get l3
+    cte l42 =
+      Distinct project=[#0..=#2]
+        Union
+          Project (#0, #2, #1)
+            Get l41
+          Project (#0, #3, #1)
+            Join on=(#0 = #2) type=differential
+              ArrangeBy keys=[[#0]]
+                Project (#0, #1)
+                  Filter (#2 = "J") AND (#0) IS NOT NULL
+                    Get l3
+              ArrangeBy keys=[[#0]]
+                Project (#0, #2)
+                  Get l41
+    cte l43 =
+      Distinct project=[#0, ((((#1 || #2) || #3) || #4) || #5)]
+        Project (#0, #1, #3, #5, #7, #9)
+          Join on=(#0 = #2 = #4 = #6 = #8) type=delta
+            ArrangeBy keys=[[#0]]
+              Project (#0, #1)
+                Filter (#2 = 1)
+                  Get l42
+            ArrangeBy keys=[[#0]]
+              Project (#0, #1)
+                Filter (#2 = 2)
+                  Get l42
+            ArrangeBy keys=[[#0]]
+              Project (#0, #1)
+                Filter (#2 = 3)
+                  Get l42
+            ArrangeBy keys=[[#0]]
+              Project (#0, #1)
+                Filter (#2 = 4)
+                  Get l42
+            ArrangeBy keys=[[#0]]
+              Project (#0, #1)
+                Filter (#2 = 5)
+                  Get l42
+    cte l44 =
+      Project (#1)
+        Get l43
+    cte l45 =
+      Project (#0, #3)
+        Map (bigint_to_integer(#2))
+          Reduce group_by=[#0, #1] aggregates=[count(*)]
+            Project (#0, #1)
+              Distinct project=[#0, substr(#0, #1, 1), #1]
+                CrossJoin type=differential
+                  ArrangeBy keys=[[]]
+                    Get l44
+                  Get l2
+    cte l46 =
+      Distinct project=[#0]
+        Get l44
+    cte l47 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Get l46
+          ArrangeBy keys=[[]]
+            Project (#0)
+              Filter (#1 = 5)
+                Get l45
+    cte l48 =
+      Union
+        Get l47
+        Map (false)
+          Union
+            Negate
+              Project (#0)
+                Get l47
+            Get l46
+    cte l49 =
+      Project (#0, #1, #3)
+        Join on=(#1 = #2) type=differential
+          ArrangeBy keys=[[#1]]
+            Get l43
+          ArrangeBy keys=[[#0]]
+            Union
+              Get l48
+              Map (null)
+                Union
+                  Negate
+                    Project (#0)
+                      Get l48
+                  Get l46
+    cte l50 =
+      Filter ((#2) IS NULL OR (#2 = false))
+        Get l49
+    cte l51 =
+      Distinct project=[#0]
+        Project (#1)
+          Get l50
+    cte l52 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Get l51
+          ArrangeBy keys=[[]]
+            Project (#0)
+              Filter (#1 = 4)
+                Get l45
+    cte l53 =
+      Union
+        Get l52
+        Map (false)
+          Union
+            Negate
+              Project (#0)
+                Get l52
+            Get l51
+    cte l54 =
+      Project (#0, #1, #3)
+        Join on=(#1 = #2) type=differential
+          ArrangeBy keys=[[#1]]
+            Project (#0, #1)
+              Get l50
+          ArrangeBy keys=[[#0]]
+            Union
+              Get l53
+              Map (null)
+                Union
+                  Negate
+                    Project (#0)
+                      Get l53
+                  Get l51
+    cte l55 =
+      Filter ((#2) IS NULL OR (#2 = false))
+        Get l54
+    cte l56 =
+      Distinct project=[#0]
+        Project (#1)
+          Get l55
+    cte l57 =
+      ArrangeBy keys=[[]]
+        Project (#0)
+          Filter (#1 = 3)
+            Get l45
+    cte l58 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Get l56
+          Get l57
+    cte l59 =
+      Union
+        Get l58
+        Map (false)
+          Union
+            Negate
+              Project (#0)
+                Get l58
+            Get l56
+    cte l60 =
+      Project (#0, #1, #3)
+        Join on=(#1 = #2) type=differential
+          ArrangeBy keys=[[#1]]
+            Project (#0, #1)
+              Get l55
+          ArrangeBy keys=[[#0]]
+            Union
+              Get l59
+              Map (null)
+                Union
+                  Negate
+                    Project (#0)
+                      Get l59
+                  Get l56
+    cte l61 =
+      Distinct project=[#0]
+        Project (#1)
+          Get l60
+    cte l62 =
+      ArrangeBy keys=[[]]
+        Project (#0)
+          Filter (#1 = 2)
+            Get l45
+    cte l63 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Get l61
+          Get l62
+    cte l64 =
+      Union
+        Get l63
+        Map (false)
+          Union
+            Negate
+              Project (#0)
+                Get l63
+            Get l61
+    cte l65 =
+      Project (#0..=#2, #4)
+        Join on=(#1 = #3) type=differential
+          ArrangeBy keys=[[#1]]
+            Get l60
+          ArrangeBy keys=[[#0]]
+            Union
+              Get l64
+              Map (null)
+                Union
+                  Negate
+                    Project (#0)
+                      Get l64
+                  Get l61
+    cte l66 =
+      Filter ((#4) IS NULL OR (#4 = false))
+        Map ((#2 AND #3))
+          Get l65
+    cte l67 =
+      Distinct project=[#0]
+        Project (#1)
+          Get l66
+    cte l68 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Get l67
+          Get l57
+    cte l69 =
+      Union
+        Get l68
+        Map (false)
+          Union
+            Negate
+              Project (#0)
+                Get l68
+            Get l67
+    cte l70 =
+      Project (#0, #1, #3)
+        Join on=(#1 = #2) type=differential
+          ArrangeBy keys=[[#1]]
+            Project (#0, #1)
+              Get l66
+          ArrangeBy keys=[[#0]]
+            Union
+              Get l69
+              Map (null)
+                Union
+                  Negate
+                    Project (#0)
+                      Get l69
+                  Get l67
+    cte l71 =
+      Filter ((#2) IS NULL OR (#2 = false))
+        Get l70
+    cte l72 =
+      Distinct project=[#0]
+        Project (#1)
+          Get l71
+    cte l73 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        Project (#0, #1)
+          Filter (#2 = 2)
+            Reduce group_by=[#0, #1] aggregates=[count(*)]
+              CrossJoin type=differential
+                ArrangeBy keys=[[]]
+                  Get l72
+                Get l62
+    cte l74 =
+      Union
+        Get l73
+        Map (false)
+          Union
+            Negate
+              Project (#0)
+                Get l73
+            Get l72
+    cte l75 =
+      Project (#0, #1, #3)
+        Join on=(#1 = #2) type=differential
+          ArrangeBy keys=[[#1]]
+            Project (#0, #1)
+              Get l71
+          ArrangeBy keys=[[#0]]
+            Union
+              Get l74
+              Map (null)
+                Union
+                  Negate
+                    Project (#0)
+                      Get l74
+                  Get l72
+    cte l76 =
+      Filter ((#2) IS NULL OR (#2 = false))
+        Get l75
+    cte l77 =
+      Distinct project=[#0]
+        Project (#1)
+          Get l76
+    cte l78 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Get l77
+          Get l62
+    cte l79 =
+      Union
+        Get l78
+        Map (false)
+          Union
+            Negate
+              Project (#0)
+                Get l78
+            Get l77
     cte l80 =
       Project (#1, #3, #4)
         Join on=(#0 = #2) type=differential
@@ -350,647 +955,42 @@ Explained Query:
                                   Project (#0)
                                     Get l79
                                 Get l77
-    cte l79 =
-      Union
-        Get l78
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l78
-            Get l77
-    cte l78 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l77
-          Get l62
-    cte l77 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l76
-    cte l76 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l75
-    cte l75 =
-      Project (#0, #1, #3)
-        Join on=(#1 = #2) type=differential
-          ArrangeBy keys=[[#1]]
-            Project (#0, #1)
-              Get l71
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l74
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l74
-                  Get l72
-    cte l74 =
-      Union
-        Get l73
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l73
-            Get l72
-    cte l73 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        Project (#0, #1)
-          Filter (#2 = 2)
-            Reduce group_by=[#0, #1] aggregates=[count(*)]
-              CrossJoin type=differential
-                ArrangeBy keys=[[]]
-                  Get l72
-                Get l62
-    cte l72 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l71
-    cte l71 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l70
-    cte l70 =
-      Project (#0, #1, #3)
-        Join on=(#1 = #2) type=differential
-          ArrangeBy keys=[[#1]]
-            Project (#0, #1)
-              Get l66
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l69
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l69
-                  Get l67
-    cte l69 =
-      Union
-        Get l68
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l68
-            Get l67
-    cte l68 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l67
-          Get l57
-    cte l67 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l66
-    cte l66 =
-      Filter ((#4) IS NULL OR (#4 = false))
-        Map ((#2 AND #3))
-          Get l65
-    cte l65 =
-      Project (#0..=#2, #4)
-        Join on=(#1 = #3) type=differential
-          ArrangeBy keys=[[#1]]
-            Get l60
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l64
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l64
-                  Get l61
-    cte l64 =
-      Union
-        Get l63
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l63
-            Get l61
-    cte l63 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l61
-          Get l62
-    cte l62 =
-      ArrangeBy keys=[[]]
-        Project (#0)
-          Filter (#1 = 2)
-            Get l45
-    cte l61 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l60
-    cte l60 =
-      Project (#0, #1, #3)
-        Join on=(#1 = #2) type=differential
-          ArrangeBy keys=[[#1]]
-            Project (#0, #1)
-              Get l55
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l59
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l59
-                  Get l56
-    cte l59 =
-      Union
-        Get l58
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l58
-            Get l56
-    cte l58 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l56
-          Get l57
-    cte l57 =
-      ArrangeBy keys=[[]]
-        Project (#0)
-          Filter (#1 = 3)
-            Get l45
-    cte l56 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l55
-    cte l55 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l54
-    cte l54 =
-      Project (#0, #1, #3)
-        Join on=(#1 = #2) type=differential
-          ArrangeBy keys=[[#1]]
-            Project (#0, #1)
-              Get l50
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l53
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l53
-                  Get l51
-    cte l53 =
-      Union
-        Get l52
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l52
-            Get l51
-    cte l52 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l51
-          ArrangeBy keys=[[]]
-            Project (#0)
-              Filter (#1 = 4)
-                Get l45
-    cte l51 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l50
-    cte l50 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l49
-    cte l49 =
-      Project (#0, #1, #3)
-        Join on=(#1 = #2) type=differential
-          ArrangeBy keys=[[#1]]
-            Get l43
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l48
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l48
-                  Get l46
-    cte l48 =
-      Union
-        Get l47
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l47
-            Get l46
-    cte l47 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l46
-          ArrangeBy keys=[[]]
-            Project (#0)
-              Filter (#1 = 5)
-                Get l45
-    cte l46 =
-      Distinct project=[#0]
-        Get l44
-    cte l45 =
-      Project (#0, #3)
-        Map (bigint_to_integer(#2))
-          Reduce group_by=[#0, #1] aggregates=[count(*)]
-            Project (#0, #1)
-              Distinct project=[#0, substr(#0, #1, 1), #1]
-                CrossJoin type=differential
-                  ArrangeBy keys=[[]]
-                    Get l44
-                  Get l2
-    cte l44 =
-      Project (#1)
-        Get l43
-    cte l43 =
-      Distinct project=[#0, ((((#1 || #2) || #3) || #4) || #5)]
-        Project (#0, #1, #3, #5, #7, #9)
-          Join on=(#0 = #2 = #4 = #6 = #8) type=delta
-            ArrangeBy keys=[[#0]]
-              Project (#0, #1)
-                Filter (#2 = 1)
-                  Get l42
-            ArrangeBy keys=[[#0]]
-              Project (#0, #1)
-                Filter (#2 = 2)
-                  Get l42
-            ArrangeBy keys=[[#0]]
-              Project (#0, #1)
-                Filter (#2 = 3)
-                  Get l42
-            ArrangeBy keys=[[#0]]
-              Project (#0, #1)
-                Filter (#2 = 4)
-                  Get l42
-            ArrangeBy keys=[[#0]]
-              Project (#0, #1)
-                Filter (#2 = 5)
-                  Get l42
-    cte l42 =
-      Distinct project=[#0..=#2]
-        Union
-          Project (#0, #2, #1)
-            Get l41
-          Project (#0, #3, #1)
-            Join on=(#0 = #2) type=differential
-              ArrangeBy keys=[[#0]]
-                Project (#0, #1)
-                  Filter (#2 = "J") AND (#0) IS NOT NULL
-                    Get l3
-              ArrangeBy keys=[[#0]]
-                Project (#0, #2)
-                  Get l41
-    cte l41 =
-      Filter (#0) IS NOT NULL
-        Get l3
-    cte l40 =
+    cte l81 =
       Reduce aggregates=[sum(#0)]
         Project (#0)
           Filter ((#1 < #3) OR ((#1 = #3) AND (#2 <= #4)))
             CrossJoin type=differential
               ArrangeBy keys=[[]]
-                Get l39
+                Get l80
               ArrangeBy keys=[[]]
                 Project (#1, #2)
-                  Get l39
-    cte l39 =
-      Project (#1..=#3)
-        Map (translate(#0, "AKQJT98765432", "ABCDEFGHIJKLM"))
-          Union
-            Project (#0, #1, #3)
-              Filter #2
-                Map (1)
-                  Get l8
-            Project (#0, #1, #3)
-              Filter #2
-                Map (2)
-                  Get l13
-            Project (#0, #1, #4)
-              Filter #2 AND #3
-                Map (3)
-                  Get l24
-            Project (#0, #1, #3)
-              Filter #2
-                Map (4)
-                  Get l29
-            Project (#0, #1, #3)
-              Filter #2
-                Map (5)
-                  Get l34
-            Project (#0, #1, #4)
-              Map (case when #3 then 6 else 7 end)
-                Join on=(#0 = #2) type=differential
-                  ArrangeBy keys=[[#0]]
-                    Project (#0, #1)
-                      Get l35
-                  ArrangeBy keys=[[#0]]
-                    Union
-                      Get l38
-                      Map (null)
-                        Union
-                          Negate
-                            Project (#0)
-                              Get l38
-                          Get l36
-    cte l38 =
-      Union
-        Get l37
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l37
-            Get l36
-    cte l37 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l36
-          Get l21
-    cte l36 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l35
-    cte l35 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l34
-    cte l34 =
-      Project (#0, #1, #3)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Project (#0, #1)
-              Get l30
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l33
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l33
-                  Get l31
-    cte l33 =
-      Union
-        Get l32
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l32
-            Get l31
-    cte l32 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        Project (#0, #1)
-          Filter (#2 = 2)
-            Reduce group_by=[#0, #1] aggregates=[count(*)]
-              CrossJoin type=differential
-                ArrangeBy keys=[[]]
-                  Get l31
-                Get l21
-    cte l31 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l30
-    cte l30 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l29
-    cte l29 =
-      Project (#0, #1, #3)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Project (#0, #1)
-              Get l25
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l28
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l28
-                  Get l26
-    cte l28 =
-      Union
-        Get l27
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l27
-            Get l26
-    cte l27 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l26
-          Get l16
-    cte l26 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l25
-    cte l25 =
-      Filter ((#4) IS NULL OR (#4 = false))
-        Map ((#2 AND #3))
-          Get l24
-    cte l24 =
-      Project (#0..=#2, #4)
-        Join on=(#0 = #3) type=differential
-          ArrangeBy keys=[[#0]]
-            Get l19
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l23
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l23
-                  Get l20
-    cte l23 =
-      Union
-        Get l22
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l22
-            Get l20
-    cte l22 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l20
-          Get l21
-    cte l21 =
+                  Get l80
+  Return
+    CrossJoin type=differential
       ArrangeBy keys=[[]]
-        Project (#0)
-          Filter (#1 = 2)
-            Get l4
-    cte l20 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l19
-    cte l19 =
-      Project (#0, #1, #3)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Project (#0, #1)
-              Get l14
-          ArrangeBy keys=[[#0]]
+        Project (#1)
+          Map (bigint_to_integer(#0))
             Union
-              Get l18
+              Get l40
               Map (null)
                 Union
                   Negate
-                    Project (#0)
-                      Get l18
-                  Get l15
-    cte l18 =
-      Union
-        Get l17
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l17
-            Get l15
-    cte l17 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l15
-          Get l16
-    cte l16 =
+                    Project ()
+                      Get l40
+                  Constant
+                    - ()
       ArrangeBy keys=[[]]
-        Project (#0)
-          Filter (#1 = 3)
-            Get l4
-    cte l15 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l14
-    cte l14 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l13
-    cte l13 =
-      Project (#0, #1, #3)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Project (#0, #1)
-              Get l9
-          ArrangeBy keys=[[#0]]
+        Project (#1)
+          Map (bigint_to_integer(#0))
             Union
-              Get l12
+              Get l81
               Map (null)
                 Union
                   Negate
-                    Project (#0)
-                      Get l12
-                  Get l10
-    cte l12 =
-      Union
-        Get l11
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l11
-            Get l10
-    cte l11 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l10
-          ArrangeBy keys=[[]]
-            Project (#0)
-              Filter (#1 = 4)
-                Get l4
-    cte l10 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l9
-    cte l9 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l8
-    cte l8 =
-      Project (#0, #1, #3)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Get l0
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l7
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l7
-                  Get l5
-    cte l7 =
-      Union
-        Get l6
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l6
-            Get l5
-    cte l6 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l5
-          ArrangeBy keys=[[]]
-            Project (#0)
-              Filter (#1 = 5)
-                Get l4
-    cte l5 =
-      Distinct project=[#0]
-        Get l1
-    cte l4 =
-      Project (#0, #3)
-        Map (bigint_to_integer(#2))
-          Reduce group_by=[#0, #1] aggregates=[count(*)]
-            Project (#0, #2)
-              Get l3
-    cte l3 =
-      Map (substr(#0, #1, 1))
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l1
-          Get l2
-    cte l2 =
-      ArrangeBy keys=[[]]
-        Constant
-          - (1)
-          - (2)
-          - (3)
-          - (4)
-          - (5)
-    cte l1 =
-      Project (#0)
-        Get l0
-    cte l0 =
-      Project (#3, #4)
-        Map (regexp_split_to_array[" ", case_insensitive=false](#1), array_index(#2, 1), text_to_integer(array_index(#2, 2)))
-          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-            ReadStorage materialize.public.input
+                    Project ()
+                      Get l81
+                  Constant
+                    - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1208.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1208.slt
@@ -66,9 +66,6 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM pos2 WHERE substring(state, 3, 1) = 'Z';
 ----
 Explained Query:
-  Return
-    Filter ("Z" = substr(#1, 3, 1))
-      Get l0
   With Mutually Recursive
     cte l0 =
       Union
@@ -90,6 +87,9 @@ Explained Query:
                   Map (substr(#0, #1, 1))
                     FlatMap generate_series(1, char_length(#0), 1)
                       ReadStorage materialize.public.steps_input
+  Return
+    Filter ("Z" = substr(#1, 3, 1))
+      Get l0
 
 Source materialize.public.steps_input
 Source materialize.public.paths

--- a/test/sqllogictest/advent-of-code/2023/aoc_1209.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1209.slt
@@ -63,43 +63,24 @@ EXPLAIN WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 30)
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  Return
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Union
-            Get l4
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l4
-                Constant
-                  - ()
-        ArrangeBy keys=[[]]
-          Project (#1)
-            Map (f64toi64(#0))
-              Union
-                Get l5
-                Map (null)
-                  Union
-                    Negate
-                      Project ()
-                        Get l5
-                    Constant
-                      - ()
-    With
-      cte l5 =
-        Reduce aggregates=[sum((power(-1, integer_to_double((#1 + 1))) * integer_to_double(#0)))]
-          Project (#0, #2)
-            Filter (#2 = #3)
-              Get l3
-      cte l4 =
-        Reduce aggregates=[sum(#0)]
-          Project (#0)
-            Filter (#2 = 21)
-              Get l3
   With Mutually Recursive
+    cte l0 =
+      Map ((#2 + 1))
+        Get l3
+    cte l1 =
+      Project (#0..=#4, #6)
+        Join on=(#1 = #5 AND #3 = #7 AND #6 = (#2 + 1)) type=differential
+          ArrangeBy keys=[[#1, (#2 + 1), #3]]
+            Project (#0..=#3)
+              Filter (#4 <= 21) AND (#1) IS NOT NULL AND (#4 > #3)
+                Get l0
+          ArrangeBy keys=[[#1..=#3]]
+            Filter (#2 <= 21) AND (#1) IS NOT NULL AND (#2 > #3)
+              Get l3
+    cte l2 =
+      Distinct project=[#0..=#2]
+        Project (#1, #3, #5)
+          Get l1
     cte [recursion_limit=30, return_at_limit] l3 =
       Distinct project=[#0..=#3]
         Union
@@ -143,23 +124,42 @@ Explained Query:
                 Project (#0..=#4, #1, #5, #3)
                   Filter (0 != (coalesce(#4, 0) - coalesce(#0, 0)))
                     Get l1
-    cte l2 =
-      Distinct project=[#0..=#2]
-        Project (#1, #3, #5)
-          Get l1
-    cte l1 =
-      Project (#0..=#4, #6)
-        Join on=(#1 = #5 AND #3 = #7 AND #6 = (#2 + 1)) type=differential
-          ArrangeBy keys=[[#1, (#2 + 1), #3]]
-            Project (#0..=#3)
-              Filter (#4 <= 21) AND (#1) IS NOT NULL AND (#4 > #3)
-                Get l0
-          ArrangeBy keys=[[#1..=#3]]
-            Filter (#2 <= 21) AND (#1) IS NOT NULL AND (#2 > #3)
+  Return
+    With
+      cte l4 =
+        Reduce aggregates=[sum(#0)]
+          Project (#0)
+            Filter (#2 = 21)
               Get l3
-    cte l0 =
-      Map ((#2 + 1))
-        Get l3
+      cte l5 =
+        Reduce aggregates=[sum((power(-1, integer_to_double((#1 + 1))) * integer_to_double(#0)))]
+          Project (#0, #2)
+            Filter (#2 = #3)
+              Get l3
+    Return
+      CrossJoin type=differential
+        ArrangeBy keys=[[]]
+          Union
+            Get l4
+            Map (null)
+              Union
+                Negate
+                  Project ()
+                    Get l4
+                Constant
+                  - ()
+        ArrangeBy keys=[[]]
+          Project (#1)
+            Map (f64toi64(#0))
+              Union
+                Get l5
+                Map (null)
+                  Union
+                    Negate
+                      Project ()
+                        Get l5
+                    Constant
+                      - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1210.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1210.slt
@@ -370,181 +370,21 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  Return
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Project (#1)
-            Map ((#0 / 2))
-              Union
-                Get l7
-                Map (0)
-                  Union
-                    Negate
-                      Project ()
-                        Get l7
-                    Constant
-                      - ()
-        ArrangeBy keys=[[]]
-          Union
-            Get l19
-            Map (0)
-              Union
-                Negate
-                  Project ()
-                    Get l19
-                Constant
-                  - ()
-    With
-      cte l19 =
-        Reduce aggregates=[count(*)]
-          Union
-            Negate
-              Project ()
-                Join on=(#0 = #2 AND #1 = #3) type=differential
-                  ArrangeBy keys=[[#0, #1]]
-                    Project (#0, #1)
-                      Get l18
-                  ArrangeBy keys=[[#0, #1]]
-                    Distinct project=[#0, #1]
-                      Project (#0, #1)
-                        Get l8
-            Project ()
-              Get l18
-      cte l18 =
-        Filter (#2 = true)
-          Get l17
   With Mutually Recursive
-    cte l17 =
-      Distinct project=[#0..=#2]
-        Union
-          Project (#0, #1, #3)
-            Filter ((#0 = 1) OR (#1 = 1))
-              Map (false)
-                Get l0
-          Project (#2, #3, #6)
-            Map (case when #5 then NOT(#0) else #0 end)
-              Join on=(#1 = #4) type=differential
-                ArrangeBy keys=[[#1]]
-                  Get l11
-                ArrangeBy keys=[[#0]]
-                  Union
-                    Get l16
-                    Project (#0, #2)
-                      Map (null)
-                        Join on=(#0 = #1) type=differential
-                          ArrangeBy keys=[[#0]]
-                            Union
-                              Negate
-                                Distinct project=[#0]
-                                  Project (#0)
-                                    Get l16
-                              Get l12
-                          Get l14
-    cte l16 =
-      Union
-        Get l15
-        Map (error("more than one record produced in subquery"))
-          Project (#0)
-            Filter (#1 > 1)
-              Reduce group_by=[#0] aggregates=[count(*)]
-                Project (#0)
-                  Get l15
-    cte l15 =
-      Union
-        Get l13
-        Project (#0, #2)
-          Map (false)
-            Join on=(#0 = #1) type=differential
-              ArrangeBy keys=[[#0]]
-                Union
-                  Negate
-                    Project (#0)
-                      Get l13
-                  Get l12
-              Get l14
-    cte l14 =
-      ArrangeBy keys=[[#0]]
-        Get l12
-    cte l13 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        FlatMap wrap1("J", "-", "|", "F")
-          Get l12
-    cte l12 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l11
-    cte l11 =
-      Project (#2, #3, #6, #7)
-        Map ((#0 + 1), (#1 + 1))
-          Join on=(#0 = #4 AND #1 = #5) type=differential
-            ArrangeBy keys=[[#0, #1]]
-              Union
-                Map (null)
-                  Union
-                    Negate
-                      Project (#0..=#2)
-                        Join on=(#0 = #3 AND #1 = #4) type=differential
-                          Get l9
-                          ArrangeBy keys=[[#0, #1]]
-                            Distinct project=[#0, #1]
-                              Project (#0, #1)
-                                Get l10
-                    Get l17
-                Get l10
-            ArrangeBy keys=[[#0, #1]]
-              Project (#0, #1)
-                Get l0
-    cte l10 =
-      Project (#0..=#2, #5)
-        Join on=(#0 = #3 AND #1 = #4) type=differential
-          Get l9
-          ArrangeBy keys=[[#0, #1]]
-            Get l8
-    cte l9 =
-      ArrangeBy keys=[[#0, #1]]
-        Get l17
-    cte l8 =
-      Distinct project=[#0..=#2]
-        Union
-          Project (#0, #1, #4)
-            Join on=(#0 = #2 AND #1 = #3) type=differential
-              ArrangeBy keys=[[#0, #1]]
-                Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-                  Get l6
-              ArrangeBy keys=[[#0, #1]]
-                Filter (#2 != "S")
-                  Get l0
-          Project (#0, #1, #8)
-            Map (case when ((#0 = #0) AND (#0 = (#6 + 1)) AND (#1 = #7) AND (#1 = (#1 + 1))) then "J" else case when ((#0 = #0) AND (#0 = #6) AND (#1 = (#1 + 1)) AND (#1 = (#7 - 1))) then "-" else case when ((#0 = #0) AND (#0 = (#6 - 1)) AND (#1 = #7) AND (#1 = (#1 + 1))) then "7" else case when ((#0 = #6) AND (#0 = (#0 + 1)) AND (#1 = #1) AND (#1 = (#7 - 1))) then "L" else case when ((#0 = (#0 + 1)) AND (#0 = (#6 - 1)) AND (#1 = #1) AND (#1 = #7)) then "|" else case when ((#0 = #0) AND (#0 = #6) AND (#1 = (#1 - 1)) AND (#1 = (#7 - 1))) then "F" else "???" end end end end end end)
-              Join on=(#0 = #2 = #4 AND #1 = #3 = #5) type=delta
-                ArrangeBy keys=[[#0, #1]]
-                  Get l4
-                ArrangeBy keys=[[#0, #1]]
-                  Project (#0, #1)
-                    Get l3
-                Get l5
-    cte l7 =
-      Reduce aggregates=[count(*)]
-        Project ()
-          Get l6
-    cte l6 =
-      Distinct project=[#0, #1]
-        Union
-          Get l4
-          Project (#4, #5)
-            Join on=(#0 = #2 AND #1 = #3) type=differential
-              ArrangeBy keys=[[#0, #1]]
-                Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-                  Get l6
-              Get l5
-    cte l5 =
-      ArrangeBy keys=[[#0, #1]]
-        Get l3
-    cte l4 =
-      Project (#0, #1)
-        Filter (#2 = "S")
-          Get l0
+    cte l0 =
+      Project (#0, #2, #3)
+        Map (substr(#1, #2, 1))
+          FlatMap generate_series(1, char_length(#1), 1)
+            Project (#1, #2)
+              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
+                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
+                  ReadStorage materialize.public.input
+    cte l1 =
+      Map ((#2 = "-"), case when #3 then #0 else case when (#2 = "|") then (#0 - 1) else case when (#2 = "F") then (#0 + 1) else case when (#2 = "L") then (#0 - 1) else case when (#2 = "J") then #0 else case when (#2 = "7") then #0 else null end end end end end end, case when #3 then (#1 - 1) else case when (#2 = "|") then #1 else case when (#2 = "F") then #1 else case when (#2 = "L") then #1 else case when (#2 = "J") then (#1 - 1) else case when (#2 = "7") then (#1 - 1) else null end end end end end end)
+        Get l0
+    cte l2 =
+      Map ((#2 = "-"), case when #3 then #0 else case when (#2 = "|") then (#0 + 1) else case when (#2 = "F") then #0 else case when (#2 = "L") then #0 else case when (#2 = "J") then (#0 - 1) else case when (#2 = "7") then (#0 + 1) else null end end end end end end, case when #3 then (#1 + 1) else case when (#2 = "|") then #1 else case when (#2 = "F") then (#1 + 1) else case when (#2 = "L") then (#1 + 1) else case when (#2 = "J") then #1 else case when (#2 = "7") then #1 else null end end end end end end)
+        Get l0
     cte l3 =
       Project (#0..=#3)
         Filter (#4 = 2)
@@ -578,20 +418,180 @@ Explained Query:
                 Filter (#2 = "S")
                   Map ((#1 - 1))
                     Get l0
-    cte l2 =
-      Map ((#2 = "-"), case when #3 then #0 else case when (#2 = "|") then (#0 + 1) else case when (#2 = "F") then #0 else case when (#2 = "L") then #0 else case when (#2 = "J") then (#0 - 1) else case when (#2 = "7") then (#0 + 1) else null end end end end end end, case when #3 then (#1 + 1) else case when (#2 = "|") then #1 else case when (#2 = "F") then (#1 + 1) else case when (#2 = "L") then (#1 + 1) else case when (#2 = "J") then #1 else case when (#2 = "7") then #1 else null end end end end end end)
-        Get l0
-    cte l1 =
-      Map ((#2 = "-"), case when #3 then #0 else case when (#2 = "|") then (#0 - 1) else case when (#2 = "F") then (#0 + 1) else case when (#2 = "L") then (#0 - 1) else case when (#2 = "J") then #0 else case when (#2 = "7") then #0 else null end end end end end end, case when #3 then (#1 - 1) else case when (#2 = "|") then #1 else case when (#2 = "F") then #1 else case when (#2 = "L") then #1 else case when (#2 = "J") then (#1 - 1) else case when (#2 = "7") then (#1 - 1) else null end end end end end end)
-        Get l0
-    cte l0 =
-      Project (#0, #2, #3)
-        Map (substr(#1, #2, 1))
-          FlatMap generate_series(1, char_length(#1), 1)
-            Project (#1, #2)
-              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-                  ReadStorage materialize.public.input
+    cte l4 =
+      Project (#0, #1)
+        Filter (#2 = "S")
+          Get l0
+    cte l5 =
+      ArrangeBy keys=[[#0, #1]]
+        Get l3
+    cte l6 =
+      Distinct project=[#0, #1]
+        Union
+          Get l4
+          Project (#4, #5)
+            Join on=(#0 = #2 AND #1 = #3) type=differential
+              ArrangeBy keys=[[#0, #1]]
+                Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+                  Get l6
+              Get l5
+    cte l7 =
+      Reduce aggregates=[count(*)]
+        Project ()
+          Get l6
+    cte l8 =
+      Distinct project=[#0..=#2]
+        Union
+          Project (#0, #1, #4)
+            Join on=(#0 = #2 AND #1 = #3) type=differential
+              ArrangeBy keys=[[#0, #1]]
+                Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+                  Get l6
+              ArrangeBy keys=[[#0, #1]]
+                Filter (#2 != "S")
+                  Get l0
+          Project (#0, #1, #8)
+            Map (case when ((#0 = #0) AND (#0 = (#6 + 1)) AND (#1 = #7) AND (#1 = (#1 + 1))) then "J" else case when ((#0 = #0) AND (#0 = #6) AND (#1 = (#1 + 1)) AND (#1 = (#7 - 1))) then "-" else case when ((#0 = #0) AND (#0 = (#6 - 1)) AND (#1 = #7) AND (#1 = (#1 + 1))) then "7" else case when ((#0 = #6) AND (#0 = (#0 + 1)) AND (#1 = #1) AND (#1 = (#7 - 1))) then "L" else case when ((#0 = (#0 + 1)) AND (#0 = (#6 - 1)) AND (#1 = #1) AND (#1 = #7)) then "|" else case when ((#0 = #0) AND (#0 = #6) AND (#1 = (#1 - 1)) AND (#1 = (#7 - 1))) then "F" else "???" end end end end end end)
+              Join on=(#0 = #2 = #4 AND #1 = #3 = #5) type=delta
+                ArrangeBy keys=[[#0, #1]]
+                  Get l4
+                ArrangeBy keys=[[#0, #1]]
+                  Project (#0, #1)
+                    Get l3
+                Get l5
+    cte l9 =
+      ArrangeBy keys=[[#0, #1]]
+        Get l17
+    cte l10 =
+      Project (#0..=#2, #5)
+        Join on=(#0 = #3 AND #1 = #4) type=differential
+          Get l9
+          ArrangeBy keys=[[#0, #1]]
+            Get l8
+    cte l11 =
+      Project (#2, #3, #6, #7)
+        Map ((#0 + 1), (#1 + 1))
+          Join on=(#0 = #4 AND #1 = #5) type=differential
+            ArrangeBy keys=[[#0, #1]]
+              Union
+                Map (null)
+                  Union
+                    Negate
+                      Project (#0..=#2)
+                        Join on=(#0 = #3 AND #1 = #4) type=differential
+                          Get l9
+                          ArrangeBy keys=[[#0, #1]]
+                            Distinct project=[#0, #1]
+                              Project (#0, #1)
+                                Get l10
+                    Get l17
+                Get l10
+            ArrangeBy keys=[[#0, #1]]
+              Project (#0, #1)
+                Get l0
+    cte l12 =
+      Distinct project=[#0]
+        Project (#1)
+          Get l11
+    cte l13 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        FlatMap wrap1("J", "-", "|", "F")
+          Get l12
+    cte l14 =
+      ArrangeBy keys=[[#0]]
+        Get l12
+    cte l15 =
+      Union
+        Get l13
+        Project (#0, #2)
+          Map (false)
+            Join on=(#0 = #1) type=differential
+              ArrangeBy keys=[[#0]]
+                Union
+                  Negate
+                    Project (#0)
+                      Get l13
+                  Get l12
+              Get l14
+    cte l16 =
+      Union
+        Get l15
+        Map (error("more than one record produced in subquery"))
+          Project (#0)
+            Filter (#1 > 1)
+              Reduce group_by=[#0] aggregates=[count(*)]
+                Project (#0)
+                  Get l15
+    cte l17 =
+      Distinct project=[#0..=#2]
+        Union
+          Project (#0, #1, #3)
+            Filter ((#0 = 1) OR (#1 = 1))
+              Map (false)
+                Get l0
+          Project (#2, #3, #6)
+            Map (case when #5 then NOT(#0) else #0 end)
+              Join on=(#1 = #4) type=differential
+                ArrangeBy keys=[[#1]]
+                  Get l11
+                ArrangeBy keys=[[#0]]
+                  Union
+                    Get l16
+                    Project (#0, #2)
+                      Map (null)
+                        Join on=(#0 = #1) type=differential
+                          ArrangeBy keys=[[#0]]
+                            Union
+                              Negate
+                                Distinct project=[#0]
+                                  Project (#0)
+                                    Get l16
+                              Get l12
+                          Get l14
+  Return
+    With
+      cte l18 =
+        Filter (#2 = true)
+          Get l17
+      cte l19 =
+        Reduce aggregates=[count(*)]
+          Union
+            Negate
+              Project ()
+                Join on=(#0 = #2 AND #1 = #3) type=differential
+                  ArrangeBy keys=[[#0, #1]]
+                    Project (#0, #1)
+                      Get l18
+                  ArrangeBy keys=[[#0, #1]]
+                    Distinct project=[#0, #1]
+                      Project (#0, #1)
+                        Get l8
+            Project ()
+              Get l18
+    Return
+      CrossJoin type=differential
+        ArrangeBy keys=[[]]
+          Project (#1)
+            Map ((#0 / 2))
+              Union
+                Get l7
+                Map (0)
+                  Union
+                    Negate
+                      Project ()
+                        Get l7
+                    Constant
+                      - ()
+        ArrangeBy keys=[[]]
+          Union
+            Get l19
+            Map (0)
+              Union
+                Negate
+                  Project ()
+                    Get l19
+                Constant
+                  - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1211.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1211.slt
@@ -199,51 +199,74 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  Return
-    CrossJoin type=differential
-      ArrangeBy keys=[[]]
-        Union
-          Get l11
-          Map (null)
-            Union
-              Negate
-                Project ()
-                  Get l11
-              Constant
-                - ()
-      ArrangeBy keys=[[]]
-        Union
-          Get l13
-          Map (null)
-            Union
-              Negate
-                Project ()
-                  Get l13
-              Constant
-                - ()
   With
-    cte l13 =
-      Reduce aggregates=[sum((abs((#0 - #2)) + abs((#1 - #3))))]
-        Filter ((#0 < #2) OR ((#0 = #2) AND (#1 < #3)))
-          CrossJoin type=differential
-            Get l12
-            Get l12
-    cte l12 =
-      ArrangeBy keys=[[]]
-        Project (#4, #5)
-          Map (bigint_to_integer((integer_to_bigint(#0) + (999999 * #2))), bigint_to_integer((integer_to_bigint(#1) + (999999 * #3))))
-            Get l9
-    cte l11 =
-      Reduce aggregates=[sum((abs((#0 - #2)) + abs((#1 - #3))))]
-        Filter ((#0 < #2) OR ((#0 = #2) AND (#1 < #3)))
-          CrossJoin type=differential
-            Get l10
-            Get l10
-    cte l10 =
-      ArrangeBy keys=[[]]
-        Project (#4, #5)
-          Map (bigint_to_integer((integer_to_bigint(#0) + #2)), bigint_to_integer((integer_to_bigint(#1) + #3)))
-            Get l9
+    cte l0 =
+      Project (#0, #2, #3)
+        Map (substr(#1, #2, 1))
+          FlatMap generate_series(1, char_length(#1), 1)
+            Project (#1, #2)
+              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
+                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
+                  ReadStorage materialize.public.input
+    cte l1 =
+      Project (#0, #1)
+        Filter (#2 = "#")
+          Get l0
+    cte l2 =
+      Distinct project=[#0, #1]
+        Get l1
+    cte l3 =
+      Distinct project=[#0]
+        Project (#0)
+          Get l2
+    cte l4 =
+      Reduce group_by=[#0] aggregates=[count(*)]
+        Project (#0)
+          Filter (#1 < #0)
+            CrossJoin type=differential
+              ArrangeBy keys=[[]]
+                Get l3
+              ArrangeBy keys=[[]]
+                Project (#0)
+                  Filter (#1 = 0)
+                    Reduce group_by=[#0] aggregates=[count((null OR ((#1) IS NOT NULL AND (#1 = "#"))))]
+                      Project (#0, #2)
+                        Get l0
+    cte l5 =
+      Union
+        Get l4
+        Map (0)
+          Union
+            Negate
+              Project (#0)
+                Get l4
+            Get l3
+    cte l6 =
+      Distinct project=[#0]
+        Project (#1)
+          Get l2
+    cte l7 =
+      Reduce group_by=[#0] aggregates=[count(*)]
+        Project (#0)
+          Filter (#1 < #0)
+            CrossJoin type=differential
+              ArrangeBy keys=[[]]
+                Get l6
+              ArrangeBy keys=[[]]
+                Project (#0)
+                  Filter (#1 = 0)
+                    Reduce group_by=[#0] aggregates=[count((null OR ((#1) IS NOT NULL AND (#1 = "#"))))]
+                      Project (#1, #2)
+                        Get l0
+    cte l8 =
+      Union
+        Get l7
+        Map (0)
+          Union
+            Negate
+              Project (#0)
+                Get l7
+            Get l6
     cte l9 =
       Project (#0, #1, #3, #5)
         Join on=(#0 = #2 AND #1 = #4) type=delta
@@ -267,73 +290,50 @@ Explained Query:
                     Project (#0)
                       Get l8
                   Get l6
-    cte l8 =
-      Union
-        Get l7
-        Map (0)
-          Union
-            Negate
-              Project (#0)
-                Get l7
-            Get l6
-    cte l7 =
-      Reduce group_by=[#0] aggregates=[count(*)]
-        Project (#0)
-          Filter (#1 < #0)
-            CrossJoin type=differential
-              ArrangeBy keys=[[]]
-                Get l6
-              ArrangeBy keys=[[]]
-                Project (#0)
-                  Filter (#1 = 0)
-                    Reduce group_by=[#0] aggregates=[count((null OR ((#1) IS NOT NULL AND (#1 = "#"))))]
-                      Project (#1, #2)
-                        Get l0
-    cte l6 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l2
-    cte l5 =
-      Union
-        Get l4
-        Map (0)
-          Union
-            Negate
-              Project (#0)
-                Get l4
-            Get l3
-    cte l4 =
-      Reduce group_by=[#0] aggregates=[count(*)]
-        Project (#0)
-          Filter (#1 < #0)
-            CrossJoin type=differential
-              ArrangeBy keys=[[]]
-                Get l3
-              ArrangeBy keys=[[]]
-                Project (#0)
-                  Filter (#1 = 0)
-                    Reduce group_by=[#0] aggregates=[count((null OR ((#1) IS NOT NULL AND (#1 = "#"))))]
-                      Project (#0, #2)
-                        Get l0
-    cte l3 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l2
-    cte l2 =
-      Distinct project=[#0, #1]
-        Get l1
-    cte l1 =
-      Project (#0, #1)
-        Filter (#2 = "#")
-          Get l0
-    cte l0 =
-      Project (#0, #2, #3)
-        Map (substr(#1, #2, 1))
-          FlatMap generate_series(1, char_length(#1), 1)
-            Project (#1, #2)
-              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-                  ReadStorage materialize.public.input
+    cte l10 =
+      ArrangeBy keys=[[]]
+        Project (#4, #5)
+          Map (bigint_to_integer((integer_to_bigint(#0) + #2)), bigint_to_integer((integer_to_bigint(#1) + #3)))
+            Get l9
+    cte l11 =
+      Reduce aggregates=[sum((abs((#0 - #2)) + abs((#1 - #3))))]
+        Filter ((#0 < #2) OR ((#0 = #2) AND (#1 < #3)))
+          CrossJoin type=differential
+            Get l10
+            Get l10
+    cte l12 =
+      ArrangeBy keys=[[]]
+        Project (#4, #5)
+          Map (bigint_to_integer((integer_to_bigint(#0) + (999999 * #2))), bigint_to_integer((integer_to_bigint(#1) + (999999 * #3))))
+            Get l9
+    cte l13 =
+      Reduce aggregates=[sum((abs((#0 - #2)) + abs((#1 - #3))))]
+        Filter ((#0 < #2) OR ((#0 = #2) AND (#1 < #3)))
+          CrossJoin type=differential
+            Get l12
+            Get l12
+  Return
+    CrossJoin type=differential
+      ArrangeBy keys=[[]]
+        Union
+          Get l11
+          Map (null)
+            Union
+              Negate
+                Project ()
+                  Get l11
+              Constant
+                - ()
+      ArrangeBy keys=[[]]
+        Union
+          Get l13
+          Map (null)
+            Union
+              Negate
+                Project ()
+                  Get l13
+              Constant
+                - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1212.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1212.slt
@@ -91,25 +91,39 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT SUM(count) FROM counts;
 ----
 Explained Query:
-  Return
-    Return
-      Union
-        Get l6
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l6
-            Constant
-              - ()
-    With
-      cte l6 =
-        Reduce aggregates=[sum(#0)]
-          Project (#3)
-            TopK group_by=[#0] order_by=[#1 desc nulls_first, #2 desc nulls_first] limit=1
-              Reduce group_by=[#0..=#2] aggregates=[count(*)]
-                Get l5
   With Mutually Recursive
+    cte l0 =
+      Project (#1, #3, #4)
+        Map (regexp_split_to_array[" ", case_insensitive=false](array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1))), (array_index(#2, 1) || "."), array_index(#2, 2))
+          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
+            ReadStorage materialize.public.input
+    cte l1 =
+      Project (#0, #2, #3)
+        Map (substr(#1, #2, 1))
+          FlatMap generate_series(1, char_length(#1), 1)
+            Project (#0, #1)
+              Get l0
+    cte l2 =
+      ArrangeBy keys=[[#0, #1]]
+        Project (#0, #1)
+          Filter (#2 != "#")
+            Get l1
+    cte l3 =
+      Project (#0..=#2, #5)
+        Join on=(#0 = #3 = #6 AND #4 = (#2 + 1) AND #7 = ((#1 + #5) + 1)) type=delta
+          ArrangeBy keys=[[#0], [#0, (#2 + 1)]]
+            Get l5
+          ArrangeBy keys=[[#0, #1]]
+            Project (#0, #2, #3)
+              Map (text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2))))
+                FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#1) array_length 1), 1)
+                  Project (#0, #2)
+                    Get l0
+          Get l2
+    cte l4 =
+      Distinct project=[#0..=#2]
+        Project (#0, #1, #3)
+          Get l3
     cte l5 =
       Union
         Project (#0, #3, #4)
@@ -140,38 +154,24 @@ Explained Query:
                                 Filter (#2 = ".")
                                   Get l1
                   Get l4
-    cte l4 =
-      Distinct project=[#0..=#2]
-        Project (#0, #1, #3)
-          Get l3
-    cte l3 =
-      Project (#0..=#2, #5)
-        Join on=(#0 = #3 = #6 AND #4 = (#2 + 1) AND #7 = ((#1 + #5) + 1)) type=delta
-          ArrangeBy keys=[[#0], [#0, (#2 + 1)]]
-            Get l5
-          ArrangeBy keys=[[#0, #1]]
-            Project (#0, #2, #3)
-              Map (text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2))))
-                FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#1) array_length 1), 1)
-                  Project (#0, #2)
-                    Get l0
-          Get l2
-    cte l2 =
-      ArrangeBy keys=[[#0, #1]]
-        Project (#0, #1)
-          Filter (#2 != "#")
-            Get l1
-    cte l1 =
-      Project (#0, #2, #3)
-        Map (substr(#1, #2, 1))
-          FlatMap generate_series(1, char_length(#1), 1)
-            Project (#0, #1)
-              Get l0
-    cte l0 =
-      Project (#1, #3, #4)
-        Map (regexp_split_to_array[" ", case_insensitive=false](array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1))), (array_index(#2, 1) || "."), array_index(#2, 2))
-          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-            ReadStorage materialize.public.input
+  Return
+    With
+      cte l6 =
+        Reduce aggregates=[sum(#0)]
+          Project (#3)
+            TopK group_by=[#0] order_by=[#1 desc nulls_first, #2 desc nulls_first] limit=1
+              Reduce group_by=[#0..=#2] aggregates=[count(*)]
+                Get l5
+    Return
+      Union
+        Get l6
+        Map (null)
+          Union
+            Negate
+              Project ()
+                Get l6
+            Constant
+              - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1213.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1213.slt
@@ -315,6 +315,133 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0, #2, #3)
+        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#1), integer_to_bigint(#2)))
+          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#1) array_length 1), 1)
+            Project (#1, #2)
+              Map (array_index(regexp_split_to_array["\n\n", case_insensitive=false](#0), integer_to_bigint(#1)))
+                FlatMap generate_series(1, (regexp_split_to_array["\n\n", case_insensitive=false](#0) array_length 1), 1)
+                  ReadStorage materialize.public.input
+    cte l1 =
+      Project (#0, #1, #3, #4)
+        Map (substr(#2, #3, 1))
+          FlatMap generate_series(1, char_length(#2), 1)
+            Get l0
+    cte l2 =
+      Distinct project=[#0, #1]
+        Project (#0, #1)
+          Get l1
+    cte l3 =
+      Distinct project=[#0, #1]
+        Project (#0, #2)
+          Get l1
+    cte l4 =
+      ArrangeBy keys=[[#0]]
+        Get l2
+    cte l5 =
+      Reduce aggregates=[sum((#0 - 1))]
+        Union
+          Negate
+            Project (#1)
+              Distinct project=[#0, #1]
+                Project (#0, #1)
+                  Filter (#3 > 1)
+                    Reduce group_by=[#0, #1, abs(((2 * #2) - ((2 * #1) - 1)))] aggregates=[count(distinct #3)]
+                      Project (#0, #1, #3, #4)
+                        Join on=(#0 = #2) type=differential
+                          Get l4
+                          ArrangeBy keys=[[#0]]
+                            Get l0
+          Project (#1)
+            Get l2
+    cte l6 =
+      Union
+        Get l5
+        Map (null)
+          Union
+            Negate
+              Project ()
+                Get l5
+            Constant
+              - ()
+    cte l7 =
+      ArrangeBy keys=[[#0]]
+        Get l3
+    cte l8 =
+      Reduce aggregates=[sum((#0 - 1))]
+        Union
+          Negate
+            Project (#1)
+              Distinct project=[#0, #1]
+                Project (#0, #1)
+                  Filter (#3 > 1)
+                    Reduce group_by=[#0, #1, abs(((2 * #2) - ((2 * #1) - 1)))] aggregates=[count(distinct #3)]
+                      Project (#0, #1, #3, #4)
+                        Join on=(#0 = #2) type=differential
+                          Get l7
+                          ArrangeBy keys=[[#0]]
+                            Reduce group_by=[#0, #2] aggregates=[string_agg[order_by=[#0 asc nulls_last]](row(row(#3, ""), #1))]
+                              Get l1
+          Project (#1)
+            Get l3
+    cte l9 =
+      Union
+        Get l8
+        Map (null)
+          Union
+            Negate
+              Project ()
+                Get l8
+            Constant
+              - ()
+    cte l10 =
+      Reduce aggregates=[sum((#0 - 1))]
+        Project (#1)
+          Filter (#2 = 1)
+            Reduce group_by=[#0, #1] aggregates=[count(*)]
+              Project (#0, #1)
+                Filter (#5 != #9) AND (#3 < #7)
+                  Join on=(#0 = #2 = #6 AND #4 = #8 AND abs(((2 * #3) - ((2 * #1) - 1))) = abs(((2 * #7) - ((2 * #1) - 1)))) type=delta
+                    Get l4
+                    ArrangeBy keys=[[#0], [#0, #2]]
+                      Get l1
+                    ArrangeBy keys=[[#0, #2]]
+                      Get l1
+    cte l11 =
+      Union
+        Get l10
+        Map (null)
+          Union
+            Negate
+              Project ()
+                Get l10
+            Constant
+              - ()
+    cte l12 =
+      Reduce aggregates=[sum((#0 - 1))]
+        Project (#1)
+          Filter (#2 = 1)
+            Reduce group_by=[#0, #1] aggregates=[count(*)]
+              Project (#0, #1)
+                Filter (#5 != #9) AND (#4 < #8)
+                  Join on=(#0 = #2 = #6 AND #3 = #7 AND abs(((2 * #4) - ((2 * #1) - 1))) = abs(((2 * #8) - ((2 * #1) - 1)))) type=delta
+                    Get l7
+                    ArrangeBy keys=[[#0], [#0, #1]]
+                      Get l1
+                    ArrangeBy keys=[[#0, #1]]
+                      Get l1
+    cte l13 =
+      Union
+        Get l12
+        Map (null)
+          Union
+            Negate
+              Project ()
+                Get l12
+            Constant
+              - ()
   Return
     Project (#4, #5)
       Map (((coalesce(#0, 0) * 100) + coalesce(#1, 0)), ((coalesce(#2, 0) * 100) + coalesce(#3, 0)))
@@ -359,133 +486,6 @@ Explained Query:
                       Get l13
                   Constant
                     - ()
-  With
-    cte l13 =
-      Union
-        Get l12
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l12
-            Constant
-              - ()
-    cte l12 =
-      Reduce aggregates=[sum((#0 - 1))]
-        Project (#1)
-          Filter (#2 = 1)
-            Reduce group_by=[#0, #1] aggregates=[count(*)]
-              Project (#0, #1)
-                Filter (#5 != #9) AND (#4 < #8)
-                  Join on=(#0 = #2 = #6 AND #3 = #7 AND abs(((2 * #4) - ((2 * #1) - 1))) = abs(((2 * #8) - ((2 * #1) - 1)))) type=delta
-                    Get l7
-                    ArrangeBy keys=[[#0], [#0, #1]]
-                      Get l1
-                    ArrangeBy keys=[[#0, #1]]
-                      Get l1
-    cte l11 =
-      Union
-        Get l10
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l10
-            Constant
-              - ()
-    cte l10 =
-      Reduce aggregates=[sum((#0 - 1))]
-        Project (#1)
-          Filter (#2 = 1)
-            Reduce group_by=[#0, #1] aggregates=[count(*)]
-              Project (#0, #1)
-                Filter (#5 != #9) AND (#3 < #7)
-                  Join on=(#0 = #2 = #6 AND #4 = #8 AND abs(((2 * #3) - ((2 * #1) - 1))) = abs(((2 * #7) - ((2 * #1) - 1)))) type=delta
-                    Get l4
-                    ArrangeBy keys=[[#0], [#0, #2]]
-                      Get l1
-                    ArrangeBy keys=[[#0, #2]]
-                      Get l1
-    cte l9 =
-      Union
-        Get l8
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l8
-            Constant
-              - ()
-    cte l8 =
-      Reduce aggregates=[sum((#0 - 1))]
-        Union
-          Negate
-            Project (#1)
-              Distinct project=[#0, #1]
-                Project (#0, #1)
-                  Filter (#3 > 1)
-                    Reduce group_by=[#0, #1, abs(((2 * #2) - ((2 * #1) - 1)))] aggregates=[count(distinct #3)]
-                      Project (#0, #1, #3, #4)
-                        Join on=(#0 = #2) type=differential
-                          Get l7
-                          ArrangeBy keys=[[#0]]
-                            Reduce group_by=[#0, #2] aggregates=[string_agg[order_by=[#0 asc nulls_last]](row(row(#3, ""), #1))]
-                              Get l1
-          Project (#1)
-            Get l3
-    cte l7 =
-      ArrangeBy keys=[[#0]]
-        Get l3
-    cte l6 =
-      Union
-        Get l5
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l5
-            Constant
-              - ()
-    cte l5 =
-      Reduce aggregates=[sum((#0 - 1))]
-        Union
-          Negate
-            Project (#1)
-              Distinct project=[#0, #1]
-                Project (#0, #1)
-                  Filter (#3 > 1)
-                    Reduce group_by=[#0, #1, abs(((2 * #2) - ((2 * #1) - 1)))] aggregates=[count(distinct #3)]
-                      Project (#0, #1, #3, #4)
-                        Join on=(#0 = #2) type=differential
-                          Get l4
-                          ArrangeBy keys=[[#0]]
-                            Get l0
-          Project (#1)
-            Get l2
-    cte l4 =
-      ArrangeBy keys=[[#0]]
-        Get l2
-    cte l3 =
-      Distinct project=[#0, #1]
-        Project (#0, #2)
-          Get l1
-    cte l2 =
-      Distinct project=[#0, #1]
-        Project (#0, #1)
-          Get l1
-    cte l1 =
-      Project (#0, #1, #3, #4)
-        Map (substr(#2, #3, 1))
-          FlatMap generate_series(1, char_length(#2), 1)
-            Get l0
-    cte l0 =
-      Project (#0, #2, #3)
-        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#1), integer_to_bigint(#2)))
-          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#1) array_length 1), 1)
-            Project (#1, #2)
-              Map (array_index(regexp_split_to_array["\n\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                FlatMap generate_series(1, (regexp_split_to_array["\n\n", case_insensitive=false](#0) array_length 1), 1)
-                  ReadStorage materialize.public.input
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1214.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1214.slt
@@ -127,62 +127,17 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM part1;
 ----
 Explained Query:
-  Return
-    Union
-      Get l7
-      Map (null)
-        Union
-          Negate
-            Project ()
-              Get l7
-          Constant
-            - ()
   With Mutually Recursive
-    cte l8 =
-      Get l1
-    cte l7 =
-      Reduce aggregates=[sum(((1 + #1) - #0))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Project (#0)
-              Get l3
-          ArrangeBy keys=[[]]
-            Union
-              Get l6
-              Map (null)
-                Union
-                  Negate
-                    Project ()
-                      Get l6
-                  Constant
-                    - ()
-    cte l6 =
-      Union
-        Get l5
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l5
-            Constant
-              - ()
-    cte l5 =
-      Reduce aggregates=[max(#0)]
-        Project (#0)
-          Get l0
-    cte l4 =
-      Project (#0, #1)
-        Join on=(#0 = (#2 + 1) AND #1 = #3) type=differential
-          ArrangeBy keys=[[#1, #0]]
-            Project (#0, #1)
-              Get l3
-          ArrangeBy keys=[[#1, (#0 + 1)]]
-            Project (#0, #1)
-              Filter (#2 = ".")
-                Get l2
-    cte l3 =
-      Filter (#2 = "O")
-        Get l2
+    cte l0 =
+      Project (#1, #2)
+        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
+          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
+            ReadStorage materialize.public.input
+    cte l1 =
+      Project (#0, #2, #3)
+        Map (substr(#1, #2, 1))
+          FlatMap generate_series(1, char_length(#1), 1)
+            Get l0
     cte l2 =
       Threshold
         Union
@@ -206,16 +161,61 @@ Explained Query:
           Get l1
           Negate
             Get l8
-    cte l1 =
-      Project (#0, #2, #3)
-        Map (substr(#1, #2, 1))
-          FlatMap generate_series(1, char_length(#1), 1)
-            Get l0
-    cte l0 =
-      Project (#1, #2)
-        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-            ReadStorage materialize.public.input
+    cte l3 =
+      Filter (#2 = "O")
+        Get l2
+    cte l4 =
+      Project (#0, #1)
+        Join on=(#0 = (#2 + 1) AND #1 = #3) type=differential
+          ArrangeBy keys=[[#1, #0]]
+            Project (#0, #1)
+              Get l3
+          ArrangeBy keys=[[#1, (#0 + 1)]]
+            Project (#0, #1)
+              Filter (#2 = ".")
+                Get l2
+    cte l5 =
+      Reduce aggregates=[max(#0)]
+        Project (#0)
+          Get l0
+    cte l6 =
+      Union
+        Get l5
+        Map (null)
+          Union
+            Negate
+              Project ()
+                Get l5
+            Constant
+              - ()
+    cte l7 =
+      Reduce aggregates=[sum(((1 + #1) - #0))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Project (#0)
+              Get l3
+          ArrangeBy keys=[[]]
+            Union
+              Get l6
+              Map (null)
+                Union
+                  Negate
+                    Project ()
+                      Get l6
+                  Constant
+                    - ()
+    cte l8 =
+      Get l1
+  Return
+    Union
+      Get l7
+      Map (null)
+        Union
+          Negate
+            Project ()
+              Get l7
+          Constant
+            - ()
 
 Source materialize.public.input
 
@@ -568,187 +568,26 @@ EXPLAIN WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 142)
 SELECT * FROM part2;
 ----
 Explained Query:
-  Return
-    Union
-      Get l21
-      Map (null)
-        Union
-          Negate
-            Project ()
-              Get l21
-          Constant
-            - ()
   With Mutually Recursive
-    cte [recursion_limit=142, return_at_limit] l22 =
-      Get l1
-    cte l21 =
-      Reduce aggregates=[sum(((1 + #1) - #0))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Project (#0)
-              Filter (#2 = "O")
-                Get l18
-          ArrangeBy keys=[[]]
-            Union
-              Get l20
-              Map (null)
-                Union
-                  Negate
-                    Project ()
-                      Get l20
-                  Constant
-                    - ()
-    cte l20 =
-      Union
-        Get l19
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l19
-            Constant
-              - ()
-    cte l19 =
-      Reduce aggregates=[max(#0)]
-        Project (#0)
-          Get l0
-    cte [recursion_limit=142, return_at_limit] l18 =
-      Return
-        Get l15
-      With Mutually Recursive
-        cte l17 =
-          Get l14
-        cte l16 =
-          Project (#0, #1)
-            Join on=(#0 = #2 AND #1 = (#3 - 1)) type=differential
-              ArrangeBy keys=[[#0, #1]]
-                Project (#0, #1)
-                  Filter (#2 = "O")
-                    Get l15
-              ArrangeBy keys=[[#0, (#1 - 1)]]
-                Project (#0, #1)
-                  Filter (#2 = ".")
-                    Get l15
-        cte l15 =
-          Threshold
-            Union
-              Threshold
-                Union
-                  Threshold
-                    Union
-                      Get l15
-                      Project (#0, #2, #3)
-                        Map ((#1 + 1), "O")
-                          Get l16
-                      Negate
-                        Project (#0, #2, #3)
-                          Map ((#1 + 1), ".")
-                            Get l16
-                  Map (".")
-                    Get l16
-                  Negate
-                    Map ("O")
-                      Get l16
-              Get l14
-              Negate
-                Get l17
-    cte l14 =
-      Return
-        Get l11
-      With Mutually Recursive
-        cte l13 =
-          Get l10
-        cte l12 =
-          Project (#0, #1)
-            Join on=(#0 = (#2 - 1) AND #1 = #3) type=differential
-              ArrangeBy keys=[[#1, #0]]
-                Project (#0, #1)
-                  Filter (#2 = "O")
-                    Get l11
-              ArrangeBy keys=[[#1, (#0 - 1)]]
-                Project (#0, #1)
-                  Filter (#2 = ".")
-                    Get l11
-        cte l11 =
-          Threshold
-            Union
-              Threshold
-                Union
-                  Threshold
-                    Union
-                      Get l11
-                      Project (#2, #1, #3)
-                        Map ((#0 + 1), "O")
-                          Get l12
-                      Negate
-                        Project (#2, #1, #3)
-                          Map ((#0 + 1), ".")
-                            Get l12
-                  Map (".")
-                    Get l12
-                  Negate
-                    Map ("O")
-                      Get l12
-              Get l10
-              Negate
-                Get l13
-    cte l10 =
-      Return
-        Get l7
-      With Mutually Recursive
-        cte l9 =
-          Get l6
-        cte l8 =
-          Project (#0, #1)
-            Join on=(#0 = #2 AND #1 = (#3 + 1)) type=differential
-              ArrangeBy keys=[[#0, #1]]
-                Project (#0, #1)
-                  Filter (#2 = "O")
-                    Get l7
-              ArrangeBy keys=[[#0, (#1 + 1)]]
-                Project (#0, #1)
-                  Filter (#2 = ".")
-                    Get l7
-        cte l7 =
-          Threshold
-            Union
-              Threshold
-                Union
-                  Threshold
-                    Union
-                      Get l7
-                      Project (#0, #2, #3)
-                        Map ((#1 - 1), "O")
-                          Get l8
-                      Negate
-                        Project (#0, #2, #3)
-                          Map ((#1 - 1), ".")
-                            Get l8
-                  Map (".")
-                    Get l8
-                  Negate
-                    Map ("O")
-                      Get l8
-              Get l6
-              Negate
-                Get l9
+    cte l0 =
+      Project (#1, #2)
+        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
+          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
+            ReadStorage materialize.public.input
+    cte l1 =
+      Project (#0, #2, #3)
+        Map (substr(#1, #2, 1))
+          FlatMap generate_series(1, char_length(#1), 1)
+            Get l0
+    cte [recursion_limit=142, return_at_limit] l2 =
+      Threshold
+        Union
+          Get l18
+          Get l1
+          Negate
+            Get l22
     cte l6 =
-      Return
-        Get l3
       With Mutually Recursive
-        cte l5 =
-          Get l2
-        cte l4 =
-          Project (#0, #1)
-            Join on=(#0 = (#2 + 1) AND #1 = #3) type=differential
-              ArrangeBy keys=[[#1, #0]]
-                Project (#0, #1)
-                  Filter (#2 = "O")
-                    Get l3
-              ArrangeBy keys=[[#1, (#0 + 1)]]
-                Project (#0, #1)
-                  Filter (#2 = ".")
-                    Get l3
         cte l3 =
           Threshold
             Union
@@ -772,23 +611,184 @@ Explained Query:
               Get l2
               Negate
                 Get l5
-    cte [recursion_limit=142, return_at_limit] l2 =
-      Threshold
+        cte l4 =
+          Project (#0, #1)
+            Join on=(#0 = (#2 + 1) AND #1 = #3) type=differential
+              ArrangeBy keys=[[#1, #0]]
+                Project (#0, #1)
+                  Filter (#2 = "O")
+                    Get l3
+              ArrangeBy keys=[[#1, (#0 + 1)]]
+                Project (#0, #1)
+                  Filter (#2 = ".")
+                    Get l3
+        cte l5 =
+          Get l2
+      Return
+        Get l3
+    cte l10 =
+      With Mutually Recursive
+        cte l7 =
+          Threshold
+            Union
+              Threshold
+                Union
+                  Threshold
+                    Union
+                      Get l7
+                      Project (#0, #2, #3)
+                        Map ((#1 - 1), "O")
+                          Get l8
+                      Negate
+                        Project (#0, #2, #3)
+                          Map ((#1 - 1), ".")
+                            Get l8
+                  Map (".")
+                    Get l8
+                  Negate
+                    Map ("O")
+                      Get l8
+              Get l6
+              Negate
+                Get l9
+        cte l8 =
+          Project (#0, #1)
+            Join on=(#0 = #2 AND #1 = (#3 + 1)) type=differential
+              ArrangeBy keys=[[#0, #1]]
+                Project (#0, #1)
+                  Filter (#2 = "O")
+                    Get l7
+              ArrangeBy keys=[[#0, (#1 + 1)]]
+                Project (#0, #1)
+                  Filter (#2 = ".")
+                    Get l7
+        cte l9 =
+          Get l6
+      Return
+        Get l7
+    cte l14 =
+      With Mutually Recursive
+        cte l11 =
+          Threshold
+            Union
+              Threshold
+                Union
+                  Threshold
+                    Union
+                      Get l11
+                      Project (#2, #1, #3)
+                        Map ((#0 + 1), "O")
+                          Get l12
+                      Negate
+                        Project (#2, #1, #3)
+                          Map ((#0 + 1), ".")
+                            Get l12
+                  Map (".")
+                    Get l12
+                  Negate
+                    Map ("O")
+                      Get l12
+              Get l10
+              Negate
+                Get l13
+        cte l12 =
+          Project (#0, #1)
+            Join on=(#0 = (#2 - 1) AND #1 = #3) type=differential
+              ArrangeBy keys=[[#1, #0]]
+                Project (#0, #1)
+                  Filter (#2 = "O")
+                    Get l11
+              ArrangeBy keys=[[#1, (#0 - 1)]]
+                Project (#0, #1)
+                  Filter (#2 = ".")
+                    Get l11
+        cte l13 =
+          Get l10
+      Return
+        Get l11
+    cte [recursion_limit=142, return_at_limit] l18 =
+      With Mutually Recursive
+        cte l15 =
+          Threshold
+            Union
+              Threshold
+                Union
+                  Threshold
+                    Union
+                      Get l15
+                      Project (#0, #2, #3)
+                        Map ((#1 + 1), "O")
+                          Get l16
+                      Negate
+                        Project (#0, #2, #3)
+                          Map ((#1 + 1), ".")
+                            Get l16
+                  Map (".")
+                    Get l16
+                  Negate
+                    Map ("O")
+                      Get l16
+              Get l14
+              Negate
+                Get l17
+        cte l16 =
+          Project (#0, #1)
+            Join on=(#0 = #2 AND #1 = (#3 - 1)) type=differential
+              ArrangeBy keys=[[#0, #1]]
+                Project (#0, #1)
+                  Filter (#2 = "O")
+                    Get l15
+              ArrangeBy keys=[[#0, (#1 - 1)]]
+                Project (#0, #1)
+                  Filter (#2 = ".")
+                    Get l15
+        cte l17 =
+          Get l14
+      Return
+        Get l15
+    cte l19 =
+      Reduce aggregates=[max(#0)]
+        Project (#0)
+          Get l0
+    cte l20 =
+      Union
+        Get l19
+        Map (null)
+          Union
+            Negate
+              Project ()
+                Get l19
+            Constant
+              - ()
+    cte l21 =
+      Reduce aggregates=[sum(((1 + #1) - #0))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Project (#0)
+              Filter (#2 = "O")
+                Get l18
+          ArrangeBy keys=[[]]
+            Union
+              Get l20
+              Map (null)
+                Union
+                  Negate
+                    Project ()
+                      Get l20
+                  Constant
+                    - ()
+    cte [recursion_limit=142, return_at_limit] l22 =
+      Get l1
+  Return
+    Union
+      Get l21
+      Map (null)
         Union
-          Get l18
-          Get l1
           Negate
-            Get l22
-    cte l1 =
-      Project (#0, #2, #3)
-        Map (substr(#1, #2, 1))
-          FlatMap generate_series(1, char_length(#1), 1)
-            Get l0
-    cte l0 =
-      Project (#1, #2)
-        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-            ReadStorage materialize.public.input
+            Project ()
+              Get l21
+          Constant
+            - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1215.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1215.slt
@@ -197,7 +197,218 @@ EXPLAIN WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 10)
 SELECT * FROM part1, part2;
 ----
 Explained Query:
+  With Mutually Recursive
+    cte l0 =
+      Project (#1, #2)
+        Map (array_index(regexp_split_to_array[",", case_insensitive=false](#0), integer_to_bigint(#1)))
+          FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#0) array_length 1), 1)
+            ReadStorage materialize.public.input
+    cte [recursion_limit=10, return_at_limit] l1 =
+      Union
+        Project (#1, #2)
+          Map (0)
+            Get l0
+        Project (#2, #3)
+          Filter (char_length(#0) > 0)
+            Map (substr(#0, 2), (((#1 + integer_to_bigint(ascii(substr(#0, 1, 1)))) * 17) % 256))
+              Get l1
+    cte l2 =
+      Reduce aggregates=[sum(#0)]
+        Project (#1)
+          Filter (#0 = "")
+            Get l1
+    cte l3 =
+      Distinct project=[#0]
+        Project (#2)
+          Map (case when ("-" = substr(#1, char_length(#1))) then substr(#1, 1, (char_length(#1) - 1)) else substr(#1, 1, (char_length(#1) - 2)) end)
+            Get l0
+    cte l4 =
+      Reduce group_by=[#0] aggregates=[max(#1)]
+        Project (#0, #1)
+          Join on=(#0 = #2) type=differential
+            ArrangeBy keys=[[#0]]
+              Filter (#0) IS NOT NULL
+                Get l3
+            ArrangeBy keys=[[#1]]
+              Project (#0, #3)
+                Filter (#3) IS NOT NULL AND (0 = case when #2 then 0 else text_to_integer(substr(#1, char_length(#1))) end)
+                  Map (("-" = substr(#1, char_length(#1))), case when #2 then substr(#1, 1, (char_length(#1) - 1)) else substr(#1, 1, (char_length(#1) - 2)) end)
+                    Get l0
+    cte l5 =
+      ArrangeBy keys=[[#0]]
+        Get l3
+    cte l6 =
+      Union
+        Get l4
+        Project (#0, #2)
+          Map (null)
+            Join on=(#0 = #1) type=differential
+              ArrangeBy keys=[[#0]]
+                Union
+                  Negate
+                    Project (#0)
+                      Get l4
+                  Get l3
+              Get l5
+    cte l7 =
+      Union
+        Get l6
+        Map (error("more than one record produced in subquery"))
+          Project (#0)
+            Filter (#1 > 1)
+              Reduce group_by=[#0] aggregates=[count(*)]
+                Project (#0)
+                  Get l6
+    cte l8 =
+      Project (#0..=#2)
+        Filter (#0 > coalesce(#4, 0))
+          Join on=(#1 = #3) type=differential
+            ArrangeBy keys=[[#1]]
+              Project (#0, #3, #4)
+                Map (("-" = substr(#1, char_length(#1))), case when #2 then substr(#1, 1, (char_length(#1) - 1)) else substr(#1, 1, (char_length(#1) - 2)) end, case when #2 then 0 else text_to_integer(substr(#1, char_length(#1))) end)
+                  Get l0
+            ArrangeBy keys=[[#0]]
+              Union
+                Get l7
+                Project (#0, #2)
+                  Map (null)
+                    Join on=(#0 = #1) type=differential
+                      ArrangeBy keys=[[#0]]
+                        Union
+                          Negate
+                            Distinct project=[#0]
+                              Project (#0)
+                                Get l7
+                          Get l3
+                      Get l5
+    cte l9 =
+      Distinct project=[#0..=#2]
+        Get l8
+    cte l10 =
+      Distinct project=[#0]
+        Project (#1)
+          Get l9
+    cte l11 =
+      Reduce group_by=[#0] aggregates=[min(#1)]
+        Project (#0, #1)
+          Join on=(#0 = #2) type=differential
+            ArrangeBy keys=[[#0]]
+              Filter (#0) IS NOT NULL
+                Get l10
+            ArrangeBy keys=[[#1]]
+              Project (#0, #1)
+                Filter (#1) IS NOT NULL
+                  Get l8
+    cte l12 =
+      ArrangeBy keys=[[#0]]
+        Get l10
+    cte l13 =
+      Union
+        Get l11
+        Project (#0, #2)
+          Map (null)
+            Join on=(#0 = #1) type=differential
+              ArrangeBy keys=[[#0]]
+                Union
+                  Negate
+                    Project (#0)
+                      Get l11
+                  Get l10
+              Get l12
+    cte l14 =
+      Union
+        Get l13
+        Map (error("more than one record produced in subquery"))
+          Project (#0)
+            Filter (#1 > 1)
+              Reduce group_by=[#0] aggregates=[count(*)]
+                Project (#0)
+                  Get l13
+    cte l15 =
+      Project (#1..=#4)
+        TopK group_by=[#1] order_by=[#0 desc nulls_first, #2 asc nulls_last] limit=1
+          Project (#0..=#2, #7, #8)
+            Map ((#1) IS NULL)
+              Join on=(#0 = #3 AND #1 = #4 = #6 AND #2 = #5) type=delta
+                ArrangeBy keys=[[#0..=#2], [#1]]
+                  Get l8
+                ArrangeBy keys=[[#0..=#2]]
+                  Get l9
+                ArrangeBy keys=[[#0]]
+                  Union
+                    Get l14
+                    Project (#0, #2)
+                      Map (null)
+                        Join on=(#0 = #1) type=differential
+                          ArrangeBy keys=[[#0]]
+                            Union
+                              Negate
+                                Distinct project=[#0]
+                                  Project (#0)
+                                    Get l14
+                              Get l10
+                          Get l12
+    cte [recursion_limit=10, return_at_limit] l16 =
+      Union
+        Project (#0, #0, #4)
+          Map (0)
+            Get l15
+        Project (#0, #3, #4)
+          Filter (char_length(#1) > 0)
+            Map (substr(#1, 2), (((#2 + integer_to_bigint(ascii(substr(#1, 1, 1)))) * 17) % 256))
+              Get l16
   Return
+    With
+      cte l17 =
+        Project (#1, #3, #4)
+          Join on=(#0 = #2) type=differential
+            ArrangeBy keys=[[#0]]
+              Project (#0, #2)
+                Filter (#1 = "") AND (#0) IS NOT NULL
+                  Get l16
+            ArrangeBy keys=[[#0]]
+              Project (#0..=#2)
+                Filter NOT(#3)
+                  Get l15
+      cte l18 =
+        Project (#0, #2)
+          Get l17
+      cte l19 =
+        Distinct project=[#0, #1]
+          Get l18
+      cte l20 =
+        Reduce group_by=[#0, #1] aggregates=[count(*)]
+          Project (#0, #1)
+            Filter (#1 >= #3)
+              Join on=(#0 = #2) type=differential
+                ArrangeBy keys=[[#0]]
+                  Get l19
+                ArrangeBy keys=[[#0]]
+                  Get l18
+      cte l21 =
+        Union
+          Get l20
+          Map (0)
+            Union
+              Negate
+                Project (#0, #1)
+                  Get l20
+              Get l19
+      cte l22 =
+        Reduce aggregates=[sum((((1 + #0) * #2) * integer_to_bigint(#1)))]
+          Project (#0, #1, #5)
+            Join on=(#0 = #3 AND #2 = #4) type=differential
+              ArrangeBy keys=[[#0, #2]]
+                Get l17
+              ArrangeBy keys=[[#0, #1]]
+                Union
+                  Get l21
+                  Map (null)
+                    Union
+                      Negate
+                        Project (#0, #1)
+                          Get l21
+                      Get l19
     Return
       CrossJoin type=differential
         ArrangeBy keys=[[]]
@@ -224,217 +435,6 @@ Explained Query:
                         Get l22
                     Constant
                       - ()
-    With
-      cte l22 =
-        Reduce aggregates=[sum((((1 + #0) * #2) * integer_to_bigint(#1)))]
-          Project (#0, #1, #5)
-            Join on=(#0 = #3 AND #2 = #4) type=differential
-              ArrangeBy keys=[[#0, #2]]
-                Get l17
-              ArrangeBy keys=[[#0, #1]]
-                Union
-                  Get l21
-                  Map (null)
-                    Union
-                      Negate
-                        Project (#0, #1)
-                          Get l21
-                      Get l19
-      cte l21 =
-        Union
-          Get l20
-          Map (0)
-            Union
-              Negate
-                Project (#0, #1)
-                  Get l20
-              Get l19
-      cte l20 =
-        Reduce group_by=[#0, #1] aggregates=[count(*)]
-          Project (#0, #1)
-            Filter (#1 >= #3)
-              Join on=(#0 = #2) type=differential
-                ArrangeBy keys=[[#0]]
-                  Get l19
-                ArrangeBy keys=[[#0]]
-                  Get l18
-      cte l19 =
-        Distinct project=[#0, #1]
-          Get l18
-      cte l18 =
-        Project (#0, #2)
-          Get l17
-      cte l17 =
-        Project (#1, #3, #4)
-          Join on=(#0 = #2) type=differential
-            ArrangeBy keys=[[#0]]
-              Project (#0, #2)
-                Filter (#1 = "") AND (#0) IS NOT NULL
-                  Get l16
-            ArrangeBy keys=[[#0]]
-              Project (#0..=#2)
-                Filter NOT(#3)
-                  Get l15
-  With Mutually Recursive
-    cte [recursion_limit=10, return_at_limit] l16 =
-      Union
-        Project (#0, #0, #4)
-          Map (0)
-            Get l15
-        Project (#0, #3, #4)
-          Filter (char_length(#1) > 0)
-            Map (substr(#1, 2), (((#2 + integer_to_bigint(ascii(substr(#1, 1, 1)))) * 17) % 256))
-              Get l16
-    cte l15 =
-      Project (#1..=#4)
-        TopK group_by=[#1] order_by=[#0 desc nulls_first, #2 asc nulls_last] limit=1
-          Project (#0..=#2, #7, #8)
-            Map ((#1) IS NULL)
-              Join on=(#0 = #3 AND #1 = #4 = #6 AND #2 = #5) type=delta
-                ArrangeBy keys=[[#0..=#2], [#1]]
-                  Get l8
-                ArrangeBy keys=[[#0..=#2]]
-                  Get l9
-                ArrangeBy keys=[[#0]]
-                  Union
-                    Get l14
-                    Project (#0, #2)
-                      Map (null)
-                        Join on=(#0 = #1) type=differential
-                          ArrangeBy keys=[[#0]]
-                            Union
-                              Negate
-                                Distinct project=[#0]
-                                  Project (#0)
-                                    Get l14
-                              Get l10
-                          Get l12
-    cte l14 =
-      Union
-        Get l13
-        Map (error("more than one record produced in subquery"))
-          Project (#0)
-            Filter (#1 > 1)
-              Reduce group_by=[#0] aggregates=[count(*)]
-                Project (#0)
-                  Get l13
-    cte l13 =
-      Union
-        Get l11
-        Project (#0, #2)
-          Map (null)
-            Join on=(#0 = #1) type=differential
-              ArrangeBy keys=[[#0]]
-                Union
-                  Negate
-                    Project (#0)
-                      Get l11
-                  Get l10
-              Get l12
-    cte l12 =
-      ArrangeBy keys=[[#0]]
-        Get l10
-    cte l11 =
-      Reduce group_by=[#0] aggregates=[min(#1)]
-        Project (#0, #1)
-          Join on=(#0 = #2) type=differential
-            ArrangeBy keys=[[#0]]
-              Filter (#0) IS NOT NULL
-                Get l10
-            ArrangeBy keys=[[#1]]
-              Project (#0, #1)
-                Filter (#1) IS NOT NULL
-                  Get l8
-    cte l10 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l9
-    cte l9 =
-      Distinct project=[#0..=#2]
-        Get l8
-    cte l8 =
-      Project (#0..=#2)
-        Filter (#0 > coalesce(#4, 0))
-          Join on=(#1 = #3) type=differential
-            ArrangeBy keys=[[#1]]
-              Project (#0, #3, #4)
-                Map (("-" = substr(#1, char_length(#1))), case when #2 then substr(#1, 1, (char_length(#1) - 1)) else substr(#1, 1, (char_length(#1) - 2)) end, case when #2 then 0 else text_to_integer(substr(#1, char_length(#1))) end)
-                  Get l0
-            ArrangeBy keys=[[#0]]
-              Union
-                Get l7
-                Project (#0, #2)
-                  Map (null)
-                    Join on=(#0 = #1) type=differential
-                      ArrangeBy keys=[[#0]]
-                        Union
-                          Negate
-                            Distinct project=[#0]
-                              Project (#0)
-                                Get l7
-                          Get l3
-                      Get l5
-    cte l7 =
-      Union
-        Get l6
-        Map (error("more than one record produced in subquery"))
-          Project (#0)
-            Filter (#1 > 1)
-              Reduce group_by=[#0] aggregates=[count(*)]
-                Project (#0)
-                  Get l6
-    cte l6 =
-      Union
-        Get l4
-        Project (#0, #2)
-          Map (null)
-            Join on=(#0 = #1) type=differential
-              ArrangeBy keys=[[#0]]
-                Union
-                  Negate
-                    Project (#0)
-                      Get l4
-                  Get l3
-              Get l5
-    cte l5 =
-      ArrangeBy keys=[[#0]]
-        Get l3
-    cte l4 =
-      Reduce group_by=[#0] aggregates=[max(#1)]
-        Project (#0, #1)
-          Join on=(#0 = #2) type=differential
-            ArrangeBy keys=[[#0]]
-              Filter (#0) IS NOT NULL
-                Get l3
-            ArrangeBy keys=[[#1]]
-              Project (#0, #3)
-                Filter (#3) IS NOT NULL AND (0 = case when #2 then 0 else text_to_integer(substr(#1, char_length(#1))) end)
-                  Map (("-" = substr(#1, char_length(#1))), case when #2 then substr(#1, 1, (char_length(#1) - 1)) else substr(#1, 1, (char_length(#1) - 2)) end)
-                    Get l0
-    cte l3 =
-      Distinct project=[#0]
-        Project (#2)
-          Map (case when ("-" = substr(#1, char_length(#1))) then substr(#1, 1, (char_length(#1) - 1)) else substr(#1, 1, (char_length(#1) - 2)) end)
-            Get l0
-    cte l2 =
-      Reduce aggregates=[sum(#0)]
-        Project (#1)
-          Filter (#0 = "")
-            Get l1
-    cte [recursion_limit=10, return_at_limit] l1 =
-      Union
-        Project (#1, #2)
-          Map (0)
-            Get l0
-        Project (#2, #3)
-          Filter (char_length(#0) > 0)
-            Map (substr(#0, 2), (((#1 + integer_to_bigint(ascii(substr(#0, 1, 1)))) * 17) % 256))
-              Get l1
-    cte l0 =
-      Project (#1, #2)
-        Map (array_index(regexp_split_to_array[",", case_insensitive=false](#0), integer_to_bigint(#1)))
-          FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#0) array_length 1), 1)
-            ReadStorage materialize.public.input
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1216.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1216.slt
@@ -223,46 +223,129 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  Return
-    Return
+  With Mutually Recursive
+    cte l0 =
+      Project (#0, #2, #3)
+        Map (substr(#1, #2, 1))
+          FlatMap generate_series(1, char_length(#1), 1)
+            Project (#1, #2)
+              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
+                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
+                  ReadStorage materialize.public.input
+    cte l1 =
+      ArrangeBy keys=[[#0, #1]]
+        Filter (#2) IS NOT NULL
+          Get l0
+    cte l2 =
+      ArrangeBy keys=[[#0, #1]]
+        Constant
+          total_rows (diffs absed): 24
+          first_rows:
+            - ("d", "-", 0, -1, "l")
+            - ("d", "/", 0, -1, "l")
+            - ("l", "-", 0, -1, "l")
+            - ("l", ".", 0, -1, "l")
+            - ("l", "\", -1, 0, "u")
+            - ("l", "|", -1, 0, "u")
+            - ("r", "/", -1, 0, "u")
+            - ("r", "|", -1, 0, "u")
+            - ("u", "-", 0, -1, "l")
+            - ("u", ".", -1, 0, "u")
+            - ("u", "\", 0, -1, "l")
+            - ("u", "|", -1, 0, "u")
+            - ("d", "-", 0, 1, "r")
+            - ("d", ".", 1, 0, "d")
+            - ("d", "\", 0, 1, "r")
+            - ("d", "|", 1, 0, "d")
+            - ("l", "/", 1, 0, "d")
+            - ("l", "|", 1, 0, "d")
+            - ("r", "-", 0, 1, "r")
+            - ("r", ".", 0, 1, "r")
+    cte l3 =
+      Distinct project=[#0..=#2]
+        Union
+          Project (#11, #12, #10)
+            Map ((#0 + #8), (#1 + #9))
+              Join on=(#0 = #3 AND #1 = #4 AND #2 = #6 AND #5 = #7) type=differential
+                ArrangeBy keys=[[#0, #1]]
+                  Get l3
+                Get l1
+                Get l2
+          Constant
+            - (1, 1, "r")
+    cte l4 =
+      Project (#0, #1)
+        Get l0
+    cte l5 =
+      Reduce aggregates=[count(*)]
+        Project ()
+          Join on=(#0 = #2 AND #1 = #3) type=differential
+            ArrangeBy keys=[[#0, #1]]
+              Distinct project=[#0, #1]
+                Project (#0, #1)
+                  Get l3
+            ArrangeBy keys=[[#0, #1]]
+              Distinct project=[#0, #1]
+                Get l4
+    cte l6 =
+      Project (#1)
+        Get l0
+    cte l7 =
+      Reduce aggregates=[min(#0)]
+        Get l6
+    cte l8 =
+      Union
+        Get l7
+        Map (null)
+          Union
+            Negate
+              Project ()
+                Get l7
+            Constant
+              - ()
+    cte l9 =
+      Reduce aggregates=[max(#0)]
+        Get l6
+    cte l10 =
+      Union
+        Get l9
+        Map (null)
+          Union
+            Negate
+              Project ()
+                Get l9
+            Constant
+              - ()
+    cte l11 =
+      Project (#0)
+        Get l0
+    cte l12 =
+      Reduce aggregates=[min(#0)]
+        Get l11
+    cte l13 =
+      Union
+        Get l12
+        Map (null)
+          Union
+            Negate
+              Project ()
+                Get l12
+            Constant
+              - ()
+    cte l14 =
       CrossJoin type=differential
         ArrangeBy keys=[[]]
-          Union
-            Get l5
-            Map (0)
-              Union
-                Negate
-                  Project ()
-                    Get l5
-                Constant
-                  - ()
+          Get l4
         ArrangeBy keys=[[]]
           Union
-            Get l16
+            Get l10
             Map (null)
               Union
                 Negate
                   Project ()
-                    Get l16
+                    Get l10
                 Constant
                   - ()
-    With
-      cte l16 =
-        Reduce aggregates=[max(#0)]
-          Project (#1)
-            Reduce group_by=[#0] aggregates=[count(*)]
-              Project (#2)
-                Join on=(#0 = #3 AND #1 = #4) type=differential
-                  ArrangeBy keys=[[#0, #1]]
-                    Distinct project=[#0..=#2]
-                      Project (#0, #1, #3)
-                        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-                          Get l15
-                  ArrangeBy keys=[[#0, #1]]
-                    Distinct project=[#0, #1]
-                      Project (#0, #1)
-                        Get l0
-  With Mutually Recursive
     cte l15 =
       Distinct project=[#0..=#3]
         Union
@@ -310,128 +393,45 @@ Explained Query:
                     Get l15
                 Get l1
                 Get l2
-    cte l14 =
+  Return
+    With
+      cte l16 =
+        Reduce aggregates=[max(#0)]
+          Project (#1)
+            Reduce group_by=[#0] aggregates=[count(*)]
+              Project (#2)
+                Join on=(#0 = #3 AND #1 = #4) type=differential
+                  ArrangeBy keys=[[#0, #1]]
+                    Distinct project=[#0..=#2]
+                      Project (#0, #1, #3)
+                        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+                          Get l15
+                  ArrangeBy keys=[[#0, #1]]
+                    Distinct project=[#0, #1]
+                      Project (#0, #1)
+                        Get l0
+    Return
       CrossJoin type=differential
         ArrangeBy keys=[[]]
-          Get l4
+          Union
+            Get l5
+            Map (0)
+              Union
+                Negate
+                  Project ()
+                    Get l5
+                Constant
+                  - ()
         ArrangeBy keys=[[]]
           Union
-            Get l10
+            Get l16
             Map (null)
               Union
                 Negate
                   Project ()
-                    Get l10
+                    Get l16
                 Constant
                   - ()
-    cte l13 =
-      Union
-        Get l12
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l12
-            Constant
-              - ()
-    cte l12 =
-      Reduce aggregates=[min(#0)]
-        Get l11
-    cte l11 =
-      Project (#0)
-        Get l0
-    cte l10 =
-      Union
-        Get l9
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l9
-            Constant
-              - ()
-    cte l9 =
-      Reduce aggregates=[max(#0)]
-        Get l6
-    cte l8 =
-      Union
-        Get l7
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l7
-            Constant
-              - ()
-    cte l7 =
-      Reduce aggregates=[min(#0)]
-        Get l6
-    cte l6 =
-      Project (#1)
-        Get l0
-    cte l5 =
-      Reduce aggregates=[count(*)]
-        Project ()
-          Join on=(#0 = #2 AND #1 = #3) type=differential
-            ArrangeBy keys=[[#0, #1]]
-              Distinct project=[#0, #1]
-                Project (#0, #1)
-                  Get l3
-            ArrangeBy keys=[[#0, #1]]
-              Distinct project=[#0, #1]
-                Get l4
-    cte l4 =
-      Project (#0, #1)
-        Get l0
-    cte l3 =
-      Distinct project=[#0..=#2]
-        Union
-          Project (#11, #12, #10)
-            Map ((#0 + #8), (#1 + #9))
-              Join on=(#0 = #3 AND #1 = #4 AND #2 = #6 AND #5 = #7) type=differential
-                ArrangeBy keys=[[#0, #1]]
-                  Get l3
-                Get l1
-                Get l2
-          Constant
-            - (1, 1, "r")
-    cte l2 =
-      ArrangeBy keys=[[#0, #1]]
-        Constant
-          total_rows (diffs absed): 24
-          first_rows:
-            - ("d", "-", 0, -1, "l")
-            - ("d", "/", 0, -1, "l")
-            - ("l", "-", 0, -1, "l")
-            - ("l", ".", 0, -1, "l")
-            - ("l", "\", -1, 0, "u")
-            - ("l", "|", -1, 0, "u")
-            - ("r", "/", -1, 0, "u")
-            - ("r", "|", -1, 0, "u")
-            - ("u", "-", 0, -1, "l")
-            - ("u", ".", -1, 0, "u")
-            - ("u", "\", 0, -1, "l")
-            - ("u", "|", -1, 0, "u")
-            - ("d", "-", 0, 1, "r")
-            - ("d", ".", 1, 0, "d")
-            - ("d", "\", 0, 1, "r")
-            - ("d", "|", 1, 0, "d")
-            - ("l", "/", 1, 0, "d")
-            - ("l", "|", 1, 0, "d")
-            - ("r", "-", 0, 1, "r")
-            - ("r", ".", 0, 1, "r")
-    cte l1 =
-      ArrangeBy keys=[[#0, #1]]
-        Filter (#2) IS NOT NULL
-          Get l0
-    cte l0 =
-      Project (#0, #2, #3)
-        Map (substr(#1, #2, 1))
-          FlatMap generate_series(1, char_length(#1), 1)
-            Project (#1, #2)
-              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-                  ReadStorage materialize.public.input
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1217.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1217.slt
@@ -223,91 +223,21 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  Return
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Union
-            Get l4
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l4
-                Constant
-                  - ()
-        ArrangeBy keys=[[]]
-          Union
-            Get l7
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l7
-                Constant
-                  - ()
-    With
-      cte l7 =
-        Reduce aggregates=[min(#0)]
-          Project (#2)
-            Join on=(#0 = #3 AND #1 = #4) type=differential
-              ArrangeBy keys=[[#0, #1]]
-                Project (#0, #1, #5)
-                  Filter (#4 >= 4)
-                    Get l6
-              ArrangeBy keys=[[]]
-                Reduce aggregates=[max(#0)]
-                  Project (#0)
-                    Get l0
-              ArrangeBy keys=[[]]
-                Reduce aggregates=[max(#0)]
-                  Project (#1)
-                    Get l0
   With Mutually Recursive
-    cte l6 =
-      Reduce group_by=[#0..=#4] aggregates=[min(#5)]
-        Union
-          Project (#6, #7, #2, #3, #9, #10)
-            Map ((#4 + 1), (#5 + #8))
-              Join on=(#6 = (#0 + #2) AND #7 = (#1 + #3)) type=differential
-                ArrangeBy keys=[[(#0 + #2), (#1 + #3)]]
-                  Filter (#4 < 10)
-                    Get l6
-                Get l1
-          Project (#5, #6, #3, #2, #9, #8)
-            Map ((#4 + #7), 1)
-              Join on=(#5 = (#0 + #3) AND #6 = (#1 + #2)) type=differential
-                ArrangeBy keys=[[(#0 + #3), (#1 + #2)]]
-                  Get l5
-                Get l1
-          Project (#5, #6, #8, #9, #11, #10)
-            Map (-(#3), -(#2), (#4 + #7), 1)
-              Join on=(#5 = (#0 - #3) AND #6 = (#1 - #2)) type=differential
-                ArrangeBy keys=[[(#0 - #3), (#1 - #2)]]
-                  Get l5
-                Get l1
-          Constant
-            - (1, 1, 0, 1, 0, 0)
-            - (1, 1, 1, 0, 0, 0)
-    cte l5 =
+    cte l0 =
+      Project (#0, #2, #3)
+        Map (text_to_integer(substr(#1, #2, 1)))
+          FlatMap generate_series(1, char_length(#1), 1)
+            Project (#1, #2)
+              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
+                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
+                  ReadStorage materialize.public.input
+    cte l1 =
+      ArrangeBy keys=[[#0, #1]]
+        Get l0
+    cte l2 =
       Project (#0..=#3, #5)
-        Filter (#4 >= 4)
-          Get l6
-    cte l4 =
-      Reduce aggregates=[min(#0)]
-        Project (#2)
-          Join on=(#0 = #3 AND #1 = #4) type=differential
-            ArrangeBy keys=[[#0, #1]]
-              Project (#0, #1, #5)
-                Get l3
-            ArrangeBy keys=[[]]
-              Reduce aggregates=[max(#0)]
-                Project (#0)
-                  Get l0
-            ArrangeBy keys=[[]]
-              Reduce aggregates=[max(#0)]
-                Project (#1)
-                  Get l0
+        Get l3
     cte l3 =
       Reduce group_by=[#0..=#4] aggregates=[min(#5)]
         Union
@@ -333,20 +263,90 @@ Explained Query:
           Constant
             - (1, 1, 0, 1, 0, 0)
             - (1, 1, 1, 0, 0, 0)
-    cte l2 =
+    cte l4 =
+      Reduce aggregates=[min(#0)]
+        Project (#2)
+          Join on=(#0 = #3 AND #1 = #4) type=differential
+            ArrangeBy keys=[[#0, #1]]
+              Project (#0, #1, #5)
+                Get l3
+            ArrangeBy keys=[[]]
+              Reduce aggregates=[max(#0)]
+                Project (#0)
+                  Get l0
+            ArrangeBy keys=[[]]
+              Reduce aggregates=[max(#0)]
+                Project (#1)
+                  Get l0
+    cte l5 =
       Project (#0..=#3, #5)
-        Get l3
-    cte l1 =
-      ArrangeBy keys=[[#0, #1]]
-        Get l0
-    cte l0 =
-      Project (#0, #2, #3)
-        Map (text_to_integer(substr(#1, #2, 1)))
-          FlatMap generate_series(1, char_length(#1), 1)
-            Project (#1, #2)
-              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-                  ReadStorage materialize.public.input
+        Filter (#4 >= 4)
+          Get l6
+    cte l6 =
+      Reduce group_by=[#0..=#4] aggregates=[min(#5)]
+        Union
+          Project (#6, #7, #2, #3, #9, #10)
+            Map ((#4 + 1), (#5 + #8))
+              Join on=(#6 = (#0 + #2) AND #7 = (#1 + #3)) type=differential
+                ArrangeBy keys=[[(#0 + #2), (#1 + #3)]]
+                  Filter (#4 < 10)
+                    Get l6
+                Get l1
+          Project (#5, #6, #3, #2, #9, #8)
+            Map ((#4 + #7), 1)
+              Join on=(#5 = (#0 + #3) AND #6 = (#1 + #2)) type=differential
+                ArrangeBy keys=[[(#0 + #3), (#1 + #2)]]
+                  Get l5
+                Get l1
+          Project (#5, #6, #8, #9, #11, #10)
+            Map (-(#3), -(#2), (#4 + #7), 1)
+              Join on=(#5 = (#0 - #3) AND #6 = (#1 - #2)) type=differential
+                ArrangeBy keys=[[(#0 - #3), (#1 - #2)]]
+                  Get l5
+                Get l1
+          Constant
+            - (1, 1, 0, 1, 0, 0)
+            - (1, 1, 1, 0, 0, 0)
+  Return
+    With
+      cte l7 =
+        Reduce aggregates=[min(#0)]
+          Project (#2)
+            Join on=(#0 = #3 AND #1 = #4) type=differential
+              ArrangeBy keys=[[#0, #1]]
+                Project (#0, #1, #5)
+                  Filter (#4 >= 4)
+                    Get l6
+              ArrangeBy keys=[[]]
+                Reduce aggregates=[max(#0)]
+                  Project (#0)
+                    Get l0
+              ArrangeBy keys=[[]]
+                Reduce aggregates=[max(#0)]
+                  Project (#1)
+                    Get l0
+    Return
+      CrossJoin type=differential
+        ArrangeBy keys=[[]]
+          Union
+            Get l4
+            Map (null)
+              Union
+                Negate
+                  Project ()
+                    Get l4
+                Constant
+                  - ()
+        ArrangeBy keys=[[]]
+          Union
+            Get l7
+            Map (null)
+              Union
+                Negate
+                  Project ()
+                    Get l7
+                Constant
+                  - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1218.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1218.slt
@@ -217,7 +217,102 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
+  With Mutually Recursive
+    cte l0 =
+      Project (#1, #2)
+        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
+          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
+            ReadStorage materialize.public.input
+    cte l1 =
+      Distinct project=[#0..=#4]
+        Union
+          Project (#0, #1, #7..=#9)
+            Map ((#0 + (#4 * #6)), (#1 + (#5 * #6)), (#2 + 1))
+              Join on=(#2 = #3) type=differential
+                ArrangeBy keys=[[#2]]
+                  Project (#2..=#4)
+                    Get l1
+                ArrangeBy keys=[[#0]]
+                  Project (#0, #4..=#6)
+                    Map (regexp_split_to_array[" ", case_insensitive=false](#1), array_index(#2, 1), case when (#3 = "U") then -1 else case when ("D" = array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 1)) then 1 else 0 end end, case when (#3 = "L") then -1 else case when ("R" = array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 1)) then 1 else 0 end end, text_to_integer(array_index(#2, 2)))
+                      Get l0
+          Constant
+            - (0, 0, 0, 0, 1)
+    cte l2 =
+      Reduce aggregates=[sum(((#0 + #2) * (#1 - #3)))]
+        Project (#0..=#3)
+          Get l1
+    cte l3 =
+      Union
+        Get l2
+        Map (null)
+          Union
+            Negate
+              Project ()
+                Get l2
+            Constant
+              - ()
+    cte l4 =
+      Reduce aggregates=[sum(#0)]
+        Project (#2)
+          Map (text_to_integer(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 2)))
+            Get l0
+    cte l5 =
+      Union
+        Get l4
+        Map (null)
+          Union
+            Negate
+              Project ()
+                Get l4
+            Constant
+              - ()
+    cte l6 =
+      Distinct project=[#0..=#4]
+        Union
+          Project (#0, #1, #7..=#9)
+            Map ((#0 + integer_to_bigint((#4 * #6))), (#1 + integer_to_bigint((#5 * #6))), (#2 + 1))
+              Join on=(#2 = #3) type=differential
+                ArrangeBy keys=[[#2]]
+                  Project (#2..=#4)
+                    Get l6
+                ArrangeBy keys=[[#0]]
+                  Project (#0, #4, #5, #7)
+                    Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), substr(#2, 8, 1), case when (#3 = "3") then -1 else case when ("1" = substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 8, 1)) then 1 else 0 end end, case when (#3 = "2") then -1 else case when ("0" = substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 8, 1)) then 1 else 0 end end, decode(("0" || substr(#2, 3, 5)), "hex"), (((65536 * get_byte(#6, 0)) + (256 * get_byte(#6, 1))) + get_byte(#6, 2)))
+                      Get l0
+          Constant
+            - (0, 0, 0, 0, 1)
   Return
+    With
+      cte l7 =
+        Reduce aggregates=[sum(((#0 + #2) * (#1 - #3)))]
+          Project (#0..=#3)
+            Get l6
+      cte l8 =
+        Union
+          Get l7
+          Map (null)
+            Union
+              Negate
+                Project ()
+                  Get l7
+              Constant
+                - ()
+      cte l9 =
+        Reduce aggregates=[sum(#0)]
+          Project (#3)
+            Map (decode(("0" || substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 3, 5)), "hex"), (((65536 * get_byte(#2, 0)) + (256 * get_byte(#2, 1))) + get_byte(#2, 2)))
+              Get l0
+      cte l10 =
+        Union
+          Get l9
+          Map (null)
+            Union
+              Negate
+                Project ()
+                  Get l9
+              Constant
+                - ()
     Return
       Project (#4, #5)
         Map ((((abs(#0) / 2) + (#1 / 2)) + 1), numeric_to_bigint((((abs(#2) / 2) + bigint_to_numeric((#3 / 2))) + 1)))
@@ -262,101 +357,6 @@ Explained Query:
                         Get l10
                     Constant
                       - ()
-    With
-      cte l10 =
-        Union
-          Get l9
-          Map (null)
-            Union
-              Negate
-                Project ()
-                  Get l9
-              Constant
-                - ()
-      cte l9 =
-        Reduce aggregates=[sum(#0)]
-          Project (#3)
-            Map (decode(("0" || substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 3, 5)), "hex"), (((65536 * get_byte(#2, 0)) + (256 * get_byte(#2, 1))) + get_byte(#2, 2)))
-              Get l0
-      cte l8 =
-        Union
-          Get l7
-          Map (null)
-            Union
-              Negate
-                Project ()
-                  Get l7
-              Constant
-                - ()
-      cte l7 =
-        Reduce aggregates=[sum(((#0 + #2) * (#1 - #3)))]
-          Project (#0..=#3)
-            Get l6
-  With Mutually Recursive
-    cte l6 =
-      Distinct project=[#0..=#4]
-        Union
-          Project (#0, #1, #7..=#9)
-            Map ((#0 + integer_to_bigint((#4 * #6))), (#1 + integer_to_bigint((#5 * #6))), (#2 + 1))
-              Join on=(#2 = #3) type=differential
-                ArrangeBy keys=[[#2]]
-                  Project (#2..=#4)
-                    Get l6
-                ArrangeBy keys=[[#0]]
-                  Project (#0, #4, #5, #7)
-                    Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), substr(#2, 8, 1), case when (#3 = "3") then -1 else case when ("1" = substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 8, 1)) then 1 else 0 end end, case when (#3 = "2") then -1 else case when ("0" = substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 8, 1)) then 1 else 0 end end, decode(("0" || substr(#2, 3, 5)), "hex"), (((65536 * get_byte(#6, 0)) + (256 * get_byte(#6, 1))) + get_byte(#6, 2)))
-                      Get l0
-          Constant
-            - (0, 0, 0, 0, 1)
-    cte l5 =
-      Union
-        Get l4
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l4
-            Constant
-              - ()
-    cte l4 =
-      Reduce aggregates=[sum(#0)]
-        Project (#2)
-          Map (text_to_integer(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 2)))
-            Get l0
-    cte l3 =
-      Union
-        Get l2
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l2
-            Constant
-              - ()
-    cte l2 =
-      Reduce aggregates=[sum(((#0 + #2) * (#1 - #3)))]
-        Project (#0..=#3)
-          Get l1
-    cte l1 =
-      Distinct project=[#0..=#4]
-        Union
-          Project (#0, #1, #7..=#9)
-            Map ((#0 + (#4 * #6)), (#1 + (#5 * #6)), (#2 + 1))
-              Join on=(#2 = #3) type=differential
-                ArrangeBy keys=[[#2]]
-                  Project (#2..=#4)
-                    Get l1
-                ArrangeBy keys=[[#0]]
-                  Project (#0, #4..=#6)
-                    Map (regexp_split_to_array[" ", case_insensitive=false](#1), array_index(#2, 1), case when (#3 = "U") then -1 else case when ("D" = array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 1)) then 1 else 0 end end, case when (#3 = "L") then -1 else case when ("R" = array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 1)) then 1 else 0 end end, text_to_integer(array_index(#2, 2)))
-                      Get l0
-          Constant
-            - (0, 0, 0, 0, 1)
-    cte l0 =
-      Project (#1, #2)
-        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-            ReadStorage materialize.public.input
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1219.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1219.slt
@@ -321,7 +321,66 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
+  With Mutually Recursive
+    cte l0 =
+      Project (#0, #2, #6..=#9)
+        Map (array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2)), substr(#3, 2, 1), ((#4 = "<") OR (#4 = ">")), case when #5 then substr(#3, 1, 1) else "x" end, case when #5 then #4 else ">" end, case when #5 then text_to_integer(array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 1)) else 0 end, case when #5 then array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 2) else #3 end)
+          FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#1) array_length 1), 1)
+            Project (#3, #4)
+              Filter (#3) IS NOT NULL
+                Map (regexp_split_to_array["\{", case_insensitive=false](#1), array_index(#2, 1), btrim(array_index(#2, 2), "}"))
+                  FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
+                    Project (#1)
+                      Map (array_index(regexp_split_to_array["\n\n", case_insensitive=false](#0), 1))
+                        ReadStorage materialize.public.input
+    cte l1 =
+      Union
+        Project (#7, #3..=#6)
+          Map (regexp_split_to_array[",", case_insensitive=false](btrim(btrim(#1, "\}"), "\{")), text_to_integer(substr(array_index(#2, 1), 3)), text_to_integer(substr(array_index(#2, 2), 3)), text_to_integer(substr(array_index(#2, 3), 3)), text_to_integer(substr(array_index(#2, 4), 3)), "in")
+            FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
+              Project (#1)
+                Map (array_index(regexp_split_to_array["\n\n", case_insensitive=false](#0), 2))
+                  ReadStorage materialize.public.input
+        Project (#6, #1..=#4)
+          TopK group_by=[#0..=#4] order_by=[#5 asc nulls_last] limit=1
+            Project (#0..=#4, #6, #10)
+              Filter case when (#8 = "<") then case when (#7 = "x") then (#1 < #9) else case when (#7 = "m") then (#2 < #9) else case when (#7 = "a") then (#3 < #9) else case when (#7 = "s") then (#4 < #9) else false end end end end else case when (#8 = ">") then case when (#7 = "x") then (#1 > #9) else case when (#7 = "m") then (#2 > #9) else case when (#7 = "a") then (#3 > #9) else case when (#7 = "s") then (#4 > #9) else false end end end end else false end end
+                Join on=(#0 = #5) type=differential
+                  ArrangeBy keys=[[#0]]
+                    Filter (#0) IS NOT NULL
+                      Get l1
+                  ArrangeBy keys=[[#0]]
+                    Get l0
+    cte l2 =
+      Reduce aggregates=[sum((((#0 + #1) + #2) + #3))]
+        Project (#1..=#4)
+          Filter (#0 = "A")
+            Get l1
+    cte l3 =
+      Project (#0..=#9, #12..=#15)
+        Join on=(#0 = #10 AND #1 = #11) type=differential
+          ArrangeBy keys=[[#0, #1]]
+            Filter (#0) IS NOT NULL
+              Get l4
+          ArrangeBy keys=[[#0, #1]]
+            Get l0
+    cte l4 =
+      Union
+        Project (#13, #28, #16, #18, #20, #21, #23, #24, #26, #27)
+          Map ((#10 = "x"), (#11 = ">"), case when (#14 AND #15) then greatest((#12 + 1), #2) else #2 end, (#11 = "<"), case when (#14 AND #17) then least((#12 - 1), #3) else #3 end, (#10 = "m"), case when (#15 AND #19) then greatest((#12 + 1), #4) else #4 end, case when (#17 AND #19) then least((#12 - 1), #5) else #5 end, (#10 = "a"), case when (#15 AND #22) then greatest((#12 + 1), #6) else #6 end, case when (#17 AND #22) then least((#12 - 1), #7) else #7 end, (#10 = "s"), case when (#15 AND #25) then greatest((#12 + 1), #8) else #8 end, case when (#17 AND #25) then least((#12 - 1), #9) else #9 end, 1)
+            Get l3
+        Project (#0, #14, #17, #19, #21, #22, #24, #25, #27, #28)
+          Map ((#1 + 1), (#10 = "x"), (#11 = "<"), case when (#15 AND #16) then greatest(#12, #2) else #2 end, (#11 = ">"), case when (#15 AND #18) then least(#12, #3) else #3 end, (#10 = "m"), case when (#16 AND #20) then greatest(#12, #4) else #4 end, case when (#18 AND #20) then least(#12, #5) else #5 end, (#10 = "a"), case when (#16 AND #23) then greatest(#12, #6) else #6 end, case when (#18 AND #23) then least(#12, #7) else #7 end, (#10 = "s"), case when (#16 AND #26) then greatest(#12, #8) else #8 end, case when (#18 AND #26) then least(#12, #9) else #9 end)
+            Get l3
+        Constant
+          - ("in", 1, 1, 4000, 1, 4000, 1, 4000, 1, 4000)
   Return
+    With
+      cte l5 =
+        Reduce aggregates=[sum((((integer_to_bigint(((1 + #1) - #0)) * integer_to_bigint(((1 + #3) - #2))) * integer_to_bigint(((1 + #5) - #4))) * integer_to_bigint(((1 + #7) - #6))))]
+          Project (#2..=#9)
+            Filter (#0 = "A")
+              Get l4
     Return
       CrossJoin type=differential
         ArrangeBy keys=[[]]
@@ -344,65 +403,6 @@ Explained Query:
                     Get l5
                 Constant
                   - ()
-    With
-      cte l5 =
-        Reduce aggregates=[sum((((integer_to_bigint(((1 + #1) - #0)) * integer_to_bigint(((1 + #3) - #2))) * integer_to_bigint(((1 + #5) - #4))) * integer_to_bigint(((1 + #7) - #6))))]
-          Project (#2..=#9)
-            Filter (#0 = "A")
-              Get l4
-  With Mutually Recursive
-    cte l4 =
-      Union
-        Project (#13, #28, #16, #18, #20, #21, #23, #24, #26, #27)
-          Map ((#10 = "x"), (#11 = ">"), case when (#14 AND #15) then greatest((#12 + 1), #2) else #2 end, (#11 = "<"), case when (#14 AND #17) then least((#12 - 1), #3) else #3 end, (#10 = "m"), case when (#15 AND #19) then greatest((#12 + 1), #4) else #4 end, case when (#17 AND #19) then least((#12 - 1), #5) else #5 end, (#10 = "a"), case when (#15 AND #22) then greatest((#12 + 1), #6) else #6 end, case when (#17 AND #22) then least((#12 - 1), #7) else #7 end, (#10 = "s"), case when (#15 AND #25) then greatest((#12 + 1), #8) else #8 end, case when (#17 AND #25) then least((#12 - 1), #9) else #9 end, 1)
-            Get l3
-        Project (#0, #14, #17, #19, #21, #22, #24, #25, #27, #28)
-          Map ((#1 + 1), (#10 = "x"), (#11 = "<"), case when (#15 AND #16) then greatest(#12, #2) else #2 end, (#11 = ">"), case when (#15 AND #18) then least(#12, #3) else #3 end, (#10 = "m"), case when (#16 AND #20) then greatest(#12, #4) else #4 end, case when (#18 AND #20) then least(#12, #5) else #5 end, (#10 = "a"), case when (#16 AND #23) then greatest(#12, #6) else #6 end, case when (#18 AND #23) then least(#12, #7) else #7 end, (#10 = "s"), case when (#16 AND #26) then greatest(#12, #8) else #8 end, case when (#18 AND #26) then least(#12, #9) else #9 end)
-            Get l3
-        Constant
-          - ("in", 1, 1, 4000, 1, 4000, 1, 4000, 1, 4000)
-    cte l3 =
-      Project (#0..=#9, #12..=#15)
-        Join on=(#0 = #10 AND #1 = #11) type=differential
-          ArrangeBy keys=[[#0, #1]]
-            Filter (#0) IS NOT NULL
-              Get l4
-          ArrangeBy keys=[[#0, #1]]
-            Get l0
-    cte l2 =
-      Reduce aggregates=[sum((((#0 + #1) + #2) + #3))]
-        Project (#1..=#4)
-          Filter (#0 = "A")
-            Get l1
-    cte l1 =
-      Union
-        Project (#7, #3..=#6)
-          Map (regexp_split_to_array[",", case_insensitive=false](btrim(btrim(#1, "\}"), "\{")), text_to_integer(substr(array_index(#2, 1), 3)), text_to_integer(substr(array_index(#2, 2), 3)), text_to_integer(substr(array_index(#2, 3), 3)), text_to_integer(substr(array_index(#2, 4), 3)), "in")
-            FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-              Project (#1)
-                Map (array_index(regexp_split_to_array["\n\n", case_insensitive=false](#0), 2))
-                  ReadStorage materialize.public.input
-        Project (#6, #1..=#4)
-          TopK group_by=[#0..=#4] order_by=[#5 asc nulls_last] limit=1
-            Project (#0..=#4, #6, #10)
-              Filter case when (#8 = "<") then case when (#7 = "x") then (#1 < #9) else case when (#7 = "m") then (#2 < #9) else case when (#7 = "a") then (#3 < #9) else case when (#7 = "s") then (#4 < #9) else false end end end end else case when (#8 = ">") then case when (#7 = "x") then (#1 > #9) else case when (#7 = "m") then (#2 > #9) else case when (#7 = "a") then (#3 > #9) else case when (#7 = "s") then (#4 > #9) else false end end end end else false end end
-                Join on=(#0 = #5) type=differential
-                  ArrangeBy keys=[[#0]]
-                    Filter (#0) IS NOT NULL
-                      Get l1
-                  ArrangeBy keys=[[#0]]
-                    Get l0
-    cte l0 =
-      Project (#0, #2, #6..=#9)
-        Map (array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2)), substr(#3, 2, 1), ((#4 = "<") OR (#4 = ">")), case when #5 then substr(#3, 1, 1) else "x" end, case when #5 then #4 else ">" end, case when #5 then text_to_integer(array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 1)) else 0 end, case when #5 then array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 2) else #3 end)
-          FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#1) array_length 1), 1)
-            Project (#3, #4)
-              Filter (#3) IS NOT NULL
-                Map (regexp_split_to_array["\{", case_insensitive=false](#1), array_index(#2, 1), btrim(array_index(#2, 2), "}"))
-                  FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-                    Project (#1)
-                      Map (array_index(regexp_split_to_array["\n\n", case_insensitive=false](#0), 1))
-                        ReadStorage materialize.public.input
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1220.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1220.slt
@@ -137,50 +137,74 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM signal WHERE target = 'cn' AND pulse = 'hi';
 ----
 Explained Query:
-  Return
-    Filter (#1 = "cn") AND (#4 = "hi")
-      Get l27
   With Mutually Recursive
-    cte l27 =
-      Project (#0, #5, #1..=#3)
-        Join on=(#0 = #4) type=differential
-          ArrangeBy keys=[[#0]]
-            Get l3
-          ArrangeBy keys=[[#0]]
-            Filter (#0) IS NOT NULL
-              Get l1
-    cte l26 =
-      Project (#1, #2, #4, #11)
-        Map (case when (#5 = #10) then "lo" else "hi" end)
-          Join on=(#0 = #6 AND #1 = #9 AND #2 = #7 AND #3 = #8) type=differential
-            ArrangeBy keys=[[#0, #2, #3, #1]]
-              Get l20
-            ArrangeBy keys=[[#0..=#3]]
-              Union
-                Get l25
-                Project (#0..=#3, #8)
-                  Map (null)
-                    Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential
-                      ArrangeBy keys=[[#0..=#3]]
-                        Union
-                          Negate
-                            Distinct project=[#0..=#3]
-                              Project (#0..=#3)
-                                Get l25
-                          Get l21
-                      Get l23
-    cte l25 =
+    cte l0 =
+      Project (#1)
+        FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
+          ReadStorage materialize.public.input
+    cte l1 =
+      Project (#3, #4)
+        Map (regexp_split_to_array[" ", case_insensitive=false](#0), substr(array_index(#2, 1), 2), btrim(array_index(#2, integer_to_bigint(#1)), ","))
+          FlatMap generate_series(3, (regexp_split_to_array[" ", case_insensitive=false](#0) array_length 1), 1)
+            Get l0
+    cte l2 =
+      Distinct project=[#0, #1] monotonic
+        Union
+          Project (#0, #2)
+            Filter (#1 > 0)
+              Map ((#1 - 1))
+                Get l2
+          Project (#2, #3)
+            Filter (#1 = 0) AND (#0 < 4100)
+              Map ((#0 + 1), 20)
+                Get l2
+          Constant
+            - (1, 1)
+    cte l3 =
       Union
-        Get l24
-        Map (error("more than one record produced in subquery"))
-          Project (#0..=#3)
-            Filter (#4 > 1)
-              Reduce group_by=[#0..=#3] aggregates=[count(*)]
-                Project (#0..=#3)
-                  Get l24
-    cte l24 =
+        Project (#2, #0, #3, #4)
+          Filter (#1 = 0)
+            Map ("roadcaster", 1, "lo")
+              Get l2
+        Filter (#2 > 0)
+          Get l12
+        Filter (#2 > 0)
+          Get l26
+    cte l4 =
+      ArrangeBy keys=[[#1]]
+        Project (#0..=#3)
+          Filter (#4 = "lo") AND (#1) IS NOT NULL
+            Get l27
+    cte l5 =
+      Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#0), 1), substr(#1, 2))
+        Get l0
+    cte l6 =
+      Project (#0..=#3, #5)
+        Map ((#3 + 1))
+          Join on=(#1 = #4) type=differential
+            Get l4
+            ArrangeBy keys=[[#0]]
+              Project (#2)
+                Filter ("%" = substr(#1, 1, 1))
+                  Get l5
+    cte l7 =
+      Distinct project=[#0, #2, #3, #1]
+        Project (#0..=#3)
+          Get l6
+    cte l8 =
+      Reduce group_by=[#0..=#3] aggregates=[count(*)]
+        Project (#0..=#3)
+          Filter ((#6 < #1) OR ((#1 = #6) AND ((#7 < #2) OR ((#2 = #7) AND (#4 < #0)))))
+            Join on=(#3 = #5) type=differential
+              ArrangeBy keys=[[#3]]
+                Get l7
+              Get l4
+    cte l9 =
+      ArrangeBy keys=[[#0..=#3]]
+        Get l7
+    cte l10 =
       Union
-        Get l22
+        Get l8
         Project (#0..=#3, #8)
           Map (0)
             Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential
@@ -188,99 +212,18 @@ Explained Query:
                 Union
                   Negate
                     Project (#0..=#3)
-                      Get l22
-                  Get l21
-              Get l23
-    cte l23 =
-      ArrangeBy keys=[[#0..=#3]]
-        Get l21
-    cte l22 =
-      Reduce group_by=[#0..=#3] aggregates=[count(*)]
-        Project (#0..=#3)
-          Filter (#7 = "hi")
-            TopK group_by=[#0..=#4] order_by=[#5 desc nulls_first, #6 desc nulls_first] limit=1 exp_group_size=1000
-              Project (#0..=#4, #6..=#8)
-                Filter ((#6 < #1) OR ((#1 = #6) AND ((#7 < #2) OR ((#2 = #7) AND (#4 <= #0)))))
-                  Join on=(#3 = #5) type=differential
-                    ArrangeBy keys=[[#3]]
-                      Get l21
-                    ArrangeBy keys=[[#1]]
-                      Get l13
-    cte l21 =
-      Distinct project=[#0, #2, #3, #1]
-        Project (#0..=#3)
-          Get l20
-    cte l20 =
-      Project (#0..=#4, #6)
-        Join on=(#1 = #5) type=differential
-          ArrangeBy keys=[[#1]]
-            Get l14
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l19
-              Project (#0, #2)
-                Map (null)
-                  Join on=(#0 = #1) type=differential
-                    ArrangeBy keys=[[#0]]
-                      Union
-                        Negate
-                          Distinct project=[#0]
-                            Project (#0)
-                              Get l19
-                        Get l15
-                    Get l16
-    cte l19 =
+                      Get l8
+                  Get l7
+              Get l9
+    cte l11 =
       Union
-        Get l18
+        Get l10
         Map (error("more than one record produced in subquery"))
-          Project (#0)
-            Filter (#1 > 1)
-              Reduce group_by=[#0] aggregates=[count(*)]
-                Project (#0)
-                  Get l18
-    cte l18 =
-      Union
-        Get l17
-        Project (#0, #2)
-          Map (0)
-            Join on=(#0 = #1) type=differential
-              ArrangeBy keys=[[#0]]
-                Union
-                  Negate
-                    Project (#0)
-                      Get l17
-                  Get l15
-              Get l16
-    cte l17 =
-      Reduce group_by=[#0] aggregates=[count(*)]
-        Project (#0)
-          Join on=(#0 = #1) type=differential
-            Get l16
-            ArrangeBy keys=[[#0]]
-              Project (#1)
-                Filter (#1) IS NOT NULL
-                  Get l1
-    cte l16 =
-      ArrangeBy keys=[[#0]]
-        Get l15
-    cte l15 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l14
-    cte l14 =
-      Project (#0..=#3, #5)
-        Map ((#3 + 1))
-          Join on=(#1 = #4) type=differential
-            ArrangeBy keys=[[#1]]
-              Project (#0..=#3)
-                Get l13
-            ArrangeBy keys=[[#0]]
-              Project (#2)
-                Filter ("&" = substr(#1, 1, 1))
-                  Get l5
-    cte l13 =
-      Filter (#1) IS NOT NULL
-        Get l27
+          Project (#0..=#3)
+            Filter (#4 > 1)
+              Reduce group_by=[#0..=#3] aggregates=[count(*)]
+                Project (#0..=#3)
+                  Get l10
     cte l12 =
       Project (#1, #2, #4, #10)
         Map (case when (0 = (#9 % 2)) then "hi" else "lo" end)
@@ -301,18 +244,99 @@ Explained Query:
                                 Get l11
                           Get l7
                       Get l9
-    cte l11 =
+    cte l13 =
+      Filter (#1) IS NOT NULL
+        Get l27
+    cte l14 =
+      Project (#0..=#3, #5)
+        Map ((#3 + 1))
+          Join on=(#1 = #4) type=differential
+            ArrangeBy keys=[[#1]]
+              Project (#0..=#3)
+                Get l13
+            ArrangeBy keys=[[#0]]
+              Project (#2)
+                Filter ("&" = substr(#1, 1, 1))
+                  Get l5
+    cte l15 =
+      Distinct project=[#0]
+        Project (#1)
+          Get l14
+    cte l16 =
+      ArrangeBy keys=[[#0]]
+        Get l15
+    cte l17 =
+      Reduce group_by=[#0] aggregates=[count(*)]
+        Project (#0)
+          Join on=(#0 = #1) type=differential
+            Get l16
+            ArrangeBy keys=[[#0]]
+              Project (#1)
+                Filter (#1) IS NOT NULL
+                  Get l1
+    cte l18 =
       Union
-        Get l10
+        Get l17
+        Project (#0, #2)
+          Map (0)
+            Join on=(#0 = #1) type=differential
+              ArrangeBy keys=[[#0]]
+                Union
+                  Negate
+                    Project (#0)
+                      Get l17
+                  Get l15
+              Get l16
+    cte l19 =
+      Union
+        Get l18
         Map (error("more than one record produced in subquery"))
-          Project (#0..=#3)
-            Filter (#4 > 1)
-              Reduce group_by=[#0..=#3] aggregates=[count(*)]
-                Project (#0..=#3)
-                  Get l10
-    cte l10 =
+          Project (#0)
+            Filter (#1 > 1)
+              Reduce group_by=[#0] aggregates=[count(*)]
+                Project (#0)
+                  Get l18
+    cte l20 =
+      Project (#0..=#4, #6)
+        Join on=(#1 = #5) type=differential
+          ArrangeBy keys=[[#1]]
+            Get l14
+          ArrangeBy keys=[[#0]]
+            Union
+              Get l19
+              Project (#0, #2)
+                Map (null)
+                  Join on=(#0 = #1) type=differential
+                    ArrangeBy keys=[[#0]]
+                      Union
+                        Negate
+                          Distinct project=[#0]
+                            Project (#0)
+                              Get l19
+                        Get l15
+                    Get l16
+    cte l21 =
+      Distinct project=[#0, #2, #3, #1]
+        Project (#0..=#3)
+          Get l20
+    cte l22 =
+      Reduce group_by=[#0..=#3] aggregates=[count(*)]
+        Project (#0..=#3)
+          Filter (#7 = "hi")
+            TopK group_by=[#0..=#4] order_by=[#5 desc nulls_first, #6 desc nulls_first] limit=1 exp_group_size=1000
+              Project (#0..=#4, #6..=#8)
+                Filter ((#6 < #1) OR ((#1 = #6) AND ((#7 < #2) OR ((#2 = #7) AND (#4 <= #0)))))
+                  Join on=(#3 = #5) type=differential
+                    ArrangeBy keys=[[#3]]
+                      Get l21
+                    ArrangeBy keys=[[#1]]
+                      Get l13
+    cte l23 =
+      ArrangeBy keys=[[#0..=#3]]
+        Get l21
+    cte l24 =
       Union
-        Get l8
+        Get l22
         Project (#0..=#3, #8)
           Map (0)
             Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential
@@ -320,73 +344,49 @@ Explained Query:
                 Union
                   Negate
                     Project (#0..=#3)
-                      Get l8
-                  Get l7
-              Get l9
-    cte l9 =
-      ArrangeBy keys=[[#0..=#3]]
-        Get l7
-    cte l8 =
-      Reduce group_by=[#0..=#3] aggregates=[count(*)]
-        Project (#0..=#3)
-          Filter ((#6 < #1) OR ((#1 = #6) AND ((#7 < #2) OR ((#2 = #7) AND (#4 < #0)))))
-            Join on=(#3 = #5) type=differential
-              ArrangeBy keys=[[#3]]
-                Get l7
-              Get l4
-    cte l7 =
-      Distinct project=[#0, #2, #3, #1]
-        Project (#0..=#3)
-          Get l6
-    cte l6 =
-      Project (#0..=#3, #5)
-        Map ((#3 + 1))
-          Join on=(#1 = #4) type=differential
-            Get l4
-            ArrangeBy keys=[[#0]]
-              Project (#2)
-                Filter ("%" = substr(#1, 1, 1))
-                  Get l5
-    cte l5 =
-      Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#0), 1), substr(#1, 2))
-        Get l0
-    cte l4 =
-      ArrangeBy keys=[[#1]]
-        Project (#0..=#3)
-          Filter (#4 = "lo") AND (#1) IS NOT NULL
-            Get l27
-    cte l3 =
+                      Get l22
+                  Get l21
+              Get l23
+    cte l25 =
       Union
-        Project (#2, #0, #3, #4)
-          Filter (#1 = 0)
-            Map ("roadcaster", 1, "lo")
-              Get l2
-        Filter (#2 > 0)
-          Get l12
-        Filter (#2 > 0)
-          Get l26
-    cte l2 =
-      Distinct project=[#0, #1] monotonic
-        Union
-          Project (#0, #2)
-            Filter (#1 > 0)
-              Map ((#1 - 1))
-                Get l2
-          Project (#2, #3)
-            Filter (#1 = 0) AND (#0 < 4100)
-              Map ((#0 + 1), 20)
-                Get l2
-          Constant
-            - (1, 1)
-    cte l1 =
-      Project (#3, #4)
-        Map (regexp_split_to_array[" ", case_insensitive=false](#0), substr(array_index(#2, 1), 2), btrim(array_index(#2, integer_to_bigint(#1)), ","))
-          FlatMap generate_series(3, (regexp_split_to_array[" ", case_insensitive=false](#0) array_length 1), 1)
-            Get l0
-    cte l0 =
-      Project (#1)
-        FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-          ReadStorage materialize.public.input
+        Get l24
+        Map (error("more than one record produced in subquery"))
+          Project (#0..=#3)
+            Filter (#4 > 1)
+              Reduce group_by=[#0..=#3] aggregates=[count(*)]
+                Project (#0..=#3)
+                  Get l24
+    cte l26 =
+      Project (#1, #2, #4, #11)
+        Map (case when (#5 = #10) then "lo" else "hi" end)
+          Join on=(#0 = #6 AND #1 = #9 AND #2 = #7 AND #3 = #8) type=differential
+            ArrangeBy keys=[[#0, #2, #3, #1]]
+              Get l20
+            ArrangeBy keys=[[#0..=#3]]
+              Union
+                Get l25
+                Project (#0..=#3, #8)
+                  Map (null)
+                    Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential
+                      ArrangeBy keys=[[#0..=#3]]
+                        Union
+                          Negate
+                            Distinct project=[#0..=#3]
+                              Project (#0..=#3)
+                                Get l25
+                          Get l21
+                      Get l23
+    cte l27 =
+      Project (#0, #5, #1..=#3)
+        Join on=(#0 = #4) type=differential
+          ArrangeBy keys=[[#0]]
+            Get l3
+          ArrangeBy keys=[[#0]]
+            Filter (#0) IS NOT NULL
+              Get l1
+  Return
+    Filter (#1 = "cn") AND (#4 = "hi")
+      Get l27
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1222.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1222.slt
@@ -205,95 +205,123 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM part1, part2;
 ----
 Explained Query:
-  Return
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Union
-            Get l15
-            Map (0)
-              Union
-                Negate
-                  Project ()
-                    Get l15
-                Constant
-                  - ()
-        ArrangeBy keys=[[]]
-          Union
-            Get l23
-            Map (0)
-              Union
-                Negate
-                  Project ()
-                    Get l23
-                Constant
-                  - ()
-    With
-      cte l23 =
-        Reduce aggregates=[count(*)]
-          Project ()
-            Get l22
   With Mutually Recursive
-    cte l22 =
-      Distinct project=[#0, #1]
-        Union
-          Project (#0, #1)
-            Filter (#3 = 1)
-              Join on=(#1 = #2) type=differential
-                ArrangeBy keys=[[#1]]
-                  Get l8
-                ArrangeBy keys=[[#0]]
-                  Reduce group_by=[#0] aggregates=[count(*)]
-                    Get l9
-          Project (#0, #1)
-            Join on=(#1 = #3 AND #2 = #4) type=differential
-              ArrangeBy keys=[[#1, #2]]
-                Get l17
-              ArrangeBy keys=[[#0, #1]]
-                Union
-                  Get l21
-                  Map (error("more than one record produced in subquery"))
-                    Project (#0)
-                      Filter (#1 > 1)
-                        Reduce group_by=[#0] aggregates=[count(*)]
-                          Project (#0)
-                            Get l21
-    cte l21 =
+    cte l0 =
+      Project (#1, #2)
+        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
+          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
+            ReadStorage materialize.public.input
+    cte l1 =
+      Distinct project=[#0]
+        Project (#0)
+          Get l7
+    cte l2 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Get l1
+          ArrangeBy keys=[[]]
+            Get l10
+    cte l3 =
+      ArrangeBy keys=[[#0]]
+        Get l1
+    cte l4 =
       Union
-        Get l20
+        Get l2
         Project (#0, #2)
-          Map (0)
+          Map (false)
             Join on=(#0 = #1) type=differential
               ArrangeBy keys=[[#0]]
                 Union
                   Negate
                     Project (#0)
-                      Get l20
-                  Get l18
-              Get l19
-    cte l20 =
-      Reduce group_by=[#0] aggregates=[count(*)]
-        Project (#0)
-          Join on=(#0 = #1) type=differential
-            Get l19
-            Get l14
-    cte l19 =
-      ArrangeBy keys=[[#0]]
-        Get l18
-    cte l18 =
+                      Get l2
+                  Get l1
+              Get l3
+    cte l5 =
+      Union
+        Get l4
+        Map (error("more than one record produced in subquery"))
+          Project (#0)
+            Filter (#1 > 1)
+              Reduce group_by=[#0] aggregates=[count(*)]
+                Project (#0)
+                  Get l4
+    cte l6 =
+      Project (#0, #1, #3, #5)
+        Join on=(#0 = #2 = #4) type=delta
+          ArrangeBy keys=[[#0]]
+            Project (#0, #2)
+              FlatMap generate_series(text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 1)), 1)), text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 2)), 1)), 1)
+                Get l0
+          ArrangeBy keys=[[#0]]
+            Project (#0, #2)
+              FlatMap generate_series(text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 1)), 2)), text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 2)), 2)), 1)
+                Get l0
+          ArrangeBy keys=[[#0]]
+            Project (#0, #2)
+              FlatMap generate_series(text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 1)), 3)), text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 2)), 3)), 1)
+                Get l0
+    cte l7 =
+      Union
+        Threshold
+          Union
+            Get l6
+            Negate
+              Get l16
+        Project (#0..=#2, #6)
+          Map (case when #5 then #3 else (#3 - 1) end)
+            Join on=(#0 = #4) type=differential
+              ArrangeBy keys=[[#0]]
+                Get l7
+              ArrangeBy keys=[[#0]]
+                Union
+                  Get l5
+                  Project (#0, #2)
+                    Map (null)
+                      Join on=(#0 = #1) type=differential
+                        ArrangeBy keys=[[#0]]
+                          Union
+                            Negate
+                              Distinct project=[#0]
+                                Project (#0)
+                                  Get l5
+                            Get l1
+                        Get l3
+    cte l8 =
+      Distinct project=[#0, #1]
+        Project (#0, #4)
+          Filter (#0 != #4)
+            Join on=(#1 = #5 AND #2 = #6 AND #7 = (#3 + 1)) type=differential
+              ArrangeBy keys=[[#1, #2, (#3 + 1)]]
+                Get l7
+              ArrangeBy keys=[[#1..=#3]]
+                Get l7
+    cte l9 =
+      Project (#1)
+        Get l8
+    cte l10 =
       Distinct project=[#0]
-        Project (#1)
-          Get l17
-    cte l17 =
-      Reduce group_by=[#0, #1] aggregates=[count(*)]
-        Project (#0, #3)
-          Join on=(#1 = #2) type=differential
-            ArrangeBy keys=[[#1]]
-              Get l22
-            ArrangeBy keys=[[#0]]
-              Get l8
-    cte l16 =
-      Get l6
+        Union
+          Project (#0)
+            Filter (#3 = 1)
+              Get l7
+          Get l9
+    cte l11 =
+      Project (#0)
+        Get l0
+    cte l12 =
+      Distinct project=[#0]
+        Get l11
+    cte l13 =
+      CrossJoin type=differential
+        ArrangeBy keys=[[]]
+          Get l12
+        ArrangeBy keys=[[]]
+          Get l8
+    cte l14 =
+      ArrangeBy keys=[[#0]]
+        Get l9
     cte l15 =
       Reduce aggregates=[count(distinct #0)]
         Project (#0)
@@ -323,122 +351,94 @@ Explained Query:
                 Get l12
             ArrangeBy keys=[[#0]]
               Get l12
-    cte l14 =
+    cte l16 =
+      Get l6
+    cte l17 =
+      Reduce group_by=[#0, #1] aggregates=[count(*)]
+        Project (#0, #3)
+          Join on=(#1 = #2) type=differential
+            ArrangeBy keys=[[#1]]
+              Get l22
+            ArrangeBy keys=[[#0]]
+              Get l8
+    cte l18 =
+      Distinct project=[#0]
+        Project (#1)
+          Get l17
+    cte l19 =
       ArrangeBy keys=[[#0]]
-        Get l9
-    cte l13 =
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Get l12
-        ArrangeBy keys=[[]]
-          Get l8
-    cte l12 =
-      Distinct project=[#0]
-        Get l11
-    cte l11 =
-      Project (#0)
-        Get l0
-    cte l10 =
-      Distinct project=[#0]
-        Union
-          Project (#0)
-            Filter (#3 = 1)
-              Get l7
-          Get l9
-    cte l9 =
-      Project (#1)
-        Get l8
-    cte l8 =
-      Distinct project=[#0, #1]
-        Project (#0, #4)
-          Filter (#0 != #4)
-            Join on=(#1 = #5 AND #2 = #6 AND #7 = (#3 + 1)) type=differential
-              ArrangeBy keys=[[#1, #2, (#3 + 1)]]
-                Get l7
-              ArrangeBy keys=[[#1..=#3]]
-                Get l7
-    cte l7 =
+        Get l18
+    cte l20 =
+      Reduce group_by=[#0] aggregates=[count(*)]
+        Project (#0)
+          Join on=(#0 = #1) type=differential
+            Get l19
+            Get l14
+    cte l21 =
       Union
-        Threshold
-          Union
-            Get l6
-            Negate
-              Get l16
-        Project (#0..=#2, #6)
-          Map (case when #5 then #3 else (#3 - 1) end)
-            Join on=(#0 = #4) type=differential
-              ArrangeBy keys=[[#0]]
-                Get l7
-              ArrangeBy keys=[[#0]]
-                Union
-                  Get l5
-                  Project (#0, #2)
-                    Map (null)
-                      Join on=(#0 = #1) type=differential
-                        ArrangeBy keys=[[#0]]
-                          Union
-                            Negate
-                              Distinct project=[#0]
-                                Project (#0)
-                                  Get l5
-                            Get l1
-                        Get l3
-    cte l6 =
-      Project (#0, #1, #3, #5)
-        Join on=(#0 = #2 = #4) type=delta
-          ArrangeBy keys=[[#0]]
-            Project (#0, #2)
-              FlatMap generate_series(text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 1)), 1)), text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 2)), 1)), 1)
-                Get l0
-          ArrangeBy keys=[[#0]]
-            Project (#0, #2)
-              FlatMap generate_series(text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 1)), 2)), text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 2)), 2)), 1)
-                Get l0
-          ArrangeBy keys=[[#0]]
-            Project (#0, #2)
-              FlatMap generate_series(text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 1)), 3)), text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 2)), 3)), 1)
-                Get l0
-    cte l5 =
-      Union
-        Get l4
-        Map (error("more than one record produced in subquery"))
-          Project (#0)
-            Filter (#1 > 1)
-              Reduce group_by=[#0] aggregates=[count(*)]
-                Project (#0)
-                  Get l4
-    cte l4 =
-      Union
-        Get l2
+        Get l20
         Project (#0, #2)
-          Map (false)
+          Map (0)
             Join on=(#0 = #1) type=differential
               ArrangeBy keys=[[#0]]
                 Union
                   Negate
                     Project (#0)
-                      Get l2
-                  Get l1
-              Get l3
-    cte l3 =
-      ArrangeBy keys=[[#0]]
-        Get l1
-    cte l2 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l1
-          ArrangeBy keys=[[]]
-            Get l10
-    cte l1 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l7
-    cte l0 =
-      Project (#1, #2)
-        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-            ReadStorage materialize.public.input
+                      Get l20
+                  Get l18
+              Get l19
+    cte l22 =
+      Distinct project=[#0, #1]
+        Union
+          Project (#0, #1)
+            Filter (#3 = 1)
+              Join on=(#1 = #2) type=differential
+                ArrangeBy keys=[[#1]]
+                  Get l8
+                ArrangeBy keys=[[#0]]
+                  Reduce group_by=[#0] aggregates=[count(*)]
+                    Get l9
+          Project (#0, #1)
+            Join on=(#1 = #3 AND #2 = #4) type=differential
+              ArrangeBy keys=[[#1, #2]]
+                Get l17
+              ArrangeBy keys=[[#0, #1]]
+                Union
+                  Get l21
+                  Map (error("more than one record produced in subquery"))
+                    Project (#0)
+                      Filter (#1 > 1)
+                        Reduce group_by=[#0] aggregates=[count(*)]
+                          Project (#0)
+                            Get l21
+  Return
+    With
+      cte l23 =
+        Reduce aggregates=[count(*)]
+          Project ()
+            Get l22
+    Return
+      CrossJoin type=differential
+        ArrangeBy keys=[[]]
+          Union
+            Get l15
+            Map (0)
+              Union
+                Negate
+                  Project ()
+                    Get l15
+                Constant
+                  - ()
+        ArrangeBy keys=[[]]
+          Union
+            Get l23
+            Map (0)
+              Union
+                Negate
+                  Project ()
+                    Get l23
+                Constant
+                  - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1223.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1223.slt
@@ -291,136 +291,21 @@ SELECT * FROM longest ORDER BY d DESC;
 ----
 Explained Query:
   Finish order_by=[#2 desc nulls_first] output=[#0..=#3]
-    Return
-      Get l17
     With Mutually Recursive
-      cte l17 =
-        Project (#0, #1, #3, #2)
-          Reduce group_by=[#0, #1, #3] aggregates=[max(#2)]
-            Union
-              Project (#7, #8, #19, #20)
-                Filter (1 != ((#3 >> #18) % 2))
-                  Map (bigint_to_integer(#17), (#2 + #6), (#3 + (1 << #18)))
-                    Join on=(#0 = #4 AND #1 = #5 AND #7 = #9 = #11 = #13 = #15 AND #8 = #10 = #12 = #14 = #16) type=delta
-                      ArrangeBy keys=[[#0, #1]]
-                        Get l17
-                      ArrangeBy keys=[[#0, #1], [#3, #4]]
-                        Get l9
-                      Get l8
-                      ArrangeBy keys=[[#0, #1]]
-                        Get l10
-                      Get l15
-                      ArrangeBy keys=[[#0, #1]]
-                        Union
-                          Get l16
-                          Map (error("more than one record produced in subquery"))
-                            Project (#0, #1)
-                              Filter (#2 > 1)
-                                Reduce group_by=[#0, #1] aggregates=[count(*)]
-                                  Project (#0, #1)
-                                    Get l16
-              Constant
-                - (12, 20, 0, 0)
-      cte l16 =
-        Union
-          Get l14
-          Project (#0, #1, #4)
-            Map (0)
-              Join on=(#0 = #2 AND #1 = #3) type=differential
-                ArrangeBy keys=[[#0, #1]]
-                  Union
-                    Negate
-                      Project (#0, #1)
-                        Get l14
-                    Get l11
-                Get l15
-      cte l15 =
-        ArrangeBy keys=[[#0, #1]]
-          Get l11
-      cte l14 =
-        Reduce group_by=[#0, #1] aggregates=[count(*)]
-          Project (#0, #1)
-            Join on=(#2 = #4 AND #3 = #5) type=differential
-              ArrangeBy keys=[[#2, #3]]
-                Get l12
-              ArrangeBy keys=[[#0, #1]]
-                Union
-                  Negate
-                    Distinct project=[#0, #1]
-                      Project (#0, #1)
-                        Filter (#0 = #2) AND (#1 = #3)
-                          FlatMap wrap2(1, 2, 12, 20, 130, 126, 141, 140)
-                            Get l13
-                  Get l13
-      cte l13 =
+      cte l0 =
+        Project (#0, #2)
+          Filter ("#" != substr(#1, #2, 1))
+            FlatMap generate_series(1, char_length(#1), 1)
+              Project (#1, #2)
+                Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
+                  FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
+                    ReadStorage materialize.public.input
+      cte l1 =
         Distinct project=[#0, #1]
-          Project (#2, #3)
-            Get l12
-      cte l12 =
-        Filter ((#2 < #0) OR ((#0 = #2) AND (#3 < #1)))
-          CrossJoin type=differential
-            ArrangeBy keys=[[]]
-              Get l11
-            ArrangeBy keys=[[]]
-              Get l4
-      cte l11 =
-        Distinct project=[#0, #1]
-          Get l10
-      cte l10 =
-        Union
-          Negate
-            Distinct project=[#0, #1]
-              Project (#0, #1)
-                Filter (#0 = #2) AND (#1 = #3)
-                  FlatMap wrap2(1, 2, 12, 20, 130, 126, 141, 140)
-                    Get l4
-          Get l4
-      cte l9 =
-        Project (#0, #1, #4, #2, #3)
-          Reduce group_by=[#0, #1, #3, #4] aggregates=[min(#2)]
-            Union
-              Project (#0, #1, #6, #2, #3)
-                Map (1)
-                  Join on=(#0 = #4 AND #1 = #5) type=differential
-                    Get l5
-                    Get l8
-              Project (#0, #1, #9, #5, #6)
-                Map ((#2 + 1))
-                  Join on=(#3 = #7 AND #4 = #8) type=differential
-                    ArrangeBy keys=[[#3, #4]]
-                      Get l6
-                    ArrangeBy keys=[[#0, #1]]
-                      Union
-                        Negate
-                          Project (#0, #1)
-                            Join on=(#0 = #2 AND #1 = #3) type=differential
-                              ArrangeBy keys=[[#0, #1]]
-                                Get l7
-                              Get l8
-                        Get l7
-      cte l8 =
+          Get l0
+      cte l2 =
         ArrangeBy keys=[[#0, #1]]
-          Get l4
-      cte l7 =
-        Distinct project=[#0, #1]
-          Project (#3, #4)
-            Get l6
-      cte l6 =
-        Project (#0..=#4, #7, #8)
-          Filter ((#0 != #7) OR (#1 != #8))
-            Join on=(#3 = #5 AND #4 = #6) type=differential
-              ArrangeBy keys=[[#3, #4]]
-                Get l9
-              Get l5
-      cte l5 =
-        ArrangeBy keys=[[#0, #1]]
-          Get l3
-      cte l4 =
-        Project (#0, #1)
-          Filter (#2 != 2)
-            Reduce group_by=[#0, #1] aggregates=[count(*)]
-              Project (#0, #1)
-                Get l3
+          Get l0
       cte l3 =
         Distinct project=[#0..=#3]
           Union
@@ -471,20 +356,135 @@ Explained Query:
                           ArrangeBy keys=[[#0, (#1 - 1)]]
                             Get l1
                           Get l2
-      cte l2 =
+      cte l4 =
+        Project (#0, #1)
+          Filter (#2 != 2)
+            Reduce group_by=[#0, #1] aggregates=[count(*)]
+              Project (#0, #1)
+                Get l3
+      cte l5 =
         ArrangeBy keys=[[#0, #1]]
-          Get l0
-      cte l1 =
+          Get l3
+      cte l6 =
+        Project (#0..=#4, #7, #8)
+          Filter ((#0 != #7) OR (#1 != #8))
+            Join on=(#3 = #5 AND #4 = #6) type=differential
+              ArrangeBy keys=[[#3, #4]]
+                Get l9
+              Get l5
+      cte l7 =
         Distinct project=[#0, #1]
-          Get l0
-      cte l0 =
-        Project (#0, #2)
-          Filter ("#" != substr(#1, #2, 1))
-            FlatMap generate_series(1, char_length(#1), 1)
-              Project (#1, #2)
-                Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                  FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-                    ReadStorage materialize.public.input
+          Project (#3, #4)
+            Get l6
+      cte l8 =
+        ArrangeBy keys=[[#0, #1]]
+          Get l4
+      cte l9 =
+        Project (#0, #1, #4, #2, #3)
+          Reduce group_by=[#0, #1, #3, #4] aggregates=[min(#2)]
+            Union
+              Project (#0, #1, #6, #2, #3)
+                Map (1)
+                  Join on=(#0 = #4 AND #1 = #5) type=differential
+                    Get l5
+                    Get l8
+              Project (#0, #1, #9, #5, #6)
+                Map ((#2 + 1))
+                  Join on=(#3 = #7 AND #4 = #8) type=differential
+                    ArrangeBy keys=[[#3, #4]]
+                      Get l6
+                    ArrangeBy keys=[[#0, #1]]
+                      Union
+                        Negate
+                          Project (#0, #1)
+                            Join on=(#0 = #2 AND #1 = #3) type=differential
+                              ArrangeBy keys=[[#0, #1]]
+                                Get l7
+                              Get l8
+                        Get l7
+      cte l10 =
+        Union
+          Negate
+            Distinct project=[#0, #1]
+              Project (#0, #1)
+                Filter (#0 = #2) AND (#1 = #3)
+                  FlatMap wrap2(1, 2, 12, 20, 130, 126, 141, 140)
+                    Get l4
+          Get l4
+      cte l11 =
+        Distinct project=[#0, #1]
+          Get l10
+      cte l12 =
+        Filter ((#2 < #0) OR ((#0 = #2) AND (#3 < #1)))
+          CrossJoin type=differential
+            ArrangeBy keys=[[]]
+              Get l11
+            ArrangeBy keys=[[]]
+              Get l4
+      cte l13 =
+        Distinct project=[#0, #1]
+          Project (#2, #3)
+            Get l12
+      cte l14 =
+        Reduce group_by=[#0, #1] aggregates=[count(*)]
+          Project (#0, #1)
+            Join on=(#2 = #4 AND #3 = #5) type=differential
+              ArrangeBy keys=[[#2, #3]]
+                Get l12
+              ArrangeBy keys=[[#0, #1]]
+                Union
+                  Negate
+                    Distinct project=[#0, #1]
+                      Project (#0, #1)
+                        Filter (#0 = #2) AND (#1 = #3)
+                          FlatMap wrap2(1, 2, 12, 20, 130, 126, 141, 140)
+                            Get l13
+                  Get l13
+      cte l15 =
+        ArrangeBy keys=[[#0, #1]]
+          Get l11
+      cte l16 =
+        Union
+          Get l14
+          Project (#0, #1, #4)
+            Map (0)
+              Join on=(#0 = #2 AND #1 = #3) type=differential
+                ArrangeBy keys=[[#0, #1]]
+                  Union
+                    Negate
+                      Project (#0, #1)
+                        Get l14
+                    Get l11
+                Get l15
+      cte l17 =
+        Project (#0, #1, #3, #2)
+          Reduce group_by=[#0, #1, #3] aggregates=[max(#2)]
+            Union
+              Project (#7, #8, #19, #20)
+                Filter (1 != ((#3 >> #18) % 2))
+                  Map (bigint_to_integer(#17), (#2 + #6), (#3 + (1 << #18)))
+                    Join on=(#0 = #4 AND #1 = #5 AND #7 = #9 = #11 = #13 = #15 AND #8 = #10 = #12 = #14 = #16) type=delta
+                      ArrangeBy keys=[[#0, #1]]
+                        Get l17
+                      ArrangeBy keys=[[#0, #1], [#3, #4]]
+                        Get l9
+                      Get l8
+                      ArrangeBy keys=[[#0, #1]]
+                        Get l10
+                      Get l15
+                      ArrangeBy keys=[[#0, #1]]
+                        Union
+                          Get l16
+                          Map (error("more than one record produced in subquery"))
+                            Project (#0, #1)
+                              Filter (#2 > 1)
+                                Reduce group_by=[#0, #1] aggregates=[count(*)]
+                                  Project (#0, #1)
+                                    Get l16
+              Constant
+                - (12, 20, 0, 0)
+    Return
+      Get l17
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1224.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1224.slt
@@ -117,16 +117,6 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT x, y, ox, oy, COUNT(*) FROM coincidence_xz GROUP BY x, y, ox, oy HAVING COUNT(*) > 1;
 ----
 Explained Query:
-  Return
-    Project (#0, #1, #4, #2, #3)
-      Filter (#3 > 1)
-        Map (-117)
-          Reduce group_by=[(#0 + ((#2 * (((#5 - #0) * #8) - ((#6 - #1) * #7))) / ((#2 * #8) - (#3 * #7)))), (#1 + ((#3 * (((#5 - #0) * #8) - ((#6 - #1) * #7))) / ((#2 * #8) - (#3 * #7)))), #4] aggregates=[count(*)]
-            Project (#1..=#5, #7..=#10)
-              Filter (#0 < #6) AND ((#3 * #10) != (#4 * #9))
-                Join on=(#5 = #11) type=differential
-                  Get l0
-                  Get l0
   With
     cte l0 =
       ArrangeBy keys=[[#5]]
@@ -163,6 +153,16 @@ Explained Query:
                     - (16)
                     - (17)
                     - (18)
+  Return
+    Project (#0, #1, #4, #2, #3)
+      Filter (#3 > 1)
+        Map (-117)
+          Reduce group_by=[(#0 + ((#2 * (((#5 - #0) * #8) - ((#6 - #1) * #7))) / ((#2 * #8) - (#3 * #7)))), (#1 + ((#3 * (((#5 - #0) * #8) - ((#6 - #1) * #7))) / ((#2 * #8) - (#3 * #7)))), #4] aggregates=[count(*)]
+            Project (#1..=#5, #7..=#10)
+              Filter (#0 < #6) AND ((#3 * #10) != (#4 * #9))
+                Join on=(#5 = #11) type=differential
+                  Get l0
+                  Get l0
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1225.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1225.slt
@@ -128,65 +128,55 @@ EXPLAIN WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 50)
 SELECT * FROM part1;
 ----
 Explained Query:
-  Return
-    Return
-      Project (#2)
-        Map ((#0 * #1))
-          CrossJoin type=differential
-            ArrangeBy keys=[[]]
-              Union
-                Get l10
-                Map (null)
-                  Union
-                    Negate
-                      Project ()
-                        Get l10
-                    Constant
-                      - ()
-            ArrangeBy keys=[[]]
-              Union
-                Get l12
-                Map (null)
-                  Union
-                    Negate
-                      Project ()
-                        Get l12
-                    Constant
-                      - ()
-    With
-      cte l12 =
-        Union
-          Get l11
-          Map (0)
-            Union
-              Negate
-                Project ()
-                  Get l11
-              Constant
-                - ()
-      cte l11 =
-        Reduce aggregates=[count(*)]
-          Project ()
-            Filter (#1 > 0)
-              Get l7
-      cte l10 =
-        Union
-          Get l9
-          Map (0)
-            Union
-              Negate
-                Project ()
-                  Get l9
-              Constant
-                - ()
-      cte l9 =
-        Reduce aggregates=[count(*)]
-          Project ()
-            Filter (#1 < 0)
-              Get l7
   With Mutually Recursive
-    cte [recursion_limit=50, return_at_limit] l8 =
-      Get l1
+    cte l0 =
+      Project (#3, #4)
+        Map (regexp_split_to_array[" ", case_insensitive=false](#0), btrim(array_index(#2, 1), ":"), btrim(array_index(#2, integer_to_bigint(#1)), ","))
+          FlatMap generate_series(2, (regexp_split_to_array[" ", case_insensitive=false](#0) array_length 1), 1)
+            Project (#2)
+              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
+                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
+                  ReadStorage materialize.public.input
+    cte l1 =
+      Map (case when (#0 < "n") then 1 else -1 end)
+        Union
+          Project (#0)
+            Get l0
+          Project (#1)
+            Get l0
+    cte l2 =
+      Project (#1)
+        Get l7
+    cte l3 =
+      Reduce aggregates=[sum(#0), count(#0)]
+        Get l2
+    cte l4 =
+      Project (#2)
+        Map ((#0 / bigint_to_numeric(case when (#1 = 0) then null else #1 end)))
+          Union
+            Get l3
+            Map (null, 0)
+              Union
+                Negate
+                  Project ()
+                    Get l3
+                Constant
+                  - ()
+    cte l5 =
+      Reduce aggregates=[sum((#0 * #0)), sum(#0), count(#0)]
+        Get l2
+    cte l6 =
+      Project (#3)
+        Map (sqrtnumeric(case when ((#0) IS NULL OR (#1) IS NULL OR (case when (#2 = 0) then null else #2 end) IS NULL OR (case when (0 = (#2 - 1)) then null else (#2 - 1) end) IS NULL) then null else greatest(((#0 - ((#1 * #1) / bigint_to_numeric(case when (#2 = 0) then null else #2 end))) / bigint_to_numeric(case when (0 = (#2 - 1)) then null else (#2 - 1) end)), 0) end))
+          Union
+            Get l5
+            Map (null, null, 0)
+              Union
+                Negate
+                  Project ()
+                    Get l5
+                Constant
+                  - ()
     cte [recursion_limit=50, return_at_limit] l7 =
       Union
         Threshold
@@ -227,54 +217,64 @@ Explained Query:
                           Get l6
                       Constant
                         - ()
-    cte l6 =
-      Project (#3)
-        Map (sqrtnumeric(case when ((#0) IS NULL OR (#1) IS NULL OR (case when (#2 = 0) then null else #2 end) IS NULL OR (case when (0 = (#2 - 1)) then null else (#2 - 1) end) IS NULL) then null else greatest(((#0 - ((#1 * #1) / bigint_to_numeric(case when (#2 = 0) then null else #2 end))) / bigint_to_numeric(case when (0 = (#2 - 1)) then null else (#2 - 1) end)), 0) end))
-          Union
-            Get l5
-            Map (null, null, 0)
-              Union
-                Negate
-                  Project ()
-                    Get l5
-                Constant
-                  - ()
-    cte l5 =
-      Reduce aggregates=[sum((#0 * #0)), sum(#0), count(#0)]
-        Get l2
-    cte l4 =
-      Project (#2)
-        Map ((#0 / bigint_to_numeric(case when (#1 = 0) then null else #1 end)))
-          Union
-            Get l3
-            Map (null, 0)
-              Union
-                Negate
-                  Project ()
-                    Get l3
-                Constant
-                  - ()
-    cte l3 =
-      Reduce aggregates=[sum(#0), count(#0)]
-        Get l2
-    cte l2 =
-      Project (#1)
-        Get l7
-    cte l1 =
-      Map (case when (#0 < "n") then 1 else -1 end)
+    cte [recursion_limit=50, return_at_limit] l8 =
+      Get l1
+  Return
+    With
+      cte l9 =
+        Reduce aggregates=[count(*)]
+          Project ()
+            Filter (#1 < 0)
+              Get l7
+      cte l10 =
         Union
-          Project (#0)
-            Get l0
-          Project (#1)
-            Get l0
-    cte l0 =
-      Project (#3, #4)
-        Map (regexp_split_to_array[" ", case_insensitive=false](#0), btrim(array_index(#2, 1), ":"), btrim(array_index(#2, integer_to_bigint(#1)), ","))
-          FlatMap generate_series(2, (regexp_split_to_array[" ", case_insensitive=false](#0) array_length 1), 1)
-            Project (#2)
-              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-                  ReadStorage materialize.public.input
+          Get l9
+          Map (0)
+            Union
+              Negate
+                Project ()
+                  Get l9
+              Constant
+                - ()
+      cte l11 =
+        Reduce aggregates=[count(*)]
+          Project ()
+            Filter (#1 > 0)
+              Get l7
+      cte l12 =
+        Union
+          Get l11
+          Map (0)
+            Union
+              Negate
+                Project ()
+                  Get l11
+              Constant
+                - ()
+    Return
+      Project (#2)
+        Map ((#0 * #1))
+          CrossJoin type=differential
+            ArrangeBy keys=[[]]
+              Union
+                Get l10
+                Map (null)
+                  Union
+                    Negate
+                      Project ()
+                        Get l10
+                    Constant
+                      - ()
+            ArrangeBy keys=[[]]
+              Union
+                Get l12
+                Map (null)
+                  Union
+                    Negate
+                      Project ()
+                        Get l12
+                    Constant
+                      - ()
 
 Source materialize.public.input
 

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -722,6 +722,10 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN FOR SELECT stddev(x), sum(x) FROM t_variance;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[sum((#0 * #0)), sum(#0), count(#0)]
+        ReadStorage materialize.public.t_variance
   Return
     Project (#4, #3)
       Map (sqrtf64(case when ((#0) IS NULL OR (#1) IS NULL OR (case when (#2 = 0) then null else #2 end) IS NULL OR (case when (0 = (#2 - 1)) then null else (#2 - 1) end) IS NULL) then null else greatest(((#0 - ((#1 * #1) / bigint_to_double(case when (#2 = 0) then null else #2 end))) / bigint_to_double(case when (0 = (#2 - 1)) then null else (#2 - 1) end)), 0) end))
@@ -735,10 +739,6 @@ Explained Query:
                   Get l0
               Constant
                 - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum((#0 * #0)), sum(#0), count(#0)]
-        ReadStorage materialize.public.t_variance
 
 Source materialize.public.t_variance
 

--- a/test/sqllogictest/attributes/mir_arity.slt
+++ b/test/sqllogictest/attributes/mir_arity.slt
@@ -43,6 +43,20 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(arity) AS TEXT FOR SELECT * FROM test1
 ----
 Explained Query:
+  With
+    cte l0 =
+      FlatMap generate_series(#0, #1, 1) // { arity: 3 }
+        ReadIndex on=t t_a_idx=[*** full scan ***] // { arity: 2 }
+    cte l1 =
+      ArrangeBy keys=[[#0]] // { arity: 3 }
+        Filter (#0) IS NOT NULL // { arity: 3 }
+          Get l0 // { arity: 3 }
+    cte l2 =
+      Project (#0..=#3) // { arity: 4 }
+        Join on=(#0 = #4) type=differential // { arity: 5 }
+          Get l1 // { arity: 3 }
+          ArrangeBy keys=[[#1]] // { arity: 2 }
+            ReadIndex on=u u_d_idx=[differential join] // { arity: 2 }
   Return // { arity: 4 }
     Threshold // { arity: 4 }
       Union // { arity: 4 }
@@ -66,20 +80,6 @@ Explained Query:
                     Get l2 // { arity: 4 }
         Constant // { arity: 4 }
           - (1, 2, 11, 12)
-  With
-    cte l2 =
-      Project (#0..=#3) // { arity: 4 }
-        Join on=(#0 = #4) type=differential // { arity: 5 }
-          Get l1 // { arity: 3 }
-          ArrangeBy keys=[[#1]] // { arity: 2 }
-            ReadIndex on=u u_d_idx=[differential join] // { arity: 2 }
-    cte l1 =
-      ArrangeBy keys=[[#0]] // { arity: 3 }
-        Filter (#0) IS NOT NULL // { arity: 3 }
-          Get l0 // { arity: 3 }
-    cte l0 =
-      FlatMap generate_series(#0, #1, 1) // { arity: 3 }
-        ReadIndex on=t t_a_idx=[*** full scan ***] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -119,11 +119,6 @@ WITH u AS (select u.c + 1 as g from u)
 SELECT u.g as g, w.g as h FROM u, u as w WHERE u.g = w.g
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Project (#0, #0) // { arity: 2 }
-      Join on=(#0 = #1) type=differential // { arity: 2 }
-        Get l0 // { arity: 1 }
-        Get l0 // { arity: 1 }
   With
     cte l0 =
       ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -131,6 +126,11 @@ Explained Query:
           Filter (#0) IS NOT NULL // { arity: 3 }
             Map ((#0 + 1)) // { arity: 3 }
               ReadIndex on=u u_d_idx=[*** full scan ***] // { arity: 2 }
+  Return // { arity: 2 }
+    Project (#0, #0) // { arity: 2 }
+      Join on=(#0 = #1) type=differential // { arity: 2 }
+        Get l0 // { arity: 1 }
+        Get l0 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.u_d_idx (*** full scan ***)
@@ -146,6 +146,18 @@ EXPLAIN OPTIMIZED PLAN WITH(arity) AS TEXT FOR
 SELECT * FROM u WHERE (SELECT f FROM v WHERE v.e = u.d) = 1
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0, #2) // { arity: 2 }
+        Join on=(#0 = #1) type=differential // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Distinct project=[#0] // { arity: 1 }
+              Project (#1) // { arity: 1 }
+                Filter (#1) IS NOT NULL // { arity: 2 }
+                  ReadIndex on=u u_d_idx=[*** full scan ***] // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              ReadStorage materialize.public.v // { arity: 2 }
   Return // { arity: 2 }
     Project (#0, #1) // { arity: 2 }
       Join on=(#1 = #2) type=differential // { arity: 3 }
@@ -161,18 +173,6 @@ Explained Query:
                 Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
                   Project (#0) // { arity: 1 }
                     Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      Project (#0, #2) // { arity: 2 }
-        Join on=(#0 = #1) type=differential // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Distinct project=[#0] // { arity: 1 }
-              Project (#1) // { arity: 1 }
-                Filter (#1) IS NOT NULL // { arity: 2 }
-                  ReadIndex on=u u_d_idx=[*** full scan ***] // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.v // { arity: 2 }
 
 Source materialize.public.v
   filter=((#0) IS NOT NULL)

--- a/test/sqllogictest/attributes/mir_column_types.slt
+++ b/test/sqllogictest/attributes/mir_column_types.slt
@@ -99,6 +99,18 @@ EXPLAIN OPTIMIZED PLAN WITH(types) AS TEXT FOR
 SELECT t.* FROM u LEFT OUTER JOIN t on t.a = u.d
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { types: "(integer)" }
+        Filter (#0) IS NOT NULL // { types: "(integer)" }
+          ReadStorage materialize.public.u // { types: "(integer?)" }
+    cte l1 =
+      Project (#0, #2, #3) // { types: "(integer, text?, date?)" }
+        Join on=(#0 = #1) type=differential // { types: "(integer, integer, text?, date?)" }
+          Get l0 // { types: "(integer)" }
+          ArrangeBy keys=[[#0]] // { types: "(integer, text?, date?)" }
+            Filter (#0) IS NOT NULL // { types: "(integer, text?, date?)" }
+              ReadStorage materialize.public.t // { types: "(integer?, text?, date?)" }
   Return // { types: "(integer?, text?, date?)" }
     Union // { types: "(integer?, text?, date?)" }
       Map (null, null, null) // { types: "(integer?, text?, date?)" }
@@ -114,18 +126,6 @@ Explained Query:
           Project () // { types: "()" }
             ReadStorage materialize.public.u // { types: "(integer?)" }
       Get l1 // { types: "(integer, text?, date?)" }
-  With
-    cte l1 =
-      Project (#0, #2, #3) // { types: "(integer, text?, date?)" }
-        Join on=(#0 = #1) type=differential // { types: "(integer, integer, text?, date?)" }
-          Get l0 // { types: "(integer)" }
-          ArrangeBy keys=[[#0]] // { types: "(integer, text?, date?)" }
-            Filter (#0) IS NOT NULL // { types: "(integer, text?, date?)" }
-              ReadStorage materialize.public.t // { types: "(integer?, text?, date?)" }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { types: "(integer)" }
-        Filter (#0) IS NOT NULL // { types: "(integer)" }
-          ReadStorage materialize.public.u // { types: "(integer?)" }
 
 Source materialize.public.t
   filter=((#0) IS NOT NULL)
@@ -140,22 +140,6 @@ EXPLAIN OPTIMIZED PLAN WITH(types) AS TEXT FOR
 (SELECT null::boolean as f1, 10 as f2) EXCEPT (SELECT min(f), count(*) FROM v WHERE (select d::double FROM u) = v.e GROUP BY e LIMIT 1)
 ----
 Explained Query:
-  Return // { types: "(boolean?, bigint)" }
-    Threshold // { types: "(boolean?, bigint)" }
-      Union // { types: "(boolean?, bigint)" }
-        Negate // { types: "(boolean?, bigint)" }
-          TopK limit=1 // { types: "(boolean?, bigint)" }
-            Project (#1, #3) // { types: "(boolean?, bigint)" }
-              Join on=(#0 = #2) type=differential // { types: "(double precision, boolean?, double precision, bigint)" }
-                ArrangeBy keys=[[#0]] // { types: "(double precision, boolean?)" }
-                  Reduce group_by=[#0] aggregates=[min(#1)] // { types: "(double precision, boolean?)" }
-                    Get l0 // { types: "(double precision, boolean?)" }
-                ArrangeBy keys=[[#0]] // { types: "(double precision, bigint)" }
-                  Reduce group_by=[#0] aggregates=[count(*)] // { types: "(double precision, bigint)" }
-                    Project (#0) // { types: "(double precision)" }
-                      Get l0 // { types: "(double precision, boolean?)" }
-        Constant // { types: "(boolean?, bigint)" }
-          - (null, 10)
   With
     cte l0 =
       Project (#0, #1) // { types: "(double precision, boolean?)" }
@@ -175,6 +159,22 @@ Explained Query:
                     Reduce aggregates=[count(*)] // { types: "(bigint)" }
                       Project () // { types: "()" }
                         ReadStorage materialize.public.u // { types: "(integer?)" }
+  Return // { types: "(boolean?, bigint)" }
+    Threshold // { types: "(boolean?, bigint)" }
+      Union // { types: "(boolean?, bigint)" }
+        Negate // { types: "(boolean?, bigint)" }
+          TopK limit=1 // { types: "(boolean?, bigint)" }
+            Project (#1, #3) // { types: "(boolean?, bigint)" }
+              Join on=(#0 = #2) type=differential // { types: "(double precision, boolean?, double precision, bigint)" }
+                ArrangeBy keys=[[#0]] // { types: "(double precision, boolean?)" }
+                  Reduce group_by=[#0] aggregates=[min(#1)] // { types: "(double precision, boolean?)" }
+                    Get l0 // { types: "(double precision, boolean?)" }
+                ArrangeBy keys=[[#0]] // { types: "(double precision, bigint)" }
+                  Reduce group_by=[#0] aggregates=[count(*)] // { types: "(double precision, bigint)" }
+                    Project (#0) // { types: "(double precision)" }
+                      Get l0 // { types: "(double precision, boolean?)" }
+        Constant // { types: "(boolean?, bigint)" }
+          - (null, 10)
 
 Source materialize.public.u
 Source materialize.public.v

--- a/test/sqllogictest/attributes/mir_unique_keys.slt
+++ b/test/sqllogictest/attributes/mir_unique_keys.slt
@@ -25,6 +25,11 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(keys) AS TEXT FOR SELECT sum(a) FROM t
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[sum(#0)] // { keys: "([])" }
+        Project (#0) // { keys: "()" }
+          ReadStorage materialize.public.t // { keys: "()" }
   Return // { keys: "([])" }
     Union // { keys: "([])" }
       Get l0 // { keys: "([])" }
@@ -35,11 +40,6 @@ Explained Query:
               Get l0 // { keys: "([])" }
           Constant // { keys: "([])" }
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum(#0)] // { keys: "([])" }
-        Project (#0) // { keys: "()" }
-          ReadStorage materialize.public.t // { keys: "()" }
 
 Source materialize.public.t
 
@@ -155,6 +155,21 @@ EXPLAIN OPTIMIZED PLAN WITH(keys) AS TEXT FOR
 SELECT 1 = (Select * FROM generate_series(1, 100000) limit 3)
 ----
 Explained Query:
+  With
+    cte l0 =
+      TopK limit=3 monotonic // { keys: "()" }
+        FlatMap generate_series(1, 100000, 1) // { keys: "()" }
+          Constant // { keys: "([])" }
+            - ()
+    cte l1 =
+      Union // { keys: "()" }
+        Get l0 // { keys: "()" }
+        Map (error("more than one record produced in subquery")) // { keys: "([])" }
+          Project () // { keys: "([])" }
+            Filter (#0 > 1) // { keys: "([])" }
+              Reduce aggregates=[count(*)] // { keys: "([])" }
+                Project () // { keys: "()" }
+                  Get l0 // { keys: "()" }
   Return // { keys: "()" }
     Project (#1) // { keys: "()" }
       Map ((#0 = 1)) // { keys: "()" }
@@ -168,21 +183,6 @@ Explained Query:
                     Get l1 // { keys: "()" }
               Constant // { keys: "([])" }
                 - ()
-  With
-    cte l1 =
-      Union // { keys: "()" }
-        Get l0 // { keys: "()" }
-        Map (error("more than one record produced in subquery")) // { keys: "([])" }
-          Project () // { keys: "([])" }
-            Filter (#0 > 1) // { keys: "([])" }
-              Reduce aggregates=[count(*)] // { keys: "([])" }
-                Project () // { keys: "()" }
-                  Get l0 // { keys: "()" }
-    cte l0 =
-      TopK limit=3 monotonic // { keys: "()" }
-        FlatMap generate_series(1, 100000, 1) // { keys: "()" }
-          Constant // { keys: "([])" }
-            - ()
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/autogenerated/all_parts_essential.slt
+++ b/test/sqllogictest/autogenerated/all_parts_essential.slt
@@ -306,18 +306,6 @@ GROUP BY 1,
          2
 ----
 Explained Query:
-  Return // { arity: 6 }
-    Project (#0, #1, #6, #2, #3, #2) // { arity: 6 }
-      Join on=(#0 = #4 AND #1 = #5) type=differential // { arity: 7 }
-        implementation
-          %0[#0, #1]UKKA » %1[#0, #1]UKKA
-        ArrangeBy keys=[[#0, #1]] // { arity: 4 }
-          Reduce group_by=[#1, #2] aggregates=[min(#2), min(#0)] // { arity: 4 }
-            Get l0 // { arity: 3 }
-        ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-          Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
-            Project (#1, #2) // { arity: 2 }
-              Get l0 // { arity: 3 }
   With
     cte l0 =
       Project (#0, #1, #28) // { arity: 3 }
@@ -333,6 +321,18 @@ Explained Query:
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
             ArrangeBy keys=[[#0]] // { arity: 8 }
               ReadIndex on=customer pk_customer_custkey=[delta join lookup] // { arity: 8 }
+  Return // { arity: 6 }
+    Project (#0, #1, #6, #2, #3, #2) // { arity: 6 }
+      Join on=(#0 = #4 AND #1 = #5) type=differential // { arity: 7 }
+        implementation
+          %0[#0, #1]UKKA » %1[#0, #1]UKKA
+        ArrangeBy keys=[[#0, #1]] // { arity: 4 }
+          Reduce group_by=[#1, #2] aggregates=[min(#2), min(#0)] // { arity: 4 }
+            Get l0 // { arity: 3 }
+        ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+          Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+            Project (#1, #2) // { arity: 2 }
+              Get l0 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (delta join lookup)
@@ -431,6 +431,21 @@ WHERE l_commitDATE >= '1998-03-22'
   OR l_receiptDATE = o_orderdate
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0..=#4) // { arity: 5 }
+        Join on=(#2 = #5) type=differential // { arity: 6 }
+          implementation
+            %0:lineitem[#2]K » %1:orders[#1]K
+          ArrangeBy keys=[[#2]] // { arity: 4 }
+            Project (#0, #4, #11, #12) // { arity: 4 }
+              ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
+          ArrangeBy keys=[[#1]] // { arity: 2 }
+            Project (#0, #4) // { arity: 2 }
+              ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+    cte l1 =
+      Filter (null OR ((#0 <= 100) AND (#0 >= 59) AND (#11 >= 1998-03-22))) // { arity: 16 }
+        ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
   Return // { arity: 2 }
     Union // { arity: 2 }
       Project (#1, #0) // { arity: 2 }
@@ -453,21 +468,6 @@ Explained Query:
       Project (#4, #1) // { arity: 2 }
         Filter ((#2 = #3) OR ((#0 <= 100) AND (#0 >= 59) AND (#2 >= 1998-03-22))) // { arity: 5 }
           Get l0 // { arity: 5 }
-  With
-    cte l1 =
-      Filter (null OR ((#0 <= 100) AND (#0 >= 59) AND (#11 >= 1998-03-22))) // { arity: 16 }
-        ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
-    cte l0 =
-      Project (#0..=#4) // { arity: 5 }
-        Join on=(#2 = #5) type=differential // { arity: 6 }
-          implementation
-            %0:lineitem[#2]K » %1:orders[#1]K
-          ArrangeBy keys=[[#2]] // { arity: 4 }
-            Project (#0, #4, #11, #12) // { arity: 4 }
-              ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
-          ArrangeBy keys=[[#1]] // { arity: 2 }
-            Project (#0, #4) // { arity: 2 }
-              ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
 
 Used Indexes:
   - materialize.public.pk_orders_orderkey (*** full scan ***)
@@ -620,18 +620,6 @@ GROUP BY 1,
          2
 ----
 Explained Query:
-  Return // { arity: 4 }
-    Project (#0, #0, #1, #3) // { arity: 4 }
-      Join on=(#0 = #2) type=differential // { arity: 4 }
-        implementation
-          %0[#0]UKA » %1[#0]UKA
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#1] aggregates=[min(#0)] // { arity: 2 }
-            Get l0 // { arity: 2 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-            Project (#1) // { arity: 1 }
-              Get l0 // { arity: 2 }
   With
     cte l0 =
       Project (#2, #3) // { arity: 2 }
@@ -650,6 +638,18 @@ Explained Query:
                 ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
             ArrangeBy keys=[[#0]] // { arity: 8 }
               ReadIndex on=customer pk_customer_custkey=[delta join lookup] // { arity: 8 }
+  Return // { arity: 4 }
+    Project (#0, #0, #1, #3) // { arity: 4 }
+      Join on=(#0 = #2) type=differential // { arity: 4 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#1] aggregates=[min(#0)] // { arity: 2 }
+            Get l0 // { arity: 2 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+            Project (#1) // { arity: 1 }
+              Get l0 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (delta join lookup)

--- a/test/sqllogictest/cardinality.slt
+++ b/test/sqllogictest/cardinality.slt
@@ -63,6 +63,10 @@ query T multiline
 EXPLAIN WITH(join implementations) SELECT * FROM t as l, t as r WHERE l.x = r.x;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]]
+        ReadIndex on=t t_x=[differential join]
   Return
     Project (#0, #1, #0, #3)
       Join on=(#0 = #2) type=differential
@@ -70,10 +74,6 @@ Explained Query:
           %0:l0[#0]KA|4| » %1:l0[#0]KA|4|
         Get l0
         Get l0
-  With
-    cte l0 =
-      ArrangeBy keys=[[#0]]
-        ReadIndex on=t t_x=[differential join]
 
 Used Indexes:
   - materialize.public.t_x (differential join)
@@ -159,9 +159,32 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM pexists;
 ----
 Explained Query:
-  Return
-    Get l3
   With Mutually Recursive
+    cte l0 =
+      Project (#1, #3)
+        Join on=(#0 = #2) type=differential
+          ArrangeBy keys=[[#0]]
+            Get l3
+          ArrangeBy keys=[[#0]]
+            Project (#1, #2)
+              ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
+    cte l1 =
+      Union
+        Project (#1, #0)
+          Get l0
+        Get l3
+    cte l2 =
+      Distinct project=[]
+        Project ()
+          Join on=(#0 = #1) type=differential
+            ArrangeBy keys=[[#0]]
+              Project (#0)
+                Filter #1
+                  Get l1
+            ArrangeBy keys=[[#0]]
+              Project (#0)
+                Filter NOT(#1)
+                  Get l1
     cte l3 =
       Distinct project=[#0, #1]
         Union
@@ -181,31 +204,8 @@ Explained Query:
           Constant
             - (1, true)
             - (2, false)
-    cte l2 =
-      Distinct project=[]
-        Project ()
-          Join on=(#0 = #1) type=differential
-            ArrangeBy keys=[[#0]]
-              Project (#0)
-                Filter #1
-                  Get l1
-            ArrangeBy keys=[[#0]]
-              Project (#0)
-                Filter NOT(#1)
-                  Get l1
-    cte l1 =
-      Union
-        Project (#1, #0)
-          Get l0
-        Get l3
-    cte l0 =
-      Project (#1, #3)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Get l3
-          ArrangeBy keys=[[#0]]
-            Project (#1, #2)
-              ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
+  Return
+    Get l3
 
 Used Indexes:
   - materialize.public.person_knows_person_person1id_person2id (*** full scan ***)
@@ -257,9 +257,32 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM pexists;
 ----
 Explained Query:
-  Return
-    Get l3
   With Mutually Recursive
+    cte l0 =
+      Project (#1, #3)
+        Join on=(#0 = #2) type=differential
+          ArrangeBy keys=[[#0]]
+            Get l3
+          ArrangeBy keys=[[#0]]
+            Project (#1, #2)
+              ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
+    cte l1 =
+      Union
+        Project (#1, #0)
+          Get l0
+        Get l3
+    cte l2 =
+      Distinct project=[]
+        Project ()
+          Join on=(#0 = #1) type=differential
+            ArrangeBy keys=[[#0]]
+              Project (#0)
+                Filter #1
+                  Get l1
+            ArrangeBy keys=[[#0]]
+              Project (#0)
+                Filter NOT(#1)
+                  Get l1
     cte l3 =
       Distinct project=[#0, #1]
         Union
@@ -279,31 +302,8 @@ Explained Query:
           Constant
             - (1, true)
             - (2, false)
-    cte l2 =
-      Distinct project=[]
-        Project ()
-          Join on=(#0 = #1) type=differential
-            ArrangeBy keys=[[#0]]
-              Project (#0)
-                Filter #1
-                  Get l1
-            ArrangeBy keys=[[#0]]
-              Project (#0)
-                Filter NOT(#1)
-                  Get l1
-    cte l1 =
-      Union
-        Project (#1, #0)
-          Get l0
-        Get l3
-    cte l0 =
-      Project (#1, #3)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Get l3
-          ArrangeBy keys=[[#0]]
-            Project (#1, #2)
-              ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
+  Return
+    Get l3
 
 Used Indexes:
   - materialize.public.person_knows_person_person1id_person2id (*** full scan ***)
@@ -493,19 +493,19 @@ with mutually recursive
 (select * from t);
 ----
 Explained Query:
-  Return // { cardinality: "<UNKNOWN>" }
-    Get l0 // { cardinality: "<UNKNOWN>" }
   With Mutually Recursive
-    cte l1 =
-      Project (#1) // { cardinality: "<UNKNOWN>" }
-        Filter (#0 < 7) // { cardinality: "<UNKNOWN>" }
-          Map ((#0 + 1)) // { cardinality: "<UNKNOWN>" }
-            Get l0 // { cardinality: "<UNKNOWN>" }
     cte l0 =
       Union // { cardinality: "<UNKNOWN>" }
         Get l1 // { cardinality: "<UNKNOWN>" }
         Constant // { cardinality: "1" }
           - (1)
+    cte l1 =
+      Project (#1) // { cardinality: "<UNKNOWN>" }
+        Filter (#0 < 7) // { cardinality: "<UNKNOWN>" }
+          Map ((#0 + 1)) // { cardinality: "<UNKNOWN>" }
+            Get l0 // { cardinality: "<UNKNOWN>" }
+  Return // { cardinality: "<UNKNOWN>" }
+    Get l0 // { cardinality: "<UNKNOWN>" }
 
 Target cluster: mz_catalog_server
 

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -307,6 +307,12 @@ ORDER BY n_name, su_name, i_id
 ----
 Explained Query:
   Finish order_by=[#2 asc nulls_last, #1 asc nulls_last, #3 asc nulls_last] output=[#0..=#7]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Filter like["EUROP%"](padchar(#1)) // { arity: 3 }
+              ReadStorage materialize.public.region // { arity: 3 }
     Return // { arity: 8 }
       Project (#2, #3, #12, #0, #1, #4, #6, #7) // { arity: 8 }
         Join on=(#0 = #8 = #15 AND #2 = #10 AND #5 = #11 AND #9 = #16 AND #13 = #14) type=delta // { arity: 17 }
@@ -351,12 +357,6 @@ Explained Query:
                       Project (#0, #2) // { arity: 2 }
                         ReadIndex on=nation fk_nation_regionkey=[*** full scan ***] // { arity: 4 }
                     Get l0 // { arity: 1 }
-    With
-      cte l0 =
-        ArrangeBy keys=[[#0]] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Filter like["EUROP%"](padchar(#1)) // { arity: 3 }
-              ReadStorage materialize.public.region // { arity: 3 }
 
 Source materialize.public.item
   filter=(like["%b"](padchar(#4)))
@@ -446,6 +446,11 @@ ORDER BY o_ol_cnt
 ----
 Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0, #1]
+    With
+      cte l0 =
+        Filter (#8 < 2012-01-02 00:00:00) AND (#8 >= 2007-01-02 00:00:00) // { arity: 9 }
+          Map (date_to_timestamp(#4)) // { arity: 9 }
+            ReadIndex on=order fk_order_customer=[*** full scan ***] // { arity: 8 }
     Return // { arity: 2 }
       Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#4) // { arity: 1 }
@@ -467,11 +472,6 @@ Explained Query:
                           Get l0 // { arity: 9 }
                       ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
                         ReadIndex on=orderline fk_orderline_order=[differential join] // { arity: 10 }
-    With
-      cte l0 =
-        Filter (#8 < 2012-01-02 00:00:00) AND (#8 >= 2007-01-02 00:00:00) // { arity: 9 }
-          Map (date_to_timestamp(#4)) // { arity: 9 }
-            ReadIndex on=order fk_order_customer=[*** full scan ***] // { arity: 8 }
 
 Used Indexes:
   - materialize.public.fk_order_customer (*** full scan ***)
@@ -569,6 +569,13 @@ AND ol_delivery_d < TIMESTAMP '2020-01-01 00:00:00.000000'
 AND ol_quantity BETWEEN 1 AND 100000
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[sum(#0)] // { arity: 1 }
+        Project (#8) // { arity: 1 }
+          Filter (#10 < 2020-01-01 00:00:00) AND (#7 <= 100000) AND (#7 >= 1) AND (#10 >= 1999-01-01 00:00:00) // { arity: 11 }
+            Map (date_to_timestamp(#6)) // { arity: 11 }
+              ReadIndex on=orderline fk_orderline_order=[*** full scan ***] // { arity: 10 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       Get l0 // { arity: 1 }
@@ -579,13 +586,6 @@ Explained Query:
               Get l0 // { arity: 1 }
           Constant // { arity: 0 }
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum(#0)] // { arity: 1 }
-        Project (#8) // { arity: 1 }
-          Filter (#10 < 2020-01-01 00:00:00) AND (#7 <= 100000) AND (#7 >= 1) AND (#10 >= 1999-01-01 00:00:00) // { arity: 11 }
-            Map (date_to_timestamp(#6)) // { arity: 11 }
-              ReadIndex on=orderline fk_orderline_order=[*** full scan ***] // { arity: 10 }
 
 Used Indexes:
   - materialize.public.fk_orderline_order (*** full scan ***)
@@ -625,6 +625,12 @@ ORDER BY su_nationkey, cust_nation, l_year
 ----
 Explained Query:
   Finish order_by=[#0 asc nulls_last, #1 asc nulls_last, #2 asc nulls_last] output=[#0..=#3]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            Filter ((#1 = "GERMANY") OR (#1 = "CAMBODIA")) // { arity: 4 }
+              ReadIndex on=nation fk_nation_regionkey=[*** full scan ***] // { arity: 4 }
     Return // { arity: 4 }
       Reduce group_by=[#0, substr(char_to_text(#3), 1, 1), extract_year_d(#2)] aggregates=[sum(#1)] // { arity: 4 }
         Project (#1, #13, #19, #23) // { arity: 4 }
@@ -657,12 +663,6 @@ Explained Query:
                       ReadIndex on=customer fk_customer_district=[*** full scan ***] // { arity: 22 }
                 Get l0 // { arity: 2 }
                 Get l0 // { arity: 2 }
-    With
-      cte l0 =
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Project (#0, #1) // { arity: 2 }
-            Filter ((#1 = "GERMANY") OR (#1 = "CAMBODIA")) // { arity: 4 }
-              ReadIndex on=nation fk_nation_regionkey=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.fk_customer_district (*** full scan ***)
@@ -913,19 +913,6 @@ ORDER BY ordercount DESC
 ----
 Explained Query:
   Finish order_by=[#1 desc nulls_first] output=[#0, #1]
-    Return // { arity: 2 }
-      Project (#0, #1) // { arity: 2 }
-        Filter (bigint_to_numeric(#1) > (bigint_to_numeric(#2) * 0.005)) // { arity: 3 }
-          CrossJoin type=differential // { arity: 3 }
-            implementation
-              %1[×]UA » %0[×]
-            ArrangeBy keys=[[]] // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
-                Get l0 // { arity: 2 }
-            ArrangeBy keys=[[]] // { arity: 1 }
-              Reduce aggregates=[sum(#0)] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Get l0 // { arity: 2 }
     With
       cte l0 =
         Project (#0, #14) // { arity: 2 }
@@ -943,6 +930,19 @@ Explained Query:
               Project (#0) // { arity: 1 }
                 Filter (#1 = "GERMANY") // { arity: 4 }
                   ReadIndex on=nation fk_nation_regionkey=[*** full scan ***] // { arity: 4 }
+    Return // { arity: 2 }
+      Project (#0, #1) // { arity: 2 }
+        Filter (bigint_to_numeric(#1) > (bigint_to_numeric(#2) * 0.005)) // { arity: 3 }
+          CrossJoin type=differential // { arity: 3 }
+            implementation
+              %1[×]UA » %0[×]
+            ArrangeBy keys=[[]] // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
+                Get l0 // { arity: 2 }
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Reduce aggregates=[sum(#0)] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Get l0 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.fk_stock_supplier (delta join 1st input (full scan))
@@ -1010,6 +1010,18 @@ ORDER BY custdist DESC, c_count DESC
 ----
 Explained Query:
   Finish order_by=[#1 desc nulls_first, #0 desc nulls_first] output=[#0, #1]
+    With
+      cte l0 =
+        Project (#0..=#3) // { arity: 4 }
+          Filter (#8 > 8) // { arity: 11 }
+            Join on=(#0 = #6 AND #1 = #4 AND #2 = #5) type=differential // { arity: 11 }
+              implementation
+                %0:customer[#2, #1, #0]UKKK » %1:order[#2, #1, #3]KKKAif
+              ArrangeBy keys=[[#2, #1, #0]] // { arity: 3 }
+                Project (#0..=#2) // { arity: 3 }
+                  ReadIndex on=customer fk_customer_district=[*** full scan ***] // { arity: 22 }
+              ArrangeBy keys=[[#2, #1, #3]] // { arity: 8 }
+                ReadIndex on=order fk_order_customer=[differential join] // { arity: 8 }
     Return // { arity: 2 }
       Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
@@ -1026,18 +1038,6 @@ Explained Query:
                     ReadIndex on=customer fk_customer_district=[*** full scan ***] // { arity: 22 }
               Project (#0, #3) // { arity: 2 }
                 Get l0 // { arity: 4 }
-    With
-      cte l0 =
-        Project (#0..=#3) // { arity: 4 }
-          Filter (#8 > 8) // { arity: 11 }
-            Join on=(#0 = #6 AND #1 = #4 AND #2 = #5) type=differential // { arity: 11 }
-              implementation
-                %0:customer[#2, #1, #0]UKKK » %1:order[#2, #1, #3]KKKAif
-              ArrangeBy keys=[[#2, #1, #0]] // { arity: 3 }
-                Project (#0..=#2) // { arity: 3 }
-                  ReadIndex on=customer fk_customer_district=[*** full scan ***] // { arity: 22 }
-              ArrangeBy keys=[[#2, #1, #3]] // { arity: 8 }
-                ReadIndex on=order fk_order_customer=[differential join] // { arity: 8 }
 
 Used Indexes:
   - materialize.public.fk_customer_district (*** full scan ***)
@@ -1058,18 +1058,6 @@ AND ol_delivery_d >= TIMESTAMP '2007-01-02 00:00:00.000000'
 AND ol_delivery_d < TIMESTAMP '2020-01-02 00:00:00.000000'
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Project (#2) // { arity: 1 }
-      Map (((100 * #0) / (1 + #1))) // { arity: 3 }
-        Union // { arity: 2 }
-          Get l0 // { arity: 2 }
-          Map (null, null) // { arity: 2 }
-            Union // { arity: 0 }
-              Negate // { arity: 0 }
-                Project () // { arity: 0 }
-                  Get l0 // { arity: 2 }
-              Constant // { arity: 0 }
-                - ()
   With
     cte l0 =
       Reduce aggregates=[sum(case when like["PR%"](padchar(#1)) then #0 else 0 end), sum(#0)] // { arity: 2 }
@@ -1084,6 +1072,18 @@ Explained Query:
                 ArrangeBy keys=[[#0]] // { arity: 2 }
                   Project (#0, #4) // { arity: 2 }
                     ReadStorage materialize.public.item // { arity: 5 }
+  Return // { arity: 1 }
+    Project (#2) // { arity: 1 }
+      Map (((100 * #0) / (1 + #1))) // { arity: 3 }
+        Union // { arity: 2 }
+          Get l0 // { arity: 2 }
+          Map (null, null) // { arity: 2 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l0 // { arity: 2 }
+              Constant // { arity: 0 }
+                - ()
 
 Source materialize.public.item
 
@@ -1128,6 +1128,19 @@ ORDER BY su_suppkey
 ----
 Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0..=#4]
+    With
+      cte l0 =
+        Reduce group_by=[#1] aggregates=[sum(#0)] // { arity: 2 }
+          Project (#8, #12) // { arity: 2 }
+            Filter (date_to_timestamp(#6) >= 2007-01-02 00:00:00) // { arity: 13 }
+              Join on=(#4 = #10 AND #5 = #11) type=differential // { arity: 13 }
+                implementation
+                  %1:stock[#1, #0]UKK » %0:orderline[#5, #4]KKAif
+                ArrangeBy keys=[[#5, #4]] // { arity: 10 }
+                  ReadIndex on=orderline fk_orderline_stock=[differential join] // { arity: 10 }
+                ArrangeBy keys=[[#1, #0]] // { arity: 3 }
+                  Project (#0, #1, #17) // { arity: 3 }
+                    ReadIndex on=stock fk_stock_warehouse=[*** full scan ***] // { arity: 18 }
     Return // { arity: 5 }
       Project (#0..=#3, #5) // { arity: 5 }
         Join on=(#0 = #4 AND #5 = #6) type=delta // { arity: 7 }
@@ -1146,19 +1159,6 @@ Explained Query:
               Reduce aggregates=[max(#0)] // { arity: 1 }
                 Project (#1) // { arity: 1 }
                   Get l0 // { arity: 2 }
-    With
-      cte l0 =
-        Reduce group_by=[#1] aggregates=[sum(#0)] // { arity: 2 }
-          Project (#8, #12) // { arity: 2 }
-            Filter (date_to_timestamp(#6) >= 2007-01-02 00:00:00) // { arity: 13 }
-              Join on=(#4 = #10 AND #5 = #11) type=differential // { arity: 13 }
-                implementation
-                  %1:stock[#1, #0]UKK » %0:orderline[#5, #4]KKAif
-                ArrangeBy keys=[[#5, #4]] // { arity: 10 }
-                  ReadIndex on=orderline fk_orderline_stock=[differential join] // { arity: 10 }
-                ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-                  Project (#0, #1, #17) // { arity: 3 }
-                    ReadIndex on=stock fk_stock_warehouse=[*** full scan ***] // { arity: 18 }
 
 Used Indexes:
   - materialize.public.fk_orderline_stock (differential join)
@@ -1188,6 +1188,22 @@ ORDER BY supplier_cnt DESC
 ----
 Explained Query:
   Finish order_by=[#3 desc nulls_first] output=[#0..=#3]
+    With
+      cte l0 =
+        Project (#17, #19..=#21) // { arity: 4 }
+          Join on=(#0 = #18) type=differential // { arity: 22 }
+            implementation
+              %1:item[#0]UKf » %0:stock[#0]KAf
+            ArrangeBy keys=[[#0]] // { arity: 18 }
+              ReadIndex on=stock fk_stock_item=[differential join] // { arity: 18 }
+            ArrangeBy keys=[[#0]] // { arity: 4 }
+              Project (#0, #2..=#4) // { arity: 4 }
+                Filter NOT(like["zz%"](padchar(#4))) // { arity: 5 }
+                  ReadStorage materialize.public.item // { arity: 5 }
+      cte l1 =
+        Distinct project=[#0] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Get l0 // { arity: 4 }
     Return // { arity: 4 }
       Reduce group_by=[#1, substr(char_to_text(#3), 1, 3), #2] aggregates=[count(distinct #0)] // { arity: 4 }
         Project (#0..=#3) // { arity: 4 }
@@ -1210,22 +1226,6 @@ Explained Query:
                           Filter like["%bad%"](padchar(#6)) // { arity: 7 }
                             ReadIndex on=supplier fk_supplier_nationkey=[*** full scan ***] // { arity: 7 }
                 Get l1 // { arity: 1 }
-    With
-      cte l1 =
-        Distinct project=[#0] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Get l0 // { arity: 4 }
-      cte l0 =
-        Project (#17, #19..=#21) // { arity: 4 }
-          Join on=(#0 = #18) type=differential // { arity: 22 }
-            implementation
-              %1:item[#0]UKf » %0:stock[#0]KAf
-            ArrangeBy keys=[[#0]] // { arity: 18 }
-              ReadIndex on=stock fk_stock_item=[differential join] // { arity: 18 }
-            ArrangeBy keys=[[#0]] // { arity: 4 }
-              Project (#0, #2..=#4) // { arity: 4 }
-                Filter NOT(like["zz%"](padchar(#4))) // { arity: 5 }
-                  ReadStorage materialize.public.item // { arity: 5 }
 
 Source materialize.public.item
   filter=(NOT(like["zz%"](padchar(#4))))
@@ -1255,19 +1255,10 @@ WHERE ol_i_id = t.i_id
 AND ol_quantity < t.a
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Project (#1) // { arity: 1 }
-      Map ((#0 / 2)) // { arity: 2 }
-        Union // { arity: 1 }
-          Get l1 // { arity: 1 }
-          Map (null) // { arity: 1 }
-            Union // { arity: 0 }
-              Negate // { arity: 0 }
-                Project () // { arity: 0 }
-                  Get l1 // { arity: 1 }
-              Constant // { arity: 0 }
-                - ()
   With
+    cte l0 =
+      ArrangeBy keys=[[#4]] // { arity: 10 }
+        ReadIndex on=orderline fk_orderline_item=[differential join] // { arity: 10 }
     cte l1 =
       Reduce aggregates=[sum(#0)] // { arity: 1 }
         Project (#8) // { arity: 1 }
@@ -1287,9 +1278,18 @@ Explained Query:
                           Filter like["%b"](padchar(#4)) // { arity: 5 }
                             ReadStorage materialize.public.item // { arity: 5 }
                       Get l0 // { arity: 10 }
-    cte l0 =
-      ArrangeBy keys=[[#4]] // { arity: 10 }
-        ReadIndex on=orderline fk_orderline_item=[differential join] // { arity: 10 }
+  Return // { arity: 1 }
+    Project (#1) // { arity: 1 }
+      Map ((#0 / 2)) // { arity: 2 }
+        Union // { arity: 1 }
+          Get l1 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l1 // { arity: 1 }
+              Constant // { arity: 0 }
+                - ()
 
 Source materialize.public.item
   filter=(like["%b"](padchar(#4)))
@@ -1375,16 +1375,6 @@ WHERE (
 )
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l0 // { arity: 1 }
-      Map (null) // { arity: 1 }
-        Union // { arity: 0 }
-          Negate // { arity: 0 }
-            Project () // { arity: 0 }
-              Get l0 // { arity: 1 }
-          Constant // { arity: 0 }
-            - ()
   With
     cte l0 =
       Reduce aggregates=[sum(#0)] // { arity: 1 }
@@ -1401,6 +1391,16 @@ Explained Query:
                     Filter (#3 <= 400000) AND (#3 >= 1) AND (like["%a"](#5) OR like["%b"](#5) OR like["%c"](#5)) // { arity: 6 }
                       Map (padchar(#4)) // { arity: 6 }
                         ReadStorage materialize.public.item // { arity: 5 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l0 // { arity: 1 }
+          Constant // { arity: 0 }
+            - ()
 
 Source materialize.public.item
   filter=((#3 <= 400000) AND (#3 >= 1) AND (like["%a"](#5) OR like["%b"](#5) OR like["%c"](#5)))
@@ -1438,6 +1438,18 @@ ORDER BY su_name
 ----
 Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0, #1]
+    With
+      cte l0 =
+        Project (#0..=#2) // { arity: 3 }
+          Join on=(#3 = #7) type=differential // { arity: 8 }
+            implementation
+              %1:nation[#0]UKef » %0:supplier[#3]KAef
+            ArrangeBy keys=[[#3]] // { arity: 7 }
+              ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
+            ArrangeBy keys=[[#0]] // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Filter (#1 = "GERMANY") // { arity: 4 }
+                  ReadIndex on=nation fk_nation_regionkey=[*** full scan ***] // { arity: 4 }
     Return // { arity: 2 }
       Project (#1, #2) // { arity: 2 }
         Join on=(#0 = #3) type=differential // { arity: 4 }
@@ -1470,18 +1482,6 @@ Explained Query:
                             Project (#0) // { arity: 1 }
                               Filter like["co%"](padchar(#4)) // { arity: 5 }
                                 ReadStorage materialize.public.item // { arity: 5 }
-    With
-      cte l0 =
-        Project (#0..=#2) // { arity: 3 }
-          Join on=(#3 = #7) type=differential // { arity: 8 }
-            implementation
-              %1:nation[#0]UKef » %0:supplier[#3]KAef
-            ArrangeBy keys=[[#3]] // { arity: 7 }
-              ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Project (#0) // { arity: 1 }
-                Filter (#1 = "GERMANY") // { arity: 4 }
-                  ReadIndex on=nation fk_nation_regionkey=[*** full scan ***] // { arity: 4 }
 
 Source materialize.public.item
   filter=(like["co%"](padchar(#4)))
@@ -1525,33 +1525,7 @@ ORDER BY numwait DESC, su_name
 ----
 Explained Query:
   Finish order_by=[#1 desc nulls_first, #0 asc nulls_last] output=[#0, #1]
-    Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-        Project (#0) // { arity: 1 }
-          Join on=(#1 = #5 AND #2 = #6 AND #3 = #7 AND #4 = #8) type=differential // { arity: 9 }
-            implementation
-              %0:l0[#1..=#4]KKKK » %1[#0..=#3]KKKK
-            ArrangeBy keys=[[#1..=#4]] // { arity: 5 }
-              Get l0 // { arity: 5 }
-            ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
-              Union // { arity: 4 }
-                Negate // { arity: 4 }
-                  Distinct project=[#0..=#3] // { arity: 4 }
-                    Project (#0..=#3) // { arity: 4 }
-                      Filter (#10 > #3) // { arity: 14 }
-                        Join on=(#0 = #4 AND #1 = #5 AND #2 = #6) type=differential // { arity: 14 }
-                          implementation
-                            %0:l1[#2, #1, #0]KKK » %1:orderline[#2, #1, #0]KKKA
-                          ArrangeBy keys=[[#2, #1, #0]] // { arity: 4 }
-                            Get l1 // { arity: 4 }
-                          ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
-                            ReadIndex on=orderline fk_orderline_order=[differential join] // { arity: 10 }
-                Get l1 // { arity: 4 }
     With
-      cte l1 =
-        Distinct project=[#0..=#3] // { arity: 4 }
-          Project (#1..=#4) // { arity: 4 }
-            Get l0 // { arity: 5 }
       cte l0 =
         Project (#1, #3..=#5, #7) // { arity: 5 }
           Filter (#7 > #11) // { arity: 16 }
@@ -1579,6 +1553,32 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Filter (#1 = "GERMANY") // { arity: 4 }
                     ReadIndex on=nation fk_nation_regionkey=[*** full scan ***] // { arity: 4 }
+      cte l1 =
+        Distinct project=[#0..=#3] // { arity: 4 }
+          Project (#1..=#4) // { arity: 4 }
+            Get l0 // { arity: 5 }
+    Return // { arity: 2 }
+      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+        Project (#0) // { arity: 1 }
+          Join on=(#1 = #5 AND #2 = #6 AND #3 = #7 AND #4 = #8) type=differential // { arity: 9 }
+            implementation
+              %0:l0[#1..=#4]KKKK » %1[#0..=#3]KKKK
+            ArrangeBy keys=[[#1..=#4]] // { arity: 5 }
+              Get l0 // { arity: 5 }
+            ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+              Union // { arity: 4 }
+                Negate // { arity: 4 }
+                  Distinct project=[#0..=#3] // { arity: 4 }
+                    Project (#0..=#3) // { arity: 4 }
+                      Filter (#10 > #3) // { arity: 14 }
+                        Join on=(#0 = #4 AND #1 = #5 AND #2 = #6) type=differential // { arity: 14 }
+                          implementation
+                            %0:l1[#2, #1, #0]KKK » %1:orderline[#2, #1, #0]KKKA
+                          ArrangeBy keys=[[#2, #1, #0]] // { arity: 4 }
+                            Get l1 // { arity: 4 }
+                          ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
+                            ReadIndex on=orderline fk_orderline_order=[differential join] // { arity: 10 }
+                Get l1 // { arity: 4 }
 
 Used Indexes:
   - materialize.public.fk_order_customer (*** full scan ***)
@@ -1616,6 +1616,28 @@ ORDER BY substr(c_state, 1, 1)
 ----
 Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0..=#2]
+    With
+      cte l0 =
+        Map (substr(char_to_text(#11), 1, 1)) // { arity: 23 }
+          ReadIndex on=customer fk_customer_district=[*** full scan ***] // { arity: 22 }
+      cte l1 =
+        Project (#0..=#4) // { arity: 5 }
+          Filter (#4 > (#5 / bigint_to_numeric(case when (#6 = 0) then null else #6 end))) // { arity: 7 }
+            CrossJoin type=differential // { arity: 7 }
+              implementation
+                %1[×]UA » %0:l0[×]ef
+              ArrangeBy keys=[[]] // { arity: 5 }
+                Project (#0..=#2, #9, #16) // { arity: 5 }
+                  Filter ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
+                    Get l0 // { arity: 23 }
+              ArrangeBy keys=[[]] // { arity: 2 }
+                Reduce aggregates=[sum(#0), count(*)] // { arity: 2 }
+                  Project (#16) // { arity: 1 }
+                    Filter (#16 > 0) AND ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
+                      Get l0 // { arity: 23 }
+      cte l2 =
+        Project (#0..=#2) // { arity: 3 }
+          Get l1 // { arity: 5 }
     Return // { arity: 3 }
       Reduce group_by=[substr(char_to_text(#0), 1, 1)] aggregates=[count(*), sum(#1)] // { arity: 3 }
         Project (#3, #4) // { arity: 2 }
@@ -1639,28 +1661,6 @@ Explained Query:
                             Filter (#3) IS NOT NULL // { arity: 8 }
                               ReadIndex on=order fk_order_customer=[*** full scan ***] // { arity: 8 }
                 Get l2 // { arity: 3 }
-    With
-      cte l2 =
-        Project (#0..=#2) // { arity: 3 }
-          Get l1 // { arity: 5 }
-      cte l1 =
-        Project (#0..=#4) // { arity: 5 }
-          Filter (#4 > (#5 / bigint_to_numeric(case when (#6 = 0) then null else #6 end))) // { arity: 7 }
-            CrossJoin type=differential // { arity: 7 }
-              implementation
-                %1[×]UA » %0:l0[×]ef
-              ArrangeBy keys=[[]] // { arity: 5 }
-                Project (#0..=#2, #9, #16) // { arity: 5 }
-                  Filter ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
-                    Get l0 // { arity: 23 }
-              ArrangeBy keys=[[]] // { arity: 2 }
-                Reduce aggregates=[sum(#0), count(*)] // { arity: 2 }
-                  Project (#16) // { arity: 1 }
-                    Filter (#16 > 0) AND ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
-                      Get l0 // { arity: 23 }
-      cte l0 =
-        Map (substr(char_to_text(#11), 1, 1)) // { arity: 23 }
-          ReadIndex on=customer fk_customer_district=[*** full scan ***] // { arity: 22 }
 
 Used Indexes:
   - materialize.public.fk_customer_district (*** full scan ***)

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -67,13 +67,6 @@ EXPLAIN DECORRELATED PLAN WITH(arity) FOR
 WITH t AS (SELECT * FROM y WHERE a < 3)
   SELECT * FROM t NATURAL JOIN t a;
 ----
-Return // { arity: 1 }
-  Project (#0) // { arity: 1 }
-    Filter (#0 = #1) // { arity: 2 }
-      Project (#0, #1) // { arity: 2 }
-        CrossJoin // { arity: 2 }
-          Get l0 // { arity: 1 }
-          Get l0 // { arity: 1 }
 With
   cte l0 =
     Filter (#0 < 3) // { arity: 1 }
@@ -81,6 +74,13 @@ With
         Constant // { arity: 0 }
           - ()
         Get materialize.public.y // { arity: 1 }
+Return // { arity: 1 }
+  Project (#0) // { arity: 1 }
+    Filter (#0 = #1) // { arity: 2 }
+      Project (#0, #1) // { arity: 2 }
+        CrossJoin // { arity: 2 }
+          Get l0 // { arity: 1 }
+          Get l0 // { arity: 1 }
 
 Target cluster: quickstart
 
@@ -94,6 +94,21 @@ FROM x,
      LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
              SELECT * FROM a);
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 1 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.x // { arity: 1 }
+  cte l1 =
+    Distinct project=[#0] // { arity: 1 }
+      Get l0 // { arity: 1 }
+  cte l2 =
+    Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+      Filter (#1 < #0) // { arity: 2 }
+        CrossJoin // { arity: 2 }
+          Get l1 // { arity: 1 }
+          Get materialize.public.y // { arity: 1 }
 Return // { arity: 2 }
   Project (#0, #2) // { arity: 2 }
     Join on=(#0 = #1) // { arity: 3 }
@@ -112,21 +127,6 @@ Return // { arity: 2 }
               Get l1 // { arity: 1 }
           Constant // { arity: 1 }
             - (null)
-With
-  cte l2 =
-    Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
-      Filter (#1 < #0) // { arity: 2 }
-        CrossJoin // { arity: 2 }
-          Get l1 // { arity: 1 }
-          Get materialize.public.y // { arity: 1 }
-  cte l1 =
-    Distinct project=[#0] // { arity: 1 }
-      Get l0 // { arity: 1 }
-  cte l0 =
-    CrossJoin // { arity: 1 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.public.x // { arity: 1 }
 
 Target cluster: quickstart
 
@@ -153,6 +153,57 @@ FROM x,
      LATERAL(WITH a(m) as (SELECT max(y.a) FROM y WHERE y.a < x.a)
              SELECT (SELECT m FROM a) FROM y) b;
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 1 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.x // { arity: 1 }
+  cte l1 =
+    Distinct project=[#0] // { arity: 1 }
+      Get l0 // { arity: 1 }
+  cte l2 =
+    Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+      Filter (#1 < #0) // { arity: 2 }
+        CrossJoin // { arity: 2 }
+          Get l1 // { arity: 1 }
+          Get materialize.public.y // { arity: 1 }
+  cte l3 =
+    CrossJoin // { arity: 2 }
+      Get l1 // { arity: 1 }
+      Get materialize.public.y // { arity: 1 }
+  cte l4 =
+    Distinct project=[#0, #1] // { arity: 2 }
+      Get l3 // { arity: 2 }
+  cte l5 =
+    Distinct project=[#0] // { arity: 1 }
+      Get l4 // { arity: 2 }
+  cte l6 =
+    Project (#0, #2) // { arity: 2 }
+      Join on=(#0 = #1) // { arity: 3 }
+        Get l5 // { arity: 1 }
+        Union // { arity: 2 }
+          Get l2 // { arity: 2 }
+          CrossJoin // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              Join on=(#0 = #1) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
+                      Get l2 // { arity: 2 }
+                  Distinct project=[#0] // { arity: 1 }
+                    Get l1 // { arity: 1 }
+                Get l1 // { arity: 1 }
+            Constant // { arity: 1 }
+              - (null)
+  cte l7 =
+    Union // { arity: 2 }
+      Get l6 // { arity: 2 }
+      Map (error("more than one record produced in subquery")) // { arity: 2 }
+        Project (#0) // { arity: 1 }
+          Filter (#1 > 1) // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+              Get l6 // { arity: 2 }
 Return // { arity: 2 }
   Project (#0, #2) // { arity: 2 }
     Join on=(#0 = #1) // { arity: 3 }
@@ -179,57 +230,6 @@ Return // { arity: 2 }
                           Get l5 // { arity: 1 }
                       Constant // { arity: 1 }
                         - (null)
-With
-  cte l7 =
-    Union // { arity: 2 }
-      Get l6 // { arity: 2 }
-      Map (error("more than one record produced in subquery")) // { arity: 2 }
-        Project (#0) // { arity: 1 }
-          Filter (#1 > 1) // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-              Get l6 // { arity: 2 }
-  cte l6 =
-    Project (#0, #2) // { arity: 2 }
-      Join on=(#0 = #1) // { arity: 3 }
-        Get l5 // { arity: 1 }
-        Union // { arity: 2 }
-          Get l2 // { arity: 2 }
-          CrossJoin // { arity: 2 }
-            Project (#0) // { arity: 1 }
-              Join on=(#0 = #1) // { arity: 2 }
-                Union // { arity: 1 }
-                  Negate // { arity: 1 }
-                    Distinct project=[#0] // { arity: 1 }
-                      Get l2 // { arity: 2 }
-                  Distinct project=[#0] // { arity: 1 }
-                    Get l1 // { arity: 1 }
-                Get l1 // { arity: 1 }
-            Constant // { arity: 1 }
-              - (null)
-  cte l5 =
-    Distinct project=[#0] // { arity: 1 }
-      Get l4 // { arity: 2 }
-  cte l4 =
-    Distinct project=[#0, #1] // { arity: 2 }
-      Get l3 // { arity: 2 }
-  cte l3 =
-    CrossJoin // { arity: 2 }
-      Get l1 // { arity: 1 }
-      Get materialize.public.y // { arity: 1 }
-  cte l2 =
-    Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
-      Filter (#1 < #0) // { arity: 2 }
-        CrossJoin // { arity: 2 }
-          Get l1 // { arity: 1 }
-          Get materialize.public.y // { arity: 1 }
-  cte l1 =
-    Distinct project=[#0] // { arity: 1 }
-      Get l0 // { arity: 1 }
-  cte l0 =
-    CrossJoin // { arity: 1 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.public.x // { arity: 1 }
 
 Target cluster: quickstart
 
@@ -244,16 +244,21 @@ FROM x,
      LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
              SELECT * FROM a INNER JOIN a b ON a.m = b.m);
 ----
-Return // { arity: 3 }
-  Project (#0, #2, #3) // { arity: 3 }
-    Join on=(#0 = #1) // { arity: 4 }
-      Get l0 // { arity: 1 }
-      Filter (#1 = #2) // { arity: 3 }
-        Project (#0, #1, #3) // { arity: 3 }
-          Join on=(#0 = #2) // { arity: 4 }
-            Get l3 // { arity: 2 }
-            Get l3 // { arity: 2 }
 With
+  cte l0 =
+    CrossJoin // { arity: 1 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.x // { arity: 1 }
+  cte l1 =
+    Distinct project=[#0] // { arity: 1 }
+      Get l0 // { arity: 1 }
+  cte l2 =
+    Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+      Filter (#1 < #0) // { arity: 2 }
+        CrossJoin // { arity: 2 }
+          Get l1 // { arity: 1 }
+          Get materialize.public.y // { arity: 1 }
   cte l3 =
     Union // { arity: 2 }
       Get l2 // { arity: 2 }
@@ -269,20 +274,15 @@ With
             Get l1 // { arity: 1 }
         Constant // { arity: 1 }
           - (null)
-  cte l2 =
-    Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
-      Filter (#1 < #0) // { arity: 2 }
-        CrossJoin // { arity: 2 }
-          Get l1 // { arity: 1 }
-          Get materialize.public.y // { arity: 1 }
-  cte l1 =
-    Distinct project=[#0] // { arity: 1 }
+Return // { arity: 3 }
+  Project (#0, #2, #3) // { arity: 3 }
+    Join on=(#0 = #1) // { arity: 4 }
       Get l0 // { arity: 1 }
-  cte l0 =
-    CrossJoin // { arity: 1 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.public.x // { arity: 1 }
+      Filter (#1 = #2) // { arity: 3 }
+        Project (#0, #1, #3) // { arity: 3 }
+          Join on=(#0 = #2) // { arity: 4 }
+            Get l3 // { arity: 2 }
+            Get l3 // { arity: 2 }
 
 Target cluster: quickstart
 
@@ -315,6 +315,59 @@ FROM x,
      LATERAL(WITH a(m) as (SELECT max(y.a) FROM y WHERE y.a < x.a)
              SELECT * FROM a INNER JOIN (SELECT (SELECT m FROM a) FROM y) b ON true);
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 1 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.x // { arity: 1 }
+  cte l1 =
+    Distinct project=[#0] // { arity: 1 }
+      Get l0 // { arity: 1 }
+  cte l2 =
+    Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+      Filter (#1 < #0) // { arity: 2 }
+        CrossJoin // { arity: 2 }
+          Get l1 // { arity: 1 }
+          Get materialize.public.y // { arity: 1 }
+  cte l3 =
+    Union // { arity: 2 }
+      Get l2 // { arity: 2 }
+      CrossJoin // { arity: 2 }
+        Project (#0) // { arity: 1 }
+          Join on=(#0 = #1) // { arity: 2 }
+            Union // { arity: 1 }
+              Negate // { arity: 1 }
+                Distinct project=[#0] // { arity: 1 }
+                  Get l2 // { arity: 2 }
+              Distinct project=[#0] // { arity: 1 }
+                Get l1 // { arity: 1 }
+            Get l1 // { arity: 1 }
+        Constant // { arity: 1 }
+          - (null)
+  cte l4 =
+    CrossJoin // { arity: 2 }
+      Get l1 // { arity: 1 }
+      Get materialize.public.y // { arity: 1 }
+  cte l5 =
+    Distinct project=[#0, #1] // { arity: 2 }
+      Get l4 // { arity: 2 }
+  cte l6 =
+    Distinct project=[#0] // { arity: 1 }
+      Get l5 // { arity: 2 }
+  cte l7 =
+    Project (#0, #2) // { arity: 2 }
+      Join on=(#0 = #1) // { arity: 3 }
+        Get l6 // { arity: 1 }
+        Get l3 // { arity: 2 }
+  cte l8 =
+    Union // { arity: 2 }
+      Get l7 // { arity: 2 }
+      Map (error("more than one record produced in subquery")) // { arity: 2 }
+        Project (#0) // { arity: 1 }
+          Filter (#1 > 1) // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+              Get l7 // { arity: 2 }
 Return // { arity: 3 }
   Project (#0, #2, #3) // { arity: 3 }
     Join on=(#0 = #1) // { arity: 4 }
@@ -343,59 +396,6 @@ Return // { arity: 3 }
                             Get l6 // { arity: 1 }
                         Constant // { arity: 1 }
                           - (null)
-With
-  cte l8 =
-    Union // { arity: 2 }
-      Get l7 // { arity: 2 }
-      Map (error("more than one record produced in subquery")) // { arity: 2 }
-        Project (#0) // { arity: 1 }
-          Filter (#1 > 1) // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-              Get l7 // { arity: 2 }
-  cte l7 =
-    Project (#0, #2) // { arity: 2 }
-      Join on=(#0 = #1) // { arity: 3 }
-        Get l6 // { arity: 1 }
-        Get l3 // { arity: 2 }
-  cte l6 =
-    Distinct project=[#0] // { arity: 1 }
-      Get l5 // { arity: 2 }
-  cte l5 =
-    Distinct project=[#0, #1] // { arity: 2 }
-      Get l4 // { arity: 2 }
-  cte l4 =
-    CrossJoin // { arity: 2 }
-      Get l1 // { arity: 1 }
-      Get materialize.public.y // { arity: 1 }
-  cte l3 =
-    Union // { arity: 2 }
-      Get l2 // { arity: 2 }
-      CrossJoin // { arity: 2 }
-        Project (#0) // { arity: 1 }
-          Join on=(#0 = #1) // { arity: 2 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Distinct project=[#0] // { arity: 1 }
-                  Get l2 // { arity: 2 }
-              Distinct project=[#0] // { arity: 1 }
-                Get l1 // { arity: 1 }
-            Get l1 // { arity: 1 }
-        Constant // { arity: 1 }
-          - (null)
-  cte l2 =
-    Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
-      Filter (#1 < #0) // { arity: 2 }
-        CrossJoin // { arity: 2 }
-          Get l1 // { arity: 1 }
-          Get materialize.public.y // { arity: 1 }
-  cte l1 =
-    Distinct project=[#0] // { arity: 1 }
-      Get l0 // { arity: 1 }
-  cte l0 =
-    CrossJoin // { arity: 1 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.public.x // { arity: 1 }
 
 Target cluster: quickstart
 
@@ -426,6 +426,59 @@ FROM x,
      LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
              SELECT * FROM y INNER JOIN LATERAL(SELECT y.a FROM x WHERE (SELECT m FROM a) > 0) ON true);
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 1 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.x // { arity: 1 }
+  cte l1 =
+    Distinct project=[#0] // { arity: 1 }
+      Get l0 // { arity: 1 }
+  cte l2 =
+    Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+      Filter (#1 < #0) // { arity: 2 }
+        CrossJoin // { arity: 2 }
+          Get l1 // { arity: 1 }
+          Get materialize.public.y // { arity: 1 }
+  cte l3 =
+    CrossJoin // { arity: 2 }
+      Get l1 // { arity: 1 }
+      Get materialize.public.y // { arity: 1 }
+  cte l4 =
+    CrossJoin // { arity: 2 }
+      Distinct project=[#1] // { arity: 1 }
+        Get l3 // { arity: 2 }
+      Get materialize.public.x // { arity: 1 }
+  cte l5 =
+    Distinct project=[#0] // { arity: 1 }
+      Get l4 // { arity: 2 }
+  cte l6 =
+    Project (#0, #2) // { arity: 2 }
+      Join on=(#0 = #1) // { arity: 3 }
+        Get l5 // { arity: 1 }
+        Union // { arity: 2 }
+          Get l2 // { arity: 2 }
+          CrossJoin // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              Join on=(#0 = #1) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
+                      Get l2 // { arity: 2 }
+                  Distinct project=[#0] // { arity: 1 }
+                    Get l1 // { arity: 1 }
+                Get l1 // { arity: 1 }
+            Constant // { arity: 1 }
+              - (null)
+  cte l7 =
+    Union // { arity: 2 }
+      Get l6 // { arity: 2 }
+      Map (error("more than one record produced in subquery")) // { arity: 2 }
+        Project (#0) // { arity: 1 }
+          Filter (#1 > 1) // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+              Get l6 // { arity: 2 }
 Return // { arity: 3 }
   Project (#0, #2, #3) // { arity: 3 }
     Join on=(#0 = #1) // { arity: 4 }
@@ -454,59 +507,6 @@ Return // { arity: 3 }
                               Get l5 // { arity: 1 }
                           Constant // { arity: 1 }
                             - (null)
-With
-  cte l7 =
-    Union // { arity: 2 }
-      Get l6 // { arity: 2 }
-      Map (error("more than one record produced in subquery")) // { arity: 2 }
-        Project (#0) // { arity: 1 }
-          Filter (#1 > 1) // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-              Get l6 // { arity: 2 }
-  cte l6 =
-    Project (#0, #2) // { arity: 2 }
-      Join on=(#0 = #1) // { arity: 3 }
-        Get l5 // { arity: 1 }
-        Union // { arity: 2 }
-          Get l2 // { arity: 2 }
-          CrossJoin // { arity: 2 }
-            Project (#0) // { arity: 1 }
-              Join on=(#0 = #1) // { arity: 2 }
-                Union // { arity: 1 }
-                  Negate // { arity: 1 }
-                    Distinct project=[#0] // { arity: 1 }
-                      Get l2 // { arity: 2 }
-                  Distinct project=[#0] // { arity: 1 }
-                    Get l1 // { arity: 1 }
-                Get l1 // { arity: 1 }
-            Constant // { arity: 1 }
-              - (null)
-  cte l5 =
-    Distinct project=[#0] // { arity: 1 }
-      Get l4 // { arity: 2 }
-  cte l4 =
-    CrossJoin // { arity: 2 }
-      Distinct project=[#1] // { arity: 1 }
-        Get l3 // { arity: 2 }
-      Get materialize.public.x // { arity: 1 }
-  cte l3 =
-    CrossJoin // { arity: 2 }
-      Get l1 // { arity: 1 }
-      Get materialize.public.y // { arity: 1 }
-  cte l2 =
-    Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
-      Filter (#1 < #0) // { arity: 2 }
-        CrossJoin // { arity: 2 }
-          Get l1 // { arity: 1 }
-          Get materialize.public.y // { arity: 1 }
-  cte l1 =
-    Distinct project=[#0] // { arity: 1 }
-      Get l0 // { arity: 1 }
-  cte l0 =
-    CrossJoin // { arity: 1 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.public.x // { arity: 1 }
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/explain/aggregates.slt
+++ b/test/sqllogictest/explain/aggregates.slt
@@ -99,6 +99,10 @@ query T multiline
 EXPLAIN SELECT a, array_agg(b), max(c) FROM t WHERE c <> 'x' GROUP BY a;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Filter (#2 != "x")
+        ReadStorage materialize.public.t
   Return
     Project (#0, #3, #1)
       Join on=(#0 = #2) type=differential
@@ -110,10 +114,6 @@ Explained Query:
           Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1]))]
             Project (#0, #1)
               Get l0
-  With
-    cte l0 =
-      Filter (#2 != "x")
-        ReadStorage materialize.public.t
 
 Source materialize.public.t
   filter=((#2 != "x"))
@@ -126,6 +126,10 @@ query T multiline
 EXPLAIN SELECT a, array_agg(b), max(b) FROM t GROUP BY a HAVING count(a) > 1;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0, #1)
+        ReadStorage materialize.public.t
   Return
     Project (#0, #5, #1)
       Filter (#3 > 1)
@@ -140,10 +144,6 @@ Explained Query:
           ArrangeBy keys=[[#0]]
             Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1]))]
               Get l0
-  With
-    cte l0 =
-      Project (#0, #1)
-        ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -169,6 +169,10 @@ query T multiline
 EXPLAIN SELECT a, array_agg(b ORDER BY b ASC), array_agg(b ORDER BY b DESC) FROM t GROUP BY a;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0, #1)
+        ReadStorage materialize.public.t
   Return
     Project (#0, #1, #3)
       Join on=(#0 = #2) type=differential
@@ -178,10 +182,6 @@ Explained Query:
         ArrangeBy keys=[[#0]]
           Reduce group_by=[#0] aggregates=[array_agg[order_by=[#0 desc nulls_first]](row(array[#1], #1))]
             Get l0
-  With
-    cte l0 =
-      Project (#0, #1)
-        ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -193,6 +193,22 @@ query T multiline
 EXPLAIN SELECT array_agg(b ORDER BY b ASC), array_agg(b ORDER BY b DESC), bool_or(b IS NOT NULL) FROM t;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#1)
+        ReadStorage materialize.public.t
+    cte l1 =
+      CrossJoin type=delta
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[sum(1)]
+            Project ()
+              ReadStorage materialize.public.t
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[array_agg[order_by=[#0 asc nulls_last]](row(array[#0], #0))]
+            Get l0
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[array_agg[order_by=[#0 desc nulls_first]](row(array[#0], #0))]
+            Get l0
   Return
     Project (#0, #1, #3)
       Map ((#2 > 0))
@@ -206,22 +222,6 @@ Explained Query:
                   Get l1
               Constant
                 - ()
-  With
-    cte l1 =
-      CrossJoin type=delta
-        ArrangeBy keys=[[]]
-          Reduce aggregates=[sum(1)]
-            Project ()
-              ReadStorage materialize.public.t
-        ArrangeBy keys=[[]]
-          Reduce aggregates=[array_agg[order_by=[#0 asc nulls_last]](row(array[#0], #0))]
-            Get l0
-        ArrangeBy keys=[[]]
-          Reduce aggregates=[array_agg[order_by=[#0 desc nulls_first]](row(array[#0], #0))]
-            Get l0
-    cte l0 =
-      Project (#1)
-        ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -233,6 +233,10 @@ query T multiline
 EXPLAIN SELECT t1.a, array_agg(t1.c), array_agg(t2.c) FROM t t1 INNER JOIN t t2 ON t1.c = t2.c WHERE t1.c IS NOT NULL GROUP BY t1.a;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Filter (#2) IS NOT NULL
+        ReadStorage materialize.public.t
   Return
     Project (#0, #1, #1)
       Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1]))]
@@ -244,10 +248,6 @@ Explained Query:
             ArrangeBy keys=[[#0]]
               Project (#2)
                 Get l0
-  With
-    cte l0 =
-      Filter (#2) IS NOT NULL
-        ReadStorage materialize.public.t
 
 Source materialize.public.t
   filter=((#2) IS NOT NULL)
@@ -260,18 +260,10 @@ query T multiline
 EXPLAIN SELECT sum(a), jsonb_agg(b), array_agg(b), array_agg(b) FROM t;
 ----
 Explained Query:
-  Return
-    Project (#0..=#2, #2)
-      Union
-        Get l1
-        Map (null, null, null)
-          Union
-            Negate
-              Project ()
-                Get l1
-            Constant
-              - ()
   With
+    cte l0 =
+      Project (#1)
+        ReadStorage materialize.public.t
     cte l1 =
       CrossJoin type=delta
         ArrangeBy keys=[[]]
@@ -284,9 +276,17 @@ Explained Query:
         ArrangeBy keys=[[]]
           Reduce aggregates=[array_agg[order_by=[]](row(array[#0]))]
             Get l0
-    cte l0 =
-      Project (#1)
-        ReadStorage materialize.public.t
+  Return
+    Project (#0..=#2, #2)
+      Union
+        Get l1
+        Map (null, null, null)
+          Union
+            Negate
+              Project ()
+                Get l1
+            Constant
+              - ()
 
 Source materialize.public.t
 
@@ -298,6 +298,10 @@ query T multiline
 EXPLAIN SELECT a, array_agg(b ORDER BY b) FROM t GROUP BY a HAVING array_agg(b ORDER BY b) = array_agg(b ORDER BY b DESC);
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0, #1)
+        ReadStorage materialize.public.t
   Return
     Project (#0, #1)
       Join on=(#0 = #2 AND #1 = #3) type=differential
@@ -307,10 +311,6 @@ Explained Query:
         ArrangeBy keys=[[#0, #1]]
           Reduce group_by=[#0] aggregates=[array_agg[order_by=[#0 desc nulls_first]](row(array[#1], #1))]
             Get l0
-  With
-    cte l0 =
-      Project (#0, #1)
-        ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -323,6 +323,10 @@ EXPLAIN SELECT a, array_agg(b), array_agg(sha256(b::BYTEA)) FROM t GROUP BY a;
 
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0, #1)
+        ReadStorage materialize.public.t
   Return
     Project (#0, #3, #1)
       Join on=(#0 = #2) type=differential
@@ -332,10 +336,6 @@ Explained Query:
         ArrangeBy keys=[[#0]]
           Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1]))]
             Get l0
-  With
-    cte l0 =
-      Project (#0, #1)
-        ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -348,6 +348,10 @@ query T multiline
 EXPLAIN SELECT a, array_agg(b), array_agg(CASE WHEN a = 1 THEN 'ooo' ELSE b END) FROM t GROUP BY a;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0, #1)
+        ReadStorage materialize.public.t
   Return
     Project (#0, #1, #3)
       Join on=(#0 = #2) type=differential
@@ -357,10 +361,6 @@ Explained Query:
         ArrangeBy keys=[[#0]]
           Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[case when (#0 = 1) then "ooo" else #1 end]))]
             Get l0
-  With
-    cte l0 =
-      Project (#0, #1)
-        ReadStorage materialize.public.t
 
 Source materialize.public.t
 

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -177,6 +177,13 @@ query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT abs(min(a) - max(a)) FROM t
 ----
+With
+  cte l0 =
+    Reduce aggregates=[min(#0), max(#0)]
+      CrossJoin
+        Constant
+          - ()
+        Get materialize.public.t
 Return
   Project (#2)
     Map (abs((#0 - #1)))
@@ -196,13 +203,6 @@ Return
                 - ()
           Constant
             - (null, null)
-With
-  cte l0 =
-    Reduce aggregates=[min(#0), max(#0)]
-      CrossJoin
-        Constant
-          - ()
-        Get materialize.public.t
 
 Target cluster: quickstart
 
@@ -232,37 +232,23 @@ query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
 ----
-Return
-  Project (#0, #1)
-    Filter #2
-      Project (#0, #1, #3)
-        Join on=(#1 = #2)
-          Get l3
-          Union
-            Get l5
-            CrossJoin
-              Project (#0)
-                Join on=(#0 = #1)
-                  Union
-                    Negate
-                      Distinct project=[#0]
-                        Get l5
-                    Distinct project=[#0]
-                      Get l4
-                  Get l4
-              Constant
-                - (false)
 With
-  cte l5 =
+  cte l0 =
+    Filter (true AND true)
+      CrossJoin
+        Constant
+          - ()
+        Get materialize.public.t
+  cte l1 =
+    Distinct project=[#0]
+      Get l0
+  cte l2 =
     Map (true)
       Distinct project=[#0]
-        Filter (#0 > #2)
+        Filter (#0 < #1)
           CrossJoin
-            Get l4
+            Get l1
             Get materialize.public.mv
-  cte l4 =
-    Distinct project=[#1]
-      Get l3
   cte l3 =
     Project (#0, #1)
       Filter #2
@@ -283,22 +269,36 @@ With
                     Get l1
                 Constant
                   - (false)
-  cte l2 =
+  cte l4 =
+    Distinct project=[#1]
+      Get l3
+  cte l5 =
     Map (true)
       Distinct project=[#0]
-        Filter (#0 < #1)
+        Filter (#0 > #2)
           CrossJoin
-            Get l1
+            Get l4
             Get materialize.public.mv
-  cte l1 =
-    Distinct project=[#0]
-      Get l0
-  cte l0 =
-    Filter (true AND true)
-      CrossJoin
-        Constant
-          - ()
-        Get materialize.public.t
+Return
+  Project (#0, #1)
+    Filter #2
+      Project (#0, #1, #3)
+        Join on=(#1 = #2)
+          Get l3
+          Union
+            Get l5
+            CrossJoin
+              Project (#0)
+                Join on=(#0 = #1)
+                  Union
+                    Negate
+                      Distinct project=[#0]
+                        Get l5
+                    Distinct project=[#0]
+                      Get l4
+                  Get l4
+              Constant
+                - (false)
 
 Target cluster: quickstart
 
@@ -309,6 +309,54 @@ query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1) FROM t
 ----
+With
+  cte l0 =
+    CrossJoin
+      Constant
+        - ()
+      Get materialize.public.t
+  cte l1 =
+    Distinct project=[#0, #1]
+      Get l0
+  cte l2 =
+    Distinct project=[#1]
+      Get l1
+  cte l3 =
+    Project (#0, #1)
+      TopK group_by=[#0] limit=1
+        Filter (#2 = #0)
+          CrossJoin
+            Get l2
+            Get materialize.public.v
+  cte l4 =
+    Union
+      Get l3
+      Map (error("more than one record produced in subquery"))
+        Project (#0)
+          Filter (#1 > 1)
+            Reduce group_by=[#0] aggregates=[count(*)]
+              Get l3
+  cte l5 =
+    Distinct project=[#0, #1]
+      Get l0
+  cte l6 =
+    Distinct project=[#1]
+      Get l5
+  cte l7 =
+    Project (#0, #1)
+      TopK group_by=[#0] limit=1
+        Filter (#2 = #0)
+          CrossJoin
+            Get l6
+            Get materialize.public.mv
+  cte l8 =
+    Union
+      Get l7
+      Map (error("more than one record produced in subquery"))
+        Project (#0)
+          Filter (#1 > 1)
+            Reduce group_by=[#0] aggregates=[count(*)]
+              Get l7
 Return
   Project (#8, #9)
     Map (#4, #7)
@@ -348,54 +396,6 @@ Return
                     Get l6
                 Constant
                   - (null)
-With
-  cte l8 =
-    Union
-      Get l7
-      Map (error("more than one record produced in subquery"))
-        Project (#0)
-          Filter (#1 > 1)
-            Reduce group_by=[#0] aggregates=[count(*)]
-              Get l7
-  cte l7 =
-    Project (#0, #1)
-      TopK group_by=[#0] limit=1
-        Filter (#2 = #0)
-          CrossJoin
-            Get l6
-            Get materialize.public.mv
-  cte l6 =
-    Distinct project=[#1]
-      Get l5
-  cte l5 =
-    Distinct project=[#0, #1]
-      Get l0
-  cte l4 =
-    Union
-      Get l3
-      Map (error("more than one record produced in subquery"))
-        Project (#0)
-          Filter (#1 > 1)
-            Reduce group_by=[#0] aggregates=[count(*)]
-              Get l3
-  cte l3 =
-    Project (#0, #1)
-      TopK group_by=[#0] limit=1
-        Filter (#2 = #0)
-          CrossJoin
-            Get l2
-            Get materialize.public.v
-  cte l2 =
-    Distinct project=[#1]
-      Get l1
-  cte l1 =
-    Distinct project=[#0, #1]
-      Get l0
-  cte l0 =
-    CrossJoin
-      Constant
-        - ()
-      Get materialize.public.t
 
 Target cluster: quickstart
 
@@ -516,23 +516,26 @@ FROM t as t1
 LEFT JOIN t as t2 ON t1.b = t2.b
 RIGHT JOIN t as t3 ON t2.b = t3.b
 ----
-Return
-  Project (#0, #2)
-    Union
-      Project (#2..=#5, #0, #1)
-        Map (null, null, null, null)
-          Union
-            Negate
-              Project (#0, #1)
-                Join on=(#1 = #2)
-                  Filter (#1) IS NOT NULL
-                    Get l2
-                  Distinct project=[#0]
-                    Project (#3)
-                      Get l3
-            Get l2
-      Get l3
 With
+  cte l0 =
+    CrossJoin
+      Constant
+        - ()
+      Get materialize.public.t
+  cte l1 =
+    Filter (#1 = #3)
+      Project (#0..=#3)
+        CrossJoin
+          Get l0
+          CrossJoin
+            Constant
+              - ()
+            Get materialize.public.t
+  cte l2 =
+    CrossJoin
+      Constant
+        - ()
+      Get materialize.public.t
   cte l3 =
     Filter (#3 = #5)
       Project (#0..=#5)
@@ -551,25 +554,22 @@ With
                 Get l0
             Get l1
           Get l2
-  cte l2 =
-    CrossJoin
-      Constant
-        - ()
-      Get materialize.public.t
-  cte l1 =
-    Filter (#1 = #3)
-      Project (#0..=#3)
-        CrossJoin
-          Get l0
-          CrossJoin
-            Constant
-              - ()
-            Get materialize.public.t
-  cte l0 =
-    CrossJoin
-      Constant
-        - ()
-      Get materialize.public.t
+Return
+  Project (#0, #2)
+    Union
+      Project (#2..=#5, #0, #1)
+        Map (null, null, null, null)
+          Union
+            Negate
+              Project (#0, #1)
+                Join on=(#1 = #2)
+                  Filter (#1) IS NOT NULL
+                    Get l2
+                  Distinct project=[#0]
+                    Project (#3)
+                      Get l3
+            Get l2
+      Get l3
 
 Target cluster: quickstart
 
@@ -580,14 +580,6 @@ query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 WITH x AS (SELECT t.a * t.b as v from t) SELECT a.v + b.v FROM x as a, x as b
 ----
-Return
-  Project (#2)
-    Project (#0..=#2)
-      Map ((#0 + #1))
-        Project (#0, #1)
-          CrossJoin
-            Get l0
-            Get l0
 With
   cte l0 =
     Project (#2)
@@ -596,6 +588,14 @@ With
           Constant
             - ()
           Get materialize.public.t
+Return
+  Project (#2)
+    Project (#0..=#2)
+      Map ((#0 + #1))
+        Project (#0, #1)
+          CrossJoin
+            Get l0
+            Get l0
 
 Target cluster: quickstart
 
@@ -624,34 +624,20 @@ FROM
     SELECT * FROM r4 WHERE r4.m != r1.a OR (r4.m IS NOT NULL AND r1.a IS NULL)
   ) as r5;
 ----
-Return
-  Project (#0..=#2, #4)
-    Join on=(#0 = #3)
-      Get l3
-      Filter ((#1 != #0) OR ((#1) IS NOT NULL AND (#0) IS NULL))
-        Union
-          Get l5
-          CrossJoin
-            Project (#0)
-              Join on=(#0 = #1)
-                Union
-                  Negate
-                    Distinct project=[#0]
-                      Get l5
-                  Distinct project=[#0]
-                    Get l4
-                Get l4
-            Constant
-              - (null)
 With
-  cte l5 =
+  cte l0 =
+    CrossJoin
+      Constant
+        - ()
+      Get materialize.public.t
+  cte l1 =
+    Distinct project=[#0]
+      Get l0
+  cte l2 =
     Reduce group_by=[#0] aggregates=[max((#0 * #1))]
       CrossJoin
-        Get l4
+        Get l1
         Get materialize.public.t
-  cte l4 =
-    Distinct project=[#0]
-      Get l3
   cte l3 =
     Project (#0, #1, #3)
       Join on=(#0 = #2)
@@ -671,19 +657,33 @@ With
                   Get l1
               Constant
                 - (null)
-  cte l2 =
+  cte l4 =
+    Distinct project=[#0]
+      Get l3
+  cte l5 =
     Reduce group_by=[#0] aggregates=[max((#0 * #1))]
       CrossJoin
-        Get l1
+        Get l4
         Get materialize.public.t
-  cte l1 =
-    Distinct project=[#0]
-      Get l0
-  cte l0 =
-    CrossJoin
-      Constant
-        - ()
-      Get materialize.public.t
+Return
+  Project (#0..=#2, #4)
+    Join on=(#0 = #3)
+      Get l3
+      Filter ((#1 != #0) OR ((#1) IS NOT NULL AND (#0) IS NULL))
+        Union
+          Get l5
+          CrossJoin
+            Project (#0)
+              Join on=(#0 = #1)
+                Union
+                  Negate
+                    Distinct project=[#0]
+                      Get l5
+                  Distinct project=[#0]
+                    Get l4
+                Get l4
+            Constant
+              - (null)
 
 Target cluster: quickstart
 
@@ -716,6 +716,43 @@ FROM
     WHERE a != r1.a
   ) as r5;
 ----
+With
+  cte l0 =
+    CrossJoin
+      Constant
+        - ()
+      Get materialize.public.t
+  cte l1 =
+    Distinct project=[#0]
+      Get l0
+  cte l2 =
+    Reduce group_by=[#0] aggregates=[max((#0 * #1))]
+      CrossJoin
+        Get l1
+        Get materialize.public.t
+  cte l3 =
+    Union
+      Get l2
+      CrossJoin
+        Project (#0)
+          Join on=(#0 = #1)
+            Union
+              Negate
+                Distinct project=[#0]
+                  Get l2
+              Distinct project=[#0]
+                Get l1
+            Get l1
+        Constant
+          - (null)
+  cte l4 =
+    Distinct project=[#1, #0]
+      Get l3
+  cte l5 =
+    Reduce group_by=[#0, #1] aggregates=[max((#1 * #2))]
+      CrossJoin
+        Get l4
+        Get materialize.public.t
 Return
   Project (#0, #1, #3, #4)
     Join on=(#0 = #2)
@@ -739,43 +776,6 @@ Return
                       Get l4
                   Constant
                     - (null)
-With
-  cte l5 =
-    Reduce group_by=[#0, #1] aggregates=[max((#1 * #2))]
-      CrossJoin
-        Get l4
-        Get materialize.public.t
-  cte l4 =
-    Distinct project=[#1, #0]
-      Get l3
-  cte l3 =
-    Union
-      Get l2
-      CrossJoin
-        Project (#0)
-          Join on=(#0 = #1)
-            Union
-              Negate
-                Distinct project=[#0]
-                  Get l2
-              Distinct project=[#0]
-                Get l1
-            Get l1
-        Constant
-          - (null)
-  cte l2 =
-    Reduce group_by=[#0] aggregates=[max((#0 * #1))]
-      CrossJoin
-        Get l1
-        Get materialize.public.t
-  cte l1 =
-    Distinct project=[#0]
-      Get l0
-  cte l0 =
-    CrossJoin
-      Constant
-        - ()
-      Get materialize.public.t
 
 Target cluster: quickstart
 
@@ -784,6 +784,11 @@ EOF
 query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR SELECT COUNT(*);
 ----
+With
+  cte l0 =
+    Reduce aggregates=[count(*)]
+      Constant
+        - ()
 Return
   Union
     Get l0
@@ -801,11 +806,6 @@ Return
             - ()
       Constant
         - (0)
-With
-  cte l0 =
-    Reduce aggregates=[count(*)]
-      Constant
-        - ()
 
 Target cluster: quickstart
 
@@ -834,16 +834,16 @@ WHERE
   r0.f16=r1.f16;
 ----
 Explained Query:
-  Return
-    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
-      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
-        Get l0
-        Get l0
   With
     cte l0 =
       ArrangeBy keys=[[#0, #2..=#4, #6, #8, #9, #11..=#13, #15, #16]]
         Filter (#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL
           ReadStorage materialize.public.r
+  Return
+    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
+      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
+        Get l0
+        Get l0
 
 Source materialize.public.r
   filter=((#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL)

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -319,6 +319,11 @@ EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS TEXT FOR
 SELECT abs(min(a) - max(a)) FROM t
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[min(#0{a}), max(#0{a})]
+        Project (#0{a})
+          ReadIndex on=t t_a_idx=[*** full scan ***]
   Return
     Project (#2)
       Map (abs((#0{min_a} - #1{max_a})))
@@ -331,11 +336,6 @@ Explained Query:
                   Get l0
               Constant
                 - ()
-  With
-    cte l0 =
-      Reduce aggregates=[min(#0{a}), max(#0{a})]
-        Project (#0{a})
-          ReadIndex on=t t_a_idx=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -368,23 +368,6 @@ EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS TEXT FOR
 SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
 ----
 Explained Query:
-  Return
-    Project (#0{a}, #1{b})
-      Join on=(#1{b} = #2{b}) type=differential
-        ArrangeBy keys=[[#1{b}]]
-          Get l0
-        ArrangeBy keys=[[#0{b}]]
-          Distinct project=[#0{b}]
-            Project (#0{b})
-              Filter (#0{b} > #1{b})
-                CrossJoin type=differential
-                  ArrangeBy keys=[[]]
-                    Distinct project=[#0{b}]
-                      Project (#1)
-                        Get l0
-                  ArrangeBy keys=[[]]
-                    Project (#1)
-                      ReadStorage materialize.public.mv
   With
     cte l0 =
       Project (#0{a}, #1{b})
@@ -403,6 +386,23 @@ Explained Query:
                     ArrangeBy keys=[[]]
                       Project (#0{a})
                         ReadStorage materialize.public.mv
+  Return
+    Project (#0{a}, #1{b})
+      Join on=(#1{b} = #2{b}) type=differential
+        ArrangeBy keys=[[#1{b}]]
+          Get l0
+        ArrangeBy keys=[[#0{b}]]
+          Distinct project=[#0{b}]
+            Project (#0{b})
+              Filter (#0{b} > #1{b})
+                CrossJoin type=differential
+                  ArrangeBy keys=[[]]
+                    Distinct project=[#0{b}]
+                      Project (#1)
+                        Get l0
+                  ArrangeBy keys=[[]]
+                    Project (#1)
+                      ReadStorage materialize.public.mv
 
 Source materialize.public.mv
 
@@ -419,6 +419,32 @@ EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS TEXT FOR
 SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1) FROM t
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#1)
+        ReadIndex on=t t_a_idx=[*** full scan ***]
+    cte l1 =
+      Distinct project=[#0{b}]
+        Get l0
+    cte l2 =
+      ArrangeBy keys=[[#0{b}]]
+        Get l1
+    cte l3 =
+      TopK group_by=[#0{b}] limit=1
+        Project (#0{b}, #1{a})
+          Filter (#0{b}) IS NOT NULL
+            Join on=(#0{b} = #2{b}) type=differential
+              Get l2
+              ArrangeBy keys=[[#1{b}]]
+                ReadIndex on=iv iv_b_idx=[differential join]
+    cte l4 =
+      TopK group_by=[#0{b}] limit=1
+        Project (#0{b}, #1{a})
+          Join on=(#0{b} = #2{b}) type=differential
+            Get l2
+            ArrangeBy keys=[[#1{b}]]
+              Filter (#1{b}) IS NOT NULL
+                ReadStorage materialize.public.mv
   Return
     Project (#2, #4)
       Join on=(#0{b} = #1{b} = #3{b}) type=delta
@@ -442,32 +468,6 @@ Explained Query:
                   Project (#0{b})
                     Get l4
                 Get l1
-  With
-    cte l4 =
-      TopK group_by=[#0{b}] limit=1
-        Project (#0{b}, #1{a})
-          Join on=(#0{b} = #2{b}) type=differential
-            Get l2
-            ArrangeBy keys=[[#1{b}]]
-              Filter (#1{b}) IS NOT NULL
-                ReadStorage materialize.public.mv
-    cte l3 =
-      TopK group_by=[#0{b}] limit=1
-        Project (#0{b}, #1{a})
-          Filter (#0{b}) IS NOT NULL
-            Join on=(#0{b} = #2{b}) type=differential
-              Get l2
-              ArrangeBy keys=[[#1{b}]]
-                ReadIndex on=iv iv_b_idx=[differential join]
-    cte l2 =
-      ArrangeBy keys=[[#0{b}]]
-        Get l1
-    cte l1 =
-      Distinct project=[#0{b}]
-        Get l0
-    cte l0 =
-      Project (#1)
-        ReadIndex on=t t_a_idx=[*** full scan ***]
 
 Source materialize.public.mv
   filter=((#1{b}) IS NOT NULL)
@@ -489,6 +489,23 @@ LEFT JOIN t as t2 ON t1.b = t2.b
 RIGHT JOIN t as t3 ON t2.b = t3.b
 ----
 Explained Query:
+  With
+    cte l0 =
+      Filter (#1{b}) IS NOT NULL
+        ReadIndex on=t t_a_idx=[*** full scan ***]
+    cte l1 =
+      ArrangeBy keys=[[#1{b}]]
+        Get l0
+    cte l2 =
+      ArrangeBy keys=[[#0{b}]]
+        Project (#1)
+          Get l0
+    cte l3 =
+      Project (#0{a}..=#2{a})
+        Join on=(#1{b} = #3{b} = #4{b}) type=delta
+          Get l1
+          Get l1
+          Get l2
   Return
     Union
       Map (null, null)
@@ -505,23 +522,6 @@ Explained Query:
             ReadIndex on=t t_a_idx=[*** full scan ***]
       Project (#0{a}, #2)
         Get l3
-  With
-    cte l3 =
-      Project (#0{a}..=#2{a})
-        Join on=(#1{b} = #3{b} = #4{b}) type=delta
-          Get l1
-          Get l1
-          Get l2
-    cte l2 =
-      ArrangeBy keys=[[#0{b}]]
-        Project (#1)
-          Get l0
-    cte l1 =
-      ArrangeBy keys=[[#1{b}]]
-        Get l0
-    cte l0 =
-      Filter (#1{b}) IS NOT NULL
-        ReadIndex on=t t_a_idx=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -536,18 +536,18 @@ EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS TEXT FOR
 WITH x AS (SELECT t.a * t.b as v from t) SELECT a.v + b.v FROM x as a, x as b
 ----
 Explained Query:
-  Return
-    Project (#2)
-      Map ((#0 + #1))
-        CrossJoin type=differential
-          Get l0
-          Get l0
   With
     cte l0 =
       ArrangeBy keys=[[]]
         Project (#2)
           Map ((#0{a} * #1{b}))
             ReadIndex on=t t_a_idx=[*** full scan ***]
+  Return
+    Project (#2)
+      Map ((#0 + #1))
+        CrossJoin type=differential
+          Get l0
+          Get l0
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -651,6 +651,26 @@ FROM
   ) as r5;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0{a})
+        ReadIndex on=t t_a_idx=[*** full scan ***]
+    cte l1 =
+      ArrangeBy keys=[[]]
+        Get l0
+    cte l2 =
+      Project (#0{a}, #1{b}, #3)
+        Filter (#0{a} != #3{max})
+          Join on=(#0{a} = #2{a}) type=differential
+            ArrangeBy keys=[[#0{a}]]
+              ReadIndex on=t t_a_idx=[differential join]
+            ArrangeBy keys=[[#0{a}]]
+              Reduce group_by=[#0{a}] aggregates=[max((#0{a} * #1{a}))]
+                CrossJoin type=differential
+                  ArrangeBy keys=[[]]
+                    Distinct project=[#0{a}]
+                      Get l0
+                  Get l1
   Return
     Project (#0{a}..=#2{max}, #4)
       Filter (#0{a} != #4{max})
@@ -665,26 +685,6 @@ Explained Query:
                     Project (#0{a})
                       Get l2
                 Get l1
-  With
-    cte l2 =
-      Project (#0{a}, #1{b}, #3)
-        Filter (#0{a} != #3{max})
-          Join on=(#0{a} = #2{a}) type=differential
-            ArrangeBy keys=[[#0{a}]]
-              ReadIndex on=t t_a_idx=[differential join]
-            ArrangeBy keys=[[#0{a}]]
-              Reduce group_by=[#0{a}] aggregates=[max((#0{a} * #1{a}))]
-                CrossJoin type=differential
-                  ArrangeBy keys=[[]]
-                    Distinct project=[#0{a}]
-                      Get l0
-                  Get l1
-    cte l1 =
-      ArrangeBy keys=[[]]
-        Get l0
-    cte l0 =
-      Project (#0{a})
-        ReadIndex on=t t_a_idx=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***, differential join)
@@ -699,15 +699,15 @@ EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS TEXT FOR
 SELECT t1.a, t2.a FROM t as t1, t as t2
 ----
 Explained Query:
-  Return
-    CrossJoin type=differential
-      Get l0
-      Get l0
   With
     cte l0 =
       ArrangeBy keys=[[]]
         Project (#0{a})
           ReadIndex on=t t_a_idx=[*** full scan ***]
+  Return
+    CrossJoin type=differential
+      Get l0
+      Get l0
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -727,6 +727,13 @@ FROM
 WHERE t1.b = t2.b AND t2.b = t3.b
 ----
 Explained Query:
+  With
+    cte l0 =
+      Filter (#1{b}) IS NOT NULL
+        ReadIndex on=t t_a_idx=[*** full scan ***]
+    cte l1 =
+      ArrangeBy keys=[[#1{b}]]
+        Get l0
   Return
     Project (#0{a}, #2)
       Join on=(#1{b} = #3{b} = #4{b}) type=delta
@@ -735,13 +742,6 @@ Explained Query:
         ArrangeBy keys=[[#0{b}]]
           Project (#1)
             Get l0
-  With
-    cte l1 =
-      ArrangeBy keys=[[#1{b}]]
-        Get l0
-    cte l0 =
-      Filter (#1{b}) IS NOT NULL
-        ReadIndex on=t t_a_idx=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -1015,16 +1015,16 @@ WHERE
   r0.f16=r1.f16;
 ----
 Explained Query:
-  Return
-    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
-      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
-        Get l0
-        Get l0
   With
     cte l0 =
       ArrangeBy keys=[[#0, #2..=#4, #6, #8, #9, #11..=#13, #15, #16]]
         Filter (#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL
           ReadStorage materialize.public.r
+  Return
+    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
+      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
+        Get l0
+        Get l0
 
 Source materialize.public.r
   filter=((#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL)
@@ -1243,6 +1243,10 @@ FROM t AS t1, t AS t2, t AS t3
 WHERE t1.a = t2.a AND t2.a = t3.a;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0{a}]]
+        ReadIndex on=t t_a_idx_1=[delta join lookup, delta join 1st input (full scan)]
   Return
     Project (#0{a}, #1{b}, #0{a}, #3{b}, #0{a}, #5{b})
       Filter (#0{a}) IS NOT NULL
@@ -1250,10 +1254,6 @@ Explained Query:
           Get l0
           Get l0
           Get l0
-  With
-    cte l0 =
-      ArrangeBy keys=[[#0{a}]]
-        ReadIndex on=t t_a_idx_1=[delta join lookup, delta join 1st input (full scan)]
 
 Used Indexes:
   - materialize.public.t_a_idx_1 (delta join lookup, delta join 1st input (full scan))
@@ -1274,6 +1274,10 @@ UNION
  WHERE b > 5)
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0{a}]]
+        ReadIndex on=t t_a_idx_1=[differential join]
   Return
     Distinct project=[#0{a}, #1{b}]
       Union
@@ -1285,10 +1289,6 @@ Explained Query:
                 Get l0
         Filter (#1{b} > 5)
           ReadIndex on=t t_a_idx_1=[*** full scan ***]
-  With
-    cte l0 =
-      ArrangeBy keys=[[#0{a}]]
-        ReadIndex on=t t_a_idx_1=[differential join]
 
 Used Indexes:
   - materialize.public.t_a_idx_1 (*** full scan ***, differential join)
@@ -1309,6 +1309,11 @@ UNION
  WHERE b > 5)
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#1{b}]]
+        Filter (#1{b}) IS NOT NULL
+          ReadIndex on=t t_a_idx_1=[*** full scan ***]
   Return
     Distinct project=[#0{a}, #1{b}]
       Union
@@ -1318,11 +1323,6 @@ Explained Query:
               Get l0
               Get l0
         Filter (#1{b} > 5)
-          ReadIndex on=t t_a_idx_1=[*** full scan ***]
-  With
-    cte l0 =
-      ArrangeBy keys=[[#1{b}]]
-        Filter (#1{b}) IS NOT NULL
           ReadIndex on=t t_a_idx_1=[*** full scan ***]
 
 Used Indexes:
@@ -1355,6 +1355,10 @@ UNION
  WHERE b > 5)
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#1{b}]]
+        ReadIndex on=t_non_null t_non_null_a_idx=[*** full scan ***]
   Return
     Distinct project=[#0{a}, #1{b}]
       Union
@@ -1365,10 +1369,6 @@ Explained Query:
               Get l0
         Filter (#1{b} > 5)
           ReadIndex on=t_non_null t_non_null_a_idx=[*** full scan ***]
-  With
-    cte l0 =
-      ArrangeBy keys=[[#1{b}]]
-        ReadIndex on=t_non_null t_non_null_a_idx=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.t_non_null_a_idx (*** full scan ***)

--- a/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
@@ -188,6 +188,11 @@ EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, redacted) AS TEXT FOR
 SELECT abs(min(a) - max(a)) FROM t
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[min(#0{a}), max(#0{a})]
+        Project (#0{a})
+          ReadIndex on=t t_a_idx=[*** full scan ***]
   Return
     Project (#2)
       Map (abs((#0{min_a} - #1{max_a})))
@@ -200,11 +205,6 @@ Explained Query:
                   Get l0
               Constant
                 - ()
-  With
-    cte l0 =
-      Reduce aggregates=[min(#0{a}), max(#0{a})]
-        Project (#0{a})
-          ReadIndex on=t t_a_idx=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -237,23 +237,6 @@ EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, redacted) AS TEXT FOR
 SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
 ----
 Explained Query:
-  Return
-    Project (#0{a}, #1{b})
-      Join on=(#1{b} = #2{b}) type=differential
-        ArrangeBy keys=[[#1{b}]]
-          Get l0
-        ArrangeBy keys=[[#0{b}]]
-          Distinct project=[#0{b}]
-            Project (#0{b})
-              Filter (#0{b} > #1{b})
-                CrossJoin type=differential
-                  ArrangeBy keys=[[]]
-                    Distinct project=[#0{b}]
-                      Project (#1)
-                        Get l0
-                  ArrangeBy keys=[[]]
-                    Project (#1)
-                      ReadStorage materialize.public.mv
   With
     cte l0 =
       Project (#0{a}, #1{b})
@@ -272,6 +255,23 @@ Explained Query:
                     ArrangeBy keys=[[]]
                       Project (#0{a})
                         ReadStorage materialize.public.mv
+  Return
+    Project (#0{a}, #1{b})
+      Join on=(#1{b} = #2{b}) type=differential
+        ArrangeBy keys=[[#1{b}]]
+          Get l0
+        ArrangeBy keys=[[#0{b}]]
+          Distinct project=[#0{b}]
+            Project (#0{b})
+              Filter (#0{b} > #1{b})
+                CrossJoin type=differential
+                  ArrangeBy keys=[[]]
+                    Distinct project=[#0{b}]
+                      Project (#1)
+                        Get l0
+                  ArrangeBy keys=[[]]
+                    Project (#1)
+                      ReadStorage materialize.public.mv
 
 Source materialize.public.mv
 
@@ -288,6 +288,32 @@ EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, redacted) AS TEXT FOR
 SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1) FROM t
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#1)
+        ReadIndex on=t t_a_idx=[*** full scan ***]
+    cte l1 =
+      Distinct project=[#0{b}]
+        Get l0
+    cte l2 =
+      ArrangeBy keys=[[#0{b}]]
+        Get l1
+    cte l3 =
+      TopK group_by=[#0{b}] limit=█
+        Project (#0{b}, #1{a})
+          Filter (#0{b}) IS NOT NULL
+            Join on=(#0{b} = #2{b}) type=differential
+              Get l2
+              ArrangeBy keys=[[#1{b}]]
+                ReadIndex on=iv iv_b_idx=[differential join]
+    cte l4 =
+      TopK group_by=[#0{b}] limit=█
+        Project (#0{b}, #1{a})
+          Join on=(#0{b} = #2{b}) type=differential
+            Get l2
+            ArrangeBy keys=[[#1{b}]]
+              Filter (#1{b}) IS NOT NULL
+                ReadStorage materialize.public.mv
   Return
     Project (#2, #4)
       Join on=(#0{b} = #1{b} = #3{b}) type=delta
@@ -311,32 +337,6 @@ Explained Query:
                   Project (#0{b})
                     Get l4
                 Get l1
-  With
-    cte l4 =
-      TopK group_by=[#0{b}] limit=█
-        Project (#0{b}, #1{a})
-          Join on=(#0{b} = #2{b}) type=differential
-            Get l2
-            ArrangeBy keys=[[#1{b}]]
-              Filter (#1{b}) IS NOT NULL
-                ReadStorage materialize.public.mv
-    cte l3 =
-      TopK group_by=[#0{b}] limit=█
-        Project (#0{b}, #1{a})
-          Filter (#0{b}) IS NOT NULL
-            Join on=(#0{b} = #2{b}) type=differential
-              Get l2
-              ArrangeBy keys=[[#1{b}]]
-                ReadIndex on=iv iv_b_idx=[differential join]
-    cte l2 =
-      ArrangeBy keys=[[#0{b}]]
-        Get l1
-    cte l1 =
-      Distinct project=[#0{b}]
-        Get l0
-    cte l0 =
-      Project (#1)
-        ReadIndex on=t t_a_idx=[*** full scan ***]
 
 Source materialize.public.mv
   filter=((#1{b}) IS NOT NULL)
@@ -358,6 +358,23 @@ LEFT JOIN t as t2 ON t1.b = t2.b
 RIGHT JOIN t as t3 ON t2.b = t3.b
 ----
 Explained Query:
+  With
+    cte l0 =
+      Filter (#1{b}) IS NOT NULL
+        ReadIndex on=t t_a_idx=[*** full scan ***]
+    cte l1 =
+      ArrangeBy keys=[[#1{b}]]
+        Get l0
+    cte l2 =
+      ArrangeBy keys=[[#0{b}]]
+        Project (#1)
+          Get l0
+    cte l3 =
+      Project (#0{a}..=#2{a})
+        Join on=(#1{b} = #3{b} = #4{b}) type=delta
+          Get l1
+          Get l1
+          Get l2
   Return
     Union
       Map (█, █)
@@ -374,23 +391,6 @@ Explained Query:
             ReadIndex on=t t_a_idx=[*** full scan ***]
       Project (#0{a}, #2)
         Get l3
-  With
-    cte l3 =
-      Project (#0{a}..=#2{a})
-        Join on=(#1{b} = #3{b} = #4{b}) type=delta
-          Get l1
-          Get l1
-          Get l2
-    cte l2 =
-      ArrangeBy keys=[[#0{b}]]
-        Project (#1)
-          Get l0
-    cte l1 =
-      ArrangeBy keys=[[#1{b}]]
-        Get l0
-    cte l0 =
-      Filter (#1{b}) IS NOT NULL
-        ReadIndex on=t t_a_idx=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -487,16 +487,16 @@ WHERE
   r0.f16=r1.f16;
 ----
 Explained Query:
-  Return
-    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
-      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
-        Get l0
-        Get l0
   With
     cte l0 =
       ArrangeBy keys=[[#0, #2..=#4, #6, #8, #9, #11..=#13, #15, #16]]
         Filter (#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL
           ReadStorage materialize.public.r
+  Return
+    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
+      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
+        Get l0
+        Get l0
 
 Source materialize.public.r
   filter=((#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL)
@@ -715,6 +715,10 @@ FROM t AS t1, t AS t2, t AS t3
 WHERE t1.a = t2.a AND t2.a = t3.a;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0{a}]]
+        ReadIndex on=t t_a_idx_1=[delta join lookup, delta join 1st input (full scan)]
   Return
     Project (#0{a}, #1{b}, #0{a}, #3{b}, #0{a}, #5{b})
       Filter (#0{a}) IS NOT NULL
@@ -722,10 +726,6 @@ Explained Query:
           Get l0
           Get l0
           Get l0
-  With
-    cte l0 =
-      ArrangeBy keys=[[#0{a}]]
-        ReadIndex on=t t_a_idx_1=[delta join lookup, delta join 1st input (full scan)]
 
 Used Indexes:
   - materialize.public.t_a_idx_1 (delta join lookup, delta join 1st input (full scan))
@@ -746,6 +746,10 @@ UNION
  WHERE b > 5)
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0{a}]]
+        ReadIndex on=t t_a_idx_1=[differential join]
   Return
     Distinct project=[#0{a}, #1{b}]
       Union
@@ -757,10 +761,6 @@ Explained Query:
                 Get l0
         Filter (#1{b} > █)
           ReadIndex on=t t_a_idx_1=[*** full scan ***]
-  With
-    cte l0 =
-      ArrangeBy keys=[[#0{a}]]
-        ReadIndex on=t t_a_idx_1=[differential join]
 
 Used Indexes:
   - materialize.public.t_a_idx_1 (*** full scan ***, differential join)
@@ -781,6 +781,11 @@ UNION
  WHERE b > 5)
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#1{b}]]
+        Filter (#1{b}) IS NOT NULL
+          ReadIndex on=t t_a_idx_1=[*** full scan ***]
   Return
     Distinct project=[#0{a}, #1{b}]
       Union
@@ -790,11 +795,6 @@ Explained Query:
               Get l0
               Get l0
         Filter (#1{b} > █)
-          ReadIndex on=t t_a_idx_1=[*** full scan ***]
-  With
-    cte l0 =
-      ArrangeBy keys=[[#1{b}]]
-        Filter (#1{b}) IS NOT NULL
           ReadIndex on=t t_a_idx_1=[*** full scan ***]
 
 Used Indexes:
@@ -827,6 +827,10 @@ UNION
  WHERE b > 5)
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#1{b}]]
+        ReadIndex on=t_non_null t_non_null_a_idx=[*** full scan ***]
   Return
     Distinct project=[#0{a}, #1{b}]
       Union
@@ -837,10 +841,6 @@ Explained Query:
               Get l0
         Filter (#1{b} > █)
           ReadIndex on=t_non_null t_non_null_a_idx=[*** full scan ***]
-  With
-    cte l0 =
-      ArrangeBy keys=[[#1{b}]]
-        ReadIndex on=t_non_null t_non_null_a_idx=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.t_non_null_a_idx (*** full scan ***)

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -1673,16 +1673,16 @@ WHERE
   r0.f16=r1.f16;
 ----
 Explained Query:
-  Return
-    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
-      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
-        Get l0
-        Get l0
   With
     cte l0 =
       ArrangeBy keys=[[#0, #2..=#4, #6, #8, #9, #11..=#13, #15, #16]]
         Filter (#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL
           ReadStorage materialize.public.r
+  Return
+    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
+      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
+        Get l0
+        Get l0
 
 Source materialize.public.r
   filter=((#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL)

--- a/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
@@ -1658,16 +1658,16 @@ WHERE
   r0.f16=r1.f16;
 ----
 Explained Query:
-  Return
-    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
-      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
-        Get l0
-        Get l0
   With
     cte l0 =
       ArrangeBy keys=[[#0, #2..=#4, #6, #8, #9, #11..=#13, #15, #16]]
         Filter (#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL
           ReadStorage materialize.public.r
+  Return
+    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
+      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
+        Get l0
+        Get l0
 
 Source materialize.public.r
   filter=((#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL)

--- a/test/sqllogictest/explain/plan_insights.slt
+++ b/test/sqllogictest/explain/plan_insights.slt
@@ -175,7 +175,7 @@ EXPLAIN PLAN INSIGHTS AS JSON FOR SELECT * FROM t t1, t t2
     },
     "optimized": {
       "global": {
-        "text": "Explained Query:\n  Return\n    CrossJoin type=differential\n      Get l0\n      Get l0\n  With\n    cte l0 =\n      ArrangeBy keys=[[]]\n        ReadStorage materialize.public.t\n\nSource materialize.public.t\n\nTarget cluster: quickstart\n",
+        "text": "Explained Query:\n  With\n    cte l0 =\n      ArrangeBy keys=[[]]\n        ReadStorage materialize.public.t\n  Return\n    CrossJoin type=differential\n      Get l0\n      Get l0\n\nSource materialize.public.t\n\nTarget cluster: quickstart\n",
         "json": {
           "plans": [
             {
@@ -529,7 +529,7 @@ EXPLAIN PLAN INSIGHTS AS JSON FOR SELECT * FROM t t1, t t2
     },
     "optimized": {
       "global": {
-        "text": "Explained Query:\n  Return\n    CrossJoin type=differential\n      Get l0\n      Get l0\n  With\n    cte l0 =\n      ArrangeBy keys=[[]]\n        ReadIndex on=t t_primary_idx=[*** full scan ***]\n\nUsed Indexes:\n  - materialize.public.t_primary_idx (*** full scan ***)\n\nTarget cluster: quickstart\n",
+        "text": "Explained Query:\n  With\n    cte l0 =\n      ArrangeBy keys=[[]]\n        ReadIndex on=t t_primary_idx=[*** full scan ***]\n  Return\n    CrossJoin type=differential\n      Get l0\n      Get l0\n\nUsed Indexes:\n  - materialize.public.t_primary_idx (*** full scan ***)\n\nTarget cluster: quickstart\n",
         "json": {
           "plans": [
             {
@@ -862,7 +862,7 @@ EXPLAIN PLAN INSIGHTS AS JSON FOR SELECT count(*) FROM t
     },
     "optimized": {
       "global": {
-        "text": "Explained Query:\n  Return\n    Union\n      Get l0\n      Map (0)\n        Union\n          Negate\n            Project ()\n              Get l0\n          Constant\n            - ()\n  With\n    cte l0 =\n      Reduce aggregates=[count(*)]\n        Project ()\n          ReadStorage materialize.public.t\n\nSource materialize.public.t\n\nTarget cluster: other\n",
+        "text": "Explained Query:\n  With\n    cte l0 =\n      Reduce aggregates=[count(*)]\n        Project ()\n          ReadStorage materialize.public.t\n  Return\n    Union\n      Get l0\n      Map (0)\n        Union\n          Negate\n            Project ()\n              Get l0\n          Constant\n            - ()\n\nSource materialize.public.t\n\nTarget cluster: other\n",
         "json": {
           "plans": [
             {

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -461,16 +461,16 @@ WHERE
   r0.f16=r1.f16;
 ----
 Explained Query:
-  Return
-    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
-      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
-        Get l0
-        Get l0
   With
     cte l0 =
       ArrangeBy keys=[[#0, #2..=#4, #6, #8, #9, #11..=#13, #15, #16]]
         Filter (#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL
           ReadStorage materialize.public.r
+  Return
+    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
+      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
+        Get l0
+        Get l0
 
 Source materialize.public.r
   filter=((#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL)

--- a/test/sqllogictest/explain/view.slt
+++ b/test/sqllogictest/explain/view.slt
@@ -50,6 +50,16 @@ query T multiline
 EXPLAIN LOCALLY OPTIMIZED PLAN FOR
 VIEW v;
 ----
+With
+  cte l0 =
+    Join on=(#2 = integer_to_bigint(#0))
+      Filter (#1 = 100) AND (#0) IS NOT NULL
+        Get materialize.public.accounts
+      Filter (#0) IS NOT NULL
+        Get materialize.public.account_details
+  cte l1 =
+    Filter (#1 = 100)
+      Get materialize.public.accounts
 Return
   Project (#0, #1, #3)
     Union
@@ -64,16 +74,6 @@ Return
               Distinct project=[#0]
                 Get l1
             Get l1
-With
-  cte l1 =
-    Filter (#1 = 100)
-      Get materialize.public.accounts
-  cte l0 =
-    Join on=(#2 = integer_to_bigint(#0))
-      Filter (#1 = 100) AND (#0) IS NOT NULL
-        Get materialize.public.accounts
-      Filter (#0) IS NOT NULL
-        Get materialize.public.account_details
 
 EOF
 
@@ -82,6 +82,16 @@ query T multiline
 EXPLAIN LOCALLY OPTIMIZED PLAN FOR
 REPLAN VIEW v;
 ----
+With
+  cte l0 =
+    Join on=(#2 = integer_to_bigint(#0))
+      Filter (#1 = 100) AND (#0) IS NOT NULL
+        Get materialize.public.accounts
+      Filter (#0) IS NOT NULL
+        Get materialize.public.account_details
+  cte l1 =
+    Filter (#1 = 100)
+      Get materialize.public.accounts
 Return
   Project (#0, #1, #3)
     Union
@@ -96,16 +106,6 @@ Return
               Distinct project=[#0]
                 Get l1
             Get l1
-With
-  cte l1 =
-    Filter (#1 = 100)
-      Get materialize.public.accounts
-  cte l0 =
-    Join on=(#2 = integer_to_bigint(#0))
-      Filter (#1 = 100) AND (#0) IS NOT NULL
-        Get materialize.public.accounts
-      Filter (#0) IS NOT NULL
-        Get materialize.public.account_details
 
 EOF
 
@@ -115,6 +115,13 @@ query T multiline
 EXPLAIN LOCALLY OPTIMIZED PLAN WITH(ENABLE NEW OUTER JOIN LOWERING = TRUE) FOR
 REPLAN VIEW v;
 ----
+With
+  cte l0 =
+    Join on=(#2 = integer_to_bigint(#0))
+      Filter (#0) IS NOT NULL
+        Get materialize.public.accounts
+      Filter (#0) IS NOT NULL
+        Get materialize.public.account_details
 Return
   Project (#0, #1, #3)
     Union
@@ -131,13 +138,6 @@ Return
             Get materialize.public.accounts
       Filter (#1 = 100)
         Get l0
-With
-  cte l0 =
-    Join on=(#2 = integer_to_bigint(#0))
-      Filter (#0) IS NOT NULL
-        Get materialize.public.accounts
-      Filter (#0) IS NOT NULL
-        Get materialize.public.account_details
 
 EOF
 
@@ -163,6 +163,13 @@ query T multiline
 EXPLAIN LOCALLY OPTIMIZED PLAN FOR
 VIEW v;
 ----
+With
+  cte l0 =
+    Join on=(#2 = integer_to_bigint(#0))
+      Filter (#0) IS NOT NULL
+        Get materialize.public.accounts
+      Filter (#0) IS NOT NULL
+        Get materialize.public.account_details
 Return
   Project (#0, #1, #3)
     Union
@@ -179,13 +186,6 @@ Return
             Get materialize.public.accounts
       Filter (#1 = 100)
         Get l0
-With
-  cte l0 =
-    Join on=(#2 = integer_to_bigint(#0))
-      Filter (#0) IS NOT NULL
-        Get materialize.public.accounts
-      Filter (#0) IS NOT NULL
-        Get materialize.public.account_details
 
 EOF
 
@@ -194,6 +194,16 @@ query T multiline
 EXPLAIN LOCALLY OPTIMIZED PLAN WITH(ENABLE NEW OUTER JOIN LOWERING = FALSE) FOR
 REPLAN VIEW v;
 ----
+With
+  cte l0 =
+    Join on=(#2 = integer_to_bigint(#0))
+      Filter (#1 = 100) AND (#0) IS NOT NULL
+        Get materialize.public.accounts
+      Filter (#0) IS NOT NULL
+        Get materialize.public.account_details
+  cte l1 =
+    Filter (#1 = 100)
+      Get materialize.public.accounts
 Return
   Project (#0, #1, #3)
     Union
@@ -208,15 +218,5 @@ Return
               Distinct project=[#0]
                 Get l1
             Get l1
-With
-  cte l1 =
-    Filter (#1 = 100)
-      Get materialize.public.accounts
-  cte l0 =
-    Join on=(#2 = integer_to_bigint(#0))
-      Filter (#1 = 100) AND (#0) IS NOT NULL
-        Get materialize.public.accounts
-      Filter (#0) IS NOT NULL
-        Get materialize.public.account_details
 
 EOF

--- a/test/sqllogictest/filter-pushdown.slt
+++ b/test/sqllogictest/filter-pushdown.slt
@@ -33,6 +33,12 @@ WHERE mz_now() >= insert_ms
   AND mz_now() < delete_ms;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[count(*)]
+        Project ()
+          Filter (mz_now() < numeric_to_mz_timestamp(#2{delete_ms})) AND (mz_now() >= numeric_to_mz_timestamp(#1{insert_ms}))
+            ReadStorage materialize.public.events
   Return
     Union
       Get l0
@@ -43,12 +49,6 @@ Explained Query:
               Get l0
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[count(*)]
-        Project ()
-          Filter (mz_now() < numeric_to_mz_timestamp(#2{delete_ms})) AND (mz_now() >= numeric_to_mz_timestamp(#1{insert_ms}))
-            ReadStorage materialize.public.events
 
 Source materialize.public.events
   filter=((mz_now() >= numeric_to_mz_timestamp(#1{insert_ms})) AND (mz_now() < numeric_to_mz_timestamp(#2{delete_ms})))

--- a/test/sqllogictest/github-14116.slt
+++ b/test/sqllogictest/github-14116.slt
@@ -31,6 +31,21 @@ query T multiline
 explain with(arity, join implementations) select a, b, ( select c from test3 where a = test3.a and b = test3.b) from test1;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#2) // { arity: 1 }
+        Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+          Filter (#0 = #0) AND (#1 = #1) // { arity: 2 }
+            ReadStorage materialize.public.test2 // { arity: 2 }
+    cte l1 =
+      Union // { arity: 1 }
+        Get l0 // { arity: 1 }
+        Map (error("more than one record produced in subquery")) // { arity: 1 }
+          Project () // { arity: 0 }
+            Filter (#0 > 1) // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
+                Project () // { arity: 0 }
+                  Get l0 // { arity: 1 }
   Return // { arity: 3 }
     CrossJoin type=differential // { arity: 3 }
       implementation
@@ -48,21 +63,6 @@ Explained Query:
                     Get l1 // { arity: 1 }
               Constant // { arity: 0 }
                 - ()
-  With
-    cte l1 =
-      Union // { arity: 1 }
-        Get l0 // { arity: 1 }
-        Map (error("more than one record produced in subquery")) // { arity: 1 }
-          Project () // { arity: 0 }
-            Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(*)] // { arity: 1 }
-                Project () // { arity: 0 }
-                  Get l0 // { arity: 1 }
-    cte l0 =
-      Project (#2) // { arity: 1 }
-        Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
-          Filter (#0 = #0) AND (#1 = #1) // { arity: 2 }
-            ReadStorage materialize.public.test2 // { arity: 2 }
 
 Source materialize.public.test1
 Source materialize.public.test2

--- a/test/sqllogictest/github-17808.slt
+++ b/test/sqllogictest/github-17808.slt
@@ -35,17 +35,17 @@ EXPLAIN with mutually recursive
 select * from c;
 ----
 Explained Query:
+  With Mutually Recursive
+    cte l0 =
+      Get l1
+    cte l1 =
+      ReadStorage materialize.public.foo
   Return
     Threshold
       Union
         ReadStorage materialize.public.foo
         Negate
           Get l0
-  With Mutually Recursive
-    cte l1 =
-      ReadStorage materialize.public.foo
-    cte l0 =
-      Get l1
 
 Source materialize.public.foo
 

--- a/test/sqllogictest/github-2969.slt
+++ b/test/sqllogictest/github-2969.slt
@@ -75,6 +75,22 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT *  FROM table_f1 , ( table_f4_f5_f6 AS a2 LEFT JOIN table_f5_f6 AS a3 USING ( f5 , f6  ) ) WHERE f5 = f6 AND  f4 = f6;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0..=#2) // { arity: 3 }
+        Join on=(#1 = #3) type=differential // { arity: 4 }
+          implementation
+            %0:table_f4_f5_f6[#1]Kf » %1:table_f5_f6[#0]Kf
+          ArrangeBy keys=[[#1]] // { arity: 3 }
+            Filter (#1 = #2) // { arity: 3 }
+              ReadStorage materialize.public.table_f4_f5_f6 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#0 = #1) // { arity: 2 }
+                ReadStorage materialize.public.table_f5_f6 // { arity: 2 }
+    cte l1 =
+      Filter (#0 = #1) AND (#0 = #2) AND (#1 = #2) // { arity: 3 }
+        ReadStorage materialize.public.table_f4_f5_f6 // { arity: 3 }
   Return // { arity: 4 }
     Project (#0, #2, #3, #1) // { arity: 4 }
       CrossJoin type=differential // { arity: 4 }
@@ -99,22 +115,6 @@ Explained Query:
             Get l1 // { arity: 3 }
             Filter (#0 = #1) // { arity: 3 }
               Get l0 // { arity: 3 }
-  With
-    cte l1 =
-      Filter (#0 = #1) AND (#0 = #2) AND (#1 = #2) // { arity: 3 }
-        ReadStorage materialize.public.table_f4_f5_f6 // { arity: 3 }
-    cte l0 =
-      Project (#0..=#2) // { arity: 3 }
-        Join on=(#1 = #3) type=differential // { arity: 4 }
-          implementation
-            %0:table_f4_f5_f6[#1]Kf » %1:table_f5_f6[#0]Kf
-          ArrangeBy keys=[[#1]] // { arity: 3 }
-            Filter (#1 = #2) // { arity: 3 }
-              ReadStorage materialize.public.table_f4_f5_f6 // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0 = #1) // { arity: 2 }
-                ReadStorage materialize.public.table_f5_f6 // { arity: 2 }
 
 Source materialize.public.table_f1
 Source materialize.public.table_f4_f5_f6

--- a/test/sqllogictest/github-5126.slt
+++ b/test/sqllogictest/github-5126.slt
@@ -47,6 +47,32 @@ FROM
     FROM t2
   ) AS sq1
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 3 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.t1 // { arity: 3 }
+  cte l1 =
+    CrossJoin // { arity: 3 }
+      Distinct project=[#1] // { arity: 1 }
+        Get l0 // { arity: 3 }
+      Get materialize.public.t2 // { arity: 2 }
+  cte l2 =
+    Distinct project=[#0..=#2] // { arity: 3 }
+      Get l1 // { arity: 3 }
+  cte l3 =
+    Project (#0..=#3) // { arity: 4 }
+      Map (3) // { arity: 4 }
+        Get l2 // { arity: 3 }
+  cte l4 =
+    Union // { arity: 4 }
+      Get l3 // { arity: 4 }
+      Map (error("more than one record produced in subquery")) // { arity: 4 }
+        Project (#0..=#2) // { arity: 3 }
+          Filter (#3 > 1) // { arity: 4 }
+            Reduce group_by=[#0..=#2] aggregates=[count(*)] // { arity: 4 }
+              Get l3 // { arity: 4 }
 Return // { arity: 3 }
   Project (#3..=#5) // { arity: 3 }
     Project (#0..=#2, #4..=#6) // { arity: 6 }
@@ -72,32 +98,6 @@ Return // { arity: 3 }
                           Get l2 // { arity: 3 }
                       Constant // { arity: 1 }
                         - (null)
-With
-  cte l4 =
-    Union // { arity: 4 }
-      Get l3 // { arity: 4 }
-      Map (error("more than one record produced in subquery")) // { arity: 4 }
-        Project (#0..=#2) // { arity: 3 }
-          Filter (#3 > 1) // { arity: 4 }
-            Reduce group_by=[#0..=#2] aggregates=[count(*)] // { arity: 4 }
-              Get l3 // { arity: 4 }
-  cte l3 =
-    Project (#0..=#3) // { arity: 4 }
-      Map (3) // { arity: 4 }
-        Get l2 // { arity: 3 }
-  cte l2 =
-    Distinct project=[#0..=#2] // { arity: 3 }
-      Get l1 // { arity: 3 }
-  cte l1 =
-    CrossJoin // { arity: 3 }
-      Distinct project=[#1] // { arity: 1 }
-        Get l0 // { arity: 3 }
-      Get materialize.public.t2 // { arity: 2 }
-  cte l0 =
-    CrossJoin // { arity: 3 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.public.t1 // { arity: 3 }
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -116,6 +116,13 @@ FROM l as l1, l as l2, l as l3
 WHERE l1.la + 1 = l2.la AND l3.la = l1.la + l2.la
 ----
 Explained Query:
+  With
+    cte l0 =
+      Filter (#0) IS NOT NULL // { arity: 2 }
+        ReadStorage materialize.public.l // { arity: 2 }
+    cte l1 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Get l0 // { arity: 2 }
   Return // { arity: 3 }
     Project (#0, #2, #4) // { arity: 3 }
       Join on=(#1 = (#0 + 1) AND #3 = (#0 + #1)) type=delta // { arity: 5 }
@@ -128,13 +135,6 @@ Explained Query:
             Get l0 // { arity: 2 }
         Get l1 // { arity: 2 }
         Get l1 // { arity: 2 }
-  With
-    cte l1 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        Get l0 // { arity: 2 }
-    cte l0 =
-      Filter (#0) IS NOT NULL // { arity: 2 }
-        ReadStorage materialize.public.l // { arity: 2 }
 
 Source materialize.public.l
   filter=((#0) IS NOT NULL)
@@ -163,6 +163,19 @@ WHERE l1.la IN (
 )
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0) // { arity: 1 }
+        ReadStorage materialize.public.l // { arity: 2 }
+    cte l1 =
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0[×] » %1:l0[×]
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Distinct project=[#0] // { arity: 1 }
+            Get l0 // { arity: 1 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Get l0 // { arity: 1 }
   Return // { arity: 2 }
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2) type=differential // { arity: 3 }
@@ -191,19 +204,6 @@ Explained Query:
                     Project (#0) // { arity: 1 }
                       Filter (#0) IS NOT NULL // { arity: 2 }
                         ReadStorage materialize.public.l // { arity: 2 }
-  With
-    cte l1 =
-      CrossJoin type=differential // { arity: 2 }
-        implementation
-          %0[×] » %1:l0[×]
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Distinct project=[#0] // { arity: 1 }
-            Get l0 // { arity: 1 }
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Get l0 // { arity: 1 }
-    cte l0 =
-      Project (#0) // { arity: 1 }
-        ReadStorage materialize.public.l // { arity: 2 }
 
 Source materialize.public.l
 
@@ -329,6 +329,20 @@ EXPLAIN WITH(arity, join implementations)
 SELECT * FROM l LEFT JOIN r ON l.la = r.ra
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.l // { arity: 2 }
+    cte l1 =
+      Project (#0, #1, #3) // { arity: 3 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %0:l0[#0]K » %1:r[#0]K
+          Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              ReadStorage materialize.public.r // { arity: 2 }
   Return // { arity: 4 }
     Union // { arity: 4 }
       Map (null, null) // { arity: 4 }
@@ -346,20 +360,6 @@ Explained Query:
           ReadStorage materialize.public.l // { arity: 2 }
       Project (#0, #1, #0, #2) // { arity: 4 }
         Get l1 // { arity: 3 }
-  With
-    cte l1 =
-      Project (#0, #1, #3) // { arity: 3 }
-        Join on=(#0 = #2) type=differential // { arity: 4 }
-          implementation
-            %0:l0[#0]K » %1:r[#0]K
-          Get l0 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.r // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          ReadStorage materialize.public.l // { arity: 2 }
 
 Source materialize.public.l
 Source materialize.public.r
@@ -374,6 +374,20 @@ EXPLAIN WITH(arity, join implementations)
 SELECT * FROM l RIGHT JOIN r ON l.la = r.ra
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.r // { arity: 2 }
+    cte l1 =
+      Project (#0, #1, #3) // { arity: 3 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %0:l[#0]K » %1:l0[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              ReadStorage materialize.public.l // { arity: 2 }
+          Get l0 // { arity: 2 }
   Return // { arity: 4 }
     Union // { arity: 4 }
       Project (#2, #3, #0, #1) // { arity: 4 }
@@ -392,20 +406,6 @@ Explained Query:
             ReadStorage materialize.public.r // { arity: 2 }
       Project (#0, #1, #0, #2) // { arity: 4 }
         Get l1 // { arity: 3 }
-  With
-    cte l1 =
-      Project (#0, #1, #3) // { arity: 3 }
-        Join on=(#0 = #2) type=differential // { arity: 4 }
-          implementation
-            %0:l[#0]K » %1:l0[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.l // { arity: 2 }
-          Get l0 // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          ReadStorage materialize.public.r // { arity: 2 }
 
 Source materialize.public.l
   filter=((#0) IS NOT NULL)
@@ -420,6 +420,27 @@ EXPLAIN WITH(arity, join implementations)
 SELECT * FROM l FULL JOIN r ON l.la = r.ra
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.l // { arity: 2 }
+    cte l1 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.r // { arity: 2 }
+    cte l2 =
+      Project (#0, #1, #3) // { arity: 3 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %0:l0[#0]K » %1:l1[#0]K
+          Get l0 // { arity: 2 }
+          Get l1 // { arity: 2 }
+    cte l3 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Distinct project=[#0] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Get l2 // { arity: 3 }
   Return // { arity: 4 }
     Union // { arity: 4 }
       Project (#2, #3, #0, #1) // { arity: 4 }
@@ -445,27 +466,6 @@ Explained Query:
           ReadStorage materialize.public.l // { arity: 2 }
       Project (#0, #1, #0, #2) // { arity: 4 }
         Get l2 // { arity: 3 }
-  With
-    cte l3 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Distinct project=[#0] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Get l2 // { arity: 3 }
-    cte l2 =
-      Project (#0, #1, #3) // { arity: 3 }
-        Join on=(#0 = #2) type=differential // { arity: 4 }
-          implementation
-            %0:l0[#0]K » %1:l1[#0]K
-          Get l0 // { arity: 2 }
-          Get l1 // { arity: 2 }
-    cte l1 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          ReadStorage materialize.public.r // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          ReadStorage materialize.public.l // { arity: 2 }
 
 Source materialize.public.l
 Source materialize.public.r
@@ -547,6 +547,10 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT name, id FROM v4362 WHERE name = (SELECT name FROM v4362 WHERE id = 1)
 ----
 Explained Query:
+  With
+    cte l0 =
+      Filter (#1 = 1) // { arity: 2 }
+        ReadStorage materialize.public.t4362 // { arity: 2 }
   Return // { arity: 2 }
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2) type=differential // { arity: 3 }
@@ -564,10 +568,6 @@ Explained Query:
                   Reduce aggregates=[count(*)] // { arity: 1 }
                     Project () // { arity: 0 }
                       Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      Filter (#1 = 1) // { arity: 2 }
-        ReadStorage materialize.public.t4362 // { arity: 2 }
 
 Source materialize.public.t4362
 
@@ -1162,6 +1162,22 @@ SELECT (SELECT NULL FROM a) AS c1, ref_0."?column?" AS c4 FROM b AS ref_0
 WHERE EXISTS (SELECT FROM c AS ref_7 WHERE EXISTS (SELECT ref_0."?column?" AS c2)) OR ref_0."?column?" IS NOT NULL;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[] // { arity: 0 }
+        Project () // { arity: 0 }
+          ReadStorage materialize.public.c // { arity: 1 }
+    cte l1 =
+      Union // { arity: 1 }
+        Project (#2) // { arity: 1 }
+          Map (null) // { arity: 3 }
+            ReadStorage materialize.public.a // { arity: 2 }
+        Map (error("more than one record produced in subquery")) // { arity: 1 }
+          Project () // { arity: 0 }
+            Filter (#0 > 1) // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
+                Project () // { arity: 0 }
+                  ReadStorage materialize.public.a // { arity: 2 }
   Return // { arity: 2 }
     Map (4) // { arity: 2 }
       CrossJoin type=differential // { arity: 1 }
@@ -1185,22 +1201,6 @@ Explained Query:
                       Get l1 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
-  With
-    cte l1 =
-      Union // { arity: 1 }
-        Project (#2) // { arity: 1 }
-          Map (null) // { arity: 3 }
-            ReadStorage materialize.public.a // { arity: 2 }
-        Map (error("more than one record produced in subquery")) // { arity: 1 }
-          Project () // { arity: 0 }
-            Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(*)] // { arity: 1 }
-                Project () // { arity: 0 }
-                  ReadStorage materialize.public.a // { arity: 2 }
-    cte l0 =
-      Distinct project=[] // { arity: 0 }
-        Project () // { arity: 0 }
-          ReadStorage materialize.public.c // { arity: 1 }
 
 Source materialize.public.a
 Source materialize.public.c
@@ -1229,6 +1229,14 @@ query T multiline
 EXPLAIN SELECT sum(a + b) FROM fuel_test_1, fuel_test_2
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[sum((#0 + #1))]
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            ReadStorage materialize.public.fuel_test_1
+          ArrangeBy keys=[[]]
+            ReadStorage materialize.public.fuel_test_2
   Return
     Union
       Get l0
@@ -1239,14 +1247,6 @@ Explained Query:
               Get l0
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum((#0 + #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            ReadStorage materialize.public.fuel_test_1
-          ArrangeBy keys=[[]]
-            ReadStorage materialize.public.fuel_test_2
 
 Source materialize.public.fuel_test_1
 Source materialize.public.fuel_test_2

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -441,6 +441,12 @@ SELECT messageYear, isComment, lengthCategory
 ----
 Explained Query:
   Finish order_by=[#0 desc nulls_first, #1 asc nulls_last, #2 asc nulls_last] output=[#0..=#6]
+    With
+      cte l0 =
+        Reduce aggregates=[count(*)] // { arity: 1 }
+          Project () // { arity: 0 }
+            Filter (#0{creationdate} < 2010-06-11 09:21:46 UTC) // { arity: 13 }
+              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
     Return // { arity: 7 }
       Project (#0..=#2, #4, #7, #5{sum}, #8) // { arity: 7 }
         Map ((#5{sum} / bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end)), (bigint_to_numeric(#4{count}) / #3)) // { arity: 9 }
@@ -465,12 +471,6 @@ Explained Query:
                               Get l0 // { arity: 1 }
                           Constant // { arity: 0 }
                             - ()
-    With
-      cte l0 =
-        Reduce aggregates=[count(*)] // { arity: 1 }
-          Project () // { arity: 0 }
-            Filter (#0{creationdate} < 2010-06-11 09:21:46 UTC) // { arity: 13 }
-              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
   - materialize.public.message_messageid (*** full scan ***)
@@ -518,19 +518,19 @@ SELECT t.name AS "tag.name"
 ----
 Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0..=#3]
-    Return // { arity: 4 }
-      Project (#0{name}, #3..=#5) // { arity: 4 }
-        Map (coalesce(#1{count}, 0), coalesce(#2{count}, 0), abs((#3 - #4))) // { arity: 6 }
-          Union // { arity: 3 }
-            Map (null, null) // { arity: 3 }
-              Union // { arity: 1 }
-                Negate // { arity: 1 }
-                  Project (#0{name}) // { arity: 1 }
-                    Get l2 // { arity: 3 }
-                Project (#1) // { arity: 1 }
-                  Get l0 // { arity: 2 }
-            Get l2 // { arity: 3 }
     With
+      cte l0 =
+        Project (#5, #6) // { arity: 2 }
+          Join on=(#0{id} = #8{typetagclassid}) type=differential // { arity: 9 }
+            implementation
+              %0:tagclass[#0]KAe » %1:tag[#3]KAe
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("ChristianBishop")] // { arity: 5 }
+            ArrangeBy keys=[[#3{typetagclassid}]] // { arity: 4 }
+              ReadIndex on=tag tag_typetagclassid=[differential join] // { arity: 4 }
+      cte l1 =
+        Filter (#0{id}) IS NOT NULL // { arity: 2 }
+          Get l0 // { arity: 2 }
       cte l2 =
         Project (#1{count}, #3, #4) // { arity: 3 }
           Join on=(#0{id} = #2{id}) type=differential // { arity: 5 }
@@ -554,18 +554,18 @@ Explained Query:
                         ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
                       ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
                         ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
-      cte l1 =
-        Filter (#0{id}) IS NOT NULL // { arity: 2 }
-          Get l0 // { arity: 2 }
-      cte l0 =
-        Project (#5, #6) // { arity: 2 }
-          Join on=(#0{id} = #8{typetagclassid}) type=differential // { arity: 9 }
-            implementation
-              %0:tagclass[#0]KAe » %1:tag[#3]KAe
-            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-              ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("ChristianBishop")] // { arity: 5 }
-            ArrangeBy keys=[[#3{typetagclassid}]] // { arity: 4 }
-              ReadIndex on=tag tag_typetagclassid=[differential join] // { arity: 4 }
+    Return // { arity: 4 }
+      Project (#0{name}, #3..=#5) // { arity: 4 }
+        Map (coalesce(#1{count}, 0), coalesce(#2{count}, 0), abs((#3 - #4))) // { arity: 6 }
+          Union // { arity: 3 }
+            Map (null, null) // { arity: 3 }
+              Union // { arity: 1 }
+                Negate // { arity: 1 }
+                  Project (#0{name}) // { arity: 1 }
+                    Get l2 // { arity: 3 }
+                Project (#1) // { arity: 1 }
+                  Get l0 // { arity: 2 }
+            Get l2 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_typetagclassid (differential join)
@@ -741,40 +741,13 @@ LIMIT 100
 ----
 Explained Query:
   Finish order_by=[#4{count_messageid} desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
-    Return // { arity: 5 }
-      Reduce group_by=[#1{id}..=#3{lastname}, #0{creationdate}] aggregates=[count(#4{messageid})] // { arity: 5 }
-        Union // { arity: 5 }
-          Map (null) // { arity: 5 }
-            Union // { arity: 4 }
-              Negate // { arity: 4 }
-                Project (#0{creationdate}..=#3{lastname}) // { arity: 4 }
-                  Join on=(#1{id} = #4{id}) type=differential // { arity: 5 }
-                    implementation
-                      %1[#0]UKA » %0:l2[#1]K
-                    Get l2 // { arity: 4 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                      Distinct project=[#0{id}] // { arity: 1 }
-                        Project (#1) // { arity: 1 }
-                          Get l3 // { arity: 5 }
-              Get l1 // { arity: 4 }
-          Get l3 // { arity: 5 }
     With
-      cte l3 =
-        Project (#0{creationdate}..=#3{lastname}, #5) // { arity: 5 }
-          Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{id}) type=delta // { arity: 18 }
-            implementation
-              %0:l2 » %1:message[#9]KA » %2[#0]UKA
-              %1:message » %2[#0]UKA » %0:l2[#1]K
-              %2 » %1:message[#10]KA » %0:l2[#1]K
-            Get l2 // { arity: 4 }
-            ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
-              ReadIndex on=message message_containerforumid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Get l0 // { arity: 1 }
-      cte l2 =
-        ArrangeBy keys=[[#1{id}]] // { arity: 4 }
-          Get l1 // { arity: 4 }
+      cte l0 =
+        Project (#0{id}) // { arity: 1 }
+          TopK order_by=[#1{maxnumberofmembers} desc nulls_first, #0{id} asc nulls_last] limit=100 // { arity: 2 }
+            Project (#0{id}, #2) // { arity: 2 }
+              Filter (#1{creationdate} > 2010-02-12 00:00:00 UTC) // { arity: 3 }
+                ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
       cte l1 =
         Project (#0{creationdate}..=#3{lastname}) // { arity: 4 }
           Join on=(#1{id} = #11{personid}) type=differential // { arity: 12 }
@@ -792,12 +765,39 @@ Explained Query:
                       Get l0 // { arity: 1 }
                     ArrangeBy keys=[[#1{forumid}]] // { arity: 3 }
                       ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[differential join] // { arity: 3 }
-      cte l0 =
-        Project (#0{id}) // { arity: 1 }
-          TopK order_by=[#1{maxnumberofmembers} desc nulls_first, #0{id} asc nulls_last] limit=100 // { arity: 2 }
-            Project (#0{id}, #2) // { arity: 2 }
-              Filter (#1{creationdate} > 2010-02-12 00:00:00 UTC) // { arity: 3 }
-                ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
+      cte l2 =
+        ArrangeBy keys=[[#1{id}]] // { arity: 4 }
+          Get l1 // { arity: 4 }
+      cte l3 =
+        Project (#0{creationdate}..=#3{lastname}, #5) // { arity: 5 }
+          Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{id}) type=delta // { arity: 18 }
+            implementation
+              %0:l2 » %1:message[#9]KA » %2[#0]UKA
+              %1:message » %2[#0]UKA » %0:l2[#1]K
+              %2 » %1:message[#10]KA » %0:l2[#1]K
+            Get l2 // { arity: 4 }
+            ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
+              ReadIndex on=message message_containerforumid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
+                Get l0 // { arity: 1 }
+    Return // { arity: 5 }
+      Reduce group_by=[#1{id}..=#3{lastname}, #0{creationdate}] aggregates=[count(#4{messageid})] // { arity: 5 }
+        Union // { arity: 5 }
+          Map (null) // { arity: 5 }
+            Union // { arity: 4 }
+              Negate // { arity: 4 }
+                Project (#0{creationdate}..=#3{lastname}) // { arity: 4 }
+                  Join on=(#1{id} = #4{id}) type=differential // { arity: 5 }
+                    implementation
+                      %1[#0]UKA » %0:l2[#1]K
+                    Get l2 // { arity: 4 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                      Distinct project=[#0{id}] // { arity: 1 }
+                        Project (#1) // { arity: 1 }
+                          Get l3 // { arity: 5 }
+              Get l1 // { arity: 4 }
+          Get l3 // { arity: 5 }
 
 Used Indexes:
   - materialize.public.person_id (differential join)
@@ -844,6 +844,33 @@ SELECT CreatorPersonId AS "person.id"
 ----
 Explained Query:
   Finish order_by=[#4 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0..=#4]
+    With
+      cte l0 =
+        Project (#1{messageid}, #5, #16) // { arity: 3 }
+          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
+            implementation
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+      cte l1 =
+        Reduce group_by=[#0{parentmessageid}] aggregates=[count(*)] // { arity: 2 }
+          Project (#12) // { arity: 1 }
+            Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+      cte l2 =
+        Reduce group_by=[#0{messageid}] aggregates=[count(*)] // { arity: 2 }
+          Project (#2) // { arity: 1 }
+            ReadIndex on=person_likes_message person_likes_message_personid=[*** full scan ***] // { arity: 3 }
+      cte l3 =
+        Distinct project=[#0{messageid}] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Get l0 // { arity: 3 }
     Return // { arity: 5 }
       Map (((bigint_to_numeric((1 * #3{count})) + (2 * #1{sum})) + (10 * #2{sum}))) // { arity: 5 }
         Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(case when (#2) IS NULL then null else #1{count} end, 0)), sum(coalesce(case when (#4) IS NULL then null else #3{count} end, 0)), count(*)] // { arity: 4 }
@@ -879,33 +906,6 @@ Explained Query:
                           Project (#0{messageid}) // { arity: 1 }
                             Get l2 // { arity: 2 }
                         Get l3 // { arity: 1 }
-    With
-      cte l3 =
-        Distinct project=[#0{messageid}] // { arity: 1 }
-          Project (#1) // { arity: 1 }
-            Get l0 // { arity: 3 }
-      cte l2 =
-        Reduce group_by=[#0{messageid}] aggregates=[count(*)] // { arity: 2 }
-          Project (#2) // { arity: 1 }
-            ReadIndex on=person_likes_message person_likes_message_personid=[*** full scan ***] // { arity: 3 }
-      cte l1 =
-        Reduce group_by=[#0{parentmessageid}] aggregates=[count(*)] // { arity: 2 }
-          Project (#12) // { arity: 1 }
-            Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-      cte l0 =
-        Project (#1{messageid}, #5, #16) // { arity: 3 }
-          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-              %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
-              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
-            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join 1st input (full scan))
@@ -971,28 +971,31 @@ LIMIT 100
 ----
 Explained Query:
   Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
-    Return // { arity: 2 }
-      Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
-        Union // { arity: 2 }
-          Map (null) // { arity: 2 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Project (#0{creatorpersonid}) // { arity: 1 }
-                  Get l4 // { arity: 2 }
-              Project (#0{creatorpersonid}) // { arity: 1 }
-                Get l3 // { arity: 2 }
-          Get l4 // { arity: 2 }
     With
-      cte l4 =
-        Project (#0{creatorpersonid}, #3) // { arity: 2 }
-          Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
+      cte l0 =
+        Project (#6, #17) // { arity: 2 }
+          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
             implementation
-              %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
-            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
-              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
-                Get l3 // { arity: 2 }
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+      cte l1 =
+        ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
+          Get l0 // { arity: 2 }
+      cte l2 =
+        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
+          Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
+            implementation
+              %1:person_likes_message[#2]KA » %0:l1[#0]K
+            Get l1 // { arity: 2 }
+            ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
+              ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l3 =
         Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
           Union // { arity: 2 }
@@ -1012,30 +1015,27 @@ Explained Query:
                   Get l0 // { arity: 2 }
             Project (#1{personid}, #2) // { arity: 2 }
               Get l2 // { arity: 3 }
-      cte l2 =
-        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
-          Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
+      cte l4 =
+        Project (#0{creatorpersonid}, #3) // { arity: 2 }
+          Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %1:person_likes_message[#2]KA » %0:l1[#0]K
-            Get l1 // { arity: 2 }
-            ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
-              ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
-      cte l1 =
-        ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-          Get l0 // { arity: 2 }
-      cte l0 =
-        Project (#6, #17) // { arity: 2 }
-          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-              %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
-              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
-            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+              %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
+            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
+              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
+                Get l3 // { arity: 2 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+              ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
+    Return // { arity: 2 }
+      Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
+        Union // { arity: 2 }
+          Map (null) // { arity: 2 }
+            Union // { arity: 1 }
+              Negate // { arity: 1 }
+                Project (#0{creatorpersonid}) // { arity: 1 }
+                  Get l4 // { arity: 2 }
+              Project (#0{creatorpersonid}) // { arity: 1 }
+                Get l3 // { arity: 2 }
+          Get l4 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -1077,28 +1077,31 @@ LIMIT 100
 ----
 Explained Query:
   Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
-    Return // { arity: 2 }
-      Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
-        Union // { arity: 2 }
-          Map (null) // { arity: 2 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Project (#0{creatorpersonid}) // { arity: 1 }
-                  Get l4 // { arity: 2 }
-              Project (#0{creatorpersonid}) // { arity: 1 }
-                Get l3 // { arity: 2 }
-          Get l4 // { arity: 2 }
     With
-      cte l4 =
-        Project (#0{creatorpersonid}, #3) // { arity: 2 }
-          Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
+      cte l0 =
+        Project (#6, #17) // { arity: 2 }
+          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
             implementation
-              %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
-            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
-              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
-                Get l3 // { arity: 2 }
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+      cte l1 =
+        ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
+          Get l0 // { arity: 2 }
+      cte l2 =
+        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
+          Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
+            implementation
+              %1:person_likes_message[#2]KA » %0:l1[#0]K
+            Get l1 // { arity: 2 }
+            ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
+              ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l3 =
         Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
           Union // { arity: 2 }
@@ -1118,30 +1121,27 @@ Explained Query:
                   Get l0 // { arity: 2 }
             Project (#1{personid}, #2) // { arity: 2 }
               Get l2 // { arity: 3 }
-      cte l2 =
-        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
-          Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
+      cte l4 =
+        Project (#0{creatorpersonid}, #3) // { arity: 2 }
+          Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %1:person_likes_message[#2]KA » %0:l1[#0]K
-            Get l1 // { arity: 2 }
-            ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
-              ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
-      cte l1 =
-        ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-          Get l0 // { arity: 2 }
-      cte l0 =
-        Project (#6, #17) // { arity: 2 }
-          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-              %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
-              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
-            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+              %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
+            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
+              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
+                Get l3 // { arity: 2 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+              ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
+    Return // { arity: 2 }
+      Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
+        Union // { arity: 2 }
+          Map (null) // { arity: 2 }
+            Union // { arity: 1 }
+              Negate // { arity: 1 }
+                Project (#0{creatorpersonid}) // { arity: 1 }
+                  Get l4 // { arity: 2 }
+              Project (#0{creatorpersonid}) // { arity: 1 }
+                Get l3 // { arity: 2 }
+          Get l4 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -1184,28 +1184,32 @@ LIMIT 100
 ----
 Explained Query:
   Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
-    Return // { arity: 2 }
-      Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
-        Union // { arity: 2 }
-          Map (null) // { arity: 2 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Project (#0{creatorpersonid}) // { arity: 1 }
-                  Get l4 // { arity: 2 }
-              Project (#0{creatorpersonid}) // { arity: 1 }
-                Get l3 // { arity: 2 }
-          Get l4 // { arity: 2 }
     With
-      cte l4 =
-        Project (#0{creatorpersonid}, #3) // { arity: 2 }
-          Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
+      cte l0 =
+        Project (#1{messageid}, #5, #16) // { arity: 3 }
+          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
             implementation
-              %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
-            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
-              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
-                Get l3 // { arity: 2 }
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+      cte l1 =
+        Project (#0{name}..=#2{creatorpersonid}, #4) // { arity: 4 }
+          Join on=(#1{messageid} = #5{messageid}) type=differential // { arity: 6 }
+            implementation
+              %1:person_likes_message[#2]KA » %0:l0[#1]K
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 3 }
+              Get l0 // { arity: 3 }
+            ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
+              ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
+      cte l2 =
+        Filter (#0{name} = "Bob_Geldof") // { arity: 3 }
+          Get l0 // { arity: 3 }
       cte l3 =
         Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
           Union // { arity: 2 }
@@ -1228,31 +1232,27 @@ Explained Query:
             Project (#2, #3) // { arity: 2 }
               Filter (#0{name} = "Bob_Geldof") // { arity: 4 }
                 Get l1 // { arity: 4 }
-      cte l2 =
-        Filter (#0{name} = "Bob_Geldof") // { arity: 3 }
-          Get l0 // { arity: 3 }
-      cte l1 =
-        Project (#0{name}..=#2{creatorpersonid}, #4) // { arity: 4 }
-          Join on=(#1{messageid} = #5{messageid}) type=differential // { arity: 6 }
+      cte l4 =
+        Project (#0{creatorpersonid}, #3) // { arity: 2 }
+          Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %1:person_likes_message[#2]KA » %0:l0[#1]K
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 3 }
-              Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
-              ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
-      cte l0 =
-        Project (#1{messageid}, #5, #16) // { arity: 3 }
-          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-              %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
-              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
-            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+              %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
+            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
+              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
+                Get l3 // { arity: 2 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+              ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
+    Return // { arity: 2 }
+      Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
+        Union // { arity: 2 }
+          Map (null) // { arity: 2 }
+            Union // { arity: 1 }
+              Negate // { arity: 1 }
+                Project (#0{creatorpersonid}) // { arity: 1 }
+                  Get l4 // { arity: 2 }
+              Project (#0{creatorpersonid}) // { arity: 1 }
+                Get l3 // { arity: 2 }
+          Get l4 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join 1st input (full scan))
@@ -1301,6 +1301,36 @@ SELECT RelatedTag.name AS "relatedTag.name"
 ----
 Explained Query:
   Finish order_by=[#1{count} desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0, #1]
+    With
+      cte l0 =
+        Project (#1) // { arity: 1 }
+          Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+            implementation
+              %1:tag[#0]KAe » %0:message_hastag_tag[#2]KAe
+            ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
+      cte l1 =
+        Project (#2, #18) // { arity: 2 }
+          Join on=(#0{messageid} = #13{parentmessageid} AND #2{messageid} = #15{messageid} AND #16{tagid} = #17{id}) type=delta // { arity: 21 }
+            implementation
+              %0:l0 » %1:message[#12]KA » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA
+              %1:message » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
+              %2:message_hastag_tag » %1:message[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
+              %3:tag » %2:message_hastag_tag[#2]KA » %1:message[#1]KA » %0:l0[#0]K
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Get l0 // { arity: 1 }
+            ArrangeBy keys=[[#1{messageid}], [#12{parentmessageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+              ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
+      cte l2 =
+        Distinct project=[#0{messageid}] // { arity: 1 }
+          Project (#0{messageid}) // { arity: 1 }
+            Get l1 // { arity: 2 }
     Return // { arity: 2 }
       Reduce group_by=[#0{name}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
@@ -1322,36 +1352,6 @@ Explained Query:
                         Distinct project=[#0{messageid}] // { arity: 1 }
                           Get l0 // { arity: 1 }
                 Get l2 // { arity: 1 }
-    With
-      cte l2 =
-        Distinct project=[#0{messageid}] // { arity: 1 }
-          Project (#0{messageid}) // { arity: 1 }
-            Get l1 // { arity: 2 }
-      cte l1 =
-        Project (#2, #18) // { arity: 2 }
-          Join on=(#0{messageid} = #13{parentmessageid} AND #2{messageid} = #15{messageid} AND #16{tagid} = #17{id}) type=delta // { arity: 21 }
-            implementation
-              %0:l0 » %1:message[#12]KA » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA
-              %1:message » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
-              %2:message_hastag_tag » %1:message[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
-              %3:tag » %2:message_hastag_tag[#2]KA » %1:message[#1]KA » %0:l0[#0]K
-            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-              Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#1{messageid}], [#12{parentmessageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-              ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
-      cte l0 =
-        Project (#1) // { arity: 1 }
-          Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-            implementation
-              %1:tag[#0]KAe » %0:message_hastag_tag[#2]KAe
-            ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join lookup)
@@ -1420,6 +1420,79 @@ SELECT p.PersonId AS "person.id"
 ----
 Explained Query:
   Finish order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0, #1, #3]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#1{id}]] // { arity: 11 }
+          ReadIndex on=person person_id=[delta join lookup, delta join 1st input (full scan)] // { arity: 11 }
+      cte l1 =
+        ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+          ReadIndex on=materialize.public.tag tag_name=[lookup value=("Abbas_I_of_Persia")] // { arity: 5 }
+      cte l2 =
+        Project (#1) // { arity: 1 }
+          Join on=(#1{id} = #11{personid} AND #12{tagid} = #13{id}) type=delta // { arity: 18 }
+            implementation
+              %0:l0 » %1:person_hasinterest_tag[#0]K » %2:l1[#0]KAe
+              %1:person_hasinterest_tag » %2:l1[#0]KAe » %0:l0[#1]KA
+              %2:l1 » %1:person_hasinterest_tag[#1]KA » %0:l0[#1]KA
+            Get l0 // { arity: 11 }
+            ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
+              Project (#1{tagid}, #2) // { arity: 2 }
+                ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
+            Get l1 // { arity: 5 }
+      cte l3 =
+        Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*)] // { arity: 2 }
+          Project (#17) // { arity: 1 }
+            Filter (#8{creationdate} < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8{creationdate}) // { arity: 32 }
+              Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid} AND #17{creatorpersonid} = #22{id}) type=delta // { arity: 32 }
+                implementation
+                  %0:l1 » %1:message_hastag_tag[#2]KA » %2:message[#1]KAiif » %3:l0[#1]KA
+                  %1:message_hastag_tag » %0:l1[#0]KAe » %2:message[#1]KAiif » %3:l0[#1]KA
+                  %2:message » %1:message_hastag_tag[#1]KA » %0:l1[#0]KAe » %3:l0[#1]KA
+                  %3:l0 » %2:message[#9]KAiif » %1:message_hastag_tag[#1]KA » %0:l1[#0]KAe
+                Get l1 // { arity: 5 }
+                ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+                  ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+                ArrangeBy keys=[[#1{messageid}], [#9{creatorpersonid}]] // { arity: 13 }
+                  ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
+                Get l0 // { arity: 11 }
+      cte l4 =
+        ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 2 }
+          Get l3 // { arity: 2 }
+      cte l5 =
+        Project (#0{id}, #2) // { arity: 2 }
+          Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 3 }
+            implementation
+              %1:l4[#0]UKA » %0:l2[#0]K
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Get l2 // { arity: 1 }
+            Get l4 // { arity: 2 }
+      cte l6 =
+        Project (#0{id}) // { arity: 1 }
+          Get l5 // { arity: 2 }
+      cte l7 =
+        Project (#3, #4) // { arity: 2 }
+          Map (coalesce(#0{id}, #1{creatorpersonid}), (integer_to_bigint(case when (#0{id}) IS NULL then 0 else 100 end) + coalesce(#2{count}, 0))) // { arity: 5 }
+            Union // { arity: 3 }
+              Project (#2{count}, #0, #1{creatorpersonid}) // { arity: 3 }
+                Map (null) // { arity: 3 }
+                  Union // { arity: 2 }
+                    Negate // { arity: 2 }
+                      Project (#0{creatorpersonid}, #1{count}) // { arity: 2 }
+                        Join on=(#0{creatorpersonid} = #2{id}) type=differential // { arity: 3 }
+                          implementation
+                            %0:l4[#0]UKA » %1[#0]UKA
+                          Get l4 // { arity: 2 }
+                          ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                            Distinct project=[#0{id}] // { arity: 1 }
+                              Get l6 // { arity: 1 }
+                    Get l3 // { arity: 2 }
+              Map (null, null) // { arity: 3 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Get l6 // { arity: 1 }
+                  Get l2 // { arity: 1 }
+              Project (#0{id}, #0{id}, #1{id}) // { arity: 3 }
+                Get l5 // { arity: 2 }
     Return // { arity: 5 }
       Map (coalesce(#2{sum}, 0), (bigint_to_numeric(#1) + #3)) // { arity: 5 }
         Reduce group_by=[#0, #1] aggregates=[sum(case when (#3) IS NULL then null else #2 end)] // { arity: 3 }
@@ -1466,79 +1539,6 @@ Explained Query:
                               ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                             Constant // { arity: 1 }
                               - (null)
-    With
-      cte l7 =
-        Project (#3, #4) // { arity: 2 }
-          Map (coalesce(#0{id}, #1{creatorpersonid}), (integer_to_bigint(case when (#0{id}) IS NULL then 0 else 100 end) + coalesce(#2{count}, 0))) // { arity: 5 }
-            Union // { arity: 3 }
-              Project (#2{count}, #0, #1{creatorpersonid}) // { arity: 3 }
-                Map (null) // { arity: 3 }
-                  Union // { arity: 2 }
-                    Negate // { arity: 2 }
-                      Project (#0{creatorpersonid}, #1{count}) // { arity: 2 }
-                        Join on=(#0{creatorpersonid} = #2{id}) type=differential // { arity: 3 }
-                          implementation
-                            %0:l4[#0]UKA » %1[#0]UKA
-                          Get l4 // { arity: 2 }
-                          ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                            Distinct project=[#0{id}] // { arity: 1 }
-                              Get l6 // { arity: 1 }
-                    Get l3 // { arity: 2 }
-              Map (null, null) // { arity: 3 }
-                Union // { arity: 1 }
-                  Negate // { arity: 1 }
-                    Get l6 // { arity: 1 }
-                  Get l2 // { arity: 1 }
-              Project (#0{id}, #0{id}, #1{id}) // { arity: 3 }
-                Get l5 // { arity: 2 }
-      cte l6 =
-        Project (#0{id}) // { arity: 1 }
-          Get l5 // { arity: 2 }
-      cte l5 =
-        Project (#0{id}, #2) // { arity: 2 }
-          Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 3 }
-            implementation
-              %1:l4[#0]UKA » %0:l2[#0]K
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Get l2 // { arity: 1 }
-            Get l4 // { arity: 2 }
-      cte l4 =
-        ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 2 }
-          Get l3 // { arity: 2 }
-      cte l3 =
-        Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*)] // { arity: 2 }
-          Project (#17) // { arity: 1 }
-            Filter (#8{creationdate} < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8{creationdate}) // { arity: 32 }
-              Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid} AND #17{creatorpersonid} = #22{id}) type=delta // { arity: 32 }
-                implementation
-                  %0:l1 » %1:message_hastag_tag[#2]KA » %2:message[#1]KAiif » %3:l0[#1]KA
-                  %1:message_hastag_tag » %0:l1[#0]KAe » %2:message[#1]KAiif » %3:l0[#1]KA
-                  %2:message » %1:message_hastag_tag[#1]KA » %0:l1[#0]KAe » %3:l0[#1]KA
-                  %3:l0 » %2:message[#9]KAiif » %1:message_hastag_tag[#1]KA » %0:l1[#0]KAe
-                Get l1 // { arity: 5 }
-                ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-                  ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-                ArrangeBy keys=[[#1{messageid}], [#9{creatorpersonid}]] // { arity: 13 }
-                  ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-                Get l0 // { arity: 11 }
-      cte l2 =
-        Project (#1) // { arity: 1 }
-          Join on=(#1{id} = #11{personid} AND #12{tagid} = #13{id}) type=delta // { arity: 18 }
-            implementation
-              %0:l0 » %1:person_hasinterest_tag[#0]K » %2:l1[#0]KAe
-              %1:person_hasinterest_tag » %2:l1[#0]KAe » %0:l0[#1]KA
-              %2:l1 » %1:person_hasinterest_tag[#1]KA » %0:l0[#1]KA
-            Get l0 // { arity: 11 }
-            ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-              Project (#1{tagid}, #2) // { arity: 2 }
-                ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
-            Get l1 // { arity: 5 }
-      cte l1 =
-        ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-          ReadIndex on=materialize.public.tag tag_name=[lookup value=("Abbas_I_of_Persia")] // { arity: 5 }
-      cte l0 =
-        ArrangeBy keys=[[#1{id}]] // { arity: 11 }
-          ReadIndex on=person person_id=[delta join lookup, delta join 1st input (full scan)] // { arity: 11 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -1691,6 +1691,24 @@ SELECT m.friendId AS "person.id"
 ----
 Explained Query:
   Finish order_by=[#2{count} desc nulls_first, #1{name} asc nulls_last, #0{person2id} asc nulls_last] limit=100 output=[#0..=#2]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
+          ReadIndex on=person_knows_person person_knows_person_person1id=[differential join, delta join lookup, lookup] // { arity: 3 }
+      cte l1 =
+        ReadIndex on=materialize.public.person_knows_person person_knows_person_person1id=[lookup value=(6597069770479)] // { arity: 4 }
+      cte l2 =
+        Distinct project=[#0{person2id}] // { arity: 1 }
+          Union // { arity: 1 }
+            Project (#2) // { arity: 1 }
+              Get l1 // { arity: 4 }
+            Project (#6) // { arity: 1 }
+              Join on=(#2{person2id} = #5{person1id}) type=differential // { arity: 7 }
+                implementation
+                  %0:l1[#2]KAe » %1:l0[#1]KAe
+                ArrangeBy keys=[[#2{person2id}]] // { arity: 4 }
+                  Get l1 // { arity: 4 }
+                Get l0 // { arity: 3 }
     Return // { arity: 3 }
       Reduce group_by=[#0{person2id}, #1{name}] aggregates=[count(*)] // { arity: 3 }
         Project (#0{person2id}, #9) // { arity: 2 }
@@ -1757,24 +1775,6 @@ Explained Query:
               ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
             ArrangeBy keys=[[#0{id}]] // { arity: 4 }
               ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
-    With
-      cte l2 =
-        Distinct project=[#0{person2id}] // { arity: 1 }
-          Union // { arity: 1 }
-            Project (#2) // { arity: 1 }
-              Get l1 // { arity: 4 }
-            Project (#6) // { arity: 1 }
-              Join on=(#2{person2id} = #5{person1id}) type=differential // { arity: 7 }
-                implementation
-                  %0:l1[#2]KAe » %1:l0[#1]KAe
-                ArrangeBy keys=[[#2{person2id}]] // { arity: 4 }
-                  Get l1 // { arity: 4 }
-                Get l0 // { arity: 3 }
-      cte l1 =
-        ReadIndex on=materialize.public.person_knows_person person_knows_person_person1id=[lookup value=(6597069770479)] // { arity: 4 }
-      cte l0 =
-        ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
-          ReadIndex on=person_knows_person person_knows_person_person1id=[differential join, delta join lookup, lookup] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join lookup)
@@ -1833,32 +1833,7 @@ SELECT count(*)
    AND '2012-09-28'::TIMESTAMP <= p3.creationDate AND p3.creationDate <= '2013-01-10'::TIMESTAMP
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l2 // { arity: 1 }
-      Map (0) // { arity: 1 }
-        Union // { arity: 0 }
-          Negate // { arity: 0 }
-            Project () // { arity: 0 }
-              Get l2 // { arity: 1 }
-          Constant // { arity: 0 }
-            - ()
   With
-    cte l2 =
-      Reduce aggregates=[count(*)] // { arity: 1 }
-        Project () // { arity: 0 }
-          Join on=(#0{id} = #5{person2id} AND #1{person2id} = #2{id} AND #3{person2id} = #4{id}) type=differential // { arity: 6 }
-            implementation
-              %0:l1[#1]Kf » %1:l1[#0]Kf » %2:l0[#0, #1]KKf
-            ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
-              Get l1 // { arity: 2 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
-              Get l1 // { arity: 2 }
-            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 2 }
-              Get l0 // { arity: 2 }
-    cte l1 =
-      Filter (#0{id} < #1{person2id}) // { arity: 2 }
-        Get l0 // { arity: 2 }
     cte l0 =
       Project (#1{person2id}, #21) // { arity: 2 }
         Filter (#16{name} = "India") AND (#19{creationdate} <= 2013-01-10 00:00:00 UTC) AND (2012-09-28 00:00:00 UTC <= #19{creationdate}) AND (#14{partofcountryid}) IS NOT NULL // { arity: 22 }
@@ -1876,6 +1851,31 @@ Explained Query:
               ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
             ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
               ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] // { arity: 3 }
+    cte l1 =
+      Filter (#0{id} < #1{person2id}) // { arity: 2 }
+        Get l0 // { arity: 2 }
+    cte l2 =
+      Reduce aggregates=[count(*)] // { arity: 1 }
+        Project () // { arity: 0 }
+          Join on=(#0{id} = #5{person2id} AND #1{person2id} = #2{id} AND #3{person2id} = #4{id}) type=differential // { arity: 6 }
+            implementation
+              %0:l1[#1]Kf » %1:l1[#0]Kf » %2:l0[#0, #1]KKf
+            ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
+              Get l1 // { arity: 2 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
+              Get l1 // { arity: 2 }
+            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 2 }
+              Get l0 // { arity: 2 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l2 // { arity: 1 }
+      Map (0) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l2 // { arity: 1 }
+          Constant // { arity: 0 }
+            - ()
 
 Used Indexes:
   - materialize.public.person_id (delta join 1st input (full scan))
@@ -1927,6 +1927,19 @@ ORDER BY personCount DESC, messageCount DESC
 ----
 Explained Query:
   Finish order_by=[#1{count} desc nulls_first, #0{count_messageid} desc nulls_first] output=[#0, #1]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#1{id}]] // { arity: 11 }
+          ReadIndex on=person person_id=[differential join] // { arity: 11 }
+      cte l1 =
+        Project (#1{messageid}, #12) // { arity: 2 }
+          Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#15{content}) IS NOT NULL // { arity: 25 }
+            Join on=(#1{id} = #20{creatorpersonid}) type=differential // { arity: 25 }
+              implementation
+                %1:message[#9]KAeiif » %0:l0[#1]KAeiif
+              Get l0 // { arity: 11 }
+              ArrangeBy keys=[[#9{creatorpersonid}]] // { arity: 14 }
+                ReadIndex on=materialize.public.message message_rootpostlanguage=[lookup values=[("es"); ("pt"); ("ta")]] // { arity: 14 }
     Return // { arity: 2 }
       Reduce group_by=[#0{count_messageid}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
@@ -1947,19 +1960,6 @@ Explained Query:
                   Project (#1) // { arity: 1 }
                     ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
               Get l1 // { arity: 2 }
-    With
-      cte l1 =
-        Project (#1{messageid}, #12) // { arity: 2 }
-          Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#15{content}) IS NOT NULL // { arity: 25 }
-            Join on=(#1{id} = #20{creatorpersonid}) type=differential // { arity: 25 }
-              implementation
-                %1:message[#9]KAeiif » %0:l0[#1]KAeiif
-              Get l0 // { arity: 11 }
-              ArrangeBy keys=[[#9{creatorpersonid}]] // { arity: 14 }
-                ReadIndex on=materialize.public.message message_rootpostlanguage=[lookup values=[("es"); ("pt"); ("ta")]] // { arity: 14 }
-      cte l0 =
-        ArrangeBy keys=[[#1{id}]] // { arity: 11 }
-          ReadIndex on=person person_id=[differential join] // { arity: 11 }
 
 Used Indexes:
   - materialize.public.person_id (*** full scan ***, differential join)
@@ -1995,6 +1995,33 @@ ORDER BY personCount DESC, messageCount DESC
 ----
 Explained Query:
   Finish order_by=[#1{count} desc nulls_first, #0{count_messageid} desc nulls_first] output=[#0, #1]
+    With
+      cte l0 =
+        CrossJoin type=differential // { arity: 17 }
+          implementation
+            %0:person[×] » %1:message[×]
+          ArrangeBy keys=[[]] // { arity: 11 }
+            ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
+          ArrangeBy keys=[[]] // { arity: 6 }
+            Project (#0{creationdate}, #1{messageid}, #3{content}, #4{length}, #8, #9) // { arity: 6 }
+              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+      cte l1 =
+        Project (#0{creationdate}..=#11{messageid}) // { arity: 12 }
+          Join on=(#12{rootpostlanguage} = #13{rootpostlanguage}) type=differential // { arity: 14 }
+            implementation
+              %1[#0]UKA » %0:l0[#12]Kiif
+            ArrangeBy keys=[[#12{rootpostlanguage}]] // { arity: 13 }
+              Project (#0{creationdate}..=#10{email}, #12{rootpostlanguage}, #13) // { arity: 13 }
+                Filter (#15{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#14{content}) IS NOT NULL AND (#1{id} = #16{creatorpersonid}) // { arity: 17 }
+                  Get l0 // { arity: 17 }
+            ArrangeBy keys=[[#0{rootpostlanguage}]] // { arity: 1 }
+              Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
+                Project (#0{rootpostlanguage}) // { arity: 1 }
+                  Filter (#0{rootpostlanguage} = varchar_to_text(#1)) // { arity: 2 }
+                    FlatMap unnest_array({"es", "ta", "pt"}) // { arity: 2 }
+                      Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
+                        Project (#13) // { arity: 1 }
+                          Get l0 // { arity: 17 }
     Return // { arity: 2 }
       Reduce group_by=[#0{count_messageid}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
@@ -2017,33 +2044,6 @@ Explained Query:
                           ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
                     ArrangeBy keys=[[#0{creationdate}..=#10{email}]] // { arity: 11 }
                       ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
-    With
-      cte l1 =
-        Project (#0{creationdate}..=#11{messageid}) // { arity: 12 }
-          Join on=(#12{rootpostlanguage} = #13{rootpostlanguage}) type=differential // { arity: 14 }
-            implementation
-              %1[#0]UKA » %0:l0[#12]Kiif
-            ArrangeBy keys=[[#12{rootpostlanguage}]] // { arity: 13 }
-              Project (#0{creationdate}..=#10{email}, #12{rootpostlanguage}, #13) // { arity: 13 }
-                Filter (#15{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#14{content}) IS NOT NULL AND (#1{id} = #16{creatorpersonid}) // { arity: 17 }
-                  Get l0 // { arity: 17 }
-            ArrangeBy keys=[[#0{rootpostlanguage}]] // { arity: 1 }
-              Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
-                Project (#0{rootpostlanguage}) // { arity: 1 }
-                  Filter (#0{rootpostlanguage} = varchar_to_text(#1)) // { arity: 2 }
-                    FlatMap unnest_array({"es", "ta", "pt"}) // { arity: 2 }
-                      Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
-                        Project (#13) // { arity: 1 }
-                          Get l0 // { arity: 17 }
-      cte l0 =
-        CrossJoin type=differential // { arity: 17 }
-          implementation
-            %0:person[×] » %1:message[×]
-          ArrangeBy keys=[[]] // { arity: 11 }
-            ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
-          ArrangeBy keys=[[]] // { arity: 6 }
-            Project (#0{creationdate}, #1{messageid}, #3{content}, #4{length}, #8, #9) // { arity: 6 }
-              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
   - materialize.public.person_id (*** full scan ***)
@@ -2095,77 +2095,32 @@ SELECT Z.zombieid AS "zombie.id"
 ----
 Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#3]
-    Return // { arity: 4 }
-      Project (#0{id}, #3..=#5) // { arity: 4 }
-        Map (coalesce(#2{sum}, 0), coalesce(#1{count}, 0), case when (#1{count} > 0) then (bigint_to_double(#2{sum}) / bigint_to_double(#1{count})) else 0 end) // { arity: 6 }
-          Union // { arity: 3 }
-            Map (null, null) // { arity: 3 }
-              Union // { arity: 1 }
-                Negate // { arity: 1 }
-                  Project (#0{id}) // { arity: 1 }
-                    Get l8 // { arity: 3 }
-                Get l2 // { arity: 1 }
-            Get l8 // { arity: 3 }
     With
-      cte l8 =
-        Project (#0{id}, #2{sum}, #3) // { arity: 3 }
-          Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 4 }
-            implementation
-              %1[#0]UKA » %0:l4[#0]K
-            Get l4 // { arity: 1 }
-            ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 3 }
-              Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*), sum(case when #1 then 1 else 0 end)] // { arity: 3 }
-                Project (#1, #3) // { arity: 2 }
-                  Join on=(#0{id} = #2{id}) type=differential // { arity: 4 }
-                    implementation
-                      %0:l5[#0]K » %1[#0]K
-                    ArrangeBy keys=[[#0{id}]] // { arity: 2 }
-                      Get l5 // { arity: 2 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 2 }
-                      Union // { arity: 2 }
-                        Map (true) // { arity: 2 }
-                          Get l7 // { arity: 1 }
-                        Map (false) // { arity: 2 }
-                          Union // { arity: 1 }
-                            Negate // { arity: 1 }
-                              Get l7 // { arity: 1 }
-                            Get l6 // { arity: 1 }
-      cte l7 =
-        Project (#0{id}) // { arity: 1 }
-          Join on=(#0{id} = #1{id}) type=differential // { arity: 2 }
-            implementation
-              %0:l6[#0]UKA » %1[#0]UKA
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Get l6 // { arity: 1 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Get l3 // { arity: 1 }
-      cte l6 =
-        Distinct project=[#0{id}] // { arity: 1 }
-          Project (#0{id}) // { arity: 1 }
-            Get l5 // { arity: 2 }
-      cte l5 =
-        Project (#1{creatorpersonid}, #23) // { arity: 2 }
-          Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) // { arity: 28 }
-            Join on=(#1{id} = #12{personid} AND #13{messageid} = #15{messageid} AND #23{creatorpersonid} = #27{id}) type=delta // { arity: 28 }
+      cte l0 =
+        Project (#0{id}, #2{partofcontinentid}..=#6{creationdate}, #8{firstname}..=#15{email}, #17, #18) // { arity: 16 }
+          Filter (#1{name} = "India") AND (#8{creationdate} < 2012-11-09 00:00:00 UTC) AND (#0{id}) IS NOT NULL // { arity: 19 }
+            Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid}) type=delta // { arity: 19 }
               implementation
-                %0:person » %1:person_likes_message[#1]KA » %2:message[#1]KA » %3:l4[#0]K
-                %1:person_likes_message » %0:person[#1]KAif » %2:message[#1]KA » %3:l4[#0]K
-                %2:message » %1:person_likes_message[#2]KA » %0:person[#1]KAif » %3:l4[#0]K
-                %3:l4 » %2:message[#9]KA » %1:person_likes_message[#2]KA » %0:person[#1]KAif
-              ArrangeBy keys=[[#1{id}]] // { arity: 11 }
-                ReadIndex on=person person_id=[delta join 1st input (full scan)] // { arity: 11 }
-              ArrangeBy keys=[[#1{personid}], [#2{messageid}]] // { arity: 3 }
-                ReadIndex on=person_likes_message person_likes_message_personid=[delta join lookup] person_likes_message_messageid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#1{messageid}], [#9{creatorpersonid}]] // { arity: 13 }
-                ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-              Get l4 // { arity: 1 }
-      cte l4 =
-        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-          Get l3 // { arity: 1 }
-      cte l3 =
-        Filter (#0{id}) IS NOT NULL // { arity: 1 }
-          Get l2 // { arity: 1 }
+                %0:country » %1:city[#3]KA » %2:person[#8]KAif
+                %1:city » %0:country[#0]KAef » %2:person[#8]KAif
+                %2:person » %1:city[#0]KA » %0:country[#0]KAef
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                ReadIndex on=country country_id=[delta join 1st input (full scan)] // { arity: 4 }
+              ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
+                ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
+              ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
+                ReadIndex on=person person_locationcityid=[delta join lookup] // { arity: 11 }
+      cte l1 =
+        Project (#0{id}..=#15{email}, #17) // { arity: 17 }
+          Filter (#16{creationdate} <= 2012-11-09 00:00:00 UTC) AND (#16{creationdate} >= #6{creationdate}) // { arity: 29 }
+            Join on=(#7{id} = #25{creatorpersonid}) type=differential // { arity: 29 }
+              implementation
+                %1:message[#9]KAif » %0:l0[#7]Kif
+              ArrangeBy keys=[[#7{id}]] // { arity: 16 }
+                Filter (#7{id}) IS NOT NULL // { arity: 16 }
+                  Get l0 // { arity: 16 }
+              ArrangeBy keys=[[#9{creatorpersonid}]] // { arity: 13 }
+                ReadIndex on=message message_creatorpersonid=[differential join] // { arity: 13 }
       cte l2 =
         Project (#0{id}) // { arity: 1 }
           Filter (bigint_to_numeric(#2{count_messageid}) < ((24155 - ((12 * extract_year_tstz(#1{creationdate})) + extract_month_tstz(#1{creationdate}))) + 1)) // { arity: 3 }
@@ -2190,31 +2145,76 @@ Explained Query:
                               Get l0 // { arity: 16 }
                       ArrangeBy keys=[[#0{id}..=#15{email}]] // { arity: 16 }
                         Get l0 // { arity: 16 }
-      cte l1 =
-        Project (#0{id}..=#15{email}, #17) // { arity: 17 }
-          Filter (#16{creationdate} <= 2012-11-09 00:00:00 UTC) AND (#16{creationdate} >= #6{creationdate}) // { arity: 29 }
-            Join on=(#7{id} = #25{creatorpersonid}) type=differential // { arity: 29 }
+      cte l3 =
+        Filter (#0{id}) IS NOT NULL // { arity: 1 }
+          Get l2 // { arity: 1 }
+      cte l4 =
+        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+          Get l3 // { arity: 1 }
+      cte l5 =
+        Project (#1{creatorpersonid}, #23) // { arity: 2 }
+          Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) // { arity: 28 }
+            Join on=(#1{id} = #12{personid} AND #13{messageid} = #15{messageid} AND #23{creatorpersonid} = #27{id}) type=delta // { arity: 28 }
               implementation
-                %1:message[#9]KAif » %0:l0[#7]Kif
-              ArrangeBy keys=[[#7{id}]] // { arity: 16 }
-                Filter (#7{id}) IS NOT NULL // { arity: 16 }
-                  Get l0 // { arity: 16 }
-              ArrangeBy keys=[[#9{creatorpersonid}]] // { arity: 13 }
-                ReadIndex on=message message_creatorpersonid=[differential join] // { arity: 13 }
-      cte l0 =
-        Project (#0{id}, #2{partofcontinentid}..=#6{creationdate}, #8{firstname}..=#15{email}, #17, #18) // { arity: 16 }
-          Filter (#1{name} = "India") AND (#8{creationdate} < 2012-11-09 00:00:00 UTC) AND (#0{id}) IS NOT NULL // { arity: 19 }
-            Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid}) type=delta // { arity: 19 }
-              implementation
-                %0:country » %1:city[#3]KA » %2:person[#8]KAif
-                %1:city » %0:country[#0]KAef » %2:person[#8]KAif
-                %2:person » %1:city[#0]KA » %0:country[#0]KAef
-              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                ReadIndex on=country country_id=[delta join 1st input (full scan)] // { arity: 4 }
-              ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
-                ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
-              ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
-                ReadIndex on=person person_locationcityid=[delta join lookup] // { arity: 11 }
+                %0:person » %1:person_likes_message[#1]KA » %2:message[#1]KA » %3:l4[#0]K
+                %1:person_likes_message » %0:person[#1]KAif » %2:message[#1]KA » %3:l4[#0]K
+                %2:message » %1:person_likes_message[#2]KA » %0:person[#1]KAif » %3:l4[#0]K
+                %3:l4 » %2:message[#9]KA » %1:person_likes_message[#2]KA » %0:person[#1]KAif
+              ArrangeBy keys=[[#1{id}]] // { arity: 11 }
+                ReadIndex on=person person_id=[delta join 1st input (full scan)] // { arity: 11 }
+              ArrangeBy keys=[[#1{personid}], [#2{messageid}]] // { arity: 3 }
+                ReadIndex on=person_likes_message person_likes_message_personid=[delta join lookup] person_likes_message_messageid=[delta join lookup] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}], [#9{creatorpersonid}]] // { arity: 13 }
+                ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
+              Get l4 // { arity: 1 }
+      cte l6 =
+        Distinct project=[#0{id}] // { arity: 1 }
+          Project (#0{id}) // { arity: 1 }
+            Get l5 // { arity: 2 }
+      cte l7 =
+        Project (#0{id}) // { arity: 1 }
+          Join on=(#0{id} = #1{id}) type=differential // { arity: 2 }
+            implementation
+              %0:l6[#0]UKA » %1[#0]UKA
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Get l6 // { arity: 1 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
+                Get l3 // { arity: 1 }
+      cte l8 =
+        Project (#0{id}, #2{sum}, #3) // { arity: 3 }
+          Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 4 }
+            implementation
+              %1[#0]UKA » %0:l4[#0]K
+            Get l4 // { arity: 1 }
+            ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 3 }
+              Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*), sum(case when #1 then 1 else 0 end)] // { arity: 3 }
+                Project (#1, #3) // { arity: 2 }
+                  Join on=(#0{id} = #2{id}) type=differential // { arity: 4 }
+                    implementation
+                      %0:l5[#0]K » %1[#0]K
+                    ArrangeBy keys=[[#0{id}]] // { arity: 2 }
+                      Get l5 // { arity: 2 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 2 }
+                      Union // { arity: 2 }
+                        Map (true) // { arity: 2 }
+                          Get l7 // { arity: 1 }
+                        Map (false) // { arity: 2 }
+                          Union // { arity: 1 }
+                            Negate // { arity: 1 }
+                              Get l7 // { arity: 1 }
+                            Get l6 // { arity: 1 }
+    Return // { arity: 4 }
+      Project (#0{id}, #3..=#5) // { arity: 4 }
+        Map (coalesce(#2{sum}, 0), coalesce(#1{count}, 0), case when (#1{count} > 0) then (bigint_to_double(#2{sum}) / bigint_to_double(#1{count})) else 0 end) // { arity: 6 }
+          Union // { arity: 3 }
+            Map (null, null) // { arity: 3 }
+              Union // { arity: 1 }
+                Negate // { arity: 1 }
+                  Project (#0{id}) // { arity: 1 }
+                    Get l8 // { arity: 3 }
+                Get l2 // { arity: 1 }
+            Get l8 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_id (delta join 1st input (full scan))
@@ -2299,20 +2299,104 @@ SELECT score_ranks.Person1Id AS "person1.id"
 ----
 Explained Query:
   Finish order_by=[#3{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=100 output=[#0..=#3]
-    Return // { arity: 4 }
-      Project (#0{id}, #1{person2id}, #3{sum}, #4) // { arity: 4 }
-        TopK group_by=[#2{id}] order_by=[#4{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=1 // { arity: 5 }
-          Union // { arity: 5 }
-            Map (null) // { arity: 5 }
-              Union // { arity: 4 }
-                Negate // { arity: 4 }
-                  Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
-                    Get l11 // { arity: 5 }
-                Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
-                  Get l3 // { arity: 4 }
-            Project (#2{id}, #3{name}, #0{id}, #1{person2id}, #4{sum}) // { arity: 5 }
-              Get l11 // { arity: 5 }
     With
+      cte l0 =
+        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+          ReadIndex on=country country_id=[delta join lookup, delta join 1st input (full scan)] // { arity: 4 }
+      cte l1 =
+        ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
+          ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
+      cte l2 =
+        ArrangeBy keys=[[#1{id}], [#8{locationcityid}]] // { arity: 11 }
+          ReadIndex on=person person_id=[delta join lookup] person_locationcityid=[delta join lookup] // { arity: 11 }
+      cte l3 =
+        Project (#4, #5, #9, #21) // { arity: 4 }
+          Filter (#1{name} = "Philippines") AND (#38{name} = "Taiwan") AND (#0{id}) IS NOT NULL AND (#36{partofcountryid}) IS NOT NULL // { arity: 41 }
+            Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid} AND #9{id} = #20{person1id} AND #21{person2id} = #23{id} AND #30{locationcityid} = #33{id} AND #36{partofcountryid} = #37{id}) type=delta // { arity: 41 }
+              implementation
+                %0:l0 » %1:l1[#3]KA » %2:l2[#8]KA » %3:person_knows_person[#1]KA » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
+                %1:l1 » %0:l0[#0]KAef » %2:l2[#8]KA » %3:person_knows_person[#1]KA » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
+                %2:l2 » %1:l1[#0]KA » %0:l0[#0]KAef » %3:person_knows_person[#1]KA » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
+                %3:person_knows_person » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
+                %4:l2 » %3:person_knows_person[#2]KA » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef » %5:l1[#0]KA » %6:l0[#0]KAef
+                %5:l1 » %6:l0[#0]KAef » %4:l2[#8]KA » %3:person_knows_person[#2]KA » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef
+                %6:l0 » %5:l1[#3]KA » %4:l2[#8]KA » %3:person_knows_person[#2]KA » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef
+              Get l0 // { arity: 4 }
+              Get l1 // { arity: 4 }
+              Get l2 // { arity: 11 }
+              ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+              Get l2 // { arity: 11 }
+              Get l1 // { arity: 4 }
+              Get l0 // { arity: 4 }
+      cte l4 =
+        Map (case when #2 then #1{person2id} else #0{id} end, case when #2 then #0{id} else #1{person2id} end) // { arity: 5 }
+          Union // { arity: 3 }
+            Project (#2..=#4) // { arity: 3 }
+              Map (false) // { arity: 5 }
+                Get l3 // { arity: 4 }
+            Project (#3, #2, #4) // { arity: 3 }
+              Map (true) // { arity: 5 }
+                Get l3 // { arity: 4 }
+      cte l5 =
+        Distinct project=[#0{id}, #1{person2id}] // { arity: 2 }
+          Project (#0{id}, #1{person2id}) // { arity: 2 }
+            Get l4 // { arity: 5 }
+      cte l6 =
+        ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+          ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
+      cte l7 =
+        Project (#0{id}, #1{person2id}) // { arity: 2 }
+          Join on=(#0{id} = #2{creatorpersonid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
+            implementation
+              %0:l5[#0, #1]UKKA » %1[#0, #1]UKKA
+            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 2 }
+              Get l5 // { arity: 2 }
+            ArrangeBy keys=[[#0{creatorpersonid}, #1{creatorpersonid}]] // { arity: 2 }
+              Distinct project=[#1{creatorpersonid}, #0{creatorpersonid}] // { arity: 2 }
+                Project (#9, #22) // { arity: 2 }
+                  Join on=(#1{messageid} = #25{parentmessageid}) type=differential // { arity: 26 }
+                    implementation
+                      %0:l6[#1]KA » %1:message[#12]KA
+                    Get l6 // { arity: 13 }
+                    ArrangeBy keys=[[#12{parentmessageid}]] // { arity: 13 }
+                      ReadIndex on=message message_parentmessageid=[differential join] // { arity: 13 }
+      cte l8 =
+        Project (#0{id}..=#4, #7) // { arity: 6 }
+          Join on=(#0{id} = #5{id} AND #1{person2id} = #6{person2id}) type=differential // { arity: 8 }
+            implementation
+              %0:l4[#0, #1]KK » %1[#0, #1]KK
+            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 5 }
+              Get l4 // { arity: 5 }
+            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 3 }
+              Union // { arity: 3 }
+                Map (true) // { arity: 3 }
+                  Get l7 // { arity: 2 }
+                Map (false) // { arity: 3 }
+                  Union // { arity: 2 }
+                    Negate // { arity: 2 }
+                      Get l7 // { arity: 2 }
+                    Get l5 // { arity: 2 }
+      cte l9 =
+        Distinct project=[#0{id}, #1{person2id}] // { arity: 2 }
+          Project (#0{id}, #1{person2id}) // { arity: 2 }
+            Get l8 // { arity: 6 }
+      cte l10 =
+        Project (#0{id}, #1{person2id}) // { arity: 2 }
+          Join on=(#0{id} = #2{personid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
+            implementation
+              %0:l9[#0, #1]UKKA » %1[#0, #1]UKKA
+            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 2 }
+              Get l9 // { arity: 2 }
+            ArrangeBy keys=[[#0{personid}, #1{creatorpersonid}]] // { arity: 2 }
+              Distinct project=[#1{personid}, #0{creatorpersonid}] // { arity: 2 }
+                Project (#9, #14) // { arity: 2 }
+                  Join on=(#1{messageid} = #15{messageid}) type=differential // { arity: 16 }
+                    implementation
+                      %0:l6[#1]KA » %1:person_likes_message[#2]KA
+                    Get l6 // { arity: 13 }
+                    ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
+                      ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l11 =
         Project (#0{id}..=#3{person2id}, #6) // { arity: 5 }
           Join on=(#2{id} = #4 AND #3{person2id} = #5) type=differential // { arity: 7 }
@@ -2337,103 +2421,19 @@ Explained Query:
                             Negate // { arity: 2 }
                               Get l10 // { arity: 2 }
                             Get l9 // { arity: 2 }
-      cte l10 =
-        Project (#0{id}, #1{person2id}) // { arity: 2 }
-          Join on=(#0{id} = #2{personid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
-            implementation
-              %0:l9[#0, #1]UKKA » %1[#0, #1]UKKA
-            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 2 }
-              Get l9 // { arity: 2 }
-            ArrangeBy keys=[[#0{personid}, #1{creatorpersonid}]] // { arity: 2 }
-              Distinct project=[#1{personid}, #0{creatorpersonid}] // { arity: 2 }
-                Project (#9, #14) // { arity: 2 }
-                  Join on=(#1{messageid} = #15{messageid}) type=differential // { arity: 16 }
-                    implementation
-                      %0:l6[#1]KA » %1:person_likes_message[#2]KA
-                    Get l6 // { arity: 13 }
-                    ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
-                      ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
-      cte l9 =
-        Distinct project=[#0{id}, #1{person2id}] // { arity: 2 }
-          Project (#0{id}, #1{person2id}) // { arity: 2 }
-            Get l8 // { arity: 6 }
-      cte l8 =
-        Project (#0{id}..=#4, #7) // { arity: 6 }
-          Join on=(#0{id} = #5{id} AND #1{person2id} = #6{person2id}) type=differential // { arity: 8 }
-            implementation
-              %0:l4[#0, #1]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 5 }
-              Get l4 // { arity: 5 }
-            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 3 }
-              Union // { arity: 3 }
-                Map (true) // { arity: 3 }
-                  Get l7 // { arity: 2 }
-                Map (false) // { arity: 3 }
-                  Union // { arity: 2 }
-                    Negate // { arity: 2 }
-                      Get l7 // { arity: 2 }
-                    Get l5 // { arity: 2 }
-      cte l7 =
-        Project (#0{id}, #1{person2id}) // { arity: 2 }
-          Join on=(#0{id} = #2{creatorpersonid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
-            implementation
-              %0:l5[#0, #1]UKKA » %1[#0, #1]UKKA
-            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 2 }
-              Get l5 // { arity: 2 }
-            ArrangeBy keys=[[#0{creatorpersonid}, #1{creatorpersonid}]] // { arity: 2 }
-              Distinct project=[#1{creatorpersonid}, #0{creatorpersonid}] // { arity: 2 }
-                Project (#9, #22) // { arity: 2 }
-                  Join on=(#1{messageid} = #25{parentmessageid}) type=differential // { arity: 26 }
-                    implementation
-                      %0:l6[#1]KA » %1:message[#12]KA
-                    Get l6 // { arity: 13 }
-                    ArrangeBy keys=[[#12{parentmessageid}]] // { arity: 13 }
-                      ReadIndex on=message message_parentmessageid=[differential join] // { arity: 13 }
-      cte l6 =
-        ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-          ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
-      cte l5 =
-        Distinct project=[#0{id}, #1{person2id}] // { arity: 2 }
-          Project (#0{id}, #1{person2id}) // { arity: 2 }
-            Get l4 // { arity: 5 }
-      cte l4 =
-        Map (case when #2 then #1{person2id} else #0{id} end, case when #2 then #0{id} else #1{person2id} end) // { arity: 5 }
-          Union // { arity: 3 }
-            Project (#2..=#4) // { arity: 3 }
-              Map (false) // { arity: 5 }
-                Get l3 // { arity: 4 }
-            Project (#3, #2, #4) // { arity: 3 }
-              Map (true) // { arity: 5 }
-                Get l3 // { arity: 4 }
-      cte l3 =
-        Project (#4, #5, #9, #21) // { arity: 4 }
-          Filter (#1{name} = "Philippines") AND (#38{name} = "Taiwan") AND (#0{id}) IS NOT NULL AND (#36{partofcountryid}) IS NOT NULL // { arity: 41 }
-            Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid} AND #9{id} = #20{person1id} AND #21{person2id} = #23{id} AND #30{locationcityid} = #33{id} AND #36{partofcountryid} = #37{id}) type=delta // { arity: 41 }
-              implementation
-                %0:l0 » %1:l1[#3]KA » %2:l2[#8]KA » %3:person_knows_person[#1]KA » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
-                %1:l1 » %0:l0[#0]KAef » %2:l2[#8]KA » %3:person_knows_person[#1]KA » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
-                %2:l2 » %1:l1[#0]KA » %0:l0[#0]KAef » %3:person_knows_person[#1]KA » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
-                %3:person_knows_person » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
-                %4:l2 » %3:person_knows_person[#2]KA » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef » %5:l1[#0]KA » %6:l0[#0]KAef
-                %5:l1 » %6:l0[#0]KAef » %4:l2[#8]KA » %3:person_knows_person[#2]KA » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef
-                %6:l0 » %5:l1[#3]KA » %4:l2[#8]KA » %3:person_knows_person[#2]KA » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef
-              Get l0 // { arity: 4 }
-              Get l1 // { arity: 4 }
-              Get l2 // { arity: 11 }
-              ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-              Get l2 // { arity: 11 }
-              Get l1 // { arity: 4 }
-              Get l0 // { arity: 4 }
-      cte l2 =
-        ArrangeBy keys=[[#1{id}], [#8{locationcityid}]] // { arity: 11 }
-          ReadIndex on=person person_id=[delta join lookup] person_locationcityid=[delta join lookup] // { arity: 11 }
-      cte l1 =
-        ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
-          ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
-      cte l0 =
-        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-          ReadIndex on=country country_id=[delta join lookup, delta join 1st input (full scan)] // { arity: 4 }
+    Return // { arity: 4 }
+      Project (#0{id}, #1{person2id}, #3{sum}, #4) // { arity: 4 }
+        TopK group_by=[#2{id}] order_by=[#4{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=1 // { arity: 5 }
+          Union // { arity: 5 }
+            Map (null) // { arity: 5 }
+              Union // { arity: 4 }
+                Negate // { arity: 4 }
+                  Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
+                    Get l11 // { arity: 5 }
+                Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
+                  Get l3 // { arity: 4 }
+            Project (#2{id}, #3{name}, #0{id}, #1{person2id}, #4{sum}) // { arity: 5 }
+              Get l11 // { arity: 5 }
 
 Used Indexes:
   - materialize.public.person_id (delta join lookup)
@@ -2517,11 +2517,45 @@ SELECT coalesce(w, -1) FROM results ORDER BY w ASC LIMIT 20
 ----
 Explained Query:
   Finish order_by=[#1{min} asc nulls_last] limit=20 output=[#2]
-    Return // { arity: 3 }
-      Project (#1{min}, #2{min}, #2{min}) // { arity: 3 }
-        Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
-          Get l4 // { arity: 3 }
     With Mutually Recursive
+      cte l0 =
+        Project (#1{person2id}, #2) // { arity: 2 }
+          ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+      cte l1 =
+        ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
+          Get l0 // { arity: 2 }
+      cte l2 =
+        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+          Distinct project=[#0{id}] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
+                ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+      cte l3 =
+        Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
+          implementation
+            %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+          Get l1 // { arity: 2 }
+          ArrangeBy keys=[[#1, #0]] // { arity: 3 }
+            Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
+              Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
+                  implementation
+                    %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                    %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                    Project (#9, #10, #12) // { arity: 3 }
+                      Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  Get l2 // { arity: 1 }
+                  Get l2 // { arity: 1 }
       cte l4 =
         Project (#2{min}, #0, #1{person2id}) // { arity: 3 }
           Map (1450) // { arity: 3 }
@@ -2557,44 +2591,10 @@ Explained Query:
                                   Get l3 // { arity: 5 }
                   Constant // { arity: 2 }
                     - (1450, 0)
-      cte l3 =
-        Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
-          implementation
-            %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
-          Get l1 // { arity: 2 }
-          ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-            Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-              Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
-                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
-                  implementation
-                    %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
-                    %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                    %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                    %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                    %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                    Project (#9, #10, #12) // { arity: 3 }
-                      Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                  Get l2 // { arity: 1 }
-                  Get l2 // { arity: 1 }
-      cte l2 =
-        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-          Distinct project=[#0{id}] // { arity: 1 }
-            Project (#1) // { arity: 1 }
-              Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
-      cte l1 =
-        ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-          Get l0 // { arity: 2 }
-      cte l0 =
-        Project (#1{person2id}, #2) // { arity: 2 }
-          ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+    Return // { arity: 3 }
+      Project (#1{min}, #2{min}, #2{min}) // { arity: 3 }
+        Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
+          Get l4 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -2713,113 +2713,136 @@ EXPLAIN WITH(humanized expressions, arity, join implementations) WITH MUTUALLY R
 SELECT coalesce(min(w), -1) FROM results
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Return // { arity: 1 }
-      Project (#1) // { arity: 1 }
-        Map (coalesce(#0{min_min}, -1)) // { arity: 2 }
-          Union // { arity: 1 }
-            Get l19 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l19 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
-    With
-      cte l19 =
-        Reduce aggregates=[min(#0{min})] // { arity: 1 }
-          Project (#2) // { arity: 1 }
-            Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
-              Project (#0, #2, #3, #5) // { arity: 4 }
-                Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
-                  implementation
-                    %0:l18[#1]Kef » %1:l18[#1]Kef
-                  ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1{person2id}..=#3) // { arity: 3 }
-                      Filter (#0 = false) // { arity: 4 }
-                        Get l18 // { arity: 4 }
-                  ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1{person2id}..=#3) // { arity: 3 }
-                      Filter (#0 = true) // { arity: 4 }
-                        Get l18 // { arity: 4 }
-      cte l18 =
-        Project (#0..=#3) // { arity: 4 }
-          Join on=(#4 = #5{max}) type=differential // { arity: 6 }
-            implementation
-              %1[#0]UK » %0:l17[#4]K
-            ArrangeBy keys=[[#4]] // { arity: 5 }
-              Project (#0..=#3, #5) // { arity: 5 }
-                Get l17 // { arity: 6 }
-            ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-              Reduce aggregates=[max(#0)] // { arity: 1 }
-                Project (#5) // { arity: 1 }
-                  Get l17 // { arity: 6 }
   With Mutually Recursive
-    cte l17 =
-      Distinct project=[#0..=#5] // { arity: 6 }
-        Union // { arity: 6 }
-          Project (#1, #0, #0, #2..=#4) // { arity: 6 }
-            Map (0, false, 0) // { arity: 5 }
-              Union // { arity: 2 }
-                Map (1450, false) // { arity: 2 }
-                  Get l16 // { arity: 0 }
-                Map (15393162796819, true) // { arity: 2 }
-                  Get l16 // { arity: 0 }
-          Project (#0..=#3, #7, #8) // { arity: 6 }
-            Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
-              CrossJoin type=delta // { arity: 7 }
+    cte l0 =
+      Project (#1{person2id}, #2) // { arity: 2 }
+        ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+    cte l1 =
+      ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
+        Get l0 // { arity: 2 }
+    cte l2 =
+      ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+        Distinct project=[#0{id}] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
+              ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+    cte l3 =
+      Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
+        implementation
+          %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+        Get l1 // { arity: 2 }
+        ArrangeBy keys=[[#1, #0]] // { arity: 3 }
+          Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
+            Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+              Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                 implementation
-                  %0:l13 » %1[×]U » %2[×]U
-                  %1 » %2[×]U » %0:l13[×]
-                  %2 » %1[×]U » %0:l13[×]
-                ArrangeBy keys=[[]] // { arity: 5 }
-                  Get l13 // { arity: 5 }
-                ArrangeBy keys=[[]] // { arity: 1 }
-                  TopK limit=1 // { arity: 1 }
-                    Project (#4) // { arity: 1 }
-                      Get l9 // { arity: 5 }
-                ArrangeBy keys=[[]] // { arity: 1 }
-                  Union // { arity: 1 }
-                    Get l15 // { arity: 1 }
-                    Map (null) // { arity: 1 }
-                      Union // { arity: 0 }
-                        Negate // { arity: 0 }
-                          Project () // { arity: 0 }
-                            Get l15 // { arity: 1 }
-                        Constant // { arity: 0 }
-                          - ()
-    cte l16 =
+                  %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
+                  %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                  %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                  %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                  %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                  ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                  Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                  Project (#9, #10, #12) // { arity: 3 }
+                    Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                Get l2 // { arity: 1 }
+                Get l2 // { arity: 1 }
+    cte l4 =
+      Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
+        Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
+          Union // { arity: 3 }
+            Map (null) // { arity: 3 }
+              Union // { arity: 2 }
+                Negate // { arity: 2 }
+                  Project (#0{person1id}, #1{person2id}) // { arity: 2 }
+                    Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
+                      implementation
+                        %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+                      Get l1 // { arity: 2 }
+                      ArrangeBy keys=[[#1, #0]] // { arity: 2 }
+                        Distinct project=[#0, #1] // { arity: 2 }
+                          Project (#2, #3) // { arity: 2 }
+                            Get l3 // { arity: 5 }
+                Get l0 // { arity: 2 }
+            Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
+              Get l3 // { arity: 5 }
+    cte l5 =
+      Project (#1{person2id}, #3) // { arity: 2 }
+        Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
+          implementation
+            %0:l8[#0]K » %1:l4[#0]K
+          ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+            Get l8 // { arity: 2 }
+          ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
+            Project (#0{person1id}, #1{person2id}) // { arity: 2 }
+              Get l4 // { arity: 3 }
+    cte l6 =
+      Union // { arity: 2 }
+        Project (#1, #0{person2id}) // { arity: 2 }
+          Get l5 // { arity: 2 }
+        Get l8 // { arity: 2 }
+    cte l7 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
-          Filter #1 AND (#0{person2id} = -1) // { arity: 2 }
-            Get l8 // { arity: 2 }
-    cte l15 =
-      Project (#1) // { arity: 1 }
-        Map ((#0{min} / 2)) // { arity: 2 }
-          Union // { arity: 1 }
-            Get l14 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l14 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
-    cte l14 =
-      Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
-        Project (#1, #3) // { arity: 2 }
-          Join on=(#0{person2id} = #2{person2id}) type=differential // { arity: 4 }
+          Join on=(#0{person2id} = #1{person2id}) type=differential // { arity: 2 }
             implementation
-              %0:l13[#0]Kef » %1:l13[#0]Kef
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              Project (#2, #3) // { arity: 2 }
-                Filter (#0 = false) // { arity: 5 }
-                  Get l13 // { arity: 5 }
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              Project (#2, #3) // { arity: 2 }
-                Filter (#0 = true) // { arity: 5 }
-                  Get l13 // { arity: 5 }
+              %0:l6[#0]Kf » %1:l6[#0]Kf
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+              Project (#0{person2id}) // { arity: 1 }
+                Filter #1 // { arity: 2 }
+                  Get l6 // { arity: 2 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+              Project (#0{person2id}) // { arity: 1 }
+                Filter NOT(#1) // { arity: 2 }
+                  Get l6 // { arity: 2 }
+    cte l8 =
+      Distinct project=[#0{person2id}, #1] // { arity: 2 }
+        Union // { arity: 2 }
+          Project (#1, #0{person2id}) // { arity: 2 }
+            CrossJoin type=differential // { arity: 2 }
+              implementation
+                %0:l5[×] » %1[×]
+              ArrangeBy keys=[[]] // { arity: 2 }
+                Get l5 // { arity: 2 }
+              ArrangeBy keys=[[]] // { arity: 0 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Get l7 // { arity: 0 }
+                  Constant // { arity: 0 }
+                    - ()
+          Project (#1, #0) // { arity: 2 }
+            Map (true, -1) // { arity: 2 }
+              Get l7 // { arity: 0 }
+          Constant // { arity: 2 }
+            - (1450, true)
+            - (15393162796819, false)
+    cte l9 =
+      TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
+        Project (#0..=#3, #5) // { arity: 5 }
+          Filter (#4 = false) // { arity: 6 }
+            Get l17 // { arity: 6 }
+    cte l10 =
+      Distinct project=[#0..=#2] // { arity: 3 }
+        Project (#0..=#2) // { arity: 3 }
+          Get l17 // { arity: 6 }
+    cte l11 =
+      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+        Get l10 // { arity: 3 }
+    cte l12 =
+      Project (#0..=#2) // { arity: 3 }
+        Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+          implementation
+            %1[#0..=#2]UKKKA » %0:l11[#0..=#2]UKKK
+          Get l11 // { arity: 3 }
+          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+            Distinct project=[#0..=#2] // { arity: 3 }
+              Project (#0..=#2) // { arity: 3 }
+                Get l9 // { arity: 5 }
     cte l13 =
       TopK group_by=[#0, #1, #2{person2id}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
         Union // { arity: 5 }
@@ -2856,135 +2879,112 @@ Explained Query:
                                 Get l12 // { arity: 3 }
                               Get l10 // { arity: 3 }
                           Get l11 // { arity: 3 }
-    cte l12 =
-      Project (#0..=#2) // { arity: 3 }
-        Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-          implementation
-            %1[#0..=#2]UKKKA » %0:l11[#0..=#2]UKKK
-          Get l11 // { arity: 3 }
-          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-            Distinct project=[#0..=#2] // { arity: 3 }
-              Project (#0..=#2) // { arity: 3 }
-                Get l9 // { arity: 5 }
-    cte l11 =
-      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-        Get l10 // { arity: 3 }
-    cte l10 =
-      Distinct project=[#0..=#2] // { arity: 3 }
-        Project (#0..=#2) // { arity: 3 }
-          Get l17 // { arity: 6 }
-    cte l9 =
-      TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
-        Project (#0..=#3, #5) // { arity: 5 }
-          Filter (#4 = false) // { arity: 6 }
-            Get l17 // { arity: 6 }
-    cte l8 =
-      Distinct project=[#0{person2id}, #1] // { arity: 2 }
-        Union // { arity: 2 }
-          Project (#1, #0{person2id}) // { arity: 2 }
-            CrossJoin type=differential // { arity: 2 }
-              implementation
-                %0:l5[×] » %1[×]
-              ArrangeBy keys=[[]] // { arity: 2 }
-                Get l5 // { arity: 2 }
-              ArrangeBy keys=[[]] // { arity: 0 }
-                Union // { arity: 0 }
-                  Negate // { arity: 0 }
-                    Get l7 // { arity: 0 }
-                  Constant // { arity: 0 }
-                    - ()
-          Project (#1, #0) // { arity: 2 }
-            Map (true, -1) // { arity: 2 }
-              Get l7 // { arity: 0 }
-          Constant // { arity: 2 }
-            - (1450, true)
-            - (15393162796819, false)
-    cte l7 =
+    cte l14 =
+      Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
+        Project (#1, #3) // { arity: 2 }
+          Join on=(#0{person2id} = #2{person2id}) type=differential // { arity: 4 }
+            implementation
+              %0:l13[#0]Kef » %1:l13[#0]Kef
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+              Project (#2, #3) // { arity: 2 }
+                Filter (#0 = false) // { arity: 5 }
+                  Get l13 // { arity: 5 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+              Project (#2, #3) // { arity: 2 }
+                Filter (#0 = true) // { arity: 5 }
+                  Get l13 // { arity: 5 }
+    cte l15 =
+      Project (#1) // { arity: 1 }
+        Map ((#0{min} / 2)) // { arity: 2 }
+          Union // { arity: 1 }
+            Get l14 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l14 // { arity: 1 }
+                Constant // { arity: 0 }
+                  - ()
+    cte l16 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
-          Join on=(#0{person2id} = #1{person2id}) type=differential // { arity: 2 }
-            implementation
-              %0:l6[#0]Kf » %1:l6[#0]Kf
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-              Project (#0{person2id}) // { arity: 1 }
-                Filter #1 // { arity: 2 }
-                  Get l6 // { arity: 2 }
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-              Project (#0{person2id}) // { arity: 1 }
-                Filter NOT(#1) // { arity: 2 }
-                  Get l6 // { arity: 2 }
-    cte l6 =
-      Union // { arity: 2 }
-        Project (#1, #0{person2id}) // { arity: 2 }
-          Get l5 // { arity: 2 }
-        Get l8 // { arity: 2 }
-    cte l5 =
-      Project (#1{person2id}, #3) // { arity: 2 }
-        Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
-          implementation
-            %0:l8[#0]K » %1:l4[#0]K
-          ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+          Filter #1 AND (#0{person2id} = -1) // { arity: 2 }
             Get l8 // { arity: 2 }
-          ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
-            Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-              Get l4 // { arity: 3 }
-    cte l4 =
-      Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
-        Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
-          Union // { arity: 3 }
-            Map (null) // { arity: 3 }
+    cte l17 =
+      Distinct project=[#0..=#5] // { arity: 6 }
+        Union // { arity: 6 }
+          Project (#1, #0, #0, #2..=#4) // { arity: 6 }
+            Map (0, false, 0) // { arity: 5 }
               Union // { arity: 2 }
-                Negate // { arity: 2 }
-                  Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-                    Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
-                      implementation
-                        %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
-                      Get l1 // { arity: 2 }
-                      ArrangeBy keys=[[#1, #0]] // { arity: 2 }
-                        Distinct project=[#0, #1] // { arity: 2 }
-                          Project (#2, #3) // { arity: 2 }
-                            Get l3 // { arity: 5 }
-                Get l0 // { arity: 2 }
-            Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
-              Get l3 // { arity: 5 }
-    cte l3 =
-      Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
-        implementation
-          %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
-        Get l1 // { arity: 2 }
-        ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-          Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-            Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
-              Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
+                Map (1450, false) // { arity: 2 }
+                  Get l16 // { arity: 0 }
+                Map (15393162796819, true) // { arity: 2 }
+                  Get l16 // { arity: 0 }
+          Project (#0..=#3, #7, #8) // { arity: 6 }
+            Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
+              CrossJoin type=delta // { arity: 7 }
                 implementation
-                  %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
-                  %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                  %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                  %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                  %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                  ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                  Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                  Project (#9, #10, #12) // { arity: 3 }
-                    Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                Get l2 // { arity: 1 }
-                Get l2 // { arity: 1 }
-    cte l2 =
-      ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-        Distinct project=[#0{id}] // { arity: 1 }
-          Project (#1) // { arity: 1 }
-            Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-              ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
-    cte l1 =
-      ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-        Get l0 // { arity: 2 }
-    cte l0 =
-      Project (#1{person2id}, #2) // { arity: 2 }
-        ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+                  %0:l13 » %1[×]U » %2[×]U
+                  %1 » %2[×]U » %0:l13[×]
+                  %2 » %1[×]U » %0:l13[×]
+                ArrangeBy keys=[[]] // { arity: 5 }
+                  Get l13 // { arity: 5 }
+                ArrangeBy keys=[[]] // { arity: 1 }
+                  TopK limit=1 // { arity: 1 }
+                    Project (#4) // { arity: 1 }
+                      Get l9 // { arity: 5 }
+                ArrangeBy keys=[[]] // { arity: 1 }
+                  Union // { arity: 1 }
+                    Get l15 // { arity: 1 }
+                    Map (null) // { arity: 1 }
+                      Union // { arity: 0 }
+                        Negate // { arity: 0 }
+                          Project () // { arity: 0 }
+                            Get l15 // { arity: 1 }
+                        Constant // { arity: 0 }
+                          - ()
+  Return // { arity: 1 }
+    With
+      cte l18 =
+        Project (#0..=#3) // { arity: 4 }
+          Join on=(#4 = #5{max}) type=differential // { arity: 6 }
+            implementation
+              %1[#0]UK » %0:l17[#4]K
+            ArrangeBy keys=[[#4]] // { arity: 5 }
+              Project (#0..=#3, #5) // { arity: 5 }
+                Get l17 // { arity: 6 }
+            ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+              Reduce aggregates=[max(#0)] // { arity: 1 }
+                Project (#5) // { arity: 1 }
+                  Get l17 // { arity: 6 }
+      cte l19 =
+        Reduce aggregates=[min(#0{min})] // { arity: 1 }
+          Project (#2) // { arity: 1 }
+            Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
+              Project (#0, #2, #3, #5) // { arity: 4 }
+                Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
+                  implementation
+                    %0:l18[#1]Kef » %1:l18[#1]Kef
+                  ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
+                    Project (#1{person2id}..=#3) // { arity: 3 }
+                      Filter (#0 = false) // { arity: 4 }
+                        Get l18 // { arity: 4 }
+                  ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
+                    Project (#1{person2id}..=#3) // { arity: 3 }
+                      Filter (#0 = true) // { arity: 4 }
+                        Get l18 // { arity: 4 }
+    Return // { arity: 1 }
+      Project (#1) // { arity: 1 }
+        Map (coalesce(#0{min_min}, -1)) // { arity: 2 }
+          Union // { arity: 1 }
+            Get l19 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l19 // { arity: 1 }
+                Constant // { arity: 0 }
+                  - ()
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -3072,6 +3072,94 @@ LIMIT 20
 ----
 Explained Query:
   Finish order_by=[#6 desc nulls_first, #0{id} asc nulls_last] limit=20 output=[#0, #1, #4]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+          Distinct project=[#0{id}] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Filter (#1{id}) IS NOT NULL // { arity: 11 }
+                ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
+      cte l1 =
+        ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+          ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
+      cte l2 =
+        ArrangeBy keys=[[#1{name}]] // { arity: 4 }
+          ReadIndex on=tag tag_name=[lookup] // { arity: 4 }
+      cte l3 =
+        Project (#0{id}, #2) // { arity: 2 }
+          Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
+            implementation
+              %0:l0 » %1[#0]K » %2[#0]UKA
+              %1 » %0:l0[#0]UKA » %2[#0]UKA
+              %2 » %1[#1]K » %0:l0[#0]UKA
+            Get l0 // { arity: 1 }
+            ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
+              Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
+                Project (#1{creatorpersonid}, #9) // { arity: 2 }
+                  Filter (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
+                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Distinct project=[#0{messageid}] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+                    implementation
+                      %1:tag[#0]KAe » %0:l1[#2]KAe
+                    Get l1 // { arity: 3 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Diosdado_Macapagal")] // { arity: 5 }
+      cte l4 =
+        ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+          ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+      cte l5 =
+        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
+          Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
+            implementation
+              %0:l3 » %1:l4[#1]KA » %2[#0]UKA
+              %1:l4 » %2[#0]UKA » %0:l3[#0]K
+              %2 » %1:l4[#2]KA » %0:l3[#0]K
+            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
+              Get l3 // { arity: 2 }
+            Get l4 // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
+                Project (#0{id}) // { arity: 1 }
+                  Get l3 // { arity: 2 }
+      cte l6 =
+        Project (#0{id}, #2) // { arity: 2 }
+          Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
+            implementation
+              %0:l0 » %1[#0]K » %2[#0]UKA
+              %1 » %0:l0[#0]UKA » %2[#0]UKA
+              %2 » %1[#1]K » %0:l0[#0]UKA
+            Get l0 // { arity: 1 }
+            ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
+              Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
+                Project (#1{creatorpersonid}, #9) // { arity: 2 }
+                  Filter (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
+                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Distinct project=[#0{messageid}] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+                    implementation
+                      %1:tag[#0]KAe » %0:l1[#2]KAe
+                    Get l1 // { arity: 3 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
+      cte l7 =
+        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
+          Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
+            implementation
+              %0:l6 » %1:l4[#1]KA » %2[#0]UKA
+              %1:l4 » %2[#0]UKA » %0:l6[#0]K
+              %2 » %1:l4[#2]KA » %0:l6[#0]K
+            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
+              Get l6 // { arity: 2 }
+            Get l4 // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
+                Project (#0{id}) // { arity: 1 }
+                  Get l6 // { arity: 2 }
     Return // { arity: 7 }
       Project (#0{id}..=#2{count_person2id}, #0{id}, #4{count_messageid}..=#6) // { arity: 7 }
         Filter (#2{count_person2id} <= 5) AND (#5{count_person2id} <= 5) // { arity: 7 }
@@ -3101,94 +3189,6 @@ Explained Query:
                             Project (#0{id}, #1{messageid}) // { arity: 2 }
                               Get l7 // { arity: 3 }
                         Get l6 // { arity: 2 }
-    With
-      cte l7 =
-        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
-          Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
-            implementation
-              %0:l6 » %1:l4[#1]KA » %2[#0]UKA
-              %1:l4 » %2[#0]UKA » %0:l6[#0]K
-              %2 » %1:l4[#2]KA » %0:l6[#0]K
-            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
-              Get l6 // { arity: 2 }
-            Get l4 // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#0{id}) // { arity: 1 }
-                  Get l6 // { arity: 2 }
-      cte l6 =
-        Project (#0{id}, #2) // { arity: 2 }
-          Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
-            implementation
-              %0:l0 » %1[#0]K » %2[#0]UKA
-              %1 » %0:l0[#0]UKA » %2[#0]UKA
-              %2 » %1[#1]K » %0:l0[#0]UKA
-            Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
-              Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1{creatorpersonid}, #9) // { arity: 2 }
-                  Filter (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
-                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-              Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-                    implementation
-                      %1:tag[#0]KAe » %0:l1[#2]KAe
-                    Get l1 // { arity: 3 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
-      cte l5 =
-        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
-          Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
-            implementation
-              %0:l3 » %1:l4[#1]KA » %2[#0]UKA
-              %1:l4 » %2[#0]UKA » %0:l3[#0]K
-              %2 » %1:l4[#2]KA » %0:l3[#0]K
-            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
-              Get l3 // { arity: 2 }
-            Get l4 // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#0{id}) // { arity: 1 }
-                  Get l3 // { arity: 2 }
-      cte l4 =
-        ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-          ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-      cte l3 =
-        Project (#0{id}, #2) // { arity: 2 }
-          Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
-            implementation
-              %0:l0 » %1[#0]K » %2[#0]UKA
-              %1 » %0:l0[#0]UKA » %2[#0]UKA
-              %2 » %1[#1]K » %0:l0[#0]UKA
-            Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
-              Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1{creatorpersonid}, #9) // { arity: 2 }
-                  Filter (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
-                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-              Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-                    implementation
-                      %1:tag[#0]KAe » %0:l1[#2]KAe
-                    Get l1 // { arity: 3 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Diosdado_Macapagal")] // { arity: 5 }
-      cte l2 =
-        ArrangeBy keys=[[#1{name}]] // { arity: 4 }
-          ReadIndex on=tag tag_name=[lookup] // { arity: 4 }
-      cte l1 =
-        ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-          ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-      cte l0 =
-        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-          Distinct project=[#0{id}] // { arity: 1 }
-            Project (#1) // { arity: 1 }
-              Filter (#1{id}) IS NOT NULL // { arity: 11 }
-                ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -3247,33 +3247,30 @@ LIMIT 10
 ----
 Explained Query:
   Finish order_by=[#1{count_messageid} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=10 output=[#0, #1]
-    Return // { arity: 2 }
-      Reduce group_by=[#0{creatorpersonid}] aggregates=[count(distinct #1{messageid})] // { arity: 2 }
-        Project (#0{creatorpersonid}, #1{messageid}) // { arity: 2 }
-          Join on=(#0{creatorpersonid} = #3{creatorpersonid} AND #2{containerforumid} = #4{containerforumid}) type=differential // { arity: 5 }
-            implementation
-              %0:l2[#0, #2]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[#0{creatorpersonid}, #2{containerforumid}]] // { arity: 3 }
-              Get l2 // { arity: 3 }
-            ArrangeBy keys=[[#0{creatorpersonid}, #1{containerforumid}]] // { arity: 2 }
-              Union // { arity: 2 }
-                Negate // { arity: 2 }
-                  Project (#0{creatorpersonid}, #1{containerforumid}) // { arity: 2 }
-                    Join on=(#0{creatorpersonid} = #2{personid} AND #1{containerforumid} = #3{forumid}) type=differential // { arity: 4 }
-                      implementation
-                        %0:l3[#0, #1]UKKA » %1[#0, #1]UKKA
-                      ArrangeBy keys=[[#0{creatorpersonid}, #1{containerforumid}]] // { arity: 2 }
-                        Get l3 // { arity: 2 }
-                      ArrangeBy keys=[[#0{personid}, #1{forumid}]] // { arity: 2 }
-                        Distinct project=[#1{personid}, #0{forumid}] // { arity: 2 }
-                          Project (#1{personid}, #2) // { arity: 2 }
-                            ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[*** full scan ***] // { arity: 3 }
-                Get l3 // { arity: 2 }
     With
-      cte l3 =
-        Distinct project=[#0{creatorpersonid}, #1{containerforumid}] // { arity: 2 }
-          Project (#0{creatorpersonid}, #2) // { arity: 2 }
-            Get l2 // { arity: 3 }
+      cte l0 =
+        Project (#0{creationdate}, #1{messageid}, #9, #10, #12) // { arity: 5 }
+          Join on=(#1{messageid} = #13{messageid}) type=differential // { arity: 14 }
+            implementation
+              %1[#0]UKA » %0:message[#1]KA
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Distinct project=[#0{messageid}] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 4 }
+                    implementation
+                      %1[#0]UKA » %0:message_hastag_tag[#2]KA
+                    ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+                      ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                      Distinct project=[#0{id}] // { arity: 1 }
+                        Project (#0{id}) // { arity: 1 }
+                          Filter (#0{id}) IS NOT NULL // { arity: 5 }
+                            ReadIndex on=materialize.public.tag tag_name=[lookup value=("Cosmic_Egg")] // { arity: 5 }
+      cte l1 =
+        ArrangeBy keys=[[#1{forumid}], [#2{personid}]] // { arity: 3 }
+          ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[delta join lookup] forum_hasmember_person_personid=[delta join lookup] // { arity: 3 }
       cte l2 =
         Project (#1{messageid}, #4, #6) // { arity: 3 }
           Filter (#2{containerforumid} != #6{containerforumid}) AND (#5{creatorpersonid} != #7{creatorpersonid}) AND ((#0{creationdate} + 12:00:00) < #3{creationdate}) // { arity: 15 }
@@ -3296,29 +3293,32 @@ Explained Query:
                     Get l0 // { arity: 5 }
               Get l1 // { arity: 3 }
               Get l1 // { arity: 3 }
-      cte l1 =
-        ArrangeBy keys=[[#1{forumid}], [#2{personid}]] // { arity: 3 }
-          ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[delta join lookup] forum_hasmember_person_personid=[delta join lookup] // { arity: 3 }
-      cte l0 =
-        Project (#0{creationdate}, #1{messageid}, #9, #10, #12) // { arity: 5 }
-          Join on=(#1{messageid} = #13{messageid}) type=differential // { arity: 14 }
+      cte l3 =
+        Distinct project=[#0{creatorpersonid}, #1{containerforumid}] // { arity: 2 }
+          Project (#0{creatorpersonid}, #2) // { arity: 2 }
+            Get l2 // { arity: 3 }
+    Return // { arity: 2 }
+      Reduce group_by=[#0{creatorpersonid}] aggregates=[count(distinct #1{messageid})] // { arity: 2 }
+        Project (#0{creatorpersonid}, #1{messageid}) // { arity: 2 }
+          Join on=(#0{creatorpersonid} = #3{creatorpersonid} AND #2{containerforumid} = #4{containerforumid}) type=differential // { arity: 5 }
             implementation
-              %1[#0]UKA » %0:message[#1]KA
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
-            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-              Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 4 }
-                    implementation
-                      %1[#0]UKA » %0:message_hastag_tag[#2]KA
-                    ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-                      ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                      Distinct project=[#0{id}] // { arity: 1 }
-                        Project (#0{id}) // { arity: 1 }
-                          Filter (#0{id}) IS NOT NULL // { arity: 5 }
-                            ReadIndex on=materialize.public.tag tag_name=[lookup value=("Cosmic_Egg")] // { arity: 5 }
+              %0:l2[#0, #2]KK » %1[#0, #1]KK
+            ArrangeBy keys=[[#0{creatorpersonid}, #2{containerforumid}]] // { arity: 3 }
+              Get l2 // { arity: 3 }
+            ArrangeBy keys=[[#0{creatorpersonid}, #1{containerforumid}]] // { arity: 2 }
+              Union // { arity: 2 }
+                Negate // { arity: 2 }
+                  Project (#0{creatorpersonid}, #1{containerforumid}) // { arity: 2 }
+                    Join on=(#0{creatorpersonid} = #2{personid} AND #1{containerforumid} = #3{forumid}) type=differential // { arity: 4 }
+                      implementation
+                        %0:l3[#0, #1]UKKA » %1[#0, #1]UKKA
+                      ArrangeBy keys=[[#0{creatorpersonid}, #1{containerforumid}]] // { arity: 2 }
+                        Get l3 // { arity: 2 }
+                      ArrangeBy keys=[[#0{personid}, #1{forumid}]] // { arity: 2 }
+                        Distinct project=[#1{personid}, #0{forumid}] // { arity: 2 }
+                          Project (#1{personid}, #2) // { arity: 2 }
+                            ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[*** full scan ***] // { arity: 3 }
+                Get l3 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -3366,6 +3366,33 @@ LIMIT 20
 ----
 Explained Query:
   Finish order_by=[#2{count} desc nulls_first, #0{personid} asc nulls_last, #1{personid} asc nulls_last] limit=20 output=[#0..=#2]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
+          Project (#0{personid}, #9) // { arity: 2 }
+            Join on=(#0{personid} = #8{person1id} AND #1{tagid} = #2{id}) type=delta // { arity: 10 }
+              implementation
+                %0:person_hasinterest_tag » %1:tag[#0]KAe » %2:person_knows_person[#1]KA
+                %1:tag » %0:person_hasinterest_tag[#1]KA » %2:person_knows_person[#1]KA
+                %2:person_knows_person » %0:person_hasinterest_tag[#0]K » %1:tag[#0]KAe
+              ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
+                Project (#1{tagid}, #2) // { arity: 2 }
+                  ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Fyodor_Dostoyevsky")] // { arity: 5 }
+              ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
+                ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] // { arity: 3 }
+      cte l1 =
+        Project (#0{personid}, #2) // { arity: 2 }
+          Filter (#0{personid} != #2{personid}) // { arity: 4 }
+            Join on=(#1{person2id} = #3{person2id}) type=differential // { arity: 4 }
+              implementation
+                %0:l0[#1]K » %1:l0[#1]K
+              Get l0 // { arity: 2 }
+              Get l0 // { arity: 2 }
+      cte l2 =
+        Distinct project=[#0{personid}, #1{personid}] // { arity: 2 }
+          Get l1 // { arity: 2 }
     Return // { arity: 3 }
       Reduce group_by=[#0{personid}, #1{personid}] aggregates=[count(*)] // { arity: 3 }
         Project (#0{personid}, #1{personid}) // { arity: 2 }
@@ -3388,33 +3415,6 @@ Explained Query:
                           Project (#1{person2id}, #2) // { arity: 2 }
                             ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                 Get l2 // { arity: 2 }
-    With
-      cte l2 =
-        Distinct project=[#0{personid}, #1{personid}] // { arity: 2 }
-          Get l1 // { arity: 2 }
-      cte l1 =
-        Project (#0{personid}, #2) // { arity: 2 }
-          Filter (#0{personid} != #2{personid}) // { arity: 4 }
-            Join on=(#1{person2id} = #3{person2id}) type=differential // { arity: 4 }
-              implementation
-                %0:l0[#1]K » %1:l0[#1]K
-              Get l0 // { arity: 2 }
-              Get l0 // { arity: 2 }
-      cte l0 =
-        ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
-          Project (#0{personid}, #9) // { arity: 2 }
-            Join on=(#0{personid} = #8{person1id} AND #1{tagid} = #2{id}) type=delta // { arity: 10 }
-              implementation
-                %0:person_hasinterest_tag » %1:tag[#0]KAe » %2:person_knows_person[#1]KA
-                %1:tag » %0:person_hasinterest_tag[#1]KA » %2:person_knows_person[#1]KA
-                %2:person_knows_person » %0:person_hasinterest_tag[#0]K » %1:tag[#0]KAe
-              ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-                Project (#1{tagid}, #2) // { arity: 2 }
-                  ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
-              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Fyodor_Dostoyevsky")] // { arity: 5 }
-              ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
-                ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -3462,11 +3462,6 @@ UNION ALL
 SELECT dst, src, w FROM weights;
 ----
 materialize.public.pathq19:
-  Return // { arity: 3 }
-    Union // { arity: 3 }
-      Get l0 // { arity: 3 }
-      Project (#1{person1id}, #0{person2id}, #2) // { arity: 3 }
-        Get l0 // { arity: 3 }
   With
     cte l0 =
       Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
@@ -3487,6 +3482,11 @@ materialize.public.pathq19:
                     ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
                   ArrangeBy keys=[[#1{person1id}, #2{person2id}]] // { arity: 3 }
                     ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[delta join lookup] // { arity: 3 }
+  Return // { arity: 3 }
+    Union // { arity: 3 }
+      Get l0 // { arity: 3 }
+      Project (#1{person1id}, #0{person2id}, #2) // { arity: 3 }
+        Get l0 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_knows_person_person1id_person2id (delta join lookup)
@@ -3561,32 +3561,6 @@ SELECT src, dst, w
  WHERE w = (SELECT min(w) FROM completed_paths)
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Return // { arity: 3 }
-      Project (#0{id}..=#2{min}) // { arity: 3 }
-        Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
-          implementation
-            %1[#0]UK » %0:l1[#2]K
-          ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-            Get l1 // { arity: 3 }
-          ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-            Reduce aggregates=[min(#0{min})] // { arity: 1 }
-              Project (#2) // { arity: 1 }
-                Get l1 // { arity: 3 }
-    With
-      cte l1 =
-        Project (#0{id}..=#2{min}) // { arity: 3 }
-          Join on=(#1{id} = #3{id}) type=differential // { arity: 4 }
-            implementation
-              %1[#0]UKA » %0:l0[#1]K
-            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Filter (#1{id}) IS NOT NULL // { arity: 12 }
-                    ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
   With Mutually Recursive
     cte l0 =
       Reduce group_by=[#0{id}, #1{id}] aggregates=[min(#2)] // { arity: 3 }
@@ -3605,6 +3579,32 @@ Explained Query:
                       Get l0 // { arity: 3 }
                   ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                     ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
+  Return // { arity: 3 }
+    With
+      cte l1 =
+        Project (#0{id}..=#2{min}) // { arity: 3 }
+          Join on=(#1{id} = #3{id}) type=differential // { arity: 4 }
+            implementation
+              %1[#0]UKA » %0:l0[#1]K
+            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                Get l0 // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Filter (#1{id}) IS NOT NULL // { arity: 12 }
+                    ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
+    Return // { arity: 3 }
+      Project (#0{id}..=#2{min}) // { arity: 3 }
+        Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UK » %0:l1[#2]K
+          ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+            Get l1 // { arity: 3 }
+          ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+            Reduce aggregates=[min(#0{min})] // { arity: 1 }
+              Project (#2) // { arity: 1 }
+                Get l1 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -3670,63 +3670,26 @@ FROM paths
 WHERE w = (SELECT MIN(w) FROM paths)
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Project (#0{id}..=#2{min}) // { arity: 3 }
-      Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
-        implementation
-          %1[#0]UK » %0:l5[#2]K
-        ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-          Get l5 // { arity: 3 }
-        ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-          Reduce aggregates=[min(#0{min})] // { arity: 1 }
-            Project (#2) // { arity: 1 }
-              Get l5 // { arity: 3 }
   With Mutually Recursive
-    cte l7 =
-      Union // { arity: 1 }
-        Get l6 // { arity: 1 }
-        Map (null) // { arity: 1 }
-          Union // { arity: 0 }
-            Negate // { arity: 0 }
-              Project () // { arity: 0 }
-                Get l6 // { arity: 1 }
-            Constant // { arity: 0 }
-              - ()
-    cte l6 =
-      Reduce aggregates=[min(#0{min})] // { arity: 1 }
-        Project (#2) // { arity: 1 }
-          Get l5 // { arity: 3 }
-    cte l5 =
-      Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-        Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
-          Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
-            implementation
-              %0:l3[#1]K » %1:l4[#1]K
-            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                Get l3 // { arity: 3 }
-            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                Get l4 // { arity: 3 }
-    cte l4 =
-      TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
-        Union // { arity: 3 }
-          Project (#1{id}, #1{id}, #12) // { arity: 3 }
-            Map (0) // { arity: 13 }
-              ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
-          Project (#0, #5, #7) // { arity: 3 }
-            Filter coalesce((#2 < #3), true) // { arity: 8 }
-              Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
-                Join on=(#1 = #4{src}) type=delta // { arity: 7 }
-                  implementation
-                    %0:l4 » %2:l2[#0]KA » %1:l1[×]
-                    %1:l1 » %0:l4[×] » %2:l2[#0]KA
-                    %2:l2 » %0:l4[#1]K » %1:l1[×]
-                  ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
-                    Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                      Get l4 // { arity: 3 }
-                  Get l1 // { arity: 1 }
-                  Get l2 // { arity: 3 }
+    cte l0 =
+      ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
+        ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
+    cte l1 =
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Union // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Map ((#0 / 2)) // { arity: 2 }
+              Get l7 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l7 // { arity: 1 }
+              Constant // { arity: 0 }
+                - ()
+    cte l2 =
+      ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+        ReadIndex on=pathq19 pathq19_src=[delta join lookup] // { arity: 3 }
     cte l3 =
       TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
         Union // { arity: 3 }
@@ -3746,25 +3709,62 @@ Explained Query:
                       Get l3 // { arity: 3 }
                   Get l1 // { arity: 1 }
                   Get l2 // { arity: 3 }
-    cte l2 =
-      ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-        ReadIndex on=pathq19 pathq19_src=[delta join lookup] // { arity: 3 }
-    cte l1 =
-      ArrangeBy keys=[[]] // { arity: 1 }
-        Union // { arity: 1 }
-          Project (#1) // { arity: 1 }
-            Map ((#0 / 2)) // { arity: 2 }
-              Get l7 // { arity: 1 }
-          Map (null) // { arity: 1 }
-            Union // { arity: 0 }
-              Negate // { arity: 0 }
-                Project () // { arity: 0 }
-                  Get l7 // { arity: 1 }
-              Constant // { arity: 0 }
-                - ()
-    cte l0 =
-      ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
-        ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
+    cte l4 =
+      TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
+        Union // { arity: 3 }
+          Project (#1{id}, #1{id}, #12) // { arity: 3 }
+            Map (0) // { arity: 13 }
+              ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
+          Project (#0, #5, #7) // { arity: 3 }
+            Filter coalesce((#2 < #3), true) // { arity: 8 }
+              Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
+                Join on=(#1 = #4{src}) type=delta // { arity: 7 }
+                  implementation
+                    %0:l4 » %2:l2[#0]KA » %1:l1[×]
+                    %1:l1 » %0:l4[×] » %2:l2[#0]KA
+                    %2:l2 » %0:l4[#1]K » %1:l1[×]
+                  ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
+                    Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                      Get l4 // { arity: 3 }
+                  Get l1 // { arity: 1 }
+                  Get l2 // { arity: 3 }
+    cte l5 =
+      Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
+        Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
+          Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
+            implementation
+              %0:l3[#1]K » %1:l4[#1]K
+            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                Get l3 // { arity: 3 }
+            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                Get l4 // { arity: 3 }
+    cte l6 =
+      Reduce aggregates=[min(#0{min})] // { arity: 1 }
+        Project (#2) // { arity: 1 }
+          Get l5 // { arity: 3 }
+    cte l7 =
+      Union // { arity: 1 }
+        Get l6 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l6 // { arity: 1 }
+            Constant // { arity: 0 }
+              - ()
+  Return // { arity: 3 }
+    Project (#0{id}..=#2{min}) // { arity: 3 }
+      Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
+        implementation
+          %1[#0]UK » %0:l5[#2]K
+        ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+          Get l5 // { arity: 3 }
+        ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+          Reduce aggregates=[min(#0{min})] // { arity: 1 }
+            Project (#2) // { arity: 1 }
+              Get l5 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -3829,111 +3829,29 @@ SELECT * FROM results WHERE w = (SELECT min(w) FROM results) ORDER BY f, t
 ----
 Explained Query:
   Finish order_by=[#0{id} asc nulls_last, #1{id} asc nulls_last] output=[#0..=#2]
-    Return // { arity: 3 }
-      Return // { arity: 3 }
-        Project (#0{id}..=#2{min}) // { arity: 3 }
-          Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
-            implementation
-              %1[#0]UK » %0:l9[#2]K
-            ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-              Get l9 // { arity: 3 }
-            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-              Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                Project (#2) // { arity: 1 }
-                  Get l9 // { arity: 3 }
-      With
-        cte l9 =
-          Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-            Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
-              Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
-                implementation
-                  %0:l8[#1]Kef » %1:l8[#1]Kef
-                ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-                  Project (#1{id}..=#3) // { arity: 3 }
-                    Filter (#0 = false) // { arity: 4 }
-                      Get l8 // { arity: 4 }
-                ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-                  Project (#1{id}..=#3) // { arity: 3 }
-                    Filter (#0 = true) // { arity: 4 }
-                      Get l8 // { arity: 4 }
-        cte l8 =
-          Project (#0..=#3) // { arity: 4 }
-            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
-              implementation
-                %1[#0]UK » %0:l7[#4]K
-              ArrangeBy keys=[[#4]] // { arity: 5 }
-                Project (#0..=#3, #5) // { arity: 5 }
-                  Filter (#2{id}) IS NOT NULL // { arity: 6 }
-                    Get l7 // { arity: 6 }
-              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-                Reduce aggregates=[max(#0)] // { arity: 1 }
-                  Project (#5) // { arity: 1 }
-                    Get l7 // { arity: 6 }
     With Mutually Recursive
-      cte l7 =
-        Distinct project=[#0..=#5] // { arity: 6 }
-          Union // { arity: 6 }
-            Project (#1{id}, #0, #0, #2{id}..=#4) // { arity: 6 }
-              Map (0, false, 0) // { arity: 5 }
-                Union // { arity: 2 }
-                  Project (#1, #12) // { arity: 2 }
-                    Map (false) // { arity: 13 }
-                      ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
-                  Project (#1, #12) // { arity: 2 }
-                    Map (true) // { arity: 13 }
-                      ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
-            Project (#0..=#3, #7, #8) // { arity: 6 }
-              Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
-                CrossJoin type=delta // { arity: 7 }
-                  implementation
-                    %0:l3 » %1[×]U » %2[×]U
-                    %1 » %2[×]U » %0:l3[×]
-                    %2 » %1[×]U » %0:l3[×]
-                  ArrangeBy keys=[[]] // { arity: 5 }
-                    Get l3 // { arity: 5 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    TopK limit=1 // { arity: 1 }
-                      Project (#4) // { arity: 1 }
-                        Get l0 // { arity: 5 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    Union // { arity: 1 }
-                      Get l5 // { arity: 1 }
-                      Map (null) // { arity: 1 }
-                        Union // { arity: 0 }
-                          Negate // { arity: 0 }
-                            Project () // { arity: 0 }
-                              Get l5 // { arity: 1 }
-                          Constant // { arity: 0 }
-                            - ()
-      cte l6 =
-        ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
-          ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
-      cte l5 =
-        Project (#1) // { arity: 1 }
-          Map ((#0{min} / 2)) // { arity: 2 }
-            Union // { arity: 1 }
-              Get l4 // { arity: 1 }
-              Map (null) // { arity: 1 }
-                Union // { arity: 0 }
-                  Negate // { arity: 0 }
-                    Project () // { arity: 0 }
-                      Get l4 // { arity: 1 }
-                  Constant // { arity: 0 }
-                    - ()
-      cte l4 =
-        Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
-          Project (#1, #3) // { arity: 2 }
-            Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
-              implementation
-                %0:l3[#0]Kef » %1:l3[#0]Kef
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = false) AND (#2{dst}) IS NOT NULL // { arity: 5 }
-                    Get l3 // { arity: 5 }
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = true) AND (#2{dst}) IS NOT NULL // { arity: 5 }
-                    Get l3 // { arity: 5 }
+      cte l0 =
+        TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
+          Project (#0..=#3, #5) // { arity: 5 }
+            Filter (#4 = false) // { arity: 6 }
+              Get l7 // { arity: 6 }
+      cte l1 =
+        Distinct project=[#0..=#2] // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            Get l7 // { arity: 6 }
+      cte l2 =
+        Project (#0..=#2) // { arity: 3 }
+          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+            implementation
+              %1[#0..=#2]UKKKA » %0:l1[#0..=#2]UKKK
+            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+              Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 3 }
+                Get l1 // { arity: 3 }
+            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+              Distinct project=[#0..=#2] // { arity: 3 }
+                Project (#0..=#2) // { arity: 3 }
+                  Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 5 }
+                    Get l0 // { arity: 5 }
       cte l3 =
         TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
           Distinct project=[#0..=#4] // { arity: 5 }
@@ -3973,28 +3891,110 @@ Explained Query:
                                   Get l1 // { arity: 3 }
                               ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                                 Get l1 // { arity: 3 }
-      cte l2 =
-        Project (#0..=#2) // { arity: 3 }
-          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+      cte l4 =
+        Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
+          Project (#1, #3) // { arity: 2 }
+            Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
+              implementation
+                %0:l3[#0]Kef » %1:l3[#0]Kef
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                Project (#2, #3) // { arity: 2 }
+                  Filter (#0 = false) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                    Get l3 // { arity: 5 }
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                Project (#2, #3) // { arity: 2 }
+                  Filter (#0 = true) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                    Get l3 // { arity: 5 }
+      cte l5 =
+        Project (#1) // { arity: 1 }
+          Map ((#0{min} / 2)) // { arity: 2 }
+            Union // { arity: 1 }
+              Get l4 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l4 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
+      cte l6 =
+        ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
+          ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
+      cte l7 =
+        Distinct project=[#0..=#5] // { arity: 6 }
+          Union // { arity: 6 }
+            Project (#1{id}, #0, #0, #2{id}..=#4) // { arity: 6 }
+              Map (0, false, 0) // { arity: 5 }
+                Union // { arity: 2 }
+                  Project (#1, #12) // { arity: 2 }
+                    Map (false) // { arity: 13 }
+                      ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
+                  Project (#1, #12) // { arity: 2 }
+                    Map (true) // { arity: 13 }
+                      ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
+            Project (#0..=#3, #7, #8) // { arity: 6 }
+              Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
+                CrossJoin type=delta // { arity: 7 }
+                  implementation
+                    %0:l3 » %1[×]U » %2[×]U
+                    %1 » %2[×]U » %0:l3[×]
+                    %2 » %1[×]U » %0:l3[×]
+                  ArrangeBy keys=[[]] // { arity: 5 }
+                    Get l3 // { arity: 5 }
+                  ArrangeBy keys=[[]] // { arity: 1 }
+                    TopK limit=1 // { arity: 1 }
+                      Project (#4) // { arity: 1 }
+                        Get l0 // { arity: 5 }
+                  ArrangeBy keys=[[]] // { arity: 1 }
+                    Union // { arity: 1 }
+                      Get l5 // { arity: 1 }
+                      Map (null) // { arity: 1 }
+                        Union // { arity: 0 }
+                          Negate // { arity: 0 }
+                            Project () // { arity: 0 }
+                              Get l5 // { arity: 1 }
+                          Constant // { arity: 0 }
+                            - ()
+    Return // { arity: 3 }
+      With
+        cte l8 =
+          Project (#0..=#3) // { arity: 4 }
+            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
+              implementation
+                %1[#0]UK » %0:l7[#4]K
+              ArrangeBy keys=[[#4]] // { arity: 5 }
+                Project (#0..=#3, #5) // { arity: 5 }
+                  Filter (#2{id}) IS NOT NULL // { arity: 6 }
+                    Get l7 // { arity: 6 }
+              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+                Reduce aggregates=[max(#0)] // { arity: 1 }
+                  Project (#5) // { arity: 1 }
+                    Get l7 // { arity: 6 }
+        cte l9 =
+          Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
+            Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
+              Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
+                implementation
+                  %0:l8[#1]Kef » %1:l8[#1]Kef
+                ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+                  Project (#1{id}..=#3) // { arity: 3 }
+                    Filter (#0 = false) // { arity: 4 }
+                      Get l8 // { arity: 4 }
+                ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+                  Project (#1{id}..=#3) // { arity: 3 }
+                    Filter (#0 = true) // { arity: 4 }
+                      Get l8 // { arity: 4 }
+      Return // { arity: 3 }
+        Project (#0{id}..=#2{min}) // { arity: 3 }
+          Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
             implementation
-              %1[#0..=#2]UKKKA » %0:l1[#0..=#2]UKKK
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 3 }
-                Get l1 // { arity: 3 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Distinct project=[#0..=#2] // { arity: 3 }
-                Project (#0..=#2) // { arity: 3 }
-                  Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 5 }
-                    Get l0 // { arity: 5 }
-      cte l1 =
-        Distinct project=[#0..=#2] // { arity: 3 }
-          Project (#0..=#2) // { arity: 3 }
-            Get l7 // { arity: 6 }
-      cte l0 =
-        TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
-          Project (#0..=#3, #5) // { arity: 5 }
-            Filter (#4 = false) // { arity: 6 }
-              Get l7 // { arity: 6 }
+              %1[#0]UK » %0:l9[#2]K
+            ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+              Get l9 // { arity: 3 }
+            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+              Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                Project (#2) // { arity: 1 }
+                  Get l9 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -4059,48 +4059,6 @@ SELECT dst, w FROM results ORDER BY dst LIMIT 20
 ----
 Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0, #1]
-    Return // { arity: 2 }
-      Return // { arity: 2 }
-        Project (#0{dst}, #1{min}) // { arity: 2 }
-          Filter (#1{min} = #3{min_min}) // { arity: 4 }
-            Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
-              implementation
-                %1[#0]UKAf » %0:l1[#1]Kf
-              ArrangeBy keys=[[#1{min}]] // { arity: 2 }
-                Get l1 // { arity: 2 }
-              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
-                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
-                  CrossJoin type=differential // { arity: 2 }
-                    implementation
-                      %0[×] » %1:l2[×]
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct project=[#0{min}] // { arity: 1 }
-                        Get l2 // { arity: 1 }
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Get l2 // { arity: 1 }
-      With
-        cte l2 =
-          Project (#1) // { arity: 1 }
-            Get l1 // { arity: 2 }
-        cte l1 =
-          Project (#0{dst}, #1{min}) // { arity: 2 }
-            Join on=(#0{dst} = #2{personid}) type=differential // { arity: 3 }
-              implementation
-                %1[#0]UKA » %0:l0[#0]UK
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#1{min}, #2) // { arity: 2 }
-                  Get l0 // { arity: 3 }
-              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
-                Distinct project=[#0{personid}] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
-                    Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
-                      Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
-                        implementation
-                          %1:company[#0]KAef » %0:person_workat_company[#2]KAef
-                        ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
-                          ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
-                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                          ReadIndex on=company company_id=[differential join] // { arity: 4 }
     With Mutually Recursive
       cte l0 =
         Project (#2{min}, #0, #1{dst}) // { arity: 3 }
@@ -4120,6 +4078,48 @@ Explained Query:
                           ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                   Constant // { arity: 2 }
                     - (10995116285979, 0)
+    Return // { arity: 2 }
+      With
+        cte l1 =
+          Project (#0{dst}, #1{min}) // { arity: 2 }
+            Join on=(#0{dst} = #2{personid}) type=differential // { arity: 3 }
+              implementation
+                %1[#0]UKA » %0:l0[#0]UK
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                Project (#1{min}, #2) // { arity: 2 }
+                  Get l0 // { arity: 3 }
+              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+                Distinct project=[#0{personid}] // { arity: 1 }
+                  Project (#1) // { arity: 1 }
+                    Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
+                      Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
+                        implementation
+                          %1:company[#0]KAef » %0:person_workat_company[#2]KAef
+                        ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
+                          ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                          ReadIndex on=company company_id=[differential join] // { arity: 4 }
+        cte l2 =
+          Project (#1) // { arity: 1 }
+            Get l1 // { arity: 2 }
+      Return // { arity: 2 }
+        Project (#0{dst}, #1{min}) // { arity: 2 }
+          Filter (#1{min} = #3{min_min}) // { arity: 4 }
+            Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
+              implementation
+                %1[#0]UKAf » %0:l1[#1]Kf
+              ArrangeBy keys=[[#1{min}]] // { arity: 2 }
+                Get l1 // { arity: 2 }
+              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
+                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
+                  CrossJoin type=differential // { arity: 2 }
+                    implementation
+                      %0[×] » %1:l2[×]
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Distinct project=[#0{min}] // { arity: 1 }
+                        Get l2 // { arity: 1 }
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Get l2 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.person_workat_company_companyid (differential join)
@@ -4167,29 +4167,24 @@ SELECT dst, w FROM results ORDER BY dst LIMIT 20
 ----
 Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0, #1]
-    Return // { arity: 2 }
-      Return // { arity: 2 }
-        Project (#0{dst}, #1{min}) // { arity: 2 }
-          Filter (#1{min} = #3{min_min}) // { arity: 4 }
-            Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
-              implementation
-                %1[#0]UKAf » %0:l1[#1]Kf
-              ArrangeBy keys=[[#1{min}]] // { arity: 2 }
-                Get l1 // { arity: 2 }
-              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
-                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
-                  CrossJoin type=differential // { arity: 2 }
+    With Mutually Recursive
+      cte l0 =
+        Reduce group_by=[#0{dst}] aggregates=[min(#1)] // { arity: 2 }
+          Distinct project=[#0{dst}, #1] // { arity: 2 }
+            Union // { arity: 2 }
+              Project (#3, #5) // { arity: 2 }
+                Map ((#1 + integer_to_bigint(#4{w}))) // { arity: 6 }
+                  Join on=(#0 = #2{src}) type=differential // { arity: 5 }
                     implementation
-                      %0[×] » %1:l2[×]
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct project=[#0{min}] // { arity: 1 }
-                        Get l2 // { arity: 1 }
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Get l2 // { arity: 1 }
+                      %0:l0[#0]UK » %1:pathq20[#0]KA
+                    ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                      Get l0 // { arity: 2 }
+                    ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+                      ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
+              Constant // { arity: 2 }
+                - (10995116285979, 0)
+    Return // { arity: 2 }
       With
-        cte l2 =
-          Project (#1) // { arity: 1 }
-            Get l1 // { arity: 2 }
         cte l1 =
           Project (#0{dst}, #1{min}) // { arity: 2 }
             Join on=(#0{dst} = #2{personid}) type=differential // { arity: 3 }
@@ -4208,22 +4203,27 @@ Explained Query:
                           ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
                         ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
-    With Mutually Recursive
-      cte l0 =
-        Reduce group_by=[#0{dst}] aggregates=[min(#1)] // { arity: 2 }
-          Distinct project=[#0{dst}, #1] // { arity: 2 }
-            Union // { arity: 2 }
-              Project (#3, #5) // { arity: 2 }
-                Map ((#1 + integer_to_bigint(#4{w}))) // { arity: 6 }
-                  Join on=(#0 = #2{src}) type=differential // { arity: 5 }
+        cte l2 =
+          Project (#1) // { arity: 1 }
+            Get l1 // { arity: 2 }
+      Return // { arity: 2 }
+        Project (#0{dst}, #1{min}) // { arity: 2 }
+          Filter (#1{min} = #3{min_min}) // { arity: 4 }
+            Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
+              implementation
+                %1[#0]UKAf » %0:l1[#1]Kf
+              ArrangeBy keys=[[#1{min}]] // { arity: 2 }
+                Get l1 // { arity: 2 }
+              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
+                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
+                  CrossJoin type=differential // { arity: 2 }
                     implementation
-                      %0:l0[#0]UK » %1:pathq20[#0]KA
-                    ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                      Get l0 // { arity: 2 }
-                    ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-                      ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
-              Constant // { arity: 2 }
-                - (10995116285979, 0)
+                      %0[×] » %1:l2[×]
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Distinct project=[#0{min}] // { arity: 1 }
+                        Get l2 // { arity: 1 }
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Get l2 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.person_workat_company_companyid (differential join)
@@ -4276,48 +4276,6 @@ SELECT dst, w, hops FROM results ORDER BY dst LIMIT 20
 ----
 Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0..=#2]
-    Return // { arity: 3 }
-      Return // { arity: 3 }
-        Project (#0{dst}..=#2{min}) // { arity: 3 }
-          Filter (#1{min} = #4{min_min}) // { arity: 5 }
-            Join on=(#1{min} = #3{min}) type=differential // { arity: 5 }
-              implementation
-                %1[#0]UKAf » %0:l1[#1]Kf
-              ArrangeBy keys=[[#1{min}]] // { arity: 3 }
-                Get l1 // { arity: 3 }
-              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
-                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
-                  CrossJoin type=differential // { arity: 2 }
-                    implementation
-                      %0[×] » %1:l2[×]
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct project=[#0{min}] // { arity: 1 }
-                        Get l2 // { arity: 1 }
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Get l2 // { arity: 1 }
-      With
-        cte l2 =
-          Project (#1) // { arity: 1 }
-            Get l1 // { arity: 3 }
-        cte l1 =
-          Project (#0{dst}..=#2{min}) // { arity: 3 }
-            Join on=(#0{dst} = #3{personid}) type=differential // { arity: 4 }
-              implementation
-                %1[#0]UKA » %0:l0[#0]K
-              ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
-                Project (#1{min}..=#3) // { arity: 3 }
-                  Get l0 // { arity: 4 }
-              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
-                Distinct project=[#0{personid}] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
-                    Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
-                      Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
-                        implementation
-                          %1:company[#0]KAef » %0:person_workat_company[#2]KAef
-                        ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
-                          ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
-                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                          ReadIndex on=company company_id=[differential join] // { arity: 4 }
     With Mutually Recursive
       cte l0 =
         Project (#3{min}, #0..=#2{min}) // { arity: 4 }
@@ -4338,6 +4296,48 @@ Explained Query:
                             ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                     Constant // { arity: 3 }
                       - (10995116285979, 0, 0)
+    Return // { arity: 3 }
+      With
+        cte l1 =
+          Project (#0{dst}..=#2{min}) // { arity: 3 }
+            Join on=(#0{dst} = #3{personid}) type=differential // { arity: 4 }
+              implementation
+                %1[#0]UKA » %0:l0[#0]K
+              ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
+                Project (#1{min}..=#3) // { arity: 3 }
+                  Get l0 // { arity: 4 }
+              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+                Distinct project=[#0{personid}] // { arity: 1 }
+                  Project (#1) // { arity: 1 }
+                    Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
+                      Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
+                        implementation
+                          %1:company[#0]KAef » %0:person_workat_company[#2]KAef
+                        ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
+                          ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                          ReadIndex on=company company_id=[differential join] // { arity: 4 }
+        cte l2 =
+          Project (#1) // { arity: 1 }
+            Get l1 // { arity: 3 }
+      Return // { arity: 3 }
+        Project (#0{dst}..=#2{min}) // { arity: 3 }
+          Filter (#1{min} = #4{min_min}) // { arity: 5 }
+            Join on=(#1{min} = #3{min}) type=differential // { arity: 5 }
+              implementation
+                %1[#0]UKAf » %0:l1[#1]Kf
+              ArrangeBy keys=[[#1{min}]] // { arity: 3 }
+                Get l1 // { arity: 3 }
+              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
+                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
+                  CrossJoin type=differential // { arity: 2 }
+                    implementation
+                      %0[×] » %1:l2[×]
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Distinct project=[#0{min}] // { arity: 1 }
+                        Get l2 // { arity: 1 }
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Get l2 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.person_workat_company_companyid (differential join)
@@ -4427,47 +4427,142 @@ SELECT t, w FROM results WHERE w = (SELECT min(w) FROM results) ORDER BY t LIMIT
 ----
 Explained Query:
   Finish order_by=[#0{personid} asc nulls_last] limit=20 output=[#0, #1]
-    Return // { arity: 2 }
-      Return // { arity: 2 }
-        Project (#0{personid}, #1{min}) // { arity: 2 }
-          Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
-            implementation
-              %1[#0]UK » %0:l14[#1]K
-            ArrangeBy keys=[[#1{min}]] // { arity: 2 }
-              Get l14 // { arity: 2 }
-            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-              Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Get l14 // { arity: 2 }
-      With
-        cte l14 =
-          Project (#1{min}, #2) // { arity: 2 }
-            Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1 + #3))] // { arity: 3 }
-              Project (#0{personid}, #2{personid}, #3, #5) // { arity: 4 }
-                Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
-                  implementation
-                    %0:l13[#1]Kef » %1:l13[#1]Kef
-                  ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
-                    Project (#1{personid}..=#3) // { arity: 3 }
-                      Filter (#0 = false) // { arity: 4 }
-                        Get l13 // { arity: 4 }
-                  ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
-                    Project (#1{personid}..=#3) // { arity: 3 }
-                      Filter (#0 = true) // { arity: 4 }
-                        Get l13 // { arity: 4 }
-        cte l13 =
-          Project (#0..=#3) // { arity: 4 }
-            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
-              implementation
-                %1[#0]UK » %0:l12[#4]K
-              ArrangeBy keys=[[#4]] // { arity: 5 }
-                Project (#0..=#3, #5) // { arity: 5 }
-                  Get l12 // { arity: 6 }
-              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-                Reduce aggregates=[max(#0)] // { arity: 1 }
-                  Project (#5) // { arity: 1 }
-                    Get l12 // { arity: 6 }
     With Mutually Recursive
+      cte l0 =
+        Project (#1) // { arity: 1 }
+          Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
+            Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
+              implementation
+                %1:company[#0]KAef » %0:person_workat_company[#2]KAef
+              ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
+                ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                ReadIndex on=company company_id=[differential join] // { arity: 4 }
+      cte l1 =
+        ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+          ReadIndex on=pathq20 pathq20_src=[differential join, delta join lookup] // { arity: 3 }
+      cte l2 =
+        ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+          Get l0 // { arity: 1 }
+      cte l3 =
+        Distinct project=[#0{dst}] // { arity: 1 }
+          Union // { arity: 1 }
+            Project (#2) // { arity: 1 }
+              Join on=(#0 = #1{src}) type=delta // { arity: 4 }
+                implementation
+                  %0:l3 » %1:l1[#0]KA » %2[×]
+                  %1:l1 » %0:l3[#0]UK » %2[×]
+                  %2 » %0:l3[×] » %1:l1[#0]KA
+                ArrangeBy keys=[[], [#0{dst}]] // { arity: 1 }
+                  Get l3 // { arity: 1 }
+                Get l1 // { arity: 3 }
+                ArrangeBy keys=[[]] // { arity: 0 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Distinct project=[] // { arity: 0 }
+                        Project () // { arity: 0 }
+                          Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
+                            implementation
+                              %0:l3[#0]UK » %1:l2[#0]K
+                            ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
+                              Get l3 // { arity: 1 }
+                            Get l2 // { arity: 1 }
+                    Constant // { arity: 0 }
+                      - ()
+            Constant // { arity: 1 }
+              - (10995116285979)
+      cte l4 =
+        TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
+          Project (#0..=#3, #5) // { arity: 5 }
+            Filter (#4 = false) // { arity: 6 }
+              Get l12 // { arity: 6 }
+      cte l5 =
+        Distinct project=[#0..=#2] // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            Get l12 // { arity: 6 }
+      cte l6 =
+        ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+          Get l5 // { arity: 3 }
+      cte l7 =
+        Project (#0..=#2) // { arity: 3 }
+          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+            implementation
+              %1[#0..=#2]UKKKA » %0:l6[#0..=#2]UKKK
+            Get l6 // { arity: 3 }
+            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+              Distinct project=[#0..=#2] // { arity: 3 }
+                Project (#0..=#2) // { arity: 3 }
+                  Get l4 // { arity: 5 }
+      cte l8 =
+        TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
+          Union // { arity: 5 }
+            Project (#3, #4, #1, #7, #8) // { arity: 5 }
+              Map ((#6 + integer_to_bigint(#2{w})), false) // { arity: 9 }
+                Join on=(#0{src} = #5) type=differential // { arity: 7 }
+                  implementation
+                    %0:l1[#0]KA » %1:l4[#2]K
+                  Get l1 // { arity: 3 }
+                  ArrangeBy keys=[[#2]] // { arity: 4 }
+                    Project (#0..=#3) // { arity: 4 }
+                      Get l4 // { arity: 5 }
+            Project (#0..=#3, #9) // { arity: 5 }
+              Map ((#4 OR #8)) // { arity: 10 }
+                Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
+                  implementation
+                    %0:l12[#0..=#2]KKK » %1[#0..=#2]KKK
+                  ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
+                    Project (#0..=#4) // { arity: 5 }
+                      Get l12 // { arity: 6 }
+                  ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                    Union // { arity: 4 }
+                      Map (true) // { arity: 4 }
+                        Get l7 // { arity: 3 }
+                      Project (#0..=#2, #6) // { arity: 4 }
+                        Map (false) // { arity: 7 }
+                          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                            implementation
+                              %1:l6[#0..=#2]UKKK » %0[#0..=#2]KKK
+                            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                              Union // { arity: 3 }
+                                Negate // { arity: 3 }
+                                  Get l7 // { arity: 3 }
+                                Get l5 // { arity: 3 }
+                            Get l6 // { arity: 3 }
+      cte l9 =
+        Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
+          Project (#1, #3) // { arity: 2 }
+            Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
+              implementation
+                %0:l8[#0]Kef » %1:l8[#0]Kef
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                Project (#2, #3) // { arity: 2 }
+                  Filter (#0 = false) // { arity: 5 }
+                    Get l8 // { arity: 5 }
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                Project (#2, #3) // { arity: 2 }
+                  Filter (#0 = true) // { arity: 5 }
+                    Get l8 // { arity: 5 }
+      cte l10 =
+        Project (#1) // { arity: 1 }
+          Map ((#0{min} / 2)) // { arity: 2 }
+            Union // { arity: 1 }
+              Get l9 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l9 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
+      cte l11 =
+        Distinct project=[] // { arity: 0 }
+          Project () // { arity: 0 }
+            Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
+              implementation
+                %0:l3[#0]UK » %1:l2[#0]K
+              ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
+                Get l3 // { arity: 1 }
+              Get l2 // { arity: 1 }
       cte l12 =
         Distinct project=[#0..=#5] // { arity: 6 }
           Union // { arity: 6 }
@@ -4510,141 +4605,46 @@ Explained Query:
                               Get l10 // { arity: 1 }
                           Constant // { arity: 0 }
                             - ()
-      cte l11 =
-        Distinct project=[] // { arity: 0 }
-          Project () // { arity: 0 }
-            Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
+    Return // { arity: 2 }
+      With
+        cte l13 =
+          Project (#0..=#3) // { arity: 4 }
+            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
               implementation
-                %0:l3[#0]UK » %1:l2[#0]K
-              ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                Get l3 // { arity: 1 }
-              Get l2 // { arity: 1 }
-      cte l10 =
-        Project (#1) // { arity: 1 }
-          Map ((#0{min} / 2)) // { arity: 2 }
-            Union // { arity: 1 }
-              Get l9 // { arity: 1 }
-              Map (null) // { arity: 1 }
-                Union // { arity: 0 }
-                  Negate // { arity: 0 }
-                    Project () // { arity: 0 }
-                      Get l9 // { arity: 1 }
-                  Constant // { arity: 0 }
-                    - ()
-      cte l9 =
-        Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
-          Project (#1, #3) // { arity: 2 }
-            Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
-              implementation
-                %0:l8[#0]Kef » %1:l8[#0]Kef
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = false) // { arity: 5 }
-                    Get l8 // { arity: 5 }
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = true) // { arity: 5 }
-                    Get l8 // { arity: 5 }
-      cte l8 =
-        TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
-          Union // { arity: 5 }
-            Project (#3, #4, #1, #7, #8) // { arity: 5 }
-              Map ((#6 + integer_to_bigint(#2{w})), false) // { arity: 9 }
-                Join on=(#0{src} = #5) type=differential // { arity: 7 }
+                %1[#0]UK » %0:l12[#4]K
+              ArrangeBy keys=[[#4]] // { arity: 5 }
+                Project (#0..=#3, #5) // { arity: 5 }
+                  Get l12 // { arity: 6 }
+              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+                Reduce aggregates=[max(#0)] // { arity: 1 }
+                  Project (#5) // { arity: 1 }
+                    Get l12 // { arity: 6 }
+        cte l14 =
+          Project (#1{min}, #2) // { arity: 2 }
+            Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1 + #3))] // { arity: 3 }
+              Project (#0{personid}, #2{personid}, #3, #5) // { arity: 4 }
+                Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
                   implementation
-                    %0:l1[#0]KA » %1:l4[#2]K
-                  Get l1 // { arity: 3 }
-                  ArrangeBy keys=[[#2]] // { arity: 4 }
-                    Project (#0..=#3) // { arity: 4 }
-                      Get l4 // { arity: 5 }
-            Project (#0..=#3, #9) // { arity: 5 }
-              Map ((#4 OR #8)) // { arity: 10 }
-                Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
-                  implementation
-                    %0:l12[#0..=#2]KKK » %1[#0..=#2]KKK
-                  ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-                    Project (#0..=#4) // { arity: 5 }
-                      Get l12 // { arity: 6 }
-                  ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-                    Union // { arity: 4 }
-                      Map (true) // { arity: 4 }
-                        Get l7 // { arity: 3 }
-                      Project (#0..=#2, #6) // { arity: 4 }
-                        Map (false) // { arity: 7 }
-                          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-                            implementation
-                              %1:l6[#0..=#2]UKKK » %0[#0..=#2]KKK
-                            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                              Union // { arity: 3 }
-                                Negate // { arity: 3 }
-                                  Get l7 // { arity: 3 }
-                                Get l5 // { arity: 3 }
-                            Get l6 // { arity: 3 }
-      cte l7 =
-        Project (#0..=#2) // { arity: 3 }
-          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                    %0:l13[#1]Kef » %1:l13[#1]Kef
+                  ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
+                    Project (#1{personid}..=#3) // { arity: 3 }
+                      Filter (#0 = false) // { arity: 4 }
+                        Get l13 // { arity: 4 }
+                  ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
+                    Project (#1{personid}..=#3) // { arity: 3 }
+                      Filter (#0 = true) // { arity: 4 }
+                        Get l13 // { arity: 4 }
+      Return // { arity: 2 }
+        Project (#0{personid}, #1{min}) // { arity: 2 }
+          Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
             implementation
-              %1[#0..=#2]UKKKA » %0:l6[#0..=#2]UKKK
-            Get l6 // { arity: 3 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Distinct project=[#0..=#2] // { arity: 3 }
-                Project (#0..=#2) // { arity: 3 }
-                  Get l4 // { arity: 5 }
-      cte l6 =
-        ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-          Get l5 // { arity: 3 }
-      cte l5 =
-        Distinct project=[#0..=#2] // { arity: 3 }
-          Project (#0..=#2) // { arity: 3 }
-            Get l12 // { arity: 6 }
-      cte l4 =
-        TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
-          Project (#0..=#3, #5) // { arity: 5 }
-            Filter (#4 = false) // { arity: 6 }
-              Get l12 // { arity: 6 }
-      cte l3 =
-        Distinct project=[#0{dst}] // { arity: 1 }
-          Union // { arity: 1 }
-            Project (#2) // { arity: 1 }
-              Join on=(#0 = #1{src}) type=delta // { arity: 4 }
-                implementation
-                  %0:l3 » %1:l1[#0]KA » %2[×]
-                  %1:l1 » %0:l3[#0]UK » %2[×]
-                  %2 » %0:l3[×] » %1:l1[#0]KA
-                ArrangeBy keys=[[], [#0{dst}]] // { arity: 1 }
-                  Get l3 // { arity: 1 }
-                Get l1 // { arity: 3 }
-                ArrangeBy keys=[[]] // { arity: 0 }
-                  Union // { arity: 0 }
-                    Negate // { arity: 0 }
-                      Distinct project=[] // { arity: 0 }
-                        Project () // { arity: 0 }
-                          Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
-                            implementation
-                              %0:l3[#0]UK » %1:l2[#0]K
-                            ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                              Get l3 // { arity: 1 }
-                            Get l2 // { arity: 1 }
-                    Constant // { arity: 0 }
-                      - ()
-            Constant // { arity: 1 }
-              - (10995116285979)
-      cte l2 =
-        ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
-          Get l0 // { arity: 1 }
-      cte l1 =
-        ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-          ReadIndex on=pathq20 pathq20_src=[differential join, delta join lookup] // { arity: 3 }
-      cte l0 =
-        Project (#1) // { arity: 1 }
-          Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
-            Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
-              implementation
-                %1:company[#0]KAef » %0:person_workat_company[#2]KAef
-              ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
-                ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
-              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                ReadIndex on=company company_id=[differential join] // { arity: 4 }
+              %1[#0]UK » %0:l14[#1]K
+            ArrangeBy keys=[[#1{min}]] // { arity: 2 }
+              Get l14 // { arity: 2 }
+            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+              Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Get l14 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.person_workat_company_companyid (differential join)

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -448,6 +448,12 @@ SELECT messageYear, isComment, lengthCategory
 ----
 Explained Query:
   Finish order_by=[#0 desc nulls_first, #1 asc nulls_last, #2 asc nulls_last] output=[#0..=#6]
+    With
+      cte l0 =
+        Reduce aggregates=[count(*)] // { arity: 1 }
+          Project () // { arity: 0 }
+            Filter (#0{creationdate} < 2010-06-11 09:21:46 UTC) // { arity: 13 }
+              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
     Return // { arity: 7 }
       Project (#0..=#2, #4, #7, #5{sum}, #8) // { arity: 7 }
         Map ((#5{sum} / bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end)), (bigint_to_numeric(#4{count}) / #3)) // { arity: 9 }
@@ -472,12 +478,6 @@ Explained Query:
                               Get l0 // { arity: 1 }
                           Constant // { arity: 0 }
                             - ()
-    With
-      cte l0 =
-        Reduce aggregates=[count(*)] // { arity: 1 }
-          Project () // { arity: 0 }
-            Filter (#0{creationdate} < 2010-06-11 09:21:46 UTC) // { arity: 13 }
-              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
   - materialize.public.message_messageid (*** full scan ***)
@@ -525,19 +525,19 @@ SELECT t.name AS "tag.name"
 ----
 Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0..=#3]
-    Return // { arity: 4 }
-      Project (#0{name}, #3..=#5) // { arity: 4 }
-        Map (coalesce(#1{count}, 0), coalesce(#2{count}, 0), abs((#3 - #4))) // { arity: 6 }
-          Union // { arity: 3 }
-            Map (null, null) // { arity: 3 }
-              Union // { arity: 1 }
-                Negate // { arity: 1 }
-                  Project (#0{name}) // { arity: 1 }
-                    Get l2 // { arity: 3 }
-                Project (#1) // { arity: 1 }
-                  Get l0 // { arity: 2 }
-            Get l2 // { arity: 3 }
     With
+      cte l0 =
+        Project (#5, #6) // { arity: 2 }
+          Join on=(#0{id} = #8{typetagclassid}) type=differential // { arity: 9 }
+            implementation
+              %0:tagclass[#0]KAe » %1:tag[#3]KAe
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("ChristianBishop")] // { arity: 5 }
+            ArrangeBy keys=[[#3{typetagclassid}]] // { arity: 4 }
+              ReadIndex on=tag tag_typetagclassid=[differential join] // { arity: 4 }
+      cte l1 =
+        Filter (#0{id}) IS NOT NULL // { arity: 2 }
+          Get l0 // { arity: 2 }
       cte l2 =
         Project (#1{count}, #3, #4) // { arity: 3 }
           Join on=(#0{id} = #2{id}) type=differential // { arity: 5 }
@@ -561,18 +561,18 @@ Explained Query:
                         ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
                       ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
                         ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
-      cte l1 =
-        Filter (#0{id}) IS NOT NULL // { arity: 2 }
-          Get l0 // { arity: 2 }
-      cte l0 =
-        Project (#5, #6) // { arity: 2 }
-          Join on=(#0{id} = #8{typetagclassid}) type=differential // { arity: 9 }
-            implementation
-              %0:tagclass[#0]KAe » %1:tag[#3]KAe
-            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-              ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("ChristianBishop")] // { arity: 5 }
-            ArrangeBy keys=[[#3{typetagclassid}]] // { arity: 4 }
-              ReadIndex on=tag tag_typetagclassid=[differential join] // { arity: 4 }
+    Return // { arity: 4 }
+      Project (#0{name}, #3..=#5) // { arity: 4 }
+        Map (coalesce(#1{count}, 0), coalesce(#2{count}, 0), abs((#3 - #4))) // { arity: 6 }
+          Union // { arity: 3 }
+            Map (null, null) // { arity: 3 }
+              Union // { arity: 1 }
+                Negate // { arity: 1 }
+                  Project (#0{name}) // { arity: 1 }
+                    Get l2 // { arity: 3 }
+                Project (#1) // { arity: 1 }
+                  Get l0 // { arity: 2 }
+            Get l2 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_typetagclassid (differential join)
@@ -748,40 +748,13 @@ LIMIT 100
 ----
 Explained Query:
   Finish order_by=[#4{count_messageid} desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
-    Return // { arity: 5 }
-      Reduce group_by=[#1{id}..=#3{lastname}, #0{creationdate}] aggregates=[count(#4{messageid})] // { arity: 5 }
-        Union // { arity: 5 }
-          Map (null) // { arity: 5 }
-            Union // { arity: 4 }
-              Negate // { arity: 4 }
-                Project (#0{creationdate}..=#3{lastname}) // { arity: 4 }
-                  Join on=(#1{id} = #4{id}) type=differential // { arity: 5 }
-                    implementation
-                      %1[#0]UKA » %0:l2[#1]K
-                    Get l2 // { arity: 4 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                      Distinct project=[#0{id}] // { arity: 1 }
-                        Project (#1) // { arity: 1 }
-                          Get l3 // { arity: 5 }
-              Get l1 // { arity: 4 }
-          Get l3 // { arity: 5 }
     With
-      cte l3 =
-        Project (#0{creationdate}..=#3{lastname}, #5) // { arity: 5 }
-          Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{id}) type=delta // { arity: 18 }
-            implementation
-              %0:l2 » %1:message[#9]KA » %2[#0]UKA
-              %1:message » %2[#0]UKA » %0:l2[#1]K
-              %2 » %1:message[#10]KA » %0:l2[#1]K
-            Get l2 // { arity: 4 }
-            ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
-              ReadIndex on=message message_containerforumid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Get l0 // { arity: 1 }
-      cte l2 =
-        ArrangeBy keys=[[#1{id}]] // { arity: 4 }
-          Get l1 // { arity: 4 }
+      cte l0 =
+        Project (#0{id}) // { arity: 1 }
+          TopK order_by=[#1{maxnumberofmembers} desc nulls_first, #0{id} asc nulls_last] limit=100 // { arity: 2 }
+            Project (#0{id}, #2) // { arity: 2 }
+              Filter (#1{creationdate} > 2010-02-12 00:00:00 UTC) // { arity: 3 }
+                ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
       cte l1 =
         Project (#0{creationdate}..=#3{lastname}) // { arity: 4 }
           Join on=(#1{id} = #11{personid}) type=differential // { arity: 12 }
@@ -799,12 +772,39 @@ Explained Query:
                       Get l0 // { arity: 1 }
                     ArrangeBy keys=[[#1{forumid}]] // { arity: 3 }
                       ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[differential join] // { arity: 3 }
-      cte l0 =
-        Project (#0{id}) // { arity: 1 }
-          TopK order_by=[#1{maxnumberofmembers} desc nulls_first, #0{id} asc nulls_last] limit=100 // { arity: 2 }
-            Project (#0{id}, #2) // { arity: 2 }
-              Filter (#1{creationdate} > 2010-02-12 00:00:00 UTC) // { arity: 3 }
-                ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
+      cte l2 =
+        ArrangeBy keys=[[#1{id}]] // { arity: 4 }
+          Get l1 // { arity: 4 }
+      cte l3 =
+        Project (#0{creationdate}..=#3{lastname}, #5) // { arity: 5 }
+          Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{id}) type=delta // { arity: 18 }
+            implementation
+              %0:l2 » %1:message[#9]KA » %2[#0]UKA
+              %1:message » %2[#0]UKA » %0:l2[#1]K
+              %2 » %1:message[#10]KA » %0:l2[#1]K
+            Get l2 // { arity: 4 }
+            ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
+              ReadIndex on=message message_containerforumid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
+                Get l0 // { arity: 1 }
+    Return // { arity: 5 }
+      Reduce group_by=[#1{id}..=#3{lastname}, #0{creationdate}] aggregates=[count(#4{messageid})] // { arity: 5 }
+        Union // { arity: 5 }
+          Map (null) // { arity: 5 }
+            Union // { arity: 4 }
+              Negate // { arity: 4 }
+                Project (#0{creationdate}..=#3{lastname}) // { arity: 4 }
+                  Join on=(#1{id} = #4{id}) type=differential // { arity: 5 }
+                    implementation
+                      %1[#0]UKA » %0:l2[#1]K
+                    Get l2 // { arity: 4 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                      Distinct project=[#0{id}] // { arity: 1 }
+                        Project (#1) // { arity: 1 }
+                          Get l3 // { arity: 5 }
+              Get l1 // { arity: 4 }
+          Get l3 // { arity: 5 }
 
 Used Indexes:
   - materialize.public.person_id (differential join)
@@ -851,6 +851,33 @@ SELECT CreatorPersonId AS "person.id"
 ----
 Explained Query:
   Finish order_by=[#4 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0..=#4]
+    With
+      cte l0 =
+        Project (#1{messageid}, #5, #16) // { arity: 3 }
+          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
+            implementation
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+      cte l1 =
+        Reduce group_by=[#0{parentmessageid}] aggregates=[count(*)] // { arity: 2 }
+          Project (#12) // { arity: 1 }
+            Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+      cte l2 =
+        Reduce group_by=[#0{messageid}] aggregates=[count(*)] // { arity: 2 }
+          Project (#2) // { arity: 1 }
+            ReadIndex on=person_likes_message person_likes_message_personid=[*** full scan ***] // { arity: 3 }
+      cte l3 =
+        Distinct project=[#0{messageid}] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Get l0 // { arity: 3 }
     Return // { arity: 5 }
       Map (((bigint_to_numeric((1 * #3{count})) + (2 * #1{sum})) + (10 * #2{sum}))) // { arity: 5 }
         Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(case when (#2) IS NULL then null else #1{count} end, 0)), sum(coalesce(case when (#4) IS NULL then null else #3{count} end, 0)), count(*)] // { arity: 4 }
@@ -886,33 +913,6 @@ Explained Query:
                           Project (#0{messageid}) // { arity: 1 }
                             Get l2 // { arity: 2 }
                         Get l3 // { arity: 1 }
-    With
-      cte l3 =
-        Distinct project=[#0{messageid}] // { arity: 1 }
-          Project (#1) // { arity: 1 }
-            Get l0 // { arity: 3 }
-      cte l2 =
-        Reduce group_by=[#0{messageid}] aggregates=[count(*)] // { arity: 2 }
-          Project (#2) // { arity: 1 }
-            ReadIndex on=person_likes_message person_likes_message_personid=[*** full scan ***] // { arity: 3 }
-      cte l1 =
-        Reduce group_by=[#0{parentmessageid}] aggregates=[count(*)] // { arity: 2 }
-          Project (#12) // { arity: 1 }
-            Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-      cte l0 =
-        Project (#1{messageid}, #5, #16) // { arity: 3 }
-          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-              %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
-              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
-            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join 1st input (full scan))
@@ -978,28 +978,31 @@ LIMIT 100
 ----
 Explained Query:
   Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
-    Return // { arity: 2 }
-      Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
-        Union // { arity: 2 }
-          Map (null) // { arity: 2 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Project (#0{creatorpersonid}) // { arity: 1 }
-                  Get l4 // { arity: 2 }
-              Project (#0{creatorpersonid}) // { arity: 1 }
-                Get l3 // { arity: 2 }
-          Get l4 // { arity: 2 }
     With
-      cte l4 =
-        Project (#0{creatorpersonid}, #3) // { arity: 2 }
-          Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
+      cte l0 =
+        Project (#6, #17) // { arity: 2 }
+          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
             implementation
-              %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
-            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
-              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
-                Get l3 // { arity: 2 }
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+      cte l1 =
+        ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
+          Get l0 // { arity: 2 }
+      cte l2 =
+        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
+          Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
+            implementation
+              %1:person_likes_message[#2]KA » %0:l1[#0]K
+            Get l1 // { arity: 2 }
+            ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
+              ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l3 =
         Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
           Union // { arity: 2 }
@@ -1019,30 +1022,27 @@ Explained Query:
                   Get l0 // { arity: 2 }
             Project (#1{personid}, #2) // { arity: 2 }
               Get l2 // { arity: 3 }
-      cte l2 =
-        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
-          Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
+      cte l4 =
+        Project (#0{creatorpersonid}, #3) // { arity: 2 }
+          Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %1:person_likes_message[#2]KA » %0:l1[#0]K
-            Get l1 // { arity: 2 }
-            ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
-              ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
-      cte l1 =
-        ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-          Get l0 // { arity: 2 }
-      cte l0 =
-        Project (#6, #17) // { arity: 2 }
-          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-              %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
-              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
-            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+              %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
+            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
+              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
+                Get l3 // { arity: 2 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+              ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
+    Return // { arity: 2 }
+      Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
+        Union // { arity: 2 }
+          Map (null) // { arity: 2 }
+            Union // { arity: 1 }
+              Negate // { arity: 1 }
+                Project (#0{creatorpersonid}) // { arity: 1 }
+                  Get l4 // { arity: 2 }
+              Project (#0{creatorpersonid}) // { arity: 1 }
+                Get l3 // { arity: 2 }
+          Get l4 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -1084,28 +1084,31 @@ LIMIT 100
 ----
 Explained Query:
   Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
-    Return // { arity: 2 }
-      Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
-        Union // { arity: 2 }
-          Map (null) // { arity: 2 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Project (#0{creatorpersonid}) // { arity: 1 }
-                  Get l4 // { arity: 2 }
-              Project (#0{creatorpersonid}) // { arity: 1 }
-                Get l3 // { arity: 2 }
-          Get l4 // { arity: 2 }
     With
-      cte l4 =
-        Project (#0{creatorpersonid}, #3) // { arity: 2 }
-          Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
+      cte l0 =
+        Project (#6, #17) // { arity: 2 }
+          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
             implementation
-              %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
-            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
-              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
-                Get l3 // { arity: 2 }
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+      cte l1 =
+        ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
+          Get l0 // { arity: 2 }
+      cte l2 =
+        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
+          Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
+            implementation
+              %1:person_likes_message[#2]KA » %0:l1[#0]K
+            Get l1 // { arity: 2 }
+            ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
+              ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l3 =
         Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
           Union // { arity: 2 }
@@ -1125,30 +1128,27 @@ Explained Query:
                   Get l0 // { arity: 2 }
             Project (#1{personid}, #2) // { arity: 2 }
               Get l2 // { arity: 3 }
-      cte l2 =
-        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
-          Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
+      cte l4 =
+        Project (#0{creatorpersonid}, #3) // { arity: 2 }
+          Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %1:person_likes_message[#2]KA » %0:l1[#0]K
-            Get l1 // { arity: 2 }
-            ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
-              ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
-      cte l1 =
-        ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-          Get l0 // { arity: 2 }
-      cte l0 =
-        Project (#6, #17) // { arity: 2 }
-          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-              %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
-              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
-            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+              %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
+            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
+              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
+                Get l3 // { arity: 2 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+              ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
+    Return // { arity: 2 }
+      Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
+        Union // { arity: 2 }
+          Map (null) // { arity: 2 }
+            Union // { arity: 1 }
+              Negate // { arity: 1 }
+                Project (#0{creatorpersonid}) // { arity: 1 }
+                  Get l4 // { arity: 2 }
+              Project (#0{creatorpersonid}) // { arity: 1 }
+                Get l3 // { arity: 2 }
+          Get l4 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -1191,28 +1191,32 @@ LIMIT 100
 ----
 Explained Query:
   Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
-    Return // { arity: 2 }
-      Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
-        Union // { arity: 2 }
-          Map (null) // { arity: 2 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Project (#0{creatorpersonid}) // { arity: 1 }
-                  Get l4 // { arity: 2 }
-              Project (#0{creatorpersonid}) // { arity: 1 }
-                Get l3 // { arity: 2 }
-          Get l4 // { arity: 2 }
     With
-      cte l4 =
-        Project (#0{creatorpersonid}, #3) // { arity: 2 }
-          Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
+      cte l0 =
+        Project (#1{messageid}, #5, #16) // { arity: 3 }
+          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
             implementation
-              %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
-            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
-              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
-                Get l3 // { arity: 2 }
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+      cte l1 =
+        Project (#0{name}..=#2{creatorpersonid}, #4) // { arity: 4 }
+          Join on=(#1{messageid} = #5{messageid}) type=differential // { arity: 6 }
+            implementation
+              %1:person_likes_message[#2]KA » %0:l0[#1]K
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 3 }
+              Get l0 // { arity: 3 }
+            ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
+              ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
+      cte l2 =
+        Filter (#0{name} = "Bob_Geldof") // { arity: 3 }
+          Get l0 // { arity: 3 }
       cte l3 =
         Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
           Union // { arity: 2 }
@@ -1235,31 +1239,27 @@ Explained Query:
             Project (#2, #3) // { arity: 2 }
               Filter (#0{name} = "Bob_Geldof") // { arity: 4 }
                 Get l1 // { arity: 4 }
-      cte l2 =
-        Filter (#0{name} = "Bob_Geldof") // { arity: 3 }
-          Get l0 // { arity: 3 }
-      cte l1 =
-        Project (#0{name}..=#2{creatorpersonid}, #4) // { arity: 4 }
-          Join on=(#1{messageid} = #5{messageid}) type=differential // { arity: 6 }
+      cte l4 =
+        Project (#0{creatorpersonid}, #3) // { arity: 2 }
+          Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %1:person_likes_message[#2]KA » %0:l0[#1]K
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 3 }
-              Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
-              ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
-      cte l0 =
-        Project (#1{messageid}, #5, #16) // { arity: 3 }
-          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
-            implementation
-              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-              %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
-              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
-            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+              %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
+            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
+              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
+                Get l3 // { arity: 2 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+              ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
+    Return // { arity: 2 }
+      Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
+        Union // { arity: 2 }
+          Map (null) // { arity: 2 }
+            Union // { arity: 1 }
+              Negate // { arity: 1 }
+                Project (#0{creatorpersonid}) // { arity: 1 }
+                  Get l4 // { arity: 2 }
+              Project (#0{creatorpersonid}) // { arity: 1 }
+                Get l3 // { arity: 2 }
+          Get l4 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join 1st input (full scan))
@@ -1308,6 +1308,36 @@ SELECT RelatedTag.name AS "relatedTag.name"
 ----
 Explained Query:
   Finish order_by=[#1{count} desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0, #1]
+    With
+      cte l0 =
+        Project (#1) // { arity: 1 }
+          Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+            implementation
+              %1:tag[#0]KAe » %0:message_hastag_tag[#2]KAe
+            ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
+      cte l1 =
+        Project (#2, #18) // { arity: 2 }
+          Join on=(#0{messageid} = #13{parentmessageid} AND #2{messageid} = #15{messageid} AND #16{tagid} = #17{id}) type=delta // { arity: 21 }
+            implementation
+              %0:l0 » %1:message[#12]KA » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA
+              %1:message » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
+              %2:message_hastag_tag » %1:message[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
+              %3:tag » %2:message_hastag_tag[#2]KA » %1:message[#1]KA » %0:l0[#0]K
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Get l0 // { arity: 1 }
+            ArrangeBy keys=[[#1{messageid}], [#12{parentmessageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+              ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
+      cte l2 =
+        Distinct project=[#0{messageid}] // { arity: 1 }
+          Project (#0{messageid}) // { arity: 1 }
+            Get l1 // { arity: 2 }
     Return // { arity: 2 }
       Reduce group_by=[#0{name}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
@@ -1329,36 +1359,6 @@ Explained Query:
                         Distinct project=[#0{messageid}] // { arity: 1 }
                           Get l0 // { arity: 1 }
                 Get l2 // { arity: 1 }
-    With
-      cte l2 =
-        Distinct project=[#0{messageid}] // { arity: 1 }
-          Project (#0{messageid}) // { arity: 1 }
-            Get l1 // { arity: 2 }
-      cte l1 =
-        Project (#2, #18) // { arity: 2 }
-          Join on=(#0{messageid} = #13{parentmessageid} AND #2{messageid} = #15{messageid} AND #16{tagid} = #17{id}) type=delta // { arity: 21 }
-            implementation
-              %0:l0 » %1:message[#12]KA » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA
-              %1:message » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
-              %2:message_hastag_tag » %1:message[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
-              %3:tag » %2:message_hastag_tag[#2]KA » %1:message[#1]KA » %0:l0[#0]K
-            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-              Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#1{messageid}], [#12{parentmessageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
-            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-              ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
-      cte l0 =
-        Project (#1) // { arity: 1 }
-          Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-            implementation
-              %1:tag[#0]KAe » %0:message_hastag_tag[#2]KAe
-            ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-              ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join lookup)
@@ -1427,6 +1427,79 @@ SELECT p.PersonId AS "person.id"
 ----
 Explained Query:
   Finish order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0, #1, #3]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#1{id}]] // { arity: 11 }
+          ReadIndex on=person person_id=[delta join lookup, delta join 1st input (full scan)] // { arity: 11 }
+      cte l1 =
+        ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+          ReadIndex on=materialize.public.tag tag_name=[lookup value=("Abbas_I_of_Persia")] // { arity: 5 }
+      cte l2 =
+        Project (#1) // { arity: 1 }
+          Join on=(#1{id} = #11{personid} AND #12{tagid} = #13{id}) type=delta // { arity: 18 }
+            implementation
+              %0:l0 » %1:person_hasinterest_tag[#0]K » %2:l1[#0]KAe
+              %1:person_hasinterest_tag » %2:l1[#0]KAe » %0:l0[#1]KA
+              %2:l1 » %1:person_hasinterest_tag[#1]KA » %0:l0[#1]KA
+            Get l0 // { arity: 11 }
+            ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
+              Project (#1{tagid}, #2) // { arity: 2 }
+                ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
+            Get l1 // { arity: 5 }
+      cte l3 =
+        Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*)] // { arity: 2 }
+          Project (#17) // { arity: 1 }
+            Filter (#8{creationdate} < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8{creationdate}) // { arity: 32 }
+              Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid} AND #17{creatorpersonid} = #22{id}) type=delta // { arity: 32 }
+                implementation
+                  %0:l1 » %1:message_hastag_tag[#2]KA » %2:message[#1]KAiif » %3:l0[#1]KA
+                  %1:message_hastag_tag » %0:l1[#0]KAe » %2:message[#1]KAiif » %3:l0[#1]KA
+                  %2:message » %1:message_hastag_tag[#1]KA » %0:l1[#0]KAe » %3:l0[#1]KA
+                  %3:l0 » %2:message[#9]KAiif » %1:message_hastag_tag[#1]KA » %0:l1[#0]KAe
+                Get l1 // { arity: 5 }
+                ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+                  ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+                ArrangeBy keys=[[#1{messageid}], [#9{creatorpersonid}]] // { arity: 13 }
+                  ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
+                Get l0 // { arity: 11 }
+      cte l4 =
+        ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 2 }
+          Get l3 // { arity: 2 }
+      cte l5 =
+        Project (#0{id}, #2) // { arity: 2 }
+          Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 3 }
+            implementation
+              %1:l4[#0]UKA » %0:l2[#0]K
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Get l2 // { arity: 1 }
+            Get l4 // { arity: 2 }
+      cte l6 =
+        Project (#0{id}) // { arity: 1 }
+          Get l5 // { arity: 2 }
+      cte l7 =
+        Project (#3, #4) // { arity: 2 }
+          Map (coalesce(#0{id}, #1{creatorpersonid}), (integer_to_bigint(case when (#0{id}) IS NULL then 0 else 100 end) + coalesce(#2{count}, 0))) // { arity: 5 }
+            Union // { arity: 3 }
+              Project (#2{count}, #0, #1{creatorpersonid}) // { arity: 3 }
+                Map (null) // { arity: 3 }
+                  Union // { arity: 2 }
+                    Negate // { arity: 2 }
+                      Project (#0{creatorpersonid}, #1{count}) // { arity: 2 }
+                        Join on=(#0{creatorpersonid} = #2{id}) type=differential // { arity: 3 }
+                          implementation
+                            %0:l4[#0]UKA » %1[#0]UKA
+                          Get l4 // { arity: 2 }
+                          ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                            Distinct project=[#0{id}] // { arity: 1 }
+                              Get l6 // { arity: 1 }
+                    Get l3 // { arity: 2 }
+              Map (null, null) // { arity: 3 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Get l6 // { arity: 1 }
+                  Get l2 // { arity: 1 }
+              Project (#0{id}, #0{id}, #1{id}) // { arity: 3 }
+                Get l5 // { arity: 2 }
     Return // { arity: 5 }
       Map (coalesce(#2{sum}, 0), (bigint_to_numeric(#1) + #3)) // { arity: 5 }
         Reduce group_by=[#0, #1] aggregates=[sum(case when (#3) IS NULL then null else #2 end)] // { arity: 3 }
@@ -1473,79 +1546,6 @@ Explained Query:
                               ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                             Constant // { arity: 1 }
                               - (null)
-    With
-      cte l7 =
-        Project (#3, #4) // { arity: 2 }
-          Map (coalesce(#0{id}, #1{creatorpersonid}), (integer_to_bigint(case when (#0{id}) IS NULL then 0 else 100 end) + coalesce(#2{count}, 0))) // { arity: 5 }
-            Union // { arity: 3 }
-              Project (#2{count}, #0, #1{creatorpersonid}) // { arity: 3 }
-                Map (null) // { arity: 3 }
-                  Union // { arity: 2 }
-                    Negate // { arity: 2 }
-                      Project (#0{creatorpersonid}, #1{count}) // { arity: 2 }
-                        Join on=(#0{creatorpersonid} = #2{id}) type=differential // { arity: 3 }
-                          implementation
-                            %0:l4[#0]UKA » %1[#0]UKA
-                          Get l4 // { arity: 2 }
-                          ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                            Distinct project=[#0{id}] // { arity: 1 }
-                              Get l6 // { arity: 1 }
-                    Get l3 // { arity: 2 }
-              Map (null, null) // { arity: 3 }
-                Union // { arity: 1 }
-                  Negate // { arity: 1 }
-                    Get l6 // { arity: 1 }
-                  Get l2 // { arity: 1 }
-              Project (#0{id}, #0{id}, #1{id}) // { arity: 3 }
-                Get l5 // { arity: 2 }
-      cte l6 =
-        Project (#0{id}) // { arity: 1 }
-          Get l5 // { arity: 2 }
-      cte l5 =
-        Project (#0{id}, #2) // { arity: 2 }
-          Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 3 }
-            implementation
-              %1:l4[#0]UKA » %0:l2[#0]K
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Get l2 // { arity: 1 }
-            Get l4 // { arity: 2 }
-      cte l4 =
-        ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 2 }
-          Get l3 // { arity: 2 }
-      cte l3 =
-        Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*)] // { arity: 2 }
-          Project (#17) // { arity: 1 }
-            Filter (#8{creationdate} < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8{creationdate}) // { arity: 32 }
-              Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid} AND #17{creatorpersonid} = #22{id}) type=delta // { arity: 32 }
-                implementation
-                  %0:l1 » %1:message_hastag_tag[#2]KA » %2:message[#1]KAiif » %3:l0[#1]KA
-                  %1:message_hastag_tag » %0:l1[#0]KAe » %2:message[#1]KAiif » %3:l0[#1]KA
-                  %2:message » %1:message_hastag_tag[#1]KA » %0:l1[#0]KAe » %3:l0[#1]KA
-                  %3:l0 » %2:message[#9]KAiif » %1:message_hastag_tag[#1]KA » %0:l1[#0]KAe
-                Get l1 // { arity: 5 }
-                ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-                  ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-                ArrangeBy keys=[[#1{messageid}], [#9{creatorpersonid}]] // { arity: 13 }
-                  ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-                Get l0 // { arity: 11 }
-      cte l2 =
-        Project (#1) // { arity: 1 }
-          Join on=(#1{id} = #11{personid} AND #12{tagid} = #13{id}) type=delta // { arity: 18 }
-            implementation
-              %0:l0 » %1:person_hasinterest_tag[#0]K » %2:l1[#0]KAe
-              %1:person_hasinterest_tag » %2:l1[#0]KAe » %0:l0[#1]KA
-              %2:l1 » %1:person_hasinterest_tag[#1]KA » %0:l0[#1]KA
-            Get l0 // { arity: 11 }
-            ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-              Project (#1{tagid}, #2) // { arity: 2 }
-                ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
-            Get l1 // { arity: 5 }
-      cte l1 =
-        ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-          ReadIndex on=materialize.public.tag tag_name=[lookup value=("Abbas_I_of_Persia")] // { arity: 5 }
-      cte l0 =
-        ArrangeBy keys=[[#1{id}]] // { arity: 11 }
-          ReadIndex on=person person_id=[delta join lookup, delta join 1st input (full scan)] // { arity: 11 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -1698,6 +1698,24 @@ SELECT m.friendId AS "person.id"
 ----
 Explained Query:
   Finish order_by=[#2{count} desc nulls_first, #1{name} asc nulls_last, #0{person2id} asc nulls_last] limit=100 output=[#0..=#2]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
+          ReadIndex on=person_knows_person person_knows_person_person1id=[differential join, delta join lookup, lookup] // { arity: 3 }
+      cte l1 =
+        ReadIndex on=materialize.public.person_knows_person person_knows_person_person1id=[lookup value=(6597069770479)] // { arity: 4 }
+      cte l2 =
+        Distinct project=[#0{person2id}] // { arity: 1 }
+          Union // { arity: 1 }
+            Project (#2) // { arity: 1 }
+              Get l1 // { arity: 4 }
+            Project (#6) // { arity: 1 }
+              Join on=(#2{person2id} = #5{person1id}) type=differential // { arity: 7 }
+                implementation
+                  %0:l1[#2]KAe » %1:l0[#1]KAe
+                ArrangeBy keys=[[#2{person2id}]] // { arity: 4 }
+                  Get l1 // { arity: 4 }
+                Get l0 // { arity: 3 }
     Return // { arity: 3 }
       Reduce group_by=[#0{person2id}, #1{name}] aggregates=[count(*)] // { arity: 3 }
         Project (#0{person2id}, #9) // { arity: 2 }
@@ -1764,24 +1782,6 @@ Explained Query:
               ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
             ArrangeBy keys=[[#0{id}]] // { arity: 4 }
               ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
-    With
-      cte l2 =
-        Distinct project=[#0{person2id}] // { arity: 1 }
-          Union // { arity: 1 }
-            Project (#2) // { arity: 1 }
-              Get l1 // { arity: 4 }
-            Project (#6) // { arity: 1 }
-              Join on=(#2{person2id} = #5{person1id}) type=differential // { arity: 7 }
-                implementation
-                  %0:l1[#2]KAe » %1:l0[#1]KAe
-                ArrangeBy keys=[[#2{person2id}]] // { arity: 4 }
-                  Get l1 // { arity: 4 }
-                Get l0 // { arity: 3 }
-      cte l1 =
-        ReadIndex on=materialize.public.person_knows_person person_knows_person_person1id=[lookup value=(6597069770479)] // { arity: 4 }
-      cte l0 =
-        ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
-          ReadIndex on=person_knows_person person_knows_person_person1id=[differential join, delta join lookup, lookup] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join lookup)
@@ -1840,32 +1840,7 @@ SELECT count(*)
    AND '2012-09-28'::TIMESTAMP <= p3.creationDate AND p3.creationDate <= '2013-01-10'::TIMESTAMP
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l2 // { arity: 1 }
-      Map (0) // { arity: 1 }
-        Union // { arity: 0 }
-          Negate // { arity: 0 }
-            Project () // { arity: 0 }
-              Get l2 // { arity: 1 }
-          Constant // { arity: 0 }
-            - ()
   With
-    cte l2 =
-      Reduce aggregates=[count(*)] // { arity: 1 }
-        Project () // { arity: 0 }
-          Join on=(#0{id} = #5{person2id} AND #1{person2id} = #2{id} AND #3{person2id} = #4{id}) type=differential // { arity: 6 }
-            implementation
-              %0:l1[#1]Kf » %1:l1[#0]Kf » %2:l0[#0, #1]KKf
-            ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
-              Get l1 // { arity: 2 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
-              Get l1 // { arity: 2 }
-            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 2 }
-              Get l0 // { arity: 2 }
-    cte l1 =
-      Filter (#0{id} < #1{person2id}) // { arity: 2 }
-        Get l0 // { arity: 2 }
     cte l0 =
       Project (#1{person2id}, #21) // { arity: 2 }
         Filter (#16{name} = "India") AND (#19{creationdate} <= 2013-01-10 00:00:00 UTC) AND (2012-09-28 00:00:00 UTC <= #19{creationdate}) AND (#14{partofcountryid}) IS NOT NULL // { arity: 22 }
@@ -1883,6 +1858,31 @@ Explained Query:
               ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
             ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
               ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] // { arity: 3 }
+    cte l1 =
+      Filter (#0{id} < #1{person2id}) // { arity: 2 }
+        Get l0 // { arity: 2 }
+    cte l2 =
+      Reduce aggregates=[count(*)] // { arity: 1 }
+        Project () // { arity: 0 }
+          Join on=(#0{id} = #5{person2id} AND #1{person2id} = #2{id} AND #3{person2id} = #4{id}) type=differential // { arity: 6 }
+            implementation
+              %0:l1[#1]Kf » %1:l1[#0]Kf » %2:l0[#0, #1]KKf
+            ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
+              Get l1 // { arity: 2 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
+              Get l1 // { arity: 2 }
+            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 2 }
+              Get l0 // { arity: 2 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l2 // { arity: 1 }
+      Map (0) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l2 // { arity: 1 }
+          Constant // { arity: 0 }
+            - ()
 
 Used Indexes:
   - materialize.public.person_id (delta join 1st input (full scan))
@@ -1934,6 +1934,19 @@ ORDER BY personCount DESC, messageCount DESC
 ----
 Explained Query:
   Finish order_by=[#1{count} desc nulls_first, #0{count_messageid} desc nulls_first] output=[#0, #1]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#1{id}]] // { arity: 11 }
+          ReadIndex on=person person_id=[differential join] // { arity: 11 }
+      cte l1 =
+        Project (#1{messageid}, #12) // { arity: 2 }
+          Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#15{content}) IS NOT NULL // { arity: 25 }
+            Join on=(#1{id} = #20{creatorpersonid}) type=differential // { arity: 25 }
+              implementation
+                %1:message[#9]KAeiif » %0:l0[#1]KAeiif
+              Get l0 // { arity: 11 }
+              ArrangeBy keys=[[#9{creatorpersonid}]] // { arity: 14 }
+                ReadIndex on=materialize.public.message message_rootpostlanguage=[lookup values=[("es"); ("pt"); ("ta")]] // { arity: 14 }
     Return // { arity: 2 }
       Reduce group_by=[#0{count_messageid}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
@@ -1954,19 +1967,6 @@ Explained Query:
                   Project (#1) // { arity: 1 }
                     ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
               Get l1 // { arity: 2 }
-    With
-      cte l1 =
-        Project (#1{messageid}, #12) // { arity: 2 }
-          Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#15{content}) IS NOT NULL // { arity: 25 }
-            Join on=(#1{id} = #20{creatorpersonid}) type=differential // { arity: 25 }
-              implementation
-                %1:message[#9]KAeiif » %0:l0[#1]KAeiif
-              Get l0 // { arity: 11 }
-              ArrangeBy keys=[[#9{creatorpersonid}]] // { arity: 14 }
-                ReadIndex on=materialize.public.message message_rootpostlanguage=[lookup values=[("es"); ("pt"); ("ta")]] // { arity: 14 }
-      cte l0 =
-        ArrangeBy keys=[[#1{id}]] // { arity: 11 }
-          ReadIndex on=person person_id=[differential join] // { arity: 11 }
 
 Used Indexes:
   - materialize.public.person_id (*** full scan ***, differential join)
@@ -2002,6 +2002,33 @@ ORDER BY personCount DESC, messageCount DESC
 ----
 Explained Query:
   Finish order_by=[#1{count} desc nulls_first, #0{count_messageid} desc nulls_first] output=[#0, #1]
+    With
+      cte l0 =
+        CrossJoin type=differential // { arity: 17 }
+          implementation
+            %0:person[×] » %1:message[×]
+          ArrangeBy keys=[[]] // { arity: 11 }
+            ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
+          ArrangeBy keys=[[]] // { arity: 6 }
+            Project (#0{creationdate}, #1{messageid}, #3{content}, #4{length}, #8, #9) // { arity: 6 }
+              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+      cte l1 =
+        Project (#0{creationdate}..=#11{messageid}) // { arity: 12 }
+          Join on=(#12{rootpostlanguage} = #13{rootpostlanguage}) type=differential // { arity: 14 }
+            implementation
+              %1[#0]UKA » %0:l0[#12]Kiif
+            ArrangeBy keys=[[#12{rootpostlanguage}]] // { arity: 13 }
+              Project (#0{creationdate}..=#10{email}, #12{rootpostlanguage}, #13) // { arity: 13 }
+                Filter (#15{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#14{content}) IS NOT NULL AND (#1{id} = #16{creatorpersonid}) // { arity: 17 }
+                  Get l0 // { arity: 17 }
+            ArrangeBy keys=[[#0{rootpostlanguage}]] // { arity: 1 }
+              Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
+                Project (#0{rootpostlanguage}) // { arity: 1 }
+                  Filter (#0{rootpostlanguage} = varchar_to_text(#1)) // { arity: 2 }
+                    FlatMap unnest_array({"es", "ta", "pt"}) // { arity: 2 }
+                      Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
+                        Project (#13) // { arity: 1 }
+                          Get l0 // { arity: 17 }
     Return // { arity: 2 }
       Reduce group_by=[#0{count_messageid}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
@@ -2024,33 +2051,6 @@ Explained Query:
                           ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
                     ArrangeBy keys=[[#0{creationdate}..=#10{email}]] // { arity: 11 }
                       ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
-    With
-      cte l1 =
-        Project (#0{creationdate}..=#11{messageid}) // { arity: 12 }
-          Join on=(#12{rootpostlanguage} = #13{rootpostlanguage}) type=differential // { arity: 14 }
-            implementation
-              %1[#0]UKA » %0:l0[#12]Kiif
-            ArrangeBy keys=[[#12{rootpostlanguage}]] // { arity: 13 }
-              Project (#0{creationdate}..=#10{email}, #12{rootpostlanguage}, #13) // { arity: 13 }
-                Filter (#15{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#14{content}) IS NOT NULL AND (#1{id} = #16{creatorpersonid}) // { arity: 17 }
-                  Get l0 // { arity: 17 }
-            ArrangeBy keys=[[#0{rootpostlanguage}]] // { arity: 1 }
-              Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
-                Project (#0{rootpostlanguage}) // { arity: 1 }
-                  Filter (#0{rootpostlanguage} = varchar_to_text(#1)) // { arity: 2 }
-                    FlatMap unnest_array({"es", "ta", "pt"}) // { arity: 2 }
-                      Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
-                        Project (#13) // { arity: 1 }
-                          Get l0 // { arity: 17 }
-      cte l0 =
-        CrossJoin type=differential // { arity: 17 }
-          implementation
-            %0:person[×] » %1:message[×]
-          ArrangeBy keys=[[]] // { arity: 11 }
-            ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
-          ArrangeBy keys=[[]] // { arity: 6 }
-            Project (#0{creationdate}, #1{messageid}, #3{content}, #4{length}, #8, #9) // { arity: 6 }
-              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
   - materialize.public.person_id (*** full scan ***)
@@ -2102,77 +2102,32 @@ SELECT Z.zombieid AS "zombie.id"
 ----
 Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#3]
-    Return // { arity: 4 }
-      Project (#0{id}, #3..=#5) // { arity: 4 }
-        Map (coalesce(#2{sum}, 0), coalesce(#1{count}, 0), case when (#1{count} > 0) then (bigint_to_double(#2{sum}) / bigint_to_double(#1{count})) else 0 end) // { arity: 6 }
-          Union // { arity: 3 }
-            Map (null, null) // { arity: 3 }
-              Union // { arity: 1 }
-                Negate // { arity: 1 }
-                  Project (#0{id}) // { arity: 1 }
-                    Get l8 // { arity: 3 }
-                Get l2 // { arity: 1 }
-            Get l8 // { arity: 3 }
     With
-      cte l8 =
-        Project (#0{id}, #2{sum}, #3) // { arity: 3 }
-          Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 4 }
-            implementation
-              %1[#0]UKA » %0:l4[#0]K
-            Get l4 // { arity: 1 }
-            ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 3 }
-              Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*), sum(case when #1 then 1 else 0 end)] // { arity: 3 }
-                Project (#1, #3) // { arity: 2 }
-                  Join on=(#0{id} = #2{id}) type=differential // { arity: 4 }
-                    implementation
-                      %0:l5[#0]K » %1[#0]K
-                    ArrangeBy keys=[[#0{id}]] // { arity: 2 }
-                      Get l5 // { arity: 2 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 2 }
-                      Union // { arity: 2 }
-                        Map (true) // { arity: 2 }
-                          Get l7 // { arity: 1 }
-                        Map (false) // { arity: 2 }
-                          Union // { arity: 1 }
-                            Negate // { arity: 1 }
-                              Get l7 // { arity: 1 }
-                            Get l6 // { arity: 1 }
-      cte l7 =
-        Project (#0{id}) // { arity: 1 }
-          Join on=(#0{id} = #1{id}) type=differential // { arity: 2 }
-            implementation
-              %0:l6[#0]UKA » %1[#0]UKA
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Get l6 // { arity: 1 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Get l3 // { arity: 1 }
-      cte l6 =
-        Distinct project=[#0{id}] // { arity: 1 }
-          Project (#0{id}) // { arity: 1 }
-            Get l5 // { arity: 2 }
-      cte l5 =
-        Project (#1{creatorpersonid}, #23) // { arity: 2 }
-          Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) // { arity: 28 }
-            Join on=(#1{id} = #12{personid} AND #13{messageid} = #15{messageid} AND #23{creatorpersonid} = #27{id}) type=delta // { arity: 28 }
+      cte l0 =
+        Project (#0{id}, #2{partofcontinentid}..=#6{creationdate}, #8{firstname}..=#15{email}, #17, #18) // { arity: 16 }
+          Filter (#1{name} = "India") AND (#8{creationdate} < 2012-11-09 00:00:00 UTC) AND (#0{id}) IS NOT NULL // { arity: 19 }
+            Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid}) type=delta // { arity: 19 }
               implementation
-                %0:person » %1:person_likes_message[#1]KA » %2:message[#1]KA » %3:l4[#0]K
-                %1:person_likes_message » %0:person[#1]KAif » %2:message[#1]KA » %3:l4[#0]K
-                %2:message » %1:person_likes_message[#2]KA » %0:person[#1]KAif » %3:l4[#0]K
-                %3:l4 » %2:message[#9]KA » %1:person_likes_message[#2]KA » %0:person[#1]KAif
-              ArrangeBy keys=[[#1{id}]] // { arity: 11 }
-                ReadIndex on=person person_id=[delta join 1st input (full scan)] // { arity: 11 }
-              ArrangeBy keys=[[#1{personid}], [#2{messageid}]] // { arity: 3 }
-                ReadIndex on=person_likes_message person_likes_message_personid=[delta join lookup] person_likes_message_messageid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#1{messageid}], [#9{creatorpersonid}]] // { arity: 13 }
-                ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-              Get l4 // { arity: 1 }
-      cte l4 =
-        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-          Get l3 // { arity: 1 }
-      cte l3 =
-        Filter (#0{id}) IS NOT NULL // { arity: 1 }
-          Get l2 // { arity: 1 }
+                %0:country » %1:city[#3]KA » %2:person[#8]KAif
+                %1:city » %0:country[#0]KAef » %2:person[#8]KAif
+                %2:person » %1:city[#0]KA » %0:country[#0]KAef
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                ReadIndex on=country country_id=[delta join 1st input (full scan)] // { arity: 4 }
+              ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
+                ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
+              ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
+                ReadIndex on=person person_locationcityid=[delta join lookup] // { arity: 11 }
+      cte l1 =
+        Project (#0{id}..=#15{email}, #17) // { arity: 17 }
+          Filter (#16{creationdate} <= 2012-11-09 00:00:00 UTC) AND (#16{creationdate} >= #6{creationdate}) // { arity: 29 }
+            Join on=(#7{id} = #25{creatorpersonid}) type=differential // { arity: 29 }
+              implementation
+                %1:message[#9]KAif » %0:l0[#7]Kif
+              ArrangeBy keys=[[#7{id}]] // { arity: 16 }
+                Filter (#7{id}) IS NOT NULL // { arity: 16 }
+                  Get l0 // { arity: 16 }
+              ArrangeBy keys=[[#9{creatorpersonid}]] // { arity: 13 }
+                ReadIndex on=message message_creatorpersonid=[differential join] // { arity: 13 }
       cte l2 =
         Project (#0{id}) // { arity: 1 }
           Filter (bigint_to_numeric(#2{count_messageid}) < ((24155 - ((12 * extract_year_tstz(#1{creationdate})) + extract_month_tstz(#1{creationdate}))) + 1)) // { arity: 3 }
@@ -2197,31 +2152,76 @@ Explained Query:
                               Get l0 // { arity: 16 }
                       ArrangeBy keys=[[#0{id}..=#15{email}]] // { arity: 16 }
                         Get l0 // { arity: 16 }
-      cte l1 =
-        Project (#0{id}..=#15{email}, #17) // { arity: 17 }
-          Filter (#16{creationdate} <= 2012-11-09 00:00:00 UTC) AND (#16{creationdate} >= #6{creationdate}) // { arity: 29 }
-            Join on=(#7{id} = #25{creatorpersonid}) type=differential // { arity: 29 }
+      cte l3 =
+        Filter (#0{id}) IS NOT NULL // { arity: 1 }
+          Get l2 // { arity: 1 }
+      cte l4 =
+        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+          Get l3 // { arity: 1 }
+      cte l5 =
+        Project (#1{creatorpersonid}, #23) // { arity: 2 }
+          Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) // { arity: 28 }
+            Join on=(#1{id} = #12{personid} AND #13{messageid} = #15{messageid} AND #23{creatorpersonid} = #27{id}) type=delta // { arity: 28 }
               implementation
-                %1:message[#9]KAif » %0:l0[#7]Kif
-              ArrangeBy keys=[[#7{id}]] // { arity: 16 }
-                Filter (#7{id}) IS NOT NULL // { arity: 16 }
-                  Get l0 // { arity: 16 }
-              ArrangeBy keys=[[#9{creatorpersonid}]] // { arity: 13 }
-                ReadIndex on=message message_creatorpersonid=[differential join] // { arity: 13 }
-      cte l0 =
-        Project (#0{id}, #2{partofcontinentid}..=#6{creationdate}, #8{firstname}..=#15{email}, #17, #18) // { arity: 16 }
-          Filter (#1{name} = "India") AND (#8{creationdate} < 2012-11-09 00:00:00 UTC) AND (#0{id}) IS NOT NULL // { arity: 19 }
-            Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid}) type=delta // { arity: 19 }
-              implementation
-                %0:country » %1:city[#3]KA » %2:person[#8]KAif
-                %1:city » %0:country[#0]KAef » %2:person[#8]KAif
-                %2:person » %1:city[#0]KA » %0:country[#0]KAef
-              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                ReadIndex on=country country_id=[delta join 1st input (full scan)] // { arity: 4 }
-              ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
-                ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
-              ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
-                ReadIndex on=person person_locationcityid=[delta join lookup] // { arity: 11 }
+                %0:person » %1:person_likes_message[#1]KA » %2:message[#1]KA » %3:l4[#0]K
+                %1:person_likes_message » %0:person[#1]KAif » %2:message[#1]KA » %3:l4[#0]K
+                %2:message » %1:person_likes_message[#2]KA » %0:person[#1]KAif » %3:l4[#0]K
+                %3:l4 » %2:message[#9]KA » %1:person_likes_message[#2]KA » %0:person[#1]KAif
+              ArrangeBy keys=[[#1{id}]] // { arity: 11 }
+                ReadIndex on=person person_id=[delta join 1st input (full scan)] // { arity: 11 }
+              ArrangeBy keys=[[#1{personid}], [#2{messageid}]] // { arity: 3 }
+                ReadIndex on=person_likes_message person_likes_message_personid=[delta join lookup] person_likes_message_messageid=[delta join lookup] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}], [#9{creatorpersonid}]] // { arity: 13 }
+                ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
+              Get l4 // { arity: 1 }
+      cte l6 =
+        Distinct project=[#0{id}] // { arity: 1 }
+          Project (#0{id}) // { arity: 1 }
+            Get l5 // { arity: 2 }
+      cte l7 =
+        Project (#0{id}) // { arity: 1 }
+          Join on=(#0{id} = #1{id}) type=differential // { arity: 2 }
+            implementation
+              %0:l6[#0]UKA » %1[#0]UKA
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Get l6 // { arity: 1 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
+                Get l3 // { arity: 1 }
+      cte l8 =
+        Project (#0{id}, #2{sum}, #3) // { arity: 3 }
+          Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 4 }
+            implementation
+              %1[#0]UKA » %0:l4[#0]K
+            Get l4 // { arity: 1 }
+            ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 3 }
+              Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*), sum(case when #1 then 1 else 0 end)] // { arity: 3 }
+                Project (#1, #3) // { arity: 2 }
+                  Join on=(#0{id} = #2{id}) type=differential // { arity: 4 }
+                    implementation
+                      %0:l5[#0]K » %1[#0]K
+                    ArrangeBy keys=[[#0{id}]] // { arity: 2 }
+                      Get l5 // { arity: 2 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 2 }
+                      Union // { arity: 2 }
+                        Map (true) // { arity: 2 }
+                          Get l7 // { arity: 1 }
+                        Map (false) // { arity: 2 }
+                          Union // { arity: 1 }
+                            Negate // { arity: 1 }
+                              Get l7 // { arity: 1 }
+                            Get l6 // { arity: 1 }
+    Return // { arity: 4 }
+      Project (#0{id}, #3..=#5) // { arity: 4 }
+        Map (coalesce(#2{sum}, 0), coalesce(#1{count}, 0), case when (#1{count} > 0) then (bigint_to_double(#2{sum}) / bigint_to_double(#1{count})) else 0 end) // { arity: 6 }
+          Union // { arity: 3 }
+            Map (null, null) // { arity: 3 }
+              Union // { arity: 1 }
+                Negate // { arity: 1 }
+                  Project (#0{id}) // { arity: 1 }
+                    Get l8 // { arity: 3 }
+                Get l2 // { arity: 1 }
+            Get l8 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_id (delta join 1st input (full scan))
@@ -2306,20 +2306,104 @@ SELECT score_ranks.Person1Id AS "person1.id"
 ----
 Explained Query:
   Finish order_by=[#3{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=100 output=[#0..=#3]
-    Return // { arity: 4 }
-      Project (#0{id}, #1{person2id}, #3{sum}, #4) // { arity: 4 }
-        TopK group_by=[#2{id}] order_by=[#4{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=1 // { arity: 5 }
-          Union // { arity: 5 }
-            Map (null) // { arity: 5 }
-              Union // { arity: 4 }
-                Negate // { arity: 4 }
-                  Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
-                    Get l11 // { arity: 5 }
-                Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
-                  Get l3 // { arity: 4 }
-            Project (#2{id}, #3{name}, #0{id}, #1{person2id}, #4{sum}) // { arity: 5 }
-              Get l11 // { arity: 5 }
     With
+      cte l0 =
+        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+          ReadIndex on=country country_id=[delta join lookup, delta join 1st input (full scan)] // { arity: 4 }
+      cte l1 =
+        ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
+          ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
+      cte l2 =
+        ArrangeBy keys=[[#1{id}], [#8{locationcityid}]] // { arity: 11 }
+          ReadIndex on=person person_id=[delta join lookup] person_locationcityid=[delta join lookup] // { arity: 11 }
+      cte l3 =
+        Project (#4, #5, #9, #21) // { arity: 4 }
+          Filter (#1{name} = "Philippines") AND (#38{name} = "Taiwan") AND (#0{id}) IS NOT NULL AND (#36{partofcountryid}) IS NOT NULL // { arity: 41 }
+            Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid} AND #9{id} = #20{person1id} AND #21{person2id} = #23{id} AND #30{locationcityid} = #33{id} AND #36{partofcountryid} = #37{id}) type=delta // { arity: 41 }
+              implementation
+                %0:l0 » %1:l1[#3]KA » %2:l2[#8]KA » %3:person_knows_person[#1]KA » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
+                %1:l1 » %0:l0[#0]KAef » %2:l2[#8]KA » %3:person_knows_person[#1]KA » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
+                %2:l2 » %1:l1[#0]KA » %0:l0[#0]KAef » %3:person_knows_person[#1]KA » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
+                %3:person_knows_person » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
+                %4:l2 » %3:person_knows_person[#2]KA » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef » %5:l1[#0]KA » %6:l0[#0]KAef
+                %5:l1 » %6:l0[#0]KAef » %4:l2[#8]KA » %3:person_knows_person[#2]KA » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef
+                %6:l0 » %5:l1[#3]KA » %4:l2[#8]KA » %3:person_knows_person[#2]KA » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef
+              Get l0 // { arity: 4 }
+              Get l1 // { arity: 4 }
+              Get l2 // { arity: 11 }
+              ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+              Get l2 // { arity: 11 }
+              Get l1 // { arity: 4 }
+              Get l0 // { arity: 4 }
+      cte l4 =
+        Map (case when #2 then #1{person2id} else #0{id} end, case when #2 then #0{id} else #1{person2id} end) // { arity: 5 }
+          Union // { arity: 3 }
+            Project (#2..=#4) // { arity: 3 }
+              Map (false) // { arity: 5 }
+                Get l3 // { arity: 4 }
+            Project (#3, #2, #4) // { arity: 3 }
+              Map (true) // { arity: 5 }
+                Get l3 // { arity: 4 }
+      cte l5 =
+        Distinct project=[#0{id}, #1{person2id}] // { arity: 2 }
+          Project (#0{id}, #1{person2id}) // { arity: 2 }
+            Get l4 // { arity: 5 }
+      cte l6 =
+        ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+          ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
+      cte l7 =
+        Project (#0{id}, #1{person2id}) // { arity: 2 }
+          Join on=(#0{id} = #2{creatorpersonid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
+            implementation
+              %0:l5[#0, #1]UKKA » %1[#0, #1]UKKA
+            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 2 }
+              Get l5 // { arity: 2 }
+            ArrangeBy keys=[[#0{creatorpersonid}, #1{creatorpersonid}]] // { arity: 2 }
+              Distinct project=[#1{creatorpersonid}, #0{creatorpersonid}] // { arity: 2 }
+                Project (#9, #22) // { arity: 2 }
+                  Join on=(#1{messageid} = #25{parentmessageid}) type=differential // { arity: 26 }
+                    implementation
+                      %0:l6[#1]KA » %1:message[#12]KA
+                    Get l6 // { arity: 13 }
+                    ArrangeBy keys=[[#12{parentmessageid}]] // { arity: 13 }
+                      ReadIndex on=message message_parentmessageid=[differential join] // { arity: 13 }
+      cte l8 =
+        Project (#0{id}..=#4, #7) // { arity: 6 }
+          Join on=(#0{id} = #5{id} AND #1{person2id} = #6{person2id}) type=differential // { arity: 8 }
+            implementation
+              %0:l4[#0, #1]KK » %1[#0, #1]KK
+            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 5 }
+              Get l4 // { arity: 5 }
+            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 3 }
+              Union // { arity: 3 }
+                Map (true) // { arity: 3 }
+                  Get l7 // { arity: 2 }
+                Map (false) // { arity: 3 }
+                  Union // { arity: 2 }
+                    Negate // { arity: 2 }
+                      Get l7 // { arity: 2 }
+                    Get l5 // { arity: 2 }
+      cte l9 =
+        Distinct project=[#0{id}, #1{person2id}] // { arity: 2 }
+          Project (#0{id}, #1{person2id}) // { arity: 2 }
+            Get l8 // { arity: 6 }
+      cte l10 =
+        Project (#0{id}, #1{person2id}) // { arity: 2 }
+          Join on=(#0{id} = #2{personid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
+            implementation
+              %0:l9[#0, #1]UKKA » %1[#0, #1]UKKA
+            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 2 }
+              Get l9 // { arity: 2 }
+            ArrangeBy keys=[[#0{personid}, #1{creatorpersonid}]] // { arity: 2 }
+              Distinct project=[#1{personid}, #0{creatorpersonid}] // { arity: 2 }
+                Project (#9, #14) // { arity: 2 }
+                  Join on=(#1{messageid} = #15{messageid}) type=differential // { arity: 16 }
+                    implementation
+                      %0:l6[#1]KA » %1:person_likes_message[#2]KA
+                    Get l6 // { arity: 13 }
+                    ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
+                      ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l11 =
         Project (#0{id}..=#3{person2id}, #6) // { arity: 5 }
           Join on=(#2{id} = #4 AND #3{person2id} = #5) type=differential // { arity: 7 }
@@ -2344,103 +2428,19 @@ Explained Query:
                             Negate // { arity: 2 }
                               Get l10 // { arity: 2 }
                             Get l9 // { arity: 2 }
-      cte l10 =
-        Project (#0{id}, #1{person2id}) // { arity: 2 }
-          Join on=(#0{id} = #2{personid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
-            implementation
-              %0:l9[#0, #1]UKKA » %1[#0, #1]UKKA
-            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 2 }
-              Get l9 // { arity: 2 }
-            ArrangeBy keys=[[#0{personid}, #1{creatorpersonid}]] // { arity: 2 }
-              Distinct project=[#1{personid}, #0{creatorpersonid}] // { arity: 2 }
-                Project (#9, #14) // { arity: 2 }
-                  Join on=(#1{messageid} = #15{messageid}) type=differential // { arity: 16 }
-                    implementation
-                      %0:l6[#1]KA » %1:person_likes_message[#2]KA
-                    Get l6 // { arity: 13 }
-                    ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
-                      ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
-      cte l9 =
-        Distinct project=[#0{id}, #1{person2id}] // { arity: 2 }
-          Project (#0{id}, #1{person2id}) // { arity: 2 }
-            Get l8 // { arity: 6 }
-      cte l8 =
-        Project (#0{id}..=#4, #7) // { arity: 6 }
-          Join on=(#0{id} = #5{id} AND #1{person2id} = #6{person2id}) type=differential // { arity: 8 }
-            implementation
-              %0:l4[#0, #1]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 5 }
-              Get l4 // { arity: 5 }
-            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 3 }
-              Union // { arity: 3 }
-                Map (true) // { arity: 3 }
-                  Get l7 // { arity: 2 }
-                Map (false) // { arity: 3 }
-                  Union // { arity: 2 }
-                    Negate // { arity: 2 }
-                      Get l7 // { arity: 2 }
-                    Get l5 // { arity: 2 }
-      cte l7 =
-        Project (#0{id}, #1{person2id}) // { arity: 2 }
-          Join on=(#0{id} = #2{creatorpersonid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
-            implementation
-              %0:l5[#0, #1]UKKA » %1[#0, #1]UKKA
-            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 2 }
-              Get l5 // { arity: 2 }
-            ArrangeBy keys=[[#0{creatorpersonid}, #1{creatorpersonid}]] // { arity: 2 }
-              Distinct project=[#1{creatorpersonid}, #0{creatorpersonid}] // { arity: 2 }
-                Project (#9, #22) // { arity: 2 }
-                  Join on=(#1{messageid} = #25{parentmessageid}) type=differential // { arity: 26 }
-                    implementation
-                      %0:l6[#1]KA » %1:message[#12]KA
-                    Get l6 // { arity: 13 }
-                    ArrangeBy keys=[[#12{parentmessageid}]] // { arity: 13 }
-                      ReadIndex on=message message_parentmessageid=[differential join] // { arity: 13 }
-      cte l6 =
-        ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-          ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
-      cte l5 =
-        Distinct project=[#0{id}, #1{person2id}] // { arity: 2 }
-          Project (#0{id}, #1{person2id}) // { arity: 2 }
-            Get l4 // { arity: 5 }
-      cte l4 =
-        Map (case when #2 then #1{person2id} else #0{id} end, case when #2 then #0{id} else #1{person2id} end) // { arity: 5 }
-          Union // { arity: 3 }
-            Project (#2..=#4) // { arity: 3 }
-              Map (false) // { arity: 5 }
-                Get l3 // { arity: 4 }
-            Project (#3, #2, #4) // { arity: 3 }
-              Map (true) // { arity: 5 }
-                Get l3 // { arity: 4 }
-      cte l3 =
-        Project (#4, #5, #9, #21) // { arity: 4 }
-          Filter (#1{name} = "Philippines") AND (#38{name} = "Taiwan") AND (#0{id}) IS NOT NULL AND (#36{partofcountryid}) IS NOT NULL // { arity: 41 }
-            Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid} AND #9{id} = #20{person1id} AND #21{person2id} = #23{id} AND #30{locationcityid} = #33{id} AND #36{partofcountryid} = #37{id}) type=delta // { arity: 41 }
-              implementation
-                %0:l0 » %1:l1[#3]KA » %2:l2[#8]KA » %3:person_knows_person[#1]KA » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
-                %1:l1 » %0:l0[#0]KAef » %2:l2[#8]KA » %3:person_knows_person[#1]KA » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
-                %2:l2 » %1:l1[#0]KA » %0:l0[#0]KAef » %3:person_knows_person[#1]KA » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
-                %3:person_knows_person » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
-                %4:l2 » %3:person_knows_person[#2]KA » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef » %5:l1[#0]KA » %6:l0[#0]KAef
-                %5:l1 » %6:l0[#0]KAef » %4:l2[#8]KA » %3:person_knows_person[#2]KA » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef
-                %6:l0 » %5:l1[#3]KA » %4:l2[#8]KA » %3:person_knows_person[#2]KA » %2:l2[#1]KA » %1:l1[#0]KA » %0:l0[#0]KAef
-              Get l0 // { arity: 4 }
-              Get l1 // { arity: 4 }
-              Get l2 // { arity: 11 }
-              ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-              Get l2 // { arity: 11 }
-              Get l1 // { arity: 4 }
-              Get l0 // { arity: 4 }
-      cte l2 =
-        ArrangeBy keys=[[#1{id}], [#8{locationcityid}]] // { arity: 11 }
-          ReadIndex on=person person_id=[delta join lookup] person_locationcityid=[delta join lookup] // { arity: 11 }
-      cte l1 =
-        ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
-          ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
-      cte l0 =
-        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-          ReadIndex on=country country_id=[delta join lookup, delta join 1st input (full scan)] // { arity: 4 }
+    Return // { arity: 4 }
+      Project (#0{id}, #1{person2id}, #3{sum}, #4) // { arity: 4 }
+        TopK group_by=[#2{id}] order_by=[#4{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=1 // { arity: 5 }
+          Union // { arity: 5 }
+            Map (null) // { arity: 5 }
+              Union // { arity: 4 }
+                Negate // { arity: 4 }
+                  Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
+                    Get l11 // { arity: 5 }
+                Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
+                  Get l3 // { arity: 4 }
+            Project (#2{id}, #3{name}, #0{id}, #1{person2id}, #4{sum}) // { arity: 5 }
+              Get l11 // { arity: 5 }
 
 Used Indexes:
   - materialize.public.person_id (delta join lookup)
@@ -2524,11 +2524,45 @@ SELECT coalesce(w, -1) FROM results ORDER BY w ASC LIMIT 20
 ----
 Explained Query:
   Finish order_by=[#1{min} asc nulls_last] limit=20 output=[#2]
-    Return // { arity: 3 }
-      Project (#1{min}, #2{min}, #2{min}) // { arity: 3 }
-        Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
-          Get l4 // { arity: 3 }
     With Mutually Recursive
+      cte l0 =
+        Project (#1{person2id}, #2) // { arity: 2 }
+          ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+      cte l1 =
+        ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
+          Get l0 // { arity: 2 }
+      cte l2 =
+        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+          Distinct project=[#0{id}] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
+                ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+      cte l3 =
+        Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
+          implementation
+            %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+          Get l1 // { arity: 2 }
+          ArrangeBy keys=[[#1, #0]] // { arity: 3 }
+            Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
+              Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
+                  implementation
+                    %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                    %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                    %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                    Project (#9, #10, #12) // { arity: 3 }
+                      Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  Get l2 // { arity: 1 }
+                  Get l2 // { arity: 1 }
       cte l4 =
         Project (#2{min}, #0, #1{person2id}) // { arity: 3 }
           Map (1450) // { arity: 3 }
@@ -2564,44 +2598,10 @@ Explained Query:
                                   Get l3 // { arity: 5 }
                   Constant // { arity: 2 }
                     - (1450, 0)
-      cte l3 =
-        Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
-          implementation
-            %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
-          Get l1 // { arity: 2 }
-          ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-            Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-              Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
-                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
-                  implementation
-                    %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
-                    %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                    %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                    %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                    %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                    Project (#9, #10, #12) // { arity: 3 }
-                      Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                  Get l2 // { arity: 1 }
-                  Get l2 // { arity: 1 }
-      cte l2 =
-        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-          Distinct project=[#0{id}] // { arity: 1 }
-            Project (#1) // { arity: 1 }
-              Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
-      cte l1 =
-        ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-          Get l0 // { arity: 2 }
-      cte l0 =
-        Project (#1{person2id}, #2) // { arity: 2 }
-          ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+    Return // { arity: 3 }
+      Project (#1{min}, #2{min}, #2{min}) // { arity: 3 }
+        Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
+          Get l4 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -2720,113 +2720,136 @@ EXPLAIN WITH(humanized expressions, arity, join implementations) WITH MUTUALLY R
 SELECT coalesce(min(w), -1) FROM results
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Return // { arity: 1 }
-      Project (#1) // { arity: 1 }
-        Map (coalesce(#0{min_min}, -1)) // { arity: 2 }
-          Union // { arity: 1 }
-            Get l19 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l19 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
-    With
-      cte l19 =
-        Reduce aggregates=[min(#0{min})] // { arity: 1 }
-          Project (#2) // { arity: 1 }
-            Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
-              Project (#0, #2, #3, #5) // { arity: 4 }
-                Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
-                  implementation
-                    %0:l18[#1]Kef » %1:l18[#1]Kef
-                  ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1{person2id}..=#3) // { arity: 3 }
-                      Filter (#0 = false) // { arity: 4 }
-                        Get l18 // { arity: 4 }
-                  ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1{person2id}..=#3) // { arity: 3 }
-                      Filter (#0 = true) // { arity: 4 }
-                        Get l18 // { arity: 4 }
-      cte l18 =
-        Project (#0..=#3) // { arity: 4 }
-          Join on=(#4 = #5{max}) type=differential // { arity: 6 }
-            implementation
-              %1[#0]UK » %0:l17[#4]K
-            ArrangeBy keys=[[#4]] // { arity: 5 }
-              Project (#0..=#3, #5) // { arity: 5 }
-                Get l17 // { arity: 6 }
-            ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-              Reduce aggregates=[max(#0)] // { arity: 1 }
-                Project (#5) // { arity: 1 }
-                  Get l17 // { arity: 6 }
   With Mutually Recursive
-    cte l17 =
-      Distinct project=[#0..=#5] // { arity: 6 }
-        Union // { arity: 6 }
-          Project (#1, #0, #0, #2..=#4) // { arity: 6 }
-            Map (0, false, 0) // { arity: 5 }
-              Union // { arity: 2 }
-                Map (1450, false) // { arity: 2 }
-                  Get l16 // { arity: 0 }
-                Map (15393162796819, true) // { arity: 2 }
-                  Get l16 // { arity: 0 }
-          Project (#0..=#3, #7, #8) // { arity: 6 }
-            Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
-              CrossJoin type=delta // { arity: 7 }
+    cte l0 =
+      Project (#1{person2id}, #2) // { arity: 2 }
+        ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+    cte l1 =
+      ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
+        Get l0 // { arity: 2 }
+    cte l2 =
+      ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+        Distinct project=[#0{id}] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
+              ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+    cte l3 =
+      Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
+        implementation
+          %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+        Get l1 // { arity: 2 }
+        ArrangeBy keys=[[#1, #0]] // { arity: 3 }
+          Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
+            Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+              Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                 implementation
-                  %0:l13 » %1[×]U » %2[×]U
-                  %1 » %2[×]U » %0:l13[×]
-                  %2 » %1[×]U » %0:l13[×]
-                ArrangeBy keys=[[]] // { arity: 5 }
-                  Get l13 // { arity: 5 }
-                ArrangeBy keys=[[]] // { arity: 1 }
-                  TopK limit=1 // { arity: 1 }
-                    Project (#4) // { arity: 1 }
-                      Get l9 // { arity: 5 }
-                ArrangeBy keys=[[]] // { arity: 1 }
-                  Union // { arity: 1 }
-                    Get l15 // { arity: 1 }
-                    Map (null) // { arity: 1 }
-                      Union // { arity: 0 }
-                        Negate // { arity: 0 }
-                          Project () // { arity: 0 }
-                            Get l15 // { arity: 1 }
-                        Constant // { arity: 0 }
-                          - ()
-    cte l16 =
+                  %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
+                  %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                  %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                  %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
+                  %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
+                ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                  ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                  Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                  Project (#9, #10, #12) // { arity: 3 }
+                    Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                Get l2 // { arity: 1 }
+                Get l2 // { arity: 1 }
+    cte l4 =
+      Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
+        Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
+          Union // { arity: 3 }
+            Map (null) // { arity: 3 }
+              Union // { arity: 2 }
+                Negate // { arity: 2 }
+                  Project (#0{person1id}, #1{person2id}) // { arity: 2 }
+                    Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
+                      implementation
+                        %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
+                      Get l1 // { arity: 2 }
+                      ArrangeBy keys=[[#1, #0]] // { arity: 2 }
+                        Distinct project=[#0, #1] // { arity: 2 }
+                          Project (#2, #3) // { arity: 2 }
+                            Get l3 // { arity: 5 }
+                Get l0 // { arity: 2 }
+            Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
+              Get l3 // { arity: 5 }
+    cte l5 =
+      Project (#1{person2id}, #3) // { arity: 2 }
+        Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
+          implementation
+            %0:l8[#0]K » %1:l4[#0]K
+          ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+            Get l8 // { arity: 2 }
+          ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
+            Project (#0{person1id}, #1{person2id}) // { arity: 2 }
+              Get l4 // { arity: 3 }
+    cte l6 =
+      Union // { arity: 2 }
+        Project (#1, #0{person2id}) // { arity: 2 }
+          Get l5 // { arity: 2 }
+        Get l8 // { arity: 2 }
+    cte l7 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
-          Filter #1 AND (#0{person2id} = -1) // { arity: 2 }
-            Get l8 // { arity: 2 }
-    cte l15 =
-      Project (#1) // { arity: 1 }
-        Map ((#0{min} / 2)) // { arity: 2 }
-          Union // { arity: 1 }
-            Get l14 // { arity: 1 }
-            Map (null) // { arity: 1 }
-              Union // { arity: 0 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l14 // { arity: 1 }
-                Constant // { arity: 0 }
-                  - ()
-    cte l14 =
-      Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
-        Project (#1, #3) // { arity: 2 }
-          Join on=(#0{person2id} = #2{person2id}) type=differential // { arity: 4 }
+          Join on=(#0{person2id} = #1{person2id}) type=differential // { arity: 2 }
             implementation
-              %0:l13[#0]Kef » %1:l13[#0]Kef
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              Project (#2, #3) // { arity: 2 }
-                Filter (#0 = false) // { arity: 5 }
-                  Get l13 // { arity: 5 }
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              Project (#2, #3) // { arity: 2 }
-                Filter (#0 = true) // { arity: 5 }
-                  Get l13 // { arity: 5 }
+              %0:l6[#0]Kf » %1:l6[#0]Kf
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+              Project (#0{person2id}) // { arity: 1 }
+                Filter #1 // { arity: 2 }
+                  Get l6 // { arity: 2 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+              Project (#0{person2id}) // { arity: 1 }
+                Filter NOT(#1) // { arity: 2 }
+                  Get l6 // { arity: 2 }
+    cte l8 =
+      Distinct project=[#0{person2id}, #1] // { arity: 2 }
+        Union // { arity: 2 }
+          Project (#1, #0{person2id}) // { arity: 2 }
+            CrossJoin type=differential // { arity: 2 }
+              implementation
+                %0:l5[×] » %1[×]
+              ArrangeBy keys=[[]] // { arity: 2 }
+                Get l5 // { arity: 2 }
+              ArrangeBy keys=[[]] // { arity: 0 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Get l7 // { arity: 0 }
+                  Constant // { arity: 0 }
+                    - ()
+          Project (#1, #0) // { arity: 2 }
+            Map (true, -1) // { arity: 2 }
+              Get l7 // { arity: 0 }
+          Constant // { arity: 2 }
+            - (1450, true)
+            - (15393162796819, false)
+    cte l9 =
+      TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
+        Project (#0..=#3, #5) // { arity: 5 }
+          Filter (#4 = false) // { arity: 6 }
+            Get l17 // { arity: 6 }
+    cte l10 =
+      Distinct project=[#0..=#2] // { arity: 3 }
+        Project (#0..=#2) // { arity: 3 }
+          Get l17 // { arity: 6 }
+    cte l11 =
+      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+        Get l10 // { arity: 3 }
+    cte l12 =
+      Project (#0..=#2) // { arity: 3 }
+        Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+          implementation
+            %1[#0..=#2]UKKKA » %0:l11[#0..=#2]UKKK
+          Get l11 // { arity: 3 }
+          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+            Distinct project=[#0..=#2] // { arity: 3 }
+              Project (#0..=#2) // { arity: 3 }
+                Get l9 // { arity: 5 }
     cte l13 =
       TopK group_by=[#0, #1, #2{person2id}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
         Union // { arity: 5 }
@@ -2863,135 +2886,112 @@ Explained Query:
                                 Get l12 // { arity: 3 }
                               Get l10 // { arity: 3 }
                           Get l11 // { arity: 3 }
-    cte l12 =
-      Project (#0..=#2) // { arity: 3 }
-        Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-          implementation
-            %1[#0..=#2]UKKKA » %0:l11[#0..=#2]UKKK
-          Get l11 // { arity: 3 }
-          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-            Distinct project=[#0..=#2] // { arity: 3 }
-              Project (#0..=#2) // { arity: 3 }
-                Get l9 // { arity: 5 }
-    cte l11 =
-      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-        Get l10 // { arity: 3 }
-    cte l10 =
-      Distinct project=[#0..=#2] // { arity: 3 }
-        Project (#0..=#2) // { arity: 3 }
-          Get l17 // { arity: 6 }
-    cte l9 =
-      TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
-        Project (#0..=#3, #5) // { arity: 5 }
-          Filter (#4 = false) // { arity: 6 }
-            Get l17 // { arity: 6 }
-    cte l8 =
-      Distinct project=[#0{person2id}, #1] // { arity: 2 }
-        Union // { arity: 2 }
-          Project (#1, #0{person2id}) // { arity: 2 }
-            CrossJoin type=differential // { arity: 2 }
-              implementation
-                %0:l5[×] » %1[×]
-              ArrangeBy keys=[[]] // { arity: 2 }
-                Get l5 // { arity: 2 }
-              ArrangeBy keys=[[]] // { arity: 0 }
-                Union // { arity: 0 }
-                  Negate // { arity: 0 }
-                    Get l7 // { arity: 0 }
-                  Constant // { arity: 0 }
-                    - ()
-          Project (#1, #0) // { arity: 2 }
-            Map (true, -1) // { arity: 2 }
-              Get l7 // { arity: 0 }
-          Constant // { arity: 2 }
-            - (1450, true)
-            - (15393162796819, false)
-    cte l7 =
+    cte l14 =
+      Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
+        Project (#1, #3) // { arity: 2 }
+          Join on=(#0{person2id} = #2{person2id}) type=differential // { arity: 4 }
+            implementation
+              %0:l13[#0]Kef » %1:l13[#0]Kef
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+              Project (#2, #3) // { arity: 2 }
+                Filter (#0 = false) // { arity: 5 }
+                  Get l13 // { arity: 5 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+              Project (#2, #3) // { arity: 2 }
+                Filter (#0 = true) // { arity: 5 }
+                  Get l13 // { arity: 5 }
+    cte l15 =
+      Project (#1) // { arity: 1 }
+        Map ((#0{min} / 2)) // { arity: 2 }
+          Union // { arity: 1 }
+            Get l14 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l14 // { arity: 1 }
+                Constant // { arity: 0 }
+                  - ()
+    cte l16 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
-          Join on=(#0{person2id} = #1{person2id}) type=differential // { arity: 2 }
-            implementation
-              %0:l6[#0]Kf » %1:l6[#0]Kf
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-              Project (#0{person2id}) // { arity: 1 }
-                Filter #1 // { arity: 2 }
-                  Get l6 // { arity: 2 }
-            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-              Project (#0{person2id}) // { arity: 1 }
-                Filter NOT(#1) // { arity: 2 }
-                  Get l6 // { arity: 2 }
-    cte l6 =
-      Union // { arity: 2 }
-        Project (#1, #0{person2id}) // { arity: 2 }
-          Get l5 // { arity: 2 }
-        Get l8 // { arity: 2 }
-    cte l5 =
-      Project (#1{person2id}, #3) // { arity: 2 }
-        Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
-          implementation
-            %0:l8[#0]K » %1:l4[#0]K
-          ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
+          Filter #1 AND (#0{person2id} = -1) // { arity: 2 }
             Get l8 // { arity: 2 }
-          ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
-            Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-              Get l4 // { arity: 3 }
-    cte l4 =
-      Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
-        Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
-          Union // { arity: 3 }
-            Map (null) // { arity: 3 }
+    cte l17 =
+      Distinct project=[#0..=#5] // { arity: 6 }
+        Union // { arity: 6 }
+          Project (#1, #0, #0, #2..=#4) // { arity: 6 }
+            Map (0, false, 0) // { arity: 5 }
               Union // { arity: 2 }
-                Negate // { arity: 2 }
-                  Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-                    Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
-                      implementation
-                        %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
-                      Get l1 // { arity: 2 }
-                      ArrangeBy keys=[[#1, #0]] // { arity: 2 }
-                        Distinct project=[#0, #1] // { arity: 2 }
-                          Project (#2, #3) // { arity: 2 }
-                            Get l3 // { arity: 5 }
-                Get l0 // { arity: 2 }
-            Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
-              Get l3 // { arity: 5 }
-    cte l3 =
-      Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
-        implementation
-          %1[#1, #0]UKK » %0:l1[greatest(#0, #1), least(#0, #1)]KK
-        Get l1 // { arity: 2 }
-        ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-          Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-            Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
-              Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
+                Map (1450, false) // { arity: 2 }
+                  Get l16 // { arity: 0 }
+                Map (15393162796819, true) // { arity: 2 }
+                  Get l16 // { arity: 0 }
+          Project (#0..=#3, #7, #8) // { arity: 6 }
+            Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
+              CrossJoin type=delta // { arity: 7 }
                 implementation
-                  %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
-                  %1:message » %3:l2[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                  %2:message » %4:l2[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                  %3:l2 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l2[#0]UK
-                  %4:l2 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l2[#0]UK
-                ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                  ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                  Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                  Project (#9, #10, #12) // { arity: 3 }
-                    Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                Get l2 // { arity: 1 }
-                Get l2 // { arity: 1 }
-    cte l2 =
-      ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-        Distinct project=[#0{id}] // { arity: 1 }
-          Project (#1) // { arity: 1 }
-            Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-              ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
-    cte l1 =
-      ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-        Get l0 // { arity: 2 }
-    cte l0 =
-      Project (#1{person2id}, #2) // { arity: 2 }
-        ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+                  %0:l13 » %1[×]U » %2[×]U
+                  %1 » %2[×]U » %0:l13[×]
+                  %2 » %1[×]U » %0:l13[×]
+                ArrangeBy keys=[[]] // { arity: 5 }
+                  Get l13 // { arity: 5 }
+                ArrangeBy keys=[[]] // { arity: 1 }
+                  TopK limit=1 // { arity: 1 }
+                    Project (#4) // { arity: 1 }
+                      Get l9 // { arity: 5 }
+                ArrangeBy keys=[[]] // { arity: 1 }
+                  Union // { arity: 1 }
+                    Get l15 // { arity: 1 }
+                    Map (null) // { arity: 1 }
+                      Union // { arity: 0 }
+                        Negate // { arity: 0 }
+                          Project () // { arity: 0 }
+                            Get l15 // { arity: 1 }
+                        Constant // { arity: 0 }
+                          - ()
+  Return // { arity: 1 }
+    With
+      cte l18 =
+        Project (#0..=#3) // { arity: 4 }
+          Join on=(#4 = #5{max}) type=differential // { arity: 6 }
+            implementation
+              %1[#0]UK » %0:l17[#4]K
+            ArrangeBy keys=[[#4]] // { arity: 5 }
+              Project (#0..=#3, #5) // { arity: 5 }
+                Get l17 // { arity: 6 }
+            ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+              Reduce aggregates=[max(#0)] // { arity: 1 }
+                Project (#5) // { arity: 1 }
+                  Get l17 // { arity: 6 }
+      cte l19 =
+        Reduce aggregates=[min(#0{min})] // { arity: 1 }
+          Project (#2) // { arity: 1 }
+            Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
+              Project (#0, #2, #3, #5) // { arity: 4 }
+                Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
+                  implementation
+                    %0:l18[#1]Kef » %1:l18[#1]Kef
+                  ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
+                    Project (#1{person2id}..=#3) // { arity: 3 }
+                      Filter (#0 = false) // { arity: 4 }
+                        Get l18 // { arity: 4 }
+                  ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
+                    Project (#1{person2id}..=#3) // { arity: 3 }
+                      Filter (#0 = true) // { arity: 4 }
+                        Get l18 // { arity: 4 }
+    Return // { arity: 1 }
+      Project (#1) // { arity: 1 }
+        Map (coalesce(#0{min_min}, -1)) // { arity: 2 }
+          Union // { arity: 1 }
+            Get l19 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l19 // { arity: 1 }
+                Constant // { arity: 0 }
+                  - ()
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -3079,6 +3079,94 @@ LIMIT 20
 ----
 Explained Query:
   Finish order_by=[#6 desc nulls_first, #0{id} asc nulls_last] limit=20 output=[#0, #1, #4]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+          Distinct project=[#0{id}] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Filter (#1{id}) IS NOT NULL // { arity: 11 }
+                ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
+      cte l1 =
+        ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+          ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
+      cte l2 =
+        ArrangeBy keys=[[#1{name}]] // { arity: 4 }
+          ReadIndex on=tag tag_name=[lookup] // { arity: 4 }
+      cte l3 =
+        Project (#0{id}, #2) // { arity: 2 }
+          Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
+            implementation
+              %0:l0 » %1[#0]K » %2[#0]UKA
+              %1 » %0:l0[#0]UKA » %2[#0]UKA
+              %2 » %1[#1]K » %0:l0[#0]UKA
+            Get l0 // { arity: 1 }
+            ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
+              Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
+                Project (#1{creatorpersonid}, #9) // { arity: 2 }
+                  Filter (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
+                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Distinct project=[#0{messageid}] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+                    implementation
+                      %1:tag[#0]KAe » %0:l1[#2]KAe
+                    Get l1 // { arity: 3 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Diosdado_Macapagal")] // { arity: 5 }
+      cte l4 =
+        ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+          ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+      cte l5 =
+        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
+          Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
+            implementation
+              %0:l3 » %1:l4[#1]KA » %2[#0]UKA
+              %1:l4 » %2[#0]UKA » %0:l3[#0]K
+              %2 » %1:l4[#2]KA » %0:l3[#0]K
+            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
+              Get l3 // { arity: 2 }
+            Get l4 // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
+                Project (#0{id}) // { arity: 1 }
+                  Get l3 // { arity: 2 }
+      cte l6 =
+        Project (#0{id}, #2) // { arity: 2 }
+          Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
+            implementation
+              %0:l0 » %1[#0]K » %2[#0]UKA
+              %1 » %0:l0[#0]UKA » %2[#0]UKA
+              %2 » %1[#1]K » %0:l0[#0]UKA
+            Get l0 // { arity: 1 }
+            ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
+              Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
+                Project (#1{creatorpersonid}, #9) // { arity: 2 }
+                  Filter (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
+                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Distinct project=[#0{messageid}] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+                    implementation
+                      %1:tag[#0]KAe » %0:l1[#2]KAe
+                    Get l1 // { arity: 3 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
+      cte l7 =
+        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
+          Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
+            implementation
+              %0:l6 » %1:l4[#1]KA » %2[#0]UKA
+              %1:l4 » %2[#0]UKA » %0:l6[#0]K
+              %2 » %1:l4[#2]KA » %0:l6[#0]K
+            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
+              Get l6 // { arity: 2 }
+            Get l4 // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
+                Project (#0{id}) // { arity: 1 }
+                  Get l6 // { arity: 2 }
     Return // { arity: 7 }
       Project (#0{id}..=#2{count_person2id}, #0{id}, #4{count_messageid}..=#6) // { arity: 7 }
         Filter (#2{count_person2id} <= 5) AND (#5{count_person2id} <= 5) // { arity: 7 }
@@ -3108,94 +3196,6 @@ Explained Query:
                             Project (#0{id}, #1{messageid}) // { arity: 2 }
                               Get l7 // { arity: 3 }
                         Get l6 // { arity: 2 }
-    With
-      cte l7 =
-        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
-          Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
-            implementation
-              %0:l6 » %1:l4[#1]KA » %2[#0]UKA
-              %1:l4 » %2[#0]UKA » %0:l6[#0]K
-              %2 » %1:l4[#2]KA » %0:l6[#0]K
-            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
-              Get l6 // { arity: 2 }
-            Get l4 // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#0{id}) // { arity: 1 }
-                  Get l6 // { arity: 2 }
-      cte l6 =
-        Project (#0{id}, #2) // { arity: 2 }
-          Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
-            implementation
-              %0:l0 » %1[#0]K » %2[#0]UKA
-              %1 » %0:l0[#0]UKA » %2[#0]UKA
-              %2 » %1[#1]K » %0:l0[#0]UKA
-            Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
-              Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1{creatorpersonid}, #9) // { arity: 2 }
-                  Filter (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
-                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-              Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-                    implementation
-                      %1:tag[#0]KAe » %0:l1[#2]KAe
-                    Get l1 // { arity: 3 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
-      cte l5 =
-        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
-          Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
-            implementation
-              %0:l3 » %1:l4[#1]KA » %2[#0]UKA
-              %1:l4 » %2[#0]UKA » %0:l3[#0]K
-              %2 » %1:l4[#2]KA » %0:l3[#0]K
-            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
-              Get l3 // { arity: 2 }
-            Get l4 // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#0{id}) // { arity: 1 }
-                  Get l3 // { arity: 2 }
-      cte l4 =
-        ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-          ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-      cte l3 =
-        Project (#0{id}, #2) // { arity: 2 }
-          Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
-            implementation
-              %0:l0 » %1[#0]K » %2[#0]UKA
-              %1 » %0:l0[#0]UKA » %2[#0]UKA
-              %2 » %1[#1]K » %0:l0[#0]UKA
-            Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
-              Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1{creatorpersonid}, #9) // { arity: 2 }
-                  Filter (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
-                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-              Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-                    implementation
-                      %1:tag[#0]KAe » %0:l1[#2]KAe
-                    Get l1 // { arity: 3 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Diosdado_Macapagal")] // { arity: 5 }
-      cte l2 =
-        ArrangeBy keys=[[#1{name}]] // { arity: 4 }
-          ReadIndex on=tag tag_name=[lookup] // { arity: 4 }
-      cte l1 =
-        ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-          ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-      cte l0 =
-        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-          Distinct project=[#0{id}] // { arity: 1 }
-            Project (#1) // { arity: 1 }
-              Filter (#1{id}) IS NOT NULL // { arity: 11 }
-                ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -3254,33 +3254,30 @@ LIMIT 10
 ----
 Explained Query:
   Finish order_by=[#1{count_messageid} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=10 output=[#0, #1]
-    Return // { arity: 2 }
-      Reduce group_by=[#0{creatorpersonid}] aggregates=[count(distinct #1{messageid})] // { arity: 2 }
-        Project (#0{creatorpersonid}, #1{messageid}) // { arity: 2 }
-          Join on=(#0{creatorpersonid} = #3{creatorpersonid} AND #2{containerforumid} = #4{containerforumid}) type=differential // { arity: 5 }
-            implementation
-              %0:l2[#0, #2]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[#0{creatorpersonid}, #2{containerforumid}]] // { arity: 3 }
-              Get l2 // { arity: 3 }
-            ArrangeBy keys=[[#0{creatorpersonid}, #1{containerforumid}]] // { arity: 2 }
-              Union // { arity: 2 }
-                Negate // { arity: 2 }
-                  Project (#0{creatorpersonid}, #1{containerforumid}) // { arity: 2 }
-                    Join on=(#0{creatorpersonid} = #2{personid} AND #1{containerforumid} = #3{forumid}) type=differential // { arity: 4 }
-                      implementation
-                        %0:l3[#0, #1]UKKA » %1[#0, #1]UKKA
-                      ArrangeBy keys=[[#0{creatorpersonid}, #1{containerforumid}]] // { arity: 2 }
-                        Get l3 // { arity: 2 }
-                      ArrangeBy keys=[[#0{personid}, #1{forumid}]] // { arity: 2 }
-                        Distinct project=[#1{personid}, #0{forumid}] // { arity: 2 }
-                          Project (#1{personid}, #2) // { arity: 2 }
-                            ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[*** full scan ***] // { arity: 3 }
-                Get l3 // { arity: 2 }
     With
-      cte l3 =
-        Distinct project=[#0{creatorpersonid}, #1{containerforumid}] // { arity: 2 }
-          Project (#0{creatorpersonid}, #2) // { arity: 2 }
-            Get l2 // { arity: 3 }
+      cte l0 =
+        Project (#0{creationdate}, #1{messageid}, #9, #10, #12) // { arity: 5 }
+          Join on=(#1{messageid} = #13{messageid}) type=differential // { arity: 14 }
+            implementation
+              %1[#0]UKA » %0:message[#1]KA
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Distinct project=[#0{messageid}] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 4 }
+                    implementation
+                      %1[#0]UKA » %0:message_hastag_tag[#2]KA
+                    ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+                      ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                      Distinct project=[#0{id}] // { arity: 1 }
+                        Project (#0{id}) // { arity: 1 }
+                          Filter (#0{id}) IS NOT NULL // { arity: 5 }
+                            ReadIndex on=materialize.public.tag tag_name=[lookup value=("Cosmic_Egg")] // { arity: 5 }
+      cte l1 =
+        ArrangeBy keys=[[#1{forumid}], [#2{personid}]] // { arity: 3 }
+          ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[delta join lookup] forum_hasmember_person_personid=[delta join lookup] // { arity: 3 }
       cte l2 =
         Project (#1{messageid}, #4, #6) // { arity: 3 }
           Filter (#2{containerforumid} != #6{containerforumid}) AND (#5{creatorpersonid} != #7{creatorpersonid}) AND ((#0{creationdate} + 12:00:00) < #3{creationdate}) // { arity: 15 }
@@ -3303,29 +3300,32 @@ Explained Query:
                     Get l0 // { arity: 5 }
               Get l1 // { arity: 3 }
               Get l1 // { arity: 3 }
-      cte l1 =
-        ArrangeBy keys=[[#1{forumid}], [#2{personid}]] // { arity: 3 }
-          ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[delta join lookup] forum_hasmember_person_personid=[delta join lookup] // { arity: 3 }
-      cte l0 =
-        Project (#0{creationdate}, #1{messageid}, #9, #10, #12) // { arity: 5 }
-          Join on=(#1{messageid} = #13{messageid}) type=differential // { arity: 14 }
+      cte l3 =
+        Distinct project=[#0{creatorpersonid}, #1{containerforumid}] // { arity: 2 }
+          Project (#0{creatorpersonid}, #2) // { arity: 2 }
+            Get l2 // { arity: 3 }
+    Return // { arity: 2 }
+      Reduce group_by=[#0{creatorpersonid}] aggregates=[count(distinct #1{messageid})] // { arity: 2 }
+        Project (#0{creatorpersonid}, #1{messageid}) // { arity: 2 }
+          Join on=(#0{creatorpersonid} = #3{creatorpersonid} AND #2{containerforumid} = #4{containerforumid}) type=differential // { arity: 5 }
             implementation
-              %1[#0]UKA » %0:message[#1]KA
-            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
-            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-              Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 4 }
-                    implementation
-                      %1[#0]UKA » %0:message_hastag_tag[#2]KA
-                    ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-                      ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                      Distinct project=[#0{id}] // { arity: 1 }
-                        Project (#0{id}) // { arity: 1 }
-                          Filter (#0{id}) IS NOT NULL // { arity: 5 }
-                            ReadIndex on=materialize.public.tag tag_name=[lookup value=("Cosmic_Egg")] // { arity: 5 }
+              %0:l2[#0, #2]KK » %1[#0, #1]KK
+            ArrangeBy keys=[[#0{creatorpersonid}, #2{containerforumid}]] // { arity: 3 }
+              Get l2 // { arity: 3 }
+            ArrangeBy keys=[[#0{creatorpersonid}, #1{containerforumid}]] // { arity: 2 }
+              Union // { arity: 2 }
+                Negate // { arity: 2 }
+                  Project (#0{creatorpersonid}, #1{containerforumid}) // { arity: 2 }
+                    Join on=(#0{creatorpersonid} = #2{personid} AND #1{containerforumid} = #3{forumid}) type=differential // { arity: 4 }
+                      implementation
+                        %0:l3[#0, #1]UKKA » %1[#0, #1]UKKA
+                      ArrangeBy keys=[[#0{creatorpersonid}, #1{containerforumid}]] // { arity: 2 }
+                        Get l3 // { arity: 2 }
+                      ArrangeBy keys=[[#0{personid}, #1{forumid}]] // { arity: 2 }
+                        Distinct project=[#1{personid}, #0{forumid}] // { arity: 2 }
+                          Project (#1{personid}, #2) // { arity: 2 }
+                            ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[*** full scan ***] // { arity: 3 }
+                Get l3 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -3373,6 +3373,33 @@ LIMIT 20
 ----
 Explained Query:
   Finish order_by=[#2{count} desc nulls_first, #0{personid} asc nulls_last, #1{personid} asc nulls_last] limit=20 output=[#0..=#2]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
+          Project (#0{personid}, #9) // { arity: 2 }
+            Join on=(#0{personid} = #8{person1id} AND #1{tagid} = #2{id}) type=delta // { arity: 10 }
+              implementation
+                %0:person_hasinterest_tag » %1:tag[#0]KAe » %2:person_knows_person[#1]KA
+                %1:tag » %0:person_hasinterest_tag[#1]KA » %2:person_knows_person[#1]KA
+                %2:person_knows_person » %0:person_hasinterest_tag[#0]K » %1:tag[#0]KAe
+              ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
+                Project (#1{tagid}, #2) // { arity: 2 }
+                  ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Fyodor_Dostoyevsky")] // { arity: 5 }
+              ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
+                ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] // { arity: 3 }
+      cte l1 =
+        Project (#0{personid}, #2) // { arity: 2 }
+          Filter (#0{personid} != #2{personid}) // { arity: 4 }
+            Join on=(#1{person2id} = #3{person2id}) type=differential // { arity: 4 }
+              implementation
+                %0:l0[#1]K » %1:l0[#1]K
+              Get l0 // { arity: 2 }
+              Get l0 // { arity: 2 }
+      cte l2 =
+        Distinct project=[#0{personid}, #1{personid}] // { arity: 2 }
+          Get l1 // { arity: 2 }
     Return // { arity: 3 }
       Reduce group_by=[#0{personid}, #1{personid}] aggregates=[count(*)] // { arity: 3 }
         Project (#0{personid}, #1{personid}) // { arity: 2 }
@@ -3395,33 +3422,6 @@ Explained Query:
                           Project (#1{person2id}, #2) // { arity: 2 }
                             ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                 Get l2 // { arity: 2 }
-    With
-      cte l2 =
-        Distinct project=[#0{personid}, #1{personid}] // { arity: 2 }
-          Get l1 // { arity: 2 }
-      cte l1 =
-        Project (#0{personid}, #2) // { arity: 2 }
-          Filter (#0{personid} != #2{personid}) // { arity: 4 }
-            Join on=(#1{person2id} = #3{person2id}) type=differential // { arity: 4 }
-              implementation
-                %0:l0[#1]K » %1:l0[#1]K
-              Get l0 // { arity: 2 }
-              Get l0 // { arity: 2 }
-      cte l0 =
-        ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
-          Project (#0{personid}, #9) // { arity: 2 }
-            Join on=(#0{personid} = #8{person1id} AND #1{tagid} = #2{id}) type=delta // { arity: 10 }
-              implementation
-                %0:person_hasinterest_tag » %1:tag[#0]KAe » %2:person_knows_person[#1]KA
-                %1:tag » %0:person_hasinterest_tag[#1]KA » %2:person_knows_person[#1]KA
-                %2:person_knows_person » %0:person_hasinterest_tag[#0]K » %1:tag[#0]KAe
-              ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-                Project (#1{tagid}, #2) // { arity: 2 }
-                  ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
-              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Fyodor_Dostoyevsky")] // { arity: 5 }
-              ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
-                ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -3469,11 +3469,6 @@ UNION ALL
 SELECT dst, src, w FROM weights;
 ----
 materialize.public.pathq19:
-  Return // { arity: 3 }
-    Union // { arity: 3 }
-      Get l0 // { arity: 3 }
-      Project (#1{person1id}, #0{person2id}, #2) // { arity: 3 }
-        Get l0 // { arity: 3 }
   With
     cte l0 =
       Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
@@ -3494,6 +3489,11 @@ materialize.public.pathq19:
                     ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
                   ArrangeBy keys=[[#1{person1id}, #2{person2id}]] // { arity: 3 }
                     ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[delta join lookup] // { arity: 3 }
+  Return // { arity: 3 }
+    Union // { arity: 3 }
+      Get l0 // { arity: 3 }
+      Project (#1{person1id}, #0{person2id}, #2) // { arity: 3 }
+        Get l0 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_knows_person_person1id_person2id (delta join lookup)
@@ -3568,32 +3568,6 @@ SELECT src, dst, w
  WHERE w = (SELECT min(w) FROM completed_paths)
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Return // { arity: 3 }
-      Project (#0{id}..=#2{min}) // { arity: 3 }
-        Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
-          implementation
-            %1[#0]UK » %0:l1[#2]K
-          ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-            Get l1 // { arity: 3 }
-          ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-            Reduce aggregates=[min(#0{min})] // { arity: 1 }
-              Project (#2) // { arity: 1 }
-                Get l1 // { arity: 3 }
-    With
-      cte l1 =
-        Project (#0{id}..=#2{min}) // { arity: 3 }
-          Join on=(#1{id} = #3{id}) type=differential // { arity: 4 }
-            implementation
-              %1[#0]UKA » %0:l0[#1]K
-            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Filter (#1{id}) IS NOT NULL // { arity: 12 }
-                    ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
   With Mutually Recursive
     cte l0 =
       Reduce group_by=[#0{id}, #1{id}] aggregates=[min(#2)] // { arity: 3 }
@@ -3612,6 +3586,32 @@ Explained Query:
                       Get l0 // { arity: 3 }
                   ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                     ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
+  Return // { arity: 3 }
+    With
+      cte l1 =
+        Project (#0{id}..=#2{min}) // { arity: 3 }
+          Join on=(#1{id} = #3{id}) type=differential // { arity: 4 }
+            implementation
+              %1[#0]UKA » %0:l0[#1]K
+            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                Get l0 // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Filter (#1{id}) IS NOT NULL // { arity: 12 }
+                    ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
+    Return // { arity: 3 }
+      Project (#0{id}..=#2{min}) // { arity: 3 }
+        Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UK » %0:l1[#2]K
+          ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+            Get l1 // { arity: 3 }
+          ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+            Reduce aggregates=[min(#0{min})] // { arity: 1 }
+              Project (#2) // { arity: 1 }
+                Get l1 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -3677,63 +3677,26 @@ FROM paths
 WHERE w = (SELECT MIN(w) FROM paths)
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Project (#0{id}..=#2{min}) // { arity: 3 }
-      Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
-        implementation
-          %1[#0]UK » %0:l5[#2]K
-        ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-          Get l5 // { arity: 3 }
-        ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-          Reduce aggregates=[min(#0{min})] // { arity: 1 }
-            Project (#2) // { arity: 1 }
-              Get l5 // { arity: 3 }
   With Mutually Recursive
-    cte l7 =
-      Union // { arity: 1 }
-        Get l6 // { arity: 1 }
-        Map (null) // { arity: 1 }
-          Union // { arity: 0 }
-            Negate // { arity: 0 }
-              Project () // { arity: 0 }
-                Get l6 // { arity: 1 }
-            Constant // { arity: 0 }
-              - ()
-    cte l6 =
-      Reduce aggregates=[min(#0{min})] // { arity: 1 }
-        Project (#2) // { arity: 1 }
-          Get l5 // { arity: 3 }
-    cte l5 =
-      Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-        Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
-          Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
-            implementation
-              %0:l3[#1]K » %1:l4[#1]K
-            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                Get l3 // { arity: 3 }
-            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                Get l4 // { arity: 3 }
-    cte l4 =
-      TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
-        Union // { arity: 3 }
-          Project (#1{id}, #1{id}, #12) // { arity: 3 }
-            Map (0) // { arity: 13 }
-              ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
-          Project (#0, #5, #7) // { arity: 3 }
-            Filter coalesce((#2 < #3), true) // { arity: 8 }
-              Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
-                Join on=(#1 = #4{src}) type=delta // { arity: 7 }
-                  implementation
-                    %0:l4 » %2:l2[#0]KA » %1:l1[×]
-                    %1:l1 » %0:l4[×] » %2:l2[#0]KA
-                    %2:l2 » %0:l4[#1]K » %1:l1[×]
-                  ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
-                    Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                      Get l4 // { arity: 3 }
-                  Get l1 // { arity: 1 }
-                  Get l2 // { arity: 3 }
+    cte l0 =
+      ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
+        ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
+    cte l1 =
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Union // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Map ((#0 / 2)) // { arity: 2 }
+              Get l7 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l7 // { arity: 1 }
+              Constant // { arity: 0 }
+                - ()
+    cte l2 =
+      ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+        ReadIndex on=pathq19 pathq19_src=[delta join lookup] // { arity: 3 }
     cte l3 =
       TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
         Union // { arity: 3 }
@@ -3753,25 +3716,62 @@ Explained Query:
                       Get l3 // { arity: 3 }
                   Get l1 // { arity: 1 }
                   Get l2 // { arity: 3 }
-    cte l2 =
-      ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-        ReadIndex on=pathq19 pathq19_src=[delta join lookup] // { arity: 3 }
-    cte l1 =
-      ArrangeBy keys=[[]] // { arity: 1 }
-        Union // { arity: 1 }
-          Project (#1) // { arity: 1 }
-            Map ((#0 / 2)) // { arity: 2 }
-              Get l7 // { arity: 1 }
-          Map (null) // { arity: 1 }
-            Union // { arity: 0 }
-              Negate // { arity: 0 }
-                Project () // { arity: 0 }
-                  Get l7 // { arity: 1 }
-              Constant // { arity: 0 }
-                - ()
-    cte l0 =
-      ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
-        ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
+    cte l4 =
+      TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
+        Union // { arity: 3 }
+          Project (#1{id}, #1{id}, #12) // { arity: 3 }
+            Map (0) // { arity: 13 }
+              ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
+          Project (#0, #5, #7) // { arity: 3 }
+            Filter coalesce((#2 < #3), true) // { arity: 8 }
+              Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
+                Join on=(#1 = #4{src}) type=delta // { arity: 7 }
+                  implementation
+                    %0:l4 » %2:l2[#0]KA » %1:l1[×]
+                    %1:l1 » %0:l4[×] » %2:l2[#0]KA
+                    %2:l2 » %0:l4[#1]K » %1:l1[×]
+                  ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
+                    Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                      Get l4 // { arity: 3 }
+                  Get l1 // { arity: 1 }
+                  Get l2 // { arity: 3 }
+    cte l5 =
+      Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
+        Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
+          Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
+            implementation
+              %0:l3[#1]K » %1:l4[#1]K
+            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                Get l3 // { arity: 3 }
+            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                Get l4 // { arity: 3 }
+    cte l6 =
+      Reduce aggregates=[min(#0{min})] // { arity: 1 }
+        Project (#2) // { arity: 1 }
+          Get l5 // { arity: 3 }
+    cte l7 =
+      Union // { arity: 1 }
+        Get l6 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l6 // { arity: 1 }
+            Constant // { arity: 0 }
+              - ()
+  Return // { arity: 3 }
+    Project (#0{id}..=#2{min}) // { arity: 3 }
+      Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
+        implementation
+          %1[#0]UK » %0:l5[#2]K
+        ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+          Get l5 // { arity: 3 }
+        ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+          Reduce aggregates=[min(#0{min})] // { arity: 1 }
+            Project (#2) // { arity: 1 }
+              Get l5 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -3836,111 +3836,29 @@ SELECT * FROM results WHERE w = (SELECT min(w) FROM results) ORDER BY f, t
 ----
 Explained Query:
   Finish order_by=[#0{id} asc nulls_last, #1{id} asc nulls_last] output=[#0..=#2]
-    Return // { arity: 3 }
-      Return // { arity: 3 }
-        Project (#0{id}..=#2{min}) // { arity: 3 }
-          Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
-            implementation
-              %1[#0]UK » %0:l9[#2]K
-            ArrangeBy keys=[[#2{min}]] // { arity: 3 }
-              Get l9 // { arity: 3 }
-            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-              Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                Project (#2) // { arity: 1 }
-                  Get l9 // { arity: 3 }
-      With
-        cte l9 =
-          Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-            Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
-              Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
-                implementation
-                  %0:l8[#1]Kef » %1:l8[#1]Kef
-                ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-                  Project (#1{id}..=#3) // { arity: 3 }
-                    Filter (#0 = false) // { arity: 4 }
-                      Get l8 // { arity: 4 }
-                ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-                  Project (#1{id}..=#3) // { arity: 3 }
-                    Filter (#0 = true) // { arity: 4 }
-                      Get l8 // { arity: 4 }
-        cte l8 =
-          Project (#0..=#3) // { arity: 4 }
-            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
-              implementation
-                %1[#0]UK » %0:l7[#4]K
-              ArrangeBy keys=[[#4]] // { arity: 5 }
-                Project (#0..=#3, #5) // { arity: 5 }
-                  Filter (#2{id}) IS NOT NULL // { arity: 6 }
-                    Get l7 // { arity: 6 }
-              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-                Reduce aggregates=[max(#0)] // { arity: 1 }
-                  Project (#5) // { arity: 1 }
-                    Get l7 // { arity: 6 }
     With Mutually Recursive
-      cte l7 =
-        Distinct project=[#0..=#5] // { arity: 6 }
-          Union // { arity: 6 }
-            Project (#1{id}, #0, #0, #2{id}..=#4) // { arity: 6 }
-              Map (0, false, 0) // { arity: 5 }
-                Union // { arity: 2 }
-                  Project (#1, #12) // { arity: 2 }
-                    Map (false) // { arity: 13 }
-                      ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
-                  Project (#1, #12) // { arity: 2 }
-                    Map (true) // { arity: 13 }
-                      ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
-            Project (#0..=#3, #7, #8) // { arity: 6 }
-              Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
-                CrossJoin type=delta // { arity: 7 }
-                  implementation
-                    %0:l3 » %1[×]U » %2[×]U
-                    %1 » %2[×]U » %0:l3[×]
-                    %2 » %1[×]U » %0:l3[×]
-                  ArrangeBy keys=[[]] // { arity: 5 }
-                    Get l3 // { arity: 5 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    TopK limit=1 // { arity: 1 }
-                      Project (#4) // { arity: 1 }
-                        Get l0 // { arity: 5 }
-                  ArrangeBy keys=[[]] // { arity: 1 }
-                    Union // { arity: 1 }
-                      Get l5 // { arity: 1 }
-                      Map (null) // { arity: 1 }
-                        Union // { arity: 0 }
-                          Negate // { arity: 0 }
-                            Project () // { arity: 0 }
-                              Get l5 // { arity: 1 }
-                          Constant // { arity: 0 }
-                            - ()
-      cte l6 =
-        ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
-          ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
-      cte l5 =
-        Project (#1) // { arity: 1 }
-          Map ((#0{min} / 2)) // { arity: 2 }
-            Union // { arity: 1 }
-              Get l4 // { arity: 1 }
-              Map (null) // { arity: 1 }
-                Union // { arity: 0 }
-                  Negate // { arity: 0 }
-                    Project () // { arity: 0 }
-                      Get l4 // { arity: 1 }
-                  Constant // { arity: 0 }
-                    - ()
-      cte l4 =
-        Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
-          Project (#1, #3) // { arity: 2 }
-            Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
-              implementation
-                %0:l3[#0]Kef » %1:l3[#0]Kef
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = false) AND (#2{dst}) IS NOT NULL // { arity: 5 }
-                    Get l3 // { arity: 5 }
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = true) AND (#2{dst}) IS NOT NULL // { arity: 5 }
-                    Get l3 // { arity: 5 }
+      cte l0 =
+        TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
+          Project (#0..=#3, #5) // { arity: 5 }
+            Filter (#4 = false) // { arity: 6 }
+              Get l7 // { arity: 6 }
+      cte l1 =
+        Distinct project=[#0..=#2] // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            Get l7 // { arity: 6 }
+      cte l2 =
+        Project (#0..=#2) // { arity: 3 }
+          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+            implementation
+              %1[#0..=#2]UKKKA » %0:l1[#0..=#2]UKKK
+            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+              Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 3 }
+                Get l1 // { arity: 3 }
+            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+              Distinct project=[#0..=#2] // { arity: 3 }
+                Project (#0..=#2) // { arity: 3 }
+                  Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 5 }
+                    Get l0 // { arity: 5 }
       cte l3 =
         TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
           Distinct project=[#0..=#4] // { arity: 5 }
@@ -3980,28 +3898,110 @@ Explained Query:
                                   Get l1 // { arity: 3 }
                               ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                                 Get l1 // { arity: 3 }
-      cte l2 =
-        Project (#0..=#2) // { arity: 3 }
-          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+      cte l4 =
+        Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
+          Project (#1, #3) // { arity: 2 }
+            Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
+              implementation
+                %0:l3[#0]Kef » %1:l3[#0]Kef
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                Project (#2, #3) // { arity: 2 }
+                  Filter (#0 = false) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                    Get l3 // { arity: 5 }
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                Project (#2, #3) // { arity: 2 }
+                  Filter (#0 = true) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                    Get l3 // { arity: 5 }
+      cte l5 =
+        Project (#1) // { arity: 1 }
+          Map ((#0{min} / 2)) // { arity: 2 }
+            Union // { arity: 1 }
+              Get l4 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l4 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
+      cte l6 =
+        ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
+          ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
+      cte l7 =
+        Distinct project=[#0..=#5] // { arity: 6 }
+          Union // { arity: 6 }
+            Project (#1{id}, #0, #0, #2{id}..=#4) // { arity: 6 }
+              Map (0, false, 0) // { arity: 5 }
+                Union // { arity: 2 }
+                  Project (#1, #12) // { arity: 2 }
+                    Map (false) // { arity: 13 }
+                      ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
+                  Project (#1, #12) // { arity: 2 }
+                    Map (true) // { arity: 13 }
+                      ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
+            Project (#0..=#3, #7, #8) // { arity: 6 }
+              Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
+                CrossJoin type=delta // { arity: 7 }
+                  implementation
+                    %0:l3 » %1[×]U » %2[×]U
+                    %1 » %2[×]U » %0:l3[×]
+                    %2 » %1[×]U » %0:l3[×]
+                  ArrangeBy keys=[[]] // { arity: 5 }
+                    Get l3 // { arity: 5 }
+                  ArrangeBy keys=[[]] // { arity: 1 }
+                    TopK limit=1 // { arity: 1 }
+                      Project (#4) // { arity: 1 }
+                        Get l0 // { arity: 5 }
+                  ArrangeBy keys=[[]] // { arity: 1 }
+                    Union // { arity: 1 }
+                      Get l5 // { arity: 1 }
+                      Map (null) // { arity: 1 }
+                        Union // { arity: 0 }
+                          Negate // { arity: 0 }
+                            Project () // { arity: 0 }
+                              Get l5 // { arity: 1 }
+                          Constant // { arity: 0 }
+                            - ()
+    Return // { arity: 3 }
+      With
+        cte l8 =
+          Project (#0..=#3) // { arity: 4 }
+            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
+              implementation
+                %1[#0]UK » %0:l7[#4]K
+              ArrangeBy keys=[[#4]] // { arity: 5 }
+                Project (#0..=#3, #5) // { arity: 5 }
+                  Filter (#2{id}) IS NOT NULL // { arity: 6 }
+                    Get l7 // { arity: 6 }
+              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+                Reduce aggregates=[max(#0)] // { arity: 1 }
+                  Project (#5) // { arity: 1 }
+                    Get l7 // { arity: 6 }
+        cte l9 =
+          Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
+            Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
+              Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
+                implementation
+                  %0:l8[#1]Kef » %1:l8[#1]Kef
+                ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+                  Project (#1{id}..=#3) // { arity: 3 }
+                    Filter (#0 = false) // { arity: 4 }
+                      Get l8 // { arity: 4 }
+                ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+                  Project (#1{id}..=#3) // { arity: 3 }
+                    Filter (#0 = true) // { arity: 4 }
+                      Get l8 // { arity: 4 }
+      Return // { arity: 3 }
+        Project (#0{id}..=#2{min}) // { arity: 3 }
+          Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
             implementation
-              %1[#0..=#2]UKKKA » %0:l1[#0..=#2]UKKK
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 3 }
-                Get l1 // { arity: 3 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Distinct project=[#0..=#2] // { arity: 3 }
-                Project (#0..=#2) // { arity: 3 }
-                  Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 5 }
-                    Get l0 // { arity: 5 }
-      cte l1 =
-        Distinct project=[#0..=#2] // { arity: 3 }
-          Project (#0..=#2) // { arity: 3 }
-            Get l7 // { arity: 6 }
-      cte l0 =
-        TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
-          Project (#0..=#3, #5) // { arity: 5 }
-            Filter (#4 = false) // { arity: 6 }
-              Get l7 // { arity: 6 }
+              %1[#0]UK » %0:l9[#2]K
+            ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+              Get l9 // { arity: 3 }
+            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+              Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                Project (#2) // { arity: 1 }
+                  Get l9 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.person_locationcityid (lookup)
@@ -4066,48 +4066,6 @@ SELECT dst, w FROM results ORDER BY dst LIMIT 20
 ----
 Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0, #1]
-    Return // { arity: 2 }
-      Return // { arity: 2 }
-        Project (#0{dst}, #1{min}) // { arity: 2 }
-          Filter (#1{min} = #3{min_min}) // { arity: 4 }
-            Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
-              implementation
-                %1[#0]UKAf » %0:l1[#1]Kf
-              ArrangeBy keys=[[#1{min}]] // { arity: 2 }
-                Get l1 // { arity: 2 }
-              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
-                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
-                  CrossJoin type=differential // { arity: 2 }
-                    implementation
-                      %0[×] » %1:l2[×]
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct project=[#0{min}] // { arity: 1 }
-                        Get l2 // { arity: 1 }
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Get l2 // { arity: 1 }
-      With
-        cte l2 =
-          Project (#1) // { arity: 1 }
-            Get l1 // { arity: 2 }
-        cte l1 =
-          Project (#0{dst}, #1{min}) // { arity: 2 }
-            Join on=(#0{dst} = #2{personid}) type=differential // { arity: 3 }
-              implementation
-                %1[#0]UKA » %0:l0[#0]UK
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#1{min}, #2) // { arity: 2 }
-                  Get l0 // { arity: 3 }
-              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
-                Distinct project=[#0{personid}] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
-                    Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
-                      Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
-                        implementation
-                          %1:company[#0]KAef » %0:person_workat_company[#2]KAef
-                        ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
-                          ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
-                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                          ReadIndex on=company company_id=[differential join] // { arity: 4 }
     With Mutually Recursive
       cte l0 =
         Project (#2{min}, #0, #1{dst}) // { arity: 3 }
@@ -4127,6 +4085,48 @@ Explained Query:
                           ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                   Constant // { arity: 2 }
                     - (10995116285979, 0)
+    Return // { arity: 2 }
+      With
+        cte l1 =
+          Project (#0{dst}, #1{min}) // { arity: 2 }
+            Join on=(#0{dst} = #2{personid}) type=differential // { arity: 3 }
+              implementation
+                %1[#0]UKA » %0:l0[#0]UK
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                Project (#1{min}, #2) // { arity: 2 }
+                  Get l0 // { arity: 3 }
+              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+                Distinct project=[#0{personid}] // { arity: 1 }
+                  Project (#1) // { arity: 1 }
+                    Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
+                      Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
+                        implementation
+                          %1:company[#0]KAef » %0:person_workat_company[#2]KAef
+                        ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
+                          ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                          ReadIndex on=company company_id=[differential join] // { arity: 4 }
+        cte l2 =
+          Project (#1) // { arity: 1 }
+            Get l1 // { arity: 2 }
+      Return // { arity: 2 }
+        Project (#0{dst}, #1{min}) // { arity: 2 }
+          Filter (#1{min} = #3{min_min}) // { arity: 4 }
+            Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
+              implementation
+                %1[#0]UKAf » %0:l1[#1]Kf
+              ArrangeBy keys=[[#1{min}]] // { arity: 2 }
+                Get l1 // { arity: 2 }
+              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
+                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
+                  CrossJoin type=differential // { arity: 2 }
+                    implementation
+                      %0[×] » %1:l2[×]
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Distinct project=[#0{min}] // { arity: 1 }
+                        Get l2 // { arity: 1 }
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Get l2 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.person_workat_company_companyid (differential join)
@@ -4174,29 +4174,24 @@ SELECT dst, w FROM results ORDER BY dst LIMIT 20
 ----
 Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0, #1]
-    Return // { arity: 2 }
-      Return // { arity: 2 }
-        Project (#0{dst}, #1{min}) // { arity: 2 }
-          Filter (#1{min} = #3{min_min}) // { arity: 4 }
-            Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
-              implementation
-                %1[#0]UKAf » %0:l1[#1]Kf
-              ArrangeBy keys=[[#1{min}]] // { arity: 2 }
-                Get l1 // { arity: 2 }
-              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
-                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
-                  CrossJoin type=differential // { arity: 2 }
+    With Mutually Recursive
+      cte l0 =
+        Reduce group_by=[#0{dst}] aggregates=[min(#1)] // { arity: 2 }
+          Distinct project=[#0{dst}, #1] // { arity: 2 }
+            Union // { arity: 2 }
+              Project (#3, #5) // { arity: 2 }
+                Map ((#1 + integer_to_bigint(#4{w}))) // { arity: 6 }
+                  Join on=(#0 = #2{src}) type=differential // { arity: 5 }
                     implementation
-                      %0[×] » %1:l2[×]
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct project=[#0{min}] // { arity: 1 }
-                        Get l2 // { arity: 1 }
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Get l2 // { arity: 1 }
+                      %0:l0[#0]UK » %1:pathq20[#0]KA
+                    ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                      Get l0 // { arity: 2 }
+                    ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+                      ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
+              Constant // { arity: 2 }
+                - (10995116285979, 0)
+    Return // { arity: 2 }
       With
-        cte l2 =
-          Project (#1) // { arity: 1 }
-            Get l1 // { arity: 2 }
         cte l1 =
           Project (#0{dst}, #1{min}) // { arity: 2 }
             Join on=(#0{dst} = #2{personid}) type=differential // { arity: 3 }
@@ -4215,22 +4210,27 @@ Explained Query:
                           ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
                         ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
-    With Mutually Recursive
-      cte l0 =
-        Reduce group_by=[#0{dst}] aggregates=[min(#1)] // { arity: 2 }
-          Distinct project=[#0{dst}, #1] // { arity: 2 }
-            Union // { arity: 2 }
-              Project (#3, #5) // { arity: 2 }
-                Map ((#1 + integer_to_bigint(#4{w}))) // { arity: 6 }
-                  Join on=(#0 = #2{src}) type=differential // { arity: 5 }
+        cte l2 =
+          Project (#1) // { arity: 1 }
+            Get l1 // { arity: 2 }
+      Return // { arity: 2 }
+        Project (#0{dst}, #1{min}) // { arity: 2 }
+          Filter (#1{min} = #3{min_min}) // { arity: 4 }
+            Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
+              implementation
+                %1[#0]UKAf » %0:l1[#1]Kf
+              ArrangeBy keys=[[#1{min}]] // { arity: 2 }
+                Get l1 // { arity: 2 }
+              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
+                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
+                  CrossJoin type=differential // { arity: 2 }
                     implementation
-                      %0:l0[#0]UK » %1:pathq20[#0]KA
-                    ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                      Get l0 // { arity: 2 }
-                    ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-                      ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
-              Constant // { arity: 2 }
-                - (10995116285979, 0)
+                      %0[×] » %1:l2[×]
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Distinct project=[#0{min}] // { arity: 1 }
+                        Get l2 // { arity: 1 }
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Get l2 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.person_workat_company_companyid (differential join)
@@ -4283,48 +4283,6 @@ SELECT dst, w, hops FROM results ORDER BY dst LIMIT 20
 ----
 Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0..=#2]
-    Return // { arity: 3 }
-      Return // { arity: 3 }
-        Project (#0{dst}..=#2{min}) // { arity: 3 }
-          Filter (#1{min} = #4{min_min}) // { arity: 5 }
-            Join on=(#1{min} = #3{min}) type=differential // { arity: 5 }
-              implementation
-                %1[#0]UKAf » %0:l1[#1]Kf
-              ArrangeBy keys=[[#1{min}]] // { arity: 3 }
-                Get l1 // { arity: 3 }
-              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
-                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
-                  CrossJoin type=differential // { arity: 2 }
-                    implementation
-                      %0[×] » %1:l2[×]
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct project=[#0{min}] // { arity: 1 }
-                        Get l2 // { arity: 1 }
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Get l2 // { arity: 1 }
-      With
-        cte l2 =
-          Project (#1) // { arity: 1 }
-            Get l1 // { arity: 3 }
-        cte l1 =
-          Project (#0{dst}..=#2{min}) // { arity: 3 }
-            Join on=(#0{dst} = #3{personid}) type=differential // { arity: 4 }
-              implementation
-                %1[#0]UKA » %0:l0[#0]K
-              ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
-                Project (#1{min}..=#3) // { arity: 3 }
-                  Get l0 // { arity: 4 }
-              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
-                Distinct project=[#0{personid}] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
-                    Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
-                      Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
-                        implementation
-                          %1:company[#0]KAef » %0:person_workat_company[#2]KAef
-                        ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
-                          ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
-                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                          ReadIndex on=company company_id=[differential join] // { arity: 4 }
     With Mutually Recursive
       cte l0 =
         Project (#3{min}, #0..=#2{min}) // { arity: 4 }
@@ -4345,6 +4303,48 @@ Explained Query:
                             ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                     Constant // { arity: 3 }
                       - (10995116285979, 0, 0)
+    Return // { arity: 3 }
+      With
+        cte l1 =
+          Project (#0{dst}..=#2{min}) // { arity: 3 }
+            Join on=(#0{dst} = #3{personid}) type=differential // { arity: 4 }
+              implementation
+                %1[#0]UKA » %0:l0[#0]K
+              ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
+                Project (#1{min}..=#3) // { arity: 3 }
+                  Get l0 // { arity: 4 }
+              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+                Distinct project=[#0{personid}] // { arity: 1 }
+                  Project (#1) // { arity: 1 }
+                    Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
+                      Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
+                        implementation
+                          %1:company[#0]KAef » %0:person_workat_company[#2]KAef
+                        ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
+                          ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                          ReadIndex on=company company_id=[differential join] // { arity: 4 }
+        cte l2 =
+          Project (#1) // { arity: 1 }
+            Get l1 // { arity: 3 }
+      Return // { arity: 3 }
+        Project (#0{dst}..=#2{min}) // { arity: 3 }
+          Filter (#1{min} = #4{min_min}) // { arity: 5 }
+            Join on=(#1{min} = #3{min}) type=differential // { arity: 5 }
+              implementation
+                %1[#0]UKAf » %0:l1[#1]Kf
+              ArrangeBy keys=[[#1{min}]] // { arity: 3 }
+                Get l1 // { arity: 3 }
+              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
+                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
+                  CrossJoin type=differential // { arity: 2 }
+                    implementation
+                      %0[×] » %1:l2[×]
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Distinct project=[#0{min}] // { arity: 1 }
+                        Get l2 // { arity: 1 }
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Get l2 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.person_workat_company_companyid (differential join)
@@ -4434,47 +4434,142 @@ SELECT t, w FROM results WHERE w = (SELECT min(w) FROM results) ORDER BY t LIMIT
 ----
 Explained Query:
   Finish order_by=[#0{personid} asc nulls_last] limit=20 output=[#0, #1]
-    Return // { arity: 2 }
-      Return // { arity: 2 }
-        Project (#0{personid}, #1{min}) // { arity: 2 }
-          Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
-            implementation
-              %1[#0]UK » %0:l14[#1]K
-            ArrangeBy keys=[[#1{min}]] // { arity: 2 }
-              Get l14 // { arity: 2 }
-            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
-              Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Get l14 // { arity: 2 }
-      With
-        cte l14 =
-          Project (#1{min}, #2) // { arity: 2 }
-            Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1 + #3))] // { arity: 3 }
-              Project (#0{personid}, #2{personid}, #3, #5) // { arity: 4 }
-                Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
-                  implementation
-                    %0:l13[#1]Kef » %1:l13[#1]Kef
-                  ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
-                    Project (#1{personid}..=#3) // { arity: 3 }
-                      Filter (#0 = false) // { arity: 4 }
-                        Get l13 // { arity: 4 }
-                  ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
-                    Project (#1{personid}..=#3) // { arity: 3 }
-                      Filter (#0 = true) // { arity: 4 }
-                        Get l13 // { arity: 4 }
-        cte l13 =
-          Project (#0..=#3) // { arity: 4 }
-            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
-              implementation
-                %1[#0]UK » %0:l12[#4]K
-              ArrangeBy keys=[[#4]] // { arity: 5 }
-                Project (#0..=#3, #5) // { arity: 5 }
-                  Get l12 // { arity: 6 }
-              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
-                Reduce aggregates=[max(#0)] // { arity: 1 }
-                  Project (#5) // { arity: 1 }
-                    Get l12 // { arity: 6 }
     With Mutually Recursive
+      cte l0 =
+        Project (#1) // { arity: 1 }
+          Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
+            Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
+              implementation
+                %1:company[#0]KAef » %0:person_workat_company[#2]KAef
+              ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
+                ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                ReadIndex on=company company_id=[differential join] // { arity: 4 }
+      cte l1 =
+        ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+          ReadIndex on=pathq20 pathq20_src=[differential join, delta join lookup] // { arity: 3 }
+      cte l2 =
+        ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+          Get l0 // { arity: 1 }
+      cte l3 =
+        Distinct project=[#0{dst}] // { arity: 1 }
+          Union // { arity: 1 }
+            Project (#2) // { arity: 1 }
+              Join on=(#0 = #1{src}) type=delta // { arity: 4 }
+                implementation
+                  %0:l3 » %1:l1[#0]KA » %2[×]
+                  %1:l1 » %0:l3[#0]UK » %2[×]
+                  %2 » %0:l3[×] » %1:l1[#0]KA
+                ArrangeBy keys=[[], [#0{dst}]] // { arity: 1 }
+                  Get l3 // { arity: 1 }
+                Get l1 // { arity: 3 }
+                ArrangeBy keys=[[]] // { arity: 0 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Distinct project=[] // { arity: 0 }
+                        Project () // { arity: 0 }
+                          Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
+                            implementation
+                              %0:l3[#0]UK » %1:l2[#0]K
+                            ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
+                              Get l3 // { arity: 1 }
+                            Get l2 // { arity: 1 }
+                    Constant // { arity: 0 }
+                      - ()
+            Constant // { arity: 1 }
+              - (10995116285979)
+      cte l4 =
+        TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
+          Project (#0..=#3, #5) // { arity: 5 }
+            Filter (#4 = false) // { arity: 6 }
+              Get l12 // { arity: 6 }
+      cte l5 =
+        Distinct project=[#0..=#2] // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            Get l12 // { arity: 6 }
+      cte l6 =
+        ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+          Get l5 // { arity: 3 }
+      cte l7 =
+        Project (#0..=#2) // { arity: 3 }
+          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+            implementation
+              %1[#0..=#2]UKKKA » %0:l6[#0..=#2]UKKK
+            Get l6 // { arity: 3 }
+            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+              Distinct project=[#0..=#2] // { arity: 3 }
+                Project (#0..=#2) // { arity: 3 }
+                  Get l4 // { arity: 5 }
+      cte l8 =
+        TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
+          Union // { arity: 5 }
+            Project (#3, #4, #1, #7, #8) // { arity: 5 }
+              Map ((#6 + integer_to_bigint(#2{w})), false) // { arity: 9 }
+                Join on=(#0{src} = #5) type=differential // { arity: 7 }
+                  implementation
+                    %0:l1[#0]KA » %1:l4[#2]K
+                  Get l1 // { arity: 3 }
+                  ArrangeBy keys=[[#2]] // { arity: 4 }
+                    Project (#0..=#3) // { arity: 4 }
+                      Get l4 // { arity: 5 }
+            Project (#0..=#3, #9) // { arity: 5 }
+              Map ((#4 OR #8)) // { arity: 10 }
+                Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
+                  implementation
+                    %0:l12[#0..=#2]KKK » %1[#0..=#2]KKK
+                  ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
+                    Project (#0..=#4) // { arity: 5 }
+                      Get l12 // { arity: 6 }
+                  ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                    Union // { arity: 4 }
+                      Map (true) // { arity: 4 }
+                        Get l7 // { arity: 3 }
+                      Project (#0..=#2, #6) // { arity: 4 }
+                        Map (false) // { arity: 7 }
+                          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                            implementation
+                              %1:l6[#0..=#2]UKKK » %0[#0..=#2]KKK
+                            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                              Union // { arity: 3 }
+                                Negate // { arity: 3 }
+                                  Get l7 // { arity: 3 }
+                                Get l5 // { arity: 3 }
+                            Get l6 // { arity: 3 }
+      cte l9 =
+        Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
+          Project (#1, #3) // { arity: 2 }
+            Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
+              implementation
+                %0:l8[#0]Kef » %1:l8[#0]Kef
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                Project (#2, #3) // { arity: 2 }
+                  Filter (#0 = false) // { arity: 5 }
+                    Get l8 // { arity: 5 }
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
+                Project (#2, #3) // { arity: 2 }
+                  Filter (#0 = true) // { arity: 5 }
+                    Get l8 // { arity: 5 }
+      cte l10 =
+        Project (#1) // { arity: 1 }
+          Map ((#0{min} / 2)) // { arity: 2 }
+            Union // { arity: 1 }
+              Get l9 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l9 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
+      cte l11 =
+        Distinct project=[] // { arity: 0 }
+          Project () // { arity: 0 }
+            Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
+              implementation
+                %0:l3[#0]UK » %1:l2[#0]K
+              ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
+                Get l3 // { arity: 1 }
+              Get l2 // { arity: 1 }
       cte l12 =
         Distinct project=[#0..=#5] // { arity: 6 }
           Union // { arity: 6 }
@@ -4517,141 +4612,46 @@ Explained Query:
                               Get l10 // { arity: 1 }
                           Constant // { arity: 0 }
                             - ()
-      cte l11 =
-        Distinct project=[] // { arity: 0 }
-          Project () // { arity: 0 }
-            Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
+    Return // { arity: 2 }
+      With
+        cte l13 =
+          Project (#0..=#3) // { arity: 4 }
+            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
               implementation
-                %0:l3[#0]UK » %1:l2[#0]K
-              ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                Get l3 // { arity: 1 }
-              Get l2 // { arity: 1 }
-      cte l10 =
-        Project (#1) // { arity: 1 }
-          Map ((#0{min} / 2)) // { arity: 2 }
-            Union // { arity: 1 }
-              Get l9 // { arity: 1 }
-              Map (null) // { arity: 1 }
-                Union // { arity: 0 }
-                  Negate // { arity: 0 }
-                    Project () // { arity: 0 }
-                      Get l9 // { arity: 1 }
-                  Constant // { arity: 0 }
-                    - ()
-      cte l9 =
-        Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
-          Project (#1, #3) // { arity: 2 }
-            Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
-              implementation
-                %0:l8[#0]Kef » %1:l8[#0]Kef
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = false) // { arity: 5 }
-                    Get l8 // { arity: 5 }
-              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = true) // { arity: 5 }
-                    Get l8 // { arity: 5 }
-      cte l8 =
-        TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
-          Union // { arity: 5 }
-            Project (#3, #4, #1, #7, #8) // { arity: 5 }
-              Map ((#6 + integer_to_bigint(#2{w})), false) // { arity: 9 }
-                Join on=(#0{src} = #5) type=differential // { arity: 7 }
+                %1[#0]UK » %0:l12[#4]K
+              ArrangeBy keys=[[#4]] // { arity: 5 }
+                Project (#0..=#3, #5) // { arity: 5 }
+                  Get l12 // { arity: 6 }
+              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+                Reduce aggregates=[max(#0)] // { arity: 1 }
+                  Project (#5) // { arity: 1 }
+                    Get l12 // { arity: 6 }
+        cte l14 =
+          Project (#1{min}, #2) // { arity: 2 }
+            Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1 + #3))] // { arity: 3 }
+              Project (#0{personid}, #2{personid}, #3, #5) // { arity: 4 }
+                Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
                   implementation
-                    %0:l1[#0]KA » %1:l4[#2]K
-                  Get l1 // { arity: 3 }
-                  ArrangeBy keys=[[#2]] // { arity: 4 }
-                    Project (#0..=#3) // { arity: 4 }
-                      Get l4 // { arity: 5 }
-            Project (#0..=#3, #9) // { arity: 5 }
-              Map ((#4 OR #8)) // { arity: 10 }
-                Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
-                  implementation
-                    %0:l12[#0..=#2]KKK » %1[#0..=#2]KKK
-                  ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-                    Project (#0..=#4) // { arity: 5 }
-                      Get l12 // { arity: 6 }
-                  ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-                    Union // { arity: 4 }
-                      Map (true) // { arity: 4 }
-                        Get l7 // { arity: 3 }
-                      Project (#0..=#2, #6) // { arity: 4 }
-                        Map (false) // { arity: 7 }
-                          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-                            implementation
-                              %1:l6[#0..=#2]UKKK » %0[#0..=#2]KKK
-                            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                              Union // { arity: 3 }
-                                Negate // { arity: 3 }
-                                  Get l7 // { arity: 3 }
-                                Get l5 // { arity: 3 }
-                            Get l6 // { arity: 3 }
-      cte l7 =
-        Project (#0..=#2) // { arity: 3 }
-          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                    %0:l13[#1]Kef » %1:l13[#1]Kef
+                  ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
+                    Project (#1{personid}..=#3) // { arity: 3 }
+                      Filter (#0 = false) // { arity: 4 }
+                        Get l13 // { arity: 4 }
+                  ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
+                    Project (#1{personid}..=#3) // { arity: 3 }
+                      Filter (#0 = true) // { arity: 4 }
+                        Get l13 // { arity: 4 }
+      Return // { arity: 2 }
+        Project (#0{personid}, #1{min}) // { arity: 2 }
+          Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
             implementation
-              %1[#0..=#2]UKKKA » %0:l6[#0..=#2]UKKK
-            Get l6 // { arity: 3 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Distinct project=[#0..=#2] // { arity: 3 }
-                Project (#0..=#2) // { arity: 3 }
-                  Get l4 // { arity: 5 }
-      cte l6 =
-        ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-          Get l5 // { arity: 3 }
-      cte l5 =
-        Distinct project=[#0..=#2] // { arity: 3 }
-          Project (#0..=#2) // { arity: 3 }
-            Get l12 // { arity: 6 }
-      cte l4 =
-        TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
-          Project (#0..=#3, #5) // { arity: 5 }
-            Filter (#4 = false) // { arity: 6 }
-              Get l12 // { arity: 6 }
-      cte l3 =
-        Distinct project=[#0{dst}] // { arity: 1 }
-          Union // { arity: 1 }
-            Project (#2) // { arity: 1 }
-              Join on=(#0 = #1{src}) type=delta // { arity: 4 }
-                implementation
-                  %0:l3 » %1:l1[#0]KA » %2[×]
-                  %1:l1 » %0:l3[#0]UK » %2[×]
-                  %2 » %0:l3[×] » %1:l1[#0]KA
-                ArrangeBy keys=[[], [#0{dst}]] // { arity: 1 }
-                  Get l3 // { arity: 1 }
-                Get l1 // { arity: 3 }
-                ArrangeBy keys=[[]] // { arity: 0 }
-                  Union // { arity: 0 }
-                    Negate // { arity: 0 }
-                      Distinct project=[] // { arity: 0 }
-                        Project () // { arity: 0 }
-                          Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
-                            implementation
-                              %0:l3[#0]UK » %1:l2[#0]K
-                            ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
-                              Get l3 // { arity: 1 }
-                            Get l2 // { arity: 1 }
-                    Constant // { arity: 0 }
-                      - ()
-            Constant // { arity: 1 }
-              - (10995116285979)
-      cte l2 =
-        ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
-          Get l0 // { arity: 1 }
-      cte l1 =
-        ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-          ReadIndex on=pathq20 pathq20_src=[differential join, delta join lookup] // { arity: 3 }
-      cte l0 =
-        Project (#1) // { arity: 1 }
-          Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
-            Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
-              implementation
-                %1:company[#0]KAef » %0:person_workat_company[#2]KAef
-              ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
-                ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
-              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                ReadIndex on=company company_id=[differential join] // { arity: 4 }
+              %1[#0]UK » %0:l14[#1]K
+            ArrangeBy keys=[[#1{min}]] // { arity: 2 }
+              Get l14 // { arity: 2 }
+            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+              Reduce aggregates=[min(#0{min})] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Get l14 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.person_workat_company_companyid (differential join)

--- a/test/sqllogictest/limit_expr.slt
+++ b/test/sqllogictest/limit_expr.slt
@@ -256,6 +256,28 @@ ORDER BY s.state, c.name;
 ----
 Explained Query:
   Finish order_by=[#0{state} asc nulls_last, #1{name} asc nulls_last] output=[#0, #1]
+    With
+      cte l0 =
+        Distinct project=[#0{state}] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            ReadStorage materialize.public.cities // { arity: 3 }
+      cte l1 =
+        Project (#0{state}, #2) // { arity: 2 }
+          Join on=(#1{sl} = substr(#0{state}, 1, 1)) type=differential // { arity: 3 }
+            ArrangeBy keys=[[substr(#0{state}, 1, 1)]] // { arity: 1 }
+              Get l0 // { arity: 1 }
+            ArrangeBy keys=[[#0{sl}]] // { arity: 2 }
+              Filter (#0{sl}) IS NOT NULL // { arity: 2 }
+                ReadStorage materialize.public.limits // { arity: 2 }
+      cte l2 =
+        Union // { arity: 2 }
+          Get l1 // { arity: 2 }
+          Map (error("more than one record produced in subquery")) // { arity: 2 }
+            Project (#0{state}) // { arity: 1 }
+              Filter (#1{count} > 1) // { arity: 2 }
+                Reduce group_by=[#0{state}] aggregates=[count(*)] // { arity: 2 }
+                  Project (#0{state}) // { arity: 1 }
+                    Get l1 // { arity: 2 }
     Return // { arity: 2 }
       Project (#1{name}, #0{state}) // { arity: 2 }
         TopK group_by=[#1{state}, #2{l}] order_by=[#0{name} asc nulls_last] limit=integer_to_bigint(#2{l}) // { arity: 3 }
@@ -274,28 +296,6 @@ Explained Query:
                           Project (#0{state}) // { arity: 1 }
                             Get l2 // { arity: 2 }
                       Get l0 // { arity: 1 }
-    With
-      cte l2 =
-        Union // { arity: 2 }
-          Get l1 // { arity: 2 }
-          Map (error("more than one record produced in subquery")) // { arity: 2 }
-            Project (#0{state}) // { arity: 1 }
-              Filter (#1{count} > 1) // { arity: 2 }
-                Reduce group_by=[#0{state}] aggregates=[count(*)] // { arity: 2 }
-                  Project (#0{state}) // { arity: 1 }
-                    Get l1 // { arity: 2 }
-      cte l1 =
-        Project (#0{state}, #2) // { arity: 2 }
-          Join on=(#1{sl} = substr(#0{state}, 1, 1)) type=differential // { arity: 3 }
-            ArrangeBy keys=[[substr(#0{state}, 1, 1)]] // { arity: 1 }
-              Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#0{sl}]] // { arity: 2 }
-              Filter (#0{sl}) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.limits // { arity: 2 }
-      cte l0 =
-        Distinct project=[#0{state}] // { arity: 1 }
-          Project (#1) // { arity: 1 }
-            ReadStorage materialize.public.cities // { arity: 3 }
 
 Source materialize.public.cities
 Source materialize.public.limits
@@ -378,6 +378,13 @@ SELECT s.state, c1.name, c2.name FROM
     LATERAL (SELECT name FROM cities c WHERE state = s.state LIMIT mod(length(s.state), 4)) c2;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0{name}, #1{state}) // { arity: 2 }
+        ReadStorage materialize.public.cities // { arity: 3 }
+    cte l1 =
+      TopK group_by=[#1{state}] limit=integer_to_bigint((char_length(#1{state}) % 3)) // { arity: 2 }
+        Get l0 // { arity: 2 }
   Return // { arity: 3 }
     Project (#1{name}, #0{state}, #3) // { arity: 3 }
       Join on=(#1{state} = #2{state}) type=differential // { arity: 4 }
@@ -393,13 +400,6 @@ Explained Query:
                       Get l1 // { arity: 2 }
                 ArrangeBy keys=[[#1{state}]] // { arity: 2 }
                   Get l0 // { arity: 2 }
-  With
-    cte l1 =
-      TopK group_by=[#1{state}] limit=integer_to_bigint((char_length(#1{state}) % 3)) // { arity: 2 }
-        Get l0 // { arity: 2 }
-    cte l0 =
-      Project (#0{name}, #1{state}) // { arity: 2 }
-        ReadStorage materialize.public.cities // { arity: 3 }
 
 Source materialize.public.cities
 

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -317,6 +317,21 @@ query T multiline
 EXPLAIN WITH(types, no fast path) SELECT MIN(col_not_null), MAX(col_not_null), AVG(col_not_null), STDDEV(col_not_null), LIST_AGG(col_not_null) FROM int_table;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#1) // { types: "(integer)" }
+        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+    cte l1 =
+      CrossJoin type=delta // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
+        ArrangeBy keys=[[]] // { types: "(integer, integer)" }
+          Reduce aggregates=[min(#0), max(#0)] // { types: "(integer, integer)" }
+            Get l0 // { types: "(integer)" }
+        ArrangeBy keys=[[]] // { types: "(bigint, bigint, numeric, numeric, bigint)" }
+          Reduce aggregates=[sum(#0), count(*), sum((integer_to_numeric(#0) * integer_to_numeric(#0))), sum(integer_to_numeric(#0)), count(integer_to_numeric(#0))] // { types: "(bigint, bigint, numeric, numeric, bigint)" }
+            Get l0 // { types: "(integer)" }
+        ArrangeBy keys=[[]] // { types: "(integer list)" }
+          Reduce aggregates=[list_agg[order_by=[]](row(list[#0]))] // { types: "(integer list)" }
+            Get l0 // { types: "(integer)" }
   Return // { types: "(integer?, integer?, numeric?, numeric?, integer list?)" }
     Project (#0, #1, #8, #9, #7) // { types: "(integer?, integer?, numeric?, numeric?, integer list?)" }
       Map ((bigint_to_numeric(#2) / bigint_to_numeric(case when (#3 = 0) then null else #3 end)), sqrtnumeric(case when ((#4) IS NULL OR (#5) IS NULL OR (case when (#6 = 0) then null else #6 end) IS NULL OR (case when (0 = (#6 - 1)) then null else (#6 - 1) end) IS NULL) then null else greatest(((#4 - ((#5 * #5) / bigint_to_numeric(case when (#6 = 0) then null else #6 end))) / bigint_to_numeric(case when (0 = (#6 - 1)) then null else (#6 - 1) end)), 0) end)) // { types: "(integer?, integer?, bigint?, bigint, numeric?, numeric?, bigint, integer list?, numeric?, numeric?)" }
@@ -329,21 +344,6 @@ Explained Query:
                   Get l1 // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
               Constant // { types: "()" }
                 - ()
-  With
-    cte l1 =
-      CrossJoin type=delta // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
-        ArrangeBy keys=[[]] // { types: "(integer, integer)" }
-          Reduce aggregates=[min(#0), max(#0)] // { types: "(integer, integer)" }
-            Get l0 // { types: "(integer)" }
-        ArrangeBy keys=[[]] // { types: "(bigint, bigint, numeric, numeric, bigint)" }
-          Reduce aggregates=[sum(#0), count(*), sum((integer_to_numeric(#0) * integer_to_numeric(#0))), sum(integer_to_numeric(#0)), count(integer_to_numeric(#0))] // { types: "(bigint, bigint, numeric, numeric, bigint)" }
-            Get l0 // { types: "(integer)" }
-        ArrangeBy keys=[[]] // { types: "(integer list)" }
-          Reduce aggregates=[list_agg[order_by=[]](row(list[#0]))] // { types: "(integer list)" }
-            Get l0 // { types: "(integer)" }
-    cte l0 =
-      Project (#1) // { types: "(integer)" }
-        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
 Source materialize.public.int_table
 
@@ -359,6 +359,11 @@ query T multiline
 EXPLAIN WITH(types, no fast path) SELECT COUNT(col_not_null), COUNT(DISTINCT col_not_null) FROM int_table;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[count(*), count(distinct #0)] // { types: "(bigint, bigint)" }
+        Project (#1) // { types: "(integer)" }
+          ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
   Return // { types: "(bigint, bigint)" }
     Union // { types: "(bigint, bigint)" }
       Get l0 // { types: "(bigint, bigint)" }
@@ -369,11 +374,6 @@ Explained Query:
               Get l0 // { types: "(bigint, bigint)" }
           Constant // { types: "()" }
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[count(*), count(distinct #0)] // { types: "(bigint, bigint)" }
-        Project (#1) // { types: "(integer)" }
-          ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
 Source materialize.public.int_table
 
@@ -506,6 +506,10 @@ query T multiline
 EXPLAIN WITH(types, no fast path) SELECT 1 = SOME (VALUES(col_null)), 1 = SOME (VALUES(col_not_null)), col_null = SOME (VALUES(NULL::int)), col_not_null = SOME (VALUES(NULL::int)) , col_null = SOME (VALUES(col_not_null)) , col_not_null = SOME (VALUES(col_null)) FROM int_table;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[#0, #1] // { types: "(integer?, integer)" }
+        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
   Return // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
     Project (#5, #4, #7, #8, #6, #6) // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
       Map ((#0 = 1), (#0 = #1), null, null) // { types: "(integer?, integer, integer?, integer, boolean, boolean?, boolean?, boolean?, boolean?)" }
@@ -523,10 +527,6 @@ Explained Query:
                     Filter (#1 = 1) // { types: "(integer?, integer)" }
                       Get l0 // { types: "(integer?, integer)" }
                   Get l0 // { types: "(integer?, integer)" }
-  With
-    cte l0 =
-      Distinct project=[#0, #1] // { types: "(integer?, integer)" }
-        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
 Source materialize.public.int_table
 
@@ -539,6 +539,10 @@ query T multiline
 EXPLAIN WITH(types, no fast path) SELECT 1 > ANY (VALUES(col_null)), 1 > ANY (VALUES(col_not_null)), col_null > ANY (VALUES(NULL::int)), col_not_null > ANY (VALUES(NULL::int)) , col_null > ANY (VALUES(col_not_null)) , col_not_null > ANY (VALUES(col_null)) FROM int_table;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[#0, #1] // { types: "(integer?, integer)" }
+        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
   Return // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
     Project (#5, #4, #8, #9, #6, #7) // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
       Map ((1 > #0), (#0 > #1), (#1 > #0), null, null) // { types: "(integer?, integer, integer?, integer, boolean, boolean?, boolean?, boolean?, boolean?, boolean?)" }
@@ -556,10 +560,6 @@ Explained Query:
                     Filter (1 > #1) // { types: "(integer?, integer)" }
                       Get l0 // { types: "(integer?, integer)" }
                   Get l0 // { types: "(integer?, integer)" }
-  With
-    cte l0 =
-      Distinct project=[#0, #1] // { types: "(integer?, integer)" }
-        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
 Source materialize.public.int_table
 
@@ -571,6 +571,10 @@ query T multiline
 EXPLAIN WITH(types, no fast path) SELECT 1 < ALL (VALUES(col_null)), 1 < ALL (VALUES(col_not_null)), col_null < ALL (VALUES(NULL::int)), col_not_null < ALL (VALUES(NULL::int)) , col_null < ALL (VALUES(col_not_null)) , col_not_null < ALL (VALUES(col_null)) FROM int_table;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[#0, #1] // { types: "(integer?, integer)" }
+        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
   Return // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
     Project (#5, #8..=#10, #6, #7) // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
       Map ((1 < #0), (#0 < #1), (#1 < #0), NOT(#4), null, null) // { types: "(integer?, integer, integer?, integer, boolean, boolean?, boolean?, boolean?, boolean, boolean?, boolean?)" }
@@ -588,10 +592,6 @@ Explained Query:
                     Filter (1 >= #1) // { types: "(integer?, integer)" }
                       Get l0 // { types: "(integer?, integer)" }
                   Get l0 // { types: "(integer?, integer)" }
-  With
-    cte l0 =
-      Distinct project=[#0, #1] // { types: "(integer?, integer)" }
-        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
 Source materialize.public.int_table
 
@@ -625,6 +625,40 @@ query T multiline
 EXPLAIN WITH(types, no fast path) SELECT 1 = SOME(VALUES(col_not_null), (NULL::int)), 1 = ALL (VALUES(col_not_null), (NULL::int)) , 1 = ANY (VALUES(col_not_null), (NULL::int)) FROM int_table;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#1) // { types: "(integer)" }
+        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+    cte l1 =
+      Distinct project=[#0] // { types: "(integer)" }
+        Get l0 // { types: "(integer)" }
+    cte l2 =
+      FlatMap wrap1(#0, null) // { types: "(integer, integer?)" }
+        Get l1 // { types: "(integer)" }
+    cte l3 =
+      Reduce group_by=[#0] aggregates=[any((#1 = 1))] // { types: "(integer, boolean?)" }
+        Get l2 // { types: "(integer, integer?)" }
+    cte l4 =
+      Union // { types: "(integer, boolean?)" }
+        Get l3 // { types: "(integer, boolean?)" }
+        Map (false) // { types: "(integer, boolean)" }
+          Union // { types: "(integer)" }
+            Negate // { types: "(integer)" }
+              Project (#0) // { types: "(integer)" }
+                Get l3 // { types: "(integer, boolean?)" }
+            Get l1 // { types: "(integer)" }
+    cte l5 =
+      Reduce group_by=[#0] aggregates=[all((#1 = 1))] // { types: "(integer, boolean?)" }
+        Get l2 // { types: "(integer, integer?)" }
+    cte l6 =
+      Union // { types: "(integer, boolean?)" }
+        Get l5 // { types: "(integer, boolean?)" }
+        Map (true) // { types: "(integer, boolean)" }
+          Union // { types: "(integer)" }
+            Negate // { types: "(integer)" }
+              Project (#0) // { types: "(integer)" }
+                Get l5 // { types: "(integer, boolean?)" }
+            Get l1 // { types: "(integer)" }
   Return // { types: "(boolean?, boolean?, boolean?)" }
     Project (#2, #4, #2) // { types: "(boolean?, boolean?, boolean?)" }
       Join on=(#0 = #1 = #3) type=delta // { types: "(integer, integer, boolean?, integer, boolean?)" }
@@ -648,40 +682,6 @@ Explained Query:
                   Project (#0) // { types: "(integer)" }
                     Get l6 // { types: "(integer, boolean?)" }
                 Get l1 // { types: "(integer)" }
-  With
-    cte l6 =
-      Union // { types: "(integer, boolean?)" }
-        Get l5 // { types: "(integer, boolean?)" }
-        Map (true) // { types: "(integer, boolean)" }
-          Union // { types: "(integer)" }
-            Negate // { types: "(integer)" }
-              Project (#0) // { types: "(integer)" }
-                Get l5 // { types: "(integer, boolean?)" }
-            Get l1 // { types: "(integer)" }
-    cte l5 =
-      Reduce group_by=[#0] aggregates=[all((#1 = 1))] // { types: "(integer, boolean?)" }
-        Get l2 // { types: "(integer, integer?)" }
-    cte l4 =
-      Union // { types: "(integer, boolean?)" }
-        Get l3 // { types: "(integer, boolean?)" }
-        Map (false) // { types: "(integer, boolean)" }
-          Union // { types: "(integer)" }
-            Negate // { types: "(integer)" }
-              Project (#0) // { types: "(integer)" }
-                Get l3 // { types: "(integer, boolean?)" }
-            Get l1 // { types: "(integer)" }
-    cte l3 =
-      Reduce group_by=[#0] aggregates=[any((#1 = 1))] // { types: "(integer, boolean?)" }
-        Get l2 // { types: "(integer, integer?)" }
-    cte l2 =
-      FlatMap wrap1(#0, null) // { types: "(integer, integer?)" }
-        Get l1 // { types: "(integer)" }
-    cte l1 =
-      Distinct project=[#0] // { types: "(integer)" }
-        Get l0 // { types: "(integer)" }
-    cte l0 =
-      Project (#1) // { types: "(integer)" }
-        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
 Source materialize.public.int_table
 
@@ -697,6 +697,19 @@ query T multiline
 EXPLAIN WITH(types, no fast path) SELECT (SELECT col_not_null FROM int_table) FROM int_table;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project () // { types: "()" }
+        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+    cte l1 =
+      Union // { types: "(integer)" }
+        Project (#1) // { types: "(integer)" }
+          ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+        Map (error("more than one record produced in subquery")) // { types: "(integer)" }
+          Project () // { types: "()" }
+            Filter (#0 > 1) // { types: "(bigint)" }
+              Reduce aggregates=[count(*)] // { types: "(bigint)" }
+                Get l0 // { types: "()" }
   Return // { types: "(integer?)" }
     CrossJoin type=differential // { types: "(integer?)" }
       ArrangeBy keys=[[]] // { types: "()" }
@@ -712,19 +725,6 @@ Explained Query:
                     Get l1 // { types: "(integer)" }
               Constant // { types: "()" }
                 - ()
-  With
-    cte l1 =
-      Union // { types: "(integer)" }
-        Project (#1) // { types: "(integer)" }
-          ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
-        Map (error("more than one record produced in subquery")) // { types: "(integer)" }
-          Project () // { types: "()" }
-            Filter (#0 > 1) // { types: "(bigint)" }
-              Reduce aggregates=[count(*)] // { types: "(bigint)" }
-                Get l0 // { types: "()" }
-    cte l0 =
-      Project () // { types: "()" }
-        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
 Source materialize.public.int_table
 
@@ -740,16 +740,12 @@ query T multiline
 EXPLAIN WITH(types, no fast path) SELECT 1 IN (SELECT col_not_null FROM int_table), 1 NOT IN (SELECT col_not_null FROM int_table) FROM int_table;
 ----
 Explained Query:
-  Return // { types: "(boolean, boolean)" }
-    Project (#0, #2) // { types: "(boolean, boolean)" }
-      Map (NOT(#1)) // { types: "(boolean, boolean, boolean)" }
-        CrossJoin type=delta // { types: "(boolean, boolean)" }
-          ArrangeBy keys=[[]] // { types: "()" }
-            Project () // { types: "()" }
-              ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
-          Get l1 // { types: "(boolean)" }
-          Get l1 // { types: "(boolean)" }
   With
+    cte l0 =
+      Distinct project=[] // { types: "()" }
+        Project () // { types: "()" }
+          Filter (#1 = 1) // { types: "(integer?, integer)" }
+            ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
     cte l1 =
       ArrangeBy keys=[[]] // { types: "(boolean)" }
         Union // { types: "(boolean)" }
@@ -761,11 +757,15 @@ Explained Query:
                 Get l0 // { types: "()" }
               Constant // { types: "()" }
                 - ()
-    cte l0 =
-      Distinct project=[] // { types: "()" }
-        Project () // { types: "()" }
-          Filter (#1 = 1) // { types: "(integer?, integer)" }
-            ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+  Return // { types: "(boolean, boolean)" }
+    Project (#0, #2) // { types: "(boolean, boolean)" }
+      Map (NOT(#1)) // { types: "(boolean, boolean, boolean)" }
+        CrossJoin type=delta // { types: "(boolean, boolean)" }
+          ArrangeBy keys=[[]] // { types: "()" }
+            Project () // { types: "()" }
+              ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+          Get l1 // { types: "(boolean)" }
+          Get l1 // { types: "(boolean)" }
 
 Source materialize.public.int_table
 
@@ -777,6 +777,13 @@ query T multiline
 EXPLAIN WITH(types, no fast path) SELECT EXISTS (SELECT col_not_null FROM int_table), NOT EXISTS (SELECT col_not_null FROM int_table) FROM int_table;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project () // { types: "()" }
+        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+    cte l1 =
+      Distinct project=[] // { types: "()" }
+        Get l0 // { types: "()" }
   Return // { types: "(boolean, boolean)" }
     Map (NOT(#0)) // { types: "(boolean, boolean)" }
       CrossJoin type=differential // { types: "(boolean)" }
@@ -792,13 +799,6 @@ Explained Query:
                   Get l1 // { types: "()" }
                 Constant // { types: "()" }
                   - ()
-  With
-    cte l1 =
-      Distinct project=[] // { types: "()" }
-        Get l0 // { types: "()" }
-    cte l0 =
-      Project () // { types: "()" }
-        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
 Source materialize.public.int_table
 
@@ -810,6 +810,36 @@ query T multiline
 EXPLAIN WITH(types, no fast path) SELECT 1 = SOME (SELECT col_not_null FROM int_table), col_not_null = SOME (SELECT 1), col_null = SOME ( SELECT col_not_null FROM int_table ) FROM int_table;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[] // { types: "()" }
+        Project () // { types: "()" }
+          Filter (#1 = 1) // { types: "(integer?, integer)" }
+            ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+    cte l1 =
+      Distinct project=[#0, #1] // { types: "(integer?, integer)" }
+        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+    cte l2 =
+      Distinct project=[#0] // { types: "(integer?)" }
+        Project (#0) // { types: "(integer?)" }
+          ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+    cte l3 =
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { types: "(integer?, boolean?)" }
+        CrossJoin type=differential // { types: "(integer?, integer)" }
+          ArrangeBy keys=[[]] // { types: "(integer?)" }
+            Get l2 // { types: "(integer?)" }
+          ArrangeBy keys=[[]] // { types: "(integer)" }
+            Project (#1) // { types: "(integer)" }
+              ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+    cte l4 =
+      Union // { types: "(integer?, boolean?)" }
+        Get l3 // { types: "(integer?, boolean?)" }
+        Map (false) // { types: "(integer?, boolean)" }
+          Union // { types: "(integer?)" }
+            Negate // { types: "(integer?)" }
+              Project (#0) // { types: "(integer?)" }
+                Get l3 // { types: "(integer?, boolean?)" }
+            Get l2 // { types: "(integer?)" }
   Return // { types: "(boolean, boolean, boolean?)" }
     Project (#2, #5, #7) // { types: "(boolean, boolean, boolean?)" }
       Join on=(#0 = #3 = #6 AND #1 = #4) type=delta // { types: "(integer?, integer, boolean, integer?, integer, boolean, integer?, boolean?)" }
@@ -845,36 +875,6 @@ Explained Query:
                   Project (#0) // { types: "(integer?)" }
                     Get l4 // { types: "(integer?, boolean?)" }
                 Get l2 // { types: "(integer?)" }
-  With
-    cte l4 =
-      Union // { types: "(integer?, boolean?)" }
-        Get l3 // { types: "(integer?, boolean?)" }
-        Map (false) // { types: "(integer?, boolean)" }
-          Union // { types: "(integer?)" }
-            Negate // { types: "(integer?)" }
-              Project (#0) // { types: "(integer?)" }
-                Get l3 // { types: "(integer?, boolean?)" }
-            Get l2 // { types: "(integer?)" }
-    cte l3 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { types: "(integer?, boolean?)" }
-        CrossJoin type=differential // { types: "(integer?, integer)" }
-          ArrangeBy keys=[[]] // { types: "(integer?)" }
-            Get l2 // { types: "(integer?)" }
-          ArrangeBy keys=[[]] // { types: "(integer)" }
-            Project (#1) // { types: "(integer)" }
-              ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
-    cte l2 =
-      Distinct project=[#0] // { types: "(integer?)" }
-        Project (#0) // { types: "(integer?)" }
-          ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
-    cte l1 =
-      Distinct project=[#0, #1] // { types: "(integer?, integer)" }
-        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
-    cte l0 =
-      Distinct project=[] // { types: "()" }
-        Project () // { types: "()" }
-          Filter (#1 = 1) // { types: "(integer?, integer)" }
-            ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
 Source materialize.public.int_table
 
@@ -922,15 +922,15 @@ query T multiline
 EXPLAIN WITH(types, no fast path) SELECT a1.col_not_null, a2.col_not_null FROM int_table AS a1 INNER JOIN int_table AS a2 ON TRUE;
 ----
 Explained Query:
-  Return // { types: "(integer, integer)" }
-    CrossJoin type=differential // { types: "(integer, integer)" }
-      Get l0 // { types: "(integer)" }
-      Get l0 // { types: "(integer)" }
   With
     cte l0 =
       ArrangeBy keys=[[]] // { types: "(integer)" }
         Project (#1) // { types: "(integer)" }
           ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+  Return // { types: "(integer, integer)" }
+    CrossJoin type=differential // { types: "(integer, integer)" }
+      Get l0 // { types: "(integer)" }
+      Get l0 // { types: "(integer)" }
 
 Source materialize.public.int_table
 
@@ -946,6 +946,14 @@ query T multiline
 EXPLAIN WITH(types, no fast path) SELECT a1.col_not_null, a2.col_not_null FROM int_table AS a1 LEFT JOIN int_table AS a2 ON TRUE;
 ----
 Explained Query:
+  With
+    cte l0 =
+      CrossJoin type=differential // { types: "(integer?, integer, integer)" }
+        ArrangeBy keys=[[]] // { types: "(integer?, integer)" }
+          ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+        ArrangeBy keys=[[]] // { types: "(integer)" }
+          Project (#1) // { types: "(integer)" }
+            ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
   Return // { types: "(integer, integer?)" }
     Union // { types: "(integer, integer?)" }
       Project (#1, #2) // { types: "(integer, integer)" }
@@ -963,14 +971,6 @@ Explained Query:
                   ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
             ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
               ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
-  With
-    cte l0 =
-      CrossJoin type=differential // { types: "(integer?, integer, integer)" }
-        ArrangeBy keys=[[]] // { types: "(integer?, integer)" }
-          ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
-        ArrangeBy keys=[[]] // { types: "(integer)" }
-          Project (#1) // { types: "(integer)" }
-            ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
 Source materialize.public.int_table
 
@@ -982,6 +982,20 @@ query T multiline
 EXPLAIN WITH(types, no fast path) SELECT a1.col_not_null, a2.col_not_null FROM int_table AS a1 FULL OUTER JOIN int_table AS a2 ON TRUE;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[]] // { types: "(integer?, integer)" }
+        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+    cte l1 =
+      CrossJoin type=differential // { types: "(integer?, integer, integer?, integer)" }
+        Get l0 // { types: "(integer?, integer)" }
+        Get l0 // { types: "(integer?, integer)" }
+    cte l2 =
+      Distinct project=[#0, #1] // { types: "(integer?, integer)" }
+        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+    cte l3 =
+      ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
+        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
   Return // { types: "(integer?, integer?)" }
     Union // { types: "(integer?, integer?)" }
       Project (#1, #3) // { types: "(integer, integer)" }
@@ -1008,20 +1022,6 @@ Explained Query:
                       Get l1 // { types: "(integer?, integer, integer?, integer)" }
                 Get l2 // { types: "(integer?, integer)" }
             Get l3 // { types: "(integer?, integer)" }
-  With
-    cte l3 =
-      ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
-        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
-    cte l2 =
-      Distinct project=[#0, #1] // { types: "(integer?, integer)" }
-        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
-    cte l1 =
-      CrossJoin type=differential // { types: "(integer?, integer, integer?, integer)" }
-        Get l0 // { types: "(integer?, integer)" }
-        Get l0 // { types: "(integer?, integer)" }
-    cte l0 =
-      ArrangeBy keys=[[]] // { types: "(integer?, integer)" }
-        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
 Source materialize.public.int_table
 
@@ -1038,14 +1038,14 @@ query T multiline
 EXPLAIN WITH(types, no fast path) SELECT col_not_null FROM int_table UNION ALL SELECT col_not_null FROM int_table;
 ----
 Explained Query:
-  Return // { types: "(integer)" }
-    Union // { types: "(integer)" }
-      Get l0 // { types: "(integer)" }
-      Get l0 // { types: "(integer)" }
   With
     cte l0 =
       Project (#1) // { types: "(integer)" }
         ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+  Return // { types: "(integer)" }
+    Union // { types: "(integer)" }
+      Get l0 // { types: "(integer)" }
+      Get l0 // { types: "(integer)" }
 
 Source materialize.public.int_table
 

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -105,6 +105,21 @@ FROM
   left_joins_raw.facts LEFT JOIN
   left_joins_raw.dim01 ON(facts.dim01_k01 > dim01.dim01_k01);
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 9 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.left_joins_raw.facts // { arity: 9 }
+  cte l1 =
+    Filter (#1{dim01_k01} > #9{dim01_k01}) // { arity: 15 }
+      Project (#0{facts_k01}..=#14{dim01_d05}) // { arity: 15 }
+        CrossJoin // { arity: 15 }
+          Get l0 // { arity: 9 }
+          CrossJoin // { arity: 6 }
+            Constant // { arity: 0 }
+              - ()
+            Get materialize.left_joins_raw.dim01 // { arity: 6 }
 Return // { arity: 4 }
   Project (#0{facts_k01}, #4, #1{facts_d01}, #10) // { arity: 4 }
     Union // { arity: 15 }
@@ -121,21 +136,6 @@ Return // { arity: 4 }
             Get l0 // { arity: 9 }
         Constant // { arity: 6 }
           - (null, null, null, null, null, null)
-With
-  cte l1 =
-    Filter (#1{dim01_k01} > #9{dim01_k01}) // { arity: 15 }
-      Project (#0{facts_k01}..=#14{dim01_d05}) // { arity: 15 }
-        CrossJoin // { arity: 15 }
-          Get l0 // { arity: 9 }
-          CrossJoin // { arity: 6 }
-            Constant // { arity: 0 }
-              - ()
-            Get materialize.left_joins_raw.dim01 // { arity: 6 }
-  cte l0 =
-    CrossJoin // { arity: 9 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.left_joins_raw.facts // { arity: 9 }
 
 Target cluster: quickstart
 
@@ -164,6 +164,21 @@ FROM
   left_joins_raw.facts LEFT JOIN
   left_joins_raw.dim01 ON(facts.dim01_k01 = dim01.dim01_k01);
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 9 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.left_joins_raw.facts // { arity: 9 }
+  cte l1 =
+    Filter (#1{dim01_k01} = #9{dim01_k01}) // { arity: 15 }
+      Project (#0{facts_k01}..=#14{dim01_d05}) // { arity: 15 }
+        CrossJoin // { arity: 15 }
+          Get l0 // { arity: 9 }
+          CrossJoin // { arity: 6 }
+            Constant // { arity: 0 }
+              - ()
+            Get materialize.left_joins_raw.dim01 // { arity: 6 }
 Return // { arity: 4 }
   Project (#0{facts_k01}, #4, #1{facts_d01}, #10) // { arity: 4 }
     Union // { arity: 15 }
@@ -179,21 +194,6 @@ Return // { arity: 4 }
                     Get l1 // { arity: 15 }
           Get l0 // { arity: 9 }
       Get l1 // { arity: 15 }
-With
-  cte l1 =
-    Filter (#1{dim01_k01} = #9{dim01_k01}) // { arity: 15 }
-      Project (#0{facts_k01}..=#14{dim01_d05}) // { arity: 15 }
-        CrossJoin // { arity: 15 }
-          Get l0 // { arity: 9 }
-          CrossJoin // { arity: 6 }
-            Constant // { arity: 0 }
-              - ()
-            Get materialize.left_joins_raw.dim01 // { arity: 6 }
-  cte l0 =
-    CrossJoin // { arity: 9 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.left_joins_raw.facts // { arity: 9 }
 
 Target cluster: quickstart
 
@@ -214,6 +214,27 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
     left_joins_raw.dim01 ON(facts.dim01_k01 + x = dim01.dim01_k01 + y)
 );
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.left_joins.outer // { arity: 2 }
+  cte l1 =
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
+      Get l0 // { arity: 2 }
+  cte l2 =
+    CrossJoin // { arity: 11 }
+      Get l1 // { arity: 2 }
+      Get materialize.left_joins_raw.facts // { arity: 9 }
+  cte l3 =
+    Filter ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
+      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
+        Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
+          Get l2 // { arity: 11 }
+          CrossJoin // { arity: 8 }
+            Get l1 // { arity: 2 }
+            Get materialize.left_joins_raw.dim01 // { arity: 6 }
 Return // { arity: 6 }
   Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
@@ -233,27 +254,6 @@ Return // { arity: 6 }
                 Get l2 // { arity: 11 }
             Constant // { arity: 6 }
               - (null, null, null, null, null, null)
-With
-  cte l3 =
-    Filter ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
-      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
-        Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
-          Get l2 // { arity: 11 }
-          CrossJoin // { arity: 8 }
-            Get l1 // { arity: 2 }
-            Get materialize.left_joins_raw.dim01 // { arity: 6 }
-  cte l2 =
-    CrossJoin // { arity: 11 }
-      Get l1 // { arity: 2 }
-      Get materialize.left_joins_raw.facts // { arity: 9 }
-  cte l1 =
-    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
-      Get l0 // { arity: 2 }
-  cte l0 =
-    CrossJoin // { arity: 2 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.left_joins.outer // { arity: 2 }
 
 Target cluster: quickstart
 
@@ -274,6 +274,27 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
     left_joins_raw.dim01 ON(facts.dim01_k01 + x = dim01.dim01_k01 + y)
 );
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.left_joins.outer // { arity: 2 }
+  cte l1 =
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
+      Get l0 // { arity: 2 }
+  cte l2 =
+    CrossJoin // { arity: 11 }
+      Get l1 // { arity: 2 }
+      Get materialize.left_joins_raw.facts // { arity: 9 }
+  cte l3 =
+    Filter ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
+      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
+        Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
+          Get l2 // { arity: 11 }
+          CrossJoin // { arity: 8 }
+            Get l1 // { arity: 2 }
+            Get materialize.left_joins_raw.dim01 // { arity: 6 }
 Return // { arity: 6 }
   Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
@@ -293,27 +314,6 @@ Return // { arity: 6 }
                           Get l3 // { arity: 17 }
               Get l2 // { arity: 11 }
           Get l3 // { arity: 17 }
-With
-  cte l3 =
-    Filter ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
-      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
-        Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
-          Get l2 // { arity: 11 }
-          CrossJoin // { arity: 8 }
-            Get l1 // { arity: 2 }
-            Get materialize.left_joins_raw.dim01 // { arity: 6 }
-  cte l2 =
-    CrossJoin // { arity: 11 }
-      Get l1 // { arity: 2 }
-      Get materialize.left_joins_raw.facts // { arity: 9 }
-  cte l1 =
-    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
-      Get l0 // { arity: 2 }
-  cte l0 =
-    CrossJoin // { arity: 2 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.left_joins.outer // { arity: 2 }
 
 Target cluster: quickstart
 
@@ -334,6 +334,27 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
     left_joins_raw.facts ON(facts.dim01_k01 + x = dim01.dim01_k01 + y)
 );
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.left_joins.outer // { arity: 2 }
+  cte l1 =
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
+      Get l0 // { arity: 2 }
+  cte l2 =
+    CrossJoin // { arity: 11 }
+      Get l1 // { arity: 2 }
+      Get materialize.left_joins_raw.facts // { arity: 9 }
+  cte l3 =
+    Filter ((#2{dim01_k01} + #1{y}) = (#9{dim01_k01} + #0{x})) // { arity: 17 }
+      Project (#0{x}..=#7{dim01_d05}, #10{dim02_k01}..=#18) // { arity: 17 }
+        Join on=(#0{x} = #8{x} AND #1{y} = #9{y}) // { arity: 19 }
+          CrossJoin // { arity: 8 }
+            Get l1 // { arity: 2 }
+            Get materialize.left_joins_raw.dim01 // { arity: 6 }
+          Get l2 // { arity: 11 }
 Return // { arity: 6 }
   Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
@@ -354,27 +375,6 @@ Return // { arity: 6 }
                             Get l3 // { arity: 17 }
                 Get l2 // { arity: 11 }
           Get l3 // { arity: 17 }
-With
-  cte l3 =
-    Filter ((#2{dim01_k01} + #1{y}) = (#9{dim01_k01} + #0{x})) // { arity: 17 }
-      Project (#0{x}..=#7{dim01_d05}, #10{dim02_k01}..=#18) // { arity: 17 }
-        Join on=(#0{x} = #8{x} AND #1{y} = #9{y}) // { arity: 19 }
-          CrossJoin // { arity: 8 }
-            Get l1 // { arity: 2 }
-            Get materialize.left_joins_raw.dim01 // { arity: 6 }
-          Get l2 // { arity: 11 }
-  cte l2 =
-    CrossJoin // { arity: 11 }
-      Get l1 // { arity: 2 }
-      Get materialize.left_joins_raw.facts // { arity: 9 }
-  cte l1 =
-    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
-      Get l0 // { arity: 2 }
-  cte l0 =
-    CrossJoin // { arity: 2 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.left_joins.outer // { arity: 2 }
 
 Target cluster: quickstart
 
@@ -399,6 +399,27 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
     )
 );
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.left_joins.outer // { arity: 2 }
+  cte l1 =
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
+      Get l0 // { arity: 2 }
+  cte l2 =
+    CrossJoin // { arity: 11 }
+      Get l1 // { arity: 2 }
+      Get materialize.left_joins_raw.facts // { arity: 9 }
+  cte l3 =
+    Filter ((((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) AND (#7{facts_d02} = 42)) AND (#13{dim01_d02} = 24)) // { arity: 17 }
+      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
+        Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
+          Get l2 // { arity: 11 }
+          CrossJoin // { arity: 8 }
+            Get l1 // { arity: 2 }
+            Get materialize.left_joins_raw.dim01 // { arity: 6 }
 Return // { arity: 6 }
   Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
@@ -418,27 +439,6 @@ Return // { arity: 6 }
                 Get l2 // { arity: 11 }
             Constant // { arity: 6 }
               - (null, null, null, null, null, null)
-With
-  cte l3 =
-    Filter ((((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) AND (#7{facts_d02} = 42)) AND (#13{dim01_d02} = 24)) // { arity: 17 }
-      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
-        Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
-          Get l2 // { arity: 11 }
-          CrossJoin // { arity: 8 }
-            Get l1 // { arity: 2 }
-            Get materialize.left_joins_raw.dim01 // { arity: 6 }
-  cte l2 =
-    CrossJoin // { arity: 11 }
-      Get l1 // { arity: 2 }
-      Get materialize.left_joins_raw.facts // { arity: 9 }
-  cte l1 =
-    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
-      Get l0 // { arity: 2 }
-  cte l0 =
-    CrossJoin // { arity: 2 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.left_joins.outer // { arity: 2 }
 
 Target cluster: quickstart
 
@@ -463,6 +463,27 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
     )
 );
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.left_joins.outer // { arity: 2 }
+  cte l1 =
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
+      Get l0 // { arity: 2 }
+  cte l2 =
+    CrossJoin // { arity: 11 }
+      Get l1 // { arity: 2 }
+      Get materialize.left_joins_raw.facts // { arity: 9 }
+  cte l3 =
+    Filter (#7{facts_d02} = 42) AND (#13{dim01_d02} = 24) AND ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
+      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
+        Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
+          Get l2 // { arity: 11 }
+          CrossJoin // { arity: 8 }
+            Get l1 // { arity: 2 }
+            Get materialize.left_joins_raw.dim01 // { arity: 6 }
 Return // { arity: 6 }
   Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
@@ -482,27 +503,6 @@ Return // { arity: 6 }
                           Get l3 // { arity: 17 }
               Get l2 // { arity: 11 }
           Get l3 // { arity: 17 }
-With
-  cte l3 =
-    Filter (#7{facts_d02} = 42) AND (#13{dim01_d02} = 24) AND ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
-      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
-        Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
-          Get l2 // { arity: 11 }
-          CrossJoin // { arity: 8 }
-            Get l1 // { arity: 2 }
-            Get materialize.left_joins_raw.dim01 // { arity: 6 }
-  cte l2 =
-    CrossJoin // { arity: 11 }
-      Get l1 // { arity: 2 }
-      Get materialize.left_joins_raw.facts // { arity: 9 }
-  cte l1 =
-    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
-      Get l0 // { arity: 2 }
-  cte l0 =
-    CrossJoin // { arity: 2 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.left_joins.outer // { arity: 2 }
 
 Target cluster: quickstart
 
@@ -527,6 +527,27 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
     )
 );
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.left_joins.outer // { arity: 2 }
+  cte l1 =
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
+      Get l0 // { arity: 2 }
+  cte l2 =
+    CrossJoin // { arity: 11 }
+      Get l1 // { arity: 2 }
+      Get materialize.left_joins_raw.facts // { arity: 9 }
+  cte l3 =
+    Filter (#4{dim01_d02} = 24) AND (#13{facts_d02} = 42) AND ((#2{dim01_k01} + #1{y}) = (#9{dim01_k01} + #0{x})) // { arity: 17 }
+      Project (#0{x}..=#7{dim01_d05}, #10{dim02_k01}..=#18) // { arity: 17 }
+        Join on=(#0{x} = #8{x} AND #1{y} = #9{y}) // { arity: 19 }
+          CrossJoin // { arity: 8 }
+            Get l1 // { arity: 2 }
+            Get materialize.left_joins_raw.dim01 // { arity: 6 }
+          Get l2 // { arity: 11 }
 Return // { arity: 6 }
   Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
@@ -547,27 +568,6 @@ Return // { arity: 6 }
                             Get l3 // { arity: 17 }
                 Get l2 // { arity: 11 }
           Get l3 // { arity: 17 }
-With
-  cte l3 =
-    Filter (#4{dim01_d02} = 24) AND (#13{facts_d02} = 42) AND ((#2{dim01_k01} + #1{y}) = (#9{dim01_k01} + #0{x})) // { arity: 17 }
-      Project (#0{x}..=#7{dim01_d05}, #10{dim02_k01}..=#18) // { arity: 17 }
-        Join on=(#0{x} = #8{x} AND #1{y} = #9{y}) // { arity: 19 }
-          CrossJoin // { arity: 8 }
-            Get l1 // { arity: 2 }
-            Get materialize.left_joins_raw.dim01 // { arity: 6 }
-          Get l2 // { arity: 11 }
-  cte l2 =
-    CrossJoin // { arity: 11 }
-      Get l1 // { arity: 2 }
-      Get materialize.left_joins_raw.facts // { arity: 9 }
-  cte l1 =
-    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
-      Get l0 // { arity: 2 }
-  cte l0 =
-    CrossJoin // { arity: 2 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.left_joins.outer // { arity: 2 }
 
 Target cluster: quickstart
 
@@ -591,6 +591,34 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
     )
 );
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.left_joins.outer // { arity: 2 }
+  cte l1 =
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
+      Get l0 // { arity: 2 }
+  cte l2 =
+    CrossJoin // { arity: 8 }
+      Get l1 // { arity: 2 }
+      Get materialize.left_joins_raw.dim01 // { arity: 6 }
+  cte l3 =
+    CrossJoin // { arity: 8 }
+      Get l1 // { arity: 2 }
+      Get materialize.left_joins_raw.dim02 // { arity: 6 }
+  cte l4 =
+    Filter (coalesce(#2{dim01_k01}, #0{x}) = coalesce(#8{dim02_k01}, #1{y})) AND (#11{dim02_d03} < 24) AND (#5{dim01_d03} > 42) // { arity: 14 }
+      Project (#0{x}..=#7{dim01_d05}, #10{dim02_d02}..=#15) // { arity: 14 }
+        Join on=(#0{x} = #8{x} AND #1{y} = #9{y}) // { arity: 16 }
+          Get l2 // { arity: 8 }
+          Get l3 // { arity: 8 }
+  cte l5 =
+    Distinct project=[#0{x}..=#2] // { arity: 3 }
+      Project (#14..=#16) // { arity: 3 }
+        Map (#0{x}, #1{y}, coalesce(#2{dim01_k01}, #0{x})) // { arity: 17 }
+          Get l4 // { arity: 14 }
 Return // { arity: 6 }
   Project (#0{x}, #1{y}, #4{dim02_d02}..=#7) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
@@ -617,34 +645,6 @@ Return // { arity: 6 }
                     Get l5 // { arity: 3 }
               Get l2 // { arity: 8 }
           Get l4 // { arity: 14 }
-With
-  cte l5 =
-    Distinct project=[#0{x}..=#2] // { arity: 3 }
-      Project (#14..=#16) // { arity: 3 }
-        Map (#0{x}, #1{y}, coalesce(#2{dim01_k01}, #0{x})) // { arity: 17 }
-          Get l4 // { arity: 14 }
-  cte l4 =
-    Filter (coalesce(#2{dim01_k01}, #0{x}) = coalesce(#8{dim02_k01}, #1{y})) AND (#11{dim02_d03} < 24) AND (#5{dim01_d03} > 42) // { arity: 14 }
-      Project (#0{x}..=#7{dim01_d05}, #10{dim02_d02}..=#15) // { arity: 14 }
-        Join on=(#0{x} = #8{x} AND #1{y} = #9{y}) // { arity: 16 }
-          Get l2 // { arity: 8 }
-          Get l3 // { arity: 8 }
-  cte l3 =
-    CrossJoin // { arity: 8 }
-      Get l1 // { arity: 2 }
-      Get materialize.left_joins_raw.dim02 // { arity: 6 }
-  cte l2 =
-    CrossJoin // { arity: 8 }
-      Get l1 // { arity: 2 }
-      Get materialize.left_joins_raw.dim01 // { arity: 6 }
-  cte l1 =
-    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
-      Get l0 // { arity: 2 }
-  cte l0 =
-    CrossJoin // { arity: 2 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.left_joins.outer // { arity: 2 }
 
 Target cluster: quickstart
 
@@ -669,26 +669,56 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
     )
 );
 ----
-Return // { arity: 6 }
-  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
-    Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
-      Get l0 // { arity: 2 }
-      Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
-        Union // { arity: 17 }
-          Get l8 // { arity: 17 }
-          CrossJoin // { arity: 17 }
-            Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
-              Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
-                Union // { arity: 11 }
-                  Negate // { arity: 11 }
-                    Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
-                      Get l8 // { arity: 17 }
-                  Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
-                    Get l2 // { arity: 11 }
-                Get l2 // { arity: 11 }
-            Constant // { arity: 6 }
-              - (null, null, null, null, null, null)
 With
+  cte l0 =
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.left_joins.outer // { arity: 2 }
+  cte l1 =
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
+      Get l0 // { arity: 2 }
+  cte l2 =
+    CrossJoin // { arity: 11 }
+      Get l1 // { arity: 2 }
+      Get materialize.left_joins_raw.facts // { arity: 9 }
+  cte l3 =
+    Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
+      Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
+        Get l2 // { arity: 11 }
+        CrossJoin // { arity: 8 }
+          Get l1 // { arity: 2 }
+          Get materialize.left_joins_raw.dim01 // { arity: 6 }
+  cte l4 =
+    Distinct project=[#12{dim01_d01}] // { arity: 1 }
+      Get l3 // { arity: 17 }
+  cte l5 =
+    Reduce group_by=[#0{dim01_d01}] aggregates=[any((#0{dim01_d01} = #1))] // { arity: 2 }
+      FlatMap unnest_array(strtoarray("{24, 42}")) // { arity: 2 }
+        Get l4 // { arity: 1 }
+  cte l6 =
+    Union // { arity: 2 }
+      Get l5 // { arity: 2 }
+      CrossJoin // { arity: 2 }
+        Project (#0{dim01_d01}) // { arity: 1 }
+          Join on=(#0{dim01_d01} = #1{dim01_d01}) // { arity: 2 }
+            Union // { arity: 1 }
+              Negate // { arity: 1 }
+                Distinct project=[#0{dim01_d01}] // { arity: 1 }
+                  Get l5 // { arity: 2 }
+              Distinct project=[#0{dim01_d01}] // { arity: 1 }
+                Get l4 // { arity: 1 }
+            Get l4 // { arity: 1 }
+        Constant // { arity: 1 }
+          - (false)
+  cte l7 =
+    Union // { arity: 2 }
+      Get l6 // { arity: 2 }
+      Map (error("more than one record produced in subquery")) // { arity: 2 }
+        Project (#0{dim01_d01}) // { arity: 1 }
+          Filter (#1{count} > 1) // { arity: 2 }
+            Reduce group_by=[#0{dim01_d01}] aggregates=[count(*)] // { arity: 2 }
+              Get l6 // { arity: 2 }
   cte l8 =
     Project (#0{x}..=#16{dim01_d05}) // { arity: 17 }
       Filter ((((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) AND (#7{facts_d02} = 42)) AND #17{any}) // { arity: 18 }
@@ -709,55 +739,25 @@ With
                     Get l4 // { arity: 1 }
                 Constant // { arity: 1 }
                   - (null)
-  cte l7 =
-    Union // { arity: 2 }
-      Get l6 // { arity: 2 }
-      Map (error("more than one record produced in subquery")) // { arity: 2 }
-        Project (#0{dim01_d01}) // { arity: 1 }
-          Filter (#1{count} > 1) // { arity: 2 }
-            Reduce group_by=[#0{dim01_d01}] aggregates=[count(*)] // { arity: 2 }
-              Get l6 // { arity: 2 }
-  cte l6 =
-    Union // { arity: 2 }
-      Get l5 // { arity: 2 }
-      CrossJoin // { arity: 2 }
-        Project (#0{dim01_d01}) // { arity: 1 }
-          Join on=(#0{dim01_d01} = #1{dim01_d01}) // { arity: 2 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Distinct project=[#0{dim01_d01}] // { arity: 1 }
-                  Get l5 // { arity: 2 }
-              Distinct project=[#0{dim01_d01}] // { arity: 1 }
-                Get l4 // { arity: 1 }
-            Get l4 // { arity: 1 }
-        Constant // { arity: 1 }
-          - (false)
-  cte l5 =
-    Reduce group_by=[#0{dim01_d01}] aggregates=[any((#0{dim01_d01} = #1))] // { arity: 2 }
-      FlatMap unnest_array(strtoarray("{24, 42}")) // { arity: 2 }
-        Get l4 // { arity: 1 }
-  cte l4 =
-    Distinct project=[#12{dim01_d01}] // { arity: 1 }
-      Get l3 // { arity: 17 }
-  cte l3 =
-    Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
-      Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
-        Get l2 // { arity: 11 }
-        CrossJoin // { arity: 8 }
-          Get l1 // { arity: 2 }
-          Get materialize.left_joins_raw.dim01 // { arity: 6 }
-  cte l2 =
-    CrossJoin // { arity: 11 }
-      Get l1 // { arity: 2 }
-      Get materialize.left_joins_raw.facts // { arity: 9 }
-  cte l1 =
-    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
+Return // { arity: 6 }
+  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
+    Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
       Get l0 // { arity: 2 }
-  cte l0 =
-    CrossJoin // { arity: 2 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.left_joins.outer // { arity: 2 }
+      Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
+        Union // { arity: 17 }
+          Get l8 // { arity: 17 }
+          CrossJoin // { arity: 17 }
+            Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
+              Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
+                Union // { arity: 11 }
+                  Negate // { arity: 11 }
+                    Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
+                      Get l8 // { arity: 17 }
+                  Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
+                    Get l2 // { arity: 11 }
+                Get l2 // { arity: 11 }
+            Constant // { arity: 6 }
+              - (null, null, null, null, null, null)
 
 Target cluster: quickstart
 
@@ -788,6 +788,19 @@ FROM
   );
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+          Filter (#4{facts_d01} > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+    cte l1 =
+      Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
+        Get l0 // { arity: 4 }
+        ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
+          Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
+            Filter (#2{dim01_d02} < 24) // { arity: 6 }
+              ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
   Return // { arity: 6 }
     Union // { arity: 6 }
       Map (null, null, null) // { arity: 6 }
@@ -804,19 +817,6 @@ Explained Query:
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
       Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
         Get l1 // { arity: 7 }
-  With
-    cte l1 =
-      Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
-        Get l0 // { arity: 4 }
-        ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
-          Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
-            Filter (#2{dim01_d02} < 24) // { arity: 6 }
-              ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
-    cte l0 =
-      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-          Filter (#4{facts_d01} > 42) // { arity: 9 }
-            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01
@@ -849,6 +849,19 @@ EXPLAIN OPTIMIZED PLAN WITH(enable new outer join lowering, reoptimize imported 
 SELECT * FROM v;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+          Filter (#4{facts_d01} > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+    cte l1 =
+      Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
+        Get l0 // { arity: 4 }
+        ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
+          Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
+            Filter (#2{dim01_d02} < 24) // { arity: 6 }
+              ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
   Return // { arity: 6 }
     Union // { arity: 6 }
       Map (null, null, null) // { arity: 6 }
@@ -865,19 +878,6 @@ Explained Query:
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
       Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
         Get l1 // { arity: 7 }
-  With
-    cte l1 =
-      Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
-        Get l0 // { arity: 4 }
-        ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
-          Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
-            Filter (#2{dim01_d02} < 24) // { arity: 6 }
-              ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
-    cte l0 =
-      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-          Filter (#4{facts_d01} > 42) // { arity: 9 }
-            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01
@@ -897,6 +897,19 @@ materialize.public.v_facts_k01_idx:
     ReadGlobalFromSameDataflow materialize.public.v // { arity: 6 }
 
 materialize.public.v:
+  With
+    cte l0 =
+      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+          Filter (#4{facts_d01} > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+    cte l1 =
+      Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
+        Get l0 // { arity: 4 }
+        ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
+          Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
+            Filter (#2{dim01_d02} < 24) // { arity: 6 }
+              ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
   Return // { arity: 6 }
     Union // { arity: 6 }
       Map (null, null, null) // { arity: 6 }
@@ -913,19 +926,6 @@ materialize.public.v:
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
       Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
         Get l1 // { arity: 7 }
-  With
-    cte l1 =
-      Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
-        Get l0 // { arity: 4 }
-        ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
-          Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
-            Filter (#2{dim01_d02} < 24) // { arity: 6 }
-              ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
-    cte l0 =
-      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-          Filter (#4{facts_d01} > 42) // { arity: 9 }
-            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01
@@ -954,6 +954,19 @@ FROM
   );
 ----
 materialize.public.mv:
+  With
+    cte l0 =
+      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+          Filter (#4{facts_d01} > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+    cte l1 =
+      Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
+        Get l0 // { arity: 4 }
+        ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
+          Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
+            Filter (#2{dim01_d02} < 24) // { arity: 6 }
+              ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
   Return // { arity: 6 }
     Union // { arity: 6 }
       Map (null, null, null) // { arity: 6 }
@@ -970,19 +983,6 @@ materialize.public.mv:
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
       Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
         Get l1 // { arity: 7 }
-  With
-    cte l1 =
-      Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
-        Get l0 // { arity: 4 }
-        ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
-          Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
-            Filter (#2{dim01_d02} < 24) // { arity: 6 }
-              ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
-    cte l0 =
-      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-          Filter (#4{facts_d01} > 42) // { arity: 9 }
-            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01

--- a/test/sqllogictest/outer_join_simplification.slt
+++ b/test/sqllogictest/outer_join_simplification.slt
@@ -69,16 +69,6 @@ select * from
 foo_raw left join bar on foo_raw.a = bar.a;
 ----
 Explained Query:
-  Return
-    Union
-      Map (null, null)
-        Union
-          Negate
-            Project (#0..=#2)
-              Get l0
-          ReadStorage materialize.public.foo_raw
-      Project (#0..=#2, #0, #3)
-        Get l0
   With
     cte l0 =
       Project (#0..=#2, #4)
@@ -89,6 +79,16 @@ Explained Query:
           ArrangeBy keys=[[#0]]
             Filter (#0) IS NOT NULL
               ReadStorage materialize.public.bar
+  Return
+    Union
+      Map (null, null)
+        Union
+          Negate
+            Project (#0..=#2)
+              Get l0
+          ReadStorage materialize.public.foo_raw
+      Project (#0..=#2, #0, #3)
+        Get l0
 
 Source materialize.public.foo_raw
 Source materialize.public.bar
@@ -106,6 +106,14 @@ select * from
 bar right join foo_raw on foo_raw.a = bar.a;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]]
+        Filter (#0) IS NOT NULL
+          ReadStorage materialize.public.foo_raw
+    cte l1 =
+      Filter (#0) IS NOT NULL
+        ReadStorage materialize.public.bar
   Return
     Union
       Project (#3, #4, #0..=#2)
@@ -124,14 +132,6 @@ Explained Query:
           ArrangeBy keys=[[#0]]
             Get l1
           Get l0
-  With
-    cte l1 =
-      Filter (#0) IS NOT NULL
-        ReadStorage materialize.public.bar
-    cte l0 =
-      ArrangeBy keys=[[#0]]
-        Filter (#0) IS NOT NULL
-          ReadStorage materialize.public.foo_raw
 
 Source materialize.public.foo_raw
 Source materialize.public.bar
@@ -220,17 +220,14 @@ foo left join bar on foo.a = bar.a
     left join quux on baz.c = quux.c;
 ----
 Explained Query:
-  Return
-    Union
-      Get l2
-      Map (0)
-        Union
-          Negate
-            Project ()
-              Get l2
-          Constant
-            - ()
   With
+    cte l0 =
+      Project (#0)
+        Filter (#0) IS NOT NULL
+          ReadStorage materialize.public.bar
+    cte l1 =
+      Project (#0)
+        ReadStorage materialize.public.quux
     cte l2 =
       Reduce aggregates=[count(*)]
         Project ()
@@ -275,13 +272,16 @@ Explained Query:
                           ReadStorage materialize.public.baz
                         Constant
                           - (null)
-    cte l1 =
-      Project (#0)
-        ReadStorage materialize.public.quux
-    cte l0 =
-      Project (#0)
-        Filter (#0) IS NOT NULL
-          ReadStorage materialize.public.bar
+  Return
+    Union
+      Get l2
+      Map (0)
+        Union
+          Negate
+            Project ()
+              Get l2
+          Constant
+            - ()
 
 Source materialize.public.foo
 Source materialize.public.bar
@@ -368,8 +368,6 @@ with mutually recursive
 select * from c0;
 ----
 Explained Query:
-  Return
-    Get l0
   With Mutually Recursive
     cte l0 =
       Distinct project=[#0..=#3]
@@ -383,6 +381,8 @@ Explained Query:
                   Filter (#0) IS NOT NULL
                     ReadStorage materialize.public.bar
           Get l0
+  Return
+    Get l0
 
 Source materialize.public.foo
 Source materialize.public.bar
@@ -589,9 +589,17 @@ with mutually recursive
 select * from c0
 ----
 Explained Query:
-  Return // { keys: "([0])" }
-    Get l1 // { keys: "([0])" }
   With Mutually Recursive
+    cte l0 =
+      Project (#0..=#2, #4) // { keys: "()" }
+        Join on=(#0 = #3) type=differential // { keys: "()" }
+          ArrangeBy keys=[[#0]] // { keys: "()" }
+            Filter (#0) IS NOT NULL // { keys: "()" }
+              ReadStorage materialize.public.foo_raw // { keys: "()" }
+          ArrangeBy keys=[[#0]] // { keys: "([0])" }
+            Project (#0, #2) // { keys: "([0])" }
+              Filter (#0) IS NOT NULL // { keys: "([0])" }
+                Get l1 // { keys: "([0])" }
     cte l1 =
       TopK group_by=[#0] limit=1 // { keys: "([0])" }
         Distinct project=[#0..=#4] // { keys: "([0, 1, 2, 3, 4])" }
@@ -606,16 +614,8 @@ Explained Query:
               Get l0 // { keys: "()" }
             Project (#0..=#2, #0, #2) // { keys: "()" }
               ReadStorage materialize.public.foo_raw // { keys: "()" }
-    cte l0 =
-      Project (#0..=#2, #4) // { keys: "()" }
-        Join on=(#0 = #3) type=differential // { keys: "()" }
-          ArrangeBy keys=[[#0]] // { keys: "()" }
-            Filter (#0) IS NOT NULL // { keys: "()" }
-              ReadStorage materialize.public.foo_raw // { keys: "()" }
-          ArrangeBy keys=[[#0]] // { keys: "([0])" }
-            Project (#0, #2) // { keys: "([0])" }
-              Filter (#0) IS NOT NULL // { keys: "([0])" }
-                Get l1 // { keys: "([0])" }
+  Return // { keys: "([0])" }
+    Get l1 // { keys: "([0])" }
 
 Source materialize.public.foo_raw
 
@@ -640,9 +640,17 @@ with mutually recursive
 select * from c0
 ----
 Explained Query:
-  Return
-    Get l1
   With Mutually Recursive
+    cte l0 =
+      Project (#0..=#2, #4)
+        Join on=(#0 = #3) type=differential
+          ArrangeBy keys=[[#0]]
+            Project (#0..=#2)
+              Filter (#0) IS NOT NULL
+                Get l1
+          ArrangeBy keys=[[#0]]
+            Filter (#0) IS NOT NULL
+              ReadStorage materialize.public.bar
     cte l1 =
       Distinct project=[#0..=#4]
         Union
@@ -657,16 +665,8 @@ Explained Query:
             Get l0
           Project (#0..=#2, #0, #2)
             ReadStorage materialize.public.foo_raw
-    cte l0 =
-      Project (#0..=#2, #4)
-        Join on=(#0 = #3) type=differential
-          ArrangeBy keys=[[#0]]
-            Project (#0..=#2)
-              Filter (#0) IS NOT NULL
-                Get l1
-          ArrangeBy keys=[[#0]]
-            Filter (#0) IS NOT NULL
-              ReadStorage materialize.public.bar
+  Return
+    Get l1
 
 Source materialize.public.foo_raw
 Source materialize.public.bar
@@ -692,9 +692,16 @@ with mutually recursive
 select * from c0
 ----
 Explained Query:
-  Return
-    Get l1
   With Mutually Recursive
+    cte l0 =
+      Project (#0..=#2, #4)
+        Join on=(#0 = #3) type=differential
+          ArrangeBy keys=[[#0]]
+            Filter (#0) IS NOT NULL
+              ReadStorage materialize.public.foo_raw
+          ArrangeBy keys=[[#0]]
+            Filter (#0) IS NOT NULL
+              ReadStorage materialize.public.bar
     cte l1 =
       Distinct project=[#0..=#4]
         Union
@@ -707,15 +714,8 @@ Explained Query:
           Project (#0..=#2, #0, #3)
             Get l0
           Get l1
-    cte l0 =
-      Project (#0..=#2, #4)
-        Join on=(#0 = #3) type=differential
-          ArrangeBy keys=[[#0]]
-            Filter (#0) IS NOT NULL
-              ReadStorage materialize.public.foo_raw
-          ArrangeBy keys=[[#0]]
-            Filter (#0) IS NOT NULL
-              ReadStorage materialize.public.bar
+  Return
+    Get l1
 
 Source materialize.public.foo_raw
 Source materialize.public.bar
@@ -742,9 +742,13 @@ with mutually recursive
 select * from c0;
 ----
 Explained Query:
-  Return
-    Get l1
   With Mutually Recursive
+    cte l0 =
+      Union
+        Project (#0, #1)
+          Get l1
+        Constant
+          - (null, null)
     cte l1 =
       Distinct project=[#0..=#2]
         Union
@@ -801,12 +805,8 @@ Explained Query:
                               Constant
                                 - (null)
           ReadStorage materialize.public.foo
-    cte l0 =
-      Union
-        Project (#0, #1)
-          Get l1
-        Constant
-          - (null, null)
+  Return
+    Get l1
 
 Source materialize.public.foo
 Source materialize.public.bar
@@ -837,9 +837,14 @@ with mutually recursive
 select * from c0;
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Get l2 // { arity: 3 }
   With Mutually Recursive
+    cte l0 =
+      Project (#0) // { arity: 1 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.bar // { arity: 2 }
+    cte l1 =
+      Project (#0) // { arity: 1 }
+        ReadStorage materialize.public.quux // { arity: 2 }
     cte l2 =
       Distinct project=[#0..=#2] // { arity: 3 }
         Union // { arity: 3 }
@@ -885,13 +890,8 @@ Explained Query:
                           Constant // { arity: 1 }
                             - (null)
           ReadStorage materialize.public.foo // { arity: 3 }
-    cte l1 =
-      Project (#0) // { arity: 1 }
-        ReadStorage materialize.public.quux // { arity: 2 }
-    cte l0 =
-      Project (#0) // { arity: 1 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          ReadStorage materialize.public.bar // { arity: 2 }
+  Return // { arity: 3 }
+    Get l2 // { arity: 3 }
 
 Source materialize.public.foo
 Source materialize.public.bar

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -49,6 +49,16 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT (SELECT * FROM t1), (SELECT * FROM t1) FROM t2
 ----
 Explained Query:
+  With
+    cte l0 =
+      Union // { arity: 1 }
+        ReadStorage materialize.public.t1 // { arity: 1 }
+        Map (error("more than one record produced in subquery")) // { arity: 1 }
+          Project () // { arity: 0 }
+            Filter (#0 > 1) // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
+                Project () // { arity: 0 }
+                  ReadStorage materialize.public.t1 // { arity: 1 }
   Return // { arity: 2 }
     Project (#0, #0) // { arity: 2 }
       CrossJoin type=differential // { arity: 1 }
@@ -68,16 +78,6 @@ Explained Query:
                       Get l0 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
-  With
-    cte l0 =
-      Union // { arity: 1 }
-        ReadStorage materialize.public.t1 // { arity: 1 }
-        Map (error("more than one record produced in subquery")) // { arity: 1 }
-          Project () // { arity: 0 }
-            Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(*)] // { arity: 1 }
-                Project () // { arity: 0 }
-                  ReadStorage materialize.public.t1 // { arity: 1 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -94,6 +94,29 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1) , (SELECT * FROM t1 WHERE t1.f1 = t2.f1) FROM t2
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[#0] // { arity: 1 }
+        ReadStorage materialize.public.t2 // { arity: 1 }
+    cte l1 =
+      Project (#0) // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l0[#0]UKA » %1:t1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Filter (#0) IS NOT NULL // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 1 }
+    cte l2 =
+      Union // { arity: 2 }
+        Project (#0, #0) // { arity: 2 }
+          Get l1 // { arity: 1 }
+        Map (error("more than one record produced in subquery")) // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Filter (#1 > 1) // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                Get l1 // { arity: 1 }
   Return // { arity: 2 }
     Project (#2, #2) // { arity: 2 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
@@ -111,29 +134,6 @@ Explained Query:
                     Project (#0) // { arity: 1 }
                       Get l2 // { arity: 2 }
                 Get l0 // { arity: 1 }
-  With
-    cte l2 =
-      Union // { arity: 2 }
-        Project (#0, #0) // { arity: 2 }
-          Get l1 // { arity: 1 }
-        Map (error("more than one record produced in subquery")) // { arity: 2 }
-          Project (#0) // { arity: 1 }
-            Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                Get l1 // { arity: 1 }
-    cte l1 =
-      Project (#0) // { arity: 1 }
-        Join on=(#0 = #1) type=differential // { arity: 2 }
-          implementation
-            %0:l0[#0]UKA » %1:t1[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Get l0 // { arity: 1 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Filter (#0) IS NOT NULL // { arity: 1 }
-              ReadStorage materialize.public.t1 // { arity: 1 }
-    cte l0 =
-      Distinct project=[#0] // { arity: 1 }
-        ReadStorage materialize.public.t2 // { arity: 1 }
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
@@ -159,6 +159,40 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 1 UNION ALL SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 2) , (SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 1 UNION ALL SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 2) FROM t2
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[#0] // { arity: 1 }
+        ReadStorage materialize.public.t2 // { arity: 1 }
+    cte l1 =
+      Filter (#0) IS NOT NULL // { arity: 1 }
+        Get l0 // { arity: 1 }
+    cte l2 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Filter (#0) IS NOT NULL // { arity: 1 }
+          ReadStorage materialize.public.t1 // { arity: 1 }
+    cte l3 =
+      Union // { arity: 2 }
+        Join on=(#1 = (#0 + 1)) type=differential // { arity: 2 }
+          implementation
+            %0:l1[(#0 + 1)]K » %1:l2[#0]K
+          ArrangeBy keys=[[(#0 + 1)]] // { arity: 1 }
+            Get l1 // { arity: 1 }
+          Get l2 // { arity: 1 }
+        Join on=(#1 = (#0 + 2)) type=differential // { arity: 2 }
+          implementation
+            %0:l1[(#0 + 2)]K » %1:l2[#0]K
+          ArrangeBy keys=[[(#0 + 2)]] // { arity: 1 }
+            Get l1 // { arity: 1 }
+          Get l2 // { arity: 1 }
+    cte l4 =
+      Union // { arity: 2 }
+        Get l3 // { arity: 2 }
+        Map (error("more than one record produced in subquery")) // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Filter (#1 > 1) // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                Project (#0) // { arity: 1 }
+                  Get l3 // { arity: 2 }
   Return // { arity: 2 }
     Project (#2, #2) // { arity: 2 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
@@ -176,40 +210,6 @@ Explained Query:
                     Project (#0) // { arity: 1 }
                       Get l4 // { arity: 2 }
                 Get l0 // { arity: 1 }
-  With
-    cte l4 =
-      Union // { arity: 2 }
-        Get l3 // { arity: 2 }
-        Map (error("more than one record produced in subquery")) // { arity: 2 }
-          Project (#0) // { arity: 1 }
-            Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                Project (#0) // { arity: 1 }
-                  Get l3 // { arity: 2 }
-    cte l3 =
-      Union // { arity: 2 }
-        Join on=(#1 = (#0 + 1)) type=differential // { arity: 2 }
-          implementation
-            %0:l1[(#0 + 1)]K » %1:l2[#0]K
-          ArrangeBy keys=[[(#0 + 1)]] // { arity: 1 }
-            Get l1 // { arity: 1 }
-          Get l2 // { arity: 1 }
-        Join on=(#1 = (#0 + 2)) type=differential // { arity: 2 }
-          implementation
-            %0:l1[(#0 + 2)]K » %1:l2[#0]K
-          ArrangeBy keys=[[(#0 + 2)]] // { arity: 1 }
-            Get l1 // { arity: 1 }
-          Get l2 // { arity: 1 }
-    cte l2 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Filter (#0) IS NOT NULL // { arity: 1 }
-          ReadStorage materialize.public.t1 // { arity: 1 }
-    cte l1 =
-      Filter (#0) IS NOT NULL // { arity: 1 }
-        Get l0 // { arity: 1 }
-    cte l0 =
-      Distinct project=[#0] // { arity: 1 }
-        ReadStorage materialize.public.t2 // { arity: 1 }
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
@@ -227,6 +227,49 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 1) , (SELECT * FROM t1 WHERE t1.f1 = t2.f1 + 2) FROM t2
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[#0] // { arity: 1 }
+        ReadStorage materialize.public.t2 // { arity: 1 }
+    cte l1 =
+      Filter (#0) IS NOT NULL // { arity: 1 }
+        Get l0 // { arity: 1 }
+    cte l2 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Filter (#0) IS NOT NULL // { arity: 1 }
+          ReadStorage materialize.public.t1 // { arity: 1 }
+    cte l3 =
+      Join on=(#1 = (#0 + 1)) type=differential // { arity: 2 }
+        implementation
+          %0:l1[(#0 + 1)]K » %1:l2[#0]K
+        ArrangeBy keys=[[(#0 + 1)]] // { arity: 1 }
+          Get l1 // { arity: 1 }
+        Get l2 // { arity: 1 }
+    cte l4 =
+      Union // { arity: 2 }
+        Get l3 // { arity: 2 }
+        Map (error("more than one record produced in subquery")) // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Filter (#1 > 1) // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                Project (#0) // { arity: 1 }
+                  Get l3 // { arity: 2 }
+    cte l5 =
+      Join on=(#1 = (#0 + 2)) type=differential // { arity: 2 }
+        implementation
+          %0:l1[(#0 + 2)]K » %1:l2[#0]K
+        ArrangeBy keys=[[(#0 + 2)]] // { arity: 1 }
+          Get l1 // { arity: 1 }
+        Get l2 // { arity: 1 }
+    cte l6 =
+      Union // { arity: 2 }
+        Get l5 // { arity: 2 }
+        Map (error("more than one record produced in subquery")) // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Filter (#1 > 1) // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                Project (#0) // { arity: 1 }
+                  Get l5 // { arity: 2 }
   Return // { arity: 2 }
     Project (#2, #4) // { arity: 2 }
       Join on=(#0 = #1 = #3) type=delta // { arity: 5 }
@@ -256,49 +299,6 @@ Explained Query:
                     Project (#0) // { arity: 1 }
                       Get l6 // { arity: 2 }
                 Get l0 // { arity: 1 }
-  With
-    cte l6 =
-      Union // { arity: 2 }
-        Get l5 // { arity: 2 }
-        Map (error("more than one record produced in subquery")) // { arity: 2 }
-          Project (#0) // { arity: 1 }
-            Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                Project (#0) // { arity: 1 }
-                  Get l5 // { arity: 2 }
-    cte l5 =
-      Join on=(#1 = (#0 + 2)) type=differential // { arity: 2 }
-        implementation
-          %0:l1[(#0 + 2)]K » %1:l2[#0]K
-        ArrangeBy keys=[[(#0 + 2)]] // { arity: 1 }
-          Get l1 // { arity: 1 }
-        Get l2 // { arity: 1 }
-    cte l4 =
-      Union // { arity: 2 }
-        Get l3 // { arity: 2 }
-        Map (error("more than one record produced in subquery")) // { arity: 2 }
-          Project (#0) // { arity: 1 }
-            Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                Project (#0) // { arity: 1 }
-                  Get l3 // { arity: 2 }
-    cte l3 =
-      Join on=(#1 = (#0 + 1)) type=differential // { arity: 2 }
-        implementation
-          %0:l1[(#0 + 1)]K » %1:l2[#0]K
-        ArrangeBy keys=[[(#0 + 1)]] // { arity: 1 }
-          Get l1 // { arity: 1 }
-        Get l2 // { arity: 1 }
-    cte l2 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Filter (#0) IS NOT NULL // { arity: 1 }
-          ReadStorage materialize.public.t1 // { arity: 1 }
-    cte l1 =
-      Filter (#0) IS NOT NULL // { arity: 1 }
-        Get l0 // { arity: 1 }
-    cte l0 =
-      Distinct project=[#0] // { arity: 1 }
-        ReadStorage materialize.public.t2 // { arity: 1 }
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
@@ -323,6 +323,36 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT (SELECT f1 + 1 FROM t1 WHERE t1.f1 = t2.f1) , (SELECT f1 + 2 FROM t1 WHERE t1.f1 = t2.f1) FROM t2
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[#0] // { arity: 1 }
+        ReadStorage materialize.public.t2 // { arity: 1 }
+    cte l1 =
+      Project (#0) // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l0[#0]UKA » %1:t1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Filter (#0) IS NOT NULL // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 1 }
+    cte l2 =
+      Map (error("more than one record produced in subquery")) // { arity: 2 }
+        Project (#0) // { arity: 1 }
+          Filter (#1 > 1) // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+              Get l1 // { arity: 1 }
+    cte l3 =
+      Union // { arity: 2 }
+        Map ((#0 + 1)) // { arity: 2 }
+          Get l1 // { arity: 1 }
+        Get l2 // { arity: 2 }
+    cte l4 =
+      Union // { arity: 2 }
+        Map ((#0 + 2)) // { arity: 2 }
+          Get l1 // { arity: 1 }
+        Get l2 // { arity: 2 }
   Return // { arity: 2 }
     Project (#2, #4) // { arity: 2 }
       Join on=(#0 = #1 = #3) type=delta // { arity: 5 }
@@ -352,36 +382,6 @@ Explained Query:
                     Project (#0) // { arity: 1 }
                       Get l4 // { arity: 2 }
                 Get l0 // { arity: 1 }
-  With
-    cte l4 =
-      Union // { arity: 2 }
-        Map ((#0 + 2)) // { arity: 2 }
-          Get l1 // { arity: 1 }
-        Get l2 // { arity: 2 }
-    cte l3 =
-      Union // { arity: 2 }
-        Map ((#0 + 1)) // { arity: 2 }
-          Get l1 // { arity: 1 }
-        Get l2 // { arity: 2 }
-    cte l2 =
-      Map (error("more than one record produced in subquery")) // { arity: 2 }
-        Project (#0) // { arity: 1 }
-          Filter (#1 > 1) // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-              Get l1 // { arity: 1 }
-    cte l1 =
-      Project (#0) // { arity: 1 }
-        Join on=(#0 = #1) type=differential // { arity: 2 }
-          implementation
-            %0:l0[#0]UKA » %1:t1[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Get l0 // { arity: 1 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Filter (#0) IS NOT NULL // { arity: 1 }
-              ReadStorage materialize.public.t1 // { arity: 1 }
-    cte l0 =
-      Distinct project=[#0] // { arity: 1 }
-        ReadStorage materialize.public.t2 // { arity: 1 }
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
@@ -402,6 +402,44 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT (SELECT MIN(f1) FROM t1 WHERE t1.f1 = t2.f1) , (SELECT MAX(f1) FROM t1 WHERE t1.f1 = t2.f1) FROM t2
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[#0] // { arity: 1 }
+        ReadStorage materialize.public.t2 // { arity: 1 }
+    cte l1 =
+      Project (#0) // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l0[#0]UKA » %1:t1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Filter (#0) IS NOT NULL // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 1 }
+    cte l2 =
+      Reduce group_by=[#0] aggregates=[min(#0)] // { arity: 2 }
+        Get l1 // { arity: 1 }
+    cte l3 =
+      Union // { arity: 2 }
+        Get l2 // { arity: 2 }
+        Map (null) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l2 // { arity: 2 }
+            Get l0 // { arity: 1 }
+    cte l4 =
+      Reduce group_by=[#0] aggregates=[max(#0)] // { arity: 2 }
+        Get l1 // { arity: 1 }
+    cte l5 =
+      Union // { arity: 2 }
+        Get l4 // { arity: 2 }
+        Map (null) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l4 // { arity: 2 }
+            Get l0 // { arity: 1 }
   Return // { arity: 2 }
     Project (#2, #4) // { arity: 2 }
       Join on=(#0 = #1 = #3) type=delta // { arity: 5 }
@@ -429,44 +467,6 @@ Explained Query:
                   Project (#0) // { arity: 1 }
                     Get l5 // { arity: 2 }
                 Get l0 // { arity: 1 }
-  With
-    cte l5 =
-      Union // { arity: 2 }
-        Get l4 // { arity: 2 }
-        Map (null) // { arity: 2 }
-          Union // { arity: 1 }
-            Negate // { arity: 1 }
-              Project (#0) // { arity: 1 }
-                Get l4 // { arity: 2 }
-            Get l0 // { arity: 1 }
-    cte l4 =
-      Reduce group_by=[#0] aggregates=[max(#0)] // { arity: 2 }
-        Get l1 // { arity: 1 }
-    cte l3 =
-      Union // { arity: 2 }
-        Get l2 // { arity: 2 }
-        Map (null) // { arity: 2 }
-          Union // { arity: 1 }
-            Negate // { arity: 1 }
-              Project (#0) // { arity: 1 }
-                Get l2 // { arity: 2 }
-            Get l0 // { arity: 1 }
-    cte l2 =
-      Reduce group_by=[#0] aggregates=[min(#0)] // { arity: 2 }
-        Get l1 // { arity: 1 }
-    cte l1 =
-      Project (#0) // { arity: 1 }
-        Join on=(#0 = #1) type=differential // { arity: 2 }
-          implementation
-            %0:l0[#0]UKA » %1:t1[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Get l0 // { arity: 1 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Filter (#0) IS NOT NULL // { arity: 1 }
-              ReadStorage materialize.public.t1 // { arity: 1 }
-    cte l0 =
-      Distinct project=[#0] // { arity: 1 }
-        ReadStorage materialize.public.t2 // { arity: 1 }
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
@@ -491,33 +491,42 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT (SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1) FROM t2 WHERE t2.f1 = t3.f1) FROM t3
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Project (#2) // { arity: 1 }
-      Join on=(#0 = #1) type=differential // { arity: 3 }
-        implementation
-          %0:t3[#0]K » %1[#0]K
-        ArrangeBy keys=[[#0]] // { arity: 1 }
-          ReadStorage materialize.public.t3 // { arity: 1 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Union // { arity: 2 }
-            Get l6 // { arity: 2 }
-            Map (null) // { arity: 2 }
-              Union // { arity: 1 }
-                Negate // { arity: 1 }
-                  Distinct project=[#0] // { arity: 1 }
-                    Project (#0) // { arity: 1 }
-                      Get l6 // { arity: 2 }
-                Get l0 // { arity: 1 }
   With
-    cte l6 =
+    cte l0 =
+      Distinct project=[#0] // { arity: 1 }
+        ReadStorage materialize.public.t3 // { arity: 1 }
+    cte l1 =
+      Project (#0) // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l0[#0]UKA » %1:t2[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Filter (#0) IS NOT NULL // { arity: 1 }
+              ReadStorage materialize.public.t2 // { arity: 1 }
+    cte l2 =
+      Distinct project=[#0] // { arity: 1 }
+        Get l1 // { arity: 1 }
+    cte l3 =
+      Project (#0) // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l2[#0]UKA » %1:t1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l2 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Filter (#0) IS NOT NULL // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 1 }
+    cte l4 =
       Union // { arity: 2 }
-        Get l5 // { arity: 2 }
+        Project (#0, #0) // { arity: 2 }
+          Get l3 // { arity: 1 }
         Map (error("more than one record produced in subquery")) // { arity: 2 }
           Project (#0) // { arity: 1 }
             Filter (#1 > 1) // { arity: 2 }
               Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                Project (#0) // { arity: 1 }
-                  Get l5 // { arity: 2 }
+                Get l3 // { arity: 1 }
     cte l5 =
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
@@ -535,41 +544,32 @@ Explained Query:
                       Project (#0) // { arity: 1 }
                         Get l4 // { arity: 2 }
                   Get l2 // { arity: 1 }
-    cte l4 =
+    cte l6 =
       Union // { arity: 2 }
-        Project (#0, #0) // { arity: 2 }
-          Get l3 // { arity: 1 }
+        Get l5 // { arity: 2 }
         Map (error("more than one record produced in subquery")) // { arity: 2 }
           Project (#0) // { arity: 1 }
             Filter (#1 > 1) // { arity: 2 }
               Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                Get l3 // { arity: 1 }
-    cte l3 =
-      Project (#0) // { arity: 1 }
-        Join on=(#0 = #1) type=differential // { arity: 2 }
-          implementation
-            %0:l2[#0]UKA » %1:t1[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Get l2 // { arity: 1 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Filter (#0) IS NOT NULL // { arity: 1 }
-              ReadStorage materialize.public.t1 // { arity: 1 }
-    cte l2 =
-      Distinct project=[#0] // { arity: 1 }
-        Get l1 // { arity: 1 }
-    cte l1 =
-      Project (#0) // { arity: 1 }
-        Join on=(#0 = #1) type=differential // { arity: 2 }
-          implementation
-            %0:l0[#0]UKA » %1:t2[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Get l0 // { arity: 1 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Filter (#0) IS NOT NULL // { arity: 1 }
-              ReadStorage materialize.public.t2 // { arity: 1 }
-    cte l0 =
-      Distinct project=[#0] // { arity: 1 }
-        ReadStorage materialize.public.t3 // { arity: 1 }
+                Project (#0) // { arity: 1 }
+                  Get l5 // { arity: 2 }
+  Return // { arity: 1 }
+    Project (#2) // { arity: 1 }
+      Join on=(#0 = #1) type=differential // { arity: 3 }
+        implementation
+          %0:t3[#0]K » %1[#0]K
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          ReadStorage materialize.public.t3 // { arity: 1 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Union // { arity: 2 }
+            Get l6 // { arity: 2 }
+            Map (null) // { arity: 2 }
+              Union // { arity: 1 }
+                Negate // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l6 // { arity: 2 }
+                Get l0 // { arity: 1 }
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
@@ -596,17 +596,69 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT MIN((SELECT f1 FROM t1 WHERE t1.f1 = t2.f1)), MAX((SELECT f1 FROM t1 WHERE t1.f1 = t2.f1)) FROM t2;
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Union // { arity: 2 }
-      Get l8 // { arity: 2 }
-      Map (null, null) // { arity: 2 }
-        Union // { arity: 0 }
-          Negate // { arity: 0 }
-            Project () // { arity: 0 }
-              Get l8 // { arity: 2 }
-          Constant // { arity: 0 }
-            - ()
   With
+    cte l0 =
+      Distinct project=[#0] // { arity: 1 }
+        ReadStorage materialize.public.t2 // { arity: 1 }
+    cte l1 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Filter (#0) IS NOT NULL // { arity: 1 }
+          ReadStorage materialize.public.t1 // { arity: 1 }
+    cte l2 =
+      Project (#0) // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l0[#0]UKA » %1:l1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l0 // { arity: 1 }
+          Get l1 // { arity: 1 }
+    cte l3 =
+      Union // { arity: 2 }
+        Project (#0, #0) // { arity: 2 }
+          Get l2 // { arity: 1 }
+        Map (error("more than one record produced in subquery")) // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Filter (#1 > 1) // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                Get l2 // { arity: 1 }
+    cte l4 =
+      Project (#0, #2) // { arity: 2 }
+        Join on=(#0 = #1) type=differential // { arity: 3 }
+          implementation
+            %0:t2[#0]K » %1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            ReadStorage materialize.public.t2 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l3 // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Get l3 // { arity: 2 }
+                  Get l0 // { arity: 1 }
+    cte l5 =
+      Distinct project=[#0] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l4 // { arity: 2 }
+    cte l6 =
+      Project (#0) // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l5[#0]UKA » %1:l1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l5 // { arity: 1 }
+          Get l1 // { arity: 1 }
+    cte l7 =
+      Union // { arity: 2 }
+        Project (#0, #0) // { arity: 2 }
+          Get l6 // { arity: 1 }
+        Map (error("more than one record produced in subquery")) // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Filter (#1 > 1) // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                Get l6 // { arity: 1 }
     cte l8 =
       Reduce aggregates=[min(#0), max(#1)] // { arity: 2 }
         Project (#1, #3) // { arity: 2 }
@@ -625,68 +677,16 @@ Explained Query:
                         Project (#0) // { arity: 1 }
                           Get l7 // { arity: 2 }
                     Get l5 // { arity: 1 }
-    cte l7 =
-      Union // { arity: 2 }
-        Project (#0, #0) // { arity: 2 }
-          Get l6 // { arity: 1 }
-        Map (error("more than one record produced in subquery")) // { arity: 2 }
-          Project (#0) // { arity: 1 }
-            Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                Get l6 // { arity: 1 }
-    cte l6 =
-      Project (#0) // { arity: 1 }
-        Join on=(#0 = #1) type=differential // { arity: 2 }
-          implementation
-            %0:l5[#0]UKA » %1:l1[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Get l5 // { arity: 1 }
-          Get l1 // { arity: 1 }
-    cte l5 =
-      Distinct project=[#0] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l4 // { arity: 2 }
-    cte l4 =
-      Project (#0, #2) // { arity: 2 }
-        Join on=(#0 = #1) type=differential // { arity: 3 }
-          implementation
-            %0:t2[#0]K » %1[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            ReadStorage materialize.public.t2 // { arity: 1 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Union // { arity: 2 }
-              Get l3 // { arity: 2 }
-              Map (null) // { arity: 2 }
-                Union // { arity: 1 }
-                  Negate // { arity: 1 }
-                    Distinct project=[#0] // { arity: 1 }
-                      Project (#0) // { arity: 1 }
-                        Get l3 // { arity: 2 }
-                  Get l0 // { arity: 1 }
-    cte l3 =
-      Union // { arity: 2 }
-        Project (#0, #0) // { arity: 2 }
-          Get l2 // { arity: 1 }
-        Map (error("more than one record produced in subquery")) // { arity: 2 }
-          Project (#0) // { arity: 1 }
-            Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                Get l2 // { arity: 1 }
-    cte l2 =
-      Project (#0) // { arity: 1 }
-        Join on=(#0 = #1) type=differential // { arity: 2 }
-          implementation
-            %0:l0[#0]UKA » %1:l1[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Get l0 // { arity: 1 }
-          Get l1 // { arity: 1 }
-    cte l1 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Filter (#0) IS NOT NULL // { arity: 1 }
-          ReadStorage materialize.public.t1 // { arity: 1 }
-    cte l0 =
-      Distinct project=[#0] // { arity: 1 }
-        ReadStorage materialize.public.t2 // { arity: 1 }
+  Return // { arity: 2 }
+    Union // { arity: 2 }
+      Get l8 // { arity: 2 }
+      Map (null, null) // { arity: 2 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l8 // { arity: 2 }
+          Constant // { arity: 0 }
+            - ()
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
@@ -713,6 +713,34 @@ EXPLAIN WITH(arity, join implementations) SELECT
 FROM t3
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[#0] // { arity: 1 }
+        ReadStorage materialize.public.t3 // { arity: 1 }
+    cte l1 =
+      Project (#0) // { arity: 1 }
+        Join on=(#0 = #1 = #2) type=delta // { arity: 3 }
+          implementation
+            %0:l0 » %1:t1[#0]K » %2:t2[#0]K
+            %1:t1 » %0:l0[#0]UKA » %2:t2[#0]K
+            %2:t2 » %0:l0[#0]UKA » %1:t1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Filter (#0) IS NOT NULL // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Filter (#0) IS NOT NULL // { arity: 1 }
+              ReadStorage materialize.public.t2 // { arity: 1 }
+    cte l2 =
+      Union // { arity: 2 }
+        Project (#0, #0) // { arity: 2 }
+          Get l1 // { arity: 1 }
+        Map (error("more than one record produced in subquery")) // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Filter (#1 > 1) // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                Get l1 // { arity: 1 }
   Return // { arity: 2 }
     Project (#2, #2) // { arity: 2 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
@@ -730,34 +758,6 @@ Explained Query:
                     Project (#0) // { arity: 1 }
                       Get l2 // { arity: 2 }
                 Get l0 // { arity: 1 }
-  With
-    cte l2 =
-      Union // { arity: 2 }
-        Project (#0, #0) // { arity: 2 }
-          Get l1 // { arity: 1 }
-        Map (error("more than one record produced in subquery")) // { arity: 2 }
-          Project (#0) // { arity: 1 }
-            Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                Get l1 // { arity: 1 }
-    cte l1 =
-      Project (#0) // { arity: 1 }
-        Join on=(#0 = #1 = #2) type=delta // { arity: 3 }
-          implementation
-            %0:l0 » %1:t1[#0]K » %2:t2[#0]K
-            %1:t1 » %0:l0[#0]UKA » %2:t2[#0]K
-            %2:t2 » %0:l0[#0]UKA » %1:t1[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Get l0 // { arity: 1 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Filter (#0) IS NOT NULL // { arity: 1 }
-              ReadStorage materialize.public.t1 // { arity: 1 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Filter (#0) IS NOT NULL // { arity: 1 }
-              ReadStorage materialize.public.t2 // { arity: 1 }
-    cte l0 =
-      Distinct project=[#0] // { arity: 1 }
-        ReadStorage materialize.public.t3 // { arity: 1 }
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
@@ -791,6 +791,38 @@ EXPLAIN WITH(arity, join implementations) SELECT
 FROM t2, t3
 ----
 Explained Query:
+  With
+    cte l0 =
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0:t2[×] » %1:t3[×]
+        ArrangeBy keys=[[]] // { arity: 1 }
+          ReadStorage materialize.public.t2 // { arity: 1 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          ReadStorage materialize.public.t3 // { arity: 1 }
+    cte l1 =
+      Distinct project=[#0, #1] // { arity: 2 }
+        Get l0 // { arity: 2 }
+    cte l2 =
+      Project (#0, #1) // { arity: 2 }
+        Join on=(#0 = #2) type=differential // { arity: 3 }
+          implementation
+            %0:l1[#0]UKf » %1:t1[#0]Kf
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0 = #1) // { arity: 2 }
+              Get l1 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Filter (#0) IS NOT NULL // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 1 }
+    cte l3 =
+      Union // { arity: 3 }
+        Project (#0, #1, #0) // { arity: 3 }
+          Get l2 // { arity: 2 }
+        Map (error("more than one record produced in subquery")) // { arity: 3 }
+          Project (#0, #1) // { arity: 2 }
+            Filter (#2 > 1) // { arity: 3 }
+              Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+                Get l2 // { arity: 2 }
   Return // { arity: 2 }
     Project (#4, #4) // { arity: 2 }
       Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 5 }
@@ -808,38 +840,6 @@ Explained Query:
                     Project (#0, #1) // { arity: 2 }
                       Get l3 // { arity: 3 }
                 Get l1 // { arity: 2 }
-  With
-    cte l3 =
-      Union // { arity: 3 }
-        Project (#0, #1, #0) // { arity: 3 }
-          Get l2 // { arity: 2 }
-        Map (error("more than one record produced in subquery")) // { arity: 3 }
-          Project (#0, #1) // { arity: 2 }
-            Filter (#2 > 1) // { arity: 3 }
-              Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
-                Get l2 // { arity: 2 }
-    cte l2 =
-      Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = #2) type=differential // { arity: 3 }
-          implementation
-            %0:l1[#0]UKf » %1:t1[#0]Kf
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0 = #1) // { arity: 2 }
-              Get l1 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Filter (#0) IS NOT NULL // { arity: 1 }
-              ReadStorage materialize.public.t1 // { arity: 1 }
-    cte l1 =
-      Distinct project=[#0, #1] // { arity: 2 }
-        Get l0 // { arity: 2 }
-    cte l0 =
-      CrossJoin type=differential // { arity: 2 }
-        implementation
-          %0:t2[×] » %1:t3[×]
-        ArrangeBy keys=[[]] // { arity: 1 }
-          ReadStorage materialize.public.t2 // { arity: 1 }
-        ArrangeBy keys=[[]] // { arity: 1 }
-          ReadStorage materialize.public.t3 // { arity: 1 }
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
@@ -886,6 +886,20 @@ EOF
 query T multiline
 EXPLAIN DECORRELATED PLAN WITH(arity, types) FOR SELECT CASE (SELECT 1) WHEN 1 THEN 0 ELSE 2 END, 'TEXT';
 ----
+With
+  cte l0 =
+    Project (#0) // { arity: 1, types: "(integer)" }
+      Map (1) // { arity: 1, types: "(integer)" }
+        Constant // { arity: 0, types: "()" }
+          - ()
+  cte l1 =
+    Union // { arity: 1, types: "(integer)" }
+      Get l0 // { arity: 1, types: "(integer)" }
+      Map (error("more than one record produced in subquery")) // { arity: 1, types: "(integer)" }
+        Project () // { arity: 0, types: "()" }
+          Filter (#0 > 1) // { arity: 1, types: "(bigint)" }
+            Reduce aggregates=[count(*)] // { arity: 1, types: "(bigint)" }
+              Get l0 // { arity: 1, types: "(integer)" }
 Return // { arity: 2, types: "(integer, text)" }
   Project (#1, #2) // { arity: 2, types: "(integer, text)" }
     Map (case when (#0 = 1) then 0 else 2 end, "TEXT") // { arity: 3, types: "(integer?, integer, text)" }
@@ -909,20 +923,6 @@ Return // { arity: 2, types: "(integer, text)" }
                     - ()
               Constant // { arity: 1, types: "(integer?)" }
                 - (null)
-With
-  cte l1 =
-    Union // { arity: 1, types: "(integer)" }
-      Get l0 // { arity: 1, types: "(integer)" }
-      Map (error("more than one record produced in subquery")) // { arity: 1, types: "(integer)" }
-        Project () // { arity: 0, types: "()" }
-          Filter (#0 > 1) // { arity: 1, types: "(bigint)" }
-            Reduce aggregates=[count(*)] // { arity: 1, types: "(bigint)" }
-              Get l0 // { arity: 1, types: "(integer)" }
-  cte l0 =
-    Project (#0) // { arity: 1, types: "(integer)" }
-      Map (1) // { arity: 1, types: "(integer)" }
-        Constant // { arity: 0, types: "()" }
-          - ()
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -474,6 +474,20 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT b IN (SELECT a FROM x) FROM y
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[#0] // { arity: 1 }
+        ReadStorage materialize.public.y // { arity: 1 }
+    cte l1 =
+      Project (#0) // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l0[#0]UKA » %1[#0]UKA
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Distinct project=[#0] // { arity: 1 }
+              ReadStorage materialize.public.x // { arity: 1 }
   Return // { arity: 1 }
     Project (#2) // { arity: 1 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
@@ -490,20 +504,6 @@ Explained Query:
                 Negate // { arity: 1 }
                   Get l1 // { arity: 1 }
                 Get l0 // { arity: 1 }
-  With
-    cte l1 =
-      Project (#0) // { arity: 1 }
-        Join on=(#0 = #1) type=differential // { arity: 2 }
-          implementation
-            %0:l0[#0]UKA » %1[#0]UKA
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Get l0 // { arity: 1 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Distinct project=[#0] // { arity: 1 }
-              ReadStorage materialize.public.x // { arity: 1 }
-    cte l0 =
-      Distinct project=[#0] // { arity: 1 }
-        ReadStorage materialize.public.y // { arity: 1 }
 
 Source materialize.public.x
 Source materialize.public.y
@@ -516,6 +516,20 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT b != ALL(SELECT a FROM x) FROM y
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[#0] // { arity: 1 }
+        ReadStorage materialize.public.y // { arity: 1 }
+    cte l1 =
+      Project (#0) // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l0[#0]UKA » %1[#0]UKA
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Distinct project=[#0] // { arity: 1 }
+              ReadStorage materialize.public.x // { arity: 1 }
   Return // { arity: 1 }
     Project (#3) // { arity: 1 }
       Map (NOT(#2)) // { arity: 4 }
@@ -533,20 +547,6 @@ Explained Query:
                   Negate // { arity: 1 }
                     Get l1 // { arity: 1 }
                   Get l0 // { arity: 1 }
-  With
-    cte l1 =
-      Project (#0) // { arity: 1 }
-        Join on=(#0 = #1) type=differential // { arity: 2 }
-          implementation
-            %0:l0[#0]UKA » %1[#0]UKA
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Get l0 // { arity: 1 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Distinct project=[#0] // { arity: 1 }
-              ReadStorage materialize.public.x // { arity: 1 }
-    cte l0 =
-      Distinct project=[#0] // { arity: 1 }
-        ReadStorage materialize.public.y // { arity: 1 }
 
 Source materialize.public.x
 Source materialize.public.y
@@ -560,6 +560,21 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT b > ALL(SELECT a FROM x) FROM y
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[#0] // { arity: 1 }
+        ReadStorage materialize.public.y // { arity: 1 }
+    cte l1 =
+      Distinct project=[#0] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#0 <= #1) // { arity: 2 }
+            CrossJoin type=differential // { arity: 2 }
+              implementation
+                %0:l0[×] » %1:x[×]
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Get l0 // { arity: 1 }
+              ArrangeBy keys=[[]] // { arity: 1 }
+                ReadStorage materialize.public.x // { arity: 1 }
   Return // { arity: 1 }
     Project (#3) // { arity: 1 }
       Map (NOT(#2)) // { arity: 4 }
@@ -577,21 +592,6 @@ Explained Query:
                   Negate // { arity: 1 }
                     Get l1 // { arity: 1 }
                   Get l0 // { arity: 1 }
-  With
-    cte l1 =
-      Distinct project=[#0] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Filter (#0 <= #1) // { arity: 2 }
-            CrossJoin type=differential // { arity: 2 }
-              implementation
-                %0:l0[×] » %1:x[×]
-              ArrangeBy keys=[[]] // { arity: 1 }
-                Get l0 // { arity: 1 }
-              ArrangeBy keys=[[]] // { arity: 1 }
-                ReadStorage materialize.public.x // { arity: 1 }
-    cte l0 =
-      Distinct project=[#0] // { arity: 1 }
-        ReadStorage materialize.public.y // { arity: 1 }
 
 Source materialize.public.x
 Source materialize.public.y

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -445,6 +445,17 @@ ON st.id = s.id
 WHERE s.id LIKE 'u%';
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]]
+        ReadIndex on=mz_sources mz_sources_ind=[differential join]
+    cte l1 =
+      Project (#0, #1, #3, #4, #6, #19, #20)
+        Filter like["u%"](#0)
+          Join on=(#0 = #15) type=differential
+            Get l0
+            ArrangeBy keys=[[#0]]
+              ReadIndex on=mz_source_statuses mz_source_statuses_ind=[differential join]
   Return
     Union
       Map (null, null)
@@ -462,17 +473,6 @@ Explained Query:
             Filter like["u%"](#0)
               ReadIndex on=mz_sources mz_sources_ind=[*** full scan ***]
       Get l1
-  With
-    cte l1 =
-      Project (#0, #1, #3, #4, #6, #19, #20)
-        Filter like["u%"](#0)
-          Join on=(#0 = #15) type=differential
-            Get l0
-            ArrangeBy keys=[[#0]]
-              ReadIndex on=mz_source_statuses mz_source_statuses_ind=[differential join]
-    cte l0 =
-      ArrangeBy keys=[[#0]]
-        ReadIndex on=mz_sources mz_sources_ind=[differential join]
 
 Used Indexes:
   - mz_catalog.mz_sources_ind (*** full scan ***, differential join)
@@ -494,6 +494,11 @@ LIMIT 10;
 ----
 Explained Query:
   Finish order_by=[#0 desc nulls_first] limit=10 output=[#0..=#2]
+    With
+      cte l0 =
+        Filter (#6 <= 100) AND (#6 >= 0) AND (#3) IS NOT NULL
+          Map (timestamp_tz_to_mz_timestamp(#0))
+            ReadIndex on=mz_internal.mz_source_status_history mz_source_status_history_ind=[lookup value=("u6")]
     Return
       Project (#1, #0, #3)
         Join on=(#0 = #2) type=differential
@@ -505,11 +510,6 @@ Explained Query:
             Reduce group_by=[#0] aggregates=[count(*)]
               Project (#3)
                 Get l0
-    With
-      cte l0 =
-        Filter (#6 <= 100) AND (#6 >= 0) AND (#3) IS NOT NULL
-          Map (timestamp_tz_to_mz_timestamp(#0))
-            ReadIndex on=mz_internal.mz_source_status_history mz_source_status_history_ind=[lookup value=("u6")]
 
 Used Indexes:
   - mz_internal.mz_source_status_history_ind (lookup)

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -263,6 +263,11 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM x x1, x x2, generate_series(x1.a, x2.a) WHERE x1.b = x2.b
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#1]] // { arity: 2 }
+        Filter (#1) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.x // { arity: 2 }
   Return // { arity: 5 }
     Project (#0..=#2, #1, #3) // { arity: 5 }
       FlatMap generate_series(#0, #2, 1) // { arity: 4 }
@@ -272,11 +277,6 @@ Explained Query:
               %0:l0[#1]K » %1:l0[#1]K
             Get l0 // { arity: 2 }
             Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[#1]] // { arity: 2 }
-        Filter (#1) IS NOT NULL // { arity: 2 }
-          ReadStorage materialize.public.x // { arity: 2 }
 
 Source materialize.public.x
   filter=((#1) IS NOT NULL)
@@ -289,6 +289,11 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM x x1, x x2, generate_series(x1.a, x2.a) WHERE x1.b = x2.b
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#1]] // { arity: 2 }
+        Filter (#1) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.x // { arity: 2 }
   Return // { arity: 5 }
     Project (#0..=#2, #1, #3) // { arity: 5 }
       FlatMap generate_series(#0, #2, 1) // { arity: 4 }
@@ -298,11 +303,6 @@ Explained Query:
               %0:l0[#1]K » %1:l0[#1]K
             Get l0 // { arity: 2 }
             Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[#1]] // { arity: 2 }
-        Filter (#1) IS NOT NULL // { arity: 2 }
-          ReadStorage materialize.public.x // { arity: 2 }
 
 Source materialize.public.x
   filter=((#1) IS NOT NULL)
@@ -317,6 +317,11 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM x x1, x x2, generate_series(x1.a, x2.b) AS x3(b) WHERE x1.b = x2.b AND x1.a = x3.b
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#1]] // { arity: 2 }
+        Filter (#1) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.x // { arity: 2 }
   Return // { arity: 5 }
     Project (#0..=#2, #1, #3) // { arity: 5 }
       Filter (#0 = #3) // { arity: 4 }
@@ -327,11 +332,6 @@ Explained Query:
                 %0:l0[#1]K » %1:l0[#1]K
               Get l0 // { arity: 2 }
               Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[#1]] // { arity: 2 }
-        Filter (#1) IS NOT NULL // { arity: 2 }
-          ReadStorage materialize.public.x // { arity: 2 }
 
 Source materialize.public.x
   filter=((#1) IS NOT NULL)

--- a/test/sqllogictest/timedomain.slt
+++ b/test/sqllogictest/timedomain.slt
@@ -211,6 +211,20 @@ query T multiline
 EXPLAIN SHOW VIEWS
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0..=#2, #4)
+        Join on=(#0 = #3) type=differential
+          ArrangeBy keys=[[#0]]
+            Project (#0, #2, #3)
+              ReadStorage mz_catalog.mz_views
+          ArrangeBy keys=[[#0]]
+            Project (#0, #3)
+              Filter (#2) IS NULL AND (#1 = "view")
+                ReadStorage mz_internal.mz_comments
+    cte l1 =
+      Filter (#2 = "u3")
+        ReadStorage mz_catalog.mz_views
   Return
     Project (#0, #2)
       Map (coalesce(#1, ""))
@@ -232,20 +246,6 @@ Explained Query:
           Project (#2, #3)
             Filter (#1 = "u3")
               Get l0
-  With
-    cte l1 =
-      Filter (#2 = "u3")
-        ReadStorage mz_catalog.mz_views
-    cte l0 =
-      Project (#0..=#2, #4)
-        Join on=(#0 = #3) type=differential
-          ArrangeBy keys=[[#0]]
-            Project (#0, #2, #3)
-              ReadStorage mz_catalog.mz_views
-          ArrangeBy keys=[[#0]]
-            Project (#0, #3)
-              Filter (#2) IS NULL AND (#1 = "view")
-                ReadStorage mz_internal.mz_comments
 
 Source mz_catalog.mz_views
 Source mz_internal.mz_comments

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -102,6 +102,11 @@ EXPLAIN WITH(arity, join implementations) SELECT state, name FROM
     LEFT JOIN LATERAL (SELECT name, pop FROM cities  where cities.state = grp.state ORDER BY pop DESC LIMIT 3) ON true
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0, #1) // { arity: 2 }
+        TopK group_by=[#1] order_by=[#2 desc nulls_first] limit=3 // { arity: 3 }
+          ReadStorage materialize.public.cities // { arity: 3 }
   Return // { arity: 2 }
     Union // { arity: 2 }
       Project (#1, #0) // { arity: 2 }
@@ -115,11 +120,6 @@ Explained Query:
           Distinct project=[#0] // { arity: 1 }
             Project (#1) // { arity: 1 }
               ReadStorage materialize.public.cities // { arity: 3 }
-  With
-    cte l0 =
-      Project (#0, #1) // { arity: 2 }
-        TopK group_by=[#1] order_by=[#2 desc nulls_first] limit=3 // { arity: 3 }
-          ReadStorage materialize.public.cities // { arity: 3 }
 
 Source materialize.public.cities
 

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -267,6 +267,35 @@ materialize.public.q02_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q02 // { arity: 8 }
 
 materialize.public.q02:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
+        ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+    cte l1 =
+      ArrangeBy keys=[[#0{ps_partkey}], [#1{ps_suppkey}]] // { arity: 5 }
+        ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
+    cte l2 =
+      ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
+        ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
+    cte l3 =
+      ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
+        ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
+    cte l4 =
+      Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
+        Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
+          Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
+            implementation
+              %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+              %1:l0 » %2:l1[#1]KA » %0:part[#0]KAelf » %3:l2[#0]KA » %4:l3[#0]KAef
+              %2:l1 » %0:part[#0]KAelf » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+              %3:l2 » %4:l3[#0]KAef » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
+              %4:l3 » %3:l2[#2]KA » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
+              ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
+            Get l0 // { arity: 7 }
+            Get l1 // { arity: 5 }
+            Get l2 // { arity: 4 }
+            Get l3 // { arity: 3 }
   Return // { arity: 8 }
     Project (#5{s_address}, #2{n_name}, #8, #0{s_acctbal}, #1{s_name}, #3{p_partkey}, #4{p_mfgr}, #6{s_phone}) // { arity: 8 }
       Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10{min_ps_supplycost}) type=differential // { arity: 11 }
@@ -293,35 +322,6 @@ materialize.public.q02:
                   Get l0 // { arity: 7 }
                   Get l2 // { arity: 4 }
                   Get l3 // { arity: 3 }
-  With
-    cte l4 =
-      Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
-        Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
-          Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
-            implementation
-              %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-              %1:l0 » %2:l1[#1]KA » %0:part[#0]KAelf » %3:l2[#0]KA » %4:l3[#0]KAef
-              %2:l1 » %0:part[#0]KAelf » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-              %3:l2 » %4:l3[#0]KAef » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-              %4:l3 » %3:l2[#2]KA » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-              ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
-            Get l0 // { arity: 7 }
-            Get l1 // { arity: 5 }
-            Get l2 // { arity: 4 }
-            Get l3 // { arity: 3 }
-    cte l3 =
-      ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
-        ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
-    cte l2 =
-      ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
-        ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
-    cte l1 =
-      ArrangeBy keys=[[#0{ps_partkey}], [#1{ps_suppkey}]] // { arity: 5 }
-        ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
-    cte l0 =
-      ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-        ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
 
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
@@ -567,6 +567,12 @@ materialize.public.q06_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q06 // { arity: 1 }
 
 materialize.public.q06:
+  With
+    cte l0 =
+      Reduce aggregates=[sum((#0{l_extendedprice} * #1{l_discount}))] // { arity: 1 }
+        Project (#5, #6) // { arity: 2 }
+          Filter (#4{l_quantity} < 24) AND (#6{l_discount} <= 0.07) AND (#6{l_discount} >= 0.05) AND (#10{l_shipdate} >= 1994-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-01-01 00:00:00) // { arity: 16 }
+            ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       Get l0 // { arity: 1 }
@@ -577,12 +583,6 @@ materialize.public.q06:
               Get l0 // { arity: 1 }
           Constant // { arity: 0 }
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum((#0{l_extendedprice} * #1{l_discount}))] // { arity: 1 }
-        Project (#5, #6) // { arity: 2 }
-          Filter (#4{l_quantity} < 24) AND (#6{l_discount} <= 0.07) AND (#6{l_discount} >= 0.05) AND (#10{l_shipdate} >= 1994-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-01-01 00:00:00) // { arity: 16 }
-            ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
   - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
@@ -646,6 +646,10 @@ materialize.public.q07_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q07 // { arity: 4 }
 
 materialize.public.q07:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
+        ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
   Return // { arity: 4 }
     Reduce group_by=[#3{n_name}, #4{n_name}, extract_year_d(#2{l_shipdate})] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 4 }
       Project (#12, #13, #17, #41, #45) // { arity: 5 }
@@ -669,10 +673,6 @@ materialize.public.q07:
                 ReadIndex on=customer pk_customer_custkey=[delta join lookup] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
               Get l0 // { arity: 4 }
               Get l0 // { arity: 4 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
-        ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
@@ -1003,19 +1003,6 @@ materialize.public.q11_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q11 // { arity: 2 }
 
 materialize.public.q11:
-  Return // { arity: 2 }
-    Project (#0{ps_partkey}, #1{sum}) // { arity: 2 }
-      Filter (#1{sum} > (#2{sum} * 0.0001)) // { arity: 3 }
-        CrossJoin type=differential // { arity: 3 }
-          implementation
-            %1[×]UA » %0[×]
-          ArrangeBy keys=[[]] // { arity: 2 }
-            Reduce group_by=[#0{ps_partkey}] aggregates=[sum((#2{ps_supplycost} * integer_to_numeric(#1{ps_availqty})))] // { arity: 2 }
-              Get l0 // { arity: 3 }
-          ArrangeBy keys=[[]] // { arity: 1 }
-            Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
-              Project (#1{ps_supplycost}, #2) // { arity: 2 }
-                Get l0 // { arity: 3 }
   With
     cte l0 =
       Project (#0{ps_partkey}, #2{ps_supplycost}, #3) // { arity: 3 }
@@ -1031,6 +1018,19 @@ materialize.public.q11:
               ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
             ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
               ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
+  Return // { arity: 2 }
+    Project (#0{ps_partkey}, #1{sum}) // { arity: 2 }
+      Filter (#1{sum} > (#2{sum} * 0.0001)) // { arity: 3 }
+        CrossJoin type=differential // { arity: 3 }
+          implementation
+            %1[×]UA » %0[×]
+          ArrangeBy keys=[[]] // { arity: 2 }
+            Reduce group_by=[#0{ps_partkey}] aggregates=[sum((#2{ps_supplycost} * integer_to_numeric(#1{ps_availqty})))] // { arity: 2 }
+              Get l0 // { arity: 3 }
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
+              Project (#1{ps_supplycost}, #2) // { arity: 2 }
+                Get l0 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
@@ -1141,6 +1141,19 @@ materialize.public.q13_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q13 // { arity: 2 }
 
 materialize.public.q13:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
+        ReadIndex on=customer pk_customer_custkey=[differential join] // { arity: 8 }
+    cte l1 =
+      Project (#0{c_custkey}, #8) // { arity: 2 }
+        Filter NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
+          Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
+            implementation
+              %1:orders[#1]KAf » %0:l0[#0]KAf
+            Get l0 // { arity: 8 }
+            ArrangeBy keys=[[#1{o_custkey}]] // { arity: 9 }
+              ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
   Return // { arity: 2 }
     Reduce group_by=[#0{count_o_orderkey}] aggregates=[count(*)] // { arity: 2 }
       Project (#1) // { arity: 1 }
@@ -1161,19 +1174,6 @@ materialize.public.q13:
                 Project (#0{c_custkey}) // { arity: 1 }
                   ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
             Get l1 // { arity: 2 }
-  With
-    cte l1 =
-      Project (#0{c_custkey}, #8) // { arity: 2 }
-        Filter NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
-          Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
-            implementation
-              %1:orders[#1]KAf » %0:l0[#0]KAf
-            Get l0 // { arity: 8 }
-            ArrangeBy keys=[[#1{o_custkey}]] // { arity: 9 }
-              ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
-    cte l0 =
-      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
-        ReadIndex on=customer pk_customer_custkey=[differential join] // { arity: 8 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (*** full scan ***, differential join)
@@ -1212,18 +1212,6 @@ materialize.public.q14_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q14 // { arity: 1 }
 
 materialize.public.q14:
-  Return // { arity: 1 }
-    Project (#2) // { arity: 1 }
-      Map (((100 * #0{sum}) / #1{sum})) // { arity: 3 }
-        Union // { arity: 2 }
-          Get l0 // { arity: 2 }
-          Map (null, null) // { arity: 2 }
-            Union // { arity: 0 }
-              Negate // { arity: 0 }
-                Project () // { arity: 0 }
-                  Get l0 // { arity: 2 }
-              Constant // { arity: 0 }
-                - ()
   With
     cte l0 =
       Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(#2{p_type})) then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
@@ -1236,6 +1224,18 @@ materialize.public.q14:
                 ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
               ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                 ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+  Return // { arity: 1 }
+    Project (#2) // { arity: 1 }
+      Map (((100 * #0{sum}) / #1{sum})) // { arity: 3 }
+        Union // { arity: 2 }
+          Get l0 // { arity: 2 }
+          Map (null, null) // { arity: 2 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l0 // { arity: 2 }
+              Constant // { arity: 0 }
+                - ()
 
 Used Indexes:
   - materialize.public.pk_part_partkey (differential join)
@@ -1293,6 +1293,12 @@ materialize.public.q15_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q15 // { arity: 5 }
 
 materialize.public.q15:
+  With
+    cte l0 =
+      Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
+        Project (#2{l_discount}, #5, #6) // { arity: 3 }
+          Filter (#10{l_shipdate} >= 1996-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1996-04-01 00:00:00) // { arity: 16 }
+            ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
   Return // { arity: 5 }
     Project (#0{s_suppkey}..=#2{s_address}, #4{sum}, #8) // { arity: 5 }
       Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
@@ -1308,12 +1314,6 @@ materialize.public.q15:
           Reduce aggregates=[max(#0{sum})] // { arity: 1 }
             Project (#1) // { arity: 1 }
               Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
-        Project (#2{l_discount}, #5, #6) // { arity: 3 }
-          Filter (#10{l_shipdate} >= 1996-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1996-04-01 00:00:00) // { arity: 16 }
-            ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
   - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
@@ -1369,6 +1369,21 @@ materialize.public.q16_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q16 // { arity: 4 }
 
 materialize.public.q16:
+  With
+    cte l0 =
+      Project (#1{p_brand}, #8..=#10) // { arity: 4 }
+        Filter (#8{p_brand} != "Brand#45") AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
+          Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
+            implementation
+              %1:part[#0]KAef » %0:partsupp[#0]KAef
+            ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 5 }
+              ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
+              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+    cte l1 =
+      Distinct project=[#0{ps_suppkey}] // { arity: 1 }
+        Project (#0{ps_suppkey}) // { arity: 1 }
+          Get l0 // { arity: 4 }
   Return // { arity: 4 }
     Reduce group_by=[#1{p_brand}..=#3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
       Project (#0{ps_suppkey}..=#3{p_size}) // { arity: 4 }
@@ -1393,21 +1408,6 @@ materialize.public.q16:
                             Filter like["%Customer%Complaints%"](varchar_to_text(#6{s_comment})) // { arity: 7 }
                               ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
               Get l1 // { arity: 1 }
-  With
-    cte l1 =
-      Distinct project=[#0{ps_suppkey}] // { arity: 1 }
-        Project (#0{ps_suppkey}) // { arity: 1 }
-          Get l0 // { arity: 4 }
-    cte l0 =
-      Project (#1{p_brand}, #8..=#10) // { arity: 4 }
-        Filter (#8{p_brand} != "Brand#45") AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
-          Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
-            implementation
-              %1:part[#0]KAef » %0:partsupp[#0]KAef
-            ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 5 }
-              ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
 
 Used Indexes:
   - materialize.public.pk_part_partkey (differential join)
@@ -1451,19 +1451,19 @@ materialize.public.q17_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q17 // { arity: 1 }
 
 materialize.public.q17:
-  Return // { arity: 1 }
-    Project (#1) // { arity: 1 }
-      Map ((#0{sum_l_extendedprice} / 7)) // { arity: 2 }
-        Union // { arity: 1 }
-          Get l2 // { arity: 1 }
-          Map (null) // { arity: 1 }
-            Union // { arity: 0 }
-              Negate // { arity: 0 }
-                Project () // { arity: 0 }
-                  Get l2 // { arity: 1 }
-              Constant // { arity: 0 }
-                - ()
   With
+    cte l0 =
+      ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
+        ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
+    cte l1 =
+      Project (#1{l_quantity}, #4, #5) // { arity: 3 }
+        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") // { arity: 25 }
+          Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
+            implementation
+              %1:part[#0]KAef » %0:l0[#1]KAef
+            Get l0 // { arity: 16 }
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
+              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
     cte l2 =
       Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
         Project (#2) // { arity: 1 }
@@ -1484,18 +1484,18 @@ materialize.public.q17:
                           Project (#0{l_partkey}) // { arity: 1 }
                             Get l1 // { arity: 3 }
                       Get l0 // { arity: 16 }
-    cte l1 =
-      Project (#1{l_quantity}, #4, #5) // { arity: 3 }
-        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") // { arity: 25 }
-          Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
-            implementation
-              %1:part[#0]KAef » %0:l0[#1]KAef
-            Get l0 // { arity: 16 }
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
-    cte l0 =
-      ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
-        ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
+  Return // { arity: 1 }
+    Project (#1) // { arity: 1 }
+      Map ((#0{sum_l_extendedprice} / 7)) // { arity: 2 }
+        Union // { arity: 1 }
+          Get l2 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l2 // { arity: 1 }
+              Constant // { arity: 0 }
+                - ()
 
 Used Indexes:
   - materialize.public.pk_part_partkey (differential join)
@@ -1553,6 +1553,22 @@ materialize.public.q18_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q18 // { arity: 6 }
 
 materialize.public.q18:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
+        ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
+    cte l1 =
+      Project (#0{c_custkey}, #1{c_name}, #8, #11, #12, #21) // { arity: 6 }
+        Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
+          implementation
+            %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
+            %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
+            %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
+          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
+            ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
+          ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
+            ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
+          Get l0 // { arity: 16 }
   Return // { arity: 6 }
     Reduce group_by=[#1{c_name}, #0{c_custkey}, #2{o_orderkey}, #4{o_orderdate}, #3{o_totalprice}] aggregates=[sum(#5{l_quantity})] // { arity: 6 }
       Project (#0{c_custkey}..=#5{l_quantity}) // { arity: 6 }
@@ -1573,22 +1589,6 @@ materialize.public.q18:
                         Project (#2) // { arity: 1 }
                           Get l1 // { arity: 6 }
                     Get l0 // { arity: 16 }
-  With
-    cte l1 =
-      Project (#0{c_custkey}, #1{c_name}, #8, #11, #12, #21) // { arity: 6 }
-        Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
-          implementation
-            %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
-            %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
-            %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
-          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
-            ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-          ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
-            ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-          Get l0 // { arity: 16 }
-    cte l0 =
-      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
-        ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
@@ -1651,16 +1651,6 @@ materialize.public.q19_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q19 // { arity: 1 }
 
 materialize.public.q19:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l0 // { arity: 1 }
-      Map (null) // { arity: 1 }
-        Union // { arity: 0 }
-          Negate // { arity: 0 }
-            Project () // { arity: 0 }
-              Get l0 // { arity: 1 }
-          Constant // { arity: 0 }
-            - ()
   With
     cte l0 =
       Reduce aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 1 }
@@ -1674,6 +1664,16 @@ materialize.public.q19:
                   ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
                 ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l0 // { arity: 1 }
+          Constant // { arity: 0 }
+            - ()
 
 Used Indexes:
   - materialize.public.pk_part_partkey (differential join)
@@ -1736,6 +1736,36 @@ materialize.public.q20_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q20 // { arity: 2 }
 
 materialize.public.q20:
+  With
+    cte l0 =
+      Project (#0{s_suppkey}..=#2{s_address}) // { arity: 3 }
+        Filter (#8{n_name} = "CANADA") // { arity: 11 }
+          Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
+            implementation
+              %1:nation[#0]KAef » %0:supplier[#3]KAef
+            ArrangeBy keys=[[#3{s_nationkey}]] // { arity: 7 }
+              ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
+            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
+              ReadIndex on=nation pk_nation_nationkey=[differential join] // { arity: 4 }
+    cte l1 =
+      Project (#0{s_suppkey}..=#3{ps_availqty}) // { arity: 4 }
+        Join on=(#1{ps_partkey} = #4{p_partkey}) type=delta // { arity: 5 }
+          implementation
+            %0 » %1:partsupp[×] » %2[#0]UKA
+            %1:partsupp » %2[#0]UKA » %0[×]
+            %2 » %1:partsupp[#0]KA » %0[×]
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Distinct project=[#0{s_suppkey}] // { arity: 1 }
+              Project (#0{s_suppkey}) // { arity: 1 }
+                Get l0 // { arity: 3 }
+          ArrangeBy keys=[[], [#0{ps_partkey}]] // { arity: 3 }
+            Project (#0{ps_partkey}..=#2{ps_availqty}) // { arity: 3 }
+              ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
+          ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+            Distinct project=[#0{p_partkey}] // { arity: 1 }
+              Project (#0{p_partkey}) // { arity: 1 }
+                Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
+                  ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
   Return // { arity: 2 }
     Project (#1{s_address}, #2) // { arity: 2 }
       Join on=(#0{s_suppkey} = #3{s_suppkey}) type=differential // { arity: 4 }
@@ -1769,36 +1799,6 @@ materialize.public.q20:
                                       Get l1 // { arity: 4 }
                                 ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
                                   ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
-  With
-    cte l1 =
-      Project (#0{s_suppkey}..=#3{ps_availqty}) // { arity: 4 }
-        Join on=(#1{ps_partkey} = #4{p_partkey}) type=delta // { arity: 5 }
-          implementation
-            %0 » %1:partsupp[×] » %2[#0]UKA
-            %1:partsupp » %2[#0]UKA » %0[×]
-            %2 » %1:partsupp[#0]KA » %0[×]
-          ArrangeBy keys=[[]] // { arity: 1 }
-            Distinct project=[#0{s_suppkey}] // { arity: 1 }
-              Project (#0{s_suppkey}) // { arity: 1 }
-                Get l0 // { arity: 3 }
-          ArrangeBy keys=[[], [#0{ps_partkey}]] // { arity: 3 }
-            Project (#0{ps_partkey}..=#2{ps_availqty}) // { arity: 3 }
-              ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
-          ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
-            Distinct project=[#0{p_partkey}] // { arity: 1 }
-              Project (#0{p_partkey}) // { arity: 1 }
-                Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
-                  ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
-    cte l0 =
-      Project (#0{s_suppkey}..=#2{s_address}) // { arity: 3 }
-        Filter (#8{n_name} = "CANADA") // { arity: 11 }
-          Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
-            implementation
-              %1:nation[#0]KAef » %0:supplier[#3]KAef
-            ArrangeBy keys=[[#3{s_nationkey}]] // { arity: 7 }
-              ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
-            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
-              ReadIndex on=nation pk_nation_nationkey=[differential join] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.pk_nation_nationkey (differential join)
@@ -1866,6 +1866,50 @@ materialize.public.q21_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q21 // { arity: 2 }
 
 materialize.public.q21:
+  With
+    cte l0 =
+      Project (#0{s_suppkey}, #1{s_name}, #7) // { arity: 3 }
+        Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
+          Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
+            implementation
+              %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
+              %1:lineitem » %2:orders[#0]KAef » %0:supplier[#0]KA » %3:nation[#0]KAef
+              %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
+              %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
+            ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
+              ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+            ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
+              ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
+            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
+              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
+            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
+              ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
+    cte l1 =
+      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
+        ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
+    cte l2 =
+      Project (#0{s_suppkey}..=#2{l_orderkey}) // { arity: 3 }
+        Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
+          implementation
+            %1[#1, #0]UKK » %0:l0[#0, #2]KK
+          ArrangeBy keys=[[#0{s_suppkey}, #2{l_orderkey}]] // { arity: 3 }
+            Get l0 // { arity: 3 }
+          ArrangeBy keys=[[#1{s_suppkey}, #0{l_orderkey}]] // { arity: 2 }
+            Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
+              Project (#0{l_orderkey}, #1{s_suppkey}) // { arity: 2 }
+                Filter (#1{s_suppkey} != #4{l_suppkey}) // { arity: 18 }
+                  Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
+                    implementation
+                      %1:l1[#0]KA » %0[#0]K
+                    ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
+                      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
+                        Project (#0{s_suppkey}, #2) // { arity: 2 }
+                          Get l0 // { arity: 3 }
+                    Get l1 // { arity: 16 }
+    cte l3 =
+      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
+        Project (#0{s_suppkey}, #2) // { arity: 2 }
+          Get l2 // { arity: 3 }
   Return // { arity: 2 }
     Reduce group_by=[#0{s_name}] aggregates=[count(*)] // { arity: 2 }
       Project (#1) // { arity: 1 }
@@ -1887,50 +1931,6 @@ materialize.public.q21:
                           Get l3 // { arity: 2 }
                         Get l1 // { arity: 16 }
               Get l3 // { arity: 2 }
-  With
-    cte l3 =
-      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-        Project (#0{s_suppkey}, #2) // { arity: 2 }
-          Get l2 // { arity: 3 }
-    cte l2 =
-      Project (#0{s_suppkey}..=#2{l_orderkey}) // { arity: 3 }
-        Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
-          implementation
-            %1[#1, #0]UKK » %0:l0[#0, #2]KK
-          ArrangeBy keys=[[#0{s_suppkey}, #2{l_orderkey}]] // { arity: 3 }
-            Get l0 // { arity: 3 }
-          ArrangeBy keys=[[#1{s_suppkey}, #0{l_orderkey}]] // { arity: 2 }
-            Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
-              Project (#0{l_orderkey}, #1{s_suppkey}) // { arity: 2 }
-                Filter (#1{s_suppkey} != #4{l_suppkey}) // { arity: 18 }
-                  Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
-                    implementation
-                      %1:l1[#0]KA » %0[#0]K
-                    ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
-                      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-                        Project (#0{s_suppkey}, #2) // { arity: 2 }
-                          Get l0 // { arity: 3 }
-                    Get l1 // { arity: 16 }
-    cte l1 =
-      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
-        ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
-    cte l0 =
-      Project (#0{s_suppkey}, #1{s_name}, #7) // { arity: 3 }
-        Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
-          Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
-            implementation
-              %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-              %1:lineitem » %2:orders[#0]KAef » %0:supplier[#0]KA » %3:nation[#0]KAef
-              %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
-              %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-            ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-              ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
-            ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
-              ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
-              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
-            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
-              ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
@@ -2007,6 +2007,29 @@ materialize.public.q22_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q22 // { arity: 3 }
 
 materialize.public.q22:
+  With
+    cte l0 =
+      Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
+        ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
+    cte l1 =
+      Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
+        Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
+          CrossJoin type=differential // { arity: 5 }
+            implementation
+              %1[×]UA » %0:l0[×]ef
+            ArrangeBy keys=[[]] // { arity: 3 }
+              Project (#0{c_custkey}, #4, #5) // { arity: 3 }
+                Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
+                  Get l0 // { arity: 9 }
+            ArrangeBy keys=[[]] // { arity: 2 }
+              Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
+                Project (#5) // { arity: 1 }
+                  Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
+                    Get l0 // { arity: 9 }
+    cte l2 =
+      Distinct project=[#0{c_custkey}] // { arity: 1 }
+        Project (#0{c_custkey}) // { arity: 1 }
+          Get l1 // { arity: 3 }
   Return // { arity: 3 }
     Reduce group_by=[substr(char_to_text(#0{c_phone}), 1, 2)] aggregates=[count(*), sum(#1{c_acctbal})] // { arity: 3 }
       Project (#1{c_acctbal}, #2) // { arity: 2 }
@@ -2029,29 +2052,6 @@ materialize.public.q22:
                         Project (#1) // { arity: 1 }
                           ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
               Get l2 // { arity: 1 }
-  With
-    cte l2 =
-      Distinct project=[#0{c_custkey}] // { arity: 1 }
-        Project (#0{c_custkey}) // { arity: 1 }
-          Get l1 // { arity: 3 }
-    cte l1 =
-      Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
-        Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
-          CrossJoin type=differential // { arity: 5 }
-            implementation
-              %1[×]UA » %0:l0[×]ef
-            ArrangeBy keys=[[]] // { arity: 3 }
-              Project (#0{c_custkey}, #4, #5) // { arity: 3 }
-                Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                  Get l0 // { arity: 9 }
-            ArrangeBy keys=[[]] // { arity: 2 }
-              Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
-                Project (#5) // { arity: 1 }
-                  Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                    Get l0 // { arity: 9 }
-    cte l0 =
-      Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
-        ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (*** full scan ***)

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -246,6 +246,35 @@ ORDER BY
     s_acctbal DESC, n_name, s_name, p_partkey;
 ----
 materialize.public.q02:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
+        ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+    cte l1 =
+      ArrangeBy keys=[[#0{ps_partkey}], [#1{ps_suppkey}]] // { arity: 5 }
+        ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
+    cte l2 =
+      ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
+        ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
+    cte l3 =
+      ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
+        ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
+    cte l4 =
+      Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
+        Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
+          Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
+            implementation
+              %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+              %1:l0 » %2:l1[#1]KA » %0:part[#0]KAelf » %3:l2[#0]KA » %4:l3[#0]KAef
+              %2:l1 » %0:part[#0]KAelf » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+              %3:l2 » %4:l3[#0]KAef » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
+              %4:l3 » %3:l2[#2]KA » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
+              ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
+            Get l0 // { arity: 7 }
+            Get l1 // { arity: 5 }
+            Get l2 // { arity: 4 }
+            Get l3 // { arity: 3 }
   Return // { arity: 8 }
     Project (#5{s_address}, #2{n_name}, #8, #0{s_acctbal}, #1{s_name}, #3{p_partkey}, #4{p_mfgr}, #6{s_phone}) // { arity: 8 }
       Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10{min_ps_supplycost}) type=differential // { arity: 11 }
@@ -272,35 +301,6 @@ materialize.public.q02:
                   Get l0 // { arity: 7 }
                   Get l2 // { arity: 4 }
                   Get l3 // { arity: 3 }
-  With
-    cte l4 =
-      Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
-        Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
-          Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
-            implementation
-              %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-              %1:l0 » %2:l1[#1]KA » %0:part[#0]KAelf » %3:l2[#0]KA » %4:l3[#0]KAef
-              %2:l1 » %0:part[#0]KAelf » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-              %3:l2 » %4:l3[#0]KAef » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-              %4:l3 » %3:l2[#2]KA » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-              ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
-            Get l0 // { arity: 7 }
-            Get l1 // { arity: 5 }
-            Get l2 // { arity: 4 }
-            Get l3 // { arity: 3 }
-    cte l3 =
-      ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
-        ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
-    cte l2 =
-      ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
-        ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
-    cte l1 =
-      ArrangeBy keys=[[#0{ps_partkey}], [#1{ps_suppkey}]] // { arity: 5 }
-        ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
-    cte l0 =
-      ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-        ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
 
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
@@ -510,6 +510,12 @@ WHERE
     AND l_discount BETWEEN 0.06 - 0.01 AND 0.07;
 ----
 materialize.public.q06:
+  With
+    cte l0 =
+      Reduce aggregates=[sum((#0{l_extendedprice} * #1{l_discount}))] // { arity: 1 }
+        Project (#5, #6) // { arity: 2 }
+          Filter (#4{l_quantity} < 24) AND (#6{l_discount} <= 0.07) AND (#6{l_discount} >= 0.05) AND (#10{l_shipdate} >= 1994-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-01-01 00:00:00) // { arity: 16 }
+            ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       Get l0 // { arity: 1 }
@@ -520,12 +526,6 @@ materialize.public.q06:
               Get l0 // { arity: 1 }
           Constant // { arity: 0 }
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum((#0{l_extendedprice} * #1{l_discount}))] // { arity: 1 }
-        Project (#5, #6) // { arity: 2 }
-          Filter (#4{l_quantity} < 24) AND (#6{l_discount} <= 0.07) AND (#6{l_discount} >= 0.05) AND (#10{l_shipdate} >= 1994-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-01-01 00:00:00) // { arity: 16 }
-            ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
   - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
@@ -580,6 +580,10 @@ ORDER BY
     l_year;
 ----
 materialize.public.q07:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
+        ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
   Return // { arity: 4 }
     Reduce group_by=[#3{n_name}, #4{n_name}, extract_year_d(#2{l_shipdate})] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 4 }
       Project (#12, #13, #17, #41, #45) // { arity: 5 }
@@ -603,10 +607,6 @@ materialize.public.q07:
                 ReadIndex on=customer pk_customer_custkey=[delta join lookup] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
               Get l0 // { arity: 4 }
               Get l0 // { arity: 4 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
-        ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
@@ -901,19 +901,6 @@ ORDER BY
     value DESC;
 ----
 materialize.public.q11:
-  Return // { arity: 2 }
-    Project (#0{ps_partkey}, #1{sum}) // { arity: 2 }
-      Filter (#1{sum} > (#2{sum} * 0.0001)) // { arity: 3 }
-        CrossJoin type=differential // { arity: 3 }
-          implementation
-            %1[×]UA » %0[×]
-          ArrangeBy keys=[[]] // { arity: 2 }
-            Reduce group_by=[#0{ps_partkey}] aggregates=[sum((#2{ps_supplycost} * integer_to_numeric(#1{ps_availqty})))] // { arity: 2 }
-              Get l0 // { arity: 3 }
-          ArrangeBy keys=[[]] // { arity: 1 }
-            Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
-              Project (#1{ps_supplycost}, #2) // { arity: 2 }
-                Get l0 // { arity: 3 }
   With
     cte l0 =
       Project (#0{ps_partkey}, #2{ps_supplycost}, #3) // { arity: 3 }
@@ -929,6 +916,19 @@ materialize.public.q11:
               ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
             ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
               ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
+  Return // { arity: 2 }
+    Project (#0{ps_partkey}, #1{sum}) // { arity: 2 }
+      Filter (#1{sum} > (#2{sum} * 0.0001)) // { arity: 3 }
+        CrossJoin type=differential // { arity: 3 }
+          implementation
+            %1[×]UA » %0[×]
+          ArrangeBy keys=[[]] // { arity: 2 }
+            Reduce group_by=[#0{ps_partkey}] aggregates=[sum((#2{ps_supplycost} * integer_to_numeric(#1{ps_availqty})))] // { arity: 2 }
+              Get l0 // { arity: 3 }
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
+              Project (#1{ps_supplycost}, #2) // { arity: 2 }
+                Get l0 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
@@ -1021,6 +1021,19 @@ ORDER BY
     c_count DESC;
 ----
 materialize.public.q13:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
+        ReadIndex on=customer pk_customer_custkey=[differential join] // { arity: 8 }
+    cte l1 =
+      Project (#0{c_custkey}, #8) // { arity: 2 }
+        Filter NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
+          Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
+            implementation
+              %1:orders[#1]KAf » %0:l0[#0]KAf
+            Get l0 // { arity: 8 }
+            ArrangeBy keys=[[#1{o_custkey}]] // { arity: 9 }
+              ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
   Return // { arity: 2 }
     Reduce group_by=[#0{count_o_orderkey}] aggregates=[count(*)] // { arity: 2 }
       Project (#1) // { arity: 1 }
@@ -1041,19 +1054,6 @@ materialize.public.q13:
                 Project (#0{c_custkey}) // { arity: 1 }
                   ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
             Get l1 // { arity: 2 }
-  With
-    cte l1 =
-      Project (#0{c_custkey}, #8) // { arity: 2 }
-        Filter NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
-          Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
-            implementation
-              %1:orders[#1]KAf » %0:l0[#0]KAf
-            Get l0 // { arity: 8 }
-            ArrangeBy keys=[[#1{o_custkey}]] // { arity: 9 }
-              ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
-    cte l0 =
-      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
-        ReadIndex on=customer pk_customer_custkey=[differential join] // { arity: 8 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (*** full scan ***, differential join)
@@ -1083,18 +1083,6 @@ WHERE
     AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' month;
 ----
 materialize.public.q14:
-  Return // { arity: 1 }
-    Project (#2) // { arity: 1 }
-      Map (((100 * #0{sum}) / #1{sum})) // { arity: 3 }
-        Union // { arity: 2 }
-          Get l0 // { arity: 2 }
-          Map (null, null) // { arity: 2 }
-            Union // { arity: 0 }
-              Negate // { arity: 0 }
-                Project () // { arity: 0 }
-                  Get l0 // { arity: 2 }
-              Constant // { arity: 0 }
-                - ()
   With
     cte l0 =
       Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(#2{p_type})) then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
@@ -1107,6 +1095,18 @@ materialize.public.q14:
                 ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
               ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                 ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+  Return // { arity: 1 }
+    Project (#2) // { arity: 1 }
+      Map (((100 * #0{sum}) / #1{sum})) // { arity: 3 }
+        Union // { arity: 2 }
+          Get l0 // { arity: 2 }
+          Map (null, null) // { arity: 2 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l0 // { arity: 2 }
+              Constant // { arity: 0 }
+                - ()
 
 Used Indexes:
   - materialize.public.pk_part_partkey (differential join)
@@ -1155,6 +1155,12 @@ ORDER BY
     s_suppkey;
 ----
 materialize.public.q15:
+  With
+    cte l0 =
+      Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
+        Project (#2{l_discount}, #5, #6) // { arity: 3 }
+          Filter (#10{l_shipdate} >= 1996-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1996-04-01 00:00:00) // { arity: 16 }
+            ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
   Return // { arity: 5 }
     Project (#0{s_suppkey}..=#2{s_address}, #4{sum}, #8) // { arity: 5 }
       Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
@@ -1170,12 +1176,6 @@ materialize.public.q15:
           Reduce aggregates=[max(#0{sum})] // { arity: 1 }
             Project (#1) // { arity: 1 }
               Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
-        Project (#2{l_discount}, #5, #6) // { arity: 3 }
-          Filter (#10{l_shipdate} >= 1996-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1996-04-01 00:00:00) // { arity: 16 }
-            ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
   - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
@@ -1225,6 +1225,21 @@ ORDER BY
     p_size;
 ----
 materialize.public.q16:
+  With
+    cte l0 =
+      Project (#1{p_brand}, #8..=#10) // { arity: 4 }
+        Filter (#8{p_brand} != "Brand#45") AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
+          Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
+            implementation
+              %1:part[#0]KAef » %0:partsupp[#0]KAef
+            ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 5 }
+              ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
+              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+    cte l1 =
+      Distinct project=[#0{ps_suppkey}] // { arity: 1 }
+        Project (#0{ps_suppkey}) // { arity: 1 }
+          Get l0 // { arity: 4 }
   Return // { arity: 4 }
     Reduce group_by=[#1{p_brand}..=#3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
       Project (#0{ps_suppkey}..=#3{p_size}) // { arity: 4 }
@@ -1249,21 +1264,6 @@ materialize.public.q16:
                             Filter like["%Customer%Complaints%"](varchar_to_text(#6{s_comment})) // { arity: 7 }
                               ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
               Get l1 // { arity: 1 }
-  With
-    cte l1 =
-      Distinct project=[#0{ps_suppkey}] // { arity: 1 }
-        Project (#0{ps_suppkey}) // { arity: 1 }
-          Get l0 // { arity: 4 }
-    cte l0 =
-      Project (#1{p_brand}, #8..=#10) // { arity: 4 }
-        Filter (#8{p_brand} != "Brand#45") AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
-          Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
-            implementation
-              %1:part[#0]KAef » %0:partsupp[#0]KAef
-            ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 5 }
-              ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
 
 Used Indexes:
   - materialize.public.pk_part_partkey (differential join)
@@ -1298,19 +1298,19 @@ WHERE
   );
 ----
 materialize.public.q17:
-  Return // { arity: 1 }
-    Project (#1) // { arity: 1 }
-      Map ((#0{sum_l_extendedprice} / 7)) // { arity: 2 }
-        Union // { arity: 1 }
-          Get l2 // { arity: 1 }
-          Map (null) // { arity: 1 }
-            Union // { arity: 0 }
-              Negate // { arity: 0 }
-                Project () // { arity: 0 }
-                  Get l2 // { arity: 1 }
-              Constant // { arity: 0 }
-                - ()
   With
+    cte l0 =
+      ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
+        ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
+    cte l1 =
+      Project (#1{l_quantity}, #4, #5) // { arity: 3 }
+        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") // { arity: 25 }
+          Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
+            implementation
+              %1:part[#0]KAef » %0:l0[#1]KAef
+            Get l0 // { arity: 16 }
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
+              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
     cte l2 =
       Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
         Project (#2) // { arity: 1 }
@@ -1331,18 +1331,18 @@ materialize.public.q17:
                           Project (#0{l_partkey}) // { arity: 1 }
                             Get l1 // { arity: 3 }
                       Get l0 // { arity: 16 }
-    cte l1 =
-      Project (#1{l_quantity}, #4, #5) // { arity: 3 }
-        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") // { arity: 25 }
-          Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
-            implementation
-              %1:part[#0]KAef » %0:l0[#1]KAef
-            Get l0 // { arity: 16 }
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
-    cte l0 =
-      ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
-        ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
+  Return // { arity: 1 }
+    Project (#1) // { arity: 1 }
+      Map ((#0{sum_l_extendedprice} / 7)) // { arity: 2 }
+        Union // { arity: 1 }
+          Get l2 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l2 // { arity: 1 }
+              Constant // { arity: 0 }
+                - ()
 
 Used Indexes:
   - materialize.public.pk_part_partkey (differential join)
@@ -1391,6 +1391,22 @@ ORDER BY
     o_orderdate;
 ----
 materialize.public.q18:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
+        ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
+    cte l1 =
+      Project (#0{c_custkey}, #1{c_name}, #8, #11, #12, #21) // { arity: 6 }
+        Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
+          implementation
+            %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
+            %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
+            %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
+          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
+            ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
+          ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
+            ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
+          Get l0 // { arity: 16 }
   Return // { arity: 6 }
     Reduce group_by=[#1{c_name}, #0{c_custkey}, #2{o_orderkey}, #4{o_orderdate}, #3{o_totalprice}] aggregates=[sum(#5{l_quantity})] // { arity: 6 }
       Project (#0{c_custkey}..=#5{l_quantity}) // { arity: 6 }
@@ -1411,22 +1427,6 @@ materialize.public.q18:
                         Project (#2) // { arity: 1 }
                           Get l1 // { arity: 6 }
                     Get l0 // { arity: 16 }
-  With
-    cte l1 =
-      Project (#0{c_custkey}, #1{c_name}, #8, #11, #12, #21) // { arity: 6 }
-        Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
-          implementation
-            %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
-            %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
-            %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
-          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
-            ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-          ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
-            ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-          Get l0 // { arity: 16 }
-    cte l0 =
-      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
-        ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
@@ -1480,16 +1480,6 @@ WHERE
     );
 ----
 materialize.public.q19:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l0 // { arity: 1 }
-      Map (null) // { arity: 1 }
-        Union // { arity: 0 }
-          Negate // { arity: 0 }
-            Project () // { arity: 0 }
-              Get l0 // { arity: 1 }
-          Constant // { arity: 0 }
-            - ()
   With
     cte l0 =
       Reduce aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 1 }
@@ -1503,6 +1493,16 @@ materialize.public.q19:
                   ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
                 ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l0 // { arity: 1 }
+          Constant // { arity: 0 }
+            - ()
 
 Used Indexes:
   - materialize.public.pk_part_partkey (differential join)
@@ -1556,6 +1556,36 @@ ORDER BY
     s_name;
 ----
 materialize.public.q20:
+  With
+    cte l0 =
+      Project (#0{s_suppkey}..=#2{s_address}) // { arity: 3 }
+        Filter (#8{n_name} = "CANADA") // { arity: 11 }
+          Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
+            implementation
+              %1:nation[#0]KAef » %0:supplier[#3]KAef
+            ArrangeBy keys=[[#3{s_nationkey}]] // { arity: 7 }
+              ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
+            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
+              ReadIndex on=nation pk_nation_nationkey=[differential join] // { arity: 4 }
+    cte l1 =
+      Project (#0{s_suppkey}..=#3{ps_availqty}) // { arity: 4 }
+        Join on=(#1{ps_partkey} = #4{p_partkey}) type=delta // { arity: 5 }
+          implementation
+            %0 » %1:partsupp[×] » %2[#0]UKA
+            %1:partsupp » %2[#0]UKA » %0[×]
+            %2 » %1:partsupp[#0]KA » %0[×]
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Distinct project=[#0{s_suppkey}] // { arity: 1 }
+              Project (#0{s_suppkey}) // { arity: 1 }
+                Get l0 // { arity: 3 }
+          ArrangeBy keys=[[], [#0{ps_partkey}]] // { arity: 3 }
+            Project (#0{ps_partkey}..=#2{ps_availqty}) // { arity: 3 }
+              ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
+          ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+            Distinct project=[#0{p_partkey}] // { arity: 1 }
+              Project (#0{p_partkey}) // { arity: 1 }
+                Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
+                  ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
   Return // { arity: 2 }
     Project (#1{s_address}, #2) // { arity: 2 }
       Join on=(#0{s_suppkey} = #3{s_suppkey}) type=differential // { arity: 4 }
@@ -1589,36 +1619,6 @@ materialize.public.q20:
                                       Get l1 // { arity: 4 }
                                 ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
                                   ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
-  With
-    cte l1 =
-      Project (#0{s_suppkey}..=#3{ps_availqty}) // { arity: 4 }
-        Join on=(#1{ps_partkey} = #4{p_partkey}) type=delta // { arity: 5 }
-          implementation
-            %0 » %1:partsupp[×] » %2[#0]UKA
-            %1:partsupp » %2[#0]UKA » %0[×]
-            %2 » %1:partsupp[#0]KA » %0[×]
-          ArrangeBy keys=[[]] // { arity: 1 }
-            Distinct project=[#0{s_suppkey}] // { arity: 1 }
-              Project (#0{s_suppkey}) // { arity: 1 }
-                Get l0 // { arity: 3 }
-          ArrangeBy keys=[[], [#0{ps_partkey}]] // { arity: 3 }
-            Project (#0{ps_partkey}..=#2{ps_availqty}) // { arity: 3 }
-              ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
-          ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
-            Distinct project=[#0{p_partkey}] // { arity: 1 }
-              Project (#0{p_partkey}) // { arity: 1 }
-                Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
-                  ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
-    cte l0 =
-      Project (#0{s_suppkey}..=#2{s_address}) // { arity: 3 }
-        Filter (#8{n_name} = "CANADA") // { arity: 11 }
-          Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
-            implementation
-              %1:nation[#0]KAef » %0:supplier[#3]KAef
-            ArrangeBy keys=[[#3{s_nationkey}]] // { arity: 7 }
-              ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
-            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
-              ReadIndex on=nation pk_nation_nationkey=[differential join] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.pk_nation_nationkey (differential join)
@@ -1677,6 +1677,50 @@ ORDER BY
     s_name;
 ----
 materialize.public.q21:
+  With
+    cte l0 =
+      Project (#0{s_suppkey}, #1{s_name}, #7) // { arity: 3 }
+        Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
+          Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
+            implementation
+              %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
+              %1:lineitem » %2:orders[#0]KAef » %0:supplier[#0]KA » %3:nation[#0]KAef
+              %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
+              %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
+            ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
+              ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+            ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
+              ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
+            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
+              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
+            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
+              ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
+    cte l1 =
+      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
+        ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
+    cte l2 =
+      Project (#0{s_suppkey}..=#2{l_orderkey}) // { arity: 3 }
+        Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
+          implementation
+            %1[#1, #0]UKK » %0:l0[#0, #2]KK
+          ArrangeBy keys=[[#0{s_suppkey}, #2{l_orderkey}]] // { arity: 3 }
+            Get l0 // { arity: 3 }
+          ArrangeBy keys=[[#1{s_suppkey}, #0{l_orderkey}]] // { arity: 2 }
+            Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
+              Project (#0{l_orderkey}, #1{s_suppkey}) // { arity: 2 }
+                Filter (#1{s_suppkey} != #4{l_suppkey}) // { arity: 18 }
+                  Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
+                    implementation
+                      %1:l1[#0]KA » %0[#0]K
+                    ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
+                      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
+                        Project (#0{s_suppkey}, #2) // { arity: 2 }
+                          Get l0 // { arity: 3 }
+                    Get l1 // { arity: 16 }
+    cte l3 =
+      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
+        Project (#0{s_suppkey}, #2) // { arity: 2 }
+          Get l2 // { arity: 3 }
   Return // { arity: 2 }
     Reduce group_by=[#0{s_name}] aggregates=[count(*)] // { arity: 2 }
       Project (#1) // { arity: 1 }
@@ -1698,50 +1742,6 @@ materialize.public.q21:
                           Get l3 // { arity: 2 }
                         Get l1 // { arity: 16 }
               Get l3 // { arity: 2 }
-  With
-    cte l3 =
-      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-        Project (#0{s_suppkey}, #2) // { arity: 2 }
-          Get l2 // { arity: 3 }
-    cte l2 =
-      Project (#0{s_suppkey}..=#2{l_orderkey}) // { arity: 3 }
-        Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
-          implementation
-            %1[#1, #0]UKK » %0:l0[#0, #2]KK
-          ArrangeBy keys=[[#0{s_suppkey}, #2{l_orderkey}]] // { arity: 3 }
-            Get l0 // { arity: 3 }
-          ArrangeBy keys=[[#1{s_suppkey}, #0{l_orderkey}]] // { arity: 2 }
-            Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
-              Project (#0{l_orderkey}, #1{s_suppkey}) // { arity: 2 }
-                Filter (#1{s_suppkey} != #4{l_suppkey}) // { arity: 18 }
-                  Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
-                    implementation
-                      %1:l1[#0]KA » %0[#0]K
-                    ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
-                      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-                        Project (#0{s_suppkey}, #2) // { arity: 2 }
-                          Get l0 // { arity: 3 }
-                    Get l1 // { arity: 16 }
-    cte l1 =
-      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
-        ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
-    cte l0 =
-      Project (#0{s_suppkey}, #1{s_name}, #7) // { arity: 3 }
-        Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
-          Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
-            implementation
-              %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-              %1:lineitem » %2:orders[#0]KAef » %0:supplier[#0]KA » %3:nation[#0]KAef
-              %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
-              %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-            ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-              ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
-            ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
-              ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
-              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
-            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
-              ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
@@ -1809,6 +1809,29 @@ ORDER BY
     cntrycode;
 ----
 materialize.public.q22:
+  With
+    cte l0 =
+      Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
+        ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
+    cte l1 =
+      Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
+        Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
+          CrossJoin type=differential // { arity: 5 }
+            implementation
+              %1[×]UA » %0:l0[×]ef
+            ArrangeBy keys=[[]] // { arity: 3 }
+              Project (#0{c_custkey}, #4, #5) // { arity: 3 }
+                Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
+                  Get l0 // { arity: 9 }
+            ArrangeBy keys=[[]] // { arity: 2 }
+              Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
+                Project (#5) // { arity: 1 }
+                  Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
+                    Get l0 // { arity: 9 }
+    cte l2 =
+      Distinct project=[#0{c_custkey}] // { arity: 1 }
+        Project (#0{c_custkey}) // { arity: 1 }
+          Get l1 // { arity: 3 }
   Return // { arity: 3 }
     Reduce group_by=[substr(char_to_text(#0{c_phone}), 1, 2)] aggregates=[count(*), sum(#1{c_acctbal})] // { arity: 3 }
       Project (#1{c_acctbal}, #2) // { arity: 2 }
@@ -1831,29 +1854,6 @@ materialize.public.q22:
                         Project (#1) // { arity: 1 }
                           ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
               Get l2 // { arity: 1 }
-  With
-    cte l2 =
-      Distinct project=[#0{c_custkey}] // { arity: 1 }
-        Project (#0{c_custkey}) // { arity: 1 }
-          Get l1 // { arity: 3 }
-    cte l1 =
-      Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
-        Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
-          CrossJoin type=differential // { arity: 5 }
-            implementation
-              %1[×]UA » %0:l0[×]ef
-            ArrangeBy keys=[[]] // { arity: 3 }
-              Project (#0{c_custkey}, #4, #5) // { arity: 3 }
-                Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                  Get l0 // { arity: 9 }
-            ArrangeBy keys=[[]] // { arity: 2 }
-              Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
-                Project (#5) // { arity: 1 }
-                  Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                    Get l0 // { arity: 9 }
-    cte l0 =
-      Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
-        ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (*** full scan ***)

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -245,6 +245,35 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#0{s_acctbal} desc nulls_first, #2{n_name} asc nulls_last, #1{s_name} asc nulls_last, #3{p_partkey} asc nulls_last] output=[#0..=#7]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
+          ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+      cte l1 =
+        ArrangeBy keys=[[#0{ps_partkey}], [#1{ps_suppkey}]] // { arity: 5 }
+          ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
+      cte l2 =
+        ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
+          ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
+      cte l3 =
+        ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
+          ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
+      cte l4 =
+        Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
+          Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
+            Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
+              implementation
+                %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+                %1:l0 » %2:l1[#1]KA » %0:part[#0]KAelf » %3:l2[#0]KA » %4:l3[#0]KAef
+                %2:l1 » %0:part[#0]KAelf » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+                %3:l2 » %4:l3[#0]KAef » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
+                %4:l3 » %3:l2[#2]KA » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
+              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
+                ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
+              Get l0 // { arity: 7 }
+              Get l1 // { arity: 5 }
+              Get l2 // { arity: 4 }
+              Get l3 // { arity: 3 }
     Return // { arity: 8 }
       Project (#5{s_address}, #2{n_name}, #8, #0{s_acctbal}, #1{s_name}, #3{p_partkey}, #4{p_mfgr}, #6{s_phone}) // { arity: 8 }
         Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10{min_ps_supplycost}) type=differential // { arity: 11 }
@@ -271,35 +300,6 @@ Explained Query:
                     Get l0 // { arity: 7 }
                     Get l2 // { arity: 4 }
                     Get l3 // { arity: 3 }
-    With
-      cte l4 =
-        Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
-          Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
-            Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
-              implementation
-                %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-                %1:l0 » %2:l1[#1]KA » %0:part[#0]KAelf » %3:l2[#0]KA » %4:l3[#0]KAef
-                %2:l1 » %0:part[#0]KAelf » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-                %3:l2 » %4:l3[#0]KAef » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-                %4:l3 » %3:l2[#2]KA » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-                ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
-              Get l0 // { arity: 7 }
-              Get l1 // { arity: 5 }
-              Get l2 // { arity: 4 }
-              Get l3 // { arity: 3 }
-      cte l3 =
-        ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
-          ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
-      cte l2 =
-        ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
-          ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
-      cte l1 =
-        ArrangeBy keys=[[#0{ps_partkey}], [#1{ps_suppkey}]] // { arity: 5 }
-          ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
-      cte l0 =
-        ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-          ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
 
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
@@ -508,6 +508,12 @@ WHERE
     AND l_discount BETWEEN 0.06 - 0.01 AND 0.07;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[sum((#0{l_extendedprice} * #1{l_discount}))] // { arity: 1 }
+        Project (#5, #6) // { arity: 2 }
+          Filter (#4{l_quantity} < 24) AND (#6{l_discount} <= 0.07) AND (#6{l_discount} >= 0.05) AND (#10{l_shipdate} >= 1994-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-01-01 00:00:00) // { arity: 16 }
+            ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       Get l0 // { arity: 1 }
@@ -518,12 +524,6 @@ Explained Query:
               Get l0 // { arity: 1 }
           Constant // { arity: 0 }
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum((#0{l_extendedprice} * #1{l_discount}))] // { arity: 1 }
-        Project (#5, #6) // { arity: 2 }
-          Filter (#4{l_quantity} < 24) AND (#6{l_discount} <= 0.07) AND (#6{l_discount} >= 0.05) AND (#10{l_shipdate} >= 1994-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-01-01 00:00:00) // { arity: 16 }
-            ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
   - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
@@ -578,6 +578,10 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#0{n_name} asc nulls_last, #1{n_name} asc nulls_last, #2 asc nulls_last] output=[#0..=#3]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
+          ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
     Return // { arity: 4 }
       Reduce group_by=[#3{n_name}, #4{n_name}, extract_year_d(#2{l_shipdate})] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 4 }
         Project (#12, #13, #17, #41, #45) // { arity: 5 }
@@ -601,10 +605,6 @@ Explained Query:
                   ReadIndex on=customer pk_customer_custkey=[delta join lookup] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
                 Get l0 // { arity: 4 }
                 Get l0 // { arity: 4 }
-    With
-      cte l0 =
-        ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
-          ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
@@ -899,19 +899,6 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#1{sum} desc nulls_first] output=[#0, #1]
-    Return // { arity: 2 }
-      Project (#0{ps_partkey}, #1{sum}) // { arity: 2 }
-        Filter (#1{sum} > (#2{sum} * 0.0001)) // { arity: 3 }
-          CrossJoin type=differential // { arity: 3 }
-            implementation
-              %1[×]UA » %0[×]
-            ArrangeBy keys=[[]] // { arity: 2 }
-              Reduce group_by=[#0{ps_partkey}] aggregates=[sum((#2{ps_supplycost} * integer_to_numeric(#1{ps_availqty})))] // { arity: 2 }
-                Get l0 // { arity: 3 }
-            ArrangeBy keys=[[]] // { arity: 1 }
-              Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
-                Project (#1{ps_supplycost}, #2) // { arity: 2 }
-                  Get l0 // { arity: 3 }
     With
       cte l0 =
         Project (#0{ps_partkey}, #2{ps_supplycost}, #3) // { arity: 3 }
@@ -927,6 +914,19 @@ Explained Query:
                 ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
               ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
                 ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
+    Return // { arity: 2 }
+      Project (#0{ps_partkey}, #1{sum}) // { arity: 2 }
+        Filter (#1{sum} > (#2{sum} * 0.0001)) // { arity: 3 }
+          CrossJoin type=differential // { arity: 3 }
+            implementation
+              %1[×]UA » %0[×]
+            ArrangeBy keys=[[]] // { arity: 2 }
+              Reduce group_by=[#0{ps_partkey}] aggregates=[sum((#2{ps_supplycost} * integer_to_numeric(#1{ps_availqty})))] // { arity: 2 }
+                Get l0 // { arity: 3 }
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
+                Project (#1{ps_supplycost}, #2) // { arity: 2 }
+                  Get l0 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
@@ -1019,6 +1019,19 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#1{count} desc nulls_first, #0{count_o_orderkey} desc nulls_first] output=[#0, #1]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
+          ReadIndex on=customer pk_customer_custkey=[differential join] // { arity: 8 }
+      cte l1 =
+        Project (#0{c_custkey}, #8) // { arity: 2 }
+          Filter NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
+            Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
+              implementation
+                %1:orders[#1]KAf » %0:l0[#0]KAf
+              Get l0 // { arity: 8 }
+              ArrangeBy keys=[[#1{o_custkey}]] // { arity: 9 }
+                ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
     Return // { arity: 2 }
       Reduce group_by=[#0{count_o_orderkey}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
@@ -1039,19 +1052,6 @@ Explained Query:
                   Project (#0{c_custkey}) // { arity: 1 }
                     ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
               Get l1 // { arity: 2 }
-    With
-      cte l1 =
-        Project (#0{c_custkey}, #8) // { arity: 2 }
-          Filter NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
-            Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
-              implementation
-                %1:orders[#1]KAf » %0:l0[#0]KAf
-              Get l0 // { arity: 8 }
-              ArrangeBy keys=[[#1{o_custkey}]] // { arity: 9 }
-                ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
-      cte l0 =
-        ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
-          ReadIndex on=customer pk_customer_custkey=[differential join] // { arity: 8 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (*** full scan ***, differential join)
@@ -1080,18 +1080,6 @@ WHERE
     AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' month;
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Project (#2) // { arity: 1 }
-      Map (((100 * #0{sum}) / #1{sum})) // { arity: 3 }
-        Union // { arity: 2 }
-          Get l0 // { arity: 2 }
-          Map (null, null) // { arity: 2 }
-            Union // { arity: 0 }
-              Negate // { arity: 0 }
-                Project () // { arity: 0 }
-                  Get l0 // { arity: 2 }
-              Constant // { arity: 0 }
-                - ()
   With
     cte l0 =
       Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(#2{p_type})) then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
@@ -1104,6 +1092,18 @@ Explained Query:
                 ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
               ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                 ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+  Return // { arity: 1 }
+    Project (#2) // { arity: 1 }
+      Map (((100 * #0{sum}) / #1{sum})) // { arity: 3 }
+        Union // { arity: 2 }
+          Get l0 // { arity: 2 }
+          Map (null, null) // { arity: 2 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l0 // { arity: 2 }
+              Constant // { arity: 0 }
+                - ()
 
 Used Indexes:
   - materialize.public.pk_part_partkey (differential join)
@@ -1152,6 +1152,12 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#0{s_suppkey} asc nulls_last] output=[#0..=#4]
+    With
+      cte l0 =
+        Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
+          Project (#2{l_discount}, #5, #6) // { arity: 3 }
+            Filter (#10{l_shipdate} >= 1996-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1996-04-01 00:00:00) // { arity: 16 }
+              ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
     Return // { arity: 5 }
       Project (#0{s_suppkey}..=#2{s_address}, #4{sum}, #8) // { arity: 5 }
         Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
@@ -1167,12 +1173,6 @@ Explained Query:
             Reduce aggregates=[max(#0{sum})] // { arity: 1 }
               Project (#1) // { arity: 1 }
                 Get l0 // { arity: 2 }
-    With
-      cte l0 =
-        Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
-          Project (#2{l_discount}, #5, #6) // { arity: 3 }
-            Filter (#10{l_shipdate} >= 1996-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1996-04-01 00:00:00) // { arity: 16 }
-              ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
   - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
@@ -1222,6 +1222,21 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#3{count_ps_suppkey} desc nulls_first, #0{p_brand} asc nulls_last, #1{p_type} asc nulls_last, #2{p_size} asc nulls_last] output=[#0..=#3]
+    With
+      cte l0 =
+        Project (#1{p_brand}, #8..=#10) // { arity: 4 }
+          Filter (#8{p_brand} != "Brand#45") AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
+            Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
+              implementation
+                %1:part[#0]KAef » %0:partsupp[#0]KAef
+              ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 5 }
+                ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
+              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
+                ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+      cte l1 =
+        Distinct project=[#0{ps_suppkey}] // { arity: 1 }
+          Project (#0{ps_suppkey}) // { arity: 1 }
+            Get l0 // { arity: 4 }
     Return // { arity: 4 }
       Reduce group_by=[#1{p_brand}..=#3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
         Project (#0{ps_suppkey}..=#3{p_size}) // { arity: 4 }
@@ -1246,21 +1261,6 @@ Explained Query:
                               Filter like["%Customer%Complaints%"](varchar_to_text(#6{s_comment})) // { arity: 7 }
                                 ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
                 Get l1 // { arity: 1 }
-    With
-      cte l1 =
-        Distinct project=[#0{ps_suppkey}] // { arity: 1 }
-          Project (#0{ps_suppkey}) // { arity: 1 }
-            Get l0 // { arity: 4 }
-      cte l0 =
-        Project (#1{p_brand}, #8..=#10) // { arity: 4 }
-          Filter (#8{p_brand} != "Brand#45") AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
-            Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
-              implementation
-                %1:part[#0]KAef » %0:partsupp[#0]KAef
-              ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 5 }
-                ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
-              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-                ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
 
 Used Indexes:
   - materialize.public.pk_part_partkey (differential join)
@@ -1294,19 +1294,19 @@ WHERE
   );
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Project (#1) // { arity: 1 }
-      Map ((#0{sum_l_extendedprice} / 7)) // { arity: 2 }
-        Union // { arity: 1 }
-          Get l2 // { arity: 1 }
-          Map (null) // { arity: 1 }
-            Union // { arity: 0 }
-              Negate // { arity: 0 }
-                Project () // { arity: 0 }
-                  Get l2 // { arity: 1 }
-              Constant // { arity: 0 }
-                - ()
   With
+    cte l0 =
+      ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
+        ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
+    cte l1 =
+      Project (#1{l_quantity}, #4, #5) // { arity: 3 }
+        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") // { arity: 25 }
+          Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
+            implementation
+              %1:part[#0]KAef » %0:l0[#1]KAef
+            Get l0 // { arity: 16 }
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
+              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
     cte l2 =
       Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
         Project (#2) // { arity: 1 }
@@ -1327,18 +1327,18 @@ Explained Query:
                           Project (#0{l_partkey}) // { arity: 1 }
                             Get l1 // { arity: 3 }
                       Get l0 // { arity: 16 }
-    cte l1 =
-      Project (#1{l_quantity}, #4, #5) // { arity: 3 }
-        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") // { arity: 25 }
-          Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
-            implementation
-              %1:part[#0]KAef » %0:l0[#1]KAef
-            Get l0 // { arity: 16 }
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
-    cte l0 =
-      ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
-        ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
+  Return // { arity: 1 }
+    Project (#1) // { arity: 1 }
+      Map ((#0{sum_l_extendedprice} / 7)) // { arity: 2 }
+        Union // { arity: 1 }
+          Get l2 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l2 // { arity: 1 }
+              Constant // { arity: 0 }
+                - ()
 
 Used Indexes:
   - materialize.public.pk_part_partkey (differential join)
@@ -1387,6 +1387,22 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#4{o_totalprice} desc nulls_first, #3{o_orderdate} asc nulls_last] output=[#0..=#5]
+    With
+      cte l0 =
+        ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
+          ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
+      cte l1 =
+        Project (#0{c_custkey}, #1{c_name}, #8, #11, #12, #21) // { arity: 6 }
+          Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
+            implementation
+              %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
+              %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
+              %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
+            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
+              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
+            ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
+              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
+            Get l0 // { arity: 16 }
     Return // { arity: 6 }
       Reduce group_by=[#1{c_name}, #0{c_custkey}, #2{o_orderkey}, #4{o_orderdate}, #3{o_totalprice}] aggregates=[sum(#5{l_quantity})] // { arity: 6 }
         Project (#0{c_custkey}..=#5{l_quantity}) // { arity: 6 }
@@ -1407,22 +1423,6 @@ Explained Query:
                           Project (#2) // { arity: 1 }
                             Get l1 // { arity: 6 }
                       Get l0 // { arity: 16 }
-    With
-      cte l1 =
-        Project (#0{c_custkey}, #1{c_name}, #8, #11, #12, #21) // { arity: 6 }
-          Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
-            implementation
-              %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
-              %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
-              %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
-            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
-              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-            ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
-              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-            Get l0 // { arity: 16 }
-      cte l0 =
-        ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
-          ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
@@ -1475,16 +1475,6 @@ WHERE
     );
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l0 // { arity: 1 }
-      Map (null) // { arity: 1 }
-        Union // { arity: 0 }
-          Negate // { arity: 0 }
-            Project () // { arity: 0 }
-              Get l0 // { arity: 1 }
-          Constant // { arity: 0 }
-            - ()
   With
     cte l0 =
       Reduce aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 1 }
@@ -1498,6 +1488,16 @@ Explained Query:
                   ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
                 ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l0 // { arity: 1 }
+          Constant // { arity: 0 }
+            - ()
 
 Used Indexes:
   - materialize.public.pk_part_partkey (differential join)
@@ -1551,6 +1551,36 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#0{s_name} asc nulls_last] output=[#0, #1]
+    With
+      cte l0 =
+        Project (#0{s_suppkey}..=#2{s_address}) // { arity: 3 }
+          Filter (#8{n_name} = "CANADA") // { arity: 11 }
+            Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
+              implementation
+                %1:nation[#0]KAef » %0:supplier[#3]KAef
+              ArrangeBy keys=[[#3{s_nationkey}]] // { arity: 7 }
+                ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
+              ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
+                ReadIndex on=nation pk_nation_nationkey=[differential join] // { arity: 4 }
+      cte l1 =
+        Project (#0{s_suppkey}..=#3{ps_availqty}) // { arity: 4 }
+          Join on=(#1{ps_partkey} = #4{p_partkey}) type=delta // { arity: 5 }
+            implementation
+              %0 » %1:partsupp[×] » %2[#0]UKA
+              %1:partsupp » %2[#0]UKA » %0[×]
+              %2 » %1:partsupp[#0]KA » %0[×]
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Distinct project=[#0{s_suppkey}] // { arity: 1 }
+                Project (#0{s_suppkey}) // { arity: 1 }
+                  Get l0 // { arity: 3 }
+            ArrangeBy keys=[[], [#0{ps_partkey}]] // { arity: 3 }
+              Project (#0{ps_partkey}..=#2{ps_availqty}) // { arity: 3 }
+                ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+              Distinct project=[#0{p_partkey}] // { arity: 1 }
+                Project (#0{p_partkey}) // { arity: 1 }
+                  Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
+                    ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
     Return // { arity: 2 }
       Project (#1{s_address}, #2) // { arity: 2 }
         Join on=(#0{s_suppkey} = #3{s_suppkey}) type=differential // { arity: 4 }
@@ -1584,36 +1614,6 @@ Explained Query:
                                         Get l1 // { arity: 4 }
                                   ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
                                     ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
-    With
-      cte l1 =
-        Project (#0{s_suppkey}..=#3{ps_availqty}) // { arity: 4 }
-          Join on=(#1{ps_partkey} = #4{p_partkey}) type=delta // { arity: 5 }
-            implementation
-              %0 » %1:partsupp[×] » %2[#0]UKA
-              %1:partsupp » %2[#0]UKA » %0[×]
-              %2 » %1:partsupp[#0]KA » %0[×]
-            ArrangeBy keys=[[]] // { arity: 1 }
-              Distinct project=[#0{s_suppkey}] // { arity: 1 }
-                Project (#0{s_suppkey}) // { arity: 1 }
-                  Get l0 // { arity: 3 }
-            ArrangeBy keys=[[], [#0{ps_partkey}]] // { arity: 3 }
-              Project (#0{ps_partkey}..=#2{ps_availqty}) // { arity: 3 }
-                ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
-              Distinct project=[#0{p_partkey}] // { arity: 1 }
-                Project (#0{p_partkey}) // { arity: 1 }
-                  Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
-                    ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
-      cte l0 =
-        Project (#0{s_suppkey}..=#2{s_address}) // { arity: 3 }
-          Filter (#8{n_name} = "CANADA") // { arity: 11 }
-            Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
-              implementation
-                %1:nation[#0]KAef » %0:supplier[#3]KAef
-              ArrangeBy keys=[[#3{s_nationkey}]] // { arity: 7 }
-                ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
-              ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
-                ReadIndex on=nation pk_nation_nationkey=[differential join] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.pk_nation_nationkey (differential join)
@@ -1672,6 +1672,50 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#1{count} desc nulls_first, #0{s_name} asc nulls_last] output=[#0, #1]
+    With
+      cte l0 =
+        Project (#0{s_suppkey}, #1{s_name}, #7) // { arity: 3 }
+          Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
+            Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
+              implementation
+                %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
+                %1:lineitem » %2:orders[#0]KAef » %0:supplier[#0]KA » %3:nation[#0]KAef
+                %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
+                %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
+              ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
+                ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+              ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
+                ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
+              ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
+                ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
+              ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
+                ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
+      cte l1 =
+        ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
+          ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
+      cte l2 =
+        Project (#0{s_suppkey}..=#2{l_orderkey}) // { arity: 3 }
+          Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
+            implementation
+              %1[#1, #0]UKK » %0:l0[#0, #2]KK
+            ArrangeBy keys=[[#0{s_suppkey}, #2{l_orderkey}]] // { arity: 3 }
+              Get l0 // { arity: 3 }
+            ArrangeBy keys=[[#1{s_suppkey}, #0{l_orderkey}]] // { arity: 2 }
+              Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
+                Project (#0{l_orderkey}, #1{s_suppkey}) // { arity: 2 }
+                  Filter (#1{s_suppkey} != #4{l_suppkey}) // { arity: 18 }
+                    Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
+                      implementation
+                        %1:l1[#0]KA » %0[#0]K
+                      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
+                        Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
+                          Project (#0{s_suppkey}, #2) // { arity: 2 }
+                            Get l0 // { arity: 3 }
+                      Get l1 // { arity: 16 }
+      cte l3 =
+        Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
+          Project (#0{s_suppkey}, #2) // { arity: 2 }
+            Get l2 // { arity: 3 }
     Return // { arity: 2 }
       Reduce group_by=[#0{s_name}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
@@ -1693,50 +1737,6 @@ Explained Query:
                             Get l3 // { arity: 2 }
                           Get l1 // { arity: 16 }
                 Get l3 // { arity: 2 }
-    With
-      cte l3 =
-        Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-          Project (#0{s_suppkey}, #2) // { arity: 2 }
-            Get l2 // { arity: 3 }
-      cte l2 =
-        Project (#0{s_suppkey}..=#2{l_orderkey}) // { arity: 3 }
-          Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
-            implementation
-              %1[#1, #0]UKK » %0:l0[#0, #2]KK
-            ArrangeBy keys=[[#0{s_suppkey}, #2{l_orderkey}]] // { arity: 3 }
-              Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#1{s_suppkey}, #0{l_orderkey}]] // { arity: 2 }
-              Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
-                Project (#0{l_orderkey}, #1{s_suppkey}) // { arity: 2 }
-                  Filter (#1{s_suppkey} != #4{l_suppkey}) // { arity: 18 }
-                    Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
-                      implementation
-                        %1:l1[#0]KA » %0[#0]K
-                      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
-                        Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-                          Project (#0{s_suppkey}, #2) // { arity: 2 }
-                            Get l0 // { arity: 3 }
-                      Get l1 // { arity: 16 }
-      cte l1 =
-        ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
-          ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
-      cte l0 =
-        Project (#0{s_suppkey}, #1{s_name}, #7) // { arity: 3 }
-          Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
-            Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
-              implementation
-                %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-                %1:lineitem » %2:orders[#0]KAef » %0:supplier[#0]KA » %3:nation[#0]KAef
-                %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
-                %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-              ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-                ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
-              ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
-                ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-              ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
-                ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
-              ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
-                ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
@@ -1804,6 +1804,29 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0..=#2]
+    With
+      cte l0 =
+        Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
+          ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
+      cte l1 =
+        Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
+          Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
+            CrossJoin type=differential // { arity: 5 }
+              implementation
+                %1[×]UA » %0:l0[×]ef
+              ArrangeBy keys=[[]] // { arity: 3 }
+                Project (#0{c_custkey}, #4, #5) // { arity: 3 }
+                  Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
+                    Get l0 // { arity: 9 }
+              ArrangeBy keys=[[]] // { arity: 2 }
+                Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
+                  Project (#5) // { arity: 1 }
+                    Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
+                      Get l0 // { arity: 9 }
+      cte l2 =
+        Distinct project=[#0{c_custkey}] // { arity: 1 }
+          Project (#0{c_custkey}) // { arity: 1 }
+            Get l1 // { arity: 3 }
     Return // { arity: 3 }
       Reduce group_by=[substr(char_to_text(#0{c_phone}), 1, 2)] aggregates=[count(*), sum(#1{c_acctbal})] // { arity: 3 }
         Project (#1{c_acctbal}, #2) // { arity: 2 }
@@ -1826,29 +1849,6 @@ Explained Query:
                           Project (#1) // { arity: 1 }
                             ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
                 Get l2 // { arity: 1 }
-    With
-      cte l2 =
-        Distinct project=[#0{c_custkey}] // { arity: 1 }
-          Project (#0{c_custkey}) // { arity: 1 }
-            Get l1 // { arity: 3 }
-      cte l1 =
-        Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
-          Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
-            CrossJoin type=differential // { arity: 5 }
-              implementation
-                %1[×]UA » %0:l0[×]ef
-              ArrangeBy keys=[[]] // { arity: 3 }
-                Project (#0{c_custkey}, #4, #5) // { arity: 3 }
-                  Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                    Get l0 // { arity: 9 }
-              ArrangeBy keys=[[]] // { arity: 2 }
-                Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
-                  Project (#5) // { arity: 1 }
-                    Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                      Get l0 // { arity: 9 }
-      cte l0 =
-        Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
-          ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (*** full scan ***)

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -976,6 +976,20 @@ query T multiline
 EXPLAIN SHOW VIEWS
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0..=#2, #4)
+        Join on=(#0 = #3) type=differential
+          ArrangeBy keys=[[#0]]
+            Project (#0, #2, #3)
+              ReadStorage mz_catalog.mz_views
+          ArrangeBy keys=[[#0]]
+            Project (#0, #3)
+              Filter (#2) IS NULL AND (#1 = "view")
+                ReadStorage mz_internal.mz_comments
+    cte l1 =
+      Filter (#2 = "u3")
+        ReadStorage mz_catalog.mz_views
   Return
     Project (#0, #2)
       Map (coalesce(#1, ""))
@@ -997,20 +1011,6 @@ Explained Query:
           Project (#2, #3)
             Filter (#1 = "u3")
               Get l0
-  With
-    cte l1 =
-      Filter (#2 = "u3")
-        ReadStorage mz_catalog.mz_views
-    cte l0 =
-      Project (#0..=#2, #4)
-        Join on=(#0 = #3) type=differential
-          ArrangeBy keys=[[#0]]
-            Project (#0, #2, #3)
-              ReadStorage mz_catalog.mz_views
-          ArrangeBy keys=[[#0]]
-            Project (#0, #3)
-              Filter (#2) IS NULL AND (#1 = "view")
-                ReadStorage mz_internal.mz_comments
 
 Source mz_catalog.mz_views
 Source mz_internal.mz_comments

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -23,6 +23,22 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having count(t2.f1) >= 0;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#0) IS NOT NULL // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
+    cte l1 =
+      Project (#0) // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#0) IS NOT NULL // { arity: 2 }
+                ReadStorage materialize.public.t2 // { arity: 2 }
   Return // { arity: 2 }
     Filter (#1 >= 0) // { arity: 2 }
       Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
@@ -42,22 +58,6 @@ Explained Query:
                 ReadStorage materialize.public.t1 // { arity: 2 }
           Project (#0, #0) // { arity: 2 }
             Get l1 // { arity: 1 }
-  With
-    cte l1 =
-      Project (#0) // { arity: 1 }
-        Join on=(#0 = #1) type=differential // { arity: 2 }
-          implementation
-            %0:l0[#0]K » %1:t2[#0]K
-          Get l0 // { arity: 1 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t2 // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Filter (#0) IS NOT NULL // { arity: 2 }
-            ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -111,18 +111,21 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1.f2), sum(t1.f2), min(t1.f2), max(t1.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1;
 ----
 Explained Query:
-  Return // { arity: 9 }
-    Project (#0, #6, #7, #1, #2, #8, #9, #3, #4) // { arity: 9 }
-      Join on=(#0 = #5) type=differential // { arity: 10 }
-        implementation
-          %0[#0]UKA » %1[#0]UKA
-        ArrangeBy keys=[[#0]] // { arity: 5 }
-          Reduce group_by=[#0] aggregates=[max(#2), min(#2), min(#1), max(#1)] // { arity: 5 }
-            Get l2 // { arity: 3 }
-        ArrangeBy keys=[[#0]] // { arity: 5 }
-          Reduce group_by=[#0] aggregates=[count(#2), sum(#2), count(#1), sum(#1)] // { arity: 5 }
-            Get l2 // { arity: 3 }
   With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.t1 // { arity: 2 }
+    cte l1 =
+      Project (#0, #1) // { arity: 2 }
+        Join on=(#0 = #2) type=differential // { arity: 3 }
+          implementation
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#0) IS NOT NULL // { arity: 2 }
+                ReadStorage materialize.public.t2 // { arity: 2 }
     cte l2 =
       Union // { arity: 3 }
         Map (null) // { arity: 3 }
@@ -140,20 +143,17 @@ Explained Query:
             ReadStorage materialize.public.t1 // { arity: 2 }
         Project (#0, #1, #0) // { arity: 3 }
           Get l1 // { arity: 2 }
-    cte l1 =
-      Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = #2) type=differential // { arity: 3 }
-          implementation
-            %0:l0[#0]K » %1:t2[#0]K
-          Get l0 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t2 // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          ReadStorage materialize.public.t1 // { arity: 2 }
+  Return // { arity: 9 }
+    Project (#0, #6, #7, #1, #2, #8, #9, #3, #4) // { arity: 9 }
+      Join on=(#0 = #5) type=differential // { arity: 10 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0]] // { arity: 5 }
+          Reduce group_by=[#0] aggregates=[max(#2), min(#2), min(#1), max(#1)] // { arity: 5 }
+            Get l2 // { arity: 3 }
+        ArrangeBy keys=[[#0]] // { arity: 5 }
+          Reduce group_by=[#0] aggregates=[count(#2), sum(#2), count(#1), sum(#1)] // { arity: 5 }
+            Get l2 // { arity: 3 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -167,19 +167,21 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1.f2), sum(t1.f2), min(t1.f2), max(t1.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having sum(t1.f2) >= 0;
 ----
 Explained Query:
-  Return // { arity: 9 }
-    Project (#0, #6, #7, #1, #2, #8, #9, #3, #4) // { arity: 9 }
-      Filter (#9 >= 0) // { arity: 10 }
-        Join on=(#0 = #5) type=differential // { arity: 10 }
-          implementation
-            %1[#0]UKAif » %0[#0]UKAif
-          ArrangeBy keys=[[#0]] // { arity: 5 }
-            Reduce group_by=[#0] aggregates=[max(#2), min(#2), min(#1), max(#1)] // { arity: 5 }
-              Get l2 // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 5 }
-            Reduce group_by=[#0] aggregates=[count(#2), sum(#2), count(#1), sum(#1)] // { arity: 5 }
-              Get l2 // { arity: 3 }
   With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.t1 // { arity: 2 }
+    cte l1 =
+      Project (#0, #1) // { arity: 2 }
+        Join on=(#0 = #2) type=differential // { arity: 3 }
+          implementation
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#0) IS NOT NULL // { arity: 2 }
+                ReadStorage materialize.public.t2 // { arity: 2 }
     cte l2 =
       Union // { arity: 3 }
         Map (null) // { arity: 3 }
@@ -197,20 +199,18 @@ Explained Query:
             ReadStorage materialize.public.t1 // { arity: 2 }
         Project (#0, #1, #0) // { arity: 3 }
           Get l1 // { arity: 2 }
-    cte l1 =
-      Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = #2) type=differential // { arity: 3 }
+  Return // { arity: 9 }
+    Project (#0, #6, #7, #1, #2, #8, #9, #3, #4) // { arity: 9 }
+      Filter (#9 >= 0) // { arity: 10 }
+        Join on=(#0 = #5) type=differential // { arity: 10 }
           implementation
-            %0:l0[#0]K » %1:t2[#0]K
-          Get l0 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t2 // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          ReadStorage materialize.public.t1 // { arity: 2 }
+            %1[#0]UKAif » %0[#0]UKAif
+          ArrangeBy keys=[[#0]] // { arity: 5 }
+            Reduce group_by=[#0] aggregates=[max(#2), min(#2), min(#1), max(#1)] // { arity: 5 }
+              Get l2 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 5 }
+            Reduce group_by=[#0] aggregates=[count(#2), sum(#2), count(#1), sum(#1)] // { arity: 5 }
+              Get l2 // { arity: 3 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -224,19 +224,21 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f1), sum(t2.f1), max(t2.f1), min(t2.f1), count(t1.f2), sum(t1.f2), min(t1.f2), max(t1.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having sum(t2.f1) >= 0;
 ----
 Explained Query:
-  Return // { arity: 9 }
-    Project (#0, #6, #7, #1, #2, #8, #9, #3, #4) // { arity: 9 }
-      Filter (#7 >= 0) // { arity: 10 }
-        Join on=(#0 = #5) type=differential // { arity: 10 }
-          implementation
-            %1[#0]UKAif » %0[#0]UKAif
-          ArrangeBy keys=[[#0]] // { arity: 5 }
-            Reduce group_by=[#0] aggregates=[max(#2), min(#2), min(#1), max(#1)] // { arity: 5 }
-              Get l2 // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 5 }
-            Reduce group_by=[#0] aggregates=[count(#2), sum(#2), count(#1), sum(#1)] // { arity: 5 }
-              Get l2 // { arity: 3 }
   With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.t1 // { arity: 2 }
+    cte l1 =
+      Project (#0, #1) // { arity: 2 }
+        Join on=(#0 = #2) type=differential // { arity: 3 }
+          implementation
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#0) IS NOT NULL // { arity: 2 }
+                ReadStorage materialize.public.t2 // { arity: 2 }
     cte l2 =
       Union // { arity: 3 }
         Map (null) // { arity: 3 }
@@ -254,20 +256,18 @@ Explained Query:
             ReadStorage materialize.public.t1 // { arity: 2 }
         Project (#0, #1, #0) // { arity: 3 }
           Get l1 // { arity: 2 }
-    cte l1 =
-      Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = #2) type=differential // { arity: 3 }
+  Return // { arity: 9 }
+    Project (#0, #6, #7, #1, #2, #8, #9, #3, #4) // { arity: 9 }
+      Filter (#7 >= 0) // { arity: 10 }
+        Join on=(#0 = #5) type=differential // { arity: 10 }
           implementation
-            %0:l0[#0]K » %1:t2[#0]K
-          Get l0 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t2 // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          ReadStorage materialize.public.t1 // { arity: 2 }
+            %1[#0]UKAif » %0[#0]UKAif
+          ArrangeBy keys=[[#0]] // { arity: 5 }
+            Reduce group_by=[#0] aggregates=[max(#2), min(#2), min(#1), max(#1)] // { arity: 5 }
+              Get l2 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 5 }
+            Reduce group_by=[#0] aggregates=[count(#2), sum(#2), count(#1), sum(#1)] // { arity: 5 }
+              Get l2 // { arity: 3 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -310,17 +310,6 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Project (#0, #3, #1) // { arity: 3 }
-      Join on=(#0 = #2) type=differential // { arity: 4 }
-        implementation
-          %0[#0]UKA » %1[#0]UKA
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#0] aggregates=[max(#0)] // { arity: 2 }
-            Get l0 // { arity: 1 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#0] aggregates=[sum(#0)] // { arity: 2 }
-            Get l0 // { arity: 1 }
   With
     cte l0 =
       Project (#0) // { arity: 1 }
@@ -335,6 +324,17 @@ Explained Query:
             Project (#0) // { arity: 1 }
               Filter (#0 >= 0) // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Join on=(#0 = #2) type=differential // { arity: 4 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[max(#0)] // { arity: 2 }
+            Get l0 // { arity: 1 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[sum(#0)] // { arity: 2 }
+            Get l0 // { arity: 1 }
 
 Source materialize.public.t1
   filter=((#0 >= 0))
@@ -350,18 +350,6 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0 and sum(t2.f1) >= 0;
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Project (#0, #3, #1) // { arity: 3 }
-      Filter (#3 >= 0) // { arity: 4 }
-        Join on=(#0 = #2) type=differential // { arity: 4 }
-          implementation
-            %1[#0]UKAif » %0[#0]UKAif
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[max(#0)] // { arity: 2 }
-              Get l0 // { arity: 1 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[sum(#0)] // { arity: 2 }
-              Get l0 // { arity: 1 }
   With
     cte l0 =
       Project (#0) // { arity: 1 }
@@ -376,6 +364,18 @@ Explained Query:
             Project (#0) // { arity: 1 }
               Filter (#0 >= 0) // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Filter (#3 >= 0) // { arity: 4 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UKAif » %0[#0]UKAif
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[max(#0)] // { arity: 2 }
+              Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[sum(#0)] // { arity: 2 }
+              Get l0 // { arity: 1 }
 
 Source materialize.public.t1
   filter=((#0 >= 0))
@@ -391,21 +391,21 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t2.f2), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Project (#0, #3, #1) // { arity: 3 }
-      Filter (#1 >= 0) // { arity: 4 }
-        Join on=(#0 = #2) type=differential // { arity: 4 }
-          implementation
-            %0[#0]UKAif » %1[#0]UKAif
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
-              Project (#0, #1) // { arity: 2 }
-                Get l2 // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
-              Project (#0, #2) // { arity: 2 }
-                Get l2 // { arity: 3 }
   With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#0) IS NOT NULL // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
+    cte l1 =
+      Project (#0, #2) // { arity: 2 }
+        Join on=(#0 = #1) type=differential // { arity: 3 }
+          implementation
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
     cte l2 =
       Union // { arity: 3 }
         Map (null, null) // { arity: 3 }
@@ -424,20 +424,20 @@ Explained Query:
               ReadStorage materialize.public.t1 // { arity: 2 }
         Project (#0, #0, #1) // { arity: 3 }
           Get l1 // { arity: 2 }
-    cte l1 =
-      Project (#0, #2) // { arity: 2 }
-        Join on=(#0 = #1) type=differential // { arity: 3 }
+  Return // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Filter (#1 >= 0) // { arity: 4 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %0:l0[#0]K » %1:t2[#0]K
-          Get l0 // { arity: 1 }
+            %0[#0]UKAif » %1[#0]UKAif
           ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.t2 // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Filter (#0) IS NOT NULL // { arity: 2 }
-            ReadStorage materialize.public.t1 // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Get l2 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
+              Project (#0, #2) // { arity: 2 }
+                Get l2 // { arity: 3 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -452,18 +452,6 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t2.f1 + t2.f2), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Project (#0, #3, #1) // { arity: 3 }
-      Join on=(#0 = #2) type=differential // { arity: 4 }
-        implementation
-          %0[#0]UKA » %1[#0]UKA
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#0] aggregates=[max(#0)] // { arity: 2 }
-            Project (#0) // { arity: 1 }
-              Get l0 // { arity: 2 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#0] aggregates=[sum((#0 + #1))] // { arity: 2 }
-            Get l0 // { arity: 2 }
   With
     cte l0 =
       Project (#0, #2) // { arity: 2 }
@@ -477,6 +465,18 @@ Explained Query:
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0 >= 0) // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Join on=(#0 = #2) type=differential // { arity: 4 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[max(#0)] // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              Get l0 // { arity: 2 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[sum((#0 + #1))] // { arity: 2 }
+            Get l0 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 >= 0))
@@ -492,17 +492,6 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t1.f1 + t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Project (#0, #3, #1) // { arity: 3 }
-      Join on=(#0 = #2) type=differential // { arity: 4 }
-        implementation
-          %0[#0]UKA » %1[#0]UKA
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#0] aggregates=[max(#0)] // { arity: 2 }
-            Get l0 // { arity: 1 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#0] aggregates=[sum((#0 + #0))] // { arity: 2 }
-            Get l0 // { arity: 1 }
   With
     cte l0 =
       Project (#0) // { arity: 1 }
@@ -517,6 +506,17 @@ Explained Query:
             Project (#0) // { arity: 1 }
               Filter (#0 >= 0) // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Join on=(#0 = #2) type=differential // { arity: 4 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[max(#0)] // { arity: 2 }
+            Get l0 // { arity: 1 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[sum((#0 + #0))] // { arity: 2 }
+            Get l0 // { arity: 1 }
 
 Source materialize.public.t1
   filter=((#0 >= 0))
@@ -532,20 +532,22 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t1.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Project (#0, #3, #1) // { arity: 3 }
-      Filter (#1 >= 0) // { arity: 4 }
-        Join on=(#0 = #2) type=differential // { arity: 4 }
-          implementation
-            %0[#0]UKAif » %1[#0]UKAif
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
-              Get l2 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[sum(#0)] // { arity: 2 }
-              Project (#0) // { arity: 1 }
-                Get l2 // { arity: 2 }
   With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#0) IS NOT NULL // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
+    cte l1 =
+      Project (#0) // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#0) IS NOT NULL // { arity: 2 }
+                ReadStorage materialize.public.t2 // { arity: 2 }
     cte l2 =
       Union // { arity: 2 }
         Map (null) // { arity: 2 }
@@ -563,21 +565,19 @@ Explained Query:
               ReadStorage materialize.public.t1 // { arity: 2 }
         Project (#0, #0) // { arity: 2 }
           Get l1 // { arity: 1 }
-    cte l1 =
-      Project (#0) // { arity: 1 }
-        Join on=(#0 = #1) type=differential // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Filter (#1 >= 0) // { arity: 4 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %0:l0[#0]K » %1:t2[#0]K
-          Get l0 // { arity: 1 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t2 // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Filter (#0) IS NOT NULL // { arity: 2 }
-            ReadStorage materialize.public.t1 // { arity: 2 }
+            %0[#0]UKAif » %1[#0]UKAif
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+              Get l2 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[sum(#0)] // { arity: 2 }
+              Project (#0) // { arity: 1 }
+                Get l2 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -592,6 +592,21 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#0) IS NOT NULL // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
+    cte l1 =
+      Project (#0, #2) // { arity: 2 }
+        Join on=(#0 = #1) type=differential // { arity: 3 }
+          implementation
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
   Return // { arity: 2 }
     Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
       Union // { arity: 2 }
@@ -610,21 +625,6 @@ Explained Query:
             Project (#0) // { arity: 1 }
               ReadStorage materialize.public.t1 // { arity: 2 }
         Get l1 // { arity: 2 }
-  With
-    cte l1 =
-      Project (#0, #2) // { arity: 2 }
-        Join on=(#0 = #1) type=differential // { arity: 3 }
-          implementation
-            %0:l0[#0]K » %1:t2[#0]K
-          Get l0 // { arity: 1 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.t2 // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Filter (#0) IS NOT NULL // { arity: 2 }
-            ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -639,18 +639,21 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f2), max(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1;
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Project (#0, #3, #1) // { arity: 3 }
-      Join on=(#0 = #2) type=differential // { arity: 4 }
-        implementation
-          %0[#0]UKA » %1[#0]UKA
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
-            Get l2 // { arity: 2 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
-            Get l2 // { arity: 2 }
   With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#0) IS NOT NULL // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
+    cte l1 =
+      Project (#0, #2) // { arity: 2 }
+        Join on=(#0 = #1) type=differential // { arity: 3 }
+          implementation
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
     cte l2 =
       Union // { arity: 2 }
         Map (null) // { arity: 2 }
@@ -668,20 +671,17 @@ Explained Query:
             Project (#0) // { arity: 1 }
               ReadStorage materialize.public.t1 // { arity: 2 }
         Get l1 // { arity: 2 }
-    cte l1 =
-      Project (#0, #2) // { arity: 2 }
-        Join on=(#0 = #1) type=differential // { arity: 3 }
-          implementation
-            %0:l0[#0]K » %1:t2[#0]K
-          Get l0 // { arity: 1 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.t2 // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Filter (#0) IS NOT NULL // { arity: 2 }
-            ReadStorage materialize.public.t1 // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Join on=(#0 = #2) type=differential // { arity: 4 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+            Get l2 // { arity: 2 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
+            Get l2 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -696,18 +696,6 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f2), max(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f2) > 0;
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Project (#0, #3, #1) // { arity: 3 }
-      Filter (#1 > 0) // { arity: 4 }
-        Join on=(#0 = #2) type=differential // { arity: 4 }
-          implementation
-            %0[#0]UKAif » %1[#0]UKAif
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
-              Get l0 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
-              Get l0 // { arity: 2 }
   With
     cte l0 =
       Project (#0, #2) // { arity: 2 }
@@ -721,6 +709,18 @@ Explained Query:
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Filter (#1 > 0) // { arity: 4 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %0[#0]UKAif » %1[#0]UKAif
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+              Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
+              Get l0 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
@@ -736,6 +736,18 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, max(t1.f1 + t2.f2), sum(t1.f2 + t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t1.f1 + t2.f2) > 0;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0, #1, #3) // { arity: 3 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %0:t1[#0]K » %1:t2[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
   Return // { arity: 3 }
     Project (#0, #1, #3) // { arity: 3 }
       Filter (#1 > 0) // { arity: 4 }
@@ -749,18 +761,6 @@ Explained Query:
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Reduce group_by=[#0] aggregates=[sum((#1 + #2))] // { arity: 2 }
               Get l0 // { arity: 3 }
-  With
-    cte l0 =
-      Project (#0, #1, #3) // { arity: 3 }
-        Join on=(#0 = #2) type=differential // { arity: 4 }
-          implementation
-            %0:t1[#0]K » %1:t2[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
@@ -804,20 +804,20 @@ query T multiline
 explain with(arity, join implementations) select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t2.f1 group by t1.f1
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Project (#0, #3, #1) // { arity: 3 }
-      Join on=(#0 = #2) type=differential // { arity: 4 }
-        implementation
-          %0[#0]UKA » %1[#0]UKA
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
-            Project (#0, #2) // { arity: 2 }
-              Get l2 // { arity: 3 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Get l2 // { arity: 3 }
   With
+    cte l0 =
+      ArrangeBy keys=[[#1]] // { arity: 2 }
+        Filter (#1) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.t1 // { arity: 2 }
+    cte l1 =
+      Project (#0, #1, #3) // { arity: 3 }
+        Join on=(#1 = #2) type=differential // { arity: 4 }
+          implementation
+            %0:l0[#1]K » %1:t2[#0]K
+          Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
     cte l2 =
       Union // { arity: 3 }
         Map (null) // { arity: 3 }
@@ -834,19 +834,19 @@ Explained Query:
                         Get l1 // { arity: 3 }
             ReadStorage materialize.public.t1 // { arity: 2 }
         Get l1 // { arity: 3 }
-    cte l1 =
-      Project (#0, #1, #3) // { arity: 3 }
-        Join on=(#1 = #2) type=differential // { arity: 4 }
-          implementation
-            %0:l0[#1]K » %1:t2[#0]K
-          Get l0 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.t2 // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[#1]] // { arity: 2 }
-        Filter (#1) IS NOT NULL // { arity: 2 }
-          ReadStorage materialize.public.t1 // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Join on=(#0 = #2) type=differential // { arity: 4 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+            Project (#0, #2) // { arity: 2 }
+              Get l2 // { arity: 3 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Get l2 // { arity: 3 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -860,6 +860,36 @@ query T multiline
 explain with(arity, join implementations) select t1.f1, count(t1.f2), max(t2.f2) from t1 left join t2 on t1.f2 = t2.f1 group by t1.f1 having max(t2.f2) > 0
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#1]] // { arity: 2 }
+        Filter (#1) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.t1 // { arity: 2 }
+    cte l1 =
+      Project (#0, #1, #3) // { arity: 3 }
+        Join on=(#1 = #2) type=differential // { arity: 4 }
+          implementation
+            %0:l0[#1]K » %1:t2[#0]K
+          Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l2 =
+      Union // { arity: 3 }
+        Map (null) // { arity: 3 }
+          Union // { arity: 2 }
+            Negate // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Join on=(#1 = #2) type=differential // { arity: 3 }
+                  implementation
+                    %1[#0]UKA » %0:l0[#1]K
+                  Get l0 // { arity: 2 }
+                  ArrangeBy keys=[[#0]] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
+                      Project (#1) // { arity: 1 }
+                        Get l1 // { arity: 3 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
+        Get l1 // { arity: 3 }
   Return // { arity: 3 }
     Project (#0, #3, #1) // { arity: 3 }
       Filter (#1 > 0) // { arity: 4 }
@@ -874,36 +904,6 @@ Explained Query:
             Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
               Project (#0, #1) // { arity: 2 }
                 Get l2 // { arity: 3 }
-  With
-    cte l2 =
-      Union // { arity: 3 }
-        Map (null) // { arity: 3 }
-          Union // { arity: 2 }
-            Negate // { arity: 2 }
-              Project (#0, #1) // { arity: 2 }
-                Join on=(#1 = #2) type=differential // { arity: 3 }
-                  implementation
-                    %1[#0]UKA » %0:l0[#1]K
-                  Get l0 // { arity: 2 }
-                  ArrangeBy keys=[[#0]] // { arity: 1 }
-                    Distinct project=[#0] // { arity: 1 }
-                      Project (#1) // { arity: 1 }
-                        Get l1 // { arity: 3 }
-            ReadStorage materialize.public.t1 // { arity: 2 }
-        Get l1 // { arity: 3 }
-    cte l1 =
-      Project (#0, #1, #3) // { arity: 3 }
-        Join on=(#1 = #2) type=differential // { arity: 4 }
-          implementation
-            %0:l0[#1]K » %1:t2[#0]K
-          Get l0 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.t2 // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[#1]] // { arity: 2 }
-        Filter (#1) IS NOT NULL // { arity: 2 }
-          ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -1020,25 +1020,18 @@ JOIN (
 WHERE t1.f2 = derived.agg2;
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Project (#2) // { arity: 1 }
-      Join on=(#0 = #1) type=delta // { arity: 3 }
-        implementation
-          %0:t1 » %1[#0]UK » %2[×]UA
-          %1 » %2[×]UA » %0:t1[#0]K
-          %2 » %1[×]UA » %0:t1[#0]K
-        ArrangeBy keys=[[#0]] // { arity: 1 }
-          Project (#1) // { arity: 1 }
-            ReadStorage materialize.public.t1 // { arity: 2 }
-        ArrangeBy keys=[[], [#0]] // { arity: 1 }
-          Filter (#0) IS NOT NULL // { arity: 1 }
-            Reduce aggregates=[max(#0)] // { arity: 1 }
-              Get l1 // { arity: 1 }
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Reduce aggregates=[count(*)] // { arity: 1 }
-            Project () // { arity: 0 }
-              Get l1 // { arity: 1 }
   With
+    cte l0 =
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %1:t3[×]ef » %0:t2[×]ef
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            ReadStorage materialize.public.t2 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Filter (#1 = 6) // { arity: 2 }
+              ReadStorage materialize.public.t3 // { arity: 2 }
     cte l1 =
       Union // { arity: 1 }
         Project (#0) // { arity: 1 }
@@ -1059,17 +1052,24 @@ Explained Query:
                     ReadStorage materialize.public.t3 // { arity: 2 }
               ArrangeBy keys=[[#0, #1]] // { arity: 2 }
                 ReadStorage materialize.public.t3 // { arity: 2 }
-    cte l0 =
-      CrossJoin type=differential // { arity: 2 }
+  Return // { arity: 1 }
+    Project (#2) // { arity: 1 }
+      Join on=(#0 = #1) type=delta // { arity: 3 }
         implementation
-          %1:t3[×]ef » %0:t2[×]ef
-        ArrangeBy keys=[[]] // { arity: 1 }
+          %0:t1 » %1[#0]UK » %2[×]UA
+          %1 » %2[×]UA » %0:t1[#0]K
+          %2 » %1[×]UA » %0:t1[#0]K
+        ArrangeBy keys=[[#0]] // { arity: 1 }
           Project (#1) // { arity: 1 }
-            ReadStorage materialize.public.t2 // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
+        ArrangeBy keys=[[], [#0]] // { arity: 1 }
+          Filter (#0) IS NOT NULL // { arity: 1 }
+            Reduce aggregates=[max(#0)] // { arity: 1 }
+              Get l1 // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Filter (#1 = 6) // { arity: 2 }
-              ReadStorage materialize.public.t3 // { arity: 2 }
+          Reduce aggregates=[count(*)] // { arity: 1 }
+            Project () // { arity: 0 }
+              Get l1 // { arity: 1 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -1109,6 +1109,16 @@ ON t1.f1 < t2.f1
 HAVING SUM(t1.f1 + t2.f1) > 0;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Filter (#1 < #0) // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0:t2[×] » %1:t1[×]
+          ArrangeBy keys=[[]] // { arity: 1 }
+            ReadStorage materialize.public.t2 // { arity: 1 }
+          ArrangeBy keys=[[]] // { arity: 1 }
+            ReadStorage materialize.public.t1 // { arity: 1 }
   Return // { arity: 2 }
     Filter (#0 > 0) // { arity: 2 }
       Reduce aggregates=[sum((#1 + #0)), sum((#0 + 0))] // { arity: 2 }
@@ -1129,16 +1139,6 @@ Explained Query:
                       ReadStorage materialize.public.t2 // { arity: 1 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   ReadStorage materialize.public.t2 // { arity: 1 }
-  With
-    cte l0 =
-      Filter (#1 < #0) // { arity: 2 }
-        CrossJoin type=differential // { arity: 2 }
-          implementation
-            %0:t2[×] » %1:t1[×]
-          ArrangeBy keys=[[]] // { arity: 1 }
-            ReadStorage materialize.public.t2 // { arity: 1 }
-          ArrangeBy keys=[[]] // { arity: 1 }
-            ReadStorage materialize.public.t1 // { arity: 1 }
 
 Source materialize.public.t1
 Source materialize.public.t2

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -75,16 +75,10 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 LEFT JOIN t2 ON (t1.f1 = t2.f1) WHERE t1.f1 = 123;
 ----
 Explained Query:
-  Return // { arity: 4 }
-    Union // { arity: 4 }
-      Map (null, null) // { arity: 4 }
-        Union // { arity: 2 }
-          Negate // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Get l1 // { arity: 4 }
-          Get l0 // { arity: 2 }
-      Get l1 // { arity: 4 }
   With
+    cte l0 =
+      Filter (#0 = 123) // { arity: 2 }
+        ReadStorage materialize.public.t1 // { arity: 2 }
     cte l1 =
       CrossJoin type=differential // { arity: 4 }
         implementation
@@ -94,9 +88,15 @@ Explained Query:
         ArrangeBy keys=[[]] // { arity: 2 }
           Filter (#0 = 123) // { arity: 2 }
             ReadStorage materialize.public.t2 // { arity: 2 }
-    cte l0 =
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
+  Return // { arity: 4 }
+    Union // { arity: 4 }
+      Map (null, null) // { arity: 4 }
+        Union // { arity: 2 }
+          Negate // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Get l1 // { arity: 4 }
+          Get l0 // { arity: 2 }
+      Get l1 // { arity: 4 }
 
 Source materialize.public.t1
   filter=((#0 = 123))
@@ -111,16 +111,10 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 LEFT JOIN t2 USING (f1) WHERE t1.f1 = 123;
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Union // { arity: 3 }
-      Map (null) // { arity: 3 }
-        Union // { arity: 2 }
-          Negate // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Get l1 // { arity: 3 }
-          Get l0 // { arity: 2 }
-      Get l1 // { arity: 3 }
   With
+    cte l0 =
+      Filter (#0 = 123) // { arity: 2 }
+        ReadStorage materialize.public.t1 // { arity: 2 }
     cte l1 =
       CrossJoin type=differential // { arity: 3 }
         implementation
@@ -131,9 +125,15 @@ Explained Query:
           Project (#1) // { arity: 1 }
             Filter (#0 = 123) // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
-    cte l0 =
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
+  Return // { arity: 3 }
+    Union // { arity: 3 }
+      Map (null) // { arity: 3 }
+        Union // { arity: 2 }
+          Negate // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Get l1 // { arity: 3 }
+          Get l0 // { arity: 2 }
+      Get l1 // { arity: 3 }
 
 Source materialize.public.t1
   filter=((#0 = 123))
@@ -235,6 +235,23 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT (SELECT t1.f1 FROM t1 WHERE t1.f1 = t2.f1) FROM t2 WHERE t2.f1 = 123;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project () // { arity: 0 }
+        Filter (#0 = 123) // { arity: 2 }
+          ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l1 =
+      ArrangeBy keys=[[]] // { arity: 0 }
+        Get l0 // { arity: 0 }
+    cte l2 =
+      CrossJoin type=differential // { arity: 1 }
+        implementation
+          %0:l1[×]Uef » %1:t1[×]Uef
+        Get l1 // { arity: 0 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
   Return // { arity: 1 }
     CrossJoin type=differential // { arity: 1 }
       implementation
@@ -249,23 +266,6 @@ Explained Query:
                 Project () // { arity: 0 }
                   Get l2 // { arity: 1 }
               Get l0 // { arity: 0 }
-  With
-    cte l2 =
-      CrossJoin type=differential // { arity: 1 }
-        implementation
-          %0:l1[×]Uef » %1:t1[×]Uef
-        Get l1 // { arity: 0 }
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Filter (#0 = 123) // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
-    cte l1 =
-      ArrangeBy keys=[[]] // { arity: 0 }
-        Get l0 // { arity: 0 }
-    cte l0 =
-      Project () // { arity: 0 }
-        Filter (#0 = 123) // { arity: 2 }
-          ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 = 123))
@@ -281,6 +281,17 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT (SELECT t1.f1 FROM t1) = t2.f1 FROM t2 WHERE t2.f1 = 123;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Union // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          ReadStorage materialize.public.t1 // { arity: 2 }
+        Map (error("more than one record produced in subquery")) // { arity: 1 }
+          Project () // { arity: 0 }
+            Filter (#0 > 1) // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
+                Project () // { arity: 0 }
+                  ReadStorage materialize.public.t1 // { arity: 2 }
   Return // { arity: 1 }
     Project (#1) // { arity: 1 }
       Map ((#0 = 123)) // { arity: 2 }
@@ -302,17 +313,6 @@ Explained Query:
                         Get l0 // { arity: 1 }
                   Constant // { arity: 0 }
                     - ()
-  With
-    cte l0 =
-      Union // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          ReadStorage materialize.public.t1 // { arity: 2 }
-        Map (error("more than one record produced in subquery")) // { arity: 1 }
-          Project () // { arity: 0 }
-            Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(*)] // { arity: 1 }
-                Project () // { arity: 0 }
-                  ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -612,9 +612,6 @@ WITH MUTUALLY RECURSIVE
 SELECT f1, f2, f1 + f2 FROM c0;
 ----
 Explained Query:
-  Return // { arity: 3, types: "(integer, integer, integer)" }
-    Map (8) // { arity: 3, types: "(integer, integer, integer)" }
-      Get l0 // { arity: 2, types: "(integer, integer)" }
   With Mutually Recursive
     cte l0 =
       Map (3, 5) // { arity: 2, types: "(integer, integer)" }
@@ -625,6 +622,9 @@ Explained Query:
                 ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
             Project () // { arity: 0, types: "()" }
               Get l0 // { arity: 2, types: "(integer, integer)" }
+  Return // { arity: 3, types: "(integer, integer, integer)" }
+    Map (8) // { arity: 3, types: "(integer, integer, integer)" }
+      Get l0 // { arity: 2, types: "(integer, integer)" }
 
 Source materialize.public.t1
   filter=((#0 = 3) AND (#1 = 5))
@@ -647,9 +647,6 @@ WITH MUTUALLY RECURSIVE
 SELECT f1, f2, f1 IS NOT NULL, f2 IS NULL FROM c0;
 ----
 Explained Query:
-  Return // { arity: 4, types: "(integer, integer, boolean, boolean)" }
-    Map (true, false) // { arity: 4, types: "(integer, integer, boolean, boolean)" }
-      Get l0 // { arity: 2, types: "(integer, integer)" }
   With Mutually Recursive
     cte l0 =
       Distinct project=[#0, #1] // { arity: 2, types: "(integer, integer)" }
@@ -657,6 +654,9 @@ Explained Query:
           Filter (#1) IS NOT NULL // { arity: 2, types: "(integer, integer)" }
             ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
           Get l0 // { arity: 2, types: "(integer, integer)" }
+  Return // { arity: 4, types: "(integer, integer, boolean, boolean)" }
+    Map (true, false) // { arity: 4, types: "(integer, integer, boolean, boolean)" }
+      Get l0 // { arity: 2, types: "(integer, integer)" }
 
 Source materialize.public.t1
   filter=((#1) IS NOT NULL)
@@ -679,10 +679,6 @@ WITH MUTUALLY RECURSIVE
 SELECT f1, f2, f1 IS NOT NULL, f2 IS NULL FROM c0;
 ----
 Explained Query:
-  Return // { arity: 4, types: "(integer, integer?, boolean, boolean)" }
-    Project (#0, #1, #3, #2) // { arity: 4, types: "(integer, integer?, boolean, boolean)" }
-      Map ((#1) IS NULL, true) // { arity: 4, types: "(integer, integer?, boolean, boolean)" }
-        Get l0 // { arity: 2, types: "(integer, integer?)" }
   With Mutually Recursive
     cte l0 =
       Distinct project=[#0, #1] // { arity: 2, types: "(integer, integer?)" }
@@ -690,6 +686,10 @@ Explained Query:
           ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
           Filter (#1) IS NOT NULL // { arity: 2, types: "(integer, integer)" }
             Get l0 // { arity: 2, types: "(integer, integer?)" }
+  Return // { arity: 4, types: "(integer, integer?, boolean, boolean)" }
+    Project (#0, #1, #3, #2) // { arity: 4, types: "(integer, integer?, boolean, boolean)" }
+      Map ((#1) IS NULL, true) // { arity: 4, types: "(integer, integer?, boolean, boolean)" }
+        Get l0 // { arity: 2, types: "(integer, integer?)" }
 
 Source materialize.public.t1
 
@@ -714,9 +714,15 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0;
 ----
 Explained Query:
-  Return // { arity: 3, types: "(integer, integer, integer?)" }
-    Get l1 // { arity: 3, types: "(integer, integer, integer?)" }
   With Mutually Recursive
+    cte l0 =
+      Map (1) // { arity: 1, types: "(integer)" }
+        Distinct project=[] monotonic // { arity: 0, types: "()" }
+          Union // { arity: 0, types: "()" }
+            Project () // { arity: 0, types: "()" }
+              Get l0 // { arity: 1, types: "(integer)" }
+            Constant // { arity: 0, types: "()" }
+              - ()
     cte l1 =
       Project (#2, #0, #1) // { arity: 3, types: "(integer, integer, integer?)" }
         Map (2) // { arity: 3, types: "(integer, integer?, integer)" }
@@ -730,14 +736,8 @@ Explained Query:
                   ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
               Project (#1, #2) // { arity: 2, types: "(integer, integer?)" }
                 Get l1 // { arity: 3, types: "(integer, integer, integer?)" }
-    cte l0 =
-      Map (1) // { arity: 1, types: "(integer)" }
-        Distinct project=[] monotonic // { arity: 0, types: "()" }
-          Union // { arity: 0, types: "()" }
-            Project () // { arity: 0, types: "()" }
-              Get l0 // { arity: 1, types: "(integer)" }
-            Constant // { arity: 0, types: "()" }
-              - ()
+  Return // { arity: 3, types: "(integer, integer, integer?)" }
+    Get l1 // { arity: 3, types: "(integer, integer, integer?)" }
 
 Source materialize.public.t1
 
@@ -767,9 +767,15 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0;
 ----
 Explained Query:
-  Return // { arity: 3, types: "(boolean, integer, integer?)" }
-    Get l1 // { arity: 3, types: "(boolean, integer, integer?)" }
   With Mutually Recursive
+    cte l0 =
+      Map (1) // { arity: 1, types: "(integer)" }
+        Distinct project=[] monotonic // { arity: 0, types: "()" }
+          Union // { arity: 0, types: "()" }
+            Project () // { arity: 0, types: "()" }
+              Get l0 // { arity: 1, types: "(integer)" }
+            Constant // { arity: 0, types: "()" }
+              - ()
     cte l1 =
       Project (#2, #0, #1) // { arity: 3, types: "(boolean, integer, integer?)" }
         Map (false) // { arity: 3, types: "(integer, integer?, boolean)" }
@@ -783,14 +789,8 @@ Explained Query:
                   ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
               Project (#1, #2) // { arity: 2, types: "(integer, integer?)" }
                 Get l1 // { arity: 3, types: "(boolean, integer, integer?)" }
-    cte l0 =
-      Map (1) // { arity: 1, types: "(integer)" }
-        Distinct project=[] monotonic // { arity: 0, types: "()" }
-          Union // { arity: 0, types: "()" }
-            Project () // { arity: 0, types: "()" }
-              Get l0 // { arity: 1, types: "(integer)" }
-            Constant // { arity: 0, types: "()" }
-              - ()
+  Return // { arity: 3, types: "(boolean, integer, integer?)" }
+    Get l1 // { arity: 3, types: "(boolean, integer, integer?)" }
 
 Source materialize.public.t1
 

--- a/test/sqllogictest/transform/demand.slt
+++ b/test/sqllogictest/transform/demand.slt
@@ -89,6 +89,13 @@ limit coalesce(43, 120);
 ----
 Explained Query:
   Finish limit=43 output=[#0..=#3]
+    With
+      cte l0 =
+        Distinct project=[] // { arity: 0 }
+          TopK limit=13 // { arity: 0 }
+            Filter error("timestamp out of range") // { arity: 0 }
+              Project () // { arity: 0 }
+                ReadIndex on=mz_columns mz_columns_ind=[*** full scan ***] // { arity: 8 }
     Return // { arity: 4 }
       Map (833564499, null, null, 2024-12-18 12:54:29.994 UTC) // { arity: 4 }
         TopK limit=90 // { arity: 0 }
@@ -98,13 +105,6 @@ Explained Query:
               Get l0 // { arity: 0 }
             Constant // { arity: 0 }
               - ()
-    With
-      cte l0 =
-        Distinct project=[] // { arity: 0 }
-          TopK limit=13 // { arity: 0 }
-            Filter error("timestamp out of range") // { arity: 0 }
-              Project () // { arity: 0 }
-                ReadIndex on=mz_columns mz_columns_ind=[*** full scan ***] // { arity: 8 }
 
 Used Indexes:
   - mz_catalog.mz_columns_ind (*** full scan ***)
@@ -136,9 +136,14 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c2;
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Get l1 // { arity: 2 }
   With Mutually Recursive
+    cte l0 =
+      Distinct project=[#0, #1] // { arity: 2 }
+        Union // { arity: 2 }
+          Get l1 // { arity: 2 }
+          Project (#0, #0) // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 1 }
+              ReadStorage materialize.public.t // { arity: 1 }
     cte l1 =
       Project (#4, #5) // { arity: 2 }
         Map ((#0 + #0), (#1 + #3)) // { arity: 6 }
@@ -151,13 +156,8 @@ Explained Query:
               Project (#2, #3) // { arity: 2 }
                 Map ((#0 + 1), -(#1)) // { arity: 4 }
                   Get l0 // { arity: 2 }
-    cte l0 =
-      Distinct project=[#0, #1] // { arity: 2 }
-        Union // { arity: 2 }
-          Get l1 // { arity: 2 }
-          Project (#0, #0) // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 1 }
-              ReadStorage materialize.public.t // { arity: 1 }
+  Return // { arity: 2 }
+    Get l1 // { arity: 2 }
 
 Source materialize.public.t
   filter=((#0) IS NOT NULL)

--- a/test/sqllogictest/transform/fold_constants.slt
+++ b/test/sqllogictest/transform/fold_constants.slt
@@ -25,6 +25,11 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT count(*) FROM billion;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[count(*)] monotonic // { arity: 1 }
+        Constant // { arity: 0 }
+          - (() x 1000000000)
   Return // { arity: 1 }
     Union // { arity: 1 }
       Get l0 // { arity: 1 }
@@ -35,11 +40,6 @@ Explained Query:
               Get l0 // { arity: 1 }
           Constant // { arity: 0 }
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[count(*)] monotonic // { arity: 1 }
-        Constant // { arity: 0 }
-          - (() x 1000000000)
 
 Target cluster: quickstart
 
@@ -94,8 +94,6 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Get l0 // { arity: 2 }
   With Mutually Recursive
     cte l0 =
       Distinct project=[#0, #1] monotonic // { arity: 2 }
@@ -108,6 +106,8 @@ Explained Query:
             - (52, 54)
             - (62, 64)
             - (66, 68)
+  Return // { arity: 2 }
+    Get l0 // { arity: 2 }
 
 Target cluster: quickstart
 
@@ -130,8 +130,6 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Get l0 // { arity: 1 }
   With Mutually Recursive
     cte l0 =
       Distinct project=[#0] // { arity: 1 }
@@ -139,6 +137,8 @@ Explained Query:
           Project (#1) // { arity: 1 }
             ReadStorage materialize.public.edges // { arity: 2 }
           Get l0 // { arity: 1 }
+  Return // { arity: 1 }
+    Get l0 // { arity: 1 }
 
 Source materialize.public.edges
 

--- a/test/sqllogictest/transform/fold_vs_dataflow/3_number_aggfns_dataflow.slt
+++ b/test/sqllogictest/transform/fold_vs_dataflow/3_number_aggfns_dataflow.slt
@@ -53,6 +53,18 @@ SELECT
 FROM t_using_dataflow_rendering;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0..=#2)
+        ReadStorage materialize.public.t_using_dataflow_rendering
+    cte l1 =
+      CrossJoin type=differential
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[min(#0), min(#1), min(#2), min((#0 + #0)), min((#1 + #1)), min((#2 + #2)), max(#0), max(#1), max(#2), max((#0 + #0)), max((#1 + #1)), max((#2 + #2))]
+            Get l0
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[sum(#0), sum(#1), sum(#2), sum((#0 + #0)), sum((#1 + #1)), sum((#2 + #2)), count(#0), count(#1), count(#2), count((#0 + #0)), count((#1 + #1)), count((#2 + #2))]
+            Get l0
   Return
     Project (#0..=#17, #24..=#29)
       Map ((#0 / bigint_to_real(case when (#18 = 0) then null else #18 end)), (#1 / bigint_to_double(case when (#19 = 0) then null else #19 end)), (#2 / bigint_to_numeric(case when (#20 = 0) then null else #20 end)), (#3 / bigint_to_real(case when (#21 = 0) then null else #21 end)), (#4 / bigint_to_double(case when (#22 = 0) then null else #22 end)), (#5 / bigint_to_numeric(case when (#23 = 0) then null else #23 end)))
@@ -66,18 +78,6 @@ Explained Query:
                   Get l1
               Constant
                 - ()
-  With
-    cte l1 =
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Reduce aggregates=[min(#0), min(#1), min(#2), min((#0 + #0)), min((#1 + #1)), min((#2 + #2)), max(#0), max(#1), max(#2), max((#0 + #0)), max((#1 + #1)), max((#2 + #2))]
-            Get l0
-        ArrangeBy keys=[[]]
-          Reduce aggregates=[sum(#0), sum(#1), sum(#2), sum((#0 + #0)), sum((#1 + #1)), sum((#2 + #2)), count(#0), count(#1), count(#2), count((#0 + #0)), count((#1 + #1)), count((#2 + #2))]
-            Get l0
-    cte l0 =
-      Project (#0..=#2)
-        ReadStorage materialize.public.t_using_dataflow_rendering
 
 Source materialize.public.t_using_dataflow_rendering
 
@@ -97,6 +97,11 @@ SELECT
 FROM t_using_dataflow_rendering;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[sum((#0 * #0)), sum(#0), count(#0)]
+        Project (#0)
+          ReadStorage materialize.public.t_using_dataflow_rendering
   Return
     Project (#3)
       Map (sqrtf64(real_to_double(case when ((#0) IS NULL OR (#1) IS NULL OR (case when (#2 = 0) then null else #2 end) IS NULL OR (case when (0 = (#2 - 1)) then null else (#2 - 1) end) IS NULL) then null else greatest(((#0 - ((#1 * #1) / bigint_to_real(case when (#2 = 0) then null else #2 end))) / bigint_to_real(case when (0 = (#2 - 1)) then null else (#2 - 1) end)), 0) end)))
@@ -109,11 +114,6 @@ Explained Query:
                   Get l0
               Constant
                 - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum((#0 * #0)), sum(#0), count(#0)]
-        Project (#0)
-          ReadStorage materialize.public.t_using_dataflow_rendering
 
 Source materialize.public.t_using_dataflow_rendering
 

--- a/test/sqllogictest/transform/fold_vs_dataflow/5_repeat_row_dataflow.slt
+++ b/test/sqllogictest/transform/fold_vs_dataflow/5_repeat_row_dataflow.slt
@@ -45,6 +45,10 @@ EXPLAIN SELECT SUM(data)
 FROM mv_using_dataflow_rendering;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[sum(#0)]
+        ReadStorage materialize.public.mv_using_dataflow_rendering
   Return
     Union
       Get l0
@@ -55,10 +59,6 @@ Explained Query:
               Get l0
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum(#0)]
-        ReadStorage materialize.public.mv_using_dataflow_rendering
 
 Source materialize.public.mv_using_dataflow_rendering
 

--- a/test/sqllogictest/transform/is_null_propagation.slt
+++ b/test/sqllogictest/transform/is_null_propagation.slt
@@ -53,26 +53,13 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT FROM t1 WHERE f2 IN ( SELECT agg1 FROM ( SELECT COUNT ( TRUE ) agg1 FROM t2 a1 JOIN ( SELECT a2.f2 FROM t1 LEFT JOIN t1 a2 ON TRUE ) a2 ON TRUE WHERE  a2.f2 IS NOT NULL AND a2.f2 > a1.f2 ) )
 ----
 Explained Query:
-  Return // { arity: 0 }
-    Project () // { arity: 0 }
-      Join on=(#0 = #1) type=differential // { arity: 2 }
-        implementation
-          %1[#0]UKA » %0:l0[#0]K
-        ArrangeBy keys=[[#0]] // { arity: 1 }
-          Get l0 // { arity: 1 }
-        ArrangeBy keys=[[#0]] // { arity: 1 }
-          Distinct project=[#0] // { arity: 1 }
-            Union // { arity: 1 }
-              Project (#0) // { arity: 1 }
-                Filter (#0 = bigint_to_double(#1)) // { arity: 2 }
-                  Get l2 // { arity: 2 }
-              Negate // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Filter (#0 = 0) // { arity: 2 }
-                    Get l2 // { arity: 2 }
-              Filter (#0 = 0) // { arity: 1 }
-                Get l1 // { arity: 1 }
   With
+    cte l0 =
+      Project (#1) // { arity: 1 }
+        ReadStorage materialize.public.t1 // { arity: 2 }
+    cte l1 =
+      Distinct project=[#0] // { arity: 1 }
+        Get l0 // { arity: 1 }
     cte l2 =
       Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#0) // { arity: 1 }
@@ -93,12 +80,25 @@ Explained Query:
                   ReadStorage materialize.public.t1 // { arity: 2 }
               ArrangeBy keys=[[]] // { arity: 1 }
                 Get l0 // { arity: 1 }
-    cte l1 =
-      Distinct project=[#0] // { arity: 1 }
-        Get l0 // { arity: 1 }
-    cte l0 =
-      Project (#1) // { arity: 1 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
+  Return // { arity: 0 }
+    Project () // { arity: 0 }
+      Join on=(#0 = #1) type=differential // { arity: 2 }
+        implementation
+          %1[#0]UKA » %0:l0[#0]K
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Get l0 // { arity: 1 }
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Distinct project=[#0] // { arity: 1 }
+            Union // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Filter (#0 = bigint_to_double(#1)) // { arity: 2 }
+                  Get l2 // { arity: 2 }
+              Negate // { arity: 1 }
+                Project (#0) // { arity: 1 }
+                  Filter (#0 = 0) // { arity: 2 }
+                    Get l2 // { arity: 2 }
+              Filter (#0 = 0) // { arity: 1 }
+                Get l1 // { arity: 1 }
 
 Source materialize.public.t1
 Source materialize.public.t2

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -149,17 +149,9 @@ EXPLAIN WITH(arity, join implementations) SELECT  MIN( o_orderkey  )
   AND o_orderkey  = (  SELECT l_orderkey  FROM lineitem  WHERE l_orderkey  =  38  )
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l1 // { arity: 1 }
-      Map (null) // { arity: 1 }
-        Union // { arity: 0 }
-          Negate // { arity: 0 }
-            Project () // { arity: 0 }
-              Get l1 // { arity: 1 }
-          Constant // { arity: 0 }
-            - ()
   With
+    cte l0 =
+      ReadIndex on=materialize.public.lineitem fk_lineitem_orderkey=[lookup value=(38)] // { arity: 9 }
     cte l1 =
       Reduce aggregates=[min(#0)] // { arity: 1 }
         Project (#1) // { arity: 1 }
@@ -186,8 +178,16 @@ Explained Query:
                       Reduce aggregates=[count(*)] // { arity: 1 }
                         Project () // { arity: 0 }
                           Get l0 // { arity: 9 }
-    cte l0 =
-      ReadIndex on=materialize.public.lineitem fk_lineitem_orderkey=[lookup value=(38)] // { arity: 9 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l1 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l1 // { arity: 1 }
+          Constant // { arity: 0 }
+            - ()
 
 Used Indexes:
   - materialize.public.pk_orders_orderkey (*** full scan ***)
@@ -206,6 +206,11 @@ EXPLAIN WITH(arity, join implementations) SELECT l_partkey AS col24843 , l_order
   AND l_extendedprice = MOD (o_totalprice , 5 ) ;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Constant // { arity: 1 }
+          - (134)
   Return // { arity: 3 }
     Project (#1, #0, #1) // { arity: 3 }
       Join on=(#2 = #4 AND #3 = #5) type=delta // { arity: 6 }
@@ -224,11 +229,6 @@ Explained Query:
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             ReadIndex on=materialize.public.customer pk_customer_custkey=[lookup values=<Get l0>] // { arity: 4 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Constant // { arity: 1 }
-          - (134)
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (lookup)
@@ -248,6 +248,11 @@ EXPLAIN WITH(arity, join implementations) SELECT *
   AND l_shipDATE = o_orderdate;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Constant // { arity: 1 }
+          - (229)
   Return // { arity: 15 }
     Project (#0..=#9, #4, #5, #12..=#14) // { arity: 15 }
       Join on=(#4 = #10 AND #5 = #11) type=delta // { arity: 15 }
@@ -264,11 +269,6 @@ Explained Query:
         ArrangeBy keys=[[]] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
             ReadIndex on=materialize.public.customer pk_customer_custkey=[lookup values=<Get l0>] // { arity: 4 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Constant // { arity: 1 }
-          - (229)
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (lookup)

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -739,6 +739,9 @@ UNION ALL
 (SELECT * FROM t);
 ----
 Explained Query:
+  With
+    cte l0 =
+      ReadIndex on=materialize.public.big big_idx_a=[lookup value=(5)] // { arity: 15 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       CrossJoin type=delta // { arity: 1 }
@@ -757,9 +760,6 @@ Explained Query:
             Get l0 // { arity: 15 }
       Project (#0) // { arity: 1 }
         Get l0 // { arity: 15 }
-  With
-    cte l0 =
-      ReadIndex on=materialize.public.big big_idx_a=[lookup value=(5)] // { arity: 15 }
 
 Used Indexes:
   - materialize.public.big_idx_a (*** full scan ***, lookup)

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -123,6 +123,11 @@ EXPLAIN WITH(arity, join implementations) SELECT count(*) FROM t1
 WHERE a = 2 AND b = 'l2' OR a = 1 + 1 + 1 AND b = 'l3'
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[count(*)] // { arity: 1 }
+        Project () // { arity: 0 }
+          ReadIndex on=materialize.public.t1 idx_t1_a_b=[lookup values=[(2, "l2"); (3, "l3")]] // { arity: 4 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       Get l0 // { arity: 1 }
@@ -133,11 +138,6 @@ Explained Query:
               Get l0 // { arity: 1 }
           Constant // { arity: 0 }
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[count(*)] // { arity: 1 }
-        Project () // { arity: 0 }
-          ReadIndex on=materialize.public.t1 idx_t1_a_b=[lookup values=[(2, "l2"); (3, "l3")]] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.idx_t1_a_b (lookup)
@@ -757,6 +757,10 @@ WHERE
     t1.b IN ('l2', 'l3')
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 3 }
+        ReadIndex on=t2 idx_t2_a=[delta join lookup] // { arity: 3 }
   Return // { arity: 3 }
     Project (#0, #1, #5) // { arity: 3 }
       Filter (#0) IS NOT NULL // { arity: 9 }
@@ -769,10 +773,6 @@ Explained Query:
             ReadIndex on=materialize.public.t1 idx_t1_b=[lookup values=[("l2"); ("l3")]] // { arity: 3 }
           Get l0 // { arity: 3 }
           Get l0 // { arity: 3 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 3 }
-        ReadIndex on=t2 idx_t2_a=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.idx_t2_a (delta join lookup)
@@ -1260,6 +1260,11 @@ SELECT sum(a*b*c*d) FROM t4
 WHERE (a,b,c) IN ((15, 16, 17), (25, 26, 111), (35, 36, 111));
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[sum((((#0 * #1) * #2) * #3))] // { arity: 1, types: "(bigint?)", keys: "([])" }
+        Project (#0..=#3) // { arity: 4, types: "(integer, integer, integer, integer?)", keys: "([1], [2])" }
+          ReadIndex on=materialize.public.t4 idx_t4_a_b_c=[lookup values=[(15, 16, 17); (25, 26, 111); (35, 36, 111)]] // { arity: 7, types: "(integer, integer, integer, integer?, integer, integer, integer)", keys: "([1], [2])" }
   Return // { arity: 1, types: "(bigint?)", keys: "([])" }
     Union // { arity: 1, types: "(bigint?)", keys: "([])" }
       Get l0 // { arity: 1, types: "(bigint?)", keys: "([])" }
@@ -1270,11 +1275,6 @@ Explained Query:
               Get l0 // { arity: 1, types: "(bigint?)", keys: "([])" }
           Constant // { arity: 0, types: "()", keys: "([])" }
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum((((#0 * #1) * #2) * #3))] // { arity: 1, types: "(bigint?)", keys: "([])" }
-        Project (#0..=#3) // { arity: 4, types: "(integer, integer, integer, integer?)", keys: "([1], [2])" }
-          ReadIndex on=materialize.public.t4 idx_t4_a_b_c=[lookup values=[(15, 16, 17); (25, 26, 111); (35, 36, 111)]] // { arity: 7, types: "(integer, integer, integer, integer?, integer, integer, integer)", keys: "([1], [2])" }
 
 Used Indexes:
   - materialize.public.idx_t4_a_b_c (lookup)
@@ -1326,8 +1326,6 @@ WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT = 3)
 SELECT * FROM c0;
 ----
 Explained Query:
-  Return
-    Get l0
   With Mutually Recursive [recursion_limit=3, return_at_limit]
     cte l0 =
       Distinct project=[#0]
@@ -1341,6 +1339,8 @@ Explained Query:
                     ReadIndex on=materialize.public.t5 idx_t5_f1=[lookup values=[(0); (2); (8)]]
                 ArrangeBy keys=[[]]
                   Get l0
+  Return
+    Get l0
 
 Used Indexes:
   - materialize.public.idx_t5_f1 (*** full scan ***, lookup)

--- a/test/sqllogictest/transform/literal_lifting.slt
+++ b/test/sqllogictest/transform/literal_lifting.slt
@@ -746,6 +746,11 @@ query T multiline
 explain with(arity, join implementations) select min(1/x) from (select a as y, 0 as x from t);
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[] // { arity: 0 }
+        Project () // { arity: 0 }
+          ReadStorage materialize.public.t // { arity: 2 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       Map (error("division by zero")) // { arity: 1 }
@@ -756,11 +761,6 @@ Explained Query:
             Get l0 // { arity: 0 }
           Constant // { arity: 0 }
             - ()
-  With
-    cte l0 =
-      Distinct project=[] // { arity: 0 }
-        Project () // { arity: 0 }
-          ReadStorage materialize.public.t // { arity: 2 }
 
 Source materialize.public.t
 
@@ -772,6 +772,11 @@ query T multiline
 explain with(arity, join implementations) select sum(1/x) from (select a as y, 0 as x from t);
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[] // { arity: 0 }
+        Project () // { arity: 0 }
+          ReadStorage materialize.public.t // { arity: 2 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       Map (error("division by zero")) // { arity: 1 }
@@ -782,11 +787,6 @@ Explained Query:
             Get l0 // { arity: 0 }
           Constant // { arity: 0 }
             - ()
-  With
-    cte l0 =
-      Distinct project=[] // { arity: 0 }
-        Project () // { arity: 0 }
-          ReadStorage materialize.public.t // { arity: 2 }
 
 Source materialize.public.t
 
@@ -798,16 +798,6 @@ query T multiline
 explain with(arity, join implementations) select min(a) from t_pk where a between 38 and 195 and a = (select a from t where a = 1308);
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l0 // { arity: 1 }
-      Map (null) // { arity: 1 }
-        Union // { arity: 0 }
-          Negate // { arity: 0 }
-            Project () // { arity: 0 }
-              Get l0 // { arity: 1 }
-          Constant // { arity: 0 }
-            - ()
   With
     cte l0 =
       Reduce aggregates=[min(#0)] // { arity: 1 }
@@ -827,6 +817,16 @@ Explained Query:
                       Project () // { arity: 0 }
                         Filter (#0 = 1308) // { arity: 2 }
                           ReadStorage materialize.public.t // { arity: 2 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l0 // { arity: 1 }
+          Constant // { arity: 0 }
+            - ()
 
 Source materialize.public.t
   filter=((#0 = 1308))
@@ -841,16 +841,6 @@ query T multiline
 explain with(arity, join implementations) select min(a) from t where a between 38 and 195 and a = (select a from t where a = 1308);
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l0 // { arity: 1 }
-      Map (null) // { arity: 1 }
-        Union // { arity: 0 }
-          Negate // { arity: 0 }
-            Project () // { arity: 0 }
-              Get l0 // { arity: 1 }
-          Constant // { arity: 0 }
-            - ()
   With
     cte l0 =
       Reduce aggregates=[min(#0)] // { arity: 1 }
@@ -870,6 +860,16 @@ Explained Query:
                       Project () // { arity: 0 }
                         Filter (#0 = 1308) // { arity: 2 }
                           ReadStorage materialize.public.t // { arity: 2 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l0 // { arity: 1 }
+          Constant // { arity: 0 }
+            - ()
 
 Source materialize.public.t
 
@@ -975,8 +975,6 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Get l0 // { arity: 2 }
   With Mutually Recursive
     cte l0 =
       Map (42) // { arity: 2 }
@@ -988,6 +986,8 @@ Explained Query:
               ReadStorage materialize.public.t1 // { arity: 2 }
             Project (#1) // { arity: 1 }
               ReadStorage materialize.public.t1 // { arity: 2 }
+  Return // { arity: 2 }
+    Get l0 // { arity: 2 }
 
 Source materialize.public.t1
 
@@ -1012,19 +1012,7 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0 UNION ALL SELECT * FROM c1
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Union // { arity: 2 }
-      Map (42) // { arity: 2 }
-        Get l0 // { arity: 1 }
-      Get l1 // { arity: 2 }
   With Mutually Recursive
-    cte l1 =
-      Map (42) // { arity: 2 }
-        Distinct project=[#0] // { arity: 1 }
-          Union // { arity: 1 }
-            Get l0 // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Get l1 // { arity: 2 }
     cte l0 =
       Distinct project=[#0] // { arity: 1 }
         Union // { arity: 1 }
@@ -1032,6 +1020,18 @@ Explained Query:
             ReadStorage materialize.public.t1 // { arity: 2 }
           Project (#1) // { arity: 1 }
             ReadStorage materialize.public.t1 // { arity: 2 }
+    cte l1 =
+      Map (42) // { arity: 2 }
+        Distinct project=[#0] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l0 // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Get l1 // { arity: 2 }
+  Return // { arity: 2 }
+    Union // { arity: 2 }
+      Map (42) // { arity: 2 }
+        Get l0 // { arity: 1 }
+      Get l1 // { arity: 2 }
 
 Source materialize.public.t1
 

--- a/test/sqllogictest/transform/monotonic.slt
+++ b/test/sqllogictest/transform/monotonic.slt
@@ -93,23 +93,7 @@ WITH MUTUALLY RECURSIVE
 SELECT x, MAX(y) FROM (SELECT * FROM c1 UNION SELECT * FROM c2) GROUP BY x
 ----
 Explained Query:
-  Return
-    Reduce group_by=[#0] aggregates=[max(#1)] monotonic
-      Distinct project=[#0, #1] monotonic
-        Union
-          Get l0
-          Get l1
   With Mutually Recursive
-    cte l1 =
-      Union
-        Distinct project=[#0, (#0 + 1)] monotonic
-          Project (#0)
-            Filter (#0 >= 1)
-              Get l0
-        Constant
-          - (1, 2)
-          - (3, 4)
-          - (5, 6)
     cte l0 =
       Union
         Distinct project=[#0, (#0 - 1)] monotonic
@@ -120,6 +104,22 @@ Explained Query:
           - (1, 2)
           - (3, 4)
           - (5, 6)
+    cte l1 =
+      Union
+        Distinct project=[#0, (#0 + 1)] monotonic
+          Project (#0)
+            Filter (#0 >= 1)
+              Get l0
+        Constant
+          - (1, 2)
+          - (3, 4)
+          - (5, 6)
+  Return
+    Reduce group_by=[#0] aggregates=[max(#1)] monotonic
+      Distinct project=[#0, #1] monotonic
+        Union
+          Get l0
+          Get l1
 
 Target cluster: quickstart
 
@@ -146,13 +146,17 @@ WITH MUTUALLY RECURSIVE
 SELECT x, MAX(y) FROM (SELECT * FROM c1 UNION SELECT * FROM c2) GROUP BY x
 ----
 Explained Query:
-  Return
-    Reduce group_by=[#0] aggregates=[max(#1)]
-      Distinct project=[#0, #1]
-        Union
-          Get l0
-          Get l1
   With Mutually Recursive
+    cte l0 =
+      Union
+        Distinct project=[#0, (#0 - 1)]
+          Project (#1)
+            Filter (#0 < 1)
+              Get l1
+        Constant
+          - (1, 2)
+          - (3, 4)
+          - (5, 6)
     cte l1 =
       TopK limit=2
         Union
@@ -164,16 +168,12 @@ Explained Query:
             - (1, 2)
             - (3, 4)
             - (5, 6)
-    cte l0 =
-      Union
-        Distinct project=[#0, (#0 - 1)]
-          Project (#1)
-            Filter (#0 < 1)
-              Get l1
-        Constant
-          - (1, 2)
-          - (3, 4)
-          - (5, 6)
+  Return
+    Reduce group_by=[#0] aggregates=[max(#1)]
+      Distinct project=[#0, #1]
+        Union
+          Get l0
+          Get l1
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -17,8 +17,6 @@ EXPLAIN WITH MUTUALLY RECURSIVE
 SELECT * FROM bar;
 ----
 Explained Query:
-  Return
-    Get l0
   With Mutually Recursive
     cte l0 =
       Project (#1)
@@ -30,6 +28,8 @@ Explained Query:
                   Get l0
               Constant
                 - (2)
+  Return
+    Get l0
 
 Target cluster: mz_catalog_server
 
@@ -100,8 +100,6 @@ SELECT * FROM
 );
 ----
 Explained Query:
-  Return
-    Get l0
   With Mutually Recursive
     cte l0 =
       Reduce group_by=[#0]
@@ -111,6 +109,8 @@ Explained Query:
           Project (#1)
             Map ((#0 + 1))
               Get l0
+  Return
+    Get l0
 
 Source materialize.public.t1
   filter=((#0 < 27))
@@ -196,11 +196,21 @@ SELECT round, COUNT(*) FROM (
 GROUP BY round;
 ----
 Explained Query:
+  With Mutually Recursive
+    cte l0 =
+      Reduce group_by=[#0] aggregates=[min(#1)]
+        Union
+          Project (#1, #1)
+            ReadStorage materialize.public.edges
+          Project (#1, #3)
+            Join on=(#0 = #2) type=differential
+              ArrangeBy keys=[[#0]]
+                Filter (#0) IS NOT NULL
+                  ReadStorage materialize.public.edges
+              ArrangeBy keys=[[#0]]
+                Filter (#0) IS NOT NULL
+                  Get l0
   Return
-    Return
-      Reduce group_by=[#0] aggregates=[count(*)]
-        Project (#2)
-          Get l1
     With Mutually Recursive
       cte l1 =
         TopK group_by=[#0] order_by=[#1 asc nulls_last] limit=1
@@ -216,20 +226,10 @@ Explained Query:
                   ArrangeBy keys=[[#0]]
                     Filter (#0) IS NOT NULL
                       Get l1
-  With Mutually Recursive
-    cte l0 =
-      Reduce group_by=[#0] aggregates=[min(#1)]
-        Union
-          Project (#1, #1)
-            ReadStorage materialize.public.edges
-          Project (#1, #3)
-            Join on=(#0 = #2) type=differential
-              ArrangeBy keys=[[#0]]
-                Filter (#0) IS NOT NULL
-                  ReadStorage materialize.public.edges
-              ArrangeBy keys=[[#0]]
-                Filter (#0) IS NOT NULL
-                  Get l0
+    Return
+      Reduce group_by=[#0] aggregates=[count(*)]
+        Project (#2)
+          Get l1
 
 Source materialize.public.edges
 
@@ -250,8 +250,6 @@ EXPLAIN WITH MUTUALLY RECURSIVE (RECURSION LIMIT 10)
 SELECT * FROM cnt;
 ----
 Explained Query:
-  Return
-    Get l0
   With Mutually Recursive [recursion_limit=10]
     cte l0 =
       Distinct project=[#0] monotonic
@@ -261,6 +259,8 @@ Explained Query:
               Get l0
           Constant
             - (1)
+  Return
+    Get l0
 
 Target cluster: mz_catalog_server
 
@@ -277,8 +277,6 @@ EXPLAIN WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 10)
 SELECT * FROM cnt;
 ----
 Explained Query:
-  Return
-    Get l0
   With Mutually Recursive [recursion_limit=10, return_at_limit]
     cte l0 =
       Distinct project=[#0] monotonic
@@ -288,6 +286,8 @@ Explained Query:
               Get l0
           Constant
             - (1)
+  Return
+    Get l0
 
 Target cluster: mz_catalog_server
 
@@ -304,8 +304,6 @@ EXPLAIN WITH MUTUALLY RECURSIVE (ERROR AT RECURSION LIMIT 10)
 SELECT * FROM cnt;
 ----
 Explained Query:
-  Return
-    Get l0
   With Mutually Recursive [recursion_limit=10]
     cte l0 =
       Distinct project=[#0] monotonic
@@ -315,6 +313,8 @@ Explained Query:
               Get l0
           Constant
             - (1)
+  Return
+    Get l0
 
 Target cluster: mz_catalog_server
 
@@ -441,11 +441,21 @@ SELECT round, COUNT(*) FROM (
 GROUP BY round;
 ----
 Explained Query:
+  With Mutually Recursive [recursion_limit=21]
+    cte l0 =
+      Reduce group_by=[#0] aggregates=[min(#1)]
+        Union
+          Project (#1, #1)
+            ReadStorage materialize.public.edges
+          Project (#1, #3)
+            Join on=(#0 = #2) type=differential
+              ArrangeBy keys=[[#0]]
+                Filter (#0) IS NOT NULL
+                  ReadStorage materialize.public.edges
+              ArrangeBy keys=[[#0]]
+                Filter (#0) IS NOT NULL
+                  Get l0
   Return
-    Return
-      Reduce group_by=[#0] aggregates=[count(*)]
-        Project (#2)
-          Get l1
     With Mutually Recursive [recursion_limit=23]
       cte l1 =
         TopK group_by=[#0] order_by=[#1 asc nulls_last] limit=1
@@ -461,20 +471,10 @@ Explained Query:
                   ArrangeBy keys=[[#0]]
                     Filter (#0) IS NOT NULL
                       Get l1
-  With Mutually Recursive [recursion_limit=21]
-    cte l0 =
-      Reduce group_by=[#0] aggregates=[min(#1)]
-        Union
-          Project (#1, #1)
-            ReadStorage materialize.public.edges
-          Project (#1, #3)
-            Join on=(#0 = #2) type=differential
-              ArrangeBy keys=[[#0]]
-                Filter (#0) IS NOT NULL
-                  ReadStorage materialize.public.edges
-              ArrangeBy keys=[[#0]]
-                Filter (#0) IS NOT NULL
-                  Get l0
+    Return
+      Reduce group_by=[#0] aggregates=[count(*)]
+        Project (#2)
+          Get l1
 
 Source materialize.public.edges
 

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -486,6 +486,10 @@ EXPLAIN OPTIMIZED PLAN AS TEXT FOR
 SELECT a FROM y as y, LATERAL(SELECT u FROM x WHERE y.a = x.a LIMIT 5) WHERE a IN (41, 42);
 ----
 Explained Query:
+  With
+    cte l0 =
+      Filter ((#0 = 41) OR (#0 = 42))
+        ReadStorage materialize.public.y
   Return
     Project (#0)
       Join on=(#0 = #1) type=differential
@@ -502,10 +506,6 @@ Explained Query:
                   Project (#0)
                     Filter ((#0 = 41) OR (#0 = 42))
                       ReadStorage materialize.public.x
-  With
-    cte l0 =
-      Filter ((#0 = 41) OR (#0 = 42))
-        ReadStorage materialize.public.y
 
 Source materialize.public.x
   filter=(((#0 = 41) OR (#0 = 42)))
@@ -596,18 +596,7 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c2;
 ----
 Explained Query:
-  Return
-    Get l2
   With Mutually Recursive
-    cte l2 =
-      Union
-        Get l0
-        Get l1
-        Get l1
-    cte l1 =
-      Project (#1)
-        Map ((#0 + #0))
-          Get l0
     cte l0 =
       Union
         Project (#0)
@@ -615,6 +604,17 @@ Explained Query:
             ReadStorage materialize.public.init
         Filter (#0 < 5)
           Get l2
+    cte l1 =
+      Project (#1)
+        Map ((#0 + #0))
+          Get l0
+    cte l2 =
+      Union
+        Get l0
+        Get l1
+        Get l1
+  Return
+    Get l2
 
 Source materialize.public.init
   filter=((#0 < 5))
@@ -646,24 +646,24 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c2;
 ----
 Explained Query:
-  Return
-    Get l2
   With Mutually Recursive
-    cte l2 =
-      Union
-        Get l0
-        Get l1
-        Get l1
-    cte l1 =
-      Project (#1)
-        Filter (#0 < 5)
-          Map ((#0 + #0))
-            Get l0
     cte l0 =
       Union
         Project (#0)
           ReadStorage materialize.public.init
         Get l2
+    cte l1 =
+      Project (#1)
+        Filter (#0 < 5)
+          Map ((#0 + #0))
+            Get l0
+    cte l2 =
+      Union
+        Get l0
+        Get l1
+        Get l1
+  Return
+    Get l2
 
 Source materialize.public.init
 
@@ -693,24 +693,24 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c2;
 ----
 Explained Query:
-  Return
-    Get l2
   With Mutually Recursive
+    cte l0 =
+      Union
+        Project (#0)
+          ReadStorage materialize.public.init
+        Get l2
+    cte l1 =
+      Project (#1)
+        Map ((#0 + #0))
+          Get l0
     cte l2 =
       Union
         Filter (#0 < 5)
           Get l0
         Get l1
         Get l1
-    cte l1 =
-      Project (#1)
-        Map ((#0 + #0))
-          Get l0
-    cte l0 =
-      Union
-        Project (#0)
-          ReadStorage materialize.public.init
-        Get l2
+  Return
+    Get l2
 
 Source materialize.public.init
 
@@ -743,28 +743,28 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM ((SELECT * FROM c2) UNION (SELECT * FROM c0));
 ----
 Explained Query:
-  Return
-    Distinct project=[#0]
-      Union
-        Get l2
-        Get l0
   With Mutually Recursive
+    cte l0 =
+      Union
+        Project (#0)
+          ReadStorage materialize.public.init
+        Get l2
+    cte l1 =
+      Project (#1)
+        Filter (#0 < 5)
+          Map ((#0 + #0))
+            Get l0
     cte l2 =
       Union
         Filter (#0 < 5)
           Get l0
         Get l1
         Get l1
-    cte l1 =
-      Project (#1)
-        Filter (#0 < 5)
-          Map ((#0 + #0))
-            Get l0
-    cte l0 =
+  Return
+    Distinct project=[#0]
       Union
-        Project (#0)
-          ReadStorage materialize.public.init
         Get l2
+        Get l0
 
 Source materialize.public.init
 
@@ -796,25 +796,25 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c2 WHERE n>7;
 ----
 Explained Query:
-  Return
-    Filter (#0 > 7)
-      Get l2
   With Mutually Recursive
-    cte l2 =
-      Union
-        Get l0
-        Get l1
-        Get l1
-    cte l1 =
-      Project (#1)
-        Map ((#0 + #0))
-          Get l0
     cte l0 =
       Union
         Project (#0)
           ReadStorage materialize.public.init
         Filter (#0 > 7)
           Get l2
+    cte l1 =
+      Project (#1)
+        Map ((#0 + #0))
+          Get l0
+    cte l2 =
+      Union
+        Get l0
+        Get l1
+        Get l1
+  Return
+    Filter (#0 > 7)
+      Get l2
 
 Source materialize.public.init
 
@@ -846,27 +846,27 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c1 WHERE n>7;
 ----
 Explained Query:
-  Return
-    Project (#1)
-      Filter (#1 > 7)
-        Map ((#0 + #0))
-          Get l0
   With Mutually Recursive
-    cte l2 =
-      Union
-        Get l0
-        Get l1
-        Get l1
-    cte l1 =
-      Project (#1)
-        Filter (#1 > 7)
-          Map ((#0 + #0))
-            Get l0
     cte l0 =
       Union
         Project (#0)
           ReadStorage materialize.public.init
         Get l2
+    cte l1 =
+      Project (#1)
+        Filter (#1 > 7)
+          Map ((#0 + #0))
+            Get l0
+    cte l2 =
+      Union
+        Get l0
+        Get l1
+        Get l1
+  Return
+    Project (#1)
+      Filter (#1 > 7)
+        Map ((#0 + #0))
+          Get l0
 
 Source materialize.public.init
 
@@ -898,26 +898,26 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c1;
 ----
 Explained Query:
-  Return
-    Project (#1)
-      Map ((#0 + #0))
-        Get l0
   With Mutually Recursive
-    cte l2 =
-      Union
-        Get l0
-        Get l1
-        Get l1
-    cte l1 =
-      Project (#1)
-        Map ((#0 + #0))
-          Get l0
     cte l0 =
       Union
         Project (#0)
           ReadStorage materialize.public.init
         Filter (#0 < 3)
           Get l2
+    cte l1 =
+      Project (#1)
+        Map ((#0 + #0))
+          Get l0
+    cte l2 =
+      Union
+        Get l0
+        Get l1
+        Get l1
+  Return
+    Project (#1)
+      Map ((#0 + #0))
+        Get l0
 
 Source materialize.public.init
 

--- a/test/sqllogictest/transform/projection_lifting.slt
+++ b/test/sqllogictest/transform/projection_lifting.slt
@@ -38,6 +38,10 @@ WHERE
   edge.src = apex.c;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+        ReadStorage materialize.public.edges
   Return
     Project (#1, #3, #0)
       Join on=(#0 = #5 AND #1 = #2 AND #3 = #4) type=differential
@@ -47,10 +51,6 @@ Explained Query:
           Get l0
         ArrangeBy keys=[[#0, #1]]
           Get l0
-  With
-    cte l0 =
-      Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-        ReadStorage materialize.public.edges
 
 Source materialize.public.edges
   filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
@@ -92,9 +92,10 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM triangle_cycles;
 ----
 Explained Query:
-  Return
-    Get l1
   With Mutually Recursive
+    cte l0 =
+      Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+        ReadStorage materialize.public.edges
     cte l1 =
       Distinct project=[#0..=#2]
         Union
@@ -108,9 +109,8 @@ Explained Query:
                 Get l0
           Project (#2, #0, #1)
             Get l1
-    cte l0 =
-      Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-        ReadStorage materialize.public.edges
+  Return
+    Get l1
 
 Source materialize.public.edges
   filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)

--- a/test/sqllogictest/transform/reduce_elision.slt
+++ b/test/sqllogictest/transform/reduce_elision.slt
@@ -74,8 +74,6 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0;
 ----
 Explained Query:
-  Return // { arity: 4, keys: "()" }
-    Get l0 // { arity: 4, keys: "()" }
   With Mutually Recursive
     cte l0 =
       Union // { arity: 4, keys: "()" }
@@ -90,6 +88,8 @@ Explained Query:
             ArrangeBy keys=[[#1]] // { arity: 2, keys: "([1])" }
               ReadStorage materialize.public.y // { arity: 2, keys: "([1])" }
         Get l0 // { arity: 4, keys: "()" }
+  Return // { arity: 4, keys: "()" }
+    Get l0 // { arity: 4, keys: "()" }
 
 Source materialize.public.x
   filter=((#1) IS NOT NULL)
@@ -117,8 +117,6 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0;
 ----
 Explained Query:
-  Return // { arity: 4, keys: "([0, 1, 2, 3])" }
-    Get l0 // { arity: 4, keys: "([0, 1, 2, 3])" }
   With Mutually Recursive
     cte l0 =
       Distinct project=[#0..=#3] // { arity: 4, keys: "([0, 1, 2, 3])" }
@@ -133,6 +131,8 @@ Explained Query:
               ArrangeBy keys=[[#1]] // { arity: 2, keys: "([1])" }
                 ReadStorage materialize.public.y // { arity: 2, keys: "([1])" }
           Get l0 // { arity: 4, keys: "([0, 1, 2, 3])" }
+  Return // { arity: 4, keys: "([0, 1, 2, 3])" }
+    Get l0 // { arity: 4, keys: "([0, 1, 2, 3])" }
 
 Source materialize.public.x
   filter=((#1) IS NOT NULL)

--- a/test/sqllogictest/transform/reduction_pushdown.slt
+++ b/test/sqllogictest/transform/reduction_pushdown.slt
@@ -60,8 +60,6 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0;
 ----
 Explained Query:
-  Return // { arity: 4 }
-    Get l0 // { arity: 4 }
   With Mutually Recursive
     cte l0 =
       Union // { arity: 4 }
@@ -78,6 +76,8 @@ Explained Query:
                 Filter (#1) IS NOT NULL // { arity: 2 }
                   ReadStorage materialize.public.y // { arity: 2 }
         Get l0 // { arity: 4 }
+  Return // { arity: 4 }
+    Get l0 // { arity: 4 }
 
 Source materialize.public.x
   filter=((#1) IS NOT NULL)

--- a/test/sqllogictest/transform/redundant_join.slt
+++ b/test/sqllogictest/transform/redundant_join.slt
@@ -67,8 +67,6 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0;
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Get l0 // { arity: 3 }
   With Mutually Recursive
     cte l0 =
       Distinct project=[#0..=#2] // { arity: 3 }
@@ -76,6 +74,8 @@ Explained Query:
           Get l0 // { arity: 3 }
           Map ((#0 % 2)) // { arity: 3 }
             ReadStorage materialize.public.t2 // { arity: 2 }
+  Return // { arity: 3 }
+    Get l0 // { arity: 3 }
 
 Source materialize.public.t2
 
@@ -98,8 +98,6 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0;
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Get l0 // { arity: 3 }
   With Mutually Recursive
     cte l0 =
       Distinct project=[#0..=#2] // { arity: 3 }
@@ -108,6 +106,8 @@ Explained Query:
           Filter (#0) IS NOT NULL // { arity: 3 }
             Map ((#0 % 2)) // { arity: 3 }
               ReadStorage materialize.public.t1 // { arity: 2 }
+  Return // { arity: 3 }
+    Get l0 // { arity: 3 }
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
@@ -140,14 +140,11 @@ SELECT * FROM (
 );
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Project (#2) // { arity: 1 }
-        Get l1 // { arity: 3 }
-      Project (#1) // { arity: 1 }
-        Map (42) // { arity: 2 }
-          Get l0 // { arity: 1 }
   With Mutually Recursive
+    cte l0 =
+      Distinct project=[(#0 % 2)] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          ReadStorage materialize.public.t2 // { arity: 2 }
     cte l1 =
       Distinct project=[#0..=#2] // { arity: 3 }
         Union // { arity: 3 }
@@ -161,10 +158,13 @@ Explained Query:
               ReadStorage materialize.public.t2 // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Get l0 // { arity: 1 }
-    cte l0 =
-      Distinct project=[(#0 % 2)] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          ReadStorage materialize.public.t2 // { arity: 2 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Project (#2) // { arity: 1 }
+        Get l1 // { arity: 3 }
+      Project (#1) // { arity: 1 }
+        Map (42) // { arity: 2 }
+          Get l0 // { arity: 1 }
 
 Source materialize.public.t2
 

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -30,16 +30,16 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 AS a1 , t1 AS a2;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[]] // { arity: 2 }
+        ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
         %0:l0[×] » %1:l0[×]
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[]] // { arity: 2 }
-        ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)
@@ -56,6 +56,10 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 AS a1 , t1 AS a2, t1 AS a3;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[]] // { arity: 2 }
+        ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
   Return // { arity: 6 }
     CrossJoin type=delta // { arity: 6 }
       implementation
@@ -65,10 +69,6 @@ Explained Query:
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[]] // { arity: 2 }
-        ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)
@@ -81,17 +81,17 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 AS a1 , t1 AS a2 WHERE a1.f1 = 1 AND a2.f1 = 1;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[]] // { arity: 2 }
+        Project (#0, #1) // { arity: 2 }
+          ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
         %0:l0[×]e » %1:l0[×]e
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[]] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
-          ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -104,6 +104,11 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 AS a1 , t1 AS a2, t1 AS a3 WHERE a1.f1 = 1 AND a2.f1 = 1 AND a3.f1 = 1;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[]] // { arity: 2 }
+        Project (#0, #1) // { arity: 2 }
+          ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
   Return // { arity: 6 }
     CrossJoin type=delta // { arity: 6 }
       implementation
@@ -113,11 +118,6 @@ Explained Query:
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[]] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
-          ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -134,6 +134,9 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 AS a1 LEFT JOIN t1 AS a2 USING (f1) WHERE a1.f1 = 1 AND a2.f1 = 1;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
   Return // { arity: 3 }
     CrossJoin type=differential // { arity: 3 }
       implementation
@@ -144,9 +147,6 @@ Explained Query:
       ArrangeBy keys=[[]] // { arity: 1 }
         Project (#1) // { arity: 1 }
           Get l0 // { arity: 3 }
-  With
-    cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -163,18 +163,6 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE f1 = (SELECT f1 FROM t1) AND f2 = (SELECT f1 FROM t1);
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Project (#0, #1) // { arity: 2 }
-      Join on=(#0 = #2 AND #1 = #3) type=delta // { arity: 4 }
-        implementation
-          %0:t1 » %1:l0[#0]K » %2:l0[#0]K
-          %1:l0 » %0:t1[#0]KA » %2:l0[#0]K
-          %2:l0 » %0:t1[#1]K » %1:l0[#0]K
-        ArrangeBy keys=[[#0], [#1]] // { arity: 2 }
-          Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
-            ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
-        Get l0 // { arity: 1 }
-        Get l0 // { arity: 1 }
   With
     cte l0 =
       ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -188,6 +176,18 @@ Explained Query:
                 Reduce aggregates=[count(*)] // { arity: 1 }
                   Project () // { arity: 0 }
                     ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+  Return // { arity: 2 }
+    Project (#0, #1) // { arity: 2 }
+      Join on=(#0 = #2 AND #1 = #3) type=delta // { arity: 4 }
+        implementation
+          %0:t1 » %1:l0[#0]K » %2:l0[#0]K
+          %1:l0 » %0:t1[#0]KA » %2:l0[#0]K
+          %2:l0 » %0:t1[#1]K » %1:l0[#0]K
+        ArrangeBy keys=[[#0], [#1]] // { arity: 2 }
+          Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
+            ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+        Get l0 // { arity: 1 }
+        Get l0 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)
@@ -200,6 +200,20 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE f1 = (SELECT f1 FROM t1 WHERE f1 = 1) AND f2 = (SELECT f1 FROM t1 WHERE f1 = 1);
 ----
 Explained Query:
+  With
+    cte l0 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+    cte l1 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Union // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Get l0 // { arity: 3 }
+          Map (error("more than one record produced in subquery")) // { arity: 1 }
+            Project () // { arity: 0 }
+              Filter (#0 > 1) // { arity: 1 }
+                Reduce aggregates=[count(*)] // { arity: 1 }
+                  Project () // { arity: 0 }
+                    Get l0 // { arity: 3 }
   Return // { arity: 2 }
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2 AND #1 = #3) type=delta // { arity: 4 }
@@ -212,20 +226,6 @@ Explained Query:
             ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
         Get l1 // { arity: 1 }
         Get l1 // { arity: 1 }
-  With
-    cte l1 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Union // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Get l0 // { arity: 3 }
-          Map (error("more than one record produced in subquery")) // { arity: 1 }
-            Project () // { arity: 0 }
-              Filter (#0 > 1) // { arity: 1 }
-                Reduce aggregates=[count(*)] // { arity: 1 }
-                  Project () // { arity: 0 }
-                    Get l0 // { arity: 3 }
-    cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***, lookup)
@@ -267,19 +267,17 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE f1 = (SELECT f1 FROM t1) OR f2 = (SELECT f1 FROM t1);
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Project (#0, #1) // { arity: 2 }
-      Filter ((#0 = #2) OR (#1 = #3)) // { arity: 4 }
-        CrossJoin type=delta // { arity: 4 }
-          implementation
-            %0:t1 » %1:l1[×] » %2:l1[×]
-            %1:l1 » %0:t1[×] » %2:l1[×]
-            %2:l1 » %0:t1[×] » %1:l1[×]
-          ArrangeBy keys=[[]] // { arity: 2 }
-            ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
-          Get l1 // { arity: 1 }
-          Get l1 // { arity: 1 }
   With
+    cte l0 =
+      Union // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+        Map (error("more than one record produced in subquery")) // { arity: 1 }
+          Project () // { arity: 0 }
+            Filter (#0 > 1) // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
+                Project () // { arity: 0 }
+                  ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
     cte l1 =
       ArrangeBy keys=[[]] // { arity: 1 }
         Union // { arity: 1 }
@@ -292,16 +290,18 @@ Explained Query:
                     Get l0 // { arity: 1 }
               Constant // { arity: 0 }
                 - ()
-    cte l0 =
-      Union // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
-        Map (error("more than one record produced in subquery")) // { arity: 1 }
-          Project () // { arity: 0 }
-            Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(*)] // { arity: 1 }
-                Project () // { arity: 0 }
-                  ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+  Return // { arity: 2 }
+    Project (#0, #1) // { arity: 2 }
+      Filter ((#0 = #2) OR (#1 = #3)) // { arity: 4 }
+        CrossJoin type=delta // { arity: 4 }
+          implementation
+            %0:t1 » %1:l1[×] » %2:l1[×]
+            %1:l1 » %0:t1[×] » %2:l1[×]
+            %2:l1 » %0:t1[×] » %1:l1[×]
+          ArrangeBy keys=[[]] // { arity: 2 }
+            ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+          Get l1 // { arity: 1 }
+          Get l1 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)
@@ -321,17 +321,17 @@ JOIN (SELECT * FROM t1 WHERE f1 = 1) AS a2
 ON TRUE
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[]] // { arity: 2 }
+        Project (#0, #1) // { arity: 2 }
+          ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
         %0:l0[×]e » %1:l0[×]e
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[]] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
-          ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -348,18 +348,18 @@ WHERE a1.f2 = 2
 AND a2.f2 = 2
 ----
 Explained Query:
-  Return // { arity: 4 }
-    CrossJoin type=differential // { arity: 4 }
-      implementation
-        %0:l0[×]ef » %1:l0[×]ef
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
   With
     cte l0 =
       ArrangeBy keys=[[]] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
           Filter (#1 = 2) // { arity: 3 }
             ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+  Return // { arity: 4 }
+    CrossJoin type=differential // { arity: 4 }
+      implementation
+        %0:l0[×]ef » %1:l0[×]ef
+      Get l0 // { arity: 2 }
+      Get l0 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -377,6 +377,9 @@ WHERE a1.f2 = 2
 AND a2.f2 = 3
 ----
 Explained Query:
+  With
+    cte l0 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
@@ -389,9 +392,6 @@ Explained Query:
         Project (#0, #1) // { arity: 2 }
           Filter (#1 = 3) // { arity: 3 }
             Get l0 // { arity: 3 }
-  With
-    cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -408,15 +408,15 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE f1 = 1 UNION ALL SELECT * FROM t1 WHERE f1 = 1 UNION ALL SELECT * FROM t1 WHERE f1 = 1;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0, #1) // { arity: 2 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
   Return // { arity: 2 }
     Union // { arity: 2 }
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      Project (#0, #1) // { arity: 2 }
-        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -429,6 +429,10 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE f1 = 1 UNION ALL SELECT * FROM t1 WHERE f1 = 1 UNION SELECT * FROM t1 WHERE f1 = 1;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#1) // { arity: 1 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
   Return // { arity: 2 }
     Project (#1, #0) // { arity: 2 }
       Map (1) // { arity: 2 }
@@ -437,10 +441,6 @@ Explained Query:
             Get l0 // { arity: 1 }
             Get l0 // { arity: 1 }
             Get l0 // { arity: 1 }
-  With
-    cte l0 =
-      Project (#1) // { arity: 1 }
-        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -457,6 +457,19 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT (SELECT f1 FROM t1 WHERE f1 = 1) , (SELECT f1 FROM t1 WHERE f1 = 1) FROM t1;
 ----
 Explained Query:
+  With
+    cte l0 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+    cte l1 =
+      Union // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l0 // { arity: 3 }
+        Map (error("more than one record produced in subquery")) // { arity: 1 }
+          Project () // { arity: 0 }
+            Filter (#0 > 1) // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
+                Project () // { arity: 0 }
+                  Get l0 // { arity: 3 }
   Return // { arity: 2 }
     Project (#0, #0) // { arity: 2 }
       CrossJoin type=differential // { arity: 1 }
@@ -476,19 +489,6 @@ Explained Query:
                       Get l1 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
-  With
-    cte l1 =
-      Union // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l0 // { arity: 3 }
-        Map (error("more than one record produced in subquery")) // { arity: 1 }
-          Project () // { arity: 0 }
-            Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(*)] // { arity: 1 }
-                Project () // { arity: 0 }
-                  Get l0 // { arity: 3 }
-    cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***, lookup)
@@ -501,29 +501,19 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT MIN((SELECT f1 FROM t1 WHERE f1 = 1)), MAX((SELECT f1 FROM t1 WHERE f1 = 1)) FROM t1;
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Union // { arity: 2 }
-      Get l3 // { arity: 2 }
-      Map (null, null) // { arity: 2 }
-        Union // { arity: 0 }
-          Negate // { arity: 0 }
-            Project () // { arity: 0 }
-              Get l3 // { arity: 2 }
-          Constant // { arity: 0 }
-            - ()
   With
-    cte l3 =
-      Reduce aggregates=[min(#0), max(#1)] // { arity: 2 }
-        CrossJoin type=delta // { arity: 2 }
-          implementation
-            %0:t1 » %1:l2[×] » %2:l2[×]
-            %1:l2 » %0:t1[×] » %2:l2[×]
-            %2:l2 » %0:t1[×] » %1:l2[×]
-          ArrangeBy keys=[[]] // { arity: 0 }
-            Project () // { arity: 0 }
-              ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
-          Get l2 // { arity: 1 }
-          Get l2 // { arity: 1 }
+    cte l0 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+    cte l1 =
+      Union // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l0 // { arity: 3 }
+        Map (error("more than one record produced in subquery")) // { arity: 1 }
+          Project () // { arity: 0 }
+            Filter (#0 > 1) // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
+                Project () // { arity: 0 }
+                  Get l0 // { arity: 3 }
     cte l2 =
       ArrangeBy keys=[[]] // { arity: 1 }
         Union // { arity: 1 }
@@ -536,18 +526,28 @@ Explained Query:
                     Get l1 // { arity: 1 }
               Constant // { arity: 0 }
                 - ()
-    cte l1 =
-      Union // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l0 // { arity: 3 }
-        Map (error("more than one record produced in subquery")) // { arity: 1 }
-          Project () // { arity: 0 }
-            Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(*)] // { arity: 1 }
-                Project () // { arity: 0 }
-                  Get l0 // { arity: 3 }
-    cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+    cte l3 =
+      Reduce aggregates=[min(#0), max(#1)] // { arity: 2 }
+        CrossJoin type=delta // { arity: 2 }
+          implementation
+            %0:t1 » %1:l2[×] » %2:l2[×]
+            %1:l2 » %0:t1[×] » %2:l2[×]
+            %2:l2 » %0:t1[×] » %1:l2[×]
+          ArrangeBy keys=[[]] // { arity: 0 }
+            Project () // { arity: 0 }
+              ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+          Get l2 // { arity: 1 }
+          Get l2 // { arity: 1 }
+  Return // { arity: 2 }
+    Union // { arity: 2 }
+      Get l3 // { arity: 2 }
+      Map (null, null) // { arity: 2 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l3 // { arity: 2 }
+          Constant // { arity: 0 }
+            - ()
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***, lookup)
@@ -564,6 +564,21 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT (SELECT f1 FROM t1 WHERE f1 = 1) FROM t1 WHERE EXISTS (SELECT f1 FROM t1 WHERE f1 = 1);
 ----
 Explained Query:
+  With
+    cte l0 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+    cte l1 =
+      Project () // { arity: 0 }
+        Get l0 // { arity: 3 }
+    cte l2 =
+      Union // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l0 // { arity: 3 }
+        Map (error("more than one record produced in subquery")) // { arity: 1 }
+          Project () // { arity: 0 }
+            Filter (#0 > 1) // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
+                Get l1 // { arity: 0 }
   Return // { arity: 1 }
     CrossJoin type=delta // { arity: 1 }
       implementation
@@ -587,21 +602,6 @@ Explained Query:
                     Get l2 // { arity: 1 }
               Constant // { arity: 0 }
                 - ()
-  With
-    cte l2 =
-      Union // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l0 // { arity: 3 }
-        Map (error("more than one record produced in subquery")) // { arity: 1 }
-          Project () // { arity: 0 }
-            Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(*)] // { arity: 1 }
-                Get l1 // { arity: 0 }
-    cte l1 =
-      Project () // { arity: 0 }
-        Get l0 // { arity: 3 }
-    cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***, lookup)
@@ -616,6 +616,21 @@ UNION ALL
 SELECT f1 FROM t1 WHERE f1 = 1
 ----
 Explained Query:
+  With
+    cte l0 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+    cte l1 =
+      Project (#0) // { arity: 1 }
+        Get l0 // { arity: 3 }
+    cte l2 =
+      Union // { arity: 1 }
+        Get l1 // { arity: 1 }
+        Map (error("more than one record produced in subquery")) // { arity: 1 }
+          Project () // { arity: 0 }
+            Filter (#0 > 1) // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
+                Project () // { arity: 0 }
+                  Get l0 // { arity: 3 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
@@ -636,21 +651,6 @@ Explained Query:
                 Constant // { arity: 0 }
                   - ()
       Get l1 // { arity: 1 }
-  With
-    cte l2 =
-      Union // { arity: 1 }
-        Get l1 // { arity: 1 }
-        Map (error("more than one record produced in subquery")) // { arity: 1 }
-          Project () // { arity: 0 }
-            Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(*)] // { arity: 1 }
-                Project () // { arity: 0 }
-                  Get l0 // { arity: 3 }
-    cte l1 =
-      Project (#0) // { arity: 1 }
-        Get l0 // { arity: 3 }
-    cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***, lookup)
@@ -674,20 +674,20 @@ UNION ALL
 SELECT * FROM t1 AS a1, t1 AS a2
 ----
 Explained Query:
-  Return // { arity: 4 }
-    Union // { arity: 4 }
-      Get l1 // { arity: 4 }
-      Get l1 // { arity: 4 }
   With
+    cte l0 =
+      ArrangeBy keys=[[]] // { arity: 2 }
+        ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
     cte l1 =
       CrossJoin type=differential // { arity: 4 }
         implementation
           %0:l0[×] » %1:l0[×]
         Get l0 // { arity: 2 }
         Get l0 // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[]] // { arity: 2 }
-        ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+  Return // { arity: 4 }
+    Union // { arity: 4 }
+      Get l1 // { arity: 4 }
+      Get l1 // { arity: 4 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)
@@ -703,13 +703,18 @@ UNION ALL
 SELECT * FROM t1 AS a1 LEFT JOIN t1 AS a2 USING (f1)
 ----
 Explained Query:
-  Return // { arity: 3 }
-    Union // { arity: 3 }
-      Get l2 // { arity: 3 }
-      Get l1 // { arity: 3 }
-      Get l2 // { arity: 3 }
-      Get l1 // { arity: 3 }
   With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        ReadIndex on=t1 i1=[differential join] // { arity: 2 }
+    cte l1 =
+      Project (#0, #1, #3) // { arity: 3 }
+        Filter (#0) IS NOT NULL // { arity: 4 }
+          Join on=(#0 = #2) type=differential // { arity: 4 }
+            implementation
+              %0:l0[#0]KA » %1:l0[#0]KA
+            Get l0 // { arity: 2 }
+            Get l0 // { arity: 2 }
     cte l2 =
       Map (null) // { arity: 3 }
         Union // { arity: 2 }
@@ -724,17 +729,12 @@ Explained Query:
                     Project (#0) // { arity: 1 }
                       Get l1 // { arity: 3 }
           ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
-    cte l1 =
-      Project (#0, #1, #3) // { arity: 3 }
-        Filter (#0) IS NOT NULL // { arity: 4 }
-          Join on=(#0 = #2) type=differential // { arity: 4 }
-            implementation
-              %0:l0[#0]KA » %1:l0[#0]KA
-            Get l0 // { arity: 2 }
-            Get l0 // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        ReadIndex on=t1 i1=[differential join] // { arity: 2 }
+  Return // { arity: 3 }
+    Union // { arity: 3 }
+      Get l2 // { arity: 3 }
+      Get l1 // { arity: 3 }
+      Get l2 // { arity: 3 }
+      Get l1 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***, differential join)
@@ -750,6 +750,14 @@ UNION ALL
 SELECT * FROM (SELECT a2.f1 AS f1 FROM t1 AS a1 LEFT JOIN t1 AS a2 USING (f1)) WHERE f1 = 2
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        ReadIndex on=t1 i1=[lookup] // { arity: 2 }
+    cte l1 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+    cte l2 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
@@ -770,14 +778,6 @@ Explained Query:
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l2 // { arity: 3 }
-  With
-    cte l2 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
-    cte l1 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        ReadIndex on=t1 i1=[lookup] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -794,6 +794,17 @@ SELECT * FROM
 WHERE s1.f1 = 1 AND s2.f1 = 1
 ----
 Explained Query:
+  With
+    cte l0 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+    cte l1 =
+      ArrangeBy keys=[[]] // { arity: 0 }
+        Project () // { arity: 0 }
+          Get l0 // { arity: 3 }
+    cte l2 =
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l0 // { arity: 3 }
   Return // { arity: 2 }
     CrossJoin type=delta // { arity: 2 }
       implementation
@@ -805,17 +816,6 @@ Explained Query:
       Get l2 // { arity: 1 }
       Get l1 // { arity: 0 }
       Get l2 // { arity: 1 }
-  With
-    cte l2 =
-      ArrangeBy keys=[[]] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l0 // { arity: 3 }
-    cte l1 =
-      ArrangeBy keys=[[]] // { arity: 0 }
-        Project () // { arity: 0 }
-          Get l0 // { arity: 3 }
-    cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -832,6 +832,14 @@ SELECT * FROM
 WHERE s1.f1 = 1 AND s2.f1 = 2
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        ReadIndex on=t1 i1=[lookup] // { arity: 2 }
+    cte l1 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+    cte l2 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
   Return // { arity: 2 }
     CrossJoin type=delta // { arity: 2 }
       implementation
@@ -851,14 +859,6 @@ Explained Query:
       ArrangeBy keys=[[]] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Get l2 // { arity: 3 }
-  With
-    cte l2 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
-    cte l1 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        ReadIndex on=t1 i1=[lookup] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -878,15 +878,15 @@ UNION ALL
 SELECT * FROM t1 WHERE f1 = 1 AND f2 = 2
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Union // { arity: 2 }
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
   With
     cte l0 =
       Project (#0, #1) // { arity: 2 }
         Filter (#1 = 2) // { arity: 3 }
           ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+  Return // { arity: 2 }
+    Union // { arity: 2 }
+      Get l0 // { arity: 2 }
+      Get l0 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -906,14 +906,14 @@ UNION ALL
 SELECT * FROM t1 WHERE f1 = 1 OR f1 = 2
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Union // { arity: 2 }
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
   With
     cte l0 =
       Project (#0, #1) // { arity: 2 }
         ReadIndex on=materialize.public.t1 i1=[lookup values=[(1); (2)]] // { arity: 3 }
+  Return // { arity: 2 }
+    Union // { arity: 2 }
+      Get l0 // { arity: 2 }
+      Get l0 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -933,10 +933,6 @@ UNION ALL
 SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t1 WHERE f1 = 1)
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Union // { arity: 2 }
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
   With
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
@@ -948,6 +944,10 @@ Explained Query:
           Distinct project=[] // { arity: 0 }
             Project () // { arity: 0 }
               ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+  Return // { arity: 2 }
+    Union // { arity: 2 }
+      Get l0 // { arity: 2 }
+      Get l0 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***, lookup)
@@ -963,11 +963,12 @@ UNION ALL
 SELECT * FROM t1 WHERE f1 = (SELECT f1 FROM t1 WHERE f1 = 1)
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Union // { arity: 2 }
-      Get l2 // { arity: 2 }
-      Get l2 // { arity: 2 }
   With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        ReadIndex on=t1 i1=[differential join, lookup] // { arity: 2 }
+    cte l1 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
     cte l2 =
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
@@ -984,11 +985,10 @@ Explained Query:
                     Reduce aggregates=[count(*)] // { arity: 1 }
                       Project () // { arity: 0 }
                         Get l1 // { arity: 3 }
-    cte l1 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        ReadIndex on=t1 i1=[differential join, lookup] // { arity: 2 }
+  Return // { arity: 2 }
+    Union // { arity: 2 }
+      Get l2 // { arity: 2 }
+      Get l2 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (differential join, lookup)
@@ -1008,15 +1008,15 @@ UNION ALL
 SELECT f1 + 1 FROM (SELECT f1 + 2 AS f1 FROM t1)
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l0 // { arity: 1 }
-      Get l0 // { arity: 1 }
   With
     cte l0 =
       Project (#2) // { arity: 1 }
         Map (((#0 + 2) + 1)) // { arity: 3 }
           ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Get l0 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)
@@ -1036,13 +1036,11 @@ UNION ALL
 SELECT MIN(f1) FROM t1;
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l0 // { arity: 1 }
-      Get l1 // { arity: 1 }
-      Get l0 // { arity: 1 }
-      Get l1 // { arity: 1 }
   With
+    cte l0 =
+      Reduce aggregates=[min(#0)] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
     cte l1 =
       Map (null) // { arity: 1 }
         Union // { arity: 0 }
@@ -1051,10 +1049,12 @@ Explained Query:
               Get l0 // { arity: 1 }
           Constant // { arity: 0 }
             - ()
-    cte l0 =
-      Reduce aggregates=[min(#0)] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Get l1 // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Get l1 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)
@@ -1070,15 +1070,15 @@ UNION ALL
 SELECT DISTINCT f1 FROM t1
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l0 // { arity: 1 }
-      Get l0 // { arity: 1 }
   With
     cte l0 =
       Distinct project=[#0] // { arity: 1 }
         Project (#0) // { arity: 1 }
           ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Get l0 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)
@@ -1094,15 +1094,15 @@ UNION ALL
 SELECT f1, COUNT(*) FROM t1 GROUP BY f1
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Union // { arity: 2 }
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
   With
     cte l0 =
       Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#0) // { arity: 1 }
           ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+  Return // { arity: 2 }
+    Union // { arity: 2 }
+      Get l0 // { arity: 2 }
+      Get l0 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)
@@ -1121,15 +1121,15 @@ UNION ALL
 SELECT f1 + f1 + f1 + f1 FROM t1
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l0 // { arity: 1 }
-      Get l0 // { arity: 1 }
   With
     cte l0 =
       Project (#2) // { arity: 1 }
         Map ((((#0 + #0) + #0) + #0)) // { arity: 3 }
           ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Get l0 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)
@@ -1145,15 +1145,15 @@ UNION ALL
 SELECT ABS(f1) FROM t1
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Get l0 // { arity: 1 }
-      Get l0 // { arity: 1 }
   With
     cte l0 =
       Project (#2) // { arity: 1 }
         Map (abs(#0)) // { arity: 3 }
           ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Get l0 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)
@@ -1173,16 +1173,16 @@ UNION ALL
 (SELECT * FROM t1 WHERE f1 = 1 UNION ALL SELECT * FROM t1 WHERE f1 = 1)
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0, #1) // { arity: 2 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
   Return // { arity: 2 }
     Union // { arity: 2 }
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      Project (#0, #1) // { arity: 2 }
-        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -1198,10 +1198,6 @@ UNION ALL
 (SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t1 WHERE f1 = 1))
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Union // { arity: 2 }
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
   With
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
@@ -1213,6 +1209,10 @@ Explained Query:
           Distinct project=[] // { arity: 0 }
             Project () // { arity: 0 }
               ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+  Return // { arity: 2 }
+    Union // { arity: 2 }
+      Get l0 // { arity: 2 }
+      Get l0 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***, lookup)
@@ -1232,12 +1232,6 @@ UNION ALL
 (SELECT f2 FROM t1 WHERE EXISTS (SELECT * FROM t1 WHERE f1 = 1))
 ----
 Explained Query:
-  Return // { arity: 1 }
-    Union // { arity: 1 }
-      Project (#0) // { arity: 1 }
-        Get l0 // { arity: 2 }
-      Project (#1) // { arity: 1 }
-        Get l0 // { arity: 2 }
   With
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
@@ -1249,6 +1243,12 @@ Explained Query:
           Distinct project=[] // { arity: 0 }
             Project () // { arity: 0 }
               ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Project (#0) // { arity: 1 }
+        Get l0 // { arity: 2 }
+      Project (#1) // { arity: 1 }
+        Get l0 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***, lookup)
@@ -1264,6 +1264,12 @@ UNION ALL
 (SELECT * FROM t2 WHERE EXISTS (SELECT * FROM t1 WHERE f1 = 1))
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[]] // { arity: 0 }
+        Distinct project=[] // { arity: 0 }
+          Project () // { arity: 0 }
+            ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
   Return // { arity: 2 }
     Union // { arity: 2 }
       CrossJoin type=differential // { arity: 2 }
@@ -1278,12 +1284,6 @@ Explained Query:
         ArrangeBy keys=[[]] // { arity: 2 }
           ReadStorage materialize.public.t2 // { arity: 2 }
         Get l0 // { arity: 0 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[]] // { arity: 0 }
-        Distinct project=[] // { arity: 0 }
-          Project () // { arity: 0 }
-            ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Source materialize.public.t2
 
@@ -1300,6 +1300,10 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM
 (SELECT f2 FROM t2 UNION ALL SELECT f1 FROM t1 WHERE f1 = 1)
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0) // { arity: 1 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
   Return // { arity: 2 }
     CrossJoin type=differential // { arity: 2 }
       implementation
@@ -1314,10 +1318,6 @@ Explained Query:
           Project (#1) // { arity: 1 }
             ReadStorage materialize.public.t2 // { arity: 2 }
           Get l0 // { arity: 1 }
-  With
-    cte l0 =
-      Project (#0) // { arity: 1 }
-        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Source materialize.public.t2
 
@@ -1336,15 +1336,15 @@ UNION ALL
 SELECT f2 FROM t1 WHERE f1 = 1
 ----
 Explained Query:
+  With
+    cte l0 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       Project (#0) // { arity: 1 }
         Get l0 // { arity: 3 }
       Project (#1) // { arity: 1 }
         Get l0 // { arity: 3 }
-  With
-    cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -1362,6 +1362,10 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 AS a1, t1 AS a2 WHERE a1.f1 = 1 AND a2.f1 = 2
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        ReadIndex on=t1 i1=[lookup] // { arity: 2 }
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
@@ -1372,10 +1376,6 @@ Explained Query:
       ArrangeBy keys=[[]] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
           ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        ReadIndex on=t1 i1=[lookup] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -1391,6 +1391,14 @@ UNION ALL
 SELECT * FROM (SELECT a2.f1 AS f1 FROM t1 AS a1 JOIN t1 AS a2 USING (f1)) WHERE f1 = 2
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        ReadIndex on=t1 i1=[lookup] // { arity: 2 }
+    cte l1 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+    cte l2 =
+      ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
@@ -1411,14 +1419,6 @@ Explained Query:
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l2 // { arity: 3 }
-  With
-    cte l2 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
-    cte l1 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        ReadIndex on=t1 i1=[lookup] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -1434,16 +1434,16 @@ UNION ALL
 SELECT * FROM t1 WHERE f1 = 2
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        ReadIndex on=t1 i1=[lookup] // { arity: 2 }
   Return // { arity: 2 }
     Union // { arity: 2 }
       Project (#0, #1) // { arity: 2 }
         ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
       Project (#0, #1) // { arity: 2 }
         ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        ReadIndex on=t1 i1=[lookup] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -1459,6 +1459,16 @@ UNION ALL
 SELECT MAX(f1) FROM t1
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0) // { arity: 1 }
+        ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+    cte l1 =
+      Reduce aggregates=[min(#0)] // { arity: 1 }
+        Get l0 // { arity: 1 }
+    cte l2 =
+      Reduce aggregates=[max(#0)] // { arity: 1 }
+        Get l0 // { arity: 1 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       Get l1 // { arity: 1 }
@@ -1477,16 +1487,6 @@ Explained Query:
               Get l2 // { arity: 1 }
           Constant // { arity: 0 }
             - ()
-  With
-    cte l2 =
-      Reduce aggregates=[max(#0)] // { arity: 1 }
-        Get l0 // { arity: 1 }
-    cte l1 =
-      Reduce aggregates=[min(#0)] // { arity: 1 }
-        Get l0 // { arity: 1 }
-    cte l0 =
-      Project (#0) // { arity: 1 }
-        ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)
@@ -1502,6 +1502,15 @@ UNION ALL
 SELECT MIN(f2) FROM t1
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[min(#0)] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+    cte l1 =
+      Reduce aggregates=[min(#0)] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       Get l0 // { arity: 1 }
@@ -1520,15 +1529,6 @@ Explained Query:
               Get l1 // { arity: 1 }
           Constant // { arity: 0 }
             - ()
-  With
-    cte l1 =
-      Reduce aggregates=[min(#0)] // { arity: 1 }
-        Project (#1) // { arity: 1 }
-          ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
-    cte l0 =
-      Reduce aggregates=[min(#0)] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)
@@ -1580,6 +1580,28 @@ UNION ALL
 SELECT * FROM c2 WHERE f1 > 7
 ----
 Explained Query:
+  With Mutually Recursive
+    cte l0 =
+      Union // { arity: 2 }
+        ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+        ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+    cte l1 =
+      Filter (#1 > 7) // { arity: 2 }
+        Get l0 // { arity: 2 }
+    cte l2 =
+      Union // { arity: 2 }
+        Get l1 // { arity: 2 }
+        Get l2 // { arity: 2 }
+        Get l2 // { arity: 2 }
+        Get l3 // { arity: 2 }
+        Get l3 // { arity: 2 }
+    cte l3 =
+      Union // { arity: 2 }
+        Get l1 // { arity: 2 }
+        Get l2 // { arity: 2 }
+        Get l2 // { arity: 2 }
+        Get l3 // { arity: 2 }
+        Get l3 // { arity: 2 }
   Return // { arity: 2 }
     Union // { arity: 2 }
       Filter (#0 > 7) // { arity: 2 }
@@ -1588,28 +1610,6 @@ Explained Query:
         Get l2 // { arity: 2 }
       Filter (#0 > 7) // { arity: 2 }
         Get l3 // { arity: 2 }
-  With Mutually Recursive
-    cte l3 =
-      Union // { arity: 2 }
-        Get l1 // { arity: 2 }
-        Get l2 // { arity: 2 }
-        Get l2 // { arity: 2 }
-        Get l3 // { arity: 2 }
-        Get l3 // { arity: 2 }
-    cte l2 =
-      Union // { arity: 2 }
-        Get l1 // { arity: 2 }
-        Get l2 // { arity: 2 }
-        Get l2 // { arity: 2 }
-        Get l3 // { arity: 2 }
-        Get l3 // { arity: 2 }
-    cte l1 =
-      Filter (#1 > 7) // { arity: 2 }
-        Get l0 // { arity: 2 }
-    cte l0 =
-      Union // { arity: 2 }
-        ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
-        ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)
@@ -1640,7 +1640,84 @@ FROM (
 );
 ----
 Explained Query:
+  With Mutually Recursive
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#1 <= #0) // { arity: 2 }
+          Get l1 // { arity: 2 }
+    cte l1 =
+      Union // { arity: 2 }
+        Distinct project=[#0, (#1 + #2)] monotonic // { arity: 2 }
+          Project (#0, #1, #3) // { arity: 3 }
+            Join on=(#0 = #2) type=differential // { arity: 4 }
+              implementation
+                %0:l0[#0]Kf » %1:l0[#0]Kf
+              Get l0 // { arity: 2 }
+              Get l0 // { arity: 2 }
+        Constant // { arity: 2 }
+          - (1, 1)
+          - (2, 1)
+          - (3, 1)
+          - (4, 1)
+          - (5, 1)
+          - (6, 1)
+          - (7, 1)
+          - (8, 1)
+          - (9, 1)
+          - (10, 1)
   Return // { arity: 2 }
+    With
+      cte l2 =
+        Reduce group_by=[#0] aggregates=[count(*)] monotonic // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Get l1 // { arity: 2 }
+      cte l3 =
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Constant // { arity: 1 }
+            - (1)
+            - (2)
+            - (3)
+            - (4)
+            - (5)
+            - (6)
+            - (7)
+            - (8)
+            - (9)
+            - (10)
+      cte l4 =
+        Union // { arity: 2 }
+          Get l2 // { arity: 2 }
+          Project (#0, #2) // { arity: 2 }
+            Map (0) // { arity: 3 }
+              Join on=(#0 = #1) type=differential // { arity: 2 }
+                implementation
+                  %1:l3[#0]UK » %0[#0]K
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Union // { arity: 1 }
+                    Negate // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Get l2 // { arity: 2 }
+                    Constant // { arity: 1 }
+                      - (1)
+                      - (2)
+                      - (3)
+                      - (4)
+                      - (5)
+                      - (6)
+                      - (7)
+                      - (8)
+                      - (9)
+                      - (10)
+                Get l3 // { arity: 1 }
+      cte l5 =
+        Union // { arity: 2 }
+          Get l4 // { arity: 2 }
+          Map (error("more than one record produced in subquery")) // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              Filter (#1 > 1) // { arity: 2 }
+                Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                  Project (#0) // { arity: 1 }
+                    Get l4 // { arity: 2 }
     Return // { arity: 2 }
       Project (#0, #3) // { arity: 2 }
         Join on=(#0 = #1 = #2) type=delta // { arity: 4 }
@@ -1687,83 +1764,6 @@ Explained Query:
                           - (9)
                           - (10)
                     Get l3 // { arity: 1 }
-    With
-      cte l5 =
-        Union // { arity: 2 }
-          Get l4 // { arity: 2 }
-          Map (error("more than one record produced in subquery")) // { arity: 2 }
-            Project (#0) // { arity: 1 }
-              Filter (#1 > 1) // { arity: 2 }
-                Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                  Project (#0) // { arity: 1 }
-                    Get l4 // { arity: 2 }
-      cte l4 =
-        Union // { arity: 2 }
-          Get l2 // { arity: 2 }
-          Project (#0, #2) // { arity: 2 }
-            Map (0) // { arity: 3 }
-              Join on=(#0 = #1) type=differential // { arity: 2 }
-                implementation
-                  %1:l3[#0]UK » %0[#0]K
-                ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Union // { arity: 1 }
-                    Negate // { arity: 1 }
-                      Project (#0) // { arity: 1 }
-                        Get l2 // { arity: 2 }
-                    Constant // { arity: 1 }
-                      - (1)
-                      - (2)
-                      - (3)
-                      - (4)
-                      - (5)
-                      - (6)
-                      - (7)
-                      - (8)
-                      - (9)
-                      - (10)
-                Get l3 // { arity: 1 }
-      cte l3 =
-        ArrangeBy keys=[[#0]] // { arity: 1 }
-          Constant // { arity: 1 }
-            - (1)
-            - (2)
-            - (3)
-            - (4)
-            - (5)
-            - (6)
-            - (7)
-            - (8)
-            - (9)
-            - (10)
-      cte l2 =
-        Reduce group_by=[#0] aggregates=[count(*)] monotonic // { arity: 2 }
-          Project (#0) // { arity: 1 }
-            Get l1 // { arity: 2 }
-  With Mutually Recursive
-    cte l1 =
-      Union // { arity: 2 }
-        Distinct project=[#0, (#1 + #2)] monotonic // { arity: 2 }
-          Project (#0, #1, #3) // { arity: 3 }
-            Join on=(#0 = #2) type=differential // { arity: 4 }
-              implementation
-                %0:l0[#0]Kf » %1:l0[#0]Kf
-              Get l0 // { arity: 2 }
-              Get l0 // { arity: 2 }
-        Constant // { arity: 2 }
-          - (1, 1)
-          - (2, 1)
-          - (3, 1)
-          - (4, 1)
-          - (5, 1)
-          - (6, 1)
-          - (7, 1)
-          - (8, 1)
-          - (9, 1)
-          - (10, 1)
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        Filter (#1 <= #0) // { arity: 2 }
-          Get l1 // { arity: 2 }
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/threshold_elision.slt
+++ b/test/sqllogictest/transform/threshold_elision.slt
@@ -189,16 +189,16 @@ EXCEPT ALL
 )
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0, #1) // { non_negative: true }
+        ReadStorage materialize.public.people // { non_negative: true }
   Return // { non_negative: true }
     Union // { non_negative: true }
       Get l0 // { non_negative: true }
       Negate // { non_negative: false }
         TopK group_by=[#0] limit=1 // { non_negative: true }
           Get l0 // { non_negative: true }
-  With
-    cte l0 =
-      Project (#0, #1) // { non_negative: true }
-        ReadStorage materialize.public.people // { non_negative: true }
 
 Source materialize.public.people
 
@@ -230,16 +230,16 @@ EXCEPT
 )
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0, #1) // { non_negative: true }
+        ReadStorage materialize.public.people // { non_negative: true }
   Return // { non_negative: true }
     Union // { non_negative: true }
       Get l0 // { non_negative: true }
       Negate // { non_negative: false }
         TopK group_by=[#0] limit=1 // { non_negative: true }
           Get l0 // { non_negative: true }
-  With
-    cte l0 =
-      Project (#0, #1) // { non_negative: true }
-        ReadStorage materialize.public.people // { non_negative: true }
 
 Source materialize.public.people
 
@@ -254,12 +254,6 @@ WITH cte AS (SELECT people.id FROM people, bands)
 SELECT * FROM cte EXCEPT ALL SELECT * FROM cte where id > 5;
 ----
 Explained Query:
-  Return // { non_negative: true }
-    Union // { non_negative: true }
-      Get l0 // { non_negative: true }
-      Negate // { non_negative: false }
-        Filter (#0 > 5) // { non_negative: true }
-          Get l0 // { non_negative: true }
   With
     cte l0 =
       CrossJoin type=differential // { non_negative: true }
@@ -269,6 +263,12 @@ Explained Query:
         ArrangeBy keys=[[]] // { non_negative: true }
           Project () // { non_negative: true }
             ReadStorage materialize.public.bands // { non_negative: true }
+  Return // { non_negative: true }
+    Union // { non_negative: true }
+      Get l0 // { non_negative: true }
+      Negate // { non_negative: false }
+        Filter (#0 > 5) // { non_negative: true }
+          Get l0 // { non_negative: true }
 
 Source materialize.public.bands
 Source materialize.public.people
@@ -284,17 +284,17 @@ WITH cte AS (SELECT DISTINCT name FROM people)
 SELECT * FROM cte EXCEPT ALL SELECT * FROM cte WHERE name LIKE 'J%'
 ----
 Explained Query:
+  With
+    cte l0 =
+      Distinct project=[#0] // { non_negative: true }
+        Project (#1) // { non_negative: true }
+          ReadStorage materialize.public.people // { non_negative: true }
   Return // { non_negative: true }
     Union // { non_negative: true }
       Get l0 // { non_negative: true }
       Negate // { non_negative: false }
         Filter like["J%"](#0) // { non_negative: true }
           Get l0 // { non_negative: true }
-  With
-    cte l0 =
-      Distinct project=[#0] // { non_negative: true }
-        Project (#1) // { non_negative: true }
-          ReadStorage materialize.public.people // { non_negative: true }
 
 Source materialize.public.people
 
@@ -313,17 +313,17 @@ WITH a(birth_year, no_people_born) AS (
 SELECT * FROM a EXCEPT (SELECT * FROM a WHERE birth_year > 1940);
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce group_by=[extract_year_d(#0)] aggregates=[count(*)] // { non_negative: true }
+        Project (#2) // { non_negative: true }
+          ReadStorage materialize.public.people // { non_negative: true }
   Return // { non_negative: true }
     Union // { non_negative: true }
       Get l0 // { non_negative: true }
       Negate // { non_negative: false }
         Filter (#0 > 1940) // { non_negative: true }
           Get l0 // { non_negative: true }
-  With
-    cte l0 =
-      Reduce group_by=[extract_year_d(#0)] aggregates=[count(*)] // { non_negative: true }
-        Project (#2) // { non_negative: true }
-          ReadStorage materialize.public.people // { non_negative: true }
 
 Source materialize.public.people
 
@@ -352,12 +352,6 @@ EXCEPT
 SELECT * FROM cte2 WHERE name LIKE 'P%';
 ----
 Explained Query:
-  Return // { non_negative: true }
-    Union // { non_negative: true }
-      Get l0 // { non_negative: true }
-      Negate // { non_negative: false }
-        Filter like["P%"](#1) // { non_negative: true }
-          Get l0 // { non_negative: true }
   With
     cte l0 =
       Distinct project=[#0..=#3] // { non_negative: true }
@@ -366,6 +360,12 @@ Explained Query:
           Negate // { non_negative: false }
             Filter like["J%"](#1) // { non_negative: true }
               ReadStorage materialize.public.people // { non_negative: true }
+  Return // { non_negative: true }
+    Union // { non_negative: true }
+      Get l0 // { non_negative: true }
+      Negate // { non_negative: false }
+        Filter like["P%"](#1) // { non_negative: true }
+          Get l0 // { non_negative: true }
 
 Source materialize.public.people
 
@@ -427,8 +427,6 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c1
 ----
 Explained Query:
-  Return // { non_negative: true }
-    Get l0 // { non_negative: true }
   With Mutually Recursive
     cte l0 =
       Distinct project=[#0, #1] // { non_negative: true }
@@ -445,6 +443,8 @@ Explained Query:
           Project (#0, #2) // { non_negative: true }
             Map ((#1 || "_iter")) // { non_negative: true }
               Get l0 // { non_negative: true }
+  Return // { non_negative: true }
+    Get l0 // { non_negative: true }
 
 Source materialize.public.people
 
@@ -475,15 +475,7 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c1
 ----
 Explained Query:
-  Return // { non_negative: true }
-    Get l0 // { non_negative: true }
   With Mutually Recursive
-    cte l1 =
-      Union // { non_negative: true }
-        Get l0 // { non_negative: true }
-        Negate // { non_negative: false }
-          Filter (#0 > 2) // { non_negative: true }
-            Get l0 // { non_negative: true }
     cte l0 =
       Distinct project=[#0, #1] // { non_negative: true }
         Union // { non_negative: false }
@@ -496,6 +488,14 @@ Explained Query:
             Distinct project=[#0, (#1 || "_iter")] // { non_negative: true }
               Filter (#0 > 1) // { non_negative: true }
                 Get l1 // { non_negative: true }
+    cte l1 =
+      Union // { non_negative: true }
+        Get l0 // { non_negative: true }
+        Negate // { non_negative: false }
+          Filter (#0 > 2) // { non_negative: true }
+            Get l0 // { non_negative: true }
+  Return // { non_negative: true }
+    Get l0 // { non_negative: true }
 
 Source materialize.public.people
 
@@ -519,8 +519,6 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0
 ----
 Explained Query:
-  Return // { non_negative: true }
-    Get l0 // { non_negative: true }
   With Mutually Recursive
     cte l0 =
       Distinct project=[#0, #1] // { non_negative: true }
@@ -534,6 +532,8 @@ Explained Query:
             Distinct project=[#0, (#1 || "_iter")] // { non_negative: true }
               Filter (#0 > 1) // { non_negative: true }
                 Get l0 // { non_negative: true }
+  Return // { non_negative: true }
+    Get l0 // { non_negative: true }
 
 Source materialize.public.people
 

--- a/test/sqllogictest/transform/union.slt
+++ b/test/sqllogictest/transform/union.slt
@@ -69,6 +69,10 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) (SELECT * FROM t1 UNION ALL SELECT * FROM t1) EXCEPT ALL (SELECT * FROM t2 UNION ALL SELECT * FROM t2);
 ----
 Explained Query:
+  With
+    cte l0 =
+      Negate // { arity: 2 }
+        ReadStorage materialize.public.t2 // { arity: 2 }
   Return // { arity: 2 }
     Threshold // { arity: 2 }
       Union // { arity: 2 }
@@ -76,10 +80,6 @@ Explained Query:
         ReadStorage materialize.public.t1 // { arity: 2 }
         Get l0 // { arity: 2 }
         Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      Negate // { arity: 2 }
-        ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -159,6 +159,21 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT a1.* FROM t3 AS a1 LEFT JOIN t2 AS a2 ON (a1.f1 = a2.nokey);
 ----
 Explained Query:
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.t3 // { arity: 2 }
+    cte l1 =
+      Project (#0, #1) // { arity: 2 }
+        Join on=(#0 = #2) type=differential // { arity: 3 }
+          implementation
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Filter (#1) IS NOT NULL // { arity: 2 }
+                ReadStorage materialize.public.t2 // { arity: 2 }
   Return // { arity: 2 }
     Union // { arity: 2 }
       Negate // { arity: 2 }
@@ -173,21 +188,6 @@ Explained Query:
                   Get l1 // { arity: 2 }
       ReadStorage materialize.public.t3 // { arity: 2 }
       Get l1 // { arity: 2 }
-  With
-    cte l1 =
-      Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = #2) type=differential // { arity: 3 }
-          implementation
-            %0:l0[#0]K » %1:t2[#0]K
-          Get l0 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#1) // { arity: 1 }
-              Filter (#1) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t2 // { arity: 2 }
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          ReadStorage materialize.public.t3 // { arity: 2 }
 
 Source materialize.public.t2
   filter=((#1) IS NOT NULL)

--- a/test/sqllogictest/transform/union_cancel.slt
+++ b/test/sqllogictest/transform/union_cancel.slt
@@ -302,23 +302,23 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c2;
 ----
 Explained Query:
-  Return
-    Get l2
   With Mutually Recursive
-    cte l2 =
-      Union
-        Get l0
-        Get l1
-        Get l1
-    cte l1 =
-      Project (#1)
-        Map ((#0 + #0))
-          Get l0
     cte l0 =
       Union
         Project (#0)
           ReadStorage materialize.public.init
         Get l2
+    cte l1 =
+      Project (#1)
+        Map ((#0 + #0))
+          Get l0
+    cte l2 =
+      Union
+        Get l0
+        Get l1
+        Get l1
+  Return
+    Get l2
 
 Source materialize.public.init
 

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -204,6 +204,28 @@ query T multiline
 EXPLAIN DECORRELATED PLAN WITH(arity) FOR SELECT f1 FROM t1
 WHERE f1 IN (SELECT ROW_NUMBER() OVER () FROM t2);
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.t1 // { arity: 2 }
+  cte l1 =
+    Distinct project=[#0] // { arity: 1 }
+      Get l0 // { arity: 2 }
+  cte l2 =
+    Map (true) // { arity: 2 }
+      Distinct project=[#0] // { arity: 1 }
+        Filter (integer_to_bigint(#0) = #1) // { arity: 2 }
+          Project (#0, #4) // { arity: 2 }
+            Map (#3) // { arity: 5 }
+              Project (#3..=#6) // { arity: 4 }
+                Map (record_get[0](record_get[1](#2)), record_get[1](record_get[1](#2)), record_get[2](record_get[1](#2)), record_get[0](#2)) // { arity: 7 }
+                  FlatMap unnest_list(#1) // { arity: 3 }
+                    Reduce group_by=[#0] aggregates=[row_number[order_by=[]](row(list[row(#0, #1, #2)]))] // { arity: 2 }
+                      CrossJoin // { arity: 3 }
+                        Get l1 // { arity: 1 }
+                        Get materialize.public.t2 // { arity: 2 }
 Return // { arity: 1 }
   Project (#0) // { arity: 1 }
     Filter #2 // { arity: 3 }
@@ -224,28 +246,6 @@ Return // { arity: 1 }
                   Get l1 // { arity: 1 }
               Constant // { arity: 1 }
                 - (false)
-With
-  cte l2 =
-    Map (true) // { arity: 2 }
-      Distinct project=[#0] // { arity: 1 }
-        Filter (integer_to_bigint(#0) = #1) // { arity: 2 }
-          Project (#0, #4) // { arity: 2 }
-            Map (#3) // { arity: 5 }
-              Project (#3..=#6) // { arity: 4 }
-                Map (record_get[0](record_get[1](#2)), record_get[1](record_get[1](#2)), record_get[2](record_get[1](#2)), record_get[0](#2)) // { arity: 7 }
-                  FlatMap unnest_list(#1) // { arity: 3 }
-                    Reduce group_by=[#0] aggregates=[row_number[order_by=[]](row(list[row(#0, #1, #2)]))] // { arity: 2 }
-                      CrossJoin // { arity: 3 }
-                        Get l1 // { arity: 1 }
-                        Get materialize.public.t2 // { arity: 2 }
-  cte l1 =
-    Distinct project=[#0] // { arity: 1 }
-      Get l0 // { arity: 2 }
-  cte l0 =
-    CrossJoin // { arity: 2 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.public.t1 // { arity: 2 }
 
 Target cluster: quickstart
 
@@ -256,6 +256,10 @@ EXPLAIN WITH(arity, join implementations) SELECT f1 FROM t1
 WHERE f1 IN (SELECT ROW_NUMBER() OVER () FROM t2);
 ----
 Explained Query:
+  With
+    cte l0 =
+      Project (#0) // { arity: 1 }
+        ReadStorage materialize.public.t1 // { arity: 2 }
   Return // { arity: 1 }
     Project (#0) // { arity: 1 }
       Join on=(#0 = #1) type=differential // { arity: 2 }
@@ -278,10 +282,6 @@ Explained Query:
                             Get l0 // { arity: 1 }
                         ArrangeBy keys=[[]] // { arity: 2 }
                           ReadStorage materialize.public.t2 // { arity: 2 }
-  With
-    cte l0 =
-      Project (#0) // { arity: 1 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -335,6 +335,12 @@ SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER() OVER() FROM t1 WHERE t1.f2 =
 query T multiline
 EXPLAIN DECORRELATED PLAN WITH(arity) FOR SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER() OVER() FROM t1 WHERE t1.f2 = t2.f2) AS foo;
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.t2 // { arity: 2 }
 Return // { arity: 5 }
   Project (#0, #1, #3..=#5) // { arity: 5 }
     Join on=(#1 = #2) // { arity: 6 }
@@ -350,12 +356,6 @@ Return // { arity: 5 }
                       Distinct project=[#1] // { arity: 1 }
                         Get l0 // { arity: 2 }
                       Get materialize.public.t1 // { arity: 2 }
-With
-  cte l0 =
-    CrossJoin // { arity: 2 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.public.t2 // { arity: 2 }
 
 Target cluster: quickstart
 
@@ -364,6 +364,12 @@ EOF
 query T multiline
 EXPLAIN DECORRELATED PLAN WITH(arity) FOR SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER() OVER(PARTITION BY f1) FROM t1 WHERE t1.f2 = t2.f2) AS foo;
 ----
+With
+  cte l0 =
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.t2 // { arity: 2 }
 Return // { arity: 5 }
   Project (#0, #1, #3..=#5) // { arity: 5 }
     Join on=(#1 = #2) // { arity: 6 }
@@ -379,12 +385,6 @@ Return // { arity: 5 }
                       Distinct project=[#1] // { arity: 1 }
                         Get l0 // { arity: 2 }
                       Get materialize.public.t1 // { arity: 2 }
-With
-  cte l0 =
-    CrossJoin // { arity: 2 }
-      Constant // { arity: 0 }
-        - ()
-      Get materialize.public.t2 // { arity: 2 }
 
 Target cluster: quickstart
 
@@ -6871,6 +6871,11 @@ SELECT
 FROM t7;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[sum(#0)] // { keys: "([])" }
+        Project (#0) // { keys: "()" }
+          ReadStorage materialize.public.t7 // { keys: "()" }
   Return // { keys: "()" }
     Project (#2) // { keys: "()" }
       Map (record_get[0](#1)) // { keys: "()" }
@@ -6886,11 +6891,6 @@ Explained Query:
                         Get l0 // { keys: "([])" }
                     Constant // { keys: "([])" }
                       - ()
-  With
-    cte l0 =
-      Reduce aggregates=[sum(#0)] // { keys: "([])" }
-        Project (#0) // { keys: "()" }
-          ReadStorage materialize.public.t7 // { keys: "()" }
 
 Source materialize.public.t7
 

--- a/test/testdrive/index-source-stuck.td
+++ b/test/testdrive/index-source-stuck.td
@@ -55,6 +55,10 @@
 # Check that index is actually used
 ? EXPLAIN SELECT min(counter) FROM mv;
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[min(#0)]
+        ReadIndex on=mv mv_counter_idx=[*** full scan ***]
   Return
     Union
       Get l0
@@ -65,10 +69,6 @@ Explained Query:
               Get l0
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[min(#0)]
-        ReadIndex on=mv mv_counter_idx=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.mv_counter_idx (*** full scan ***)

--- a/test/testdrive/primary-key-optimizations.td
+++ b/test/testdrive/primary-key-optimizations.td
@@ -213,6 +213,11 @@ Target cluster: quickstart
 
 ? EXPLAIN WITH(no notices) SELECT COUNT(DISTINCT key1) FROM t1_tbl;
 Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[count(distinct #0)]
+        Project (#0)
+          ReadIndex on=t1_tbl t1_tbl_primary_idx=[*** full scan ***]
   Return
     Union
       Get l0
@@ -223,11 +228,6 @@ Explained Query:
               Get l0
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce aggregates=[count(distinct #0)]
-        Project (#0)
-          ReadIndex on=t1_tbl t1_tbl_primary_idx=[*** full scan ***]
 
 Used Indexes:
   - t1_tbl_primary_idx (*** full scan ***)

--- a/test/testdrive/source-linear-operators.td
+++ b/test/testdrive/source-linear-operators.td
@@ -191,6 +191,10 @@ Target cluster: quickstart
 
 ? EXPLAIN SELECT * FROM v;
 Explained Query:
+  With
+    cte l0 =
+      Filter (#0) IS NOT NULL
+        ReadStorage materialize.public.data_tbl
   Return
     Project (#2)
       Join on=(#0 = #1) type=differential
@@ -200,10 +204,6 @@ Explained Query:
         ArrangeBy keys=[[#0]]
           Project (#0, #2)
             Get l0
-  With
-    cte l0 =
-      Filter (#0) IS NOT NULL
-        ReadStorage materialize.public.data_tbl
 
 Source materialize.public.data_tbl
   filter=((#0) IS NOT NULL)


### PR DESCRIPTION
This PR modifies how EXPLAIN prints Let/LetRec: It used to be `Return` first, and CTEs in bottom-up order, now it's CTEs in top-down order, and then `Return`. The main argument for the old order was that data flowed upwards both inside CTEs and across CTEs. However, the bottom-up order of CTE bindings kept tripping up optimizer developers, so it's probably better to have the CTEs in binding order (top-down). As @mgree [noted](https://materializeinc.slack.com/archives/C063H5S7NKE/p1736447818231129?thread_ts=1736350194.794989&cid=C063H5S7NKE), other databases also print in top-down order.

For example:
```
EXPLAIN
WITH MUTUALLY RECURSIVE
  c0(n int) AS (
    (SELECT n FROM init)
    UNION ALL
    (SELECT * FROM c2)
  ),
  c1(n int) AS (
    SELECT n+n FROM c0 WHERE n<5
  ),
  c2(n int) AS (
    (SELECT * FROM c0)
    UNION ALL
    (SELECT * FROM c1)
    UNION ALL
    (SELECT * FROM c1)
  )
SELECT * FROM c2;
```
used to be
```
Explained Query:
  Return
    Get l2
  With Mutually Recursive
    cte l2 =
      Union
        Get l0
        Get l1
        Get l1
    cte l1 =
      Project (#1)
        Filter (#0 < 5)
          Map ((#0 + #0))
            Get l0
    cte l0 =
      Union
        Project (#0)
          ReadStorage materialize.public.init
        Get l2
```
and now it would be
```
Explained Query:
  With Mutually Recursive
    cte l0 =
      Union
        Project (#0)
          ReadStorage materialize.public.init
        Get l2
    cte l1 =
      Project (#1)
        Filter (#0 < 5)
          Map ((#0 + #0))
            Get l0
    cte l2 =
      Union
        Get l0
        Get l1
        Get l1
  Return
    Get l2
```

The first commit is straightforward: just a few lines of code changes, and a bunch of expected test output rewrites (most of it with auto-rewrite, except for `testdrive`).

The third commit updates the docs, where we show an example EXPLAIN with a CTE.

The second commit is unfortunately not so straightforward. The problem is that the `.spec` test framework's _input_ format is supposed to correspond to EXPLAIN's _output_ format, but now we are reversing EXPLAIN's output format. There are several options on how to handle this situation:
1. Do nothing; the spec input format would keep using the old order. This has the problem that we'd have to keep the old order in mind, and any time when we want to create a new spec test in the future, we'd have to manually reverse the CTEs when copy-pasting an EXPLAIN output to be a spec input.
2. Make the spec parser be able to handle both orders. This is what I did in this PR. This has the advantage compared to 1. that creating new spec tests by copy-pasting an EXPLAIN output is possible. However, it still has a readability problem (for humans) for existing spec test inputs, as one has to keep in mind that the order might go both ways.
3. Extend the spec test framework to be able to auto-rewrite _inputs_, not just outputs. We'd have something like a `REWRITE_SPEC_INPUTS` env var (similar to `REWRITE`), which would simply roundtrip spec test inputs through the spec parser and EXPLAIN, and use the result to rewrite the inputs. This would be the cleanest solution from a usability perspective. However, it's not totally straightforward to implement, because the spec framework relies on the (external) `datadriven` framework, which doesn't provide a facility for rewriting _inputs_ out of the box. We'd probably need to crack open `datadriven`, and copy-paste some code from it to implement this ourselves. I'm open to doing this. I have a feeling that we won't be able to avoid this in the long run, when we keep making further changes to EXPLAIN output.

Now, 2. vs. 3. is open for debate. This PR just did 2. so far, because it was a matter of minutes to implement, but if we want to commit to the `spec` test framework for the long-term, then sooner or later we'll have to do 3., so might as well do it now (maybe in an immediate follow-up PR), to avoid keeping around the tech-debt of needing to keep in mind both the old and new orders when reading spec test inputs.

### Motivation

   * This PR changes EXPLAIN output, to eliminate a surprising element from it.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
