### PR TITLE
storage: round probe timestamps to the probe interval

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -148,6 +148,7 @@ def get_default_system_parameters(
         "pg_offset_known_interval": "1s",
         "statement_logging_default_sample_rate": "0.01",
         "statement_logging_max_sample_rate": "0.01",
+        "storage_reclock_to_latest": "true",
         "storage_source_decode_fuel": "100000",
         "storage_statistics_collection_interval": "1000",
         "storage_statistics_interval": "2000",

--- a/src/storage/src/source.rs
+++ b/src/storage/src/source.rs
@@ -31,6 +31,7 @@ pub mod generator;
 mod kafka;
 mod mysql;
 mod postgres;
+mod probe;
 pub(crate) mod reclock;
 mod source_reader_pipeline;
 mod statistics;

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -118,6 +118,7 @@ use tracing::{error, trace};
 use crate::metrics::source::postgres::PgSourceMetrics;
 use crate::source::postgres::verify_schema;
 use crate::source::postgres::{DefiniteError, ReplicationError, SourceOutputInfo, TransientError};
+use crate::source::probe;
 use crate::source::types::{
     Probe, ProgressStatisticsUpdate, SignaledFuture, SourceMessage, StackedCollection,
 };
@@ -757,16 +758,15 @@ async fn raw_stream<'a>(
     );
 
     let (probe_tx, mut probe_rx) = watch::channel(None);
