### PR TITLE
bazel: tidy up `bin/bazel` invocations a bit

### DIFF
--- a/misc/python/materialize/cli/bazel.py
+++ b/misc/python/materialize/cli/bazel.py
@@ -116,7 +116,10 @@ def integrity_cmd(config: BuildConfig, args: list[str]):
 def bazel_cmd(config: BuildConfig, args: list[str]):
     """Forwards all arguments to Bazel, possibly with extra configuration."""
     remote_cache = remote_cache_arg(config)
-    subprocess.run(["bazel", *args, *remote_cache], check=True)
+    try:
+        subprocess.run(["bazel", *args, *remote_cache], check=True)
+    except:
+        pass
 
 
 def gen(config: BuildConfig, path: Path | None, check: bool):

--- a/misc/python/materialize/cli/bazel.py
+++ b/misc/python/materialize/cli/bazel.py
@@ -119,7 +119,9 @@ def bazel_cmd(config: BuildConfig, args: list[str]):
     try:
         subprocess.run(["bazel", *args, *remote_cache], check=True)
     except:
-        pass
+        # Don't print any python backtrace because it's never useful. Instead
+        # just exit the process.
+        exit(1)
 
 
 def gen(config: BuildConfig, path: Path | None, check: bool):


### PR DESCRIPTION
Wrap the call to `subprocess` in a try-catch so when a Bazel build fails or is canceled we don't print the Python backtrace.

### Motivation

Makes `bin/bazel` a little nicer.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
