### PR TITLE
ci: Add separate publish_helm_charts pipeline

### DIFF
--- a/ci/publish-helm-charts/pipeline.template.yml
+++ b/ci/publish-helm-charts/pipeline.template.yml
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This file is processed by mkpipeline.py to trim unnecessary steps in PR
+# builds. The inputs for steps using the `mzcompose` plugin are computed
+# automatically. Inputs for other steps need to be manually listed in the
+# `inputs` key.
+
+dag: true
+
+steps:
+  - id: helm-charts-publish
+    label: Publish Helm Charts
+    command: bin/ci-builder run stable misc/helm-charts/publish.sh
+    timeout_in_minutes: 10
+    inputs:
+      - misc/helm-charts
+    depends_on: []
+    agents:
+      queue: linux-aarch64-small

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -158,19 +158,6 @@ steps:
             - exit_status: 1
               limit: 2
 
-      - id: helm-charts-publish
-        label: Publish Helm Charts
-        command: bin/ci-builder run stable misc/helm-charts/publish.sh
-        timeout_in_minutes: 10
-        inputs:
-          - misc/helm-charts
-        depends_on: []
-        agents:
-          queue: linux-aarch64-small
-        branches: main
-        coverage: skip
-        sanitizer: skip
-
   - group: Lints
     key: lints
     steps:


### PR DESCRIPTION
There is no way to currently automatically determine when to run the publish step, tag is not the correct one, main isn't either

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
