### PR TITLE
Fix cached hash clash in `Fixpoint`

### DIFF
--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -443,6 +443,9 @@ impl Transform for Fixpoint {
                             );
                             return Ok(());
                         }
+                        if let Some(id) = ctx.global_id {
+                            ctx.last_hash.insert(id, again.hash_to_u64());
+                        }
                         self.apply_transforms(
                             &mut again,
                             ctx,

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -442,7 +442,7 @@ impl Transform for Fixpoint {
                             // relevant issues, see
                             // https://github.com/MaterializeInc/database-issues/issues/8197#issuecomment-2200172227
                             mz_repr::explain::trace_plan(relation);
-                            soft_panic_or_log!(
+                            error!(
                                 "Fixpoint `{}` detected a loop of length {} after {} iterations",
                                 self.name,
                                 i - seen_i,

--- a/test/sqllogictest/github-8906.slt
+++ b/test/sqllogictest/github-8906.slt
@@ -1,0 +1,215 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+# Regression test for https://github.com/MaterializeInc/database-issues/issues/8906
+
+# The setup is based on https://github.com/MaterializeInc/RQG/blob/main/conf/mz/simple.sql
+
+statement ok
+DROP TABLE IF EXISTS t1 CASCADE;
+
+statement ok
+DROP TABLE IF EXISTS t2 CASCADE;
+
+statement ok
+DROP TABLE IF EXISTS t3 CASCADE;
+
+statement ok
+CREATE TABLE t1 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
+
+statement ok
+CREATE INDEX t1i1 ON t1(f1);
+
+statement ok
+CREATE INDEX t1i2 ON t1(f2, f1);
+
+# one NULL row in t1
+
+statement ok
+INSERT INTO t1 VALUES (NULL, 0);
+
+# values 1 and 2 have 2 rows each in t1
+
+statement ok
+INSERT INTO t1 VALUES (1, 1);
+
+statement ok
+INSERT INTO t1 VALUES (1, 1);
+
+statement ok
+INSERT INTO t1 VALUES (2, 2);
+
+statement ok
+INSERT INTO t1 VALUES (2, 2);
+
+statement ok
+INSERT INTO t1 VALUES (3, 3);
+
+statement ok
+INSERT INTO t1 VALUES (4, 4);
+
+statement ok
+INSERT INTO t1 VALUES (5, 5);
+
+statement ok
+INSERT INTO t1 VALUES (6, 6);
+
+statement ok
+INSERT INTO t1 VALUES (7, 7);
+
+statement ok
+INSERT INTO t1 VALUES (8, 8);
+
+# value 9 not present in either table
+
+statement ok
+CREATE TABLE t2 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
+
+statement ok
+CREATE INDEX t2i1 ON t2(f1);
+
+statement ok
+CREATE INDEX i2i2 ON t2(f2, f1);
+
+# two NULL rows in t2
+
+statement ok
+INSERT INTO t2 VALUES (NULL, 0);
+
+statement ok
+INSERT INTO t2 VALUES (NULL, 0);
+
+statement ok
+INSERT INTO t2 VALUES (1, 1);
+
+# value 2 has 2 rows in t2
+
+statement ok
+INSERT INTO t2 VALUES (2, 2);
+
+statement ok
+INSERT INTO t2 VALUES (2, 2);
+
+# value 3 has no rows in t2
+
+statement ok
+INSERT INTO t2 VALUES (4, 4);
+
+statement ok
+INSERT INTO t2 VALUES (5, 5);
+
+statement ok
+INSERT INTO t2 VALUES (6, 6);
+
+statement ok
+INSERT INTO t2 VALUES (7, 7);
+
+statement ok
+INSERT INTO t2 VALUES (8, 8);
+
+# value 9 not present in either table
+
+statement ok
+CREATE TABLE t3 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
+
+statement ok
+CREATE MATERIALIZED VIEW pk1 AS SELECT DISTINCT ON (f1) f1 , f2 FROM t1 WHERE f1 IS NOT NULL AND f2 IS NOT NULL;
+
+statement ok
+CREATE MATERIALIZED VIEW pk2 AS SELECT DISTINCT ON (f1) f1 , f2 FROM t2 WHERE f1 IS NOT NULL AND f2 IS NOT NULL;
+
+statement ok
+CREATE MATERIALIZED VIEW pk3 AS SELECT DISTINCT ON (f1) f1 , f2 FROM t3 WHERE f1 IS NOT NULL AND f2 IS NOT NULL;
+
+query RRRR
+SELECT
+    (
+        SELECT inner2.f2
+        FROM t1 AS inner1 RIGHT JOIN t2 AS inner2 ON (inner2.f2 + 1 = inner2.f2)
+        WHERE outer2.f2 BETWEEN 0 AND 0 AND outer1.f2 = outer1.f1
+        ORDER BY 1
+        LIMIT 1
+    ),
+    (
+        SELECT inner1.f1 + 1
+        FROM t1 AS inner1 LEFT JOIN t2 AS inner2 ON (inner1.f2 + 1 BETWEEN inner2.f2 AND inner1.f2)
+        WHERE outer1.f2 + 1 IS NULL AND inner2.f2 IS NULL
+        ORDER BY 1
+        LIMIT 1
+    ),
+    (
+        SELECT inner1.f1 + 1
+        FROM pk1 AS inner1, pk2 AS inner2
+        WHERE inner2.f1 + 1 IS NOT NULL AND inner2.f2 IS NULL
+        ORDER BY 1
+        LIMIT 0
+    ),
+    (
+        SELECT inner1.f1
+        FROM t1 AS inner1 JOIN t2 AS inner2 ON (inner2.f2 + 1 BETWEEN 1 AND 1)
+        WHERE inner2.f1 IS NOT NULL OR inner1.f1 IS NOT NULL
+        ORDER BY 1
+        LIMIT 1
+    )
+FROM
+    t1 AS outer1
+        JOIN
+            (
+                    SELECT DISTINCT inner1.f2 AS f1, inner1.f2 + 1 AS f2
+                    FROM pk2 AS inner1, pk2 AS inner2
+                    WHERE inner2.f1 IS NOT NULL
+                )
+                AS outer2
+            ON (outer2.f1 BETWEEN 1 AND 8)
+WHERE
+    outer1.f2 BETWEEN outer1.f1 AND outer2.f2 + 1
+        AND
+    outer2.f2
+    = (
+            SELECT inner2.f2
+            FROM t1 AS inner1 JOIN t2 AS inner2 ON (inner2.f1 BETWEEN inner1.f1 AND 1)
+            WHERE inner2.f1 + 1 IS NOT NULL AND outer2.f1 + 1 IS NULL
+            ORDER BY 1
+            LIMIT 0
+        )
+        AND
+    outer1.f1 + 1
+    = (
+            SELECT inner1.f2 FROM t1 AS inner1, pk1 AS inner2 WHERE outer2.f2 > outer2.f1 + 1
+            ORDER BY 1
+            LIMIT 1
+        )
+        AND
+    outer2.f2 + 1
+    = (
+            SELECT inner1.f1 + 1
+            FROM t1 AS inner1 LEFT JOIN t2 AS inner2 ON (inner1.f2 IS NULL)
+            WHERE inner1.f2 + 1 BETWEEN 1 AND outer2.f2
+            ORDER BY 1
+            LIMIT 1
+        )
+        AND
+    NOT
+    EXISTS (
+        SELECT DISTINCT inner2.f1
+        FROM t1 AS inner1 LEFT JOIN t2 AS inner2 ON (inner1.f2 BETWEEN inner1.f2 AND 1)
+        WHERE inner1.f2 + 1 BETWEEN 8 AND inner1.f1 AND outer1.f2 BETWEEN 9 AND 1
+    )
+        OR
+    outer2.f2 + 1 = outer1.f2 + 1;
+----
+NULL  NULL  NULL  1
+NULL  NULL  NULL  1
+NULL  NULL  NULL  1
+NULL  NULL  NULL  1
+NULL  NULL  NULL  1
+NULL  NULL  NULL  1
+NULL  NULL  NULL  1


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/database-issues/issues/8906

`TransformCtx` gives `Transform`s the hash of the plan that is the input to the transform. The hash that `TransformCtx` gives out is the one stored in `last_hash` (the "cached hash"), which has to be updated at various moments. We forgot about one such moment: `Fixpoint` sometimes jumps back to the beginning as part of its cycle detection mechanism (which, somewhat confusingly, also involves hashing, but is not currently connected to the `last_hash` mechanism). Therefore, in this case, `Transform::transform`'s `soft_assert_eq_no_log!` detects the wrong hash and reports a "cached hash clash". (And if we were to go through this `soft_assert_eq_no_log!` in prod, then the wrong hash would lead to wrong values for the `transform_hits` metric. In the future, we'd like to use these hashes for more mission-critical things than just metrics, so we'd like them to be correct.)

The first commit just fixes the bug, by updating `last_hash` to the hash of the plan that was at the beginning of the fixpoint loop.

The second commit factors out the updating of `last_hash` into a function, because it now happens in 3 places.

The third commit downgrades a `soft_panic_or_log!` to a `tracing::error!` to stop https://github.com/MaterializeInc/database-issues/issues/8197 from flaking nightly, because we have accumulated enough examples to debug this when we get to this issue. The `tracing:error!` would still show up in Sentry if this happens in prod, which would affect the prioritization of the issue. (So far, it hasn't happened in production at all in the 7 months since I added this soft_panic_or_log.)

The fourth commit adds a regression test. (This would fail with the above `soft_panic_or_log!`, so this is one more reason I wanted to downgrade this now to an error log.)

cc @mgree 

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/8906

### Tips for reviewer

I suggest reviewing commit by commit.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
