### PR TITLE
catalog: Skip item optimization for renames

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2643,6 +2643,7 @@ mod tests {
                     &create_sql,
                     &BTreeMap::new(),
                     &mut LocalExpressionCache::Closed,
+                    None,
                 )
                 .expect("unable to parse view");
             let commit_ts = catalog.current_upper().await;
@@ -3549,7 +3550,9 @@ mod tests {
                 .deserialize_item(
                     mv_gid,
                     &format!("CREATE MATERIALIZED VIEW {database_name}.{schema_name}.{mv_name} AS SELECT name FROM mz_tables"),
-                    &BTreeMap::new(), &mut LocalExpressionCache::Closed
+                    &BTreeMap::new(),
+                    &mut LocalExpressionCache::Closed,
+                    None,
                 )
                 .expect("unable to deserialize item");
             let commit_ts = catalog.current_upper().await;

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -684,7 +684,9 @@ impl CatalogState {
                         &versions,
                         None,
                         index.is_retained_metrics_object,
-                        custom_logical_compaction_window,local_expression_cache,
+                        custom_logical_compaction_window,
+                        local_expression_cache,
+                        None,
                     )
                     .unwrap_or_else(|e| {
                         panic!(
@@ -826,6 +828,7 @@ impl CatalogState {
                         false,
                         None,
                         local_expression_cache,
+                        None,
                     )
                     .unwrap_or_else(|e| {
                         panic!(
@@ -862,6 +865,7 @@ impl CatalogState {
                         false,
                         None,
                         local_expression_cache,
+                        None,
                     )
                     .unwrap_or_else(|e| {
                         panic!(
@@ -986,6 +990,7 @@ impl CatalogState {
                                     &create_sql,
                                     &extra_versions,
                                     local_expression_cache,
+                                    Some(retraction.item),
                                 )
                                 .unwrap_or_else(|e| {
                                     panic!("{e:?}: invalid persisted SQL: {create_sql}")
@@ -1007,6 +1012,7 @@ impl CatalogState {
                                 &create_sql,
                                 &extra_versions,
                                 local_expression_cache,
+                                None,
                             )
                             .unwrap_or_else(|e| {
                                 panic!("{e:?}: invalid persisted SQL: {create_sql}")
@@ -1370,6 +1376,7 @@ impl CatalogState {
                                 false,
                                 None,
                                 cached_expr,
+                                None,
                             );
                             (id, global_id, res)
                         }

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -168,6 +168,7 @@ impl CatalogItemRebuilder {
                     is_retained_metrics_object,
                     custom_logical_compaction_window,
                     &mut LocalExpressionCache::Closed,
+                    None,
                 )
                 .unwrap_or_else(|error| panic!("invalid persisted create sql ({error:?}): {sql}")),
         }


### PR DESCRIPTION
Internally, the catalog models an update by a retraction followed by an
insert. Items are represented internally by their CREATE SQL string. So
when processing an item update, we first remove the existing item,
then parse, plan, and optimize the new SQL string, and then finally
insert the new item.

Parsing, planning, and optimization can be expensive, so we first check
if the CREATE SQL of the addition of an item matches the CREATE SQL of
the retraction of an item. If so, we can skip parsing, planning, and
optimization and just copy the old item. This can happen, for example,
when updating the privileges of an item, because the privileges are not
stored in the item AST.

Sometimes, when objects are renamed, the CREATE SQL string of an item
may change, but it ends up producing the same HIR and MIR. When this
happens we will spend unnecessary time re-optimizing the HIR, only to
produce an equivalent MIR when compared to the previous item. This
scenario is known to happen for `ALTER SCHEMA ... SWAP ...`.

This commit removes the unnecessary optimization work for equivalent
HIRs. After parsing and planning the CREATE SQL string of an item
addition, we check if the resulting HIR matches the HIR of the previous
item. If so, we skip optimization and re-use the previous item's MIR.
Importantly, the skipped optimization step is a local optimization, so
equal HIRs are guaranteed to produce equal MIRs.

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
