### PR TITLE
docs: update substring function signatures

### DIFF
--- a/doc/user/content/sql/functions/substring.md
+++ b/doc/user/content/sql/functions/substring.md
@@ -10,7 +10,13 @@ menu:
 
 ## Signatures
 
-{{< diagram "func-substring.svg" >}}
+```mzsql
+substring(str, start_pos)
+substring(str, start_pos, len)
+substring(str FROM start_pos)
+substring(str FOR len)
+substring(str FROM start_pos FOR len)
+```
 
 Parameter | Type | Description
 ----------|------|------------

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -403,8 +403,6 @@ func_length ::=
   'length' '(' str (',' encoding_name)? ')'
 func_map_agg ::=
   'map_agg' '(' keys ',' values ( 'ORDER' 'BY' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? ( ',' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? )* )? ')' ('FILTER' '(' 'WHERE' filter_clause ')')?
-func_substring ::=
-  'substring' '(' str ',' start_pos (',' len)? ')'
 func_timezone ::=
     'TIMEZONE' '(' zone'::'type ',' ( 'timestamp' | 'timestamptz' ) ')'
 func_justify_days ::=


### PR DESCRIPTION
The substring function page did not reflect the different signatures listed on the [sql/functions/](https://materialize.com/docs/sql/functions/#substring) page.