### PR TITLE
loosen version upgrade checks to allow for lts version upgrades

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -876,6 +876,18 @@ steps:
               composition: platform-checks
               args: [--scenario=UpgradeEntireMz, "--seed=$BUILDKITE_JOB_ID"]
 
+      - id: checks-lts-upgrade
+        label: "Checks LTS upgrade, whole-Mz restart"
+        depends_on: build-aarch64
+        timeout_in_minutes: 180
+        parallelism: 2
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=UpgradeEntireMzFromLatestLTS, "--seed=$BUILDKITE_JOB_ID"]
+
       - id: checks-preflight-check-rollback
         label: "Checks preflight-check and roll back upgrade"
         depends_on: build-aarch64
@@ -1676,7 +1688,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: legacy-upgrade
-              args: ["--versions-source=docs"]
+              args: ["--versions-source=docs", "--lts-upgrade"]
         agents:
           queue: hetzner-aarch64-4cpu-8gb
 

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -27,6 +27,11 @@ from materialize.mz_version import MzVersion
 
 MZ_ROOT = Path(os.environ["MZ_ROOT"])
 
+LTS_VERSIONS = [
+    MzVersion.parse_mz("v0.130.1"),  # v25.1.0
+    # Put new versions at the bottom
+]
+
 # not released on Docker
 INVALID_VERSIONS = {
     MzVersion.parse_mz("v0.52.1"),

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -36,6 +36,11 @@ use crate::operators::STORAGE_SOURCE_DECODE_FUEL;
 use crate::project::OPTIMIZE_IGNORED_DATA_DECODE;
 use crate::read::READER_LEASE_DURATION;
 
+const LTS_VERSIONS: &[Version] = &[
+    // 25.1
+    Version::new(0, 130, 0),
+];
+
 /// The tunable knobs for persist.
 ///
 /// Tuning inputs:
@@ -609,6 +614,10 @@ impl BlobKnobs for PersistConfig {
     }
 }
 
+pub fn check_data_version(code_version: &Version, data_version: &Version) -> Result<(), String> {
+    check_data_version_with_lts_versions(code_version, data_version, LTS_VERSIONS)
+}
+
 // If persist gets some encoded ProtoState from the future (e.g. two versions of
 // code are running simultaneously against the same shard), it might have a
 // field that the current code doesn't know about. This would be silently
@@ -633,7 +642,44 @@ impl BlobKnobs for PersistConfig {
 // data we read is going to be because we fetched it using a pointer stored in
 // some persist state. If we can handle the state, we can handle the blobs it
 // references, too.
-pub fn check_data_version(code_version: &Version, data_version: &Version) -> Result<(), String> {
+pub(crate) fn check_data_version_with_lts_versions(
+    code_version: &Version,
+    data_version: &Version,
+    lts_versions: &[Version],
+) -> Result<(), String> {
+    // Allow upgrades specifically between consecutive LTS releases.
+    let base_code_version = Version {
+        patch: 0,
+        ..code_version.clone()
+    };
+    let base_data_version = Version {
+        patch: 0,
+        ..data_version.clone()
+    };
+    if data_version >= code_version {
+        for window in lts_versions.windows(2) {
+            if base_code_version == window[0] && base_data_version <= window[1] {
+                return Ok(());
+            }
+        }
+
+        if let Some(last) = lts_versions.last() {
+            if base_code_version == *last
+                // kind of arbitrary, but just ensure we don't accidentally
+                // upgrade too far (the previous check should ensure that a
+                // new version won't take over from a too-old previous
+                // version, but we want to make sure the other side also
+                // doesn't get confused)
+                && base_data_version
+                    .minor
+                    .saturating_sub(base_code_version.minor)
+                    < 40
+            {
+                return Ok(());
+            }
+        }
+    }
+
     // Allow one minor version of forward compatibility. We could avoid the
     // clone with some nested comparisons of the semver fields, but this code
     // isn't particularly performance sensitive and I find this impl easier to


### PR DESCRIPTION
### Motivation

lts releases are going to be on their own versioning scheme, and so we need to define the relationship between those versions and the existing weekly release versions to allow self-hosted users to upgrade and allow us to test the upgrade process between lts releases.

### Tips for reviewer

i'm a bit nervous about this change because it is pretty critical to correctness - definitely open to better ideas around testing here (i wrote some more tests for the valid upgrade check but it's not super clear to me where tests should go for the catalog compatibility check).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
