### PR TITLE
Update to latest timely and differential

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,10 +2124,11 @@ dependencies = [
 
 [[package]]
 name = "differential-dataflow"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ab97d6a1f3c8556d7d412e2350b0e56990192c479ae1eb04fd4803a11933c5"
+checksum = "86f47ab549a056e3959ce2036d6b20ba369a75e2a0605ccf64256e153626b352"
 dependencies = [
+ "columnar",
  "fnv",
  "serde",
  "timely",
@@ -2135,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "differential-dogs3"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049be01c6ae86bd3f43f8d93c82e04fd375f7a6c759b045f82cdc76b5702e61b"
+checksum = "c8ece5ac3c62f1cb6e21560b53102963aa91513d3f72911d99b6620f2d3ac6b1"
 dependencies = [
  "differential-dataflow",
  "serde",
@@ -9973,9 +9974,9 @@ dependencies = [
 
 [[package]]
 name = "timely"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fb2119e3ce8419dd56d75be1983d427a7b34746f8d62d98c635ca2d236c10c"
+checksum = "b134806db44c8452ba2a9b18e6112f3d5e0a0185c6e58524269a08ca2891149c"
 dependencies = [
  "bincode",
  "byteorder",
@@ -9992,15 +9993,15 @@ dependencies = [
 
 [[package]]
 name = "timely_bytes"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8a545b35b019b8b63afb913214695f542cbbf39032c7b7349e1a15b7f2a2cf"
+checksum = "99223f9594ab7d4dd36b55b1d7eb9bd2cd205f4304b5cc5381d5cdd417ec06f2"
 
 [[package]]
 name = "timely_communication"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e528783a4ed45b7bbe181737a98c5e67a841364f3a70bf5535dacef5ea0dc8f"
+checksum = "f00d5c7f7bbb132a32220890240e5d951fc9582f82fb94452c011a8033c39f7a"
 dependencies = [
  "byteorder",
  "columnar",
@@ -10008,14 +10009,15 @@ dependencies = [
  "getopts",
  "serde",
  "timely_bytes",
+ "timely_container",
  "timely_logging",
 ]
 
 [[package]]
 name = "timely_container"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2870d67209ded32270e0cad117d9f04ec16da4be54f19280040dc7e1a7dfbc76"
+checksum = "92b763064e76ba4f650dcdb035d82bcaad09986971fab002276e0b4cb10b3aa5"
 dependencies = [
  "columnation",
  "flatcontainer",
@@ -10024,9 +10026,12 @@ dependencies = [
 
 [[package]]
 name = "timely_logging"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c089d7d150dc1b7466b577f39d96261093d17bdbd710bd5104a1f8f5caa6809c"
+checksum = "d8300263e23bebac4ec9fbbeee65954a25402037609b7716d20191ed35829b14"
+dependencies = [
+ "timely_container",
+]
 
 [[package]]
 name = "tiny-keccak"

--- a/src/adapter-types/Cargo.toml
+++ b/src/adapter-types/Cargo.toml
@@ -15,7 +15,7 @@ mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }
 mz-storage-types = { path = "../storage-types" }
 serde = "1.0.152"
-timely = "0.15.1"
+timely = "0.16.0"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 dec = "0.4.8"
 deadpool-postgres = "0.10.3"
 derivative = "2.2.0"
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 enum-kinds = "0.5.1"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
@@ -95,7 +95,7 @@ serde_plain = "1.0.1"
 sha2 = "0.10.6"
 smallvec = { version = "1.10.0", features = ["union"] }
 static_assertions = "1.1"
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = { version = "1.38.0", features = ["rt", "time"] }
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = "0.1.11"

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -18,7 +18,7 @@ bytesize = "1.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 clap = { version = "4.5.23", features = ["derive"] }
 derivative = "2.2.0"
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
 ipnet = "2.5.0"
@@ -65,7 +65,7 @@ smallvec = { version = "1.10.0", features = ["union"] }
 static_assertions = "1.1"
 sha2 = "0.10.6"
 thiserror = "1.0.37"
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = { version = "1.38.0" }
 tracing = "0.1.37"
 uuid = "1.2.2"

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -16,7 +16,7 @@ bytesize = "1.1.0"
 clap = { version = "4.5.23", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
 dec = { version = "0.4.8", features = ["serde"] }
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 futures = "0.3.25"
 mz-build-info = { path = "../build-info" }
 mz-cluster-client = { path = "../cluster-client" }
@@ -33,7 +33,7 @@ rocksdb = { version = "0.22.0", default-features = false, features = ["snappy", 
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -18,7 +18,7 @@ bytesize = "1.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.8"
 derivative = "2.2.0"
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 futures = "0.3.25"
 http = "1.1.0"
 mz-build-info = { path = "../build-info" }
@@ -48,7 +48,7 @@ regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.125"
 thiserror = "1.0.37"
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tonic = "0.12.1"

--- a/src/compute-types/Cargo.toml
+++ b/src/compute-types/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 columnation = "0.1.0"
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 itertools = "0.12.1"
 mz-dyncfg = { path = "../dyncfg" }
 mz-expr = { path = "../expr" }
@@ -23,7 +23,7 @@ proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.5.1", features = ["boxed_union"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
-timely = "0.15.1"
+timely = "0.16.0"
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -17,8 +17,8 @@ bytesize = "1.1.0"
 clap = { version = "4.5.23", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
 dec = { version = "0.4.8", features = ["serde"] }
-differential-dataflow = "0.13.2"
-differential-dogs3 = "0.1.2"
+differential-dataflow = "0.13.3"
+differential-dogs3 = "0.1.3"
 futures = "0.3.25"
 itertools = "0.12.1"
 lgalloc = "0.4"
@@ -43,7 +43,7 @@ prometheus = { version = "0.13.3", default-features = false }
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -22,7 +22,7 @@ use timely::dataflow::{Scope, ScopeParent, StreamCore};
 use timely::progress::Timestamp;
 use timely::Container;
 
-use crate::logging::compute::ComputeEvent;
+use crate::logging::compute::{ComputeEvent, ComputeEventBuilder};
 use crate::typedefs::{KeyAgent, KeyValAgent, RowAgent, RowRowAgent, RowValAgent};
 
 /// Extension trait to arrange data.
@@ -247,7 +247,7 @@ where
     let scope = arranged.stream.scope();
     let Some(logger) = scope
         .log_register()
-        .get::<ComputeEvent>("materialize/compute")
+        .get::<ComputeEventBuilder>("materialize/compute")
     else {
         return arranged;
     };

--- a/src/compute/src/logging.rs
+++ b/src/compute/src/logging.rs
@@ -65,15 +65,11 @@ where
         }
     }
 
-    /// Flushes the contents of the builder through the current time and sends
-    /// appropriate progress statements.
-    fn flush_through(&mut self, time: &Duration) {
+    /// Indicate progress up to a specific `time`.
+    fn report_progress(&mut self, time: &Duration) {
         let time_ms = ((time.as_millis() / self.interval_ms) + 1) * self.interval_ms;
         let new_time_ms: Timestamp = time_ms.try_into().expect("must fit");
         if self.time_ms < new_time_ms {
-            // In principle we can buffer up until this point, if that is appealing to us.
-            // We could buffer more aggressively if the logging interval were exposed
-            // here, as the forward ticks would be that much less frequent.
             self.event_pusher
                 .push(Event::Progress(vec![(new_time_ms, 1), (self.time_ms, -1)]));
             self.time_ms = new_time_ms;
@@ -88,7 +84,7 @@ where
     /// Publishes a batch of logged events and advances the capability.
     fn publish_batch(&mut self, time: &Duration, data: C) {
         self.event_pusher.push(Event::Messages(self.time_ms, data));
-        self.flush_through(time);
+        self.report_progress(time);
     }
 }
 

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -44,7 +44,8 @@ use crate::row_spine::{RowRowBatcher, RowRowBuilder};
 use crate::typedefs::RowRowSpine;
 
 /// Type alias for a logger of compute events.
-pub type Logger = timely::logging_core::Logger<ComputeEvent>;
+pub type Logger = timely::logging_core::Logger<ComputeEventBuilder>;
+pub type ComputeEventBuilder = CapacityContainerBuilder<Vec<(Duration, ComputeEvent)>>;
 
 /// A logged compute event.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -221,7 +221,7 @@ impl<A: Allocate + 'static> LoggingContext<'_, A> {
                     }
                 }
                 logger.publish_batch(time, container);
-                logger.flush_through(time);
+                logger.report_progress(time);
                 event_queue.activator.activate();
             },
         )

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 use differential_dataflow::dynamic::pointstamp::PointStamp;
-use differential_dataflow::logging::DifferentialEvent;
+use differential_dataflow::logging::{DifferentialEvent, DifferentialEventBuilder};
 use differential_dataflow::Collection;
 use mz_compute_client::logging::{LogVariant, LoggingConfig};
 use mz_ore::flatcontainer::{MzRegionPreference, OwnedRegionOpinion};
@@ -21,14 +21,15 @@ use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
 use timely::communication::Allocate;
 use timely::container::flatcontainer::FlatStack;
-use timely::container::{CapacityContainerBuilder, PushInto};
-use timely::logging::{Logger, ProgressEventTimestamp, TimelyEvent};
+use timely::container::ContainerBuilder;
+use timely::logging::{ProgressEventTimestamp, TimelyEvent, TimelyEventBuilder};
+use timely::logging_core::Logger;
 use timely::order::Product;
-use timely::progress::reachability::logging::TrackerEvent;
+use timely::progress::reachability::logging::{TrackerEvent, TrackerEventBuilder};
 
 use crate::arrangement::manager::TraceBundle;
 use crate::extensions::arrange::{KeyCollection, MzArrange};
-use crate::logging::compute::ComputeEvent;
+use crate::logging::compute::{ComputeEvent, ComputeEventBuilder};
 use crate::logging::{BatchLogger, EventQueue, SharedLoggingState};
 use crate::typedefs::{ErrBatcher, ErrBuilder};
 
@@ -154,10 +155,10 @@ impl<A: Allocate + 'static> LoggingContext<'_, A> {
     }
 
     fn register_loggers(&self) {
-        let t_logger = self.simple_logger(self.t_event_queue.clone());
+        let t_logger = self.simple_logger::<TimelyEventBuilder>(self.t_event_queue.clone());
         let r_logger = self.reachability_logger();
-        let d_logger = self.simple_logger(self.d_event_queue.clone());
-        let c_logger = self.simple_logger(self.c_event_queue.clone());
+        let d_logger = self.simple_logger::<DifferentialEventBuilder>(self.d_event_queue.clone());
+        let c_logger = self.simple_logger::<ComputeEventBuilder>(self.c_event_queue.clone());
 
         let mut register = self.worker.log_register();
         register.insert_logger("timely", t_logger);
@@ -168,55 +169,62 @@ impl<A: Allocate + 'static> LoggingContext<'_, A> {
         self.shared_state.borrow_mut().compute_logger = Some(c_logger);
     }
 
-    fn simple_logger<E: Clone + 'static>(
+    fn simple_logger<CB: ContainerBuilder>(
         &self,
-        event_queue: EventQueue<Vec<(Duration, E)>>,
-    ) -> Logger<E> {
-        let mut logger =
-            BatchLogger::<CapacityContainerBuilder<_>, _>::new(event_queue.link, self.interval_ms);
+        event_queue: EventQueue<CB::Container>,
+    ) -> Logger<CB> {
+        let mut logger = BatchLogger::new(event_queue.link, self.interval_ms);
         Logger::new(self.now, self.start_offset, move |time, data| {
-            logger.publish_batch(time, data);
+            logger.publish_batch(time, std::mem::take(data));
             event_queue.activator.activate();
         })
     }
 
-    fn reachability_logger(&self) -> Logger<TrackerEvent> {
+    fn reachability_logger(&self) -> Logger<TrackerEventBuilder> {
         let event_queue = self.r_event_queue.clone();
-        let mut logger = BatchLogger::<
-            CapacityContainerBuilder<FlatStack<ReachabilityEventRegion>>,
-            _,
-        >::new(event_queue.link, self.interval_ms);
-        Logger::new(self.now, self.start_offset, move |time, data| {
-            let mut massaged = Vec::new();
-            for (time, event) in data.drain(..) {
-                match event {
-                    TrackerEvent::SourceUpdate(update) => {
-                        massaged.extend(update.updates.iter().map(|(node, port, time, diff)| {
-                            let ts = try_downcast_timestamp(time);
-                            let is_source = true;
-                            (*node, *port, is_source, ts, *diff)
-                        }));
+        let mut logger = BatchLogger::<FlatStack<ReachabilityEventRegion>, _>::new(
+            event_queue.link,
+            self.interval_ms,
+        );
+        Logger::new(
+            self.now,
+            self.start_offset,
+            move |time, data: &mut Vec<_>| {
+                let mut massaged = Vec::new();
+                let mut container = FlatStack::default();
+                for (time, event) in data.drain(..) {
+                    match event {
+                        TrackerEvent::SourceUpdate(update) => {
+                            massaged.extend(update.updates.iter().map(
+                                |(node, port, time, diff)| {
+                                    let ts = try_downcast_timestamp(time);
+                                    let is_source = true;
+                                    (*node, *port, is_source, ts, *diff)
+                                },
+                            ));
 
-                        logger.push_into((time, (update.tracker_id, &massaged)));
-                        logger.extract_and_send();
-                        massaged.clear();
-                    }
-                    TrackerEvent::TargetUpdate(update) => {
-                        massaged.extend(update.updates.iter().map(|(node, port, time, diff)| {
-                            let ts = try_downcast_timestamp(time);
-                            let is_source = false;
-                            (*node, *port, is_source, ts, *diff)
-                        }));
+                            container.copy((time, (update.tracker_id, &massaged)));
+                            massaged.clear();
+                        }
+                        TrackerEvent::TargetUpdate(update) => {
+                            massaged.extend(update.updates.iter().map(
+                                |(node, port, time, diff)| {
+                                    let ts = try_downcast_timestamp(time);
+                                    let is_source = false;
+                                    (*node, *port, is_source, ts, *diff)
+                                },
+                            ));
 
-                        logger.push_into((time, (update.tracker_id, &massaged)));
-                        logger.extract_and_send();
-                        massaged.clear();
+                            container.copy((time, (update.tracker_id, &massaged)));
+                            massaged.clear();
+                        }
                     }
                 }
-            }
-            logger.flush_through(time);
-            event_queue.activator.activate();
-        })
+                logger.publish_batch(time, container);
+                logger.flush_through(time);
+                event_queue.activator.activate();
+            },
+        )
     }
 }
 

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -204,7 +204,7 @@ pub fn build_compute_dataflow<A: Allocate>(
         .map(|(sink_id, sink)| (*sink_id, dataflow.depends_on(sink.from), sink.clone()))
         .collect::<Vec<_>>();
 
-    let worker_logging = timely_worker.log_register().get("timely");
+    let worker_logging = timely_worker.log_register().get("timely").map(Into::into);
     let apply_demands = COMPUTE_APPLY_COLUMN_DEMANDS.get(&compute_state.worker_config);
 
     let name = format!("Dataflow: {}", &dataflow.debug_name);

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -847,7 +847,7 @@ pub mod monoids {
     use timely::container::columnation::{Columnation, Region};
 
     /// A monoid containing a row and an ordering.
-    #[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, Hash)]
+    #[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, Hash, Default)]
     pub struct Top1Monoid {
         pub row: Row,
         pub order_key: Vec<ColumnOrder>,

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -14,8 +14,7 @@
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::operators::arrange::TraceAgent;
 use differential_dataflow::trace::implementations::chunker::ColumnationChunker;
-use differential_dataflow::trace::implementations::merge_batcher::MergeBatcher;
-use differential_dataflow::trace::implementations::merge_batcher_col::ColumnationMerger;
+use differential_dataflow::trace::implementations::merge_batcher::{ColMerger, MergeBatcher};
 use differential_dataflow::trace::implementations::ord_neu::{
     FlatValBatcher, FlatValBuilder, FlatValSpine, OrdValBatch,
 };
@@ -193,11 +192,8 @@ pub type RowErrBuilder<T, R> = RowValBuilder<DataflowError, T, R>;
 
 // Batchers for consolidation
 pub type KeyBatcher<K, T, D> = KeyValBatcher<K, (), T, D>;
-pub type KeyValBatcher<K, V, T, D> = MergeBatcher<
-    Vec<((K, V), T, D)>,
-    ColumnationChunker<((K, V), T, D)>,
-    ColumnationMerger<((K, V), T, D)>,
->;
+pub type KeyValBatcher<K, V, T, D> =
+    MergeBatcher<Vec<((K, V), T, D)>, ColumnationChunker<((K, V), T, D)>, ColMerger<(K, V), T, D>>;
 
 pub type FlatKeyValBatch<K, V, T, R> = OrdValBatch<MzFlatLayout<K, V, T, R>>;
 pub type FlatKeyValSpine<K, V, T, R> = FlatValSpine<MzFlatLayout<K, V, T, R>>;

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.66"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 futures = "0.3.25"
 mz-build-info = { path = "../build-info" }
 mz-cluster-client = { path = "../cluster-client" }
@@ -33,7 +33,7 @@ mz-txn-wal = { path = "../txn-wal" }
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.125"
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tracing = "0.1.37"

--- a/src/durable-cache/Cargo.toml
+++ b/src/durable-cache/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1.83"
 bytes = { version = "1.3.0" }
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 futures = "0.3.25"
 itertools = { version = "0.12.1" }
 mz-ore = { path = "../ore", features = ["process"] }
@@ -23,7 +23,7 @@ mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = { version = "1.38.0", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -150,7 +150,7 @@ reqwest = { version = "0.11.13", features = ["blocking"] }
 serde_json = "1.0.125"
 serde_urlencoded = "0.7.1"
 similar-asserts = "1.4"
-timely = "0.15.1"
+timely = "0.16.0"
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4"] }
 
 [build-dependencies]

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -59,7 +59,7 @@ serde_json = "1.0.125"
 sha1 = "0.10.5"
 sha2 = "0.10.6"
 subtle = "2.4.1"
-timely = "0.15.1"
+timely = "0.16.0"
 tracing = "0.1.37"
 uncased = "0.9.7"
 uuid = { version = "1.7.0", features = ["v5"] }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -20,7 +20,7 @@ byteorder = "1.4.3"
 bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 clap = { version = "4.5.23", features = ["derive"] }
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 itertools = "0.12.1"
 maplit = "1.0.2"
 mz-avro = { path = "../avro", features = ["snappy"] }
@@ -33,7 +33,7 @@ prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 prost-reflect = "0.14.3"
 seahash = "4"
 serde_json = "1.0.125"
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = { version = "1.38.0", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde"] }

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -23,7 +23,7 @@ async-trait = "0.1.83"
 axum = "0.7.5"
 bytes = { version = "1.3.0", features = ["serde"] }
 clap = { version = "4.5.23", features = ["derive", "env"] }
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 futures = "0.3.25"
 humantime = "2.1.0"
 mz-http-util = { path = "../http-util" }
@@ -40,7 +40,7 @@ num_enum = "0.5.7"
 prometheus = { version = "0.13.3", default-features = false }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.125"
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 url = "2.3.1"

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -35,7 +35,7 @@ async-stream = "0.3.3"
 async-trait = "0.1.83"
 bytes = { version = "1.3.0", features = ["serde"] }
 clap = { version = "4.5.23", features = ["derive"] }
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 futures = "0.3.25"
 futures-util = "0.3"
 h2 = "0.3.13"
@@ -59,7 +59,7 @@ sentry-tracing = "0.29.1"
 semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.125"
-timely = "0.15.1"
+timely = "0.16.0"
 thiserror = "1.0.37"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tokio-metrics = "0.3.0"

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -26,7 +26,7 @@ proptest-derive = { version = "0.5.1", features = ["boxed_union"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
-timely = "0.15.1"
+timely = "0.16.0"
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -33,7 +33,7 @@ aws-types = "1.1.1"
 base64 = "0.13.1"
 bytes = "1.3.0"
 deadpool-postgres = "0.10.3"
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures-util = "0.3.25"
 md-5 = "0.10.5"
@@ -54,7 +54,7 @@ proptest-derive = { version = "0.5.1", features = ["boxed_union"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.152", features = ["derive"] }
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = { version = "1.38.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -36,7 +36,7 @@ chrono = { version = "0.4.35", default-features = false, features = ["serde", "s
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
 compact_bytes = "0.1.2"
 dec = "0.4.8"
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 enum-kinds = "0.5.1"
 flatcontainer = "0.5.0"
 hex = "0.4.3"
@@ -68,7 +68,7 @@ serde_json = { version = "1.0.125", features = ["arbitrary_precision", "preserve
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
 static_assertions = "1.1"
 strsim = "0.11.1"
-timely = "0.15.1"
+timely = "0.16.0"
 tokio-postgres = { version = "0.7.8" }
 tracing-core = "0.1.30"
 url = { version = "2.3.1", features = ["serde"] }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -35,7 +35,7 @@ prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 semver = "1.0.16"
 serde = { version = "1.0.152", features = ["derive"] }
 sysinfo = "0.27.2"
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tonic = "0.12.1"

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 anyhow = "1.0.66"
 async-trait = "0.1.83"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 futures = "0.3.25"
 http = "1.1.0"
 itertools = { version = "0.12.1" }
@@ -45,7 +45,7 @@ rdkafka = { version = "0.29.0", features = [
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
 static_assertions = "1.1"
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = { version = "1.38.0", features = [
     "fs",
     "rt",

--- a/src/storage-controller/Cargo.toml
+++ b/src/storage-controller/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.83"
 bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 derivative = "2.2.0"
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 futures = "0.3.25"
 itertools = { version = "0.12.1" }
 mz-build-info = { path = "../build-info" }
@@ -38,7 +38,7 @@ proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -15,7 +15,7 @@ arrow = { version = "53.3.0", default-features = false }
 async-stream = "0.3.3"
 aws-types = "1.1.1"
 bytesize = "1.1.0"
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 futures = "0.3.25"
 http = "1.1.0"
 mz-aws-util = { path = "../aws-util" }
@@ -35,7 +35,7 @@ prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 sentry = { version = "0.29.1" }
 serde = { version = "1.0.152", features = ["derive"] }
-timely = "0.15.1"
+timely = "0.16.0"
 thiserror = "1.0.37"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tracing = "0.1.37"

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -25,7 +25,7 @@ bytes = "1.3.0"
 columnation = "0.1.0"
 dec = "0.4.8"
 derivative = "2.2.0"
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 hex = "0.4.3"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
@@ -64,7 +64,7 @@ regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125", features = ["preserve_order"] }
 thiserror = "1.0.37"
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tracing = "0.1.37"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -26,7 +26,7 @@ columnation = "0.1.0"
 crossbeam-channel = "0.5.8"
 csv-core = { version = "0.1.10" }
 dec = "0.4.8"
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 either = { version = "1.8.0", features = ["serde"] }
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
@@ -85,7 +85,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.125" }
 serde_bytes = { version = "0.11.14" }
 sha2 = "0.10.6"
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"

--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -237,7 +237,7 @@ pub fn build_ingestion_dataflow<A: Allocate>(
     source_resume_uppers: BTreeMap<GlobalId, Vec<Row>>,
 ) {
     let worker_id = timely_worker.index();
-    let worker_logging = timely_worker.log_register().get("timely");
+    let worker_logging = timely_worker.log_register().get("timely").map(Into::into);
     let debug_name = primary_source_id.to_string();
     let name = format!("Source dataflow: {debug_name}");
     timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, root_scope| {
@@ -426,7 +426,7 @@ pub fn build_export_dataflow<A: Allocate>(
     id: GlobalId,
     description: StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>,
 ) {
-    let worker_logging = timely_worker.log_register().get("timely");
+    let worker_logging = timely_worker.log_register().get("timely").map(Into::into);
     let debug_name = id.to_string();
     let name = format!("Source dataflow: {debug_name}");
     timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, root_scope| {

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 ahash = { version = "0.8.11", default-features = false }
 bincode = "1.3.3"
 columnation = "0.1.0"
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 either = "1"
 futures-util = "0.3.25"
 lgalloc = "0.4"
@@ -21,7 +21,7 @@ mz-ore = { path = "../ore", features = ["async", "process", "tracing_", "test"] 
 num-traits = "0.2"
 proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 serde = { version = "1.0.152", features = ["derive"] }
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -17,6 +17,7 @@ use std::rc::Weak;
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
 use differential_dataflow::difference::{Multiply, Semigroup};
 use differential_dataflow::lattice::Lattice;
+use differential_dataflow::logging::DifferentialEventBuilder;
 use differential_dataflow::trace::{Batcher, Builder, Description};
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use timely::container::columnation::{Columnation, TimelyStack};
@@ -792,7 +793,8 @@ where
             let scope = stream.scope();
             let register = scope.log_register();
             register
-                .get::<differential_dataflow::logging::DifferentialEvent>("differential/arrange")
+                .get::<DifferentialEventBuilder>("differential/arrange")
+                .map(Into::into)
         };
 
         let mut batcher = B::new(logger, info.global_id);

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 enum-kinds = "0.5.1"
 itertools = "0.12.1"
 mz-compute-types = { path = "../compute-types" }

--- a/src/txn-wal/Cargo.toml
+++ b/src/txn-wal/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1.83"
 bytes = { version = "1.3.0" }
-differential-dataflow = "0.13.2"
+differential-dataflow = "0.13.3"
 futures = "0.3.25"
 itertools = { version = "0.12.1" }
 mz-ore = { path = "../ore", features = ["process"] }
@@ -23,7 +23,7 @@ mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
-timely = "0.15.1"
+timely = "0.16.0"
 tokio = { version = "1.38.0", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }


### PR DESCRIPTION
As the title says, update to latest Timely and Differential.

The main changes in this release are a new merge batcher in differential, and updated logging infrastructure in timely.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
