### PR TITLE
wasm build: Fix CI step in self-managed

### DIFF
--- a/ci/deploy/npm.py
+++ b/ci/deploy/npm.py
@@ -56,10 +56,12 @@ def generate_version(
         is_development = True
     else:
         buildkite_tag = os.environ.get("BUILDKITE_TAG")
-        # buildkite_tag starts with a 'v' and node_version does not.
-        assert (
-            buildkite_tag == f"v{node_version}"
-        ), f"Buildkite tag ({buildkite_tag}) does not match environmentd version ({crate_version})"
+        # For self-managed branch the buildkite tag is not set, but we are still not in a prerelease version
+        if buildkite_tag:
+            # buildkite_tag starts with a 'v' and node_version does not.
+            assert (
+                buildkite_tag == f"v{node_version}"
+            ), f"Buildkite tag ({buildkite_tag}) does not match environmentd version ({crate_version})"
     return NpmPackageVersion(
         rust=crate_version, node=node_version, is_development=is_development
     )


### PR DESCRIPTION
Noticed in https://buildkite.com/materialize/test/builds/97356#019475be-f236-4d68-b50f-3cf6017b33f7

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
