### PR TITLE
Rename `sql/src/plan/expr.rs` to `hir.rs`

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -27,7 +27,7 @@ use crate::ast::{SelectStatement, Statement};
 use crate::catalog::{CatalogType, TypeCategory, TypeReference};
 use crate::names::{self, ResolvedItemName};
 use crate::plan::error::PlanError;
-use crate::plan::expr::{
+use crate::plan::hir::{
     AggregateFunc, BinaryFunc, CoercibleScalarExpr, CoercibleScalarType, ColumnOrder,
     HirRelationExpr, HirScalarExpr, ScalarWindowFunc, TableFunc, UnaryFunc, UnmaterializableFunc,
     ValueWindowFunc, VariadicFunc,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -87,7 +87,7 @@ use crate::names::{
 
 pub(crate) mod error;
 pub(crate) mod explain;
-pub(crate) mod expr;
+pub(crate) mod hir;
 pub(crate) mod literal;
 pub(crate) mod lowering;
 pub(crate) mod notice;
@@ -106,7 +106,7 @@ use crate::plan::statement::ddl::ClusterAlterUntilReadyOptionExtracted;
 use crate::plan::with_options::OptionalDuration;
 pub use error::PlanError;
 pub use explain::normalize_subqueries;
-pub use expr::{
+pub use hir::{
     AggregateExpr, CoercibleScalarExpr, Hir, HirRelationExpr, HirScalarExpr, JoinKind,
     WindowExprType,
 };

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -7,10 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! This file houses a representation of a SQL plan that is parallel to that found in
-//! src/expr/relation/mod.rs, but represents an earlier phase of planning. It's structurally very
-//! similar to that file, with some differences which are noted below. It gets turned into that
-//! representation via a call to lower().
+//! This file houses HIR, a representation of a SQL plan that is parallel to MIR, but represents
+//! an earlier phase of planning. It's structurally very similar to MIR, with some differences
+//! which are noted below. It gets turned into MIR via a call to lower().
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Display, Formatter};

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -40,7 +40,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::iter::repeat;
 
 use crate::optimizer_metrics::OptimizerMetrics;
-use crate::plan::expr::{
+use crate::plan::hir::{
     AggregateExpr, ColumnOrder, ColumnRef, HirRelationExpr, HirScalarExpr, JoinKind, WindowExprType,
 };
 use crate::plan::{transform_hir, PlanError};

--- a/src/sql/src/plan/lowering/variadic_left.rs
+++ b/src/sql/src/plan/lowering/variadic_left.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use mz_expr::{MirRelationExpr, MirScalarExpr};
 use mz_ore::soft_assert_eq_or_log;
 
-use crate::plan::expr::{HirRelationExpr, HirScalarExpr};
+use crate::plan::hir::{HirRelationExpr, HirScalarExpr};
 use crate::plan::lowering::{ColumnMap, Context, CteMap};
 use crate::plan::PlanError;
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -82,7 +82,7 @@ use crate::names::{
 };
 use crate::normalize;
 use crate::plan::error::PlanError;
-use crate::plan::expr::{
+use crate::plan::hir::{
     AbstractColumnType, AbstractExpr, AggregateExpr, AggregateFunc, AggregateWindowExpr,
     BinaryFunc, CoercibleScalarExpr, CoercibleScalarType, ColumnOrder, ColumnRef, Hir,
     HirRelationExpr, HirScalarExpr, JoinKind, ScalarWindowExpr, ScalarWindowFunc, UnaryFunc,

--- a/src/sql/src/plan/scope.rs
+++ b/src/sql/src/plan/scope.rs
@@ -50,7 +50,7 @@ use mz_repr::ColumnName;
 use crate::ast::Expr;
 use crate::names::{Aug, PartialItemName};
 use crate::plan::error::PlanError;
-use crate::plan::expr::ColumnRef;
+use crate::plan::hir::ColumnRef;
 use crate::plan::plan_utils::JoinSide;
 
 #[derive(Debug, Clone)]

--- a/src/sql/src/plan/transform_hir.rs
+++ b/src/sql/src/plan/transform_hir.rs
@@ -20,7 +20,7 @@ use mz_expr::{ColumnOrder, UnaryFunc, VariadicFunc};
 use mz_ore::stack::RecursionLimitError;
 use mz_repr::{ColumnName, ColumnType, RelationType, ScalarType};
 
-use crate::plan::expr::{
+use crate::plan::hir::{
     AbstractExpr, AggregateFunc, AggregateWindowExpr, ColumnRef, HirRelationExpr, HirScalarExpr,
     ValueWindowExpr, ValueWindowFunc, WindowExpr,
 };

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -23,7 +23,7 @@ use mz_repr::{ColumnName, ColumnType, Datum, RelationType, ScalarBaseType, Scala
 
 use crate::catalog::TypeCategory;
 use crate::plan::error::PlanError;
-use crate::plan::expr::{
+use crate::plan::hir::{
     AbstractColumnType, CoercibleScalarExpr, CoercibleScalarType, ColumnRef, HirScalarExpr,
     UnaryFunc,
 };

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -29,7 +29,7 @@ use tokio_postgres::Client;
 
 use crate::names::{Aug, ResolvedItemName};
 use crate::normalize;
-use crate::plan::expr::ColumnRef;
+use crate::plan::hir::ColumnRef;
 use crate::plan::typeconv::{plan_cast, CastContext};
 use crate::plan::{
     ExprContext, HirScalarExpr, PlanError, QueryContext, QueryLifetime, Scope, StatementContext,


### PR DESCRIPTION
A continuation of https://github.com/MaterializeInc/materialize/pull/31124. We have lots of `expr`s throughout our codebase, so it's better to explicitly mention HIR.

Also, slightly tweaks the comment at the top of the file.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
