### PR TITLE
QA canary: Introduce a larger/faster growing upsert source

### DIFF
--- a/test/canary-environment/models/loadgen/large_sales_product_product_category.sql
+++ b/test/canary-environment/models/loadgen/large_sales_product_product_category.sql
@@ -1,0 +1,22 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+-- depends_on: {{ ref('sales_large_tbl') }}
+-- depends_on: {{ ref('product_tbl') }}
+-- depends_on: {{ ref('product_category_tbl') }}
+
+{{ config(materialized='materialized_view', cluster="qa_canary_environment_compute", indexes=[{'default': True}]) }}
+
+SELECT
+    count(*) AS count_star,
+    count(distinct sales_large_tbl.key) As count_distinct_loadgen_sales_large_key,
+    count(distinct product_id) AS count_distinct_product_id,
+    count(distinct category_id) AS count_distinct_category_id
+FROM      {{ source('loadgen','sales_large_tbl') }}
+LEFT JOIN {{ source('loadgen','product_tbl') }} USING (product_id)
+LEFT JOIN {{ source('loadgen','product_category_tbl') }} USING (category_id)

--- a/test/canary-environment/models/loadgen/sales_large.sql
+++ b/test/canary-environment/models/loadgen/sales_large.sql
@@ -7,10 +7,5 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{% macro create_loadgen_source(name) %}
-FROM KAFKA CONNECTION kafka_connection (TOPIC 'datagen_demo_snowflakeschema_{{ name.table }}');
-{% endmacro %}
-
-{% macro create_large_loadgen_source(name) %}
-FROM KAFKA CONNECTION kafka_connection (TOPIC 'datagen_large_snowflakeschema_{{ name }}');
-{% endmacro %}
+{{ config(materialized='source', cluster='qa_canary_environment_storage', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
+{{ create_large_loadgen_source('sales') }}

--- a/test/canary-environment/models/loadgen/sales_large_tbl.sql
+++ b/test/canary-environment/models/loadgen/sales_large_tbl.sql
@@ -7,10 +7,13 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{% macro create_loadgen_source(name) %}
-FROM KAFKA CONNECTION kafka_connection (TOPIC 'datagen_demo_snowflakeschema_{{ name.table }}');
-{% endmacro %}
-
-{% macro create_large_loadgen_source(name) %}
-FROM KAFKA CONNECTION kafka_connection (TOPIC 'datagen_large_snowflakeschema_{{ name }}');
-{% endmacro %}
+-- depends_on: {{ ref('sales_large') }}
+{{ config(
+    materialized='source_table'
+) }}
+FROM SOURCE {{ ref('sales_large') }}
+(REFERENCE "datagen_large_snowflakeschema_sales")
+KEY FORMAT BYTES
+VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
+INCLUDE TIMESTAMP as kafka_timestamp
+ENVELOPE UPSERT;

--- a/test/canary-environment/models/loadgen/schema.yml
+++ b/test/canary-environment/models/loadgen/schema.yml
@@ -19,14 +19,25 @@ sources:
       - name: sales_progress
         data_tests:
           - makes_progress
+      - name: sales_large
+        data_tests:
+          - makes_progress
+      - name: sales_large_progress
+        data_tests:
+          - makes_progress
       - name: product
       - name: product_category
       - name: product_tbl
       - name: product_category_tbl
       - name: sales_tbl
+      - name: sales_large_tbl
 
 
 models:
     - name: sales_product_product_category
+      data_tests:
+        - makes_progress
+
+    - name: sales_large_product_product_category
       data_tests:
         - makes_progress


### PR DESCRIPTION
Currently growing at 33 KB/s, the old one was at 1.5 KB/s. The datagen runs on our own QA infrastructure, not in field eng. Long term plan is to move more there.

Motivation is to have a larger upsert source to find problems with long rehydration. Follow-up to the v0.128 Postmortem

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
