### PR TITLE
mzbuild: Don't ignore return code of `docker push`

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -1104,26 +1104,38 @@ class DependencySet:
 
         # Push all Docker images in parallel to minimize build time.
         ui.section("Pushing images")
-        pushes: list[subprocess.Popen] = []
-        for image in images_to_push:
-            # Piping through `cat` disables terminal control codes, and so the
-            # interleaved progress output from multiple pushes is less hectic.
-            # We don't use `docker push --quiet`, as that disables progress
-            # output entirely. Use `set -o pipefail` so the return code of
-            # `docker push` is passed through.
-            push = subprocess.Popen(
-                [
-                    "/bin/bash",
-                    "-c",
-                    f"set -o pipefail; docker push {shlex.quote(image)} | cat",
-                ]
-            )
-            pushes.append(push)
+        # Attempt to upload images a maximum of 3 times before giving up.
+        for attempts_remaining in reversed(range(3)):
+            pushes: list[subprocess.Popen] = []
+            for image in images_to_push:
+                # Piping through `cat` disables terminal control codes, and so the
+                # interleaved progress output from multiple pushes is less hectic.
+                # We don't use `docker push --quiet`, as that disables progress
+                # output entirely. Use `set -o pipefail` so the return code of
+                # `docker push` is passed through.
+                push = subprocess.Popen(
+                    [
+                        "/bin/bash",
+                        "-c",
+                        f"set -o pipefail; docker push {shlex.quote(image)} | cat",
+                    ]
+                )
+                pushes.append(push)
 
-        for push in pushes:
-            returncode = push.wait()
-            if returncode:
-                raise subprocess.CalledProcessError(returncode, push.args)
+            for i, push in reversed(list(enumerate(pushes))):
+                returncode = push.wait()
+                if returncode:
+                    if attempts_remaining == 0:
+                        # Last attempt, fail
+                        raise subprocess.CalledProcessError(returncode, push.args)
+                    else:
+                        print(f"docker push {push.args} failed: {returncode}")
+                else:
+                    del images_to_push[i]
+
+            if images_to_push:
+                time.sleep(10)
+                print("Retrying in 10 seconds")
 
     def check(self) -> bool:
         """Check all publishable images in this dependency set exist on Docker

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -1109,10 +1109,14 @@ class DependencySet:
             # Piping through `cat` disables terminal control codes, and so the
             # interleaved progress output from multiple pushes is less hectic.
             # We don't use `docker push --quiet`, as that disables progress
-            # output entirely.
+            # output entirely. Use `set -o pipefail` so the return code of
+            # `docker push` is passed through.
             push = subprocess.Popen(
-                f"docker push {shlex.quote(image)} | cat",
-                shell=True,
+                [
+                    "/bin/bash",
+                    "-c",
+                    f"set -o pipefail; docker push {shlex.quote(image)} | cat",
+                ]
             )
             pushes.append(push)
 


### PR DESCRIPTION
Proof that this works:

```python
import subprocess
push = subprocess.Popen("ls asd | cat", shell=True)
print(push.wait()) # 0
push = subprocess.Popen("ls asd", shell=True)
print(push.wait()) # 2
push = subprocess.Popen(["/bin/bash", "-c", "set -o pipefail; ls asd | cat"])
print(push.wait()) # 2
```
Context: https://materializeinc.slack.com/archives/CM7ATT65S/p1736789270342329

Crazy that we never noticed this before! Dockerhub must be pretty reliable. I could not find another usage of us using this pattern in our code.

I'll remove the last commit before submitting.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
