### PR TITLE
docs: Fixed size of version selector

### DIFF
--- a/doc/user/layouts/partials/sidebar.html
+++ b/doc/user/layouts/partials/sidebar.html
@@ -6,7 +6,7 @@
         <input type="button" value="Search the Docs/Ask AI" class="btn-ghost docs-search-button"
         title="cmd+K (⌘+K/⊞+K)" />
       </div>
-      <select id="version-select" class="version-dropdown">
+      <select id="version-select" class="version-dropdown" style="width: 100%; box-sizing: border-box;">
       </select>
 
       {{ range .Site.Menus.main.ByWeight }}


### PR DESCRIPTION
To prevent sudden jumps in the size when the json is loaded asynchronously, see attached video:

https://github.com/user-attachments/assets/0f3e7fbc-7789-4618-b2e4-834b17a6478e

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
