### PR TITLE
[copy_from] AWS source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3068,9 +3068,9 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "globset"
@@ -4789,12 +4789,15 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-types",
  "aws-types",
  "bytes",
  "bytesize",
+ "futures",
  "http 1.1.0",
  "hyper-tls 0.5.0",
  "mz-ore",
+ "pin-project",
  "thiserror",
  "tokio",
  "uuid",
@@ -7137,13 +7140,17 @@ dependencies = [
  "arrow",
  "async-compression",
  "async-stream",
+ "aws-smithy-types",
  "aws-types",
  "bytes",
  "bytesize",
  "csv-async",
+ "derivative",
  "differential-dataflow",
  "futures",
+ "glob",
  "http 1.1.0",
+ "itertools 0.12.1",
  "mz-arrow-util",
  "mz-aws-util",
  "mz-dyncfg",

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -373,7 +373,7 @@ impl Coordinator {
                             session,
                         );
                     }
-                    CopyFromSource::Url(_) => {
+                    CopyFromSource::Url(_) | CopyFromSource::AwsS3 { .. } => {
                         self.sequence_copy_from(ctx, plan, target_cluster).await;
                     }
                 },

--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -12,15 +12,20 @@ workspace = true
 [dependencies]
 anyhow = "1.0.66"
 aws-config = { version = "1.2.0", default-features = false }
-aws-sdk-s3 = { version = "1.23.0", default-features = false, features = ["rt-tokio"], optional = true }
+aws-sdk-s3 = { version = "1.23.0", default-features = false, features = [
+    "rt-tokio",
+], optional = true }
 aws-smithy-runtime-api = "1.1.1"
 aws-smithy-runtime = { version = "1.1.1", features = ["connector-hyper-0-14-x"] }
+aws-smithy-types = { version = "1.1.8", features = ["byte-stream-poll-next"] }
 aws-types = "1.1.1"
 bytes = "1.3.0"
 bytesize = "1.1.0"
+futures = "0.3.25"
 http = "1.1.0"
 hyper-tls = "0.5.0"
-mz-ore = { path = "../ore", default-features = false }
+mz-ore = { path = "../ore", features = ["async"], default-features = false }
+pin-project = "1.0.12"
 thiserror = "1.0.37"
 tokio = { version = "1.38.0", default-features = false, features = ["macros"] }
 uuid = { version = "1.7.0", features = ["v4"] }

--- a/src/aws-util/src/s3.rs
+++ b/src/aws-util/src/s3.rs
@@ -9,9 +9,9 @@
 
 use aws_sdk_s3::config::Builder;
 use aws_types::sdk_config::SdkConfig;
+use bytes::Bytes;
 
 pub use aws_sdk_s3::Client;
-use bytes::Bytes;
 
 /// Creates a new client from an [SDK config](aws_types::sdk_config::SdkConfig)
 /// with Materialize-specific customizations.

--- a/src/aws-util/src/s3.rs
+++ b/src/aws-util/src/s3.rs
@@ -8,8 +8,10 @@
 // by the Apache License, Version 2.0.
 
 use aws_sdk_s3::config::Builder;
-use aws_sdk_s3::Client;
 use aws_types::sdk_config::SdkConfig;
+
+pub use aws_sdk_s3::Client;
+use bytes::Bytes;
 
 /// Creates a new client from an [SDK config](aws_types::sdk_config::SdkConfig)
 /// with Materialize-specific customizations.
@@ -45,4 +47,31 @@ pub async fn list_bucket_path(
                 .collect::<Result<Vec<String>, _>>()
         })
         .transpose()
