### PR TITLE
adapter: actually treat `CREATE TABLE ... FROM WEBHOOK` as a Table

### DIFF
--- a/misc/python/materialize/checks/all_checks/webhook.py
+++ b/misc/python/materialize/checks/all_checks/webhook.py
@@ -125,7 +125,7 @@ class Webhook(Check):
 
 class WebhookTable(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse_mz("v0.128.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.130.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(
@@ -164,7 +164,7 @@ class WebhookTable(Check):
                 anotha_one!
                 threeeeeee
 
-                > SHOW CREATE SOURCE webhook_table_text
+                > SHOW CREATE TABLE webhook_table_text
                 materialize.public.webhook_table_text "CREATE TABLE \\"materialize\\".\\"public\\".\\"webhook_table_text\\" FROM WEBHOOK BODY FORMAT TEXT"
            """
             )

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -1082,14 +1082,21 @@ impl Source {
                     validate_using,
                     body_format,
                     headers,
-                } => DataSourceDesc::Webhook {
-                    validate_using,
-                    body_format,
-                    headers,
-                    cluster_id: plan
-                        .in_cluster
-                        .expect("webhook sources must be given a cluster ID"),
-                },
+                    cluster_id,
+                } => {
+                    mz_ore::soft_assert_or_log!(
+                        cluster_id.is_none(),
+                        "cluster_id set at Source level for Webhooks"
+                    );
+                    DataSourceDesc::Webhook {
+                        validate_using,
+                        body_format,
+                        headers,
+                        cluster_id: plan
+                            .in_cluster
+                            .expect("webhook sources must be given a cluster ID"),
+                    }
+                }
             },
             desc: plan.source.desc,
             global_id,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -61,6 +61,7 @@ use mz_storage_types::connections::{
     AwsPrivatelinkConnection, CsrConnection, KafkaConnection, MySqlConnection, PostgresConnection,
     SshConnection,
 };
+use mz_storage_types::instances::StorageInstanceId;
 use mz_storage_types::sinks::{
     S3SinkFormat, SinkEnvelope, SinkPartitionStrategy, StorageSinkConnection,
 };
@@ -272,9 +273,10 @@ impl Plan {
             StatementKind::CreateSchema => &[PlanKind::CreateSchema],
             StatementKind::CreateSecret => &[PlanKind::CreateSecret],
             StatementKind::CreateSink => &[PlanKind::CreateSink],
-            StatementKind::CreateSource
-            | StatementKind::CreateSubsource
-            | StatementKind::CreateWebhookSource => &[PlanKind::CreateSource],
+            StatementKind::CreateSource | StatementKind::CreateSubsource => {
+                &[PlanKind::CreateSource]
+            }
+            StatementKind::CreateWebhookSource => &[PlanKind::CreateSource, PlanKind::CreateTable],
             StatementKind::CreateTable => &[PlanKind::CreateTable],
             StatementKind::CreateTableFromSource => &[PlanKind::CreateTable],
             StatementKind::CreateType => &[PlanKind::CreateType],
@@ -1440,6 +1442,8 @@ pub enum DataSourceDesc {
         validate_using: Option<WebhookValidation>,
         body_format: WebhookBodyFormat,
         headers: WebhookHeaders,
+        /// Only `Some` when created via `CREATE TABLE ... FROM WEBHOOK`.
+        cluster_id: Option<StorageInstanceId>,
     },
 }
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1558,7 +1558,7 @@ where
             .into_iter()
             .partition(|id| match self.collections[id].data_source {
                 DataSource::Table => true,
-                DataSource::IngestionExport { .. } => false,
+                DataSource::IngestionExport { .. } | DataSource::Webhook => false,
                 _ => panic!("identifier is not a table: {}", id),
             });
 

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -23,6 +23,12 @@ name   nullable  type  comment
 ------------------------------
 body   false     text  ""
 
+> SHOW CREATE SOURCE webhook_text;
+materialize.public.webhook_text "CREATE SOURCE \"materialize\".\"public\".\"webhook_text\" IN CLUSTER \"webhook_cluster\" FROM WEBHOOK BODY FORMAT TEXT"
+
+> SELECT name, type FROM mz_objects WHERE name = 'webhook_text';
+webhook_text source
+
 $ webhook-append database=materialize schema=public name=webhook_text
 a
 
@@ -548,3 +554,28 @@ aaa_1
 
 > SELECT * FROM webhook_as_table;
 aaa_1
+
+> SHOW CREATE TABLE webhook_as_table;
+materialize.public.webhook_as_table "CREATE TABLE \"materialize\".\"public\".\"webhook_as_table\" FROM WEBHOOK BODY FORMAT TEXT"
+
+> SHOW COLUMNS FROM webhook_as_table;
+name   nullable  type  comment
+------------------------------
+body   false     text  ""
+
+> SHOW TABLES
+not_a_webhook ""
+webhook_as_table ""
+
+> SELECT name, type FROM mz_objects WHERE name = 'webhook_as_table';
+webhook_as_table table
+
+$ set-from-sql var=webhook-table-id
+SELECT id FROM mz_tables WHERE name = 'webhook_as_table';
+
+$ set-from-sql var=webhook-table-shard-id
+SELECT shard_id FROM mz_internal.mz_storage_shards WHERE object_id = '${webhook-table-id}';
+
+> DROP TABLE webhook_as_table;
+
+$ check-shard-tombstone shard-id=${webhook-table-shard-id}


### PR DESCRIPTION
Some refactoring in the Adapter to treat objects created by `CREATE TABLE ... FROM WEBHOOK` actually as tables. This way they show up when querying `mz_tables`, you can run `SHOW CREATE TABLE ...`, etc.


### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/8862

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
