### PR TITLE
0dt test: Fix flaky tests

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1691,7 +1691,7 @@ steps:
   - id: 0dt
     label: Zero downtime
     depends_on: build-aarch64
-    timeout_in_minutes: 120
+    timeout_in_minutes: 180
     plugins:
       - ./ci/plugins/mzcompose:
           composition: 0dt

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -1396,7 +1396,7 @@ def workflow_upsert_sources(c: Composition) -> None:
     c.down(destroy_volumes=True)
     c.up("zookeeper", "kafka", "schema-registry", "postgres", "mysql", "mz_old")
     c.up("testdrive", persistent=True)
-    num_threads = 500
+    num_threads = 100
 
     c.sql(
         f"""
@@ -1423,7 +1423,7 @@ def workflow_upsert_sources(c: Composition) -> None:
         )
     )
 
-    end_time = datetime.now() + timedelta(seconds=600)
+    end_time = datetime.now() + timedelta(seconds=300)
     mz1 = "mz_old"
     mz2 = "mz_new"
 


### PR DESCRIPTION
Seen running OoM in https://buildkite.com/materialize/nightly/builds/10849#0194623b-329d-4ea9-9ffa-7371e0c4967a and https://buildkite.com/materialize/nightly/builds/10836#01945f52-6951-497e-aa58-a250c5dce0bc
This is just a flaky test introduced by my new workflow: https://github.com/MaterializeInc/materialize/pull/30820

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
