### PR TITLE
storage: move methods from StorageController to StorageCollections

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2479,7 +2479,7 @@ impl Coordinator {
             // Fetch the current contents of the table for retraction.
             let current_contents_fut = self
                 .controller
-                .storage
+                .storage_collections
                 .snapshot(system_table.table.global_id_writes(), read_ts);
             // Fetch a snapshot of the current tables concurrently.
             let task = spawn(|| format!("snapshot-{table_id}"), async move {
@@ -2555,7 +2555,7 @@ impl Coordinator {
         debug!("coordinator init: reconciling audit log: {full_name} ({table_id})");
         let current_contents_fut = self
             .controller
-            .storage
+            .storage_collections
             .snapshot(table.global_id_writes(), read_ts);
         spawn(|| format!("snapshot-audit-log-{table_id}"), async move {
             let current_contents = current_contents_fut
@@ -3692,7 +3692,10 @@ impl Coordinator {
             .resolve_builtin_table(&MZ_STORAGE_USAGE_BY_SHARD);
         let global_id = self.catalog.get_entry(&item_id).latest_global_id();
         let read_ts = self.get_local_read_ts().await;
-        let current_contents_fut = self.controller.storage.snapshot(global_id, read_ts);
+        let current_contents_fut = self
+            .controller
+            .storage_collections
+            .snapshot(global_id, read_ts);
         let internal_cmd_tx = self.internal_cmd_tx.clone();
         spawn(|| "storage_usage_prune", async move {
             let mut current_contents = current_contents_fut

--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -71,7 +71,7 @@ impl Coordinator {
 
         let live_frontiers = self
             .controller
-            .storage
+            .storage_collections
             .snapshot_latest(replica_frontier_gid)
             .await
             .expect("can't read mz_cluster_replica_frontiers");

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1216,7 +1216,7 @@ impl Coordinator {
         }
     }
 
-    fn update_metrics_retention(&mut self) {
+    fn update_metrics_retention(&self) {
         let duration = self.catalog().system_config().metrics_retention();
         let policy = ReadPolicy::lag_writes_by(
             Timestamp::new(u64::try_from(duration.as_millis()).unwrap_or_else(|_e| {

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -521,7 +521,12 @@ impl Coordinator {
             mut builtin_table_updates,
             audit_events,
         } = catalog
-            .transact(Some(&mut *controller.storage), oracle_write_ts, conn, ops)
+            .transact(
+                Some(&mut controller.storage_collections),
+                oracle_write_ts,
+                conn,
+                ops,
+            )
             .await?;
 
         // Update in-memory cluster replica statuses.

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -274,7 +274,9 @@ impl crate::coord::Coordinator {
             .iter()
             .map(|id| (*id, read_policy.clone()))
             .collect();
-        self.controller.storage.set_read_policy(storage_policies);
+        self.controller
+            .storage_collections
+            .set_read_policies(storage_policies);
 
         for (instance_id, collection_ids) in &id_bundle.compute_ids {
             let compute_policies = collection_ids
@@ -289,7 +291,7 @@ impl crate::coord::Coordinator {
     }
 
     pub(crate) fn update_storage_read_policies(
-        &mut self,
+        &self,
         policies: Vec<(CatalogItemId, ReadPolicy<Timestamp>)>,
     ) {
         let policies = policies
@@ -303,7 +305,9 @@ impl crate::coord::Coordinator {
             })
             .flatten()
             .collect();
-        self.controller.storage.set_read_policy(policies);
+        self.controller
+            .storage_collections
+            .set_read_policies(policies);
     }
 
     pub(crate) fn update_compute_read_policies(
@@ -356,7 +360,7 @@ impl crate::coord::Coordinator {
         let desired_storage_holds = id_bundle.storage_ids.iter().map(|id| *id).collect_vec();
         let storage_read_holds = self
             .controller
-            .storage
+            .storage_collections
             .acquire_read_holds(desired_storage_holds)
             .expect("missing storage collections");
         read_holds.storage_holds = storage_read_holds

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2550,7 +2550,7 @@ impl Coordinator {
                 .into_owned();
             let stats_future = self
                 .controller
-                .storage
+                .storage_collections
                 .snapshot_parts_stats(id, as_of.clone())
                 .await;
 
@@ -4775,12 +4775,14 @@ impl CachedStatisticsOracle {
     pub async fn new<T: TimelyTimestamp>(
         ids: &BTreeSet<GlobalId>,
         as_of: &Antichain<T>,
-        storage: &dyn mz_storage_client::controller::StorageController<Timestamp = T>,
+        storage_collections: &dyn mz_storage_client::storage_collections::StorageCollections<
+            Timestamp = T,
+        >,
     ) -> Result<Self, StorageError<T>> {
         let mut cache = BTreeMap::new();
 
         for id in ids {
-            let stats = storage.snapshot_stats(*id, as_of.clone()).await;
+            let stats = storage_collections.snapshot_stats(*id, as_of.clone()).await;
 
             match stats {
                 Ok(stats) => {
@@ -4830,7 +4832,11 @@ impl Coordinator {
 
         let cached_stats = mz_ore::future::timeout(
             timeout,
-            CachedStatisticsOracle::new(source_ids, query_as_of, self.controller.storage.as_ref()),
+            CachedStatisticsOracle::new(
+                source_ids,
+                query_as_of,
+                self.controller.storage_collections.as_ref(),
+            ),
         )
         .await;
 

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -766,6 +766,7 @@ mod tests {
     use std::collections::BTreeSet;
 
     use async_trait::async_trait;
+    use differential_dataflow::lattice::Lattice;
     use futures::future::BoxFuture;
     use mz_compute_types::dataflows::{IndexDesc, IndexImport};
     use mz_compute_types::sinks::ComputeSinkConnection;
@@ -774,11 +775,12 @@ mod tests {
     use mz_compute_types::sources::SourceInstanceArguments;
     use mz_compute_types::sources::SourceInstanceDesc;
     use mz_persist_client::stats::{SnapshotPartsStats, SnapshotStats};
-    use mz_repr::RelationDesc;
-    use mz_repr::RelationType;
+    use mz_persist_types::Codec64;
     use mz_repr::Timestamp;
+    use mz_repr::{Diff, RelationType};
+    use mz_repr::{RelationDesc, Row};
     use mz_storage_client::controller::{CollectionDescription, StorageMetadata, StorageTxn};
-    use mz_storage_client::storage_collections::CollectionFrontiers;
+    use mz_storage_client::storage_collections::{CollectionFrontiers, SnapshotCursor};
     use mz_storage_types::connections::inline::InlinedConnection;
     use mz_storage_types::controller::{CollectionMetadata, StorageError};
     use mz_storage_types::parameters::StorageParameters;
@@ -786,6 +788,7 @@ mod tests {
     use mz_storage_types::sources::SourceExportDataConfig;
     use mz_storage_types::sources::{GenericSourceConnection, SourceDesc};
     use mz_storage_types::time_dependence::{TimeDependence, TimeDependenceError};
+    use timely::progress::Timestamp as TimelyTimestamp;
 
     use super::*;
 
@@ -869,6 +872,32 @@ mod tests {
             _id: GlobalId,
             _as_of: Antichain<Self::Timestamp>,
         ) -> BoxFuture<'static, Result<SnapshotPartsStats, StorageError<Self::Timestamp>>> {
+            unimplemented!()
+        }
+
+        fn snapshot(
+            &self,
+            _id: GlobalId,
+            _as_of: Self::Timestamp,
+        ) -> BoxFuture<'static, Result<Vec<(Row, Diff)>, StorageError<Self::Timestamp>>> {
+            unimplemented!()
+        }
+
+        async fn snapshot_latest(
+            &self,
+            _id: GlobalId,
+        ) -> Result<Vec<Row>, StorageError<Self::Timestamp>> {
+            unimplemented!()
+        }
+
+        async fn snapshot_cursor(
+            &mut self,
+            _id: GlobalId,
+            _as_of: Self::Timestamp,
+        ) -> Result<SnapshotCursor<Self::Timestamp>, StorageError<Self::Timestamp>>
+        where
+            Self::Timestamp: TimelyTimestamp + Lattice + Codec64,
+        {
             unimplemented!()
         }
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -633,26 +633,6 @@ pub trait StorageController: Debug {
     /// introspection type, as readers rely on this and might panic otherwise.
     fn update_introspection_collection(&mut self, type_: IntrospectionType, op: StorageWriteOp);
 
-    /// On boot, seed the controller's metadata/state.
-    async fn initialize_state(
-        &mut self,
-        txn: &mut (dyn StorageTxn<Self::Timestamp> + Send),
-        init_ids: BTreeSet<GlobalId>,
-        drop_ids: BTreeSet<GlobalId>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
-
-    /// Update the implementor of [`StorageTxn`] with the appropriate metadata
-    /// given the IDs to add and drop.
-    ///
-    /// The data modified in the `StorageTxn` must be made available in all
-    /// subsequent calls that require [`StorageMetadata`] as a parameter.
-    async fn prepare_state(
-        &self,
-        txn: &mut (dyn StorageTxn<Self::Timestamp> + Send),
-        ids_to_add: BTreeSet<GlobalId>,
-        ids_to_drop: BTreeSet<GlobalId>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
-
     async fn real_time_recent_timestamp(
         &self,
         source_ids: BTreeSet<GlobalId>,

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use differential_dataflow::lattice::Lattice;
 use futures::future::BoxFuture;
-use futures::stream::FuturesUnordered;
+use futures::stream::{BoxStream, FuturesUnordered};
 use futures::{Future, FutureExt, StreamExt};
 use itertools::Itertools;
 
@@ -30,14 +30,14 @@ use mz_ore::{assert_none, instrument, soft_assert_or_log};
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::cfg::USE_CRITICAL_SINCE_SNAPSHOT;
 use mz_persist_client::critical::SinceHandle;
-use mz_persist_client::read::ReadHandle;
+use mz_persist_client::read::{Cursor, ReadHandle};
 use mz_persist_client::stats::{SnapshotPartsStats, SnapshotStats};
 use mz_persist_client::write::WriteHandle;
 use mz_persist_client::{Diagnostics, PersistClient, PersistLocation, ShardId};
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::txn::TxnsCodec;
 use mz_persist_types::Codec64;
-use mz_repr::{Diff, GlobalId, RelationDesc, TimestampManipulation};
+use mz_repr::{Diff, GlobalId, RelationDesc, Row, TimestampManipulation};
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::connections::inline::InlinedConnection;
 use mz_storage_types::connections::ConnectionContext;
@@ -168,6 +168,29 @@ pub trait StorageCollections: Debug {
         id: GlobalId,
         as_of: Antichain<Self::Timestamp>,
     ) -> BoxFuture<'static, Result<SnapshotPartsStats, StorageError<Self::Timestamp>>>;
+
+    /// Returns a snapshot of the contents of collection `id` at `as_of`.
+    fn snapshot(
+        &self,
+        id: GlobalId,
+        as_of: Self::Timestamp,
+    ) -> BoxFuture<'static, Result<Vec<(Row, Diff)>, StorageError<Self::Timestamp>>>;
+
+    /// Returns a snapshot of the contents of collection `id` at the largest
+    /// readable `as_of`.
+    async fn snapshot_latest(
+        &self,
+        id: GlobalId,
+    ) -> Result<Vec<Row>, StorageError<Self::Timestamp>>;
+
+    /// Returns a snapshot of the contents of collection `id` at `as_of`.
+    async fn snapshot_cursor(
+        &mut self,
+        id: GlobalId,
+        as_of: Self::Timestamp,
+    ) -> Result<SnapshotCursor<Self::Timestamp>, StorageError<Self::Timestamp>>
+    where
+        Self::Timestamp: Codec64 + TimelyTimestamp + Lattice;
 
     /// Update the given [`StorageTxn`] with the appropriate metadata given the
     /// IDs to add and drop.
@@ -310,6 +333,25 @@ pub trait StorageCollections: Debug {
         &self,
         id: GlobalId,
     ) -> Result<Option<TimeDependence>, TimeDependenceError>;
+}
+
+/// A cursor over a snapshot, allowing us to read just part of a snapshot in its
+/// consolidated form.
+pub struct SnapshotCursor<T: Codec64 + TimelyTimestamp + Lattice> {
+    // We allocate a temporary read handle for each snapshot, and that handle needs to live at
+    // least as long as the cursor itself, which holds part leases. Bundling them together!
+    pub _read_handle: ReadHandle<SourceData, (), T, Diff>,
+    pub cursor: Cursor<SourceData, (), T, Diff>,
+}
+
+impl<T: Codec64 + TimelyTimestamp + Lattice + Sync> SnapshotCursor<T> {
+    pub async fn next(
+        &mut self,
+    ) -> Option<
+        impl Iterator<Item = ((Result<SourceData, String>, Result<(), String>), T, Diff)> + Sized + '_,
+    > {
+        self.cursor.next().await
+    }
 }
 
 /// Frontiers of the collection identified by `id`.
@@ -914,13 +956,39 @@ where
         Ok(())
     }
 
+    async fn recent_upper(&self, id: GlobalId) -> Result<Antichain<T>, StorageError<T>> {
+        let metadata = &self.collection_metadata(id)?;
+        let persist_client = self
+            .persist
+            .open(metadata.persist_location.clone())
+            .await
+            .unwrap();
+        // Duplicate part of open_data_handles here because we don't need the
+        // fetch_recent_upper call. The pubsub-updated shared_upper is enough.
+        let diagnostics = Diagnostics {
+            shard_name: id.to_string(),
+            handle_purpose: format!("controller data for {}", id),
+        };
+        // NB: Opening a WriteHandle is cheap if it's never used in a
+        // compare_and_append operation.
+        let write = persist_client
+            .open_writer::<SourceData, (), T, Diff>(
+                metadata.data_shard,
+                Arc::new(metadata.relation_desc.clone()),
+                Arc::new(UnitSchema),
+                diagnostics.clone(),
+            )
+            .await
+            .expect("invalid persist usage");
+        Ok(write.shared_upper())
+    }
+
     async fn read_handle_for_snapshot(
-        &self,
+        persist: Arc<PersistClientCache>,
         metadata: &CollectionMetadata,
         id: GlobalId,
     ) -> Result<ReadHandle<SourceData, (), T, Diff>, StorageError<T>> {
-        let persist_client = self
-            .persist
+        let persist_client = persist
             .open(metadata.persist_location.clone())
             .await
             .unwrap();
@@ -939,11 +1007,135 @@ where
                     shard_name: id.to_string(),
                     handle_purpose: format!("snapshot {}", id),
                 },
-                USE_CRITICAL_SINCE_SNAPSHOT.get(&self.persist.cfg),
+                USE_CRITICAL_SINCE_SNAPSHOT.get(&persist.cfg),
             )
             .await
             .expect("invalid persist usage");
         Ok(read_handle)
+    }
+
+    // TODO(petrosagg): This signature is not very useful in the context of partially ordered times
+    // where the as_of frontier might have multiple elements. In the current form the mutually
+    // incomparable updates will be accumulated together to a state of the collection that never
+    // actually existed. We should include the original time in the updates advanced by the as_of
+    // frontier in the result and let the caller decide what to do with the information.
+    fn snapshot(
+        &self,
+        id: GlobalId,
+        as_of: T,
+        txns_read: &TxnsRead<T>,
+    ) -> BoxFuture<'static, Result<Vec<(Row, Diff)>, StorageError<T>>>
+    where
+        T: Codec64 + From<EpochMillis> + TimestampManipulation,
+    {
+        let metadata = match self.collection_metadata(id) {
+            Ok(metadata) => metadata.clone(),
+            Err(e) => return async { Err(e) }.boxed(),
+        };
+        let txns_read = metadata.txns_shard.as_ref().map(|txns_id| {
+            assert_eq!(txns_id, txns_read.txns_id());
+            txns_read.clone()
+        });
+        let persist = Arc::clone(&self.persist);
+        async move {
+            let mut read_handle = Self::read_handle_for_snapshot(persist, &metadata, id).await?;
+            let contents = match txns_read {
+                None => {
+                    // We're not using txn-wal for tables, so we can take a snapshot directly.
+                    read_handle
+                        .snapshot_and_fetch(Antichain::from_elem(as_of))
+                        .await
+                }
+                Some(txns_read) => {
+                    // We _are_ using txn-wal for tables. It advances the physical upper of the
+                    // shard lazily, so we need to ask it for the snapshot to ensure the read is
+                    // unblocked.
+                    //
+                    // Consider the following scenario:
+                    // - Table A is written to via txns at time 5
+                    // - Tables other than A are written to via txns consuming timestamps up to 10
+                    // - We'd like to read A at 7
+                    // - The application process of A's txn has advanced the upper to 5+1, but we need
+                    //   it to be past 7, but the txns shard knows that (5,10) is empty of writes to A
+                    // - This branch allows it to handle that advancing the physical upper of Table A to
+                    //   10 (NB but only once we see it get past the write at 5!)
+                    // - Then we can read it normally.
+                    txns_read.update_gt(as_of.clone()).await;
+                    let data_snapshot = txns_read
+                        .data_snapshot(metadata.data_shard, as_of.clone())
+                        .await;
+                    data_snapshot.snapshot_and_fetch(&mut read_handle).await
+                }
+            };
+            match contents {
+                Ok(contents) => {
+                    let mut snapshot = Vec::with_capacity(contents.len());
+                    for ((data, _), _, diff) in contents {
+                        // TODO(petrosagg): We should accumulate the errors too and let the user
+                        // interprret the result
+                        let row = data.expect("invalid protobuf data").0?;
+                        snapshot.push((row, diff));
+                    }
+                    Ok(snapshot)
+                }
+                Err(_) => Err(StorageError::ReadBeforeSince(id)),
+            }
+        }
+        .boxed()
+    }
+
+    // TODO: This appears to have become unused at some point. Figure out if the
+    // caller is coming back or if we should delete it.
+    #[allow(dead_code)]
+    async fn snapshot_and_stream(
+        &self,
+        id: GlobalId,
+        as_of: T,
+    ) -> Result<BoxStream<(SourceData, T, Diff)>, StorageError<T>> {
+        use futures::stream::StreamExt;
+
+        let metadata = &self.collection_metadata(id)?;
+
+        // See the comments in Self::snapshot for what's going on here.
+        match metadata.txns_shard.as_ref() {
+            None => {
+                let as_of = Antichain::from_elem(as_of);
+                let persist = Arc::clone(&self.persist);
+                let mut read_handle = Self::read_handle_for_snapshot(persist, metadata, id).await?;
+                let contents = read_handle.snapshot_and_stream(as_of).await;
+                match contents {
+                    Ok(contents) => {
+                        Ok(Box::pin(contents.map(|((result_k, result_v), t, diff)| {
+                            let () = result_v.expect("invalid empty value");
+                            let data = result_k.expect("invalid key data");
+                            (data, t, diff)
+                        })))
+                    }
+                    Err(_) => Err(StorageError::ReadBeforeSince(id)),
+                }
+            }
+            Some(txns_id) => {
+                assert_eq!(txns_id, self.txns_read.txns_id());
+                self.txns_read.update_gt(as_of.clone()).await;
+                let data_snapshot = self
+                    .txns_read
+                    .data_snapshot(metadata.data_shard, as_of.clone())
+                    .await;
+                let persist = Arc::clone(&self.persist);
+                let mut handle = Self::read_handle_for_snapshot(persist, metadata, id).await?;
+                let contents = data_snapshot.snapshot_and_stream(&mut handle).await;
+                match contents {
+                    Ok(contents) => {
+                        Ok(Box::pin(contents.map(|((result_k, result_v), t, diff)| {
+                            let () = result_v.expect("invalid empty value");
+                            let data = result_k.expect("invalid key data");
+                            (data, t, diff)
+                        })))
+                    }
+                    Err(_) => Err(StorageError::ReadBeforeSince(id)),
+                }
+            }
+        }
     }
 
     fn set_read_policies_inner(
@@ -1275,7 +1467,8 @@ where
 
         // See the comments in StorageController::snapshot for what's going on
         // here.
-        let read_handle = self.read_handle_for_snapshot(&metadata, id).await;
+        let persist = Arc::clone(&self.persist);
+        let read_handle = Self::read_handle_for_snapshot(persist, &metadata, id).await;
 
         let data_snapshot = match (metadata, as_of.as_option()) {
             (
@@ -1306,6 +1499,101 @@ where
             read_handle.expire().await;
             result.map_err(|_| StorageError::ReadBeforeSince(id))
         })
+    }
+
+    // TODO(petrosagg): This signature is not very useful in the context of partially ordered times
+    // where the as_of frontier might have multiple elements. In the current form the mutually
+    // incomparable updates will be accumulated together to a state of the collection that never
+    // actually existed. We should include the original time in the updates advanced by the as_of
+    // frontier in the result and let the caller decide what to do with the information.
+    fn snapshot(
+        &self,
+        id: GlobalId,
+        as_of: Self::Timestamp,
+    ) -> BoxFuture<'static, Result<Vec<(Row, Diff)>, StorageError<Self::Timestamp>>> {
+        self.snapshot(id, as_of, &self.txns_read)
+    }
+
+    async fn snapshot_latest(
+        &self,
+        id: GlobalId,
+    ) -> Result<Vec<Row>, StorageError<Self::Timestamp>> {
+        let upper = self.recent_upper(id).await?;
+        let res = match upper.as_option() {
+            Some(f) if f > &T::minimum() => {
+                let as_of = f.step_back().unwrap();
+
+                let snapshot = self.snapshot(id, as_of, &self.txns_read).await.unwrap();
+                snapshot
+                    .into_iter()
+                    .map(|(row, diff)| {
+                        assert!(diff == 1, "snapshot doesn't accumulate to set");
+                        row
+                    })
+                    .collect()
+            }
+            Some(_min) => {
+                // The collection must be empty!
+                Vec::new()
+            }
+            // The collection is closed, we cannot determine a latest read
+            // timestamp based on the upper.
+            _ => {
+                return Err(StorageError::InvalidUsage(
+                    "collection closed, cannot determine a read timestamp based on the upper"
+                        .to_string(),
+                ));
+            }
+        };
+
+        Ok(res)
+    }
+
+    async fn snapshot_cursor(
+        &mut self,
+        id: GlobalId,
+        as_of: Self::Timestamp,
+    ) -> Result<SnapshotCursor<Self::Timestamp>, StorageError<Self::Timestamp>>
+    where
+        Self::Timestamp: TimelyTimestamp + Lattice + Codec64,
+    {
+        let metadata = &self.collection_metadata(id)?;
+
+        // See the comments in Self::snapshot for what's going on here.
+        let cursor = match metadata.txns_shard.as_ref() {
+            None => {
+                let persist = Arc::clone(&self.persist);
+                let mut handle = Self::read_handle_for_snapshot(persist, metadata, id).await?;
+                let cursor = handle
+                    .snapshot_cursor(Antichain::from_elem(as_of), |_| true)
+                    .await
+                    .map_err(|_| StorageError::ReadBeforeSince(id))?;
+                SnapshotCursor {
+                    _read_handle: handle,
+                    cursor,
+                }
+            }
+            Some(txns_id) => {
+                assert_eq!(txns_id, self.txns_read.txns_id());
+                self.txns_read.update_gt(as_of.clone()).await;
+                let data_snapshot = self
+                    .txns_read
+                    .data_snapshot(metadata.data_shard, as_of.clone())
+                    .await;
+                let persist = Arc::clone(&self.persist);
+                let mut handle = Self::read_handle_for_snapshot(persist, metadata, id).await?;
+                let cursor = data_snapshot
+                    .snapshot_cursor(&mut handle, |_| true)
+                    .await
+                    .map_err(|_| StorageError::ReadBeforeSince(id))?;
+                SnapshotCursor {
+                    _read_handle: handle,
+                    cursor,
+                }
+            }
+        };
+
+        Ok(cursor)
     }
 
     fn check_exists(&self, id: GlobalId) -> Result<(), StorageError<Self::Timestamp>> {

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2134,28 +2134,6 @@ where
         self.collection_manager.differential_write(id, op);
     }
 
-    async fn initialize_state(
-        &mut self,
-        txn: &mut (dyn StorageTxn<T> + Send),
-        init_ids: BTreeSet<GlobalId>,
-        drop_ids: BTreeSet<GlobalId>,
-    ) -> Result<(), StorageError<T>> {
-        self.storage_collections
-            .initialize_state(txn, init_ids, drop_ids)
-            .await
-    }
-
-    async fn prepare_state(
-        &self,
-        txn: &mut (dyn StorageTxn<T> + Send),
-        ids_to_add: BTreeSet<GlobalId>,
-        ids_to_drop: BTreeSet<GlobalId>,
-    ) -> Result<(), StorageError<T>> {
-        self.storage_collections
-            .prepare_state(txn, ids_to_add, ids_to_drop)
-            .await
-    }
-
     async fn real_time_recent_timestamp(
         &self,
         timestamp_objects: BTreeSet<GlobalId>,

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -39,7 +39,6 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::cfg::USE_CRITICAL_SINCE_SNAPSHOT;
 use mz_persist_client::read::ReadHandle;
 use mz_persist_client::schema::CaESchema;
-use mz_persist_client::stats::{SnapshotPartsStats, SnapshotStats};
 use mz_persist_client::write::WriteHandle;
 use mz_persist_client::{Diagnostics, PersistClient, PersistLocation, ShardId};
 use mz_persist_types::codec_impls::UnitSchema;
@@ -73,7 +72,7 @@ use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::controller::{AlterError, CollectionMetadata, StorageError, TxnsCodecRow};
 use mz_storage_types::instances::StorageInstanceId;
 use mz_storage_types::parameters::StorageParameters;
-use mz_storage_types::read_holds::{ReadHold, ReadHoldError};
+use mz_storage_types::read_holds::ReadHold;
 use mz_storage_types::read_policy::ReadPolicy;
 use mz_storage_types::sinks::{StorageSinkConnection, StorageSinkDesc};
 use mz_storage_types::sources::{
@@ -1881,36 +1880,6 @@ where
         };
 
         Ok(cursor)
-    }
-
-    async fn snapshot_stats(
-        &self,
-        id: GlobalId,
-        as_of: Antichain<Self::Timestamp>,
-    ) -> Result<SnapshotStats, StorageError<Self::Timestamp>> {
-        self.storage_collections.snapshot_stats(id, as_of).await
-    }
-
-    async fn snapshot_parts_stats(
-        &self,
-        id: GlobalId,
-        as_of: Antichain<Self::Timestamp>,
-    ) -> BoxFuture<Result<SnapshotPartsStats, StorageError<Self::Timestamp>>> {
-        self.storage_collections
-            .snapshot_parts_stats(id, as_of)
-            .await
-    }
-
-    #[instrument(level = "debug")]
-    fn set_read_policy(&mut self, policies: Vec<(GlobalId, ReadPolicy<Self::Timestamp>)>) {
-        self.storage_collections.set_read_policies(policies);
-    }
-
-    fn acquire_read_holds(
-        &self,
-        desired_holds: Vec<GlobalId>,
-    ) -> Result<Vec<ReadHold<Self::Timestamp>>, ReadHoldError> {
-        self.storage_collections.acquire_read_holds(desired_holds)
     }
 
     async fn ready(&mut self) {

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -21,7 +21,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use differential_dataflow::lattice::Lattice;
-use futures::stream::{BoxStream, FuturesUnordered};
+use futures::stream::FuturesUnordered;
 use futures::FutureExt;
 use futures::StreamExt;
 use itertools::Itertools;
@@ -54,8 +54,8 @@ use mz_storage_client::client::{
 };
 use mz_storage_client::controller::{
     BoxFuture, CollectionDescription, DataSource, ExportDescription, ExportState,
-    IntrospectionType, MonotonicAppender, PersistEpoch, Response, SnapshotCursor,
-    StorageController, StorageMetadata, StorageTxn, StorageWriteOp,
+    IntrospectionType, MonotonicAppender, PersistEpoch, Response, StorageController,
+    StorageMetadata, StorageTxn, StorageWriteOp,
 };
 use mz_storage_client::healthcheck::{
     MZ_AWS_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC, MZ_SINK_STATUS_HISTORY_DESC,
@@ -1783,105 +1783,6 @@ where
             .ok_or(StorageError::IdentifierMissing(id))
     }
 
-    // TODO(petrosagg): This signature is not very useful in the context of partially ordered times
-    // where the as_of frontier might have multiple elements. In the current form the mutually
-    // incomparable updates will be accumulated together to a state of the collection that never
-    // actually existed. We should include the original time in the updates advanced by the as_of
-    // frontier in the result and let the caller decide what to do with the information.
-    fn snapshot(
-        &self,
-        id: GlobalId,
-        as_of: Self::Timestamp,
-    ) -> BoxFuture<Result<Vec<(Row, Diff)>, StorageError<Self::Timestamp>>> {
-        snapshot(
-            id,
-            as_of,
-            &self.storage_collections,
-            &self.txns_read,
-            &self.persist,
-        )
-    }
-
-    async fn snapshot_latest(
-        &self,
-        id: GlobalId,
-    ) -> Result<Vec<Row>, StorageError<Self::Timestamp>> {
-        let upper = self.recent_upper(id).await?;
-        let res = match upper.as_option() {
-            Some(f) if f > &T::minimum() => {
-                let as_of = f.step_back().unwrap();
-
-                let snapshot = self.snapshot(id, as_of).await.unwrap();
-                snapshot
-                    .into_iter()
-                    .map(|(row, diff)| {
-                        assert!(diff == 1, "snapshot doesn't accumulate to set");
-                        row
-                    })
-                    .collect()
-            }
-            Some(_min) => {
-                // The collection must be empty!
-                Vec::new()
-            }
-            // The collection is closed, we cannot determine a latest read
-            // timestamp based on the upper.
-            _ => {
-                return Err(StorageError::InvalidUsage(
-                    "collection closed, cannot determine a read timestamp based on the upper"
-                        .to_string(),
-                ));
-            }
-        };
-
-        Ok(res)
-    }
-
-    async fn snapshot_cursor(
-        &mut self,
-        id: GlobalId,
-        as_of: Self::Timestamp,
-    ) -> Result<SnapshotCursor<Self::Timestamp>, StorageError<Self::Timestamp>>
-    where
-        Self::Timestamp: Timestamp + Lattice + Codec64,
-    {
-        let metadata = &self.storage_collections.collection_metadata(id)?;
-
-        // See the comments in Self::snapshot for what's going on here.
-        let cursor = match metadata.txns_shard.as_ref() {
-            None => {
-                let mut handle = self.read_handle_for_snapshot(id).await?;
-                let cursor = handle
-                    .snapshot_cursor(Antichain::from_elem(as_of), |_| true)
-                    .await
-                    .map_err(|_| StorageError::ReadBeforeSince(id))?;
-                SnapshotCursor {
-                    _read_handle: handle,
-                    cursor,
-                }
-            }
-            Some(txns_id) => {
-                assert_eq!(txns_id, self.txns_read.txns_id());
-                self.txns_read.update_gt(as_of.clone()).await;
-                let data_snapshot = self
-                    .txns_read
-                    .data_snapshot(metadata.data_shard, as_of.clone())
-                    .await;
-                let mut handle = self.read_handle_for_snapshot(id).await?;
-                let cursor = data_snapshot
-                    .snapshot_cursor(&mut handle, |_| true)
-                    .await
-                    .map_err(|_| StorageError::ReadBeforeSince(id))?;
-                SnapshotCursor {
-                    _read_handle: handle,
-                    cursor,
-                }
-            }
-        };
-
-        Ok(cursor)
-    }
-
     async fn ready(&mut self) {
         if self.pending_compaction_commands.len() > 0 {
             return;
@@ -2829,33 +2730,6 @@ where
             .map(|(id, e)| (*id, e))
     }
 
-    async fn recent_upper(&self, id: GlobalId) -> Result<Antichain<T>, StorageError<T>> {
-        let metadata = &self.storage_collections.collection_metadata(id)?;
-        let persist_client = self
-            .persist
-            .open(metadata.persist_location.clone())
-            .await
-            .unwrap();
-        // Duplicate part of open_data_handles here because we don't need the
-        // fetch_recent_upper call. The pubsub-updated shared_upper is enough.
-        let diagnostics = Diagnostics {
-            shard_name: id.to_string(),
-            handle_purpose: format!("controller data for {}", id),
-        };
-        // NB: Opening a WriteHandle is cheap if it's never used in a
-        // compare_and_append operation.
-        let write = persist_client
-            .open_writer::<SourceData, (), T, Diff>(
-                metadata.data_shard,
-                Arc::new(metadata.relation_desc.clone()),
-                Arc::new(UnitSchema),
-                diagnostics.clone(),
-            )
-            .await
-            .expect("invalid persist usage");
-        Ok(write.shared_upper())
-    }
-
     /// Opens a write and critical since handles for the given `shard`.
     ///
     /// `since` is an optional `since` that the read handle will be forwarded to if it is less than
@@ -2965,8 +2839,6 @@ where
                     recent_upper,
                     introspection_type,
                     storage_collections: Arc::clone(&self.storage_collections),
-                    txns_read: self.txns_read.clone(),
-                    persist: Arc::clone(&self.persist),
                     collection_manager: self.collection_manager.clone(),
                     source_statistics: Arc::clone(&self.source_statistics),
                     sink_statistics: Arc::clone(&self.sink_statistics),
@@ -2996,8 +2868,6 @@ where
                     config_set: Arc::clone(self.config.config_set()),
                     parameters: self.config.parameters.clone(),
                     storage_collections: Arc::clone(&self.storage_collections),
-                    txns_read: self.txns_read.clone(),
-                    persist: Arc::clone(&self.persist),
                 };
                 self.collection_manager.register_append_only_collection(
                     id,
@@ -3116,58 +2986,6 @@ where
     ) -> Result<ReadHandle<SourceData, (), T, Diff>, StorageError<T>> {
         let metadata = self.storage_collections.collection_metadata(id)?;
         read_handle_for_snapshot(&self.persist, id, &metadata).await
-    }
-
-    // TODO: This appears to have become unused at some point. Figure out if the
-    // caller is coming back or if we should delete it.
-    #[allow(dead_code)]
-    async fn snapshot_and_stream(
-        &self,
-        id: GlobalId,
-        as_of: T,
-    ) -> Result<BoxStream<(SourceData, T, Diff)>, StorageError<T>> {
-        use futures::stream::StreamExt;
-
-        let metadata = &self.storage_collections.collection_metadata(id)?;
-
-        // See the comments in Self::snapshot for what's going on here.
-        match metadata.txns_shard.as_ref() {
-            None => {
-                let as_of = Antichain::from_elem(as_of);
-                let mut read_handle = self.read_handle_for_snapshot(id).await?;
-                let contents = read_handle.snapshot_and_stream(as_of).await;
-                match contents {
-                    Ok(contents) => {
-                        Ok(Box::pin(contents.map(|((result_k, result_v), t, diff)| {
-                            let () = result_v.expect("invalid empty value");
-                            let data = result_k.expect("invalid key data");
-                            (data, t, diff)
-                        })))
-                    }
-                    Err(_) => Err(StorageError::ReadBeforeSince(id)),
-                }
-            }
-            Some(txns_id) => {
-                assert_eq!(txns_id, self.txns_read.txns_id());
-                self.txns_read.update_gt(as_of.clone()).await;
-                let data_snapshot = self
-                    .txns_read
-                    .data_snapshot(metadata.data_shard, as_of.clone())
-                    .await;
-                let mut handle = self.read_handle_for_snapshot(id).await?;
-                let contents = data_snapshot.snapshot_and_stream(&mut handle).await;
-                match contents {
-                    Ok(contents) => {
-                        Ok(Box::pin(contents.map(|((result_k, result_v), t, diff)| {
-                            let () = result_v.expect("invalid empty value");
-                            let data = result_k.expect("invalid key data");
-                            (data, t, diff)
-                        })))
-                    }
-                    Err(_) => Err(StorageError::ReadBeforeSince(id)),
-                }
-            }
-        }
     }
 
     /// Handles writing of status updates for sources/sinks to the appropriate
@@ -3555,8 +3373,6 @@ async fn snapshot_statistics<T>(
     id: GlobalId,
     upper: Antichain<T>,
     storage_collections: &Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
-    txns_read: &TxnsRead<T>,
-    persist: &Arc<PersistClientCache>,
 ) -> Vec<Row>
 where
     T: Codec64 + From<EpochMillis> + TimestampManipulation,
@@ -3565,9 +3381,7 @@ where
         Some(f) if f > &T::minimum() => {
             let as_of = f.step_back().unwrap();
 
-            let snapshot = snapshot(id, as_of, storage_collections, txns_read, persist)
-                .await
-                .unwrap();
+            let snapshot = storage_collections.snapshot(id, as_of).await.unwrap();
             snapshot
                 .into_iter()
                 .map(|(row, diff)| {
@@ -3580,77 +3394,6 @@ where
         // or don't need to truncate (respectively).
         _ => Vec::new(),
     }
-}
-
-// TODO(petrosagg): This signature is not very useful in the context of partially ordered times
-// where the as_of frontier might have multiple elements. In the current form the mutually
-// incomparable updates will be accumulated together to a state of the collection that never
-// actually existed. We should include the original time in the updates advanced by the as_of
-// frontier in the result and let the caller decide what to do with the information.
-pub(crate) fn snapshot<T>(
-    id: GlobalId,
-    as_of: T,
-    storage_collections: &Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
-    txns_read: &TxnsRead<T>,
-    persist: &Arc<PersistClientCache>,
-) -> BoxFuture<Result<Vec<(Row, Diff)>, StorageError<T>>>
-where
-    T: Codec64 + From<EpochMillis> + TimestampManipulation,
-{
-    let metadata = match storage_collections.collection_metadata(id) {
-        Ok(metadata) => metadata,
-        Err(e) => return async { Err(e) }.boxed(),
-    };
-    let txns_read = metadata.txns_shard.as_ref().map(|txns_id| {
-        assert_eq!(txns_id, txns_read.txns_id());
-        txns_read.clone()
-    });
-    let persist = Arc::clone(persist);
-    async move {
-        let mut read_handle = read_handle_for_snapshot(&persist, id, &metadata).await?;
-        let contents = match txns_read {
-            None => {
-                // We're not using txn-wal for tables, so we can take a snapshot directly.
-                read_handle
-                    .snapshot_and_fetch(Antichain::from_elem(as_of))
-                    .await
-            }
-            Some(txns_read) => {
-                // We _are_ using txn-wal for tables. It advances the physical upper of the
-                // shard lazily, so we need to ask it for the snapshot to ensure the read is
-                // unblocked.
-                //
-                // Consider the following scenario:
-                // - Table A is written to via txns at time 5
-                // - Tables other than A are written to via txns consuming timestamps up to 10
-                // - We'd like to read A at 7
-                // - The application process of A's txn has advanced the upper to 5+1, but we need
-                //   it to be past 7, but the txns shard knows that (5,10) is empty of writes to A
-                // - This branch allows it to handle that advancing the physical upper of Table A to
-                //   10 (NB but only once we see it get past the write at 5!)
-                // - Then we can read it normally.
-                txns_read.update_gt(as_of.clone()).await;
-                let data_snapshot = txns_read
-                    .data_snapshot(metadata.data_shard, as_of.clone())
-                    .await;
-                data_snapshot.snapshot_and_fetch(&mut read_handle).await
-            }
-        };
-        match contents {
-            Ok(contents) => {
-                let mut snapshot = Vec::with_capacity(contents.len());
-                for ((data, _), _, diff) in contents {
-                    // TODO(petrosagg): We should accumulate the errors too and let the user
-                    // interprret the result
-                    let row = data.expect("invalid protobuf data").0?;
-                    snapshot.push((row, diff));
-                }
-                Ok(snapshot)
-            }
-            Err(_) => Err(StorageError::ReadBeforeSince(id)),
-        }
-    }
-    .boxed()
 }
 
 async fn read_handle_for_snapshot<T>(


### PR DESCRIPTION
Work towards implementing https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20240117_decoupled_storage_controller.md. This design document is nice and small, and should help to explain the long-term motivations for those changes.

Prompted by a recent PR from @petrosagg (https://github.com/MaterializeInc/materialize/pull/30729), I went back to implement some of the easier changes I had in mind for moving towards the design linked above.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