+}
+
+/// A wrapper around [`ByteStream`] that implements the [`futures::stream::Stream`] trait.
+///
+/// [`ByteStream`]: aws_smithy_types::byte_stream::ByteStream
+#[pin_project::pin_project]
+pub struct ByteStreamAdapter {
+    #[pin]
+    inner: aws_smithy_types::byte_stream::ByteStream,
+}
+
+impl ByteStreamAdapter {
+    pub fn new(bytes: aws_smithy_types::byte_stream::ByteStream) -> Self {
+        ByteStreamAdapter { inner: bytes }
+    }
+}
+
+impl futures::stream::Stream for ByteStreamAdapter {
+    type Item = Result<Bytes, aws_smithy_types::byte_stream::error::Error>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let this = self.project();
+        aws_smithy_types::byte_stream::ByteStream::poll_next(this.inner, cx)
+    }
 }

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -174,6 +174,7 @@ Features
 Fetch
 Fields
 File
+Files
 Filter
 First
 Fixpoint
@@ -320,6 +321,7 @@ Partition
 Partitions
 Password
 Path
+Pattern
 Physical
 Plan
 Plans

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -374,6 +374,8 @@ pub enum CopyOptionName {
     Header,
     AwsConnection,
     MaxFileSize,
+    Files,
+    Pattern,
 }
 
 impl AstDisplay for CopyOptionName {
@@ -387,6 +389,8 @@ impl AstDisplay for CopyOptionName {
             CopyOptionName::Header => "HEADER",
             CopyOptionName::AwsConnection => "AWS CONNECTION",
             CopyOptionName::MaxFileSize => "MAX FILE SIZE",
+            CopyOptionName::Files => "FILES",
+            CopyOptionName::Pattern => "PATTERN",
         })
     }
 }
