### PR TITLE
mv-sink: stop discarding valid batch descriptions

### DIFF
--- a/src/compute/src/sink/correction.rs
+++ b/src/compute/src/sink/correction.rs
@@ -200,11 +200,6 @@ impl<D: Data> Correction<D> {
         count
     }
 
-    /// Return the current since frontier.
-    pub fn since(&self) -> &Antichain<Timestamp> {
-        &self.since
-    }
-
     /// Advance the since frontier.
     ///
     /// # Panics

--- a/test/sqllogictest/github-8867.slt
+++ b/test/sqllogictest/github-8867.slt
@@ -1,0 +1,43 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for database-issues#8867.
+
+mode cockroach
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_refresh_every_mvs = true
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE t (x int)
+
+statement ok
+INSERT INTO t VALUES (1)
+
+statement ok
+CREATE MATERIALIZED VIEW mv1
+WITH (REFRESH EVERY '10s' ALIGNED TO mz_now()::text::int8 + 10000)
+AS SELECT * FROM t
+
+statement ok
+CREATE MATERIALIZED VIEW mv2
+WITH (REFRESH EVERY '10 s' ALIGNED TO mz_now()::text::int8 + 10000)
+AS SELECT * FROM mv1
+
+query I
+SELECT * FROM mv1;
+----
+1
+
+query I
+SELECT * FROM mv2;
+----
+1


### PR DESCRIPTION
This PR fixes a bug in the MV sink v2 where the `write` operator would discard valid batch descriptions as outdated, based on an incorrect view of the persist frontier. The fix is to simply remove this particular validity check, which also requires adapting some surrounding code.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8867
Fixes https://github.com/MaterializeInc/database-issues/issues/8821

### Tips for reviewer

The `mint` operator gets the correct persist shard write frontier by instantiating a separate write handle and polling that. Thus, an alternative fix would have been to also give the `write` operator such a handle, or share the frontier stream between the two operators. But then the `write` operator would need to start reasoning about two different "persist frontiers" and know when to use which one, which seems like a more complicated solution.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
