### PR TITLE
Avoid memory leak in BoxStrStack

### DIFF
--- a/src/storage-types/src/errors.rs
+++ b/src/storage-types/src/errors.rs
@@ -417,7 +417,9 @@ mod boxed_str {
         #[inline(always)]
         unsafe fn copy(&mut self, item: &Box<str>) -> Box<str> {
             let bytes = self.region.copy_slice(item.as_bytes());
-            Box::from(std::str::from_utf8_unchecked(bytes))
+            // SAFETY: The bytes are copied from the region, and the region is stable.
+            // We never drop the box.
+            std::str::from_boxed_utf8_unchecked(Box::from_raw(bytes))
         }
         #[inline(always)]
         fn reserve_items<'a, I>(&mut self, items: I)


### PR DESCRIPTION
Previously, we'd create a new box from bytes, which allocates. Instead, we should use the same pointer to create the box.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
