### PR TITLE
[docs] Explain each LIR operator

### DIFF
--- a/doc/user/content/sql/explain-plan.md
+++ b/doc/user/content/sql/explain-plan.md
@@ -241,6 +241,10 @@ Below the plan, a "Used indexes" section indicates which indexes will be used by
 ### Reference: Plan operators
 
 {{< tabs >}}
+{{< tab "In fully optimized LIR plans" >}}
+{{< explain-plans/operator-table data="explain_plan_operators" planType="lir" >}}
+{{< /tab >}}
+
 {{< tab "In decorrelated and optimized plans" >}}
 {{< explain-plans/operator-table data="explain_plan_operators" planType="optimized" >}}
 {{< /tab >}}

--- a/doc/user/data/explain_plan_operators.yml
+++ b/doc/user/data/explain_plan_operators.yml
@@ -14,6 +14,19 @@ operators:
       - (3, 4)
       ```
 
+  - operator: Constant
+    plan_types: "lir"
+    description: |
+      Always produces the same collection of rows.
+    uses_memory: False
+    memory_details: ""
+    expansive: False
+
+    example: |
+      ```mzsql
+      Constant 2 rows
+      ```
+
   - operator: Get
     plan_types: "optimized,raw"
     description: |
@@ -22,10 +35,33 @@ operators:
     uses_memory: False
     memory_details: ""
     expansive: False
-    expansive_details: |
-      Each row has _less_ data (i.e., shorter rows, but same number of rows).
 
     example: "`Get materialize.public.ordered`"
+
+  - operator: Get::~
+    plan_types: "lir"
+    description: |
+      Produces rows from either an existing source/view or
+      from a previous operator in the same plan. There may be a
+      `MapFilterProject` included in the lookup.
+
+      There are three types of `Get`.
+
+      1. `GetPass::PassArrangements`, which means that the results are
+         available in an in-memory arrangement... _and_ that in-memory
+         arrangement will be available to whoever uses this operator
+         as input.
+
+      2. `Get::Arrangement`, which means that the results are
+         available in an in-memory arrangement.
+
+      3. `Get::Collection`, which means that the results are
+      unarranged, and will be processed as they arrive.
+
+    uses_memory: False
+    memory_details: ""
+    expansive: False
+    example: "`Get::PassArrangements materialize.public.ordered`"
 
   - operator: Project
     plan_types: "optimized,raw"
@@ -35,7 +71,8 @@ operators:
     uses_memory: False
     memory_details: ""
     expansive: False
-
+    expansive_details: |
+      Each row has _less_ data (i.e., shorter rows, but same number of rows).
     example: "`Project (#2, #3)`"
 
   - operator: Map
@@ -49,6 +86,21 @@ operators:
       Each row has more data (i.e., longer rows but same number of rows).
     example: "`Map (((#1 * 10000000dec) / #2) * 1000dec)`"
 
+  - operator: MapFilterProject
+    plan_types: "lir"
+    description: |
+      Computes new columns, filters columns, and projects away columns. Works row-by-row.
+    uses_memory: False
+    memory_details: ""
+    expansive: True
+    expansive_details: |
+      The number after the operator is the input operator's `lir_id`.
+
+      Each row may have more data, from the `Map`.
+      Each row may also have less data, from the `Project`.
+      There may be fewer rows, from the `Filter`.
+    example: "`MapFilterProject 5`"
+
   - operator: FlatMap
     plan_types: "optimized"
     description: |
@@ -59,6 +111,19 @@ operators:
     expansive_details: |
       Depends on the [table function](/sql/functions/#table-functions) used.
     example: "`FlatMap jsonb_foreach(#3)`"
+
+  - operator: FlatMap
+    plan_types: "lir"
+    description: |
+      The number after the operator is the input operator's `lir_id`.
+
+      Appends the result of some (one-to-many) [table function](/sql/functions/#table-functions) to each row in the input.
+    uses_memory: False
+    memory_details: ""
+    expansive: True
+    expansive_details: |
+      Depends on the [table function](/sql/functions/#table-functions) used.
+    example: "`FlatMap 3 (jsonb_foreach)`"
 
   - operator: CallTable
     plan_types: "raw"
@@ -107,6 +172,23 @@ operators:
       Depends on the join order and facts about the joined collections.
     example: "`Join on=(#1 = #2) type=delta`"
 
+  - operator: Join
+    plan_types: "lir"
+    description: |
+      The input operators are listed in the order performed by the join.
+
+      Returns combinations of rows from each input whenever some equality predicates are `true`.
+
+      There are two types of `Join`: `Join::Differential` and `Join::Delta`, with [documented differences](/transform-data/optimization/#join).
+    uses_memory: True
+    memory_details: |
+      Uses memory for 3-way or more differential joins.
+    expansive: True
+    expansive_details: |
+      Depends on the join order and facts about the joined collections.
+    example: "`Join::Differential 6 » 7`"
+
+
   - operator: CrossJoin
     plan_types: "optimized"
     description: |
@@ -130,6 +212,32 @@ operators:
       [`mz_introspection.mz_expected_group_size_advice`](/sql/system-catalog/mz_introspection/#mz_expected_group_size_advice).
     expansive: False
     example: "`Reduce group_by=[#0] aggregates=[max((#0 * #1))]`"
+
+  - operator: Reduce
+    plan_types: "lir"
+    description: |
+      The number after the operator is the input operator's `lir_id`.
+
+      Groups the input rows by some scalar expressions, reduces each group using some aggregate functions, and produces rows containing the group key and aggregate outputs.
+
+      There are five types of `Reduce`, ordered by increasing complexity:
+
+      1. `Reduce::Distinct` corresponds to the SQL `DISTINCT` operator.
+
+      2. `Reduce::Basic` corresponds to a single, easy to implement aggregation.
+
+      3. `Reduce::Accumulable` corresponds to several easy to implement aggregations that can be done simultaneously.
+
+      4. `Reduce::Hierarchical` corresponds to an aggregation requiring a tower of arrangements. These can be either monotonic (more efficient) or bucketed. These may benefit from a hint; [see `mz_introspection.mz_expected_group_size_advice`](/sql/system-catalog/mz_introspection/#mz_expected_group_size_advice).
+
+      5. `Reduce::Collation` corresponds to an arbitrary mix of reductions, which will be performed separately and then joined together.
+    uses_memory: True
+    memory_details: |
+      Can use significant amount as the operator can significantly overestimate
+      the size. For `MIN` and `MAX` aggregates, consult
+      [`mz_introspection.mz_expected_group_size_advice`](/sql/system-catalog/mz_introspection/#mz_expected_group_size_advice).
+    expansive: False
+    example: "`Reduce::Accumulable 8`"
 
   - operator: Reduce
     plan_types: "raw"
@@ -179,6 +287,27 @@ operators:
     expansive: False
     example: "`TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5`"
 
+  - operator: TopK
+    plan_types: "lir"
+    description: |
+      The number after the operator is the input operator's `lir_id`.
+
+      Groups the input rows, sorts them according to some ordering, and returns at most `K` rows at some offset from the top of the list, where `K` is some (possibly computed) limit.
+
+      There are three types of `TopK`. Two are special cased for monotonic inputs (i.e., inputs which never retract data).
+
+      1. `TopK::MonotonicTop1`.
+      2. `TopK::MonotonicTopK`, which may give an expression indicating the limit.
+      3. `TopK::Basic`, a generic `TopK` plan.
+    uses_memory: True
+    memory_details: |
+      Can use significant amount as the operator can significantly overestimate
+      the size. Consult
+      [`mz_introspection.mz_expected_group_size_advice`](/sql/system-catalog/mz_introspection/#mz_expected_group_size_advice).
+    expansive: False
+    example: "`TopK::Basic 10`"
+
+
   - operator: Negate
     plan_types: "optimized,raw"
     description: |
@@ -187,6 +316,16 @@ operators:
     memory_details: ""
     expansive: False
     example: "`Negate`"
+
+  - operator: Negate
+    plan_types: "lir"
+    description: |
+      Negates the row counts of the input. This is usually used in combination with union to remove rows from the other union input.
+    uses_memory: False
+    memory_details: ""
+    expansive: False
+    example: "`Negate 17`"
+
 
   - operator: Threshold
     plan_types: "optimized,raw"
@@ -198,6 +337,16 @@ operators:
     expansive: False
     example: "`Threshold`"
 
+  - operator: Threshold
+    plan_types: "lir"
+    description: |
+      Removes any rows with negative counts.
+    uses_memory: True
+    memory_details: |
+      Uses memory proportional to the number of input updates, twice.
+    expansive: False
+    example: "`Threshold 47`"
+
   - operator: Union
     plan_types: "optimized,raw"
     description: |
@@ -208,6 +357,16 @@ operators:
     expansive: False
     example: "`Union`"
 
+  - operator: Union
+    plan_types: "lir"
+    description: |
+      Sums the counts of each row of all inputs.
+    uses_memory: True
+    memory_details: |
+      If the union "consolidates output", it will make moderate use of memory, particularly at hydration time. If the union is not marked with "consolidates output", it will not consume memory.
+    expansive: False
+    example: "`Union 7 10 11 14 (consolidates output)`"
+
   - operator: ArrangeBy
     plan_types: "optimized"
     description: |
@@ -217,6 +376,26 @@ operators:
       Depends. When it does, uses memory proportional to the number of input updates.
     expansive: False
     example: "`ArrangeBy keys=[[#0]]`"
+
+  - operator: ArrangeBy
+    plan_types: "optimized"
+    description: |
+      Indicates a point that will become an arrangement in the dataflow engine (each `keys` element will be a different arrangement). Note that if the output of the previous operator is already arranged with a key that is also requested here, then this operator will just pass on that existing arrangement instead of creating a new one.
+    uses_memory: True
+    memory_details: |
+      Depends. When it does, uses memory proportional to the number of input updates.
+    expansive: False
+    example: "`ArrangeBy keys=[[#0]]`"
+
+  - operator: Arrange
+    plan_types: "lir"
+    description: |
+      Indicates a point that will become an arrangement in the dataflow engine (each `keys` element will be a different arrangement). Note that if the output of the previous operator is already arranged with a key that is also requested here, then this operator will just pass on that existing arrangement instead of creating a new one.
+    uses_memory: True
+    memory_details: |
+      Depends. When it does, uses memory proportional to the number of input updates.
+    expansive: False
+    example: "`Arrange 12`"
 
   - operator: Return ... With ...
     plan_types: "optimized,raw"


### PR DESCRIPTION
There is new syntax for showing LIR terms in `mz_introspection.mz_lir_mapping` after #29848 and #30899; this adds documentation for it.

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

I snuck in a tiny fix to how `Get` and `Project` were described---the `expansive_details` for `Get` described `Project`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
