### PR TITLE
[copy_from] Docs for `COPY (INTO)?`

### DIFF
--- a/doc/user/layouts/partials/sql-grammar/copy-from.svg
+++ b/doc/user/layouts/partials/sql-grammar/copy-from.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="569" height="255">
+<svg xmlns="http://www.w3.org/2000/svg" width="603" height="337">
    <polygon points="9 61 1 57 1 65"/>
    <polygon points="17 61 9 57 9 65"/>
    <rect x="31" y="47" width="60" height="32" rx="10"/>
@@ -9,92 +9,100 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="39" y="65">COPY</text>
-   <rect x="111" y="47" width="96" height="32"/>
-   <rect x="109" y="45" width="96" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="119" y="65">table_name</text>
-   <rect x="247" y="47" width="26" height="32" rx="10"/>
-   <rect x="245"
+   <rect x="131" y="79" width="54" height="32" rx="10"/>
+   <rect x="129"
+         y="77"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="139" y="97">INTO</text>
+   <rect x="225" y="47" width="96" height="32"/>
+   <rect x="223" y="45" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="233" y="65">table_name</text>
+   <rect x="361" y="47" width="26" height="32" rx="10"/>
+   <rect x="359"
          y="45"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="255" y="65">(</text>
-   <rect x="313" y="47" width="68" height="32"/>
-   <rect x="311" y="45" width="68" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="321" y="65">column</text>
-   <rect x="313" y="3" width="24" height="32" rx="10"/>
-   <rect x="311"
+   <text class="terminal" x="369" y="65">(</text>
+   <rect x="427" y="47" width="68" height="32"/>
+   <rect x="425" y="45" width="68" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="435" y="65">column</text>
+   <rect x="427" y="3" width="24" height="32" rx="10"/>
+   <rect x="425"
          y="1"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="321" y="21">,</text>
-   <rect x="421" y="47" width="26" height="32" rx="10"/>
-   <rect x="419"
+   <text class="terminal" x="435" y="21">,</text>
+   <rect x="535" y="47" width="26" height="32" rx="10"/>
+   <rect x="533"
          y="45"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="429" y="65">)</text>
-   <rect x="487" y="47" width="60" height="32" rx="10"/>
-   <rect x="485"
-         y="45"
+   <text class="terminal" x="543" y="65">)</text>
+   <rect x="232" y="145" width="60" height="32" rx="10"/>
+   <rect x="230"
+         y="143"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="495" y="65">FROM</text>
-   <rect x="63" y="173" width="62" height="32" rx="10"/>
-   <rect x="61"
-         y="171"
+   <text class="terminal" x="240" y="163">FROM</text>
+   <rect x="312" y="145" width="62" height="32" rx="10"/>
+   <rect x="310"
+         y="143"
          width="62"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="71" y="191">STDIN</text>
-   <rect x="185" y="205" width="58" height="32" rx="10"/>
-   <rect x="183"
-         y="203"
+   <text class="terminal" x="320" y="163">STDIN</text>
+   <rect x="219" y="287" width="58" height="32" rx="10"/>
+   <rect x="217"
+         y="285"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="193" y="223">WITH</text>
-   <rect x="283" y="173" width="26" height="32" rx="10"/>
-   <rect x="281"
-         y="171"
+   <text class="terminal" x="227" y="305">WITH</text>
+   <rect x="317" y="255" width="26" height="32" rx="10"/>
+   <rect x="315"
+         y="253"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="291" y="191">(</text>
-   <rect x="349" y="173" width="48" height="32"/>
-   <rect x="347" y="171" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="357" y="191">field</text>
-   <rect x="417" y="173" width="38" height="32"/>
-   <rect x="415" y="171" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="425" y="191">val</text>
-   <rect x="349" y="129" width="24" height="32" rx="10"/>
-   <rect x="347"
-         y="127"
+   <text class="terminal" x="325" y="273">(</text>
+   <rect x="383" y="255" width="48" height="32"/>
+   <rect x="381" y="253" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="391" y="273">field</text>
+   <rect x="451" y="255" width="38" height="32"/>
+   <rect x="449" y="253" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="459" y="273">val</text>
+   <rect x="383" y="211" width="24" height="32" rx="10"/>
+   <rect x="381"
+         y="209"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="357" y="147">,</text>
-   <rect x="495" y="173" width="26" height="32" rx="10"/>
-   <rect x="493"
-         y="171"
+   <text class="terminal" x="391" y="229">,</text>
+   <rect x="529" y="255" width="26" height="32" rx="10"/>
+   <rect x="527"
+         y="253"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="503" y="191">)</text>
+   <text class="terminal" x="537" y="273">)</text>
    <path class="line"
