### PR TITLE
storage: use root source for halting health status

### DIFF
--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -372,7 +372,7 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                     let halt_status =
                         HealthStatusUpdate::halting(err.display_with_causes().to_string(), None);
                     HealthStatusMessage {
-                        id: Some(export_id),
+                        id: None,
                         namespace: StatusNamespace::Internal,
                         update: halt_status,
                     }


### PR DESCRIPTION
Halting health status updates are only expected to be produced for the root source, not subsources/exports, and there is an assert that checks that.

### Motivation

  * This PR fixes a previously unreported bug.

In a [Nightly CI run](https://buildkite.com/materialize/nightly/builds/10839#019460a7-6c8e-4ba0-a339-09604aaf1bc7) we observed a panic "subsources should not produce halting errors".

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
