### PR TITLE
[storage] Minor controller cleanups and refactoring

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1289,11 +1289,6 @@ impl Coordinator {
         // Validate `sink.from` is in fact a storage collection
         self.controller.storage.check_exists(sink.from)?;
 
-        let status_id = self
-            .catalog()
-            .resolve_builtin_storage_collection(&mz_catalog::builtin::MZ_SINK_STATUS_HISTORY);
-        let status_id = Some(self.catalog().get_entry(&status_id).latest_global_id());
-
         // The AsOf is used to determine at what time to snapshot reading from
         // the persist collection.  This is primarily relevant when we do _not_
         // want to include the snapshot in the sink.
@@ -1334,7 +1329,6 @@ impl Coordinator {
             as_of,
             with_snapshot: sink.with_snapshot,
             version: sink.version,
-            status_id,
             from_storage_metadata: (),
         };
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3559,11 +3559,6 @@ impl Coordinator {
             }
         }
 
-        let status_id = self
-            .catalog()
-            .resolve_builtin_storage_collection(&mz_catalog::builtin::MZ_SINK_STATUS_HISTORY);
-        let status_id = Some(self.catalog().get_entry(&status_id).latest_global_id());
-
         let from_entry = self.catalog().get_entry_by_global_id(&sink.from);
         let storage_sink_desc = StorageSinkDesc {
             from: sink.from,
@@ -3580,7 +3575,6 @@ impl Coordinator {
             with_snapshot,
             version: sink.version,
             partition_strategy: sink.partition_strategy,
-            status_id,
             from_storage_metadata: (),
         };
 

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -30,7 +30,7 @@ use mz_service::grpc::{GrpcClient, GrpcServer, ProtoServiceTypes, ResponseStream
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::oneshot_sources::OneshotIngestionRequest;
 use mz_storage_types::parameters::StorageParameters;
-use mz_storage_types::sinks::{MetadataFilled, StorageSinkDesc};
+use mz_storage_types::sinks::StorageSinkDesc;
 use mz_storage_types::sources::IngestionDescription;
 use mz_timely_util::progress::any_antichain;
 use proptest::prelude::{any, Arbitrary};
@@ -260,7 +260,7 @@ impl RustType<ProtoRunSinkCommand> for RunSinkCommand<mz_repr::Timestamp> {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct RunSinkCommand<T> {
     pub id: GlobalId,
-    pub description: StorageSinkDesc<MetadataFilled, T>,
+    pub description: StorageSinkDesc<CollectionMetadata, T>,
 }
 
 impl Arbitrary for RunSinkCommand<mz_repr::Timestamp> {
@@ -270,7 +270,7 @@ impl Arbitrary for RunSinkCommand<mz_repr::Timestamp> {
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         (
             any::<GlobalId>(),
-            any::<StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>>(),
+            any::<StorageSinkDesc<CollectionMetadata, mz_repr::Timestamp>>(),
         )
             .prop_map(|(id, description)| Self { id, description })
             .boxed()

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -41,7 +41,7 @@ use mz_storage_types::oneshot_sources::{OneshotIngestionRequest, OneshotResultCa
 use mz_storage_types::parameters::StorageParameters;
 use mz_storage_types::read_holds::ReadHold;
 use mz_storage_types::read_policy::ReadPolicy;
-use mz_storage_types::sinks::{MetadataUnfilled, StorageSinkConnection, StorageSinkDesc};
+use mz_storage_types::sinks::{StorageSinkConnection, StorageSinkDesc};
 use mz_storage_types::sources::{
     GenericSourceConnection, IngestionDescription, SourceDesc, SourceExportDataConfig,
     SourceExportDetails, Timeline,
@@ -157,7 +157,7 @@ impl<T> CollectionDescription<T> {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExportDescription<T = mz_repr::Timestamp> {
-    pub sink: StorageSinkDesc<MetadataUnfilled, T>,
+    pub sink: StorageSinkDesc<(), T>,
     /// The ID of the instance in which to install the export.
     pub instance_id: StorageInstanceId,
 }

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -228,22 +228,6 @@ pub trait StorageCollections: Debug {
     /// but hold off on that initially.) Callers must provide a Some if any of
     /// the collections is a table. A None may be given if none of the
     /// collections are a table (i.e. all materialized views, sources, etc).
-    async fn create_collections(
-        &self,
-        storage_metadata: &StorageMetadata,
-        register_ts: Option<Self::Timestamp>,
-        collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
-        self.create_collections_for_bootstrap(
-            storage_metadata,
-            register_ts,
-            collections,
-            &BTreeSet::new(),
-        )
-        .await
-    }
-
-    /// Like [`Self::create_collections`], except used specifically for bootstrap.
     ///
     /// `migrated_storage_collections` is a set of migrated storage collections to be excluded
     /// from the txn-wal sub-system.
@@ -467,7 +451,7 @@ where
     /// reconcile it with the previous state using
     /// [StorageCollections::initialize_state],
     /// [StorageCollections::prepare_state], and
-    /// [StorageCollections::create_collections].
+    /// [StorageCollections::create_collections_for_bootstrap].
     pub async fn new(
         persist_location: PersistLocation,
         persist_clients: Arc<PersistClientCache>,

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1545,7 +1545,7 @@ where
                 snapshot
                     .into_iter()
                     .map(|(row, diff)| {
-                        assert!(diff == 1, "snapshot doesn't accumulate to set");
+                        assert_eq!(diff, 1, "snapshot doesn't accumulate to set");
                         row
                     })
                     .collect()

--- a/src/storage-controller/src/history.rs
+++ b/src/storage-controller/src/history.rs
@@ -238,8 +238,8 @@ mod tests {
     use mz_storage_types::instances::StorageInstanceId;
     use mz_storage_types::sinks::{
         KafkaIdStyle, KafkaSinkCompressionType, KafkaSinkConnection, KafkaSinkFormat,
-        KafkaSinkFormatType, MetadataFilled, SinkEnvelope, SinkPartitionStrategy,
-        StorageSinkConnection, StorageSinkDesc,
+        KafkaSinkFormatType, SinkEnvelope, SinkPartitionStrategy, StorageSinkConnection,
+        StorageSinkDesc,
     };
     use mz_storage_types::sources::load_generator::{
         LoadGenerator, LoadGeneratorOutput, LoadGeneratorSourceExportDetails,
@@ -342,7 +342,7 @@ mod tests {
         }
     }
 
-    fn sink_description() -> StorageSinkDesc<MetadataFilled, u64> {
+    fn sink_description() -> StorageSinkDesc<CollectionMetadata, u64> {
         StorageSinkDesc {
             from: GlobalId::System(1),
             from_desc: RelationDesc::new(

--- a/src/storage-controller/src/history.rs
+++ b/src/storage-controller/src/history.rs
@@ -390,7 +390,6 @@ mod tests {
             version: Default::default(),
             envelope: SinkEnvelope::Upsert,
             as_of: Antichain::from_elem(0),
-            status_id: Default::default(),
             from_storage_metadata: CollectionMetadata {
                 persist_location: PersistLocation {
                     blob_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1468,11 +1468,6 @@ where
         };
         *cur_export = new_export;
 
-        let status_id = match new_description.sink.status_id.clone() {
-            Some(id) => Some(self.storage_collections.collection_metadata(id)?.data_shard),
-            None => None,
-        };
-
         let cmd = RunSinkCommand {
             id,
             description: StorageSinkDesc {
@@ -1483,7 +1478,6 @@ where
                 as_of: new_description.sink.as_of,
                 version: new_description.sink.version,
                 partition_strategy: new_description.sink.partition_strategy,
-                status_id,
                 from_storage_metadata,
                 with_snapshot: new_description.sink.with_snapshot,
             },
@@ -1536,17 +1530,6 @@ where
                 .storage_collections
                 .collection_metadata(new_export_description.sink.from)?;
 
-            let status_id =
-                if let Some(status_collection_id) = new_export_description.sink.status_id {
-                    Some(
-                        self.storage_collections
-                            .collection_metadata(status_collection_id)?
-                            .data_shard,
-                    )
-                } else {
-                    None
-                };
-
             let cmd = RunSinkCommand {
                 id,
                 description: StorageSinkDesc {
@@ -1568,7 +1551,6 @@ where
                     // read holds are held for the correct amount of time.
                     // TODO(petrosagg): change the controller to explicitly track dataflow executions
                     as_of: as_of.to_owned(),
-                    status_id,
                     from_storage_metadata,
                 },
             };
@@ -3176,16 +3158,6 @@ where
             .storage_collections
             .collection_metadata(description.sink.from)?;
 
-        let status_id = if let Some(status_collection_id) = description.sink.status_id {
-            Some(
-                self.storage_collections
-                    .collection_metadata(status_collection_id)?
-                    .data_shard,
-            )
-        } else {
-            None
-        };
-
         let cmd = RunSinkCommand {
             id,
             description: StorageSinkDesc {
@@ -3196,7 +3168,6 @@ where
                 as_of: description.sink.as_of.clone(),
                 version: description.sink.version,
                 partition_strategy: description.sink.partition_strategy.clone(),
-                status_id,
                 from_storage_metadata,
                 with_snapshot: description.sink.with_snapshot,
             },

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1489,7 +1489,7 @@ where
             },
         };
 
-        // Fetch the client for this exports's cluster.
+        // Fetch the client for this export's cluster.
         let instance = self
             .instances
             .get_mut(&new_description.instance_id)

--- a/src/storage-types/src/sinks.proto
+++ b/src/storage-types/src/sinks.proto
@@ -23,13 +23,12 @@ import "storage-types/src/connections.proto";
 import "storage-types/src/controller.proto";
 
 message ProtoStorageSinkDesc {
-  reserved 5, 8, 9, 10;
+  reserved 5, 7, 8, 9, 10;
   mz_repr.global_id.ProtoGlobalId from = 1;
   mz_repr.relation_and_scalar.ProtoRelationDesc from_desc = 2;
   ProtoStorageSinkConnection connection = 3;
   optional ProtoSinkEnvelope envelope = 4;
   optional mz_storage_types.controller.ProtoCollectionMetadata from_storage_metadata = 6;
-  optional string status_id = 7;
   mz_repr.antichain.ProtoU64Antichain as_of = 11;
   bool with_snapshot = 12;
   uint64 version = 13;

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -49,7 +49,6 @@ pub struct StorageSinkDesc<S: StorageSinkDescFillState, T = mz_repr::Timestamp> 
     pub version: u64,
     pub envelope: SinkEnvelope,
     pub as_of: Antichain<T>,
-    pub status_id: Option<<S as StorageSinkDescFillState>::StatusId>,
     pub from_storage_metadata: <S as StorageSinkDescFillState>::StorageMetadata,
 }
 
@@ -79,7 +78,6 @@ impl<S: Debug + StorageSinkDescFillState + PartialEq, T: Debug + PartialEq + Par
             version: _,
             // The as of of the descriptions may differ.
             as_of: _,
-            status_id,
             from_storage_metadata,
             partition_strategy,
             with_snapshot,
@@ -93,7 +91,6 @@ impl<S: Debug + StorageSinkDescFillState + PartialEq, T: Debug + PartialEq + Par
                 "connection",
             ),
             (envelope == &other.envelope, "envelope"),
-            (status_id == &other.status_id, "status_id"),
             (with_snapshot == &other.with_snapshot, "with_snapshot"),
             (
                 partition_strategy == &other.partition_strategy,
@@ -151,7 +148,6 @@ impl Arbitrary for StorageSinkDesc<MetadataFilled, mz_repr::Timestamp> {
             any::<StorageSinkConnection>(),
             any::<SinkEnvelope>(),
             any::<Option<mz_repr::Timestamp>>(),
-            any::<Option<ShardId>>(),
             any::<CollectionMetadata>(),
             any::<SinkPartitionStrategy>(),
             any::<bool>(),
@@ -164,7 +160,6 @@ impl Arbitrary for StorageSinkDesc<MetadataFilled, mz_repr::Timestamp> {
                     connection,
                     envelope,
                     as_of,
-                    status_id,
                     from_storage_metadata,
                     partition_strategy,
                     with_snapshot,
@@ -177,7 +172,6 @@ impl Arbitrary for StorageSinkDesc<MetadataFilled, mz_repr::Timestamp> {
                         envelope,
                         version,
                         as_of: Antichain::from_iter(as_of),
-                        status_id,
                         from_storage_metadata,
                         partition_strategy,
                         with_snapshot,
@@ -196,7 +190,6 @@ impl RustType<ProtoStorageSinkDesc> for StorageSinkDesc<MetadataFilled, mz_repr:
             from_desc: Some(self.from_desc.into_proto()),
             envelope: Some(self.envelope.into_proto()),
             as_of: Some(self.as_of.into_proto()),
-            status_id: self.status_id.into_proto(),
             from_storage_metadata: Some(self.from_storage_metadata.into_proto()),
             partition_strategy: Some(self.partition_strategy.into_proto()),
             with_snapshot: self.with_snapshot,
@@ -219,7 +212,6 @@ impl RustType<ProtoStorageSinkDesc> for StorageSinkDesc<MetadataFilled, mz_repr:
             as_of: proto
                 .as_of
                 .into_rust_if_some("ProtoStorageSinkDesc::as_of")?,
-            status_id: proto.status_id.into_rust()?,
             from_storage_metadata: proto
                 .from_storage_metadata
                 .into_rust_if_some("ProtoStorageSinkDesc::from_storage_metadata")?,

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -14,7 +14,7 @@ use mz_rocksdb::config::SharedWriteBufferManager;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::oneshot_sources::OneshotIngestionRequest;
 use mz_storage_types::parameters::StorageParameters;
-use mz_storage_types::sinks::{MetadataFilled, StorageSinkDesc};
+use mz_storage_types::sinks::StorageSinkDesc;
 use mz_storage_types::sources::IngestionDescription;
 use serde::{Deserialize, Serialize};
 use timely::communication::Allocate;
@@ -98,7 +98,7 @@ pub enum InternalStorageCommand {
     /// Render a sink dataflow.
     RunSinkDataflow(
         GlobalId,
-        StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>,
+        StorageSinkDesc<CollectionMetadata, mz_repr::Timestamp>,
     ),
     /// Drop all state and operators for a dataflow. This is a vec because some
     /// dataflows have their state spread over multiple IDs (i.e. sources that

--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -206,7 +206,7 @@ use mz_repr::{GlobalId, Row};
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::dyncfgs;
 use mz_storage_types::oneshot_sources::{OneshotIngestionDescription, OneshotIngestionRequest};
-use mz_storage_types::sinks::{MetadataFilled, StorageSinkDesc};
+use mz_storage_types::sinks::StorageSinkDesc;
 use mz_storage_types::sources::{GenericSourceConnection, IngestionDescription, SourceConnection};
 use mz_timely_util::antichain::AntichainExt;
 use timely::communication::Allocate;
@@ -425,7 +425,7 @@ pub fn build_export_dataflow<A: Allocate>(
     timely_worker: &mut TimelyWorker<A>,
     storage_state: &mut StorageState,
     id: GlobalId,
-    description: StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>,
+    description: StorageSinkDesc<CollectionMetadata, mz_repr::Timestamp>,
 ) {
     let worker_logging = timely_worker.log_register().get("timely").map(Into::into);
     let debug_name = id.to_string();

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -23,8 +23,9 @@ use mz_interchange::envelopes::combine_at_timestamp;
 use mz_persist_client::operators::shard_source::SnapshotMode;
 use mz_repr::{Datum, Diff, GlobalId, Row, Timestamp};
 use mz_storage_operators::persist_source;
+use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
-use mz_storage_types::sinks::{MetadataFilled, StorageSinkConnection, StorageSinkDesc};
+use mz_storage_types::sinks::{StorageSinkConnection, StorageSinkDesc};
 use mz_timely_util::builder_async::PressOnDropButton;
 use timely::dataflow::operators::Leave;
 use timely::dataflow::scopes::Child;
@@ -42,7 +43,7 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
     scope: &mut Child<'g, G, mz_repr::Timestamp>,
     storage_state: &mut StorageState,
     sink_id: GlobalId,
-    sink: &StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>,
+    sink: &StorageSinkDesc<CollectionMetadata, mz_repr::Timestamp>,
 ) -> (Stream<G, HealthStatusMessage>, Vec<PressOnDropButton>) {
     let sink_render = get_sink_render_for(&sink.connection);
 
@@ -104,7 +105,7 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
 /// `DiffPair`s.
 fn zip_into_diff_pairs<G>(
     sink_id: GlobalId,
-    sink: &StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>,
+    sink: &StorageSinkDesc<CollectionMetadata, mz_repr::Timestamp>,
     sink_render: &dyn SinkRender<G>,
     collection: Collection<G, Row, Diff>,
 ) -> Collection<G, (Option<Row>, DiffPair<Row>), Diff>
@@ -211,7 +212,7 @@ where
     fn render_sink(
         &self,
         storage_state: &mut StorageState,
-        sink: &StorageSinkDesc<MetadataFilled, Timestamp>,
+        sink: &StorageSinkDesc<CollectionMetadata, Timestamp>,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, DiffPair<Row>), Diff>,
         err_collection: Collection<G, DataflowError, Diff>,

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -101,11 +101,11 @@ use mz_ore::vec::VecExt;
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row, RowArena, Timestamp};
 use mz_storage_client::sink::progress_key::ProgressKey;
 use mz_storage_types::configuration::StorageConfiguration;
+use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::dyncfgs::KAFKA_BUFFERED_EVENT_RESIZE_THRESHOLD_ELEMENTS;
 use mz_storage_types::errors::{ContextCreationError, ContextCreationErrorExt, DataflowError};
 use mz_storage_types::sinks::{
-    KafkaSinkConnection, KafkaSinkFormatType, MetadataFilled, SinkEnvelope, SinkPartitionStrategy,
-    StorageSinkDesc,
+    KafkaSinkConnection, KafkaSinkFormatType, SinkEnvelope, SinkPartitionStrategy, StorageSinkDesc,
 };
 use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::builder_async::{
@@ -147,7 +147,7 @@ impl<G: Scope<Timestamp = Timestamp>> SinkRender<G> for KafkaSinkConnection {
     fn render_sink(
         &self,
         storage_state: &mut StorageState,
-        sink: &StorageSinkDesc<MetadataFilled, Timestamp>,
+        sink: &StorageSinkDesc<CollectionMetadata, Timestamp>,
         sink_id: GlobalId,
         input: Collection<G, (Option<Row>, DiffPair<Row>), Diff>,
         // TODO(benesch): errors should stream out through the sink,
@@ -615,7 +615,7 @@ fn sink_collection<G: Scope<Timestamp = Timestamp>>(
     connection: KafkaSinkConnection,
     partition_strategy: SinkPartitionStrategy,
     storage_configuration: StorageConfiguration,
-    sink: &StorageSinkDesc<MetadataFilled, Timestamp>,
+    sink: &StorageSinkDesc<CollectionMetadata, Timestamp>,
     metrics: KafkaSinkMetrics,
     statistics: SinkStatistics,
     write_frontier: Rc<RefCell<Antichain<Timestamp>>>,

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -97,7 +97,7 @@ use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::oneshot_sources::OneshotIngestionDescription;
-use mz_storage_types::sinks::{MetadataFilled, StorageSinkDesc};
+use mz_storage_types::sinks::StorageSinkDesc;
 use mz_storage_types::sources::IngestionDescription;
 use mz_storage_types::AlterCompatible;
 use mz_timely_util::builder_async::PressOnDropButton;
@@ -276,7 +276,7 @@ pub struct StorageState {
     /// Descriptions of each installed ingestion.
     pub ingestions: BTreeMap<GlobalId, IngestionDescription<CollectionMetadata>>,
     /// Descriptions of each installed export.
-    pub exports: BTreeMap<GlobalId, StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>>,
+    pub exports: BTreeMap<GlobalId, StorageSinkDesc<CollectionMetadata, mz_repr::Timestamp>>,
     /// Descriptions of oneshot ingestions that are currently running.
     pub oneshot_ingestions: BTreeMap<uuid::Uuid, OneshotIngestionDescription<ProtoBatch>>,
     /// Undocumented


### PR DESCRIPTION
Some minor drive-by as I've been reading through the storage controller.

### Motivation

The first commit is inspired by a recent incident: we saw a bunch of Persist memory on the stack of an environment, some of which was allocated by this warmup code. Far from a smoking gun... but in general it feels wise to not attempt unbounded concurrent work, especially for an optimization like this one.

The others are hopefully self-explanatory, but let me know if anything seems odd!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
