### PR TITLE
Support deploying self-managed docs

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -221,6 +221,9 @@ case "$cmd" in
             --env REDPANDA_CLOUD_CLIENT_ID
             --env REDPANDA_CLOUD_CLIENT_SECRET
             --env QA_BENCHMARKING_APP_PASSWORD
+            # For self managed docs
+            --env BUILDKITE_BRANCH
+            --env BUILDKITE_ORGANIZATION_SLUG
         )
 
         if [[ $detach_container == "true" ]]; then

--- a/ci/deploy_website/pipeline.template.yml
+++ b/ci/deploy_website/pipeline.template.yml
@@ -12,7 +12,7 @@ priority: 30
 
 steps:
   - command: bin/ci-builder run nightly ci/deploy_website/website.sh
-    branches: main
+    branches: "main self-managed-docs/*"
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64-small

--- a/ci/deploy_website/website.sh
+++ b/ci/deploy_website/website.sh
@@ -37,7 +37,12 @@ declare -A shortlinks=(
 )
 
 cd doc/user
-hugo --gc --baseURL /docs --destination public/docs
+if [[ "$BUILDKITE_ORGANIZATION_SLUG" == "materialize" ]] && [[ "$BUILDKITE_BRANCH" == self-managed-docs/* ]]; then
+    VERSION=${BUILDKITE_BRANCH#self-managed-docs/}
+    hugo --gc --baseURL "/docs/self-managed/$VERSION" --destination "public/docs/self-managed/$VERSION"
+else
+    hugo --gc --baseURL /docs --destination public/docs
+fi
 hugo deploy --maxDeletes -1
 
 touch empty

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -748,7 +748,7 @@ steps:
     depends_on: lint-docs
     trigger: deploy-website
     async: true
-    branches: main
+    branches: "main self-managed-docs/*"
     build:
       commit: "$BUILDKITE_COMMIT"
       branch: "$BUILDKITE_BRANCH"

--- a/doc/user/content/versions.json
+++ b/doc/user/content/versions.json
@@ -1,0 +1,10 @@
+[
+    {
+        "name": "Cloud",
+        "base_url": ""
+    },
+    {
+        "name": "Self-Managed v25.1",
+        "base_url": "/self-managed/v25.1"
+    }
+]

--- a/doc/user/layouts/partials/sidebar.html
+++ b/doc/user/layouts/partials/sidebar.html
@@ -6,6 +6,9 @@
         <input type="button" value="Search the Docs/Ask AI" class="btn-ghost docs-search-button"
         title="cmd+K (⌘+K/⊞+K)" />
       </div>
+      <select id="version-select" class="version-dropdown">
+      </select>
+
       {{ range .Site.Menus.main.ByWeight }}
       <li class="level-1 {{if .HasChildren }}has-children{{ else }}no-children{{ end }}">
           <a {{with .URL}}href="{{.}}"{{end}} class="{{if $currentPage.IsMenuCurrent "main" .}}active{{end}}">
@@ -64,3 +67,34 @@
     <svg xmlns="http://www.w3.org/2000/svg" class="ionicon" viewBox="0 0 512 512"><title>Close</title><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32" d="M368 368L144 144M368 144L144 368"/></svg>
   </button>
 </div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const versionSelect = document.getElementById('version-select');
+    const currentPath = window.location.pathname;
+
+    fetch('/docs/versions.json')
+      .then(response => response.json())
+      .then(versions => {
+        versions.forEach(version => {
+          const option = document.createElement('option');
+          option.value = version.base_url;
+          option.textContent = version.name;
+          versionSelect.appendChild(option);
+        });
+
+        const matchingVersion = versions.find(version => currentPath.includes(version.base_url));
+        if (matchingVersion) {
+          versionSelect.value = matchingVersion.base_url;
+        }
+
+        versionSelect.addEventListener('change', function () {
+          const selectedBaseUrl = versionSelect.value;
+          if (selectedBaseUrl) {
+            window.location.href = selectedBaseUrl;
+          }
+        });
+      })
+      .catch(error => console.error('Error fetching versions:', error));
+  });
+</script>


### PR DESCRIPTION
Context: https://materializeinc.slack.com/archives/C07PN7KSB0T/p1736830571054569

Test run on the [self-managed-docs/v25.1 branch](https://github.com/MaterializeInc/materialize/tree/self-managed-docs/v25.1) I have created for now to test this: https://buildkite.com/materialize/test/builds/97158

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
