### PR TITLE
Revert "adapter: don't block the Coordinator on cluster status events (#31070)

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3495,31 +3495,10 @@ impl Coordinator {
     }
 
     /// Publishes a notice message to all sessions.
-    ///
-    /// TODO(parkmycar): This code is dead, but is a nice parallel to [`Coordinator::broadcast_notice_tx`]
-    /// so we keep it around.
-    #[allow(dead_code)]
     pub(crate) fn broadcast_notice(&self, notice: AdapterNotice) {
         for meta in self.active_conns.values() {
             let _ = meta.notice_tx.send(notice.clone());
         }
-    }
-
-    /// Returns a closure that will publish a notice to all sessions that were active at the time
-    /// this method was called.
-    pub(crate) fn broadcast_notice_tx(
-        &self,
-    ) -> Box<dyn FnOnce(AdapterNotice) -> () + Send + 'static> {
-        let senders: Vec<_> = self
-            .active_conns
-            .values()
-            .map(|meta| meta.notice_tx.clone())
-            .collect();
-        Box::new(move |notice| {
-            for tx in senders {
-                let _ = tx.send(notice.clone());
-            }
-        })
     }
 
     pub(crate) fn active_conns(&self) -> &BTreeMap<ConnectionId, ConnMeta> {


### PR DESCRIPTION
This reverts commit bb372ed6e3aa6ca049ae6bd87018cae7bc269ae9.
Data for https://github.com/MaterializeInc/database-issues/issues/8892

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