-    let offset_known_interval =
+    let probe_interval =
         mz_storage_types::dyncfgs::PG_OFFSET_KNOWN_INTERVAL.get(config.config.config_set());
     let now_fn = config.now_fn.clone();
     let max_lsn_task_handle =
         mz_ore::task::spawn(|| format!("pg_current_wal_lsn:{}", config.id), async move {
-            let mut interval = tokio::time::interval(offset_known_interval);
+            let mut probe_ticker = probe::Ticker::new(probe_interval, now_fn);
 
             while !probe_tx.is_closed() {
-                interval.tick().await;
-                let probe_ts = mz_repr::Timestamp::try_from((now_fn)()).expect("must fit");
+                let probe_ts = probe_ticker.tick().await;
                 let probe_or_err = super::fetch_max_lsn(&*metadata_client)
                     .await
                     .map(|lsn| Probe {

--- a/src/storage/src/source/probe.rs
+++ b/src/storage/src/source/probe.rs
@@ -1,0 +1,96 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Support for sending frontier probes to upstream systems.
+
+use std::time::Duration;
+
+use mz_ore::now::{EpochMillis, NowFn};
+use mz_repr::Timestamp;
+use tracing::trace;
+
+/// A ticker to drive source upstream probing.
+///
+/// This type works similar to [`tokio::time::Interval`] but returns timestamps from its
+/// [`Ticker::tick`] method that can be used as probe timestamps. These timestamps are rounded down
+/// to the nearest multiple of the tick interval, to reduce the amount of unique timestamps emitted
+/// by sources, thereby reducing churn in downstream dataflows.
+///
+/// The ticker also supports usage in non-async contexts, using [`Ticker::tick_blocking`].
+pub(super) struct Ticker {
+    interval: EpochMillis,
+    now: NowFn,
+    last_tick: Option<EpochMillis>,
+}
+
+impl Ticker {
+    pub fn new(interval: Duration, now: NowFn) -> Self {
+        let interval = interval.as_millis().try_into().unwrap();
+        Self {
+            interval,
+            now,
+            last_tick: None,
+        }
+    }
+
+    /// Wait until it is time for the next probe, returning a suitable probe timestamp.
+    ///
+    /// This method tries to resolve as close as possible to the returned probe timestamp, though
+    /// it is not guaranteed to always succeed. If a tick is missed, it is skipped entirely.
+    pub async fn tick(&mut self) -> Timestamp {
+        let target = self.next_tick_target();
+
+        let mut now = (self.now)();
+        while now < target {
+            let wait = Duration::from_millis(target - now);
+            tokio::time::sleep(wait).await;
+            now = (self.now)();
+        }
+
+        trace!(target, now, "probe ticker skew: {}ms", now - target);
+        self.apply_tick(now)
+    }
+
+    /// Wait until it is time for the next probe, returning a suitable probe timestamp.
+    ///
+    /// Blocking version of [`Ticker::tick`].
+    pub fn tick_blocking(&mut self) -> Timestamp {
+        let target = self.next_tick_target();
+
+        let mut now = (self.now)();
+        while now < target {
+            let wait = Duration::from_millis(target - now);
+            std::thread::sleep(wait);
+            now = (self.now)();
+        }
+
+        trace!(target, now, "probe ticker skew: {}ms", now - target);
+        self.apply_tick(now)
+    }
+
+    /// Return the desired time of the next tick.
+    fn next_tick_target(&self) -> EpochMillis {
+        let target = match self.last_tick {
+            Some(ms) => ms + self.interval,
+            None => (self.now)(),
+        };
+        self.round_to_interval(target)
+    }
+
+    /// Apply a tick at the given time, returning the probe timestamp.
+    fn apply_tick(&mut self, time: EpochMillis) -> Timestamp {
+        let time = self.round_to_interval(time);
+        self.last_tick = Some(time);
+        time.into()
+    }
+
+    fn round_to_interval(&self, ms: EpochMillis) -> EpochMillis {
+        ms - (ms % self.interval)
+    }
+}

--- a/test/testdrive/source-timestamps.td
+++ b/test/testdrive/source-timestamps.td
@@ -1,0 +1,93 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests to verify that source timestamps are rounded to the timestamp interval.
+
+> CREATE CLUSTER test SIZE '1'
+
+$ kafka-create-topic topic=test
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)
+> CREATE SOURCE kafka_src
+  IN CLUSTER test
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-test-${testdrive.seed}')
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP PUBLICATION IF EXISTS mz_source
+CREATE TABLE t (x int);
+ALTER TABLE t REPLICA IDENTITY FULL;
+CREATE PUBLICATION mz_source FOR ALL TABLES
+
+> CREATE SECRET pg_pass AS 'postgres'
+> CREATE CONNECTION pg_conn TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pg_pass
+  )
+> CREATE SOURCE pg_src
+  IN CLUSTER test
+  FROM POSTGRES CONNECTION pg_conn (PUBLICATION 'mz_source')
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=p@ssw0rd
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
+CREATE TABLE t (x int)
+
+> CREATE SECRET mysql_pass AS 'p@ssw0rd';
+> CREATE CONNECTION mysql_conn TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysql_pass
+  )
+> CREATE SOURCE mysql_src
+  IN CLUSTER test
+  FROM MYSQL CONNECTION mysql_conn;
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET kafka_default_metadata_fetch_interval = '1s'
+ALTER SYSTEM SET pg_offset_known_interval = '1s'
+ALTER SYSTEM SET mysql_offset_known_interval = '1s'
+
+> ALTER CLUSTER test SET (REPLICATION FACTOR 0)
+> ALTER CLUSTER test SET (REPLICATION FACTOR 1)
+
+> SELECT name, write_frontier::text::uint8 % 1000 = 1
+  FROM mz_internal.mz_frontiers
+  JOIN mz_sources ON object_id = id
+  WHERE id LIKE 'u%'
+kafka_src          true
+kafka_src_progress true
+pg_src             true
+pg_src_progress    true
+mysql_src          true
+mysql_src_progress true
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET kafka_default_metadata_fetch_interval = 1234
+ALTER SYSTEM SET pg_offset_known_interval = 1234
+ALTER SYSTEM SET mysql_offset_known_interval = 1234
+
+> ALTER CLUSTER test SET (REPLICATION FACTOR 0)
+> ALTER CLUSTER test SET (REPLICATION FACTOR 1)
+
+> SELECT name, write_frontier::text::uint8 % 1234 = 1
+  FROM mz_internal.mz_frontiers
+  JOIN mz_sources ON object_id = id
+  WHERE id LIKE 'u%'
+kafka_src          true
+kafka_src_progress true
+pg_src             true
+pg_src_progress    true
+mysql_src          true
+mysql_src_progress true


### PR DESCRIPTION
This PR ensures that probe timestamps, and therefore timestamps used for minting new bindings, are rounded down to the probe interval (typically 1s). This is to reduce the amount of distinct timestamps flowing through a dataflow joining multiple sources. Each distinct timestamp induces some amount of overhead, so forcing the timestamps of individual sources to the same values is more efficient.

### Motivation

  * This PR adds a known-desirable feature.

Closes https://github.com/MaterializeInc/database-issues/issues/8885

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
