### PR TITLE
legacy upgrade test: Ignore missing version in Test pipeline

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1564,16 +1564,31 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: balancerd
 
-  - id: legacy-upgrade
-    label: Legacy upgrade tests (last version from git)
-    depends_on: build-aarch64
-    timeout_in_minutes: 60
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: legacy-upgrade
-          args: ["--versions-source=git"]
-    agents:
-      queue: hetzner-aarch64-4cpu-8gb
+  - group: Legacy upgrade tests
+    key: legacy-upgrade
+    steps:
+      - id: legacy-upgrade-git
+        label: Legacy upgrade tests (last version from git)
+        depends_on: build-aarch64
+        timeout_in_minutes: 60
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: legacy-upgrade
+              args: ["--versions-source=git"]
+        agents:
+          queue: hetzner-aarch64-4cpu-8gb
+
+      - id: legacy-upgrade-docs
+        label: "Legacy upgrade tests (last version from docs)"
+        parallelism: 2
+        depends_on: build-aarch64
+        timeout_in_minutes: 60
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: legacy-upgrade
+              args: ["--versions-source=docs"]
+        agents:
+          queue: hetzner-aarch64-4cpu-8gb
 
   - group: Cloud tests
     key: cloudtests

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -342,15 +342,15 @@ steps:
     agents:
       queue: hetzner-aarch64-4cpu-8gb
 
-  - id: legacy-upgrade
-    label: "Legacy upgrade tests (last version from docs)"
+  - id: legacy-upgrade-docs-ignore-missing
+    label: "Legacy upgrade tests (last version from docs, ignore missing)"
     parallelism: 2
     depends_on: build-aarch64
     timeout_in_minutes: 60
     plugins:
       - ./ci/plugins/mzcompose:
           composition: legacy-upgrade
-          args: ["--versions-source=docs"]
+          args: ["--versions-source=docs", "--ignore-missing-version"]
     agents:
       queue: hetzner-aarch64-4cpu-8gb
 


### PR DESCRIPTION
Causing PRs to be blocked from merging for a second time. We will ignore this specific failure in Test pipeline now, but still report it in Nightly so that we don't miss it.

(This is not a very elegant solution but should unblock us quickly enough.)

Context: https://materializeinc.slack.com/archives/CMH6PG4CW/p1736491884771329?thread_ts=1736427104.795249&cid=CMH6PG4CW

Noticed in https://buildkite.com/materialize/test/builds/96952
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
