### PR TITLE
mysql test: Fix source status message

### DIFF
--- a/test/mysql-cdc-old-syntax/empty-table.td
+++ b/test/mysql-cdc-old-syntax/empty-table.td
@@ -41,5 +41,5 @@ CREATE TABLE empty_table (f1 BOOLEAN);
 
 # TODO: database-issues#7690 (subsource remains starting)
 > SELECT name, type, status FROM mz_internal.mz_source_statuses WHERE name in ('empty_table', 'mz_source');
-empty_table subsource starting
+empty_table subsource running
 mz_source mysql running


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/31096

Failed in nightly: https://buildkite.com/materialize/nightly/builds/10932#01948b6e-1c55-4c39-b126-7cb45d3cb699

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
