### PR TITLE
Dbt adapter deploy promote tag schemas

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,9 @@
 # dbt-materialize Changelog
 
+## Unreleased
+
+* Fix schema tagging to work with current transaction limitations.
+
 ## 1.9.1 - 2025-01-17
 
 * Fix a bug in the `deploy_init` macro where source cluster validation wasn't respecting custom cluster naming logic from user-defined `generate_cluster_name` macros.

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
@@ -224,14 +224,11 @@
         {%- endif %}
     {% endset %}
 
-    {% call statement('tag_schemas', fetch_result=True, auto_begin=False) -%}
-    BEGIN;
-
     {% for schema in schemas %}
         {{ log("Tagging schema: " ~ schema, info=True) }}
-        COMMENT ON SCHEMA {{ adapter.quote(schema) }} IS {{ dbt.string_literal(schema_comment) }};
+        {% set comment_sql %}
+            COMMENT ON SCHEMA {{ adapter.quote(schema) }} IS {{ dbt.string_literal(schema_comment) }}
+        {% endset %}
+        {% do run_query(comment_sql) %}
     {% endfor %}
-
-    COMMIT;
-    {%- endcall %}
 {% endmacro %}

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -456,8 +456,14 @@ class TestTargetDeploy:
         assert before_clusters["prod_dbt_deploy"] != after_clusters["prod"]
         assert before_schemas["prod"] != after_schemas["prod_dbt_deploy"]
         assert before_schemas["prod_dbt_deploy"] != after_schemas["prod"]
-        assert before_staging_schemas["staging"] != after_staging_schemas["staging_dbt_deploy"]
-        assert before_staging_schemas["staging_dbt_deploy"] != after_staging_schemas["staging"]
+        assert (
+            before_staging_schemas["staging"]
+            != after_staging_schemas["staging_dbt_deploy"]
+        )
+        assert (
+            before_staging_schemas["staging_dbt_deploy"]
+            != after_staging_schemas["staging"]
+        )
 
         run_dbt(["run-operation", "deploy_promote"])
 
@@ -484,11 +490,17 @@ class TestTargetDeploy:
         assert before_clusters["prod_dbt_deploy"] == after_clusters["prod"]
         assert before_schemas["prod"] == after_schemas["prod_dbt_deploy"]
         assert before_schemas["prod_dbt_deploy"] == after_schemas["prod"]
-        assert before_staging_schemas["staging"] == after_staging_schemas["staging_dbt_deploy"]
-        assert before_staging_schemas["staging_dbt_deploy"] == after_staging_schemas["staging"]
+        assert (
+            before_staging_schemas["staging"]
+            == after_staging_schemas["staging_dbt_deploy"]
+        )
+        assert (
+            before_staging_schemas["staging_dbt_deploy"]
+            == after_staging_schemas["staging"]
+        )
 
         # Verify that both schemas are tagged correctly
-        for schema_name in ['prod', 'staging']:
+        for schema_name in ["prod", "staging"]:
             tagged_schema_comment = project.run_sql(
                 f"""
                 SELECT c.comment
@@ -496,12 +508,18 @@ class TestTargetDeploy:
                 JOIN mz_schemas s USING (id)
                 WHERE s.name = '{schema_name}';
                 """,
-                fetch="one"
+                fetch="one",
             )
 
-            assert tagged_schema_comment is not None, f"No comment found for schema {schema_name}"
-            assert "Deployment by" in tagged_schema_comment[0], f"Missing deployment info in {schema_name} comment"
-            assert "on" in tagged_schema_comment[0], f"Missing timestamp in {schema_name} comment"
+            assert (
+                tagged_schema_comment is not None
+            ), f"No comment found for schema {schema_name}"
+            assert (
+                "Deployment by" in tagged_schema_comment[0]
+            ), f"Missing deployment info in {schema_name} comment"
+            assert (
+                "on" in tagged_schema_comment[0]
+            ), f"Missing timestamp in {schema_name} comment"
 
     def test_dbt_deploy_with_force(self, project):
         project.run_sql("CREATE CLUSTER prod SIZE = '1'")


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Fixing an error where tagging deployed schemas fails when there are multiple schemas to be tagged, eg:

```
18:15:45  Tagging schema: public
18:15:45  Tagging schema: public_some_other_schema
18:15:45  Encountered an error while running operation: Database Error
  COMMENT ON SCHEMA public IS '
          Deployment by mz_system on 
              | Commit SHA: 887865b83604850812f67d43134c84808965ac2c
      ' cannot be run inside a transaction block
```
