### PR TITLE
[docs] typo fixes, wordsmith

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -423,13 +423,13 @@ The suggestions are based on the graph of dependencies between objects and do
 not take into account other important factors, like the actual usage patterns
 and execution plans. This means that following the advice in this view **might
 not always lead to resource usage optimizations**. In some cases, the provided
-advice might even lead to suboptimal execution plans or even increased resource
+advice might lead to suboptimal execution plans or even increased resource
 usage. For example:
 
 - If a materialized view or an index has been created for direct querying, the
   dependency graph will not reflect this nuance and `mz_index_advice` might
-  recommend using and unindexed view instead. In this case, you should refer to
-  the the reference documentation for [query optimization](/transform-data/optimization/#indexes)
+  recommend using an unindexed view instead. In this case, you should refer to
+  the reference documentation for [query optimization](/transform-data/optimization/#indexes)
   instead.
 - If a view is depended on by multiple objects that use very selective filters,
   or multiple projections that can be pushed into or even beyond the view,


### PR DESCRIPTION
Noticed while looking things up: a few typos and some word duplication.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
