### PR TITLE
tests: Adapt to new reality when table in Pg source was dropped

### DIFF
--- a/test/pg-cdc-old-syntax/alter-table-after-source.td
+++ b/test/pg-cdc-old-syntax/alter-table-after-source.td
@@ -388,4 +388,4 @@ DROP TABLE drop_table;
 
 # Table is dropped
 ! SELECT * FROM drop_table;
-contains:table was dropped
+regex:(table was dropped|incompatible schema change)

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -64,7 +64,7 @@ ALTER TABLE table_a REPLICA IDENTITY FULL;
 INSERT INTO table_a VALUES (9, 'nine');
 
 ! SELECT * FROM table_a;
-contains:table was dropped
+regex:(table was dropped|incompatible schema change)
 
 # We are not aware that the new table_a is different
 ! CREATE TABLE table_a FROM SOURCE mz_source (REFERENCE table_a);

--- a/test/pg-cdc/alter-table-after-source.td
+++ b/test/pg-cdc/alter-table-after-source.td
@@ -406,4 +406,4 @@ DROP TABLE drop_table;
 
 # Table is dropped
 ! SELECT * FROM drop_table;
-contains:table was dropped
+regex:(table was dropped|incompatible schema change)


### PR DESCRIPTION
See https://github.com/MaterializeInc/database-issues/issues/8883

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
