### PR TITLE
bazel: make sure to build zlib from `libz-sys` crate source

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -478,8 +478,10 @@ crates_repository(
             deps = [":librdkafka"],
         )],
         "libz-sys": [crate.annotation(
+            additive_build_file = "@//misc/bazel/c_deps:rust-sys/BUILD.libz.bazel",
             gen_build_script = False,
-            deps = ["@zlib"],
+            # Note: This is a target we add from the additive build file above.
+            deps = [":zlib"],
         )],
         "openssl-sys": [crate.annotation(
             build_script_data = [

--- a/misc/bazel/c_deps/rust-sys/BUILD.libz.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.libz.bazel
@@ -1,0 +1,71 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Builds zlib.
+
+Derived from: <https://github.com/rust-lang/libz-sys/blob/8462d47d51e36c8cd7fa83db3cbcc2b725385650/build.rs>
+"""
+
+cc_library(
+    name = "zlib",
+    srcs = [
+        "src/zlib/adler32.c",
+        "src/zlib/compress.c",
+        "src/zlib/crc32.c",
+        "src/zlib/deflate.c",
+        "src/zlib/infback.c",
+        "src/zlib/inffast.c",
+        "src/zlib/inflate.c",
+        "src/zlib/inftrees.c",
+        "src/zlib/trees.c",
+        "src/zlib/uncompr.c",
+        "src/zlib/zutil.c",
+    ],
+    hdrs = [
+        "src/zlib/crc32.h",
+        "src/zlib/deflate.h",
+        "src/zlib/inffast.h",
+        "src/zlib/inffixed.h",
+        "src/zlib/inflate.h",
+        "src/zlib/inftrees.h",
+        "src/zlib/trees.h",
+        "src/zlib/zconf.h",
+        "src/zlib/zlib.h",
+        "src/zlib/zutil.h",
+    ],
+    copts = select({
+        "//conditions:default": [
+            "-Wno-unused-variable",
+            "-Wno-implicit-function-declaration",
+            "-Wno-deprecated-non-prototype",
+            "-Wno-macro-redefined",
+            "-fvisibility=hidden",
+        ],
+    }),
+    includes = ["src/zlib"],
+    local_defines = [
+       "Z_SOLO",
+       "STDC",
+       "_LARGEFILE64_SOURCE",
+       "_POSIX_SOURCE",
+    ] + select({
+       "@platforms//os:macos": [
+           "_C99_SOURCE",
+       ],
+       "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Previously we were linking the zlib built by Bazel, which might not be the same version specified by the `libz-sys` crate. Now we build the version of `zlib` included by the `libz-sys` crate.

### Motivation

Make our build easier to reason about.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
