### PR TITLE
storage: use exchange-based sequencing to broadcast internal commands

### DIFF
--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -259,7 +259,7 @@ pub trait HealthOperator {
 
 /// A default `HealthOperator` for use in normal cases.
 pub struct DefaultWriter {
-    pub command_tx: Rc<RefCell<dyn InternalCommandSender>>,
+    pub command_tx: InternalCommandSender,
     pub updates: Rc<RefCell<Vec<StatusUpdate>>>,
 }
 
@@ -293,8 +293,7 @@ impl HealthOperator for DefaultWriter {
 
     fn send_halt(&self, id: GlobalId, error: Option<(StatusNamespace, HealthStatusUpdate)>) {
         self.command_tx
-            .borrow_mut()
-            .broadcast(InternalStorageCommand::SuspendAndRestart {
+            .send(InternalStorageCommand::SuspendAndRestart {
                 // Suspend and restart is expected to operate on the primary object and
                 // not any of the sub-objects
                 id,

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -6,8 +6,10 @@
 //! Types for cluster-internal control messages that can be broadcast to all
 //! workers from individual operators/workers.
 
+use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::time::Instant;
+use std::rc::Rc;
+use std::sync::mpsc;
 
 use mz_repr::{GlobalId, Row};
 use mz_rocksdb::config::SharedWriteBufferManager;
@@ -18,8 +20,11 @@ use mz_storage_types::sinks::{MetadataFilled, StorageSinkDesc};
 use mz_storage_types::sources::IngestionDescription;
 use serde::{Deserialize, Serialize};
 use timely::communication::Allocate;
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::generic::{source, OutputHandle};
+use timely::dataflow::operators::{Broadcast, Exchange, Operator};
 use timely::progress::Antichain;
-use timely::synchronization::Sequencer;
+use timely::scheduling::{Activator, Scheduler};
 use timely::worker::Worker as TimelyWorker;
 
 use crate::statistics::{SinkStatisticsRecord, SourceStatisticsRecord};
@@ -120,31 +125,100 @@ pub enum InternalStorageCommand {
     },
 }
 
-/// Allows broadcasting [`internal commands`](InternalStorageCommand) to all
-/// workers.
-pub trait InternalCommandSender {
-    /// Broadcasts the given command to all workers.
-    fn broadcast(&mut self, internal_cmd: InternalStorageCommand);
-
-    /// Returns the next available command, if any. This returns `None` when
-    /// there are currently no commands but there might be commands again in the
-    /// future.
-    fn next(&mut self) -> Option<InternalStorageCommand>;
+/// A sender broadcasting [`InternalStorageCommand`]s to all workers.
+#[derive(Clone)]
+pub struct InternalCommandSender {
+    tx: mpsc::Sender<InternalStorageCommand>,
+    activator: Rc<RefCell<Option<Activator>>>,
 }
 
-impl InternalCommandSender for Sequencer<InternalStorageCommand> {
-    fn broadcast(&mut self, internal_cmd: InternalStorageCommand) {
-        self.push(internal_cmd);
-    }
+impl InternalCommandSender {
+    /// Broadcasts the given command to all workers.
+    pub fn send(&self, cmd: InternalStorageCommand) {
+        if self.tx.send(cmd).is_err() {
+            panic!("internal command channel disconnected");
+        }
 
-    fn next(&mut self) -> Option<InternalStorageCommand> {
-        Iterator::next(self)
+        self.activator.borrow().as_ref().map(|a| a.activate());
+    }
+}
+
+/// A receiver for [`InternalStorageCommand`]s broadcasted by workers.
+pub struct InternalCommandReceiver {
+    rx: mpsc::Receiver<InternalStorageCommand>,
+}
+
+impl InternalCommandReceiver {
+    /// Returns the next available command, if any.
+    ///
+    /// This returns `None` when there are currently no commands but there might be commands again
+    /// in the future.
+    pub fn try_recv(&self) -> Option<InternalStorageCommand> {
+        match self.rx.try_recv() {
+            Ok(cmd) => Some(cmd),
+            Err(mpsc::TryRecvError::Empty) => None,
+            Err(mpsc::TryRecvError::Disconnected) => {
+                panic!("internal command channel disconnected")
+            }
+        }
     }
 }
 
 pub(crate) fn setup_command_sequencer<'w, A: Allocate>(
     timely_worker: &'w mut TimelyWorker<A>,
-) -> Sequencer<InternalStorageCommand> {
-    // TODO(aljoscha): Use something based on `mz_ore::NowFn`?
-    Sequencer::new(timely_worker, Instant::now())
+) -> (InternalCommandSender, InternalCommandReceiver) {
+    let (input_tx, input_rx) = mpsc::channel();
+    let (output_tx, output_rx) = mpsc::channel();
+    let activator = Rc::new(RefCell::new(None));
+
+    timely_worker.dataflow_named::<(), _, _>("command_sequencer", {
+        let activator = Rc::clone(&activator);
+        move |scope| {
+            // Create a stream of commands received from `input_rx`.
+            let stream = source(scope, "command_sequencer::source", |capability, info| {
+                *activator.borrow_mut() = Some(scope.activator_for(info.address));
+
+                let mut capability = Some(capability);
+
+                move |output: &mut OutputHandle<_, _, _>| {
+                    let Some(cap) = &capability else {
+                        return;
+                    };
+
+                    let mut session = output.session(&cap);
+                    loop {
+                        match input_rx.try_recv() {
+                            Ok(cmd) => session.give(cmd),
+                            Err(mpsc::TryRecvError::Empty) => break,
+                            Err(mpsc::TryRecvError::Disconnected) => {
+                                // Drop our capability to shut down.
+                                capability = None;
+                                return;
+                            }
+                        }
+                    }
+                }
+            });
+
+            // Sequence all commands through a single worker to establish a unique order.
+            let stream = stream.exchange(|_| 0).broadcast();
+
+            // Sink the stream back into `output_tx`.
+            stream.sink(Pipeline, "command_sequencer::sink", move |input| {
+                while let Some((_cap, data)) = input.next() {
+                    for cmd in data.drain(..) {
+                        let _ = output_tx.send(cmd);
+                    }
+                }
+            });
+        }
+    });
+
+    let tx = InternalCommandSender {
+        tx: input_tx,
+        activator,
+    };
+    let rx = InternalCommandReceiver { rx: output_rx };
+
+    (tx, rx)
 }

--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -401,7 +401,7 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                 "source",
                 &health_stream,
                 crate::healthcheck::DefaultWriter {
-                    command_tx: Rc::clone(&storage_state.internal_cmd_tx),
+                    command_tx: storage_state.internal_cmd_tx.clone(),
                     updates: Rc::clone(&storage_state.object_status_updates),
                 },
                 storage_state
@@ -456,7 +456,7 @@ pub fn build_export_dataflow<A: Allocate>(
                 "sink",
                 &health_stream,
                 crate::healthcheck::DefaultWriter {
-                    command_tx: Rc::clone(&storage_state.internal_cmd_tx),
+                    command_tx: storage_state.internal_cmd_tx.clone(),
                     updates: Rc::clone(&storage_state.object_status_updates),
                 },
                 storage_state

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -9,7 +9,6 @@
 
 //! Logic related to the creation of dataflow sinks.
 
-use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -54,7 +53,7 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
         SnapshotMode::Exclude
     };
 
-    let command_tx = Rc::clone(&storage_state.internal_cmd_tx);
+    let command_tx = storage_state.internal_cmd_tx.clone();
 
     let (ok_collection, err_collection, persist_tokens) = persist_source::persist_source(
         scope,
@@ -74,8 +73,7 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
             Box::pin(async move {
                 let error = format!("storage_sink: {error}");
                 tracing::info!("{error}");
-                let mut command_tx = command_tx.borrow_mut();
-                command_tx.broadcast(InternalStorageCommand::SuspendAndRestart {
+                command_tx.send(InternalStorageCommand::SuspendAndRestart {
                     id: sink_id,
                     reason: error,
                 });


### PR DESCRIPTION
The Timely `Sequencer` doesn't behave well when different workers instantiate their parts at points in time that are sufficiently spread apart. It delays commands by that creation time difference and is prone to spinning the CPU at 100%.

To work around these issues, this PR replaces the `Sequencer` used in storage for broadcasting internal commands with a dataflow that sequences by sending all commands through a single worker.

First commit introduces a simple version of the sequencer dataflow that assumes deterministic ordering of data sent through Timely channels. The second commit removes that assumption by explicitly keeping track of the command order and waiting for outstanding commands.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8893

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
