### PR TITLE
build: remove `time` from `BuildInfo` which prevent repeatable builds

### DIFF
--- a/misc/bazel/c_deps/rust-sys/BUILD.libz.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.libz.bazel
@@ -57,15 +57,15 @@ cc_library(
     }),
     includes = ["src/zlib"],
     local_defines = [
-       "Z_SOLO",
-       "STDC",
-       "_LARGEFILE64_SOURCE",
-       "_POSIX_SOURCE",
+        "Z_SOLO",
+        "STDC",
+        "_LARGEFILE64_SOURCE",
+        "_POSIX_SOURCE",
     ] + select({
-       "@platforms//os:macos": [
-           "_C99_SOURCE",
-       ],
-       "//conditions:default": [],
+        "@platforms//os:macos": [
+            "_C99_SOURCE",
+        ],
+        "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
 )

--- a/src/build-info/src/lib.rs
+++ b/src/build-info/src/lib.rs
@@ -19,8 +19,6 @@ pub struct BuildInfo {
     pub version: &'static str,
     /// The 40-character SHA-1 hash identifying the Git commit of the build.
     pub sha: &'static str,
-    /// The time of the build in UTC as an ISO 8601-compliant string.
-    pub time: &'static str,
 }
 
 /// Dummy build information.
@@ -30,7 +28,6 @@ pub struct BuildInfo {
 pub const DUMMY_BUILD_INFO: BuildInfo = BuildInfo {
     version: "0.0.0+dummy",
     sha: "0000000000000000000000000000000000000000",
-    time: "",
 };
 
 /// The target triple of the platform.
@@ -94,7 +91,6 @@ macro_rules! build_info {
         $crate::BuildInfo {
             version: env!("CARGO_PKG_VERSION"),
             sha: $crate::__git_sha_internal!(),
-            time: $crate::__build_time_internal!(),
         }
     };
 }
@@ -154,13 +150,6 @@ macro_rules! __git_sha_internal {
     }
 }
 
-#[macro_export]
-macro_rules! __build_time_internal {
-    () => {
-        $crate::private::run_command_str!("date", "-u", "+%Y-%m-%dT%H:%M:%SZ")
-    };
-}
-
 #[doc(hidden)]
 pub mod private {
     pub use compile_time_run::run_command_str;
@@ -182,6 +171,5 @@ mod test {
         let build_info = crate::build_info!();
 
         assert_eq!(build_info.sha.len(), 40);
-        assert_eq!(build_info.time.len(), 20);
     }
 }

--- a/src/environmentd/src/http/root.rs
+++ b/src/environmentd/src/http/root.rs
@@ -18,7 +18,6 @@ use crate::BUILD_INFO;
 #[template(path = "home.html")]
 struct HomeTemplate<'a> {
     version: &'a str,
-    build_time: &'a str,
     build_sha: &'static str,
     profiling: bool,
 }
@@ -26,7 +25,6 @@ struct HomeTemplate<'a> {
 pub async fn handle_home(profiling: bool) -> impl IntoResponse {
     mz_http_util::template_response(HomeTemplate {
         version: BUILD_INFO.version,
-        build_time: BUILD_INFO.time,
         build_sha: BUILD_INFO.sha,
         profiling,
     })

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -455,7 +455,6 @@ impl Listeners {
                 sentry: None,
                 build_version: crate::BUILD_INFO.version,
                 build_sha: crate::BUILD_INFO.sha,
-                build_time: crate::BUILD_INFO.time,
                 registry: metrics_registry.clone(),
                 capture: config.capture,
             };

--- a/src/environmentd/templates/home.html
+++ b/src/environmentd/templates/home.html
@@ -3,7 +3,7 @@
 {% block title %}Home{% endblock %}
 
 {% block content %}
-<p>environmentd {{ version }} (built at {{ build_time }} from <code>{{ build_sha }}</code>)</p>
+<p>environmentd {{ version }} (built from <code>{{ build_sha }}</code>)</p>
 <ul>
     {% if profiling %}
         <li><a href="/prof/">profiling functions</a></li>

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -325,7 +325,6 @@ impl TracingCliArgs {
             }),
             build_version: build_info.version,
             build_sha: build_info.sha,
-            build_time: build_info.time,
             registry,
             #[cfg(feature = "capture")]
             capture: self.capture.clone(),

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -95,8 +95,6 @@ pub struct TracingConfig<F> {
     pub build_version: &'static str,
     /// The commit SHA of this build of the service.
     pub build_sha: &'static str,
-    /// The time of this build of the service.
-    pub build_time: &'static str,
     /// Registry for prometheus metrics.
     pub registry: MetricsRegistry,
 }
@@ -543,7 +541,6 @@ where
             sentry::configure_scope(|scope| {
                 scope.set_tag("service_name", config.service_name);
                 scope.set_tag("build_sha", config.build_sha.to_string());
-                scope.set_tag("build_time", config.build_time.to_string());
                 for (k, v) in sentry_config.tags {
                     scope.set_tag(&k, v);
                 }

--- a/src/persist-client/src/cli/args.rs
+++ b/src/persist-client/src/cli/args.rs
@@ -100,7 +100,6 @@ pub struct StateArgs {
 pub(crate) const READ_ALL_BUILD_INFO: BuildInfo = BuildInfo {
     version: "99.999.99+test",
     sha: "0000000000000000000000000000000000000000",
-    time: "",
 };
 
 // All `inspect` command are read-only.

--- a/src/service/src/boot.rs
+++ b/src/service/src/boot.rs
@@ -39,7 +39,6 @@ macro_rules! emit_boot_diagnostics {
             os.bitness = %os.bitness(),
             build.version = build_info.version,
             build.sha = build_info.sha,
-            build.time = build_info.time,
             cpus.logical = cpus.len(),
             cpus.physical = %system.physical_core_count().display_or("<unknown>"),
             cpu0.brand = cpus[0].brand(),


### PR DESCRIPTION
This PR removes the build time from `BuildInfo`, this gets baked into the static values of a build and thus prevents repeatable builds. I'm not aware of any cases where we referenced the build time, but if we need to keep it, that's fine with me.

From some limited experimentation, after this PR our Rust code is totally reproducible, although builds aren't yet end-to-end repeatable because of some issues with C deps. I also think this might be the cause of some non-determinism I was trying to track down in the `adapter` crate.

### Motivation

Reproducible builds

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
