### PR TITLE
pg-cdc old syntax: Fix test failure

### DIFF
--- a/test/pg-cdc-old-syntax/alter-source.td
+++ b/test/pg-cdc-old-syntax/alter-source.td
@@ -270,7 +270,6 @@ tb                 subsource
 # If your schema change breaks the subsource, you can fix it.
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER TABLE table_a DROP COLUMN f2;
-INSERT INTO table_a VALUES (3);
 
 ! SELECT * FROM table_a;
 contains:incompatible schema change


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/30807

Seen in https://buildkite.com/materialize/nightly/builds/10822#01944f9a-9738-4aa8-a012-bc111a2660ae

@petrosagg Is this expected? Feels like it could also be a bug since we can now still ingest a value after having dropped the column.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
