### PR TITLE
[copy_from] Proper cancelation via `CancelOneshotIngestion` message

### DIFF
--- a/src/adapter/src/active_compute_sink.rs
+++ b/src/adapter/src/active_compute_sink.rs
@@ -29,7 +29,7 @@ use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
 use crate::coord::peek::PeekResponseUnary;
-use crate::{AdapterError, ExecuteResponse};
+use crate::{AdapterError, ExecuteContext, ExecuteResponse};
 
 #[derive(Debug)]
 /// A description of an active compute sink from the coordinator's perspective.
@@ -434,4 +434,13 @@ impl ActiveCopyTo {
         };
         let _ = self.tx.send(message);
     }
+}
+
+/// State we keep in the `Coordinator` to track active `COPY FROM` statements.
+#[derive(Debug)]
+pub(crate) struct ActiveCopyFrom {
+    /// ID of the ingestion running in clusterd.
+    pub ingestion_id: uuid::Uuid,
+    /// Context of the SQL session that ran the statement.
+    pub ctx: ExecuteContext,
 }

--- a/src/adapter/src/active_compute_sink.rs
+++ b/src/adapter/src/active_compute_sink.rs
@@ -22,8 +22,9 @@ use mz_expr::compare_columns;
 use mz_ore::cast::CastFrom;
 use mz_ore::now::EpochMillis;
 use mz_repr::adt::numeric;
-use mz_repr::{Datum, GlobalId, IntoRowIterator, Row, Timestamp};
+use mz_repr::{CatalogItemId, Datum, GlobalId, IntoRowIterator, Row, Timestamp};
 use mz_sql::plan::SubscribeOutput;
+use mz_storage_types::instances::StorageInstanceId;
 use timely::progress::Antichain;
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
@@ -441,6 +442,10 @@ impl ActiveCopyTo {
 pub(crate) struct ActiveCopyFrom {
     /// ID of the ingestion running in clusterd.
     pub ingestion_id: uuid::Uuid,
+    /// The cluster this is currently running on.
+    pub cluster_id: StorageInstanceId,
+    /// The table we're currently copying into.
+    pub table_id: CatalogItemId,
     /// Context of the SQL session that ran the statement.
     pub ctx: ExecuteContext,
 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -170,7 +170,7 @@ use tracing::{debug, info, info_span, span, warn, Instrument, Level, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
 
-use crate::active_compute_sink::ActiveComputeSink;
+use crate::active_compute_sink::{ActiveComputeSink, ActiveCopyFrom};
 use crate::catalog::{BuiltinTableUpdate, Catalog, OpenCatalogResult};
 use crate::client::{Client, Handle};
 use crate::command::{Command, ExecuteResponse};
@@ -1667,7 +1667,7 @@ pub struct Coordinator {
     active_webhooks: BTreeMap<CatalogItemId, WebhookAppenderInvalidator>,
     /// A map of active `COPY FROM` statements. The Coordinator waits for `clusterd`
     /// to stage Batches in Persist that we will then link into the shard.
-    active_copies: BTreeMap<ConnectionId, ExecuteContext>,
+    active_copies: BTreeMap<ConnectionId, ActiveCopyFrom>,
 
     /// A map from connection ids to a watch channel that is set to `true` if the connection
     /// received a cancel request.

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -206,6 +206,7 @@ impl Coordinator {
         let mut cluster_replicas_to_drop = vec![];
         let mut compute_sinks_to_drop = BTreeMap::new();
         let mut peeks_to_drop = vec![];
+        let mut copies_to_drop = vec![];
         let mut clusters_to_create = vec![];
         let mut cluster_replicas_to_create = vec![];
         let mut update_tracing_config = false;
@@ -453,6 +454,18 @@ impl Coordinator {
             }
         }
 
+        // Clean up any pending `COPY` statements that rely on dropped relations or clusters.
+        for (conn_id, pending_copy) in &self.active_copies {
+            let dropping_table = table_gids_to_drop
+                .iter()
+                .any(|(item_id, _gid)| pending_copy.table_id == *item_id);
+            let dropping_cluster = clusters_to_drop.contains(&pending_copy.cluster_id);
+
+            if dropping_table || dropping_cluster {
+                copies_to_drop.push(conn_id.clone());
+            }
+        }
+
         let storage_ids_to_drop = sources_to_drop
             .iter()
             .map(|(_, gid)| *gid)
@@ -663,6 +676,11 @@ impl Coordinator {
                             pending_peek.ctx_extra,
                         );
                     }
+                }
+            }
+            if !copies_to_drop.is_empty() {
+                for conn_id in copies_to_drop {
+                    self.cancel_pending_copy(&conn_id);
                 }
             }
             if !indexes_to_drop.is_empty() {

--- a/src/adapter/src/coord/sequencer/inner/copy_from.rs
+++ b/src/adapter/src/coord/sequencer/inner/copy_from.rs
@@ -23,7 +23,7 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::coord::sequencer::inner::return_if_err;
-use crate::coord::{Coordinator, TargetCluster};
+use crate::coord::{ActiveCopyFrom, Coordinator, TargetCluster};
 use crate::optimize::dataflows::{prep_scalar_expr, EvalTime, ExprPrepStyle};
 use crate::session::{TransactionOps, WriteOp};
 use crate::{AdapterError, ExecuteContext, ExecuteResponse};
@@ -177,8 +177,9 @@ impl Coordinator {
             });
         });
         // Stash the execute context so we can cancel the COPY.
