### PR TITLE
storage: make sure the health capability is dropped

### DIFF
--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -368,10 +368,16 @@ where
         .set(mz_persist_client::metrics::encode_ts_metric(&resume_upper));
 
     builder.build(move |mut caps| {
-        let health_cap = caps.remove(1);
-        move |_frontiers| {
+        let mut health_cap = Some(caps.remove(1));
+        move |frontiers| {
             let mut statuses_by_idx = BTreeMap::new();
             let mut health_output = health_output.activate();
+
+            if frontiers.iter().all(|f| f.is_empty()) {
+                health_cap = None;
+                return;
+            }
+            let health_cap = health_cap.as_mut().unwrap();
 
             for (id, input, output) in export_handles.iter_mut() {
                 while let Some((cap, data)) = input.next() {


### PR DESCRIPTION
This is a slight oversight in #30858 that switched from the async operator builder that drops capabilities when it exits to the timely rc operator builder where capabilities need to dropped manually.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8880

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
