### PR TITLE
allow disabling workspace-hack in ore-build

### DIFF
--- a/src/ore-build/BUILD.bazel
+++ b/src/ore-build/BUILD.bazel
@@ -22,7 +22,7 @@ rust_library(
         proc_macro = True,
     ),
     compile_data = [],
-    crate_features = [],
+    crate_features = ["default"],
     data = [],
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
@@ -47,7 +47,7 @@ rust_test(
     ),
     compile_data = [],
     crate = ":mz_ore_build",
-    crate_features = [],
+    crate_features = ["default"],
     data = [],
     env = {},
     proc_macro_deps = [] + all_crate_deps(

--- a/src/ore-build/Cargo.toml
+++ b/src/ore-build/Cargo.toml
@@ -11,7 +11,10 @@ authors = ["Materialize, Inc."]
 workspace = true
 
 [dependencies]
-workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
+
+[features]
+default = ["workspace-hack"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]


### PR DESCRIPTION
### Motivation

the cloud repo is failing to build

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
