### PR TITLE
Add Mandelbrot set to WMR slt

### DIFF
--- a/test/sqllogictest/mztimestamp.slt
+++ b/test/sqllogictest/mztimestamp.slt
@@ -78,7 +78,7 @@ SELECT 1::mz_catalog.mz_timestamp
 query T
 SELECT '1970-01-02'::date::mz_timestamp
 ----
- 86400000
+86400000
 
 # Casts to timestamp[tz]. 8210266815600000 is roughly `HIGH_DATE` for `CheckedTimestamp`.
 query T

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -671,7 +671,6 @@ WITH MUTUALLY RECURSIVE
 SELECT x FROM bar
 
 ## Adapted from https://www.sqlite.org/lang_with.html#outlandish_recursive_query_examples
-## The 'x' at the beginning is to work around an sqllogictest bug.
 query T multiline
 WITH MUTUALLY RECURSIVE
   xaxis(x double) AS (VALUES(-2.0) UNION ALL SELECT x+0.05 FROM xaxis WHERE x<1.2),
@@ -689,9 +688,8 @@ WITH MUTUALLY RECURSIVE
     SELECT string_agg( substr(' .+*#', 1+least(iter/7,4), 1), '' ORDER BY cx), cy
     FROM m2 GROUP BY cy
   )
-SELECT 'x' || chr(10) || string_agg(rtrim(t), chr(10) ORDER BY cy) FROM a;
+SELECT string_agg(rtrim(t), chr(10) ORDER BY cy) FROM a;
 ----
-x
                                     ....#
                                    ..#*..
                                  ..+####+.

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -669,3 +669,49 @@ query error db error: ERROR: WITH MUTUALLY RECURSIVE query "bar" declared types 
 WITH MUTUALLY RECURSIVE
     bar(x list_numeric_scale_2) as (SELECT LIST['1'::TEXT])
 SELECT x FROM bar
+
+## Adapted from https://www.sqlite.org/lang_with.html#outlandish_recursive_query_examples
+## The 'x' at the beginning is to work around an sqllogictest bug.
+query T multiline
+WITH MUTUALLY RECURSIVE
+  xaxis(x double) AS (VALUES(-2.0) UNION ALL SELECT x+0.05 FROM xaxis WHERE x<1.2),
+  yaxis(y double) AS (VALUES(-1.0) UNION ALL SELECT y+0.1 FROM yaxis WHERE y<1.0),
+  m(iter int, cx double, cy double, x double, y double) AS (
+    SELECT 0, x, y, 0.0, 0.0 FROM xaxis, yaxis
+    UNION ALL
+    SELECT iter+1, cx, cy, x*x-y*y + cx, 2.0*x*y + cy FROM m
+     WHERE (x*x + y*y) < 4.0 AND iter<28
+  ),
+  m2(iter int, cx double, cy double) AS (
+    SELECT max(iter), cx, cy FROM m GROUP BY cx, cy
+  ),
+  a(t text, cy double) AS (
+    SELECT string_agg( substr(' .+*#', 1+least(iter/7,4), 1), '' ORDER BY cx), cy
+    FROM m2 GROUP BY cy
+  )
+SELECT 'x' || chr(10) || string_agg(rtrim(t), chr(10) ORDER BY cy) FROM a;
+----
+x
+                                    ....#
+                                   ..#*..
+                                 ..+####+.
+                            .......+####....   +
+                           ..##+*##########+.++++
+                          .+.##################+.
+              .............+###################+.+
+              ..++..#.....*#####################+.
+             ...+#######++#######################.
+          ....+*################################.
+ #############################################...
+          ....+*################################.
+             ...+#######++#######################.
+              ..++..#.....*#####################+.
+              .............+###################+.+
+                          .+.##################+.
+                           ..##+*##########+.++++
+                            .......+####....   +
+                                 ..+####+.
+                                   ..#*..
+                                    ....#
+                                    +.
+EOF


### PR DESCRIPTION
The first commit adds a WMR test, drawing an ASCII art of the Mandelbrot set. The query is based on an [SQLite example](https://www.sqlite.org/lang_with.html#outlandish_recursive_query_examples), pointed out by @umanwizard.

Had to tweak the query a bit:
- `WITH MUTUALLY RECURSIVE` instead of `WITH RECURSIVE`
- explicit types for each CTE
- `least` instead of `min` (`min` is the aggregation function in Materialize)
- `string_agg` instead of `group_concat`
- `chr(10)` instead of `x'0a'`
- added `ORDER BY` to the `string_agg`, because otherwise Materialize chooses a non-useful order inside each group.

The second commit fixes a bug in sqllogictest: When the expected output starts with a space, the `trim_start()` used to eat this. The `trim_start` was there, because the `split_at(&QUERY_OUTPUT_REGEX)` ends at the end of `----`, leaving a newline there to be returned by the `split_at` that computes the `output_str`. Now we take care to eat just a newline instead of `trim_start` eating all whitespace.

(It would be tempting to just make `QUERY_OUTPUT_REGEX` eat the newline after `----`. However, this would cause an issue for tests like `joins.slt:753`, where the expected output doesn't have any rows, and there is only one empty line. We expect two newlines to end the expected output, but in this test one of these newlines is the one directly after `----`, so if `QUERY_OUTPUT_REGEX` eats this newline, then we get into trouble. One could just tweak this and other similar tests, but I wanted to make the bugfix mostly backwards compatible with existing tests. The one change that I still needed to make in an existing test was arguably in a malformed test.)

For some reason, the change in sqllogictest auto-summoned the Adapter team. But I guess it would be better if @def- reviewed the sqllogictest change. @ParkMyCar, feel free to remove yourself and the Adapter team from the reviewers.

### Motivation

  * The Mandelbrot set is cool.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
