### PR TITLE
Split ComputeEvent into an enum of structs

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -64,7 +64,7 @@ use uuid::Uuid;
 
 use crate::arrangement::manager::{SpecializedTraceHandle, TraceBundle, TraceManager};
 use crate::logging;
-use crate::logging::compute::{CollectionLogging, ComputeEvent};
+use crate::logging::compute::{CollectionLogging, ComputeEvent, PeekEvent};
 use crate::metrics::ComputeMetrics;
 use crate::metrics::WorkerMetrics;
 use crate::render::{LinearJoinSpec, StartSignal};
@@ -1026,11 +1026,11 @@ impl PendingPeek {
             PeekTarget::Index { id } => (id, logging::compute::PeekType::Index),
             PeekTarget::Persist { id, .. } => (id, logging::compute::PeekType::Persist),
         };
-        ComputeEvent::Peek {
+        ComputeEvent::Peek(PeekEvent {
             peek: logging::compute::Peek::new(*id, peek.timestamp, peek.uuid),
             peek_type,
             installed,
-        }
+        })
     }
 
     fn index(peek: Peek, mut trace_bundle: TraceBundle) -> Self {

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -22,7 +22,10 @@ use timely::dataflow::{Scope, ScopeParent, StreamCore};
 use timely::progress::Timestamp;
 use timely::Container;
 
-use crate::logging::compute::{ComputeEvent, ComputeEventBuilder};
+use crate::logging::compute::{
+    ArrangementHeapAllocations, ArrangementHeapCapacity, ArrangementHeapSize,
+    ArrangementHeapSizeOperator, ComputeEvent, ComputeEventBuilder,
+};
 use crate::typedefs::{KeyAgent, KeyValAgent, RowAgent, RowRowAgent, RowValAgent};
 
 /// Extension trait to arrange data.
@@ -260,7 +263,9 @@ where
         .stream
         .unary(Pipeline, "ArrangementSize", |_cap, info| {
             let address = info.address;
-            logger.log(ComputeEvent::ArrangementHeapSizeOperator { operator, address });
+            logger.log(ComputeEvent::ArrangementHeapSizeOperator(
+                ArrangementHeapSizeOperator { operator, address },
+            ));
             move |input, output| {
                 while let Some((time, data)) = input.next() {
                     output.session(&time).give_container(data);
@@ -273,26 +278,30 @@ where
 
                 let size = size.try_into().expect("must fit");
                 if size != old_size {
-                    logger.log(ComputeEvent::ArrangementHeapSize {
+                    logger.log(ComputeEvent::ArrangementHeapSize(ArrangementHeapSize {
                         operator,
                         delta_size: size - old_size,
-                    });
+                    }));
                 }
 
                 let capacity = capacity.try_into().expect("must fit");
                 if capacity != old_capacity {
-                    logger.log(ComputeEvent::ArrangementHeapCapacity {
-                        operator,
-                        delta_capacity: capacity - old_capacity,
-                    });
+                    logger.log(ComputeEvent::ArrangementHeapCapacity(
+                        ArrangementHeapCapacity {
+                            operator,
+                            delta_capacity: capacity - old_capacity,
+                        },
+                    ));
                 }
 
                 let allocations = allocations.try_into().expect("must fit");
                 if allocations != old_allocations {
-                    logger.log(ComputeEvent::ArrangementHeapAllocations {
-                        operator,
-                        delta_allocations: allocations - old_allocations,
-                    });
+                    logger.log(ComputeEvent::ArrangementHeapAllocations(
+                        ArrangementHeapAllocations {
+                            operator,
+                            delta_allocations: allocations - old_allocations,
+                        },
+                    ));
                 }
 
                 old_size = size;

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -254,7 +254,7 @@ where
     else {
         return arranged;
     };
-    let operator = arranged.trace.operator().global_id;
+    let operator_id = arranged.trace.operator().global_id;
     let trace = Rc::downgrade(&arranged.trace.trace_box_unstable());
 
     let (mut old_size, mut old_capacity, mut old_allocations) = (0isize, 0isize, 0isize);
@@ -264,7 +264,10 @@ where
         .unary(Pipeline, "ArrangementSize", |_cap, info| {
             let address = info.address;
             logger.log(ComputeEvent::ArrangementHeapSizeOperator(
-                ArrangementHeapSizeOperator { operator, address },
+                ArrangementHeapSizeOperator {
+                    operator_id,
+                    address,
+                },
             ));
             move |input, output| {
                 while let Some((time, data)) = input.next() {
@@ -279,7 +282,7 @@ where
                 let size = size.try_into().expect("must fit");
                 if size != old_size {
                     logger.log(ComputeEvent::ArrangementHeapSize(ArrangementHeapSize {
-                        operator,
+                        operator_id,
                         delta_size: size - old_size,
                     }));
                 }
@@ -288,7 +291,7 @@ where
                 if capacity != old_capacity {
                     logger.log(ComputeEvent::ArrangementHeapCapacity(
                         ArrangementHeapCapacity {
-                            operator,
+                            operator_id,
                             delta_capacity: capacity - old_capacity,
                         },
                     ));
@@ -298,7 +301,7 @@ where
                 if allocations != old_allocations {
                     logger.log(ComputeEvent::ArrangementHeapAllocations(
                         ArrangementHeapAllocations {
-                            operator,
+                            operator_id,
                             delta_allocations: allocations - old_allocations,
                         },
                     ));

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -47,6 +47,7 @@ use crate::typedefs::RowRowSpine;
 pub type Logger = timely::logging_core::Logger<ComputeEventBuilder>;
 pub type ComputeEventBuilder = CapacityContainerBuilder<Vec<(Duration, ComputeEvent)>>;
 
+/// A dataflow exports a global ID.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct Export {
     /// Identifier of the export.
@@ -55,12 +56,14 @@ pub struct Export {
     pub dataflow_index: usize,
 }
 
+/// The export for a global id was dropped.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct ExportDropped {
     /// Identifier of the export.
     pub id: GlobalId,
 }
 
+/// A peek event with a [`Peek`], a [`PeekType`], and an installation status.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct PeekEvent {
     /// The data for the peek itself.
@@ -72,6 +75,7 @@ pub struct PeekEvent {
     pub installed: bool,
 }
 
+/// Frontier change event.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct Frontier {
     pub id: GlobalId,
@@ -79,6 +83,7 @@ pub struct Frontier {
     pub diff: i8,
 }
 
+/// An import frontier change.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct ImportFrontier {
     pub import_id: GlobalId,
@@ -87,6 +92,7 @@ pub struct ImportFrontier {
     pub diff: i8,
 }
 
+/// A change in an arrangement's heap size.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct ArrangementHeapSize {
     /// Operator index
@@ -95,6 +101,7 @@ pub struct ArrangementHeapSize {
     pub delta_size: isize,
 }
 
+/// A change in an arrangement's heap capacity.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct ArrangementHeapCapacity {
     /// Operator index
@@ -103,6 +110,7 @@ pub struct ArrangementHeapCapacity {
     pub delta_capacity: isize,
 }
 
+/// A change in an arrangement's heap allocation count.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct ArrangementHeapAllocations {
     /// Operator index
@@ -111,6 +119,7 @@ pub struct ArrangementHeapAllocations {
     pub delta_allocations: isize,
 }
 
+/// Announcing an operator that manages an arrangement.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct ArrangementHeapSizeOperator {
     /// Operator index
@@ -119,18 +128,21 @@ pub struct ArrangementHeapSizeOperator {
     pub address: Rc<[usize]>,
 }
 
+/// Drop event for an operator managing an arrangement.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct ArrangementHeapSizeOperatorDrop {
     /// Operator index
     pub operator: usize,
 }
 
+/// Dataflow shutdown event.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct DataflowShutdown {
     /// Timely worker index of the dataflow.
     pub dataflow_index: usize,
 }
 
+/// Error count update event.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct ErrorCount {
     /// Identifier of the export.
@@ -139,11 +151,13 @@ pub struct ErrorCount {
     pub diff: i64,
 }
 
+/// An export is hydrated.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct Hydration {
     pub export_id: GlobalId,
 }
 
+/// Announce a mapping of an LIR operator to a dataflow operator for a global ID.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct LirMapping {
     /// The `GlobalId` in which the LIR operator is rendered.
@@ -158,6 +172,7 @@ pub struct LirMapping {
     pub mapping: Box<[(LirId, LirMetadata)]>,
 }
 
+/// Announce that a dataflow supports a specific global ID.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct DataflowGlobal {
     /// The identifier of the dataflow.
@@ -202,13 +217,17 @@ pub enum ComputeEvent {
     DataflowGlobal(DataflowGlobal),
 }
 
+/// A peek type distinguishing between index and persist peeks.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub enum PeekType {
+    /// A peek against an index.
     Index,
+    /// A peek against persist.
     Persist,
 }
 
 impl PeekType {
+    /// A human-readable name for a peek type.
     fn name(self) -> &'static str {
         match self {
             PeekType::Index => "index",
@@ -252,6 +271,7 @@ pub struct LirMetadata {
 }
 
 impl LirMetadata {
+    /// Construct a new LIR metadata object.
     pub fn new(
         operator: Box<str>,
         parent_lir_id: Option<LirId>,
@@ -641,8 +661,11 @@ struct ArrangementSizeState {
     count: isize,
 }
 
+/// An update of value `D` at a time and with a diff.
 type Update<D> = (D, Timestamp, Diff);
+/// A pusher for updates of value `D` for vector-based containers.
 type Pusher<D> = Counter<Timestamp, Vec<Update<D>>, Tee<Timestamp, Vec<Update<D>>>>;
+/// An output session for vector-based containers of updates `D`, using a capacity container builder.
 type OutputSession<'a, D> =
     Session<'a, Timestamp, CapacityContainerBuilder<Vec<Update<D>>>, Pusher<D>>;
 

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -1483,6 +1483,6 @@ mod tests {
     #[mz_ore::test]
     fn test_compute_event_size() {
         // This could be a static assertion, but we don't use those yet in this crate.
-        assert_eq!(48, std::mem::size_of::<ComputeEvent>())
+        assert_eq!(56, std::mem::size_of::<ComputeEvent>())
     }
 }

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -838,7 +838,7 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
             .exports
             .insert(export_id, ExportState::new(dataflow_index));
         if existing.is_some() {
-            error!(export = %export_id, "export already registered");
+            error!(%export_id, "export already registered");
         }
 
         *self
@@ -857,7 +857,7 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
 
     fn handle_export_dropped(&mut self, ExportDropped { export_id }: ExportDropped) {
         let Some(export) = self.state.exports.remove(&export_id) else {
-            error!(export = %export_id, "missing exports entry at time of export drop");
+            error!(%export_id, "missing exports entry at time of export drop");
             return;
         };
 
@@ -873,8 +873,8 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
         match self.state.dataflow_export_counts.get_mut(&dataflow_index) {
             entry @ Some(0) | entry @ None => {
                 error!(
-                    export = %export_id,
-                    dataflow = %dataflow_index,
+                    %export_id,
+                    %dataflow_index,
                     "invalid dataflow_export_counts entry at time of export drop: {entry:?}",
                 );
             }
@@ -912,7 +912,7 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
                 .dataflow_drop_times
                 .insert(dataflow_index, self.time);
             if existing.is_some() {
-                error!(dataflow = %dataflow_index, "dataflow already dropped");
+                error!(%dataflow_index, "dataflow already dropped");
             }
         }
     }
@@ -929,7 +929,7 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
             // Dataflow has not yet been dropped.
             let was_new = self.state.shutdown_dataflows.insert(dataflow_index);
             if !was_new {
-                error!(dataflow = %dataflow_index, "dataflow already shutdown");
+                error!(%dataflow_index, "dataflow already shutdown");
             }
         }
 
@@ -1004,7 +1004,7 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
         let ts = self.ts();
 
         let Some(export) = self.state.exports.get_mut(&export_id) else {
-            error!(export = %export_id, "hydration event for unknown export");
+            error!(%export_id, "hydration event for unknown export");
             return;
         };
         if export.hydration_time_ns.is_some() {
@@ -1046,10 +1046,7 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
 
         let existing = self.state.peek_stash.insert(uuid, self.time);
         if existing.is_some() {
-            error!(
-                uuid = %uuid,
-                "peek already registered",
-            );
+            error!(%uuid, "peek already registered");
         }
     }
 
@@ -1074,10 +1071,7 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
                 .peek_duration
                 .give((PeekDurationDatum { peek_type, bucket }, ts, 1));
         } else {
-            error!(
-                uuid = %uuid,
-                "peek not yet registered",
-            );
+            error!(%uuid, "peek not yet registered");
         }
     }
 

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -33,7 +33,7 @@ use timely::dataflow::operators::Filter;
 use timely::dataflow::Stream;
 
 use crate::extensions::arrange::MzArrange;
-use crate::logging::compute::ComputeEvent;
+use crate::logging::compute::{ArrangementHeapSizeOperatorDrop, ComputeEvent};
 use crate::logging::{
     DifferentialLog, EventQueue, LogCollection, LogVariant, PermutedRowPacker, SharedLoggingState,
 };
@@ -298,7 +298,9 @@ impl DemuxHandler<'_, '_> {
                 .expect("under/overflow");
             if *sharing == 0 {
                 self.state.sharing.remove(&op);
-                logger.log(ComputeEvent::ArrangementHeapSizeOperatorDrop { operator: op });
+                logger.log(ComputeEvent::ArrangementHeapSizeOperatorDrop(
+                    ArrangementHeapSizeOperatorDrop { operator: op },
+                ));
             }
         }
     }

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -249,57 +249,57 @@ impl DemuxHandler<'_, '_> {
 
     fn handle_batch(&mut self, event: BatchEvent) {
         let ts = self.ts();
-        let op = event.operator;
-        self.output.batches.give(((op, ()), ts, 1));
+        let operator_id = event.operator;
+        self.output.batches.give(((operator_id, ()), ts, 1));
 
         let diff = Diff::try_from(event.length).expect("must fit");
-        self.output.records.give(((op, ()), ts, diff));
-        self.notify_arrangement_size(op);
+        self.output.records.give(((operator_id, ()), ts, diff));
+        self.notify_arrangement_size(operator_id);
     }
 
     fn handle_merge(&mut self, event: MergeEvent) {
         let Some(done) = event.complete else { return };
 
         let ts = self.ts();
-        let op = event.operator;
-        self.output.batches.give(((op, ()), ts, -1));
+        let operator_id = event.operator;
+        self.output.batches.give(((operator_id, ()), ts, -1));
 
         let diff = Diff::try_from(done).expect("must fit")
             - Diff::try_from(event.length1 + event.length2).expect("must fit");
         if diff != 0 {
-            self.output.records.give(((op, ()), ts, diff));
+            self.output.records.give(((operator_id, ()), ts, diff));
         }
-        self.notify_arrangement_size(op);
+        self.notify_arrangement_size(operator_id);
     }
 
     fn handle_drop(&mut self, event: DropEvent) {
         let ts = self.ts();
-        let op = event.operator;
-        self.output.batches.give(((op, ()), ts, -1));
+        let operator_id = event.operator;
+        self.output.batches.give(((operator_id, ()), ts, -1));
 
         let diff = -Diff::try_from(event.length).expect("must fit");
         if diff != 0 {
-            self.output.records.give(((op, ()), ts, diff));
+            self.output.records.give(((operator_id, ()), ts, diff));
         }
-        self.notify_arrangement_size(op);
+        self.notify_arrangement_size(operator_id);
     }
 
     fn handle_trace_share(&mut self, event: TraceShare) {
         let ts = self.ts();
-        let op = event.operator;
+        let operator_id = event.operator;
         let diff = Diff::cast_from(event.diff);
         debug_assert_ne!(diff, 0);
-        self.output.sharing.give(((op, ()), ts, diff));
+        self.output.sharing.give(((operator_id, ()), ts, diff));
 
         if let Some(logger) = &mut self.shared_state.compute_logger {
-            let sharing = self.state.sharing.entry(op).or_default();
+            let sharing = self.state.sharing.entry(operator_id).or_default();
             *sharing = (i64::try_from(*sharing).expect("must fit") + diff)
                 .try_into()
                 .expect("under/overflow");
             if *sharing == 0 {
-                self.state.sharing.remove(&op);
+                self.state.sharing.remove(&operator_id);
                 logger.log(ComputeEvent::ArrangementHeapSizeOperatorDrop(
-                    ArrangementHeapSizeOperatorDrop { operator: op },
+                    ArrangementHeapSizeOperatorDrop { operator_id },
                 ));
             }
         }
@@ -307,21 +307,23 @@ impl DemuxHandler<'_, '_> {
 
     fn handle_batcher_event(&mut self, event: BatcherEvent) {
         let ts = self.ts();
-        let op = event.operator;
+        let operator_id = event.operator;
         let records_diff = Diff::cast_from(event.records_diff);
         let size_diff = Diff::cast_from(event.size_diff);
         let capacity_diff = Diff::cast_from(event.capacity_diff);
         let allocations_diff = Diff::cast_from(event.allocations_diff);
         self.output
             .batcher_records
-            .give(((op, ()), ts, records_diff));
-        self.output.batcher_size.give(((op, ()), ts, size_diff));
+            .give(((operator_id, ()), ts, records_diff));
+        self.output
+            .batcher_size
+            .give(((operator_id, ()), ts, size_diff));
         self.output
             .batcher_capacity
-            .give(((op, ()), ts, capacity_diff));
+            .give(((operator_id, ()), ts, capacity_diff));
         self.output
             .batcher_allocations
-            .give(((op, ()), ts, allocations_diff));
+            .give(((operator_id, ()), ts, allocations_diff));
     }
 
     fn notify_arrangement_size(&self, operator: usize) {

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -37,7 +37,7 @@ use timely::logging::{
 use tracing::error;
 
 use crate::extensions::arrange::MzArrange;
-use crate::logging::compute::ComputeEvent;
+use crate::logging::compute::{ComputeEvent, DataflowShutdown};
 use crate::logging::{EventQueue, LogVariant, SharedLoggingState, TimelyLog};
 use crate::logging::{LogCollection, PermutedRowPacker};
 use crate::row_spine::{RowRowBatcher, RowRowBuilder};
@@ -566,7 +566,9 @@ impl DemuxHandler<'_, '_> {
     fn handle_dataflow_shutdown(&mut self, dataflow_index: usize) {
         // Notify compute logging about the shutdown.
         if let Some(logger) = &self.shared_state.compute_logger {
-            logger.log(ComputeEvent::DataflowShutdown { dataflow_index });
+            logger.log(ComputeEvent::DataflowShutdown(DataflowShutdown {
+                dataflow_index,
+            }));
         }
 
         // When a dataflow shuts down, we need to retract all its channels.

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -150,7 +150,9 @@ use crate::arrangement::manager::TraceBundle;
 use crate::compute_state::ComputeState;
 use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::extensions::reduce::MzReduce;
-use crate::logging::compute::{ComputeEvent, LirMetadata, LogDataflowErrors};
+use crate::logging::compute::{
+    ComputeEvent, DataflowGlobal, LirMapping, LirMetadata, LogDataflowErrors,
+};
 use crate::render::context::{
     ArrangementFlavor, Context, MzArrangement, MzArrangementImport, ShutdownToken,
 };
@@ -1184,13 +1186,16 @@ where
 
     fn log_dataflow_global_id(&self, id: usize, global_id: GlobalId) {
         if let Some(logger) = &self.compute_logger {
-            logger.log(ComputeEvent::DataflowGlobal { id, global_id });
+            logger.log(ComputeEvent::DataflowGlobal(DataflowGlobal {
+                id,
+                global_id,
+            }));
         }
     }
 
     fn log_lir_mapping(&self, global_id: GlobalId, mapping: Box<[(LirId, LirMetadata)]>) {
         if let Some(logger) = &self.compute_logger {
-            logger.log(ComputeEvent::LirMapping { global_id, mapping });
+            logger.log(ComputeEvent::LirMapping(LirMapping { global_id, mapping }));
         }
     }
 

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -1184,10 +1184,10 @@ where
         }
     }
 
-    fn log_dataflow_global_id(&self, id: usize, global_id: GlobalId) {
+    fn log_dataflow_global_id(&self, dataflow_index: usize, global_id: GlobalId) {
         if let Some(logger) = &self.compute_logger {
             logger.log(ComputeEvent::DataflowGlobal(DataflowGlobal {
-                id,
+                dataflow_index,
                 global_id,
             }));
         }


### PR DESCRIPTION
This is in preparation to derive Columnar for all events. At the moment, columnar doesn't support deriving for enums with struct members, but each member needs to be a tuple. No functional changes otherwise.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
