### PR TITLE
[persist] refactor Blob impl for Azure for higher performance

### DIFF
--- a/src/persist/src/azure.rs
+++ b/src/persist/src/azure.rs
@@ -235,6 +235,12 @@ impl Blob for AzureBlob {
                 }
             };
 
+            // Report if the content-length header didn't match the number of
+            // bytes we read from the network.
+            if content_length != u64::cast_from(lgbytes.len()) {
+                metrics.get_invalid_resp.inc();
+            }
+
             Ok(MaybeLgBytes::LgBytes(lgbytes))
         }
 


### PR DESCRIPTION
This refactors the impl of `Blob` for Azure in a way that should be faster. The `BlobClient` we use from the `azure_storage_blob` crate returns a `Stream` that when `await`-ed sends a ranged GET request for a chunk of a blob. This PR refactors our impl so we await each ranged request in a `tokio::task` which increases the concurrency at which we fetch chunks of a `Part`.

It also refactors how we handle the case when the `content-length` header is missing, and adds metrics so we can track how often this occurs.

### Motivation

Maybe progress against https://github.com/MaterializeInc/database-issues/issues/8892

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
