### PR TITLE
Provide a columnar implementation for Row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6199,6 +6199,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "chrono",
+ "columnar",
  "columnation",
  "compact_bytes",
  "criterion",

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -31,6 +31,7 @@ arrow = { version = "53.3.0", default-features = false }
 bitflags = "1.3.2"
 bytes = "1.3.0"
 cfg-if = "1.0.0"
+columnar = "0.2.0"
 columnation = "0.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["serde", "std"] }
 compact_bytes = "0.1.2"


### PR DESCRIPTION
With no functional changes, this PR adds a `Columnar` implementation for `Row`. It's not used yet, but will be in subsequent changes. The implementation follows the `String` implementation in columnar, both types are very similar.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
