### PR TITLE
self-managed: Set helm-chart version v25.1 to correspond to Materialize v0.130.0

### DIFF
--- a/ci/deploy/npm.py
+++ b/ci/deploy/npm.py
@@ -56,10 +56,12 @@ def generate_version(
         is_development = True
     else:
         buildkite_tag = os.environ.get("BUILDKITE_TAG")
-        # buildkite_tag starts with a 'v' and node_version does not.
-        assert (
-            buildkite_tag == f"v{node_version}"
-        ), f"Buildkite tag ({buildkite_tag}) does not match environmentd version ({crate_version})"
+        # For self-managed branch the buildkite tag is not set, but we are still not in a prerelease version
+        if buildkite_tag:
+            # buildkite_tag starts with a 'v' and node_version does not.
+            assert (
+                buildkite_tag == f"v{node_version}"
+            ), f"Buildkite tag ({buildkite_tag}) does not match environmentd version ({crate_version})"
     return NpmPackageVersion(
         rust=crate_version, node=node_version, is_development=is_development
     )

--- a/misc/helm-charts/operator/Chart.yaml
+++ b/misc/helm-charts/operator/Chart.yaml
@@ -11,7 +11,7 @@ apiVersion: v2
 name: materialize-operator
 description: Materialize Kubernetes Operator Helm Chart
 type: application
-version: v25.1.0-beta.1
+version: v25.1.0
 appVersion: v0.130.0
 icon: https://materialize.com/favicon.ico
 home: https://materialize.com

--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -1,6 +1,6 @@
 # Materialize Kubernetes Operator Helm Chart
 
-![Version: v25.1.0-beta.1](https://img.shields.io/badge/Version-v25.1.0--beta.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.130.0](https://img.shields.io/badge/AppVersion-v0.130.0-informational?style=flat-square)
+![Version: v25.1.0](https://img.shields.io/badge/Version-v25.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.130.0](https://img.shields.io/badge/AppVersion-v0.130.0-informational?style=flat-square)
 
 Materialize Kubernetes Operator Helm Chart
 
@@ -280,8 +280,8 @@ Or check the `Chart.yaml` file in the `misc/helm-charts/operator` directory:
 apiVersion: v2
 name: materialize-operator
 # ...
-version: v25.1.0-beta.1
-appVersion: v0.125.2  # Use this version for your Materialize instances
+version: v25.1.0
+appVersion: v0.130.0  # Use this version for your Materialize instances
 ```
 
 Use the `appVersion` (`v0.125.2` in this case) when updating your Materialize instances to ensure compatibility.

--- a/misc/helm-charts/operator/README.md.gotmpl
+++ b/misc/helm-charts/operator/README.md.gotmpl
@@ -244,8 +244,8 @@ Or check the `Chart.yaml` file in the `misc/helm-charts/operator` directory:
 apiVersion: v2
 name: materialize-operator
 # ...
-version: v25.1.0-beta.1
-appVersion: v0.125.2  # Use this version for your Materialize instances
+version: v25.1.0
+appVersion: v0.130.0  # Use this version for your Materialize instances
 ```
 
 Use the `appVersion` (`v0.125.2` in this case) when updating your Materialize instances to ensure compatibility.


### PR DESCRIPTION
We are planning to get these two features into v0.130.1 today:
- Blob deletion and columnar data CC @bkirwi : https://materializeinc.slack.com/archives/C07PN7KSB0T/p1736888847015789
- Azure blob storage CC @pH14 : https://github.com/MaterializeInc/materialize/pull/30817

Then we should bump the version here to v0.130.1 and put this out. @bobbyiliev @doy-materialize Does this work for you? Did I miss anything important?
@kay-kim Does this fit with our docs? I guess we have to update things like "Check out the v0.127.0 tag." to "Check out the lts-v0.130 branch"

Discussion on Slack: https://materializeinc.slack.com/archives/C07PN7KSB0T/p1737110822978439

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