-         d="m17 61 h2 m0 0 h10 m60 0 h10 m0 0 h10 m96 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m68 0 h10 m-108 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m88 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-88 0 h10 m24 0 h10 m0 0 h44 m20 44 h10 m26 0 h10 m-240 0 h20 m220 0 h20 m-260 0 q10 0 10 10 m240 0 q0 -10 10 -10 m-250 10 v14 m240 0 v-14 m-240 14 q0 10 10 10 m220 0 q10 0 10 -10 m-230 10 h10 m0 0 h210 m20 -34 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-528 126 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m62 0 h10 m40 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m38 0 h10 m-146 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m126 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-126 0 h10 m24 0 h10 m0 0 h82 m20 44 h10 m26 0 h10 m-396 0 h20 m376 0 h20 m-416 0 q10 0 10 10 m396 0 q0 -10 10 -10 m-406 10 v46 m396 0 v-46 m-396 46 q0 10 10 10 m376 0 q10 0 10 -10 m-386 10 h10 m0 0 h366 m23 -66 h-3"/>
-   <polygon points="559 187 567 183 567 191"/>
-   <polygon points="559 187 551 183 551 191"/>
+         d="m17 61 h2 m0 0 h10 m60 0 h10 m20 0 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m20 -32 h10 m96 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m68 0 h10 m-108 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m88 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-88 0 h10 m24 0 h10 m0 0 h44 m20 44 h10 m26 0 h10 m-240 0 h20 m220 0 h20 m-260 0 q10 0 10 10 m240 0 q0 -10 10 -10 m-250 10 v14 m240 0 v-14 m-240 14 q0 10 10 10 m220 0 q10 0 10 -10 m-230 10 h10 m0 0 h210 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-393 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m60 0 h10 m0 0 h10 m62 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-239 110 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m38 0 h10 m-146 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m126 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-126 0 h10 m24 0 h10 m0 0 h82 m20 44 h10 m26 0 h10 m-396 0 h20 m376 0 h20 m-416 0 q10 0 10 10 m396 0 q0 -10 10 -10 m-406 10 v46 m396 0 v-46 m-396 46 q0 10 10 10 m376 0 q10 0 10 -10 m-386 10 h10 m0 0 h366 m23 -66 h-3"/>
+   <polygon points="593 269 601 265 601 273"/>
+   <polygon points="593 269 585 265 585 273"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -96,7 +96,7 @@ copy_to_s3 ::=
   'COPY' ( query | object_name ) 'TO' s3_uri
   '(' 'WITH' 'AWS CONNECTION' connection_name ',' 'FORMAT' ( csv | parquet ) ( ',' field val )* ')'
 copy_from ::=
-  'COPY' table_name ('(' column ( ',' column )* ')')? 'FROM' 'STDIN'
+  'COPY' 'INTO'? table_name ('(' column ( ',' column )* ')')? 'FROM' 'STDIN'
   ( 'WITH'? '(' field val ( ',' field val )* ')' )?
 create_cluster ::=
   'CREATE' 'CLUSTER' name (


### PR DESCRIPTION
In https://github.com/MaterializeInc/materialize/pull/30959 we added support for the optional `INTO` keyword, e.g. `COPY INTO <table> FROM ...`

### Motivation

Update docs for existing feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
