### PR TITLE
ci: Add env variable and comment for how to switch to AWS

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -356,42 +356,53 @@ def switch_jobs_to_aws(pipeline: Any, priority: int) -> None:
 
     branch = os.getenv("BUILDKITE_BRANCH")
 
-    # If priority has manually been set to be low, or on main branch, we can
-    # wait for agents to become available
-    if branch == "main" or priority < 0:
-        return
-
-    # Consider Hetzner to be overloaded when at least 400 jobs exist with priority >= 0
-    try:
-        builds = generic_api.get_multiple(
-            "builds",
-            params={
-                "state[]": ["creating", "scheduled", "running", "failing", "canceling"],
-            },
-            max_fetches=None,
-        )
-
-        num_jobs = 0
-        for build in builds:
-            for job in build["jobs"]:
-                if "state" not in job:
-                    continue
-                if "agent_query_rules" not in job:
-                    continue
-                if job["state"] in ("scheduled", "running", "assigned", "accepted"):
-                    queue = job["agent_query_rules"][0].removeprefix("queue=")
-                    if not queue.startswith("hetzner-"):
-                        continue
-                    if job.get("priority", {}).get("number", 0) < 0:
-                        continue
-                    num_jobs += 1
-        print(f"Number of high-priority jobs on Hetzner: {num_jobs}")
-        if num_jobs < 400:
+    # If Hetzner is entirely broken, you have to take these actions to switch everything back to AWS:
+    # - CI_FORCE_SWITCH_TO_AWS env variable to 1
+    # - Reconfigure the agent from hetzner-aarch64-4cpu-8gb to linux-aarch64-small in https://buildkite.com/materialize/test/settings/steps and other pipelines
+    # - Reconfigure the agent from hetzner-aarch64-4cpu-8gb to linux-aarch64-small in ci/mkpipeline.sh
+    if not ui.env_is_truthy("CI_FORCE_SWITCH_TO_AWS", "0"):
+        # If priority has manually been set to be low, or on main branch, we can
+        # wait for agents to become available
+        if branch == "main" or priority < 0:
             return
-    except Exception:
-        print("switch_jobs_to_aws failed, ignoring:")
-        traceback.print_exc()
-        return
+
+        # Consider Hetzner to be overloaded when at least 400 jobs exist with priority >= 0
+        try:
+            builds = generic_api.get_multiple(
+                "builds",
+                params={
+                    "state[]": [
+                        "creating",
+                        "scheduled",
+                        "running",
+                        "failing",
+                        "canceling",
+                    ],
+                },
+                max_fetches=None,
+            )
+
+            num_jobs = 0
+            for build in builds:
+                for job in build["jobs"]:
+                    if "state" not in job:
+                        continue
+                    if "agent_query_rules" not in job:
+                        continue
+                    if job["state"] in ("scheduled", "running", "assigned", "accepted"):
+                        queue = job["agent_query_rules"][0].removeprefix("queue=")
+                        if not queue.startswith("hetzner-"):
+                            continue
+                        if job.get("priority", {}).get("number", 0) < 0:
+                            continue
+                        num_jobs += 1
+            print(f"Number of high-priority jobs on Hetzner: {num_jobs}")
+            if num_jobs < 400:
+                return
+        except Exception:
+            print("switch_jobs_to_aws failed, ignoring:")
+            traceback.print_exc()
+            return
 
     def visit(config: Any) -> None:
         if "agents" in config:


### PR DESCRIPTION
For when the QA team is not around to figure things out quickly.

Review without whitespace: https://github.com/MaterializeInc/materialize/pull/31064/files?w=1

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
