### PR TITLE
ci: Fix names in nightly pipeline

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -733,7 +733,7 @@ steps:
     key: platform-checks
     steps:
       - id: checks-no-restart-no-upgrade-azurite
-        label: "Checks without restart or upgrade with :azure: blob store %N"
+        label: "Checks without restart or upgrade with :azure: blob store"
         depends_on: build-aarch64
         inputs: [misc/python/materialize/checks]
         timeout_in_minutes: 45
@@ -760,7 +760,7 @@ steps:
               args: [--scenario=RestartEntireMz, "--seed=$BUILDKITE_JOB_ID", --azurite]
 
       - id: checks-restart-environmentd-clusterd-storage-azurite
-        label: "Checks + restart of environmentd & storage clusterd with :azure: blob store %N"
+        label: "Checks + restart of environmentd & storage clusterd with :azure: blob store"
         depends_on: build-aarch64
         inputs: [misc/python/materialize/checks]
         timeout_in_minutes: 45
@@ -841,7 +841,7 @@ steps:
               args: [--scenario=RestartEntireMz, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-parallel-restart-entire-mz-azurite
-        label: "Checks parallel + restart of the entire Mz with :azure: blob store %N"
+        label: "Checks parallel + restart of the entire Mz with :azure: blob store"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2


### PR DESCRIPTION
Don't need an explicit %N anymore

(This seems to have gotten lost in https://github.com/MaterializeInc/materialize/pull/30817 with Paul and me pushing into the same PR)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
