### PR TITLE
tests: Add large-scale mysql/pg/upsert test

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -477,3 +477,39 @@ steps:
           args: [--find-limit]
     timeout_in_minutes: 3600
     parallelism: 20
+
+  - group: Large Scale Ingestions
+    key: large-scale-ingestions
+    steps:
+      - id: mysql-cdc-large-scale
+        label: MySQL CDC large scale ingestion
+        depends_on: build-aarch64
+        timeout_in_minutes: 3600
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: mysql-cdc
+              run: large-scale
+        agents:
+          queue: hetzner-x86-64-dedi-48cpu-192gb # 1 TB disk
+
+      - id: pg-cdc-large-scale
+        label: Postgres CDC large scale ingestion
+        depends_on: build-aarch64
+        timeout_in_minutes: 3600
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: pg-cdc
+              run: large-scale
+        agents:
+          queue: hetzner-x86-64-dedi-48cpu-192gb # 1 TB disk
+
+      - id: upsert-large-scale
+        label: Upsert large scale ingestion
+        depends_on: build-aarch64
+        timeout_in_minutes: 3600
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: upsert
+              run: large-scale
+        agents:
+          queue: hetzner-x86-64-dedi-48cpu-192gb # 1 TB disk

--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -79,7 +79,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         f"Workflows in shard with index {buildkite.get_parallelism_index()}: {sharded_workflows}"
     )
     for name in sharded_workflows:
-        if name == "default":
+        if name in ("default", "large-scale"):
             continue
 
         with c.test_case(name):
@@ -270,6 +270,88 @@ def workflow_many_inserts(c: Composition, parser: WorkflowArgumentParser) -> Non
             f"""
             > SELECT count(*) FROM many_inserts
             {initial_records + concurrent_records}
+            """
+        ),
+    )
+
+
+def workflow_large_scale(c: Composition, parser: WorkflowArgumentParser) -> None:
+    """
+    The goal is to test a large scale MySQL instance and to make sure that we can successfully ingest data from it quickly.
+    """
+    mysql_version = get_targeted_mysql_version(parser)
+    with c.override(create_mysql(mysql_version)):
+        c.up("materialized", "mysql")
+        c.up("testdrive", persistent=True)
+
+        # Set up the MySQL server with the initial records, set up the connection to
+        # the MySQL server in Materialize.
+        c.testdrive(
+            dedent(
+                f"""
+                $ postgres-execute connection=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
+                ALTER SYSTEM SET max_mysql_connections = 100
+
+                $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+
+                > CREATE SECRET IF NOT EXISTS mysqlpass AS '{MySql.DEFAULT_ROOT_PASSWORD}'
+                > CREATE CONNECTION IF NOT EXISTS mysql_conn TO MYSQL (HOST mysql, USER root, PASSWORD SECRET mysqlpass)
+
+                $ mysql-execute name=mysql
+                DROP DATABASE IF EXISTS public;
+                CREATE DATABASE public;
+                USE public;
+                DROP TABLE IF EXISTS products;
+                CREATE TABLE products (id int NOT NULL, name varchar(255) DEFAULT NULL, merchant_id int NOT NULL, price int DEFAULT NULL, status int DEFAULT NULL, created_at timestamp NULL DEFAULT CURRENT_TIMESTAMP(), recordSizePayload longtext, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+                ALTER TABLE products DISABLE KEYS;
+
+                > DROP SOURCE IF EXISTS s1 CASCADE;
+                """
+            )
+        )
+
+    def make_inserts(c: Composition, start: int, batch_num: int):
+        c.testdrive(
+            args=["--no-reset"],
+            input=dedent(
+                f"""
+            $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+            $ mysql-execute name=mysql
+            SET foreign_key_checks = 0;
+            USE public;
+            SET @i:={start};
+            INSERT INTO products (id, name, merchant_id, price, status, created_at, recordSizePayload) SELECT @i:=@i+1, CONCAT("name", @i), @i % 1000, @i % 1000, @i % 10, '2024-12-12', repeat('x', 1000000) FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT {batch_num};
+            """
+            ),
+        )
+
+    num_rows = 200_000  # out of disk with 300_000 rows
+    batch_size = 100
+    for i in range(0, num_rows, batch_size):
+        batch_num = min(batch_size, num_rows - i)
+        make_inserts(c, i, batch_num)
+
+    c.testdrive(
+        args=["--no-reset"],
+        input=dedent(
+            f"""
+            > CREATE SOURCE s1
+                FROM MYSQL CONNECTION mysql_conn;
+            > CREATE TABLE products FROM SOURCE s1 (REFERENCE public.products);
+            > SELECT COUNT(*) FROM products;
+            {num_rows}
+            """
+        ),
+    )
+
+    make_inserts(c, num_rows, 1)
+
+    c.testdrive(
+        args=["--no-reset"],
+        input=dedent(
+            f"""
+            > SELECT COUNT(*) FROM products;
+            {num_rows + 1}
             """
         ),
     )


### PR DESCRIPTION
and enable in release qualification pipeline (weekly)
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
