### PR TITLE
docs: Fix version selector for self-managed versions

### DIFF
--- a/doc/user/content/versions.json
+++ b/doc/user/content/versions.json
@@ -1,10 +1,10 @@
 [
     {
         "name": "Cloud",
-        "base_url": "/docs"
+        "base_url": "/"
     },
     {
         "name": "Self-Managed v25.1",
-        "base_url": "/docs/self-managed/v25.1"
+        "base_url": "/self-managed/v25.1/"
     }
 ]

--- a/doc/user/layouts/partials/sidebar.html
+++ b/doc/user/layouts/partials/sidebar.html
@@ -74,7 +74,21 @@
     const currentPath = window.location.pathname;
 
     fetch('/docs/versions.json')
-      .then(response => response.json())
+      .then( response => {
+        if (!response.ok) {
+          throw new Error('File not found');
+        }
+        return response.json();
+      })
+      .catch(() => {
+        return fetch('{{ .Site.BaseURL }}/versions.json')
+          .then(response => {
+            if (!response.ok) {
+              throw new Error('Fallback file not found');
+            }
+            return response.json();
+          });
+      })
       .then(versions => {
         versions.forEach(version => {
           const option = document.createElement('option');
@@ -83,20 +97,16 @@
           versionSelect.appendChild(option);
         });
 
-        let matchingVersion;
+        const currentVersion = versions.filter(version => currentPath.includes(version.base_url))?.at(-1)?.base_url;
 
-        if (currentPath.includes("self-managed")) {
-          matchingVersion = versions.filter(version => version.base_url.includes("self-managed")).find(version => currentPath.includes(version.base_url));
-        } else {
-          matchingVersion = versions.filter(version => currentPath.includes(version.base_url));
-        }
-
-        if (matchingVersion) {
-          versionSelect.value = matchingVersion.base_url;
+        if (currentVersion) {
+          versionSelect.value = currentVersion;
         }
 
         versionSelect.addEventListener('change', function () {
-          const selectedBaseUrl = versionSelect.value;
+          const baseUrl = '{{ .Site.BaseURL }}';
+          const strippedBaseUrl = baseUrl.endsWith(currentVersion) ? baseUrl.slice(0, -currentVersion.length) : baseUrl;
+          const selectedBaseUrl = strippedBaseUrl + versionSelect.value;
           if (selectedBaseUrl) {
             window.location.href = selectedBaseUrl;
           }


### PR DESCRIPTION
Fall back to local versions.json when global one is missing.

Concatenate paths for links correctly

I have tested this locally with `hugo serve` and `hugo serve --baseURL localhost/docs/self-managed/v25.1` and it seems to work fine.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
