### PR TITLE
Revert "Merge pull request #30994 from def-/pr-legacy-upgrade-unblock"

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1564,31 +1564,16 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: balancerd
 
-  - group: Legacy upgrade tests
-    key: legacy-upgrade
-    steps:
-      - id: legacy-upgrade-git
-        label: Legacy upgrade tests (last version from git)
-        depends_on: build-aarch64
-        timeout_in_minutes: 60
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: legacy-upgrade
-              args: ["--versions-source=git"]
-        agents:
-          queue: hetzner-aarch64-4cpu-8gb
-
-      - id: legacy-upgrade-docs
-        label: "Legacy upgrade tests (last version from docs)"
-        parallelism: 2
-        depends_on: build-aarch64
-        timeout_in_minutes: 60
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: legacy-upgrade
-              args: ["--versions-source=docs"]
-        agents:
-          queue: hetzner-aarch64-4cpu-8gb
+  - id: legacy-upgrade
+    label: Legacy upgrade tests (last version from git)
+    depends_on: build-aarch64
+    timeout_in_minutes: 60
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: legacy-upgrade
+          args: ["--versions-source=git"]
+    agents:
+      queue: hetzner-aarch64-4cpu-8gb
 
   - group: Cloud tests
     key: cloudtests

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -342,15 +342,15 @@ steps:
     agents:
       queue: hetzner-aarch64-4cpu-8gb
 
-  - id: legacy-upgrade-docs-ignore-missing
-    label: "Legacy upgrade tests (last version from docs, ignore missing)"
+  - id: legacy-upgrade
+    label: "Legacy upgrade tests (last version from docs)"
     parallelism: 2
     depends_on: build-aarch64
     timeout_in_minutes: 60
     plugins:
       - ./ci/plugins/mzcompose:
           composition: legacy-upgrade
-          args: ["--versions-source=docs", "--ignore-missing-version"]
+          args: ["--versions-source=docs"]
     agents:
       queue: hetzner-aarch64-4cpu-8gb
 

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -15,7 +15,6 @@ operational after an upgrade. See also the newer platform-checks' upgrade scenar
 import random
 
 from materialize import buildkite
-from materialize.docker import image_of_release_version_exists
 from materialize.mz_version import MzVersion
 from materialize.mzcompose import get_default_system_parameters
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
@@ -79,7 +78,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         choices=["docs", "git"],
         help="from what source to fetch the versions",
     )
-    parser.add_argument("--ignore-missing-version", action="store_true")
     args = parser.parse_args()
 
     parallelism_index = buildkite.get_parallelism_index()
@@ -100,12 +98,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
 
     for version in tested_versions:
-        # Building the latest release might have failed, don't block PRs on
-        # test pipeline for this.
-        if args.ignore_missing_version and not image_of_release_version_exists(version):
-            print(f"Unknown version {version}, skipping")
-            continue
-
         priors = [
             v for v in all_versions if v <= version and v >= min_upgradable_version
         ]


### PR DESCRIPTION
This reverts commit 9b0c0bbda45591a6b62cd90f7ebb11975aabcc8a, reversing changes made to 769f82228ad6f3f6b9eef1c465b08a2f4ce9ce13.

x86_64 builds should be working again, let's restore the Legacy Upgrade Tests to how they used to be.

### Motivation

Revert temporary patch because of build failures.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
