### PR TITLE
dev docs: MZ_ALL_FEATURES=true

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -112,12 +112,12 @@ test more risky features of Materialize, see `get_default_system_parameters` in
 [https://github.com/MaterializeInc/materialize/blob/main/misc/python/materialize/mzcompose/__init__.py](mzcompose/__init__.py).
 On the command line specific system parameters can be set using the
 `MZSYSTEM_PARAMETER_DEFAULT` environment variable (`;`-separated).
-Alternatively `MZ_ALL_FEATURES=1` enables all available Materialize features.
+Alternatively `MZ_ALL_FEATURES=true` enables all available Materialize features.
 For example to run the `mz-arrangement-sharing.td` locally with a Debug build
 for fast turnaround times:
 
 ```shell
-$ MZ_ALL_FEATURES=1 bin/environmentd
+$ MZ_ALL_FEATURES=true bin/environmentd
 $ cargo run --bin testdrive -- test/testdrive/mz-arrangement-sharing.td
 ```
 


### PR DESCRIPTION
Since the clap update values are not implicitly converted to booleans anymore. This leads to a bunch of inconsistency. For example `MZ_UNSAFE_MODE` and `MZ_ALL_FEATURES` require `true`, but `MZ_SOFT_ASSERTIONS` and `RUST_BACKTRACE` work with `1`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