+        let conn_id = ctx.session().conn_id().clone();
         self.active_copies
-            .insert(ctx.session().conn_id().clone(), ctx);
+            .insert(conn_id, ActiveCopyFrom { ingestion_id, ctx });
 
         let _result = self
             .controller
@@ -193,10 +194,16 @@ impl Coordinator {
         table_id: CatalogItemId,
         batches: Vec<Result<ProtoBatch, String>>,
     ) {
-        let Some(mut ctx) = self.active_copies.remove(&conn_id) else {
+        let Some(active_copy) = self.active_copies.remove(&conn_id) else {
             tracing::warn!(?conn_id, "got response for canceled COPY FROM");
             return;
         };
+
+        let ActiveCopyFrom {
+            ingestion_id,
+            mut ctx,
+        } = active_copy;
+        tracing::info!(%ingestion_id, num_batches = ?batches.len(), "received batches to append");
 
         let mut all_batches = SmallVec::with_capacity(batches.len());
         let mut all_errors = SmallVec::<[String; 1]>::with_capacity(batches.len());
@@ -248,8 +255,15 @@ impl Coordinator {
     /// Cancel any active `COPY FROM` statements/oneshot ingestions.
     #[mz_ore::instrument(level = "debug")]
     pub(crate) fn cancel_pending_copy(&mut self, conn_id: &ConnectionId) {
-        // TODO(cf1): Also cancel the dataflow running on clusterd.
-        if let Some(ctx) = self.active_copies.remove(conn_id) {
+        if let Some(ActiveCopyFrom { ingestion_id, ctx }) = self.active_copies.remove(conn_id) {
+            let cancel_result = self
+                .controller
+                .storage
+                .cancel_oneshot_ingestion(ingestion_id);
+            if let Err(err) = cancel_result {
+                tracing::error!(?err, "failed to cancel OneshotIngestion");
+            }
+
             ctx.retire(Err(AdapterError::Canceled));
         }
     }

--- a/src/storage-client/src/client.proto
+++ b/src/storage-client/src/client.proto
@@ -48,11 +48,19 @@ message ProtoRunIngestionCommand {
   mz_storage_types.sources.ProtoIngestionDescription description = 2;
 }
 
-message ProtoRunOneshotIngestionCommand {
+message ProtoRunOneshotIngestion {
   mz_proto.ProtoU128 ingestion_id = 1;
   mz_repr.global_id.ProtoGlobalId collection_id = 2;
   mz_storage_types.controller.ProtoCollectionMetadata storage_metadata = 3;
   mz_storage_types.oneshot_sources.ProtoOneshotIngestionRequest request = 4;
+}
+
+message ProtoRunOneshotIngestionsCommand {
+  repeated ProtoRunOneshotIngestion ingestions = 1;
+}
+
+message ProtoCancelOneshotIngestionsCommand {
+  repeated mz_proto.ProtoU128 ingestions = 1;
 }
 
 message ProtoCreateSources {
@@ -94,7 +102,8 @@ message ProtoStorageCommand {
     google.protobuf.Empty allow_writes = 7;
     ProtoRunSinks run_sinks = 4;
     mz_storage_types.parameters.ProtoStorageParameters update_configuration = 5;
-    ProtoRunOneshotIngestionCommand oneshot_ingestion = 10;
+    ProtoRunOneshotIngestionsCommand run_oneshot_ingestions = 10;
+    ProtoCancelOneshotIngestionsCommand cancel_oneshot_ingestions = 11;
   }
 }
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -501,6 +501,12 @@ pub trait StorageController: Debug {
         result_tx: OneshotResultCallback<ProtoBatch>,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
+    /// Cancel a oneshot ingestion.
+    fn cancel_oneshot_ingestion(
+        &mut self,
+        ingestion_id: uuid::Uuid,
+    ) -> Result<(), StorageError<Self::Timestamp>>;
+
     /// Alter the sink identified by the given id to match the provided `ExportDescription`.
     async fn alter_export(
         &mut self,

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -48,7 +48,7 @@ use mz_repr::adt::interval::Interval;
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::{Datum, Diff, GlobalId, RelationDesc, RelationVersion, Row, TimestampManipulation};
 use mz_storage_client::client::{
-    ProtoStorageCommand, ProtoStorageResponse, RunIngestionCommand, RunOneshotIngestionCommand,
+    ProtoStorageCommand, ProtoStorageResponse, RunIngestionCommand, RunOneshotIngestion,
     RunSinkCommand, Status, StatusUpdate, StorageCommand, StorageResponse, TableData,
 };
 use mz_storage_client::controller::{
@@ -117,6 +117,16 @@ struct PendingCompactionCommand<T> {
     cluster_id: Option<StorageInstanceId>,
 }
 
+#[derive(Derivative)]
+#[derivative(Debug)]
+struct PendingOneshotIngestion {
+    /// Callback used to provide results of the ingestion.
+    #[derivative(Debug = "ignore")]
+    result_tx: OneshotResultCallback<ProtoBatch>,
+    /// Cluster currently running this ingestion
+    cluster_id: StorageInstanceId,
+}
+
 /// A storage controller for a storage instance.
 #[derive(Derivative)]
 #[derivative(Debug)]
@@ -161,7 +171,7 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     pending_table_handle_drops_rx: mpsc::UnboundedReceiver<GlobalId>,
     /// Closures that can be used to send responses from oneshot ingestions.
     #[derivative(Debug = "ignore")]
-    pending_oneshot_ingestions: BTreeMap<uuid::Uuid, OneshotResultCallback<ProtoBatch>>,
+    pending_oneshot_ingestions: BTreeMap<uuid::Uuid, PendingOneshotIngestion>,
 
     /// Interface for managed collections
     pub(crate) collection_manager: collection_mgmt::CollectionManager<T>,
@@ -1405,7 +1415,7 @@ where
             // TODO(cf2): Refine this error.
             StorageError::Generic(anyhow::anyhow!("missing cluster {instance_id}"))
         })?;
-        let oneshot_cmd = RunOneshotIngestionCommand {
+        let oneshot_cmd = RunOneshotIngestion {
             ingestion_id,
             collection_id,
             collection_meta,
@@ -1413,15 +1423,46 @@ where
         };
 
         if !self.read_only {
-            instance.send(StorageCommand::RunOneshotIngestion(oneshot_cmd));
+            instance.send(StorageCommand::RunOneshotIngestion(vec![oneshot_cmd]));
+            let pending = PendingOneshotIngestion {
+                result_tx,
+                cluster_id: instance_id,
+            };
             let novel = self
                 .pending_oneshot_ingestions
-                .insert(ingestion_id, result_tx);
+                .insert(ingestion_id, pending);
             assert!(novel.is_none());
             Ok(())
         } else {
             Err(StorageError::ReadOnly)
         }
+    }
+
+    fn cancel_oneshot_ingestion(
+        &mut self,
+        ingestion_id: uuid::Uuid,
+    ) -> Result<(), StorageError<Self::Timestamp>> {
+        if self.read_only {
+            return Err(StorageError::ReadOnly);
+        }
+
+        let pending = self
+            .pending_oneshot_ingestions
+            .remove(&ingestion_id)
+            .ok_or_else(|| {
+                // TODO(cf2): Refine this error.
+                StorageError::Generic(anyhow::anyhow!("missing oneshot ingestion {ingestion_id}"))
+            })?;
+
+        let instance = self.instances.get_mut(&pending.cluster_id).ok_or_else(|| {
+            // TODO(cf2): Refine this error.
+            StorageError::Generic(anyhow::anyhow!("missing cluster {}", pending.cluster_id))
+        })?;
+        instance.send(StorageCommand::CancelOneshotIngestion {
+            ingestions: vec![ingestion_id],
+        });
+
+        Ok(())
     }
 
     async fn alter_export(
@@ -1998,12 +2039,21 @@ where
                 self.record_status_updates(updates);
             }
             Some(StorageResponse::StagedBatches(batches)) => {
-                for (collection_id, batches) in batches {
-                    match self.pending_oneshot_ingestions.remove(&collection_id) {
-                        Some(sender) => (sender)(batches),
+                for (ingestion_id, batches) in batches {
+                    match self.pending_oneshot_ingestions.remove(&ingestion_id) {
+                        Some(pending) => {
+                            // Send a cancel command so our command history is correct.
+                            if let Some(instance) = self.instances.get_mut(&pending.cluster_id) {
+                                instance.send(StorageCommand::CancelOneshotIngestion {
+                                    ingestions: vec![ingestion_id],
+                                });
+                            }
+                            // Send the results down our channel.
+                            (pending.result_tx)(batches)
+                        }
                         // TODO(cf2): When we support running COPY FROM on multiple
                         // replicas we can probably just ignore the case of `None`.
-                        None => mz_ore::soft_panic_or_log!("no sender for {collection_id}!"),
+                        None => mz_ore::soft_panic_or_log!("no sender for {ingestion_id}!"),
                     }
                 }
             }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2042,7 +2042,8 @@ where
                 for (ingestion_id, batches) in batches {
                     match self.pending_oneshot_ingestions.remove(&ingestion_id) {
                         Some(pending) => {
-                            // Send a cancel command so our command history is correct.
+                            // Send a cancel command so our command history is correct. And to
+                            // avoid duplicate work once we have active replication.
                             if let Some(instance) = self.instances.get_mut(&pending.cluster_id) {
                                 instance.send(StorageCommand::CancelOneshotIngestion {
                                     ingestions: vec![ingestion_id],

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1138,6 +1138,10 @@ impl<'w, A: Allocate> Worker<'w, A> {
             .filter(|ingestion_id| {
                 let created = create_oneshot_ingestions.contains(ingestion_id);
                 let dropped = cancel_oneshot_ingestions.contains(ingestion_id);
+                mz_ore::soft_assert_or_log!(
+                    !created && dropped,
+                    "dropped non-existent oneshot source"
+                );
                 !created && !dropped
             })
             .copied()


### PR DESCRIPTION
This PR fixes the `TODO(cf1)` related to canceling oneshot ingestions. It adds a `StorageCommand::CancelOneshotIngestion` that `reduce`s/compacts away a corresponding `StorageCommand::RunOneshotIngestion`, much like `ComputeCommand::Peek` and `ComputeCommand::CancelPeek`.

We send a `StorageCommand::CancelOneshotIngestion` whenever a user has canceled a `COPY FROM` statement, but also the storage controller will send one whenever a `RunOneshotIngestion` command completes.

### Motivation

Fix `TODO(cf1)` related to cancelation

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
