### PR TITLE
Change HIR's and LIR's EXPLAIN CTE order

### DIFF
--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -141,16 +141,16 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                     head = body.as_ref();
                 }
 
-                writeln!(f, "{}Return{}", ctx.indent, annotations)?;
-                ctx.indented(|ctx| head.fmt_text(f, ctx))?;
                 writeln!(f, "{}With", ctx.indent)?;
                 ctx.indented(|ctx| {
-                    for (id, value) in bindings.iter().rev() {
+                    for (id, value) in bindings.iter() {
                         writeln!(f, "{}cte {} =", ctx.indent, *id)?;
                         ctx.indented(|ctx| value.fmt_text(f, ctx))?;
                     }
                     Ok(())
                 })?;
+                writeln!(f, "{}Return{}", ctx.indent, annotations)?;
+                ctx.indented(|ctx| head.fmt_text(f, ctx))?;
             }
             LetRec {
                 ids,
@@ -161,11 +161,9 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 let bindings = izip!(ids.iter(), values, limits).collect_vec();
                 let head = body.as_ref();
 
-                writeln!(f, "{}Return{}", ctx.indent, annotations)?;
-                ctx.indented(|ctx| head.fmt_text(f, ctx))?;
                 writeln!(f, "{}With Mutually Recursive", ctx.indent)?;
                 ctx.indented(|ctx| {
-                    for (id, value, limit) in bindings.iter().rev() {
+                    for (id, value, limit) in bindings.iter() {
                         if let Some(limit) = limit {
                             writeln!(f, "{}cte {} {} =", ctx.indent, limit, *id)?;
                         } else {
@@ -175,6 +173,8 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                     }
                     Ok(())
                 })?;
+                writeln!(f, "{}Return{}", ctx.indent, annotations)?;
+                ctx.indented(|ctx| head.fmt_text(f, ctx))?;
             }
             Mfp {
                 input,

--- a/src/sql/src/plan/explain/text.rs
+++ b/src/sql/src/plan/explain/text.rs
@@ -95,32 +95,32 @@ impl HirRelationExpr {
                 }
             }
             Let {
-                name: _,
+                name,
                 id,
                 value,
                 body,
             } => {
-                let mut bindings = vec![(id, value.as_ref())];
+                let mut bindings = vec![(id, name, value.as_ref())];
                 let mut head = body.as_ref();
 
                 // Render Let-blocks nested in the body an outer Let-block in one step
                 // with a flattened list of bindings
                 while let Let {
-                    name: _,
+                    name,
                     id,
                     value,
                     body,
                 } = head
                 {
-                    bindings.push((id, value.as_ref()));
+                    bindings.push((id, name, value.as_ref()));
                     head = body.as_ref();
                 }
 
                 writeln!(f, "{}With", ctx.indent)?;
                 ctx.indented(|ctx| {
-                    for (id, value) in bindings.iter() {
+                    for (id, name, value) in bindings.iter() {
                         // TODO: print the name and not the id
-                        writeln!(f, "{}cte {} =", ctx.indent, *id)?;
+                        writeln!(f, "{}cte [{} as {}] =", ctx.indent, *id, *name)?;
                         ctx.indented(|ctx| value.fmt_text(f, ctx))?;
                     }
                     Ok(())
@@ -139,9 +139,9 @@ impl HirRelationExpr {
                 }
                 writeln!(f)?;
                 ctx.indented(|ctx| {
-                    for (_name, id, value, _type) in bindings.iter() {
+                    for (name, id, value, _type) in bindings.iter() {
                         // TODO: print the name and not the id
-                        writeln!(f, "{}cte {} =", ctx.indent, *id)?;
+                        writeln!(f, "{}cte [{} as {}] =", ctx.indent, *id, *name)?;
                         ctx.indented(|ctx| value.fmt_text(f, ctx))?;
                     }
                     Ok(())

--- a/src/sql/src/plan/explain/text.rs
+++ b/src/sql/src/plan/explain/text.rs
@@ -116,38 +116,38 @@ impl HirRelationExpr {
                     head = body.as_ref();
                 }
 
-                writeln!(f, "{}Return", ctx.indent)?;
-                ctx.indented(|ctx| head.fmt_text(f, ctx))?;
                 writeln!(f, "{}With", ctx.indent)?;
                 ctx.indented(|ctx| {
-                    for (id, value) in bindings.iter().rev() {
+                    for (id, value) in bindings.iter() {
                         // TODO: print the name and not the id
                         writeln!(f, "{}cte {} =", ctx.indent, *id)?;
                         ctx.indented(|ctx| value.fmt_text(f, ctx))?;
                     }
                     Ok(())
                 })?;
+                writeln!(f, "{}Return", ctx.indent)?;
+                ctx.indented(|ctx| head.fmt_text(f, ctx))?;
             }
             LetRec {
                 limit,
                 bindings,
                 body,
             } => {
-                writeln!(f, "{}Return", ctx.indent)?;
-                ctx.indented(|ctx| body.fmt_text(f, ctx))?;
                 write!(f, "{}With Mutually Recursive", ctx.indent)?;
                 if let Some(limit) = limit {
                     write!(f, " {}", limit)?;
                 }
                 writeln!(f)?;
                 ctx.indented(|ctx| {
-                    for (_name, id, value, _type) in bindings.iter().rev() {
+                    for (_name, id, value, _type) in bindings.iter() {
                         // TODO: print the name and not the id
                         writeln!(f, "{}cte {} =", ctx.indent, *id)?;
                         ctx.indented(|ctx| value.fmt_text(f, ctx))?;
                     }
                     Ok(())
                 })?;
+                writeln!(f, "{}Return", ctx.indent)?;
+                ctx.indented(|ctx| body.fmt_text(f, ctx))?;
             }
             Get { id, .. } => match id {
                 Id::Local(id) => {

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -30,14 +30,14 @@ WITH t AS (SELECT * FROM y WHERE a < 3)
   SELECT * FROM t NATURAL JOIN t a;
 ----
 Project (#0)
+  With
+    cte [l0 as t] =
+      Filter (#0 < 3)
+        Get materialize.public.y
   Return
     InnerJoin (#0 = #1)
       Get l0
       Get l0
-  With
-    cte l0 =
-      Filter (#0 < 3)
-        Get materialize.public.y
 
 Target cluster: quickstart
 
@@ -49,13 +49,13 @@ EXPLAIN RAW PLAN FOR
 WITH t AS (SELECT * FROM y WHERE a < 3)
   SELECT * FROM y WHERE (select a from t) < a;
 ----
+With
+  cte [l0 as t] =
+    Filter (#0 < 3)
+      Get materialize.public.y
 Return
   Filter (select(Get l0) < #0)
     Get materialize.public.y
-With
-  cte l0 =
-    Filter (#0 < 3)
-      Get materialize.public.y
 
 Target cluster: quickstart
 
@@ -527,45 +527,45 @@ FROM (WITH e(e) AS (SELECT b FROM b)
                              < (SELECT max(x) FROM x))
 ----
 Project (#1)
-  Return
-    Map (select(Get l8))
-      Return
-        Filter (select(Get l6) < select(Get l7))
-          Get l3
-      With
-        cte l6 =
-          Return
-            Reduce aggregates=[min(#0)]
-              Get l4
-          With
-            cte l4 =
-              Get l3
-        cte l7 =
-          Reduce aggregates=[max(#0)]
-            Get l2
-        cte l3 =
-          Get l1
   With
-    cte l8 =
-      Return
-        Filter (select(Get l5) > 1)
-          Get l3
+    cte [l0 as a] =
+      Get materialize.public.y
+    cte [l1 as b] =
+      Get materialize.public.y
+    cte [l2 as x] =
+      Get l1
+    cte [l8 as subquery-8] =
       With
-        cte l5 =
+        cte [l3 as c] =
+          Get materialize.public.y
+        cte [l5 as subquery-5] =
+          With
+            cte [l4 as d] =
+              Get l3
           Return
             Reduce aggregates=[max(#0)]
               Get l4
+      Return
+        Filter (select(Get l5) > 1)
+          Get l3
+  Return
+    Map (select(Get l8))
+      With
+        cte [l3 as e] =
+          Get l1
+        cte [l7 as subquery-7] =
+          Reduce aggregates=[max(#0)]
+            Get l2
+        cte [l6 as subquery-6] =
           With
-            cte l4 =
+            cte [l4 as f] =
               Get l3
-        cte l3 =
-          Get materialize.public.y
-    cte l2 =
-      Get l1
-    cte l1 =
-      Get materialize.public.y
-    cte l0 =
-      Get materialize.public.y
+          Return
+            Reduce aggregates=[min(#0)]
+              Get l4
+      Return
+        Filter (select(Get l6) < select(Get l7))
+          Get l3
 
 Target cluster: quickstart
 
@@ -576,13 +576,13 @@ query T multiline
 EXPLAIN RAW PLAN FOR
 WITH a(a) AS (SELECT a FROM y) SELECT * FROM (WITH a(a) AS (SELECT a FROM a) SELECT a FROM a);
 ----
+With
+  cte [l0 as a] =
+    Get materialize.public.y
+  cte [l1 as a] =
+    Get l0
 Return
   Get l1
-With
-  cte l1 =
-    Get l0
-  cte l0 =
-    Get materialize.public.y
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/explain/physical_plan_aggregates.slt
+++ b/test/sqllogictest/explain/physical_plan_aggregates.slt
@@ -147,6 +147,10 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, array_agg(b), max(c) FROM t WHERE c <> 'x' GROUP BY a;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
   Return
     Join::Linear
       linear_stage[0]
@@ -177,10 +181,6 @@ Explained Query:
         Get::Collection l0
           project=(#0, #1)
           raw=true
-  With
-    cte l0 =
-      Get::Collection materialize.public.t
-        raw=true
 
 Source materialize.public.t
   filter=((#2 != "x"))
@@ -193,6 +193,10 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, array_agg(b), max(b) FROM t GROUP BY a HAVING count(a) > 1;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
   Return
     Join::Delta
       plan_path[0]
@@ -263,10 +267,6 @@ Explained Query:
           project=(#0)
         Get::PassArrangements l0
           raw=true
-  With
-    cte l0 =
-      Get::Collection materialize.public.t
-        raw=true
 
 Source materialize.public.t
   project=(#0, #1)
@@ -302,6 +302,10 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, array_agg(b ORDER BY b ASC), array_agg(b ORDER BY b DESC) FROM t GROUP BY a;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
   Return
     Join::Linear
       linear_stage[0]
@@ -326,10 +330,6 @@ Explained Query:
           project=(#0)
         Get::PassArrangements l0
           raw=true
-  With
-    cte l0 =
-      Get::Collection materialize.public.t
-        raw=true
 
 Source materialize.public.t
   project=(#0, #1)
@@ -342,25 +342,10 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT array_agg(b ORDER BY b ASC), array_agg(b ORDER BY b DESC), bool_or(b IS NOT NULL) FROM t;
 ----
 Explained Query:
-  Return
-    Mfp
-      project=(#0, #1, #3)
-      map=((#2 > 0))
-      Union
-        Get::Collection l1
-          project=(#1, #2, #0)
-          raw=true
-        Mfp
-          project=(#0..=#2)
-          map=(null, null, null)
-          Union consolidate_output=true
-            Negate
-              Get::Collection l1
-                project=()
-                raw=true
-            Constant
-              - ()
   With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
     cte l1 =
       Join::Delta
         plan_path[0]
@@ -420,9 +405,24 @@ Explained Query:
             project=()
           Get::PassArrangements l0
             raw=true
-    cte l0 =
-      Get::Collection materialize.public.t
-        raw=true
+  Return
+    Mfp
+      project=(#0, #1, #3)
+      map=((#2 > 0))
+      Union
+        Get::Collection l1
+          project=(#1, #2, #0)
+          raw=true
+        Mfp
+          project=(#0..=#2)
+          map=(null, null, null)
+          Union consolidate_output=true
+            Negate
+              Get::Collection l1
+                project=()
+                raw=true
+            Constant
+              - ()
 
 Source materialize.public.t
   project=(#1)
@@ -435,6 +435,10 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT t1.a, array_agg(t1.c), array_agg(t2.c) FROM t t1 INNER JOIN t t2 ON t1.c = t2.c WHERE t1.c IS NOT NULL GROUP BY t1.a;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
   Return
     Mfp
       project=(#0, #1, #1)
@@ -467,10 +471,6 @@ Explained Query:
             Get::Collection l0
               project=(#2)
               raw=true
-  With
-    cte l0 =
-      Get::Collection materialize.public.t
-        raw=true
 
 Source materialize.public.t
   filter=((#2) IS NOT NULL)
@@ -483,23 +483,11 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT sum(a), jsonb_agg(b), array_agg(b), array_agg(b) FROM t;
 ----
 Explained Query:
-  Return
-    Mfp
-      project=(#0..=#2, #2)
-      Union
-        Get::PassArrangements l1
-          raw=true
-        Mfp
-          project=(#0..=#2)
-          map=(null, null, null)
-          Union consolidate_output=true
-            Negate
-              Get::Collection l1
-                project=()
-                raw=true
-            Constant
-              - ()
   With
+    cte l0 =
+      Get::Collection materialize.public.t
+        project=(#1)
+        raw=true
     cte l1 =
       Join::Delta
         plan_path[0]
@@ -558,10 +546,22 @@ Explained Query:
             project=()
           Get::PassArrangements l0
             raw=true
-    cte l0 =
-      Get::Collection materialize.public.t
-        project=(#1)
-        raw=true
+  Return
+    Mfp
+      project=(#0..=#2, #2)
+      Union
+        Get::PassArrangements l1
+          raw=true
+        Mfp
+          project=(#0..=#2)
+          map=(null, null, null)
+          Union consolidate_output=true
+            Negate
+              Get::Collection l1
+                project=()
+                raw=true
+            Constant
+              - ()
 
 Source materialize.public.t
   project=(#0, #1)
@@ -574,6 +574,10 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, array_agg(b ORDER BY b) FROM t GROUP BY a HAVING array_agg(b ORDER BY b) = array_agg(b ORDER BY b DESC);
 ----
 Explained Query:
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
   Return
     Join::Linear
       linear_stage[0]
@@ -610,10 +614,6 @@ Explained Query:
             project=(#0)
           Get::PassArrangements l0
             raw=true
-  With
-    cte l0 =
-      Get::Collection materialize.public.t
-        raw=true
 
 Source materialize.public.t
   project=(#0, #1)
@@ -627,6 +627,10 @@ EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, array_agg(b), array_agg(sha256(b::BY
 
 ----
 Explained Query:
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
   Return
     Join::Linear
       linear_stage[0]
@@ -653,10 +657,6 @@ Explained Query:
           project=(#0)
         Get::PassArrangements l0
           raw=true
-  With
-    cte l0 =
-      Get::Collection materialize.public.t
-        raw=true
 
 Source materialize.public.t
   project=(#0, #1)
@@ -670,6 +670,10 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, array_agg(b), array_agg(CASE WHEN a = 1 THEN 'ooo' ELSE b END) FROM t GROUP BY a;
 ----
 Explained Query:
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
   Return
     Join::Linear
       linear_stage[0]
@@ -694,10 +698,6 @@ Explained Query:
           project=(#0)
         Get::PassArrangements l0
           raw=true
-  With
-    cte l0 =
-      Get::Collection materialize.public.t
-        raw=true
 
 Source materialize.public.t
   project=(#0, #1)

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -308,22 +308,6 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
 (SELECT x + 1 FROM cte UNION ALL SELECT x - 1 FROM cte)
 ----
 Explained Query:
-  Return
-    Union
-      Get::Arrangement l0
-        project=(#1)
-        map=((#0 + 1))
-        key=#0
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=() }
-        types=[integer?]
-      Get::Arrangement l0
-        project=(#1)
-        map=((#0 - 1))
-        key=#0
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=() }
-        types=[integer?]
   With
     cte l0 =
       Threshold::Basic ensure_arrangement={ key=[#0], permutation=id, thinning=() }
@@ -341,6 +325,22 @@ Explained Query:
             Negate
               Get::Collection materialize.public.mv
                 raw=true
+  Return
+    Union
+      Get::Arrangement l0
+        project=(#1)
+        map=((#0 + 1))
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=() }
+        types=[integer?]
+      Get::Arrangement l0
+        project=(#1)
+        map=((#0 - 1))
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=() }
+        types=[integer?]
 
 Source materialize.public.mv
   project=(#1)
@@ -486,6 +486,21 @@ SELECT
 FROM t
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce::Accumulable
+        simple_aggrs[0]=(0, 0, sum(#0))
+        distinct_aggrs[0]=(1, 1, count(distinct #0))
+        val_plan
+          project=(#0, #0)
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+          types=[integer?, integer?]
   Return
     Union
       ArrangeBy
@@ -506,21 +521,6 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce::Accumulable
-        simple_aggrs[0]=(0, 0, sum(#0))
-        distinct_aggrs[0]=(1, 1, count(distinct #0))
-        val_plan
-          project=(#0, #0)
-        key_plan
-          project=()
-        Get::Arrangement materialize.public.t
-          project=(#1)
-          key=#0
-          raw=false
-          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -590,26 +590,6 @@ EXPLAIN PHYSICAL PLAN AS TEXT FOR
 MATERIALIZED VIEW hierarchical_global_mv
 ----
 materialize.public.hierarchical_global_mv:
-  Return
-    Union
-      ArrangeBy
-        input_key=[]
-        raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
-      Mfp
-        project=(#0, #1)
-        map=(null, null)
-        Union consolidate_output=true
-          Negate
-            Get::Arrangement l0
-              project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
-          Constant
-            - ()
   With
     cte l0 =
       Reduce::Hierarchical
@@ -626,20 +606,6 @@ materialize.public.hierarchical_global_mv:
           raw=false
           arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
           types=[integer?, integer?]
-
-Used Indexes:
-  - materialize.public.t_a_idx (*** full scan ***)
-
-Target cluster: quickstart
-
-EOF
-
-# Test Reduce::Hierarchical (global aggregate, one-shot).
-query T multiline
-EXPLAIN PHYSICAL PLAN AS TEXT FOR
-SELECT * FROM hierarchical_global
-----
-Explained Query:
   Return
     Union
       ArrangeBy
@@ -660,6 +626,20 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+Target cluster: quickstart
+
+EOF
+
+# Test Reduce::Hierarchical (global aggregate, one-shot).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS TEXT FOR
+SELECT * FROM hierarchical_global
+----
+Explained Query:
   With
     cte l0 =
       Reduce::Hierarchical
@@ -677,6 +657,26 @@ Explained Query:
           raw=false
           arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
           types=[integer?, integer?]
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l0
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+      Mfp
+        project=(#0, #1)
+        map=(null, null)
+        Union consolidate_output=true
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+          Constant
+            - ()
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -742,21 +742,14 @@ SELECT
 FROM t
 ----
 Explained Query:
-  Return
-    Union
-      Get::PassArrangements l1
-        raw=true
-      Mfp
-        project=(#0, #1)
-        map=(null, null)
-        Union consolidate_output=true
-          Negate
-            Get::Collection l1
-              project=()
-              raw=true
-          Constant
-            - ()
   With
+    cte l0 =
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
     cte l1 =
       Join::Linear
         linear_stage[0]
@@ -781,13 +774,20 @@ Explained Query:
             project=()
           Get::PassArrangements l0
             raw=true
-    cte l0 =
-      Get::Arrangement materialize.public.t
-        project=(#1)
-        key=#0
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
+  Return
+    Union
+      Get::PassArrangements l1
+        raw=true
+      Mfp
+        project=(#0, #1)
+        map=(null, null)
+        Union consolidate_output=true
+          Negate
+            Get::Collection l1
+              project=()
+              raw=true
+          Constant
+            - ()
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -1059,22 +1059,14 @@ EXPLAIN PHYSICAL PLAN AS TEXT FOR
 MATERIALIZED VIEW collated_global_mv
 ----
 materialize.public.collated_global_mv:
-  Return
-    Union
-      Get::Collection l1
-        project=(#2, #4, #0, #1, #3, #5)
-        raw=true
-      Mfp
-        project=(#0..=#5)
-        map=(0, null, null, null, null, null)
-        Union consolidate_output=true
-          Negate
-            Get::Collection l1
-              project=()
-              raw=true
-          Constant
-            - ()
   With
+    cte l0 =
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
     cte l1 =
       Join::Delta
         plan_path[0]
@@ -1170,27 +1162,6 @@ materialize.public.collated_global_mv:
             project=()
           Get::PassArrangements l0
             raw=true
-    cte l0 =
-      Get::Arrangement materialize.public.t
-        project=(#1)
-        key=#0
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
-
-Used Indexes:
-  - materialize.public.t_a_idx (*** full scan ***)
-
-Target cluster: quickstart
-
-EOF
-
-# Test Reduce::Collated (global aggregate, one-shot).
-query T multiline
-EXPLAIN PHYSICAL PLAN AS TEXT FOR
-SELECT * FROM collated_global
-----
-Explained Query:
   Return
     Union
       Get::Collection l1
@@ -1206,7 +1177,28 @@ Explained Query:
               raw=true
           Constant
             - ()
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+Target cluster: quickstart
+
+EOF
+
+# Test Reduce::Collated (global aggregate, one-shot).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS TEXT FOR
+SELECT * FROM collated_global
+----
+Explained Query:
   With
+    cte l0 =
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
     cte l1 =
       Join::Delta
         plan_path[0]
@@ -1303,13 +1295,21 @@ Explained Query:
             project=()
           Get::PassArrangements l0
             raw=true
-    cte l0 =
-      Get::Arrangement materialize.public.t
-        project=(#1)
-        key=#0
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
+  Return
+    Union
+      Get::Collection l1
+        project=(#2, #4, #0, #1, #3, #5)
+        raw=true
+      Mfp
+        project=(#0..=#5)
+        map=(0, null, null, null, null, null)
+        Union consolidate_output=true
+          Negate
+            Get::Collection l1
+              project=()
+              raw=true
+          Constant
+            - ()
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -1837,6 +1837,22 @@ SELECT
 FROM t
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce::Basic
+        aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
+        aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
+        val_plan
+          project=(#2, #3)
+          map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+          types=[integer?, integer?]
   Return
     Union
       ArrangeBy
@@ -1857,22 +1873,6 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce::Basic
-        aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
-        aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
-        val_plan
-          project=(#2, #3)
-          map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
-        key_plan
-          project=()
-        Get::Arrangement materialize.public.t
-          project=(#1)
-          key=#0
-          raw=false
-          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)

--- a/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
@@ -293,22 +293,6 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
 (SELECT x + 1 FROM cte UNION ALL SELECT x - 1 FROM cte)
 ----
 Explained Query:
-  Return
-    Union
-      Get::Arrangement l0
-        project=(#1)
-        map=((#0 + █))
-        key=#0
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=() }
-        types=[integer?]
-      Get::Arrangement l0
-        project=(#1)
-        map=((#0 - █))
-        key=#0
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=() }
-        types=[integer?]
   With
     cte l0 =
       Threshold::Basic ensure_arrangement={ key=[#0], permutation=id, thinning=() }
@@ -326,6 +310,22 @@ Explained Query:
             Negate
               Get::Collection materialize.public.mv
                 raw=true
+  Return
+    Union
+      Get::Arrangement l0
+        project=(#1)
+        map=((#0 + █))
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=() }
+        types=[integer?]
+      Get::Arrangement l0
+        project=(#1)
+        map=((#0 - █))
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=() }
+        types=[integer?]
 
 Source materialize.public.mv
   project=(#1)
@@ -471,6 +471,21 @@ SELECT
 FROM t
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce::Accumulable
+        simple_aggrs[0]=(0, 0, sum(#0))
+        distinct_aggrs[0]=(1, 1, count(distinct #0))
+        val_plan
+          project=(#0, #0)
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+          types=[integer?, integer?]
   Return
     Union
       ArrangeBy
@@ -491,21 +506,6 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce::Accumulable
-        simple_aggrs[0]=(0, 0, sum(#0))
-        distinct_aggrs[0]=(1, 1, count(distinct #0))
-        val_plan
-          project=(#0, #0)
-        key_plan
-          project=()
-        Get::Arrangement materialize.public.t
-          project=(#1)
-          key=#0
-          raw=false
-          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -575,26 +575,6 @@ EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
 MATERIALIZED VIEW hierarchical_global_mv
 ----
 materialize.public.hierarchical_global_mv:
-  Return
-    Union
-      ArrangeBy
-        input_key=[]
-        raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
-      Mfp
-        project=(#0, #1)
-        map=(█, █)
-        Union consolidate_output=true
-          Negate
-            Get::Arrangement l0
-              project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
-          Constant
-            - ()
   With
     cte l0 =
       Reduce::Hierarchical
@@ -611,20 +591,6 @@ materialize.public.hierarchical_global_mv:
           raw=false
           arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
           types=[integer?, integer?]
-
-Used Indexes:
-  - materialize.public.t_a_idx (*** full scan ***)
-
-Target cluster: quickstart
-
-EOF
-
-# Test Reduce::Hierarchical (global aggregate, one-shot).
-query T multiline
-EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
-SELECT * FROM hierarchical_global
-----
-Explained Query:
   Return
     Union
       ArrangeBy
@@ -645,6 +611,20 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+Target cluster: quickstart
+
+EOF
+
+# Test Reduce::Hierarchical (global aggregate, one-shot).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT * FROM hierarchical_global
+----
+Explained Query:
   With
     cte l0 =
       Reduce::Hierarchical
@@ -662,6 +642,26 @@ Explained Query:
           raw=false
           arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
           types=[integer?, integer?]
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l0
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+      Mfp
+        project=(#0, #1)
+        map=(█, █)
+        Union consolidate_output=true
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+          Constant
+            - ()
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -727,21 +727,14 @@ SELECT
 FROM t
 ----
 Explained Query:
-  Return
-    Union
-      Get::PassArrangements l1
-        raw=true
-      Mfp
-        project=(#0, #1)
-        map=(█, █)
-        Union consolidate_output=true
-          Negate
-            Get::Collection l1
-              project=()
-              raw=true
-          Constant
-            - ()
   With
+    cte l0 =
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
     cte l1 =
       Join::Linear
         linear_stage[0]
@@ -766,13 +759,20 @@ Explained Query:
             project=()
           Get::PassArrangements l0
             raw=true
-    cte l0 =
-      Get::Arrangement materialize.public.t
-        project=(#1)
-        key=#0
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
+  Return
+    Union
+      Get::PassArrangements l1
+        raw=true
+      Mfp
+        project=(#0, #1)
+        map=(█, █)
+        Union consolidate_output=true
+          Negate
+            Get::Collection l1
+              project=()
+              raw=true
+          Constant
+            - ()
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -1044,22 +1044,14 @@ EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
 MATERIALIZED VIEW collated_global_mv
 ----
 materialize.public.collated_global_mv:
-  Return
-    Union
-      Get::Collection l1
-        project=(#2, #4, #0, #1, #3, #5)
-        raw=true
-      Mfp
-        project=(#0..=#5)
-        map=(█, █, █, █, █, █)
-        Union consolidate_output=true
-          Negate
-            Get::Collection l1
-              project=()
-              raw=true
-          Constant
-            - ()
   With
+    cte l0 =
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
     cte l1 =
       Join::Delta
         plan_path[0]
@@ -1155,27 +1147,6 @@ materialize.public.collated_global_mv:
             project=()
           Get::PassArrangements l0
             raw=true
-    cte l0 =
-      Get::Arrangement materialize.public.t
-        project=(#1)
-        key=#0
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
-
-Used Indexes:
-  - materialize.public.t_a_idx (*** full scan ***)
-
-Target cluster: quickstart
-
-EOF
-
-# Test Reduce::Collated (global aggregate, one-shot).
-query T multiline
-EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
-SELECT * FROM collated_global
-----
-Explained Query:
   Return
     Union
       Get::Collection l1
@@ -1191,7 +1162,28 @@ Explained Query:
               raw=true
           Constant
             - ()
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+Target cluster: quickstart
+
+EOF
+
+# Test Reduce::Collated (global aggregate, one-shot).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT * FROM collated_global
+----
+Explained Query:
   With
+    cte l0 =
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
     cte l1 =
       Join::Delta
         plan_path[0]
@@ -1288,13 +1280,21 @@ Explained Query:
             project=()
           Get::PassArrangements l0
             raw=true
-    cte l0 =
-      Get::Arrangement materialize.public.t
-        project=(#1)
-        key=#0
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
+  Return
+    Union
+      Get::Collection l1
+        project=(#2, #4, #0, #1, #3, #5)
+        raw=true
+      Mfp
+        project=(#0..=#5)
+        map=(█, █, █, █, █, █)
+        Union consolidate_output=true
+          Negate
+            Get::Collection l1
+              project=()
+              raw=true
+          Constant
+            - ()
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -164,16 +164,16 @@ query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
 ----
-Return
-  Filter (exists(Get l1) AND exists(Get l2))
-    Get materialize.public.t
 With
-  cte l1 =
-    Filter (#^0 < #0)
-      Get materialize.public.mv
   cte l2 =
     Filter (#^1 > #1)
       Get materialize.public.mv
+  cte l1 =
+    Filter (#^0 < #0)
+      Get materialize.public.mv
+Return
+  Filter (exists(Get l1) AND exists(Get l2))
+    Get materialize.public.t
 
 Target cluster: quickstart
 
@@ -185,20 +185,20 @@ EXPLAIN RAW PLAN AS TEXT FOR
 SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1) FROM t
 ----
 Project (#2, #3)
-  Return
-    Map (select(Get l1), select(Get l2))
-      Get materialize.public.t
   With
-    cte l1 =
-      Project (#0)
-        TopK limit=1
-          Filter (#1 = #^1)
-            Get materialize.public.v
     cte l2 =
       Project (#0)
         TopK limit=1
           Filter (#1 = #^1)
             Get materialize.public.mv
+    cte l1 =
+      Project (#0)
+        TopK limit=1
+          Filter (#1 = #^1)
+            Get materialize.public.v
+  Return
+    Map (select(Get l1), select(Get l2))
+      Get materialize.public.t
 
 Target cluster: quickstart
 
@@ -298,14 +298,14 @@ EXPLAIN RAW PLAN AS TEXT FOR
 WITH x AS (SELECT t.a * t.b as v from t) SELECT x.v + 5 FROM x
 ----
 Project (#1)
-  Return
-    Map ((#0 + 5))
-      Get l0
   With
     cte l0 =
       Project (#2)
         Map ((#0 * #1))
           Get materialize.public.t
+  Return
+    Map ((#0 + 5))
+      Get l0
 
 Target cluster: quickstart
 
@@ -316,18 +316,18 @@ query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 WITH A AS (SELECT 1 AS a), B as (SELECT a as b FROM A WHERE a > 0) SELECT * FROM A, B;
 ----
-Return
-  CrossJoin
-    Get l0
-    Get l1
 With
-  cte l1 =
-    Filter (#0 > 0)
-      Get l0
   cte l0 =
     Map (1)
       Constant
         - ()
+  cte l1 =
+    Filter (#0 > 0)
+      Get l0
+Return
+  CrossJoin
+    Get l0
+    Get l1
 
 Target cluster: mz_catalog_server
 
@@ -359,20 +359,20 @@ FROM
 CrossJoin
   CrossJoin
     Get materialize.public.t
-    Return
-      Filter (#0 != #^0)
-        Get l0
     With
       cte l0 =
         Reduce aggregates=[max((#^0 * #0))]
           Get materialize.public.t
-  Return
-    Filter ((#0 != #^0) OR ((#0) IS NOT NULL AND (#^0) IS NULL))
-      Get l0
+    Return
+      Filter (#0 != #^0)
+        Get l0
   With
     cte l0 =
       Reduce aggregates=[max((#^0 * #0))]
         Get materialize.public.t
+  Return
+    Filter ((#0 != #^0) OR ((#0) IS NOT NULL AND (#^0) IS NULL))
+      Get l0
 
 Target cluster: quickstart
 
@@ -407,21 +407,21 @@ FROM
 ----
 CrossJoin
   Get materialize.public.t
-  Return
-    Filter (#^0 != #^0)
-      CrossJoin
-        Get l0
-        Return
-          Filter ((#^^0 = #^0) AND (#0 > 5))
-            Get l1
-        With
-          cte l1 =
-            Reduce aggregates=[max((#^^0 * #0))]
-              Get materialize.public.t
   With
     cte l0 =
       Reduce aggregates=[max((#^0 * #0))]
         Get materialize.public.t
+  Return
+    Filter (#^0 != #^0)
+      CrossJoin
+        Get l0
+        With
+          cte l1 =
+            Reduce aggregates=[max((#^^0 * #0))]
+              Get materialize.public.t
+        Return
+          Filter ((#^^0 = #^0) AND (#0 > 5))
+            Get l1
 
 Target cluster: quickstart
 
@@ -591,12 +591,7 @@ WITH MUTUALLY RECURSIVE
     bar (a int) as (SELECT a FROM foo)
 SELECT * FROM bar;
 ----
-Return
-  Get l1
 With Mutually Recursive
-  cte l1 =
-    Project (#0)
-      Get l0
   cte l0 =
     Distinct
       Union
@@ -605,6 +600,11 @@ With Mutually Recursive
             - ()
         Map (7)
           Get l1
+  cte l1 =
+    Project (#0)
+      Get l0
+Return
+  Get l1
 
 Target cluster: mz_catalog_server
 
@@ -617,12 +617,7 @@ WITH MUTUALLY RECURSIVE (RECURSION LIMIT = 5)
     bar (a int) as (SELECT a FROM foo)
 SELECT * FROM bar;
 ----
-Return
-  Get l1
 With Mutually Recursive [recursion_limit=5]
-  cte l1 =
-    Project (#0)
-      Get l0
   cte l0 =
     Distinct
       Union
@@ -631,6 +626,11 @@ With Mutually Recursive [recursion_limit=5]
             - ()
         Map (7)
           Get l1
+  cte l1 =
+    Project (#0)
+      Get l0
+Return
+  Get l1
 
 Target cluster: mz_catalog_server
 
@@ -643,12 +643,7 @@ WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT = 5)
     bar (a int) as (SELECT a FROM foo)
 SELECT * FROM bar;
 ----
-Return
-  Get l1
 With Mutually Recursive [recursion_limit=5, return_at_limit]
-  cte l1 =
-    Project (#0)
-      Get l0
   cte l0 =
     Distinct
       Union
@@ -657,6 +652,11 @@ With Mutually Recursive [recursion_limit=5, return_at_limit]
             - ()
         Map (7)
           Get l1
+  cte l1 =
+    Project (#0)
+      Get l0
+Return
+  Get l1
 
 Target cluster: mz_catalog_server
 

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -165,10 +165,10 @@ EXPLAIN RAW PLAN AS TEXT FOR
 SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
 ----
 With
-  cte l2 =
+  cte [l2 as subquery-2] =
     Filter (#^1 > #1)
       Get materialize.public.mv
-  cte l1 =
+  cte [l1 as subquery-1] =
     Filter (#^0 < #0)
       Get materialize.public.mv
 Return
@@ -186,12 +186,12 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
 ----
 Project (#2, #3)
   With
-    cte l2 =
+    cte [l2 as subquery-2] =
       Project (#0)
         TopK limit=1
           Filter (#1 = #^1)
             Get materialize.public.mv
-    cte l1 =
+    cte [l1 as subquery-1] =
       Project (#0)
         TopK limit=1
           Filter (#1 = #^1)
@@ -299,7 +299,7 @@ WITH x AS (SELECT t.a * t.b as v from t) SELECT x.v + 5 FROM x
 ----
 Project (#1)
   With
-    cte l0 =
+    cte [l0 as x] =
       Project (#2)
         Map ((#0 * #1))
           Get materialize.public.t
@@ -317,11 +317,11 @@ EXPLAIN RAW PLAN AS TEXT FOR
 WITH A AS (SELECT 1 AS a), B as (SELECT a as b FROM A WHERE a > 0) SELECT * FROM A, B;
 ----
 With
-  cte l0 =
+  cte [l0 as a] =
     Map (1)
       Constant
         - ()
-  cte l1 =
+  cte [l1 as b] =
     Filter (#0 > 0)
       Get l0
 Return
@@ -360,14 +360,14 @@ CrossJoin
   CrossJoin
     Get materialize.public.t
     With
-      cte l0 =
+      cte [l0 as r2] =
         Reduce aggregates=[max((#^0 * #0))]
           Get materialize.public.t
     Return
       Filter (#0 != #^0)
         Get l0
   With
-    cte l0 =
+    cte [l0 as r4] =
       Reduce aggregates=[max((#^0 * #0))]
         Get materialize.public.t
   Return
@@ -408,7 +408,7 @@ FROM
 CrossJoin
   Get materialize.public.t
   With
-    cte l0 =
+    cte [l0 as r4] =
       Reduce aggregates=[max((#^0 * #0))]
         Get materialize.public.t
   Return
@@ -416,7 +416,7 @@ CrossJoin
       CrossJoin
         Get l0
         With
-          cte l1 =
+          cte [l1 as r2] =
             Reduce aggregates=[max((#^^0 * #0))]
               Get materialize.public.t
         Return
@@ -592,7 +592,7 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM bar;
 ----
 With Mutually Recursive
-  cte l0 =
+  cte [l0 as foo] =
     Distinct
       Union
         Map (1, 2)
@@ -600,7 +600,7 @@ With Mutually Recursive
             - ()
         Map (7)
           Get l1
-  cte l1 =
+  cte [l1 as bar] =
     Project (#0)
       Get l0
 Return
@@ -618,7 +618,7 @@ WITH MUTUALLY RECURSIVE (RECURSION LIMIT = 5)
 SELECT * FROM bar;
 ----
 With Mutually Recursive [recursion_limit=5]
-  cte l0 =
+  cte [l0 as foo] =
     Distinct
       Union
         Map (1, 2)
@@ -626,7 +626,7 @@ With Mutually Recursive [recursion_limit=5]
             - ()
         Map (7)
           Get l1
-  cte l1 =
+  cte [l1 as bar] =
     Project (#0)
       Get l0
 Return
@@ -644,7 +644,7 @@ WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT = 5)
 SELECT * FROM bar;
 ----
 With Mutually Recursive [recursion_limit=5, return_at_limit]
-  cte l0 =
+  cte [l0 as foo] =
     Distinct
       Union
         Map (1, 2)
@@ -652,7 +652,7 @@ With Mutually Recursive [recursion_limit=5, return_at_limit]
             - ()
         Map (7)
           Get l1
-  cte l1 =
+  cte [l1 as bar] =
     Project (#0)
       Get l0
 Return

--- a/test/sqllogictest/github-2746.slt
+++ b/test/sqllogictest/github-2746.slt
@@ -60,6 +60,26 @@ WHERE
  );
 ----
 Explained Query:
+  With
+    cte l0 =
+      Join::Linear
+        linear_stage[0]
+          lookup={ relation=1, key=[] }
+          stream={ key=[], thinning=(#0) }
+        source={ relation=0, key=[] }
+        ArrangeBy
+          raw=true
+          arrangements[0]={ key=[], permutation=id, thinning=(#0) }
+          types=[integer]
+          Get::Collection materialize.public.lineitem
+            project=(#0)
+            raw=true
+        ArrangeBy
+          raw=true
+          arrangements[0]={ key=[], permutation=id, thinning=() }
+          Get::Collection materialize.public.orders
+            project=()
+            raw=true
   Return
     Join::Linear
       final_closure
@@ -141,26 +161,6 @@ Explained Query:
             Get::Collection materialize.public.orders
               filter=((#0) IS NOT NULL)
               raw=true
-  With
-    cte l0 =
-      Join::Linear
-        linear_stage[0]
-          lookup={ relation=1, key=[] }
-          stream={ key=[], thinning=(#0) }
-        source={ relation=0, key=[] }
-        ArrangeBy
-          raw=true
-          arrangements[0]={ key=[], permutation=id, thinning=(#0) }
-          types=[integer]
-          Get::Collection materialize.public.lineitem
-            project=(#0)
-            raw=true
-        ArrangeBy
-          raw=true
-          arrangements[0]={ key=[], permutation=id, thinning=() }
-          Get::Collection materialize.public.orders
-            project=()
-            raw=true
 
 Source materialize.public.orders
   project=(#0, #4)

--- a/test/sqllogictest/outer_join.slt
+++ b/test/sqllogictest/outer_join.slt
@@ -106,6 +106,22 @@ from
   LEFT JOIN right2 ON left.x = right2.x;
 ----
 Explained Query:
+  With
+    cte l0 =
+      TopK::MonotonicTop1 group_by=[#0] must_consolidate
+        Get::Collection materialize.public.right1
+          raw=true
+    cte l1 =
+      Reduce::Distinct
+        val_plan
+          project=()
+        key_plan=id
+        Union
+          Get::Collection materialize.public.left
+            project=(#0)
+            raw=true
+          Constant
+            - (null)
   Return
     Join::Delta
       plan_path[0]
@@ -222,22 +238,6 @@ Explained Query:
                     Get::PassArrangements l1
                       raw=false
                       arrangements[0]={ key=[#0], permutation=id, thinning=() }
-  With
-    cte l1 =
-      Reduce::Distinct
-        val_plan
-          project=()
-        key_plan=id
-        Union
-          Get::Collection materialize.public.left
-            project=(#0)
-            raw=true
-          Constant
-            - (null)
-    cte l0 =
-      TopK::MonotonicTop1 group_by=[#0] must_consolidate
-        Get::Collection materialize.public.right1
-          raw=true
 
 Source materialize.public.left
 Source materialize.public.right1

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -869,15 +869,15 @@ NULL  NULL
 query T multiline
 EXPLAIN RAW PLAN WITH(types) FOR SELECT CASE (SELECT 1) WHEN 1 THEN 0 ELSE 2 END, 'TEXT';
 ----
+With
+  cte [l1 as subquery-1] =
+    Map (1)
+      Constant
+        - ()
 Return
   Map (case when (select(Get l1) = 1) then 0 else 2 end, "TEXT")
     Constant
       - ()
-With
-  cte l1 =
-    Map (1)
-      Constant
-        - ()
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -1911,30 +1911,30 @@ ORDER BY
 ----
 TopK order_by=[#0 asc nulls_last]
   Project (#1, #2)
-    Return
-      Filter ((select(Get l3) AND (#3 = #7)) AND (#8 = text_to_char("CANADA")))
-        CrossJoin
-          Get materialize.public.supplier
-          Get materialize.public.nation
     With
-      cte l3 =
+      cte [l3 as subquery-3] =
         Reduce aggregates=[any((#^0 = #0))]
           Project (#1)
-            Return
-              Filter (select(Get l1) AND (integer_to_numeric(#2) > select(Get l2)))
-                Get materialize.public.partsupp
             With
-              cte l1 =
-                Reduce aggregates=[any((#^0 = #0))]
-                  Project (#0)
-                    Filter (varchar_to_text(#1) like "forest%")
-                      Get materialize.public.part
-              cte l2 =
+              cte [l2 as subquery-2] =
                 Project (#1)
                   Map ((0.5 * #0))
                     Reduce aggregates=[sum(#4)]
                       Filter ((((#1 = #^0) AND (#2 = #^1)) AND (#10 >= text_to_date("1995-01-01"))) AND (date_to_timestamp(#10) < (text_to_date("1995-01-01") + 1 year)))
                         Get materialize.public.lineitem
+              cte [l1 as subquery-1] =
+                Reduce aggregates=[any((#^0 = #0))]
+                  Project (#0)
+                    Filter (varchar_to_text(#1) like "forest%")
+                      Get materialize.public.part
+            Return
+              Filter (select(Get l1) AND (integer_to_numeric(#2) > select(Get l2)))
+                Get materialize.public.partsupp
+    Return
+      Filter ((select(Get l3) AND (#3 = #7)) AND (#8 = text_to_char("CANADA")))
+        CrossJoin
+          Get materialize.public.supplier
+          Get materialize.public.nation
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -1904,30 +1904,30 @@ ORDER BY
 ----
 Finish order_by=[#0 asc nulls_last] output=[#0, #1]
   Project (#1, #2)
-    Return
-      Filter ((select(Get l3) AND (#3 = #7)) AND (#8 = text_to_char("CANADA")))
-        CrossJoin
-          Get materialize.public.supplier
-          Get materialize.public.nation
     With
-      cte l3 =
+      cte [l3 as subquery-3] =
         Reduce aggregates=[any((#^0 = #0))]
           Project (#1)
-            Return
-              Filter (select(Get l1) AND (integer_to_numeric(#2) > select(Get l2)))
-                Get materialize.public.partsupp
             With
-              cte l1 =
-                Reduce aggregates=[any((#^0 = #0))]
-                  Project (#0)
-                    Filter (varchar_to_text(#1) like "forest%")
-                      Get materialize.public.part
-              cte l2 =
+              cte [l2 as subquery-2] =
                 Project (#1)
                   Map ((0.5 * #0))
                     Reduce aggregates=[sum(#4)]
                       Filter ((((#1 = #^0) AND (#2 = #^1)) AND (#10 >= text_to_date("1995-01-01"))) AND (date_to_timestamp(#10) < (text_to_date("1995-01-01") + 1 year)))
                         Get materialize.public.lineitem
+              cte [l1 as subquery-1] =
+                Reduce aggregates=[any((#^0 = #0))]
+                  Project (#0)
+                    Filter (varchar_to_text(#1) like "forest%")
+                      Get materialize.public.part
+            Return
+              Filter (select(Get l1) AND (integer_to_numeric(#2) > select(Get l2)))
+                Get materialize.public.partsupp
+    Return
+      Filter ((select(Get l3) AND (#3 = #7)) AND (#8 = text_to_char("CANADA")))
+        CrossJoin
+          Get materialize.public.supplier
+          Get materialize.public.nation
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -159,26 +159,6 @@ EXPLAIN PHYSICAL PLAN FOR SELECT count(*) FROM t1
 WHERE a = 2 AND b = 'l2' OR a = 1 + 1 + 1 AND b = 'l3'
 ----
 Explained Query:
-  Return
-    Union
-      ArrangeBy
-        input_key=[]
-        raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0) }
-      Mfp
-        project=(#0)
-        map=(0)
-        Union consolidate_output=true
-          Negate
-            Get::Arrangement l0
-              project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0) }
-          Constant
-            - ()
   With
     cte l0 =
       Reduce::Accumulable
@@ -205,6 +185,26 @@ Explained Query:
             Constant
               - (2, "l2")
               - (3, "l3")
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l0
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0) }
+      Mfp
+        project=(#0)
+        map=(0)
+        Union consolidate_output=true
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0) }
+          Constant
+            - ()
 
 Used Indexes:
   - materialize.public.idx_t1_a_b (lookup)

--- a/test/sqllogictest/transform/relax_must_consolidate.slt
+++ b/test/sqllogictest/transform/relax_must_consolidate.slt
@@ -41,6 +41,19 @@ FROM (
 );
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce::Hierarchical
+        aggr_funcs=[min, max]
+        skips=[0, 0]
+        monotonic
+        must_consolidate
+        val_plan
+          project=(#1, #0)
+        key_plan
+          project=()
+        Get::PassArrangements materialize.public.t
+          raw=true
   Return
     Union
       ArrangeBy
@@ -61,19 +74,6 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce::Hierarchical
-        aggr_funcs=[min, max]
-        skips=[0, 0]
-        monotonic
-        must_consolidate
-        val_plan
-          project=(#1, #0)
-        key_plan
-          project=()
-        Get::PassArrangements materialize.public.t
-          raw=true
 
 Source materialize.public.t
 
@@ -103,6 +103,18 @@ FROM (
 );
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce::Hierarchical
+        aggr_funcs=[min, max]
+        skips=[0, 0]
+        monotonic
+        must_consolidate
+        val_plan=id
+        key_plan
+          project=()
+        Get::Collection materialize.public.t
+          raw=true
   Return
     Union
       ArrangeBy
@@ -123,18 +135,6 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce::Hierarchical
-        aggr_funcs=[min, max]
-        skips=[0, 0]
-        monotonic
-        must_consolidate
-        val_plan=id
-        key_plan
-          project=()
-        Get::Collection materialize.public.t
-          raw=true
 
 Source materialize.public.t
   filter=((1 = (#0 % 2)))
@@ -163,6 +163,22 @@ FROM (
 );
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce::Hierarchical
+        aggr_funcs=[min, max]
+        skips=[0, 0]
+        monotonic
+        must_consolidate
+        val_plan
+          project=(#1, #0)
+        key_plan
+          project=()
+        FlatMap generate_series(1, #0, 1)
+          mfp_after
+            project=(#1, #2)
+          Get::PassArrangements materialize.public.t
+            raw=true
   Return
     Union
       ArrangeBy
@@ -183,22 +199,6 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce::Hierarchical
-        aggr_funcs=[min, max]
-        skips=[0, 0]
-        monotonic
-        must_consolidate
-        val_plan
-          project=(#1, #0)
-        key_plan
-          project=()
-        FlatMap generate_series(1, #0, 1)
-          mfp_after
-            project=(#1, #2)
-          Get::PassArrangements materialize.public.t
-            raw=true
 
 Source materialize.public.t
 
@@ -236,6 +236,24 @@ FROM (
 );
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce::Hierarchical
+        aggr_funcs=[min, max]
+        skips=[0, 0]
+        monotonic
+        must_consolidate
+        val_plan
+          project=(#1, #0)
+        key_plan
+          project=()
+        Union
+          Get::Collection materialize.public.t
+            filter=((1 = (#0 % 2)))
+            raw=true
+          Get::Collection materialize.public.t
+            filter=((0 = (#0 % 2)))
+            raw=true
   Return
     Union
       ArrangeBy
@@ -256,24 +274,6 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce::Hierarchical
-        aggr_funcs=[min, max]
-        skips=[0, 0]
-        monotonic
-        must_consolidate
-        val_plan
-          project=(#1, #0)
-        key_plan
-          project=()
-        Union
-          Get::Collection materialize.public.t
-            filter=((1 = (#0 % 2)))
-            raw=true
-          Get::Collection materialize.public.t
-            filter=((0 = (#0 % 2)))
-            raw=true
 
 Target cluster: quickstart
 
@@ -309,26 +309,6 @@ FROM (
 );
 ----
 Explained Query:
-  Return
-    Union
-      ArrangeBy
-        input_key=[]
-        raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
-      Mfp
-        project=(#0, #1)
-        map=(null, null)
-        Union consolidate_output=true
-          Negate
-            Get::Arrangement l0
-              project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
-          Constant
-            - ()
   With
     cte l0 =
       Reduce::Hierarchical
@@ -353,6 +333,26 @@ Explained Query:
                 Get::Collection materialize.public.t
                   filter=((0 = (#0 % 2)))
                   raw=true
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l0
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+      Mfp
+        project=(#0, #1)
+        map=(null, null)
+        Union consolidate_output=true
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+          Constant
+            - ()
 
 Target cluster: quickstart
 
@@ -397,27 +397,12 @@ FROM (
 );
 ----
 Explained Query:
-  Return
-    Union
-      Get::Arrangement l1
-        project=(#1, #0)
-        map=(5)
-        key=
-        raw=false
-        arrangements[0]={ key=[], permutation=id, thinning=(#0) }
-      Mfp
-        project=(#0, #1)
-        map=(null, null)
-        Union consolidate_output=true
-          Negate
-            Get::Arrangement l1
-              project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0) }
-          Constant
-            - ()
   With
+    cte l0 =
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
+        types=[integer?, integer?]
     cte l1 =
       Reduce::Hierarchical
         aggr_funcs=[max]
@@ -443,11 +428,26 @@ Explained Query:
             raw=false
             arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
             types=[integer?, integer?]
-    cte l0 =
-      Get::PassArrangements materialize.public.t
+  Return
+    Union
+      Get::Arrangement l1
+        project=(#1, #0)
+        map=(5)
+        key=
         raw=false
-        arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
-        types=[integer?, integer?]
+        arrangements[0]={ key=[], permutation=id, thinning=(#0) }
+      Mfp
+        project=(#0, #1)
+        map=(null, null)
+        Union consolidate_output=true
+          Negate
+            Get::Arrangement l1
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0) }
+          Constant
+            - ()
 
 Used Indexes:
   - materialize.public.t_idx (differential join)
@@ -502,26 +502,6 @@ FROM (
 );
 ----
 Explained Query:
-  Return
-    Union
-      Get::Arrangement l0
-        project=(#1, #0)
-        map=(5)
-        key=
-        raw=false
-        arrangements[0]={ key=[], permutation=id, thinning=(#0) }
-      Mfp
-        project=(#0, #1)
-        map=(null, null)
-        Union consolidate_output=true
-          Negate
-            Get::Arrangement l0
-              project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0) }
-          Constant
-            - ()
   With
     cte l0 =
       Reduce::Hierarchical
@@ -553,6 +533,26 @@ Explained Query:
               project=(#1)
               filter=((#0 = 5) AND (#1) IS NOT NULL)
               raw=true
+  Return
+    Union
+      Get::Arrangement l0
+        project=(#1, #0)
+        map=(5)
+        key=
+        raw=false
+        arrangements[0]={ key=[], permutation=id, thinning=(#0) }
+      Mfp
+        project=(#0, #1)
+        map=(null, null)
+        Union consolidate_output=true
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0) }
+          Constant
+            - ()
 
 Source materialize.public.t
   filter=((#0 = 5) AND (#1) IS NOT NULL)
@@ -583,6 +583,24 @@ FROM (
 );
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce::Hierarchical
+        aggr_funcs=[min, max]
+        skips=[0, 0]
+        monotonic
+        val_plan=id
+        key_plan
+          project=()
+        input_key=#0
+        Reduce::Accumulable
+          simple_aggrs[0]=(0, 0, sum(#0))
+          val_plan
+            project=(#0)
+          key_plan
+            project=(#1)
+          Get::PassArrangements materialize.public.t
+            raw=true
   Return
     Union
       ArrangeBy
@@ -603,24 +621,6 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce::Hierarchical
-        aggr_funcs=[min, max]
-        skips=[0, 0]
-        monotonic
-        val_plan=id
-        key_plan
-          project=()
-        input_key=#0
-        Reduce::Accumulable
-          simple_aggrs[0]=(0, 0, sum(#0))
-          val_plan
-            project=(#0)
-          key_plan
-            project=(#1)
-          Get::PassArrangements materialize.public.t
-            raw=true
 
 Source materialize.public.t
 
@@ -646,6 +646,24 @@ FROM (
 );
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce::Hierarchical
+        aggr_funcs=[min, max]
+        skips=[0, 0]
+        monotonic
+        val_plan
+          project=(#1, #0)
+        key_plan
+          project=()
+        input_key=#0, #1
+        Reduce::Distinct
+          val_plan
+            project=()
+          key_plan
+            project=(#1, #0)
+          Get::PassArrangements materialize.public.t
+            raw=true
   Return
     Union
       ArrangeBy
@@ -666,24 +684,6 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce::Hierarchical
-        aggr_funcs=[min, max]
-        skips=[0, 0]
-        monotonic
-        val_plan
-          project=(#1, #0)
-        key_plan
-          project=()
-        input_key=#0, #1
-        Reduce::Distinct
-          val_plan
-            project=()
-          key_plan
-            project=(#1, #0)
-          Get::PassArrangements materialize.public.t
-            raw=true
 
 Source materialize.public.t
 
@@ -748,27 +748,19 @@ FROM (
 );
 ----
 Explained Query:
-  Return
-    Union
-      ArrangeBy
-        input_key=[]
-        raw=true
-        Get::PassArrangements l1
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
-      Mfp
-        project=(#0, #1)
-        map=(null, null)
-        Union consolidate_output=true
-          Negate
-            Get::Arrangement l1
-              project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
-          Constant
-            - ()
   With
+    cte l0 =
+      Reduce::Accumulable
+        simple_aggrs[0]=(0, 0, count(*))
+        val_plan
+          project=(#2)
+          map=(true)
+        key_plan
+          project=(#1, #0)
+        mfp_after
+          filter=((2 = (#2 + 1)))
+        Get::Collection materialize.public.t
+          raw=true
     cte l1 =
       Reduce::Hierarchical
         aggr_funcs=[min, max]
@@ -794,18 +786,26 @@ Explained Query:
               key=#0, #1
               raw=false
               arrangements[0]={ key=[#0, #1], permutation=id, thinning=(#2) }
-    cte l0 =
-      Reduce::Accumulable
-        simple_aggrs[0]=(0, 0, count(*))
-        val_plan
-          project=(#2)
-          map=(true)
-        key_plan
-          project=(#1, #0)
-        mfp_after
-          filter=((2 = (#2 + 1)))
-        Get::Collection materialize.public.t
-          raw=true
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l1
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+      Mfp
+        project=(#0, #1)
+        map=(null, null)
+        Union consolidate_output=true
+          Negate
+            Get::Arrangement l1
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+          Constant
+            - ()
 
 Source materialize.public.t
   filter=((6 = (#0 + 1)))
@@ -836,6 +836,19 @@ FROM (
 );
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce::Hierarchical
+        aggr_funcs=[min, max]
+        skips=[0, 0]
+        monotonic
+        val_plan
+          project=(#1, #0)
+        key_plan
+          project=()
+        TopK::MonotonicTop1 group_by=[#0] order_by=[#1 desc nulls_first] must_consolidate
+          Get::PassArrangements materialize.public.t
+            raw=true
   Return
     Union
       ArrangeBy
@@ -856,19 +869,6 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce::Hierarchical
-        aggr_funcs=[min, max]
-        skips=[0, 0]
-        monotonic
-        val_plan
-          project=(#1, #0)
-        key_plan
-          project=()
-        TopK::MonotonicTop1 group_by=[#0] order_by=[#1 desc nulls_first] must_consolidate
-          Get::PassArrangements materialize.public.t
-            raw=true
 
 Source materialize.public.t
 
@@ -900,6 +900,19 @@ FROM (
 );
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce::Hierarchical
+        aggr_funcs=[min, max]
+        skips=[0, 0]
+        monotonic
+        val_plan
+          project=(#1, #0)
+        key_plan
+          project=()
+        TopK::MonotonicTopK order_by=[#1 desc nulls_first] limit=2 must_consolidate
+          Get::PassArrangements materialize.public.t
+            raw=true
   Return
     Union
       ArrangeBy
@@ -920,19 +933,6 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-  With
-    cte l0 =
-      Reduce::Hierarchical
-        aggr_funcs=[min, max]
-        skips=[0, 0]
-        monotonic
-        val_plan
-          project=(#1, #0)
-        key_plan
-          project=()
-        TopK::MonotonicTopK order_by=[#1 desc nulls_first] limit=2 must_consolidate
-          Get::PassArrangements materialize.public.t
-            raw=true
 
 Source materialize.public.t
 
@@ -1024,26 +1024,6 @@ FROM (
 );
 ----
 Explained Query:
-  Return
-    Union
-      ArrangeBy
-        input_key=[]
-        raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0) }
-      Mfp
-        project=(#0)
-        map=(null)
-        Union consolidate_output=true
-          Negate
-            Get::Arrangement l0
-              project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0) }
-          Constant
-            - ()
   With
     cte l0 =
       Reduce::Hierarchical
@@ -1070,6 +1050,26 @@ Explained Query:
                   project=(#1)
                 Get::PassArrangements materialize.public.t
                   raw=true
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l0
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0) }
+      Mfp
+        project=(#0)
+        map=(null)
+        Union consolidate_output=true
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0) }
+          Constant
+            - ()
 
 Source materialize.public.t
 
@@ -1094,6 +1094,18 @@ FROM (
 );
 ----
 Explained Query:
+  With
+    cte l0 =
+      Reduce::Hierarchical
+        aggr_funcs=[max]
+        skips=[0]
+        monotonic
+        val_plan=id
+        key_plan
+          project=()
+        FlatMap generate_series(1, 20000, 1)
+          Constant
+            - ()
   Return
     Union
       ArrangeBy
@@ -1112,18 +1124,6 @@ Explained Query:
               key=
               raw=false
               arrangements[0]={ key=[], permutation=id, thinning=(#0) }
-          Constant
-            - ()
-  With
-    cte l0 =
-      Reduce::Hierarchical
-        aggr_funcs=[max]
-        skips=[0]
-        monotonic
-        val_plan=id
-        key_plan
-          project=()
-        FlatMap generate_series(1, 20000, 1)
           Constant
             - ()
 
@@ -1161,7 +1161,36 @@ SELECT MAX(a)
 FROM input;
 ----
 Explained Query:
+  With Mutually Recursive
+    cte l0 =
+      ArrangeBy
+        input_key=[#0]
+        raw=true
+        Reduce::Distinct
+          val_plan
+            project=()
+          key_plan=id
+          Union
+            FlatMap generate_series(1, 40000, 1)
+              Constant
+                - ()
+            TopK::Basic group_by=[#0] limit=1
+              Get::Collection l0
+                filter=((#0 > 20000))
+                raw=true
   Return
+    With
+      cte l1 =
+        Reduce::Hierarchical
+          aggr_funcs=[max]
+          skips=[0]
+          monotonic
+          must_consolidate
+          val_plan=id
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
     Return
       Union
         ArrangeBy
@@ -1182,35 +1211,6 @@ Explained Query:
                 arrangements[0]={ key=[], permutation=id, thinning=(#0) }
             Constant
               - ()
-    With
-      cte l1 =
-        Reduce::Hierarchical
-          aggr_funcs=[max]
-          skips=[0]
-          monotonic
-          must_consolidate
-          val_plan=id
-          key_plan
-            project=()
-          Get::PassArrangements l0
-            raw=true
-  With Mutually Recursive
-    cte l0 =
-      ArrangeBy
-        input_key=[#0]
-        raw=true
-        Reduce::Distinct
-          val_plan
-            project=()
-          key_plan=id
-          Union
-            FlatMap generate_series(1, 40000, 1)
-              Constant
-                - ()
-            TopK::Basic group_by=[#0] limit=1
-              Get::Collection l0
-                filter=((#0 > 20000))
-                raw=true
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -5969,6 +5969,12 @@ FROM (
 ORDER BY outer_a, outer_b;
 ----
 Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#2]
+  With
+    cte [l1 as subquery-1] =
+      Reduce aggregates=[sum(#0)]
+        Project (#3)
+          Map (lead(row(#0, 1, null)) over (partition by [((4 * #0) / (#^0 + char_length(#^1)))] order by [#0 asc nulls_last]), (3 + #2))
+            Get materialize.public.foo
   Return
     Map (select(Get l1))
       Distinct
@@ -5982,12 +5988,6 @@ Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#2]
           Project (#2, #1)
             Map ((#0 + 5))
               Get materialize.public.foo
-  With
-    cte l1 =
-      Reduce aggregates=[sum(#0)]
-        Project (#3)
-          Map (lead(row(#0, 1, null)) over (partition by [((4 * #0) / (#^0 + char_length(#^1)))] order by [#0 asc nulls_last]), (3 + #2))
-            Get materialize.public.foo
 
 Target cluster: quickstart
 


### PR DESCRIPTION
This is a follow-up to https://github.com/MaterializeInc/materialize/pull/30983, which changed CTE order in MIR EXPLAIN. This PR does the same for HIR and LIR. Additionally (2nd commit), it also makes the HIR EXPLAIN print CTE names. (Names are still available at the HIR level.)

(The RQG fail in Nightly is unrelated, and is fixed in https://github.com/MaterializeInc/materialize/pull/31140 )

### Motivation

Same as https://github.com/MaterializeInc/materialize/pull/30983, this PR eliminates the surprising CTE order in EXPLAIN. Also, it makes the CTE order consistent across HIR, MIR, and LIR.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
