### PR TITLE
docs: self-managed add redirects

### DIFF
--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -3,7 +3,7 @@ title: "Self-managed Materialize"
 description: ""
 aliases:
   - /self-hosted/
-robots: "noindex, nofollow"
+  - /self-managed/
 ---
 
 With self-managed Materialize, you can deploy and operate Materialize in your

--- a/doc/user/content/installation/_index.md
+++ b/doc/user/content/installation/_index.md
@@ -2,7 +2,8 @@
 title: "Installation"
 description: "Installation guides for self-managed Materialize."
 disable_list: true
-
+aliases:
+  - /self-managed/installation/
 menu:
   main:
     identifier: "installation"

--- a/doc/user/content/installation/install-on-aws.md
+++ b/doc/user/content/installation/install-on-aws.md
@@ -3,6 +3,7 @@ title: "Install on AWS"
 description: ""
 aliases:
   - /self-hosted/install-on-aws/
+  - /self-managed/installation/install-on-aws/
 menu:
   main:
     parent: "installation"

--- a/doc/user/content/installation/install-on-gcp.md
+++ b/doc/user/content/installation/install-on-gcp.md
@@ -3,6 +3,7 @@ title: "Install on GCP"
 description: ""
 aliases:
   - /self-hosted/install-on-gcp/
+  - /self-managed/installation/install-on-gcp/
 menu:
   main:
     parent: "installation"

--- a/doc/user/content/installation/install-on-local-kind.md
+++ b/doc/user/content/installation/install-on-local-kind.md
@@ -3,6 +3,7 @@ title: "Install locally on kind"
 description: ""
 aliases:
   - /self-hosted/install-on-local-kind/
+  - /self-managed/installation/install-on-local-kind/
 menu:
   main:
     parent: "installation"

--- a/doc/user/content/installation/install-on-local-minikube.md
+++ b/doc/user/content/installation/install-on-local-minikube.md
@@ -3,6 +3,7 @@ title: "Install locally on minikube"
 description: ""
 aliases:
   - /self-hosted/install-on-local-minikube/
+  - /self-managed/installation/install-on-local-minikube/
 menu:
   main:
     parent: "installation"

--- a/doc/user/content/installation/operational-guidelines.md
+++ b/doc/user/content/installation/operational-guidelines.md
@@ -3,6 +3,7 @@ title: "Operational guidelines"
 description: ""
 aliases:
   - /self-hosted/operational-guidelines/
+  - /self-managed/operational-guidelines/
 menu:
   main:
     parent: "installation"

--- a/doc/user/content/installation/troubleshooting.md
+++ b/doc/user/content/installation/troubleshooting.md
@@ -3,6 +3,7 @@ title: "Troubleshooting"
 description: ""
 aliases:
   - /self-hosted/troubleshooting/
+  - /self-managed/troubleshooting/
 menu:
   main:
     parent: "installation"

--- a/doc/user/content/installation/upgrading.md
+++ b/doc/user/content/installation/upgrading.md
@@ -3,6 +3,7 @@ title: "Upgrading"
 description: "Upgrading Helm chart and Materialize."
 aliases:
   - /self-hosted/upgrading/
+  - /self-managed/upgrading/
 menu:
   main:
     parent: "installation"


### PR DESCRIPTION
The /self-managed/ docs (the preview ones without the v25.1) seem to be gone now.  Adding redirects so as not to strand current users of those docs.
