### PR TITLE
bin/environmentd: Fix default blob path

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -50,7 +50,8 @@ SANITIZER_TARGET = (
     else f"{Arch.host()}-apple-darwin"
 )
 DEFAULT_POSTGRES = "postgres://root@localhost:26257/materialize"
-DEFAULT_BLOB = "file://mzdata/persist/blob"
+MZDATA = MZ_ROOT / "mzdata"
+DEFAULT_BLOB = f"file://{MZDATA}/persist/blob"
 
 # sets entitlements on the built binary, e.g. environmentd, so you can inspect it with Instruments
 MACOS_ENTITLEMENTS_DATA = """
@@ -234,7 +235,6 @@ def main() -> int:
             command += ["--tokio-console-listen-addr=127.0.0.1:6669"]
         if args.program == "environmentd":
             _handle_lingering_services(kill=args.reset)
-            mzdata = MZ_ROOT / "mzdata"
             scratch = MZ_ROOT / "scratch"
             urlparse(args.postgres).path.removeprefix("/")
             dbconn = _connect_sql(args.postgres)
@@ -249,10 +249,10 @@ def main() -> int:
             if args.reset:
                 # Remove everything in the `mzdata`` directory *except* for
                 # the `prometheus` directory and all contents of `tempo`.
-                paths = list(mzdata.glob("prometheus/*"))
+                paths = list(MZDATA.glob("prometheus/*"))
                 paths.extend(
                     p
-                    for p in mzdata.glob("*")
+                    for p in MZDATA.glob("*")
                     if p.name != "prometheus" and p.name != "tempo"
                 )
                 paths.extend(p for p in scratch.glob("*"))
@@ -263,24 +263,25 @@ def main() -> int:
                     else:
                         path.unlink()
 
-            mzdata.mkdir(exist_ok=True)
+            MZDATA.mkdir(exist_ok=True)
             scratch.mkdir(exist_ok=True)
-            environment_file = mzdata / "environment-id"
+            environment_file = MZDATA / "environment-id"
             try:
                 environment_id = environment_file.read_text().rstrip()
             except FileNotFoundError:
                 environment_id = f"local-az1-{uuid.uuid4()}-0"
                 environment_file.write_text(environment_id)
 
+            print(f"persist-blob-url: {args.blob}")
             command += [
                 # Setting the listen addresses below to 0.0.0.0 is required
                 # to allow Prometheus running in Docker (misc/prometheus)
                 # access these services to scrape metrics.
                 "--internal-http-listen-addr=0.0.0.0:6878",
                 "--orchestrator=process",
-                f"--orchestrator-process-secrets-directory={mzdata}/secrets",
+                f"--orchestrator-process-secrets-directory={MZDATA}/secrets",
                 "--orchestrator-process-tcp-proxy-listen-addr=0.0.0.0",
-                f"--orchestrator-process-prometheus-service-discovery-directory={mzdata}/prometheus",
+                f"--orchestrator-process-prometheus-service-discovery-directory={MZDATA}/prometheus",
                 f"--orchestrator-process-scratch-directory={scratch}",
                 "--secrets-controller=local-file",
                 f"--persist-consensus-url={args.postgres}?options=--search_path=consensus",


### PR DESCRIPTION
Broken in https://github.com/MaterializeInc/materialize/pull/30817

Noticed by Gabor in https://materializeinc.slack.com/archives/CM7ATT65S/p1737202942223419

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
