### PR TITLE
dbt-materialize: make seeds aware of user-defined cluster naming logic

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,12 +1,20 @@
 # dbt-materialize Changelog
 
+## Unreleased
+
+* Fix a bug in the `truncate_relation_sql` macro where specifying a cluster for
+  seeds wasn't respecting custom cluster naming logic from user-defined
+  `generate_cluster_name` macros.
+
 ## 1.9.2 - 2025-01-21
 
 * Fix schema tagging to work with current transaction limitations.
 
 ## 1.9.1 - 2025-01-17
 
-* Fix a bug in the `deploy_init` macro where source cluster validation wasn't respecting custom cluster naming logic from user-defined `generate_cluster_name` macros.
+* Fix a bug in the `deploy_init` macro where source cluster validation wasn't
+  respecting custom cluster naming logic from user-defined
+  `generate_cluster_name` macros.
 
 ## 1.9.0 - 2024-12-17
 
@@ -79,7 +87,10 @@
 
 ## 1.8.3 - 2024-07-19
 
-* Enable cross-database references ([#27686](https://github.com/MaterializeInc/materialize/pull/27686)). Although cross-database references are not supported in `dbt-postgres`, databases in Materialize are purely used for namespacing, and therefore do not present the same constraint.
+* Enable cross-database references ([#27686](https://github.com/MaterializeInc/materialize/pull/27686)).
+  Although cross-database references are not supported in `dbt-postgres`,
+  databases in Materialize are purely used for namespacing, and therefore do not
+  present the same constraint.
 
 * Add the `create_cluster` and `drop_cluster` macros, which allow managing the
   creation and deletion of clusters in workflows requiring transient

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -180,7 +180,8 @@
   -- default cluster for the user is invalid(or intentionally set to
   -- mz_catalog_server, which cannot query user data).
   {% if cluster -%}
-      {% do run_query(set_cluster(cluster)) -%}
+      {%- set origin_cluster = adapter.generate_final_cluster_name(cluster) -%}
+      {% do run_query(set_cluster(origin_cluster)) -%}
   {%- endif %}
   {{ truncate_relation(relation) }}
 {% endmacro %}


### PR DESCRIPTION
The underlying logic to rebuild seeds didn't take into account the scenario where users provide a `generate_cluster_name ` macro override.

Using the new logic, if a custom `generate_cluster_name` macro is provided when running against a target named `dev`:

```sql
{% macro generate_cluster_name(custom_cluster_name) -%}
    {%- if target.name == 'prod' -%}
        {{ custom_cluster_name }}
    {%- else -%}
        {{ target.name }}_{{ custom_cluster_name }}
    {%- endif -%}
{%- endmacro %}
```

```sql
14:22:50  On seed.mz_get_started.test_29324: /* {"app": "dbt", "dbt_version": "1.9.1", "profile_name": "mz_get_started", "target_name": "dev", "node_id": "seed.mz_get_started.test_29324"} */


  set cluster = dev_quickstart;


14:22:50  Opening a new connection, currently in state closed
```

If `generate_cluster_name` is not overridden:

```
13:03:04  On seed.mz_get_started.test_29324: /* {"app": "dbt", "dbt_version": "1.9.1", "profile_name": "mz_get_started", "target_name": "dev", "node_id": "seed.mz_get_started.test_29324"} */


  set cluster = quickstart;


13:03:04  Opening a new connection, currently in state closed
```