### PR TITLE
ci: Bump some low timeouts

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -50,7 +50,7 @@ steps:
         inputs:
           - "*"
         depends_on: [build-x86_64]
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         priority: 50
         if: build.tag != null
         agents:
@@ -79,7 +79,7 @@ steps:
           - "*"
         depends_on: [build-aarch64]
         priority: 50
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         if: build.tag != null
         agents:
           queue: builder-linux-aarch64-mem
@@ -116,7 +116,7 @@ steps:
         inputs:
           - "*"
         depends_on: []
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         agents:
           # Error: no prebuilt wasm-opt binaries are available for this platform: Unrecognized target!
           queue: linux-x86_64-small
@@ -147,7 +147,7 @@ steps:
         depends_on:
           - build-x86_64
           - build-aarch64
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         agents:
           queue: linux-aarch64-small
         coverage: skip


### PR DESCRIPTION
Noticed a timeout while docker pulling in https://buildkite.com/materialize/test/builds/97430#01948309-08e1-4fe7-9d3b-195a4ad94675

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