@@ -407,6 +411,7 @@ impl WithOptionName for CopyOptionName {
             | CopyOptionName::Header
             | CopyOptionName::AwsConnection
             | CopyOptionName::MaxFileSize => false,
+            CopyOptionName::Files | CopyOptionName::Pattern => true,
         }
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -6403,9 +6403,9 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_copy_option(&mut self) -> Result<CopyOption<Raw>, ParserError> {
-        let name = match self
-            .expect_one_of_keywords(&[FORMAT, DELIMITER, NULL, ESCAPE, QUOTE, HEADER, AWS, MAX])?
-        {
+        let name = match self.expect_one_of_keywords(&[
+            FORMAT, DELIMITER, NULL, ESCAPE, QUOTE, HEADER, AWS, MAX, FILES, PATTERN,
+        ])? {
             FORMAT => CopyOptionName::Format,
             DELIMITER => CopyOptionName::Delimiter,
             NULL => CopyOptionName::Null,
@@ -6423,6 +6423,8 @@ impl<'a> Parser<'a> {
                 self.expect_keywords(&[FILE, SIZE])?;
                 CopyOptionName::MaxFileSize
             }
+            FILES => CopyOptionName::Files,
+            PATTERN => CopyOptionName::Pattern,
             _ => unreachable!(),
         };
         Ok(CopyOption {

--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -79,7 +79,7 @@ Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t")
 parse-statement
 COPY t TO STDOUT ()
 ----
-error: Expected one of FORMAT or DELIMITER or NULL or ESCAPE or QUOTE or HEADER or AWS or MAX, found right parenthesis
+error: Expected one of FORMAT or DELIMITER or NULL or ESCAPE or QUOTE or HEADER or AWS or MAX or FILES or PATTERN, found right parenthesis
 COPY t TO STDOUT ()
                   ^
 
@@ -184,3 +184,24 @@ COPY INTO t(a, b) TO '/any/path'
 error: Expected identifier, found INTO
 COPY INTO t(a, b) TO '/any/path'
      ^
+
+parse-statement
+COPY INTO t1 FROM 'http://spacemonkey.info' WITH (FILES = ['foo.csv', 'bar.csv']);
+----
+COPY t1 FROM 'http://spacemonkey.info' WITH (FILES = ('foo.csv', 'bar.csv'))
+=>
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t1")])), columns: [] }, direction: From, target: Expr(Value(String("http://spacemonkey.info"))), options: [CopyOption { name: Files, value: Some(Sequence([Value(String("foo.csv")), Value(String("bar.csv"))])) }] })
+
+parse-statement
+COPY INTO t1 FROM 'http://spacemonkey.info' WITH (FILES = ['foo.csv', 'bar.csv'], FORMAT CSV);
+----
+COPY t1 FROM 'http://spacemonkey.info' WITH (FILES = ('foo.csv', 'bar.csv'), FORMAT = csv)
+=>
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t1")])), columns: [] }, direction: From, target: Expr(Value(String("http://spacemonkey.info"))), options: [CopyOption { name: Files, value: Some(Sequence([Value(String("foo.csv")), Value(String("bar.csv"))])) }, CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }] })
+
+parse-statement
+COPY INTO t1 FROM 'http://spacemonkey.info' WITH (FILES = ['foo.csv']);
+----
+COPY t1 FROM 'http://spacemonkey.info' WITH (FILES = ('foo.csv'))
+=>
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t1")])), columns: [] }, direction: From, target: Expr(Value(String("http://spacemonkey.info"))), options: [CopyOption { name: Files, value: Some(Sequence([Value(String("foo.csv"))])) }] })

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -936,16 +936,32 @@ pub struct CopyFromPlan {
     pub source: CopyFromSource,
     pub columns: Vec<usize>,
     pub params: CopyFormatParams<'static>,
+    pub filter: Option<CopyFromFilter>,
 }
 
 #[derive(Debug)]
 pub enum CopyFromSource {
     /// Copying from a file local to the user, transmitted via pgwire.
     Stdin,
-    /// A remote resource, e.g. S3.
+    /// A remote resource, e.g. HTTP file.
     ///
     /// The contained [`HirScalarExpr`] evaluates to the Url for the remote resource.
     Url(HirScalarExpr),
+    /// A file in an S3 bucket.
+    AwsS3 {
+        /// Expression that evaluates to the file we want to copy.
+        uri: HirScalarExpr,
+        /// Details for how we connect to AWS S3.
+        connection: AwsConnection,
+        /// ID of the connection object.
+        connection_id: CatalogItemId,
+    },
+}
+
+#[derive(Debug)]
+pub enum CopyFromFilter {
+    Files(Vec<String>),
+    Pattern(String),
 }
 
 #[derive(Debug, Clone)]

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -841,6 +841,7 @@ fn generate_rbac_requirements(
             source: _,
             columns: _,
             params: _,
+            filter: _,
         }) => RbacRequirements {
             privileges: vec![
                 (

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -15,12 +15,16 @@ arrow = { version = "53.3.0", default-features = false }
 async-compression = { version = "0.4.5", features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
 async-stream = "0.3.3"
 aws-types = "1.1.1"
+aws-smithy-types = "1.1.8"
 bytes = "1.3.0"
 bytesize = "1.1.0"
-differential-dataflow = "0.13.4"
 csv-async = { version = "1.3.0", features = ["tokio"] }
+derivative = "2.2.0"
+differential-dataflow = "0.13.3"
 futures = "0.3.25"
+glob = "0.3.2"
 http = "1.1.0"
+itertools = "0.12.1"
 mz-aws-util = { path = "../aws-util" }
 mz-arrow-util = { path = "../arrow-util" }
 mz-dyncfg = { path = "../dyncfg" }

--- a/src/storage-operators/src/oneshot_source/aws_source.rs
+++ b/src/storage-operators/src/oneshot_source/aws_source.rs
@@ -1,0 +1,223 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! AWS S3 [`OneshotSource`].
+
+use std::path::Path;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use derivative::Derivative;
+use futures::stream::{BoxStream, TryStreamExt};
+use futures::StreamExt;
+use mz_ore::future::InTask;
+use mz_repr::CatalogItemId;
+use mz_storage_types::connections::aws::AwsConnection;
+use mz_storage_types::connections::ConnectionContext;
+use serde::{Deserialize, Serialize};
+
+use crate::oneshot_source::{
+    OneshotObject, OneshotSource, StorageErrorX, StorageErrorXContext, StorageErrorXKind,
+};
+
+#[derive(Clone, Derivative)]
+#[derivative(Debug)]
+pub struct AwsS3Source {
+    // Only used for initialization.
+    #[derivative(Debug = "ignore")]
+    connection: Arc<AwsConnection>,
+    connection_id: CatalogItemId,
+    #[derivative(Debug = "ignore")]
+    context: Arc<ConnectionContext>,
+
+    /// Name of the S3 bucket we'll list from.
+    bucket: String,
+    /// Optional prefix that can be specified via an S3 URI.
+    prefix: Option<String>,
+    /// S3 client that is lazily initialized.
+    #[derivative(Debug = "ignore")]
+    client: std::sync::OnceLock<mz_aws_util::s3::Client>,
+}
+
+impl AwsS3Source {
+    pub fn new(
+        connection: AwsConnection,
+        connection_id: CatalogItemId,
+        context: ConnectionContext,
+        uri: String,
+    ) -> Self {
+        let uri = http::Uri::from_str(&uri).expect("validated URI in sequencing");
+
+        let bucket = uri
+            .host()
+            .expect("validated host in sequencing")
+            .to_string();
+        let prefix = if uri.path().is_empty() || uri.path() == "/" {
+            None
+        } else {
+            // The S3 client expects a trailing `/` but no leading `/`.
+            let mut prefix = uri.path().to_string();
+
+            if let Some(suffix) = prefix.strip_prefix('/') {
+                prefix = suffix.to_string();
+            }
+            if !prefix.ends_with('/') {
+                prefix = format!("{prefix}/");
+            }
+
+            Some(prefix)
+        };
+
+        AwsS3Source {
+            connection: Arc::new(connection),
+            context: Arc::new(context),
+            connection_id,
+            bucket,
+            prefix,
+            client: std::sync::OnceLock::new(),
+        }
+    }
+
+    pub async fn initialize(&self) -> Result<mz_aws_util::s3::Client, anyhow::Error> {
+        let sdk_config = self
+            .connection
+            .load_sdk_config(&self.context, self.connection_id, InTask::Yes)
+            .await?;
+        let s3_client = mz_aws_util::s3::new_client(&sdk_config);
+
+        Ok(s3_client)
+    }
+
+    pub async fn client(&self) -> Result<&mz_aws_util::s3::Client, anyhow::Error> {
+        if self.client.get().is_none() {
+            let client = self.initialize().await?;
+            let _ = self.client.set(client);
+        }
+
+        Ok(self.client.get().expect("just initialized"))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct S3Object {
+    /// Key from S3 list operation.
+    key: String,
+    /// Name of the object, generally the last component of the key.
+    name: String,
+    /// Size of the object in bytes.
+    size: usize,
+}
+
+impl OneshotObject for S3Object {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn encodings(&self) -> &[super::Encoding] {
+        &[]
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct S3Checksum {
+    e_tag: Option<String>,
+}
+
+impl OneshotSource for AwsS3Source {
+    type Object = S3Object;
+    type Checksum = S3Checksum;
+
+    async fn list<'a>(
+        &'a self,
+    ) -> Result<Vec<(Self::Object, Self::Checksum)>, super::StorageErrorX> {
+        let client = self.client().await.map_err(StorageErrorXKind::generic)?;
+        let mut objects_request = client.list_objects_v2().bucket(&self.bucket);
+
+        // Users can optionally specify a prefix via the S3 uri they originally specify.
+        if let Some(prefix) = &self.prefix {
+            objects_request = objects_request.prefix(prefix);
+        }
+
+        let objects = objects_request
+            .send()
+            .await
+            .map_err(StorageErrorXKind::generic)
+            .context("list_objects_v2")?;
+
+        // TODO(cf1): Pagination.
+
+        let objects: Vec<_> = objects
+            .contents()
+            .iter()
+            .map(|o| {
+                let key = o
+                    .key()
+                    .ok_or_else(|| StorageErrorXKind::MissingField("key".into()))?
+                    .to_owned();
+                let name = Path::new(&key)
+                    .file_name()
+                    .and_then(|os_name| os_name.to_str())
+                    .ok_or_else(|| StorageErrorXKind::Generic(format!("malformed key: {key}")))?
+                    .to_string();
+                let size = o
+                    .size()
+                    .ok_or_else(|| StorageErrorXKind::MissingField("size".into()))?;
+                let size: usize = size.try_into().map_err(StorageErrorXKind::generic)?;
+
+                let object = S3Object { key, name, size };
+                let checksum = S3Checksum {
+                    e_tag: o.e_tag().map(|x| x.to_owned()),
+                };
+
+                Ok::<_, StorageErrorXKind>((object, checksum))
+            })
+            .collect::<Result<_, _>>()
+            .context("list")?;
+
+        Ok(objects)
+    }
+
+    fn get<'s>(
+        &'s self,
+        object: Self::Object,
+        _checksum: Self::Checksum,
+        range: Option<std::ops::RangeInclusive<usize>>,
+    ) -> BoxStream<'s, Result<bytes::Bytes, StorageErrorX>> {
+        let initial_response = async move {
+            tracing::info!(name = %object.name(), ?range, "fetching object");
+
+            // TODO(cf1): Validate our checksum.
+            let client = self.client().await.map_err(StorageErrorXKind::generic)?;
+
+            let mut request = client.get_object().bucket(&self.bucket).key(&object.name);
+            if let Some(range) = range {
+                // See the below link for the specifics of this format.
+                //
+                // <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range>
+                let range = format!("byte={}-{}", range.start(), range.end());
+                request = request.range(range);
+            }
+
+            let object = request
+                .send()
+                .await
+                .map_err(|err| StorageErrorXKind::AwsS3Request(err.to_string()))?;
+            // AWS's ByteStream doesn't implement the Stream trait.
+            let stream = mz_aws_util::s3::ByteStreamAdapter::new(object.body)
+                .err_into()
+                .boxed();
+
+            Ok::<_, StorageErrorXKind>(stream)
+        };
+
+        futures::stream::once(initial_response)
+            .try_flatten()
+            .boxed()
+    }
+}

--- a/src/storage-operators/src/oneshot_source/http_source.rs
+++ b/src/storage-operators/src/oneshot_source/http_source.rs
@@ -10,6 +10,7 @@
 //! Generic HTTP oneshot source that will fetch a file from the public internet.
 
 use bytes::Bytes;
+use derivative::Derivative;
 use futures::stream::{BoxStream, StreamExt};
 use futures::TryStreamExt;
 use reqwest::Client;
@@ -21,8 +22,10 @@ use crate::oneshot_source::{
 };
 
 /// Generic oneshot source that fetches a file from a URL on the public internet.
-#[derive(Clone)]
+#[derive(Clone, Derivative)]
+#[derivative(Debug)]
 pub struct HttpOneshotSource {
+    #[derivative(Debug = "ignore")]
     client: Client,
     origin: Url,
 }
@@ -122,7 +125,7 @@ impl OneshotSource for HttpOneshotSource {
         &'s self,
         object: Self::Object,
         _checksum: Self::Checksum,
-        _range: Option<std::ops::Range<usize>>,
+        _range: Option<std::ops::RangeInclusive<usize>>,
     ) -> BoxStream<'s, Result<Bytes, StorageErrorX>> {
         // TODO(cf1): Support the range param.
         // TODO(cf1): Validate our checksum.

--- a/src/storage-types/src/oneshot_sources.proto
+++ b/src/storage-types/src/oneshot_sources.proto
@@ -11,15 +11,25 @@ syntax = "proto3";
 
 package mz_storage_types.oneshot_sources;
 
+import "google/protobuf/empty.proto";
 import "pgcopy/src/copy.proto";
+import "repr/src/catalog_item_id.proto";
+import "storage-types/src/connections/aws.proto";
 
 message ProtoOneshotIngestionRequest {
   oneof source {
     ProtoHttpContentSource http = 1;
+    ProtoAwsS3Source aws_s3 = 4;
   }
 
   oneof format {
     ProtoCsvContentFormat csv = 2;
+  }
+
+  oneof filter {
+    google.protobuf.Empty none = 5;
+    ProtoFilterFiles files = 6;
+    ProtoFilterPattern pattern = 7;
   }
 }
 
@@ -27,6 +37,20 @@ message ProtoHttpContentSource {
   string url = 1;
 }
 
+message ProtoAwsS3Source {
+  mz_storage_types.connections.aws.ProtoAwsConnection connection = 1;
+  mz_repr.catalog_item_id.ProtoCatalogItemId connection_id = 2;
+  string uri = 3;
+}
+
 message ProtoCsvContentFormat {
   mz_pgcopy.copy.ProtoCopyCsvFormatParams params = 1;
+}
+
+message ProtoFilterFiles {
+  repeated string files = 1;
+}
+
+message ProtoFilterPattern {
+  string pattern = 1;
 }

--- a/src/storage-types/src/oneshot_sources.rs
+++ b/src/storage-types/src/oneshot_sources.rs
@@ -11,11 +11,14 @@
 
 use mz_pgcopy::CopyCsvFormatParams;
 use mz_proto::{IntoRustIfSome, RustType};
+use mz_repr::CatalogItemId;
 use mz_timely_util::builder_async::PressOnDropButton;
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::UnboundedReceiver;
 use url::Url;
+
+use crate::connections::aws::AwsConnection;
 
 include!(concat!(
     env!("OUT_DIR"),
@@ -37,6 +40,7 @@ pub struct OneshotIngestionDescription<Batch> {
 pub struct OneshotIngestionRequest {
     pub source: ContentSource,
     pub format: ContentFormat,
+    pub filter: ContentFilter,
 }
 
 impl RustType<ProtoOneshotIngestionRequest> for OneshotIngestionRequest {
@@ -44,6 +48,7 @@ impl RustType<ProtoOneshotIngestionRequest> for OneshotIngestionRequest {
         ProtoOneshotIngestionRequest {
             source: Some(self.source.into_proto()),
             format: Some(self.format.into_proto()),
+            filter: Some(self.filter.into_proto()),
         }
     }
 
@@ -56,14 +61,28 @@ impl RustType<ProtoOneshotIngestionRequest> for OneshotIngestionRequest {
         let format = proto
             .format
             .into_rust_if_some("ProtoOneshotIngestionRequest::format")?;
+        let filter = proto
+            .filter
+            .into_rust_if_some("ProtoOneshotIngestionRequest::filter")?;
 
-        Ok(OneshotIngestionRequest { source, format })
+        Ok(OneshotIngestionRequest {
+            source,
+            format,
+            filter,
+        })
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub enum ContentSource {
-    Http { url: Url },
+    Http {
+        url: Url,
+    },
+    AwsS3 {
+        connection: AwsConnection,
+        connection_id: CatalogItemId,
+        uri: String,
+    },
 }
 
 impl RustType<proto_oneshot_ingestion_request::Source> for ContentSource {
@@ -74,6 +93,15 @@ impl RustType<proto_oneshot_ingestion_request::Source> for ContentSource {
                     url: url.to_string(),
                 })
             }
+            ContentSource::AwsS3 {
+                connection,
+                connection_id,
+                uri,
+            } => proto_oneshot_ingestion_request::Source::AwsS3(ProtoAwsS3Source {
+                connection: Some(connection.into_proto()),
+                connection_id: Some(connection_id.into_proto()),
+                uri: uri.to_string(),
+            }),
         }
     }
 
@@ -84,6 +112,17 @@ impl RustType<proto_oneshot_ingestion_request::Source> for ContentSource {
             proto_oneshot_ingestion_request::Source::Http(source) => {
                 let url = Url::parse(&source.url).expect("failed to roundtrip Url");
                 Ok(ContentSource::Http { url })
+            }
+            proto_oneshot_ingestion_request::Source::AwsS3(source) => {
+                let connection = source.connection.into_rust_if_some("AwsS3::connection")?;
+                let connection_id = source
+                    .connection_id
+                    .into_rust_if_some("AwsS3::connection_id")?;
+                Ok(ContentSource::AwsS3 {
+                    connection,
+                    connection_id,
+                    uri: source.uri,
+                })
             }
         }
     }
@@ -112,6 +151,50 @@ impl RustType<proto_oneshot_ingestion_request::Format> for ContentFormat {
             proto_oneshot_ingestion_request::Format::Csv(ProtoCsvContentFormat { params }) => {
                 let params = params.into_rust_if_some("ProtoCsvContentFormat::params")?;
                 Ok(ContentFormat::Csv(params))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub enum ContentFilter {
+    /// No filtering, fetch everything at a remote resource.
+    None,
+    /// Filter to only the files specified in this list.
+    Files(Vec<String>),
+    /// Regex pattern to filter the files with.
+    Pattern(String),
+}
+
+impl RustType<proto_oneshot_ingestion_request::Filter> for ContentFilter {
+    fn into_proto(&self) -> proto_oneshot_ingestion_request::Filter {
+        match self {
+            ContentFilter::None => {
+                proto_oneshot_ingestion_request::Filter::None(Default::default())
+            }
+            ContentFilter::Files(files) => {
+                proto_oneshot_ingestion_request::Filter::Files(ProtoFilterFiles {
+                    files: files.clone(),
+                })
+            }
+            ContentFilter::Pattern(pattern) => {
+                proto_oneshot_ingestion_request::Filter::Pattern(ProtoFilterPattern {
+                    pattern: pattern.clone(),
+                })
+            }
+        }
+    }
+
+    fn from_proto(
+        proto: proto_oneshot_ingestion_request::Filter,
+    ) -> Result<Self, mz_proto::TryFromProtoError> {
+        match proto {
+            proto_oneshot_ingestion_request::Filter::None(()) => Ok(ContentFilter::None),
+            proto_oneshot_ingestion_request::Filter::Files(files) => {
+                Ok(ContentFilter::Files(files.files))
+            }
+            proto_oneshot_ingestion_request::Filter::Pattern(pattern) => {
+                Ok(ContentFilter::Pattern(pattern.pattern))
             }
         }
     }

--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -489,11 +489,16 @@ pub(crate) fn build_oneshot_ingestion_dataflow<A: Allocate>(
         // here, but that might run into the infamous async-Drop problem.
         let _ = results_tx.send(result);
     };
+    let connection_context = storage_state
+        .storage_configuration
+        .connection_context
+        .clone();
 
     let tokens = timely_worker.dataflow(|scope| {
         mz_storage_operators::oneshot_source::render(
             scope.clone(),
             Arc::clone(&storage_state.persist_clients),
+            connection_context,
             collection_id,
             collection_meta,
             description,


### PR DESCRIPTION
_Stacked on top of_: https://github.com/MaterializeInc/materialize/pull/30956

This PR implements a new AwsS3 `OneshotSource` that allows copying in files from S3, e.g.
```
COPY INTO my_table FROM 's3://my-test-bucket' (FORMAT CSV, FILES = ['important.csv']);
```

Along with `FILES = [<files>]` we also support a `PATTERN = <glob>` option which allows copying multiple files all at once.

### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/8860
Fixes https://github.com/MaterializeInc/database-issues/issues/8855

### Tips for reviewer

Review only the final commit, the one titled "start, implementation of an S3 oneshot source"

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
