### PR TITLE
[persist] Structured file format

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1050,8 +1050,11 @@ class FlipFlagsAction(Action):
             BOOLEAN_FLAG_VALUES
         )
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
-        self.flags_with_values["persist_batch_columnar_format"] = ["row", "both_v2"]
-        self.flags_with_values["persist_record_schema_id"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["persist_batch_columnar_format"] = [
+            "row",
+            "both_v2",
+            "structured",
+        ]
         self.flags_with_values["persist_batch_structured_order"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_builder_structured"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -1135,6 +1135,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
             BatchColumnarFormat::Both(_) => {
                 self.cfg.inline_writes_single_max_bytes.saturating_div(2)
             }
+            BatchColumnarFormat::Structured => self.cfg.inline_writes_single_max_bytes,
         };
 
         let (name, write_future) = if updates.goodbytes() < inline_threshold {

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -688,13 +688,7 @@ where
                     .codecs
                     .val
                     .encode(|| V::encode(val, &mut self.val_buf));
-                validate_schema(
-                    &self.builder.write_schemas,
-                    &self.key_buf,
-                    &self.val_buf,
-                    Some(key),
-                    Some(val),
-                );
+                validate_schema(&self.builder.write_schemas, key, val);
 
                 let update = (
                     (self.key_buf.as_slice(), self.val_buf.as_slice()),
@@ -881,32 +875,18 @@ where
 // inline it at the two callers.
 pub(crate) fn validate_schema<K: Codec, V: Codec>(
     stats_schemas: &Schemas<K, V>,
-    key: &[u8],
-    val: &[u8],
-    decoded_key: Option<&K>,
-    decoded_val: Option<&V>,
+    decoded_key: &K,
+    decoded_val: &V,
 ) {
     // Attempt to catch any bad schema usage in CI. This is probably too
     // expensive to run in prod.
     if !mz_ore::assert::SOFT_ASSERTIONS.load(Ordering::Relaxed) {
         return;
     }
-    let key_valid = match decoded_key {
-        Some(key) => K::validate(key, &stats_schemas.key),
-        None => {
-            let key = K::decode(key, &stats_schemas.key).expect("valid encoded key");
-            K::validate(&key, &stats_schemas.key)
-        }
-    };
+    let key_valid = K::validate(decoded_key, &stats_schemas.key);
     let () = key_valid
         .unwrap_or_else(|err| panic!("constructing batch with mismatched key schema: {}", err));
-    let val_valid = match decoded_val {
-        Some(val) => V::validate(val, &stats_schemas.val),
-        None => {
-            let val = V::decode(val, &stats_schemas.val).expect("valid encoded val");
-            V::validate(&val, &stats_schemas.val)
-        }
-    };
+    let val_valid = V::validate(decoded_val, &stats_schemas.val);
     let () = val_valid
         .unwrap_or_else(|err| panic!("constructing batch with mismatched val schema: {}", err));
 }

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -1524,6 +1524,7 @@ impl RustType<proto_hollow_batch_part::Format> for BatchColumnarFormat {
             BatchColumnarFormat::Both(version) => {
                 proto_hollow_batch_part::Format::RowAndColumnar((*version).cast_into())
             }
+            BatchColumnarFormat::Structured => proto_hollow_batch_part::Format::Structured(()),
         }
     }
 
@@ -1533,6 +1534,7 @@ impl RustType<proto_hollow_batch_part::Format> for BatchColumnarFormat {
             proto_hollow_batch_part::Format::RowAndColumnar(version) => {
                 BatchColumnarFormat::Both(version.cast_into())
             }
+            proto_hollow_batch_part::Format::Structured(_) => BatchColumnarFormat::Structured,
         };
         Ok(format)
     }

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -56,6 +56,7 @@ message ProtoHollowBatchPart {
   oneof format {
     google.protobuf.Empty row = 7;
     uint64 row_and_columnar = 8;
+    google.protobuf.Empty structured = 13;
   }
   optional uint64 schema_id = 12;
 

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -826,8 +826,12 @@ mod tests {
             .await
             .expect("failed to fetch part")
             .expect("missing part");
-        let part =
+        let mut part =
             BlobTraceBatchPart::decode(&value, &metrics.columnar).expect("failed to decode part");
+        // Ensure codec data is present even if it was not generated at write time.
+        let _ = part
+            .updates
+            .get_or_make_codec::<K, V>(&read_schemas.key, &read_schemas.val);
         let mut updates = Vec::new();
         // TODO(bkirwi): switch to structured data in tests
         for ((k, v), t, d) in part.updates.records().expect("codec data").iter() {

--- a/src/persist-client/src/schema.rs
+++ b/src/persist-client/src/schema.rs
@@ -402,16 +402,6 @@ impl<K: Codec, V: Codec> PartMigration<K, V> {
             PartMigration::Either { read, .. } => read,
         }
     }
-
-    pub(crate) fn structured_write(&self) -> &Schemas<K, V> {
-        match self {
-            PartMigration::SameSchema { both } => both,
-            // We should have a write schema set for all parts that are written with the structured-
-            // only parquet format.
-            PartMigration::Codec { read } => read,
-            PartMigration::Either { write, .. } => write,
-        }
-    }
 }
 
 /// Returns if `new` is at least as nullable as `old`.

--- a/src/persist-client/src/schema.rs
+++ b/src/persist-client/src/schema.rs
@@ -306,7 +306,7 @@ pub(crate) enum PartMigration<K: Codec, V: Codec> {
     Codec { read: Schemas<K, V> },
     /// We have both write and read schemas, and they don't match.
     Either {
-        _write: Schemas<K, V>,
+        write: Schemas<K, V>,
         read: Schemas<K, V>,
         key_migration: Arc<Migration>,
         val_migration: Arc<Migration>,
@@ -319,12 +319,12 @@ impl<K: Codec, V: Codec> Clone for PartMigration<K, V> {
             Self::SameSchema { both } => Self::SameSchema { both: both.clone() },
             Self::Codec { read } => Self::Codec { read: read.clone() },
             Self::Either {
-                _write,
+                write,
                 read,
                 key_migration,
                 val_migration,
             } => Self::Either {
-                _write: _write.clone(),
+                write: write.clone(),
                 read: read.clone(),
                 key_migration: Arc::clone(key_migration),
                 val_migration: Arc::clone(val_migration),
@@ -384,7 +384,7 @@ where
                     .inc_by(start.elapsed().as_secs_f64());
 
                 Ok(PartMigration::Either {
-                    _write: write,
+                    write,
                     read,
                     key_migration,
                     val_migration,
@@ -400,6 +400,16 @@ impl<K: Codec, V: Codec> PartMigration<K, V> {
             PartMigration::SameSchema { both } => both,
             PartMigration::Codec { read } => read,
             PartMigration::Either { read, .. } => read,
+        }
+    }
+
+    pub(crate) fn structured_write(&self) -> &Schemas<K, V> {
+        match self {
+            PartMigration::SameSchema { both } => both,
+            // We should have a write schema set for all parts that are written with the structured-
+            // only parquet format.
+            PartMigration::Codec { read } => read,
+            PartMigration::Either { write, .. } => write,
         }
     }
 }

--- a/src/persist/src/indexed/columnar/parquet.rs
+++ b/src/persist/src/indexed/columnar/parquet.rs
@@ -12,8 +12,6 @@
 use std::io::Write;
 use std::sync::Arc;
 
-use arrow::datatypes::Schema;
-use arrow::record_batch::RecordBatch;
 use differential_dataflow::trace::Description;
 use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::CastFrom;
@@ -30,10 +28,7 @@ use tracing::warn;
 use crate::error::Error;
 use crate::gen::persist::proto_batch_part_inline::FormatMetadata as ProtoFormatMetadata;
 use crate::gen::persist::ProtoBatchFormat;
-use crate::indexed::columnar::arrow::{
-    decode_arrow_batch_kvtd, decode_arrow_batch_kvtd_ks_vs, encode_arrow_batch, realloc_any,
-};
-use crate::indexed::columnar::ColumnarRecords;
+use crate::indexed::columnar::arrow::{decode_arrow_batch, encode_arrow_batch};
 use crate::indexed::encoding::{
     decode_trace_inline_meta, encode_trace_inline_meta, BlobTraceBatchPart, BlobTraceUpdates,
 };
@@ -171,23 +166,17 @@ pub fn decode_parquet_file_kvtd(
             let mut ret = Vec::new();
             for batch in reader {
                 let batch = batch.map_err(|e| Error::String(e.to_string()))?;
-                ret.push(decode_arrow_batch_kvtd(batch.columns(), metrics)?);
+                ret.push(batch);
             }
             if ret.len() != 1 {
                 warn!("unexpected number of row groups: {}", ret.len());
             }
-            Ok(BlobTraceUpdates::Row(ColumnarRecords::concat(
-                &ret, metrics,
-            )))
+            let batch = ::arrow::compute::concat_batches(&schema, &ret)?;
+            let updates = decode_arrow_batch(&batch, metrics).map_err(|e| e.to_string())?;
+            Ok(updates)
         }
-        Some(ProtoFormatMetadata::StructuredMigration(v @ 1 | v @ 2)) => {
-            if schema.fields().len() > 6 {
-                return Err(
-                    format!("expected at most 6 columns, got {}", schema.fields().len()).into(),
-                );
-            }
-
-            let batch = reader
+        Some(ProtoFormatMetadata::StructuredMigration(v @ 1..=3)) => {
+            let mut batch = reader
                 .next()
                 .ok_or_else(|| Error::String("found empty batch".to_string()))??;
 
@@ -195,45 +184,14 @@ pub fn decode_parquet_file_kvtd(
             if reader.next().is_some() {
                 return Err(Error::String("found more than one RowGroup".to_string()));
             }
-            let columns = batch.columns();
-
-            // The first 4 columns are our primary (K, V, T, D) and optionally
-            // we also have K_S and/or V_S if we wrote structured data.
-            let primary_columns = &columns[..4];
 
             // Version 1 is a deprecated format so we just ignored the k_s and v_s columns.
-            if *v == 1 {
-                let records = decode_arrow_batch_kvtd(primary_columns, metrics)?;
-                return Ok(BlobTraceUpdates::Row(records));
+            if *v == 1 && batch.num_columns() > 4 {
+                batch = batch.project(&[0, 1, 2, 3])?;
             }
 
-            let k_s_column = schema
-                .fields()
-                .iter()
-                .position(|field| field.name() == "k_s")
-                .map(|idx| realloc_any(Arc::clone(&columns[idx]), metrics));
-            let v_s_column = schema
-                .fields()
-                .iter()
-                .position(|field| field.name() == "v_s")
-                .map(|idx| realloc_any(Arc::clone(&columns[idx]), metrics));
-
-            match (k_s_column, v_s_column) {
-                (Some(ks), Some(vs)) => {
-                    let (records, structured_ext) =
-                        decode_arrow_batch_kvtd_ks_vs(primary_columns, ks, vs, metrics)?;
-                    Ok(BlobTraceUpdates::Both(records, structured_ext))
-                }
-                (ks, vs) => {
-                    warn!(
-                        "unable to read back structured data! version={v} ks={} vs={}",
-                        ks.is_some(),
-                        vs.is_some()
-                    );
-                    let records = decode_arrow_batch_kvtd(primary_columns, metrics)?;
-                    Ok(BlobTraceUpdates::Row(records))
-                }
-            }
+            let updates = decode_arrow_batch(&batch, metrics).map_err(|e| e.to_string())?;
+            Ok(updates)
         }
         unknown => Err(format!("unkown ProtoFormatMetadata, {unknown:?}"))?,
     }

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -686,9 +686,9 @@ pub fn encode_trace_inline_meta<T: Timestamp + Codec64>(batch: &BlobTraceBatchPa
             let metadata = ProtoFormatMetadata::StructuredMigration(2);
             (ProtoBatchFormat::ParquetStructured, Some(metadata))
         }
-
         BlobTraceUpdates::Structured { .. } => {
-            unimplemented!("codec data should exist before reaching parquet encoding")
+            let metadata = ProtoFormatMetadata::StructuredMigration(3);
+            (ProtoBatchFormat::ParquetStructured, Some(metadata))
         }
     };
 


### PR DESCRIPTION
### Motivation

Adds a new on-disk file format for Persist - the non-dual-write structured-data-only version.

We'd like this format to be supported in our on-prem releases, so folks aren't stuck with the migration midpoint.

### Tips for reviewer

I've intentionally left this off in CI, out of the parallel workload. For our existing cloud envs I think it's most important to verify that the (substantial) refactorings here don't cause any regression for existing flag settings. However, it is enabled in parallel workload so we should be able to spot any bugs. (And empirically those tests are good at finding bugs in this corner of Persist.)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
