### PR TITLE
scratch: Add profile for x86_64 CI runner

### DIFF
--- a/misc/scratch/ci-x86_64-large.json
+++ b/misc/scratch/ci-x86_64-large.json
@@ -1,0 +1,8 @@
+{
+    "name": "m7a.8xlarge as used by CI",
+    "launch_script": "true",
+    "instance_type": "m7a.8xlarge",
+    "ami": "ami-09d56f8956ab235b3",
+    "size_gb": 250,
+    "tags": {}
+}


### PR DESCRIPTION
### Motivation

Was useful for debugging a build failure, I figured it would be good to have

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
