### PR TITLE
[storage] Add a progress shard for sinks and skip the snapshot when possible

### DIFF
--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -1058,8 +1058,10 @@ impl Catalog {
                     CatalogItem::ContinualTask(ct) => {
                         storage_collections_to_create.insert(ct.global_id());
                     }
+                    CatalogItem::Sink(sink) => {
+                        storage_collections_to_create.insert(sink.global_id());
+                    }
                     CatalogItem::Log(_)
-                    | CatalogItem::Sink(_)
                     | CatalogItem::View(_)
                     | CatalogItem::Index(_)
                     | CatalogItem::Type(_)

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2735,6 +2735,14 @@ impl Coordinator {
                     }
                 }
                 CatalogItem::Sink(sink) => {
+                    let storage_sink_from_entry = self.catalog().get_entry_by_global_id(&sink.from);
+                    let from_desc = storage_sink_from_entry
+                        .desc(&self.catalog().resolve_full_name(
+                            storage_sink_from_entry.name(),
+                            storage_sink_from_entry.conn_id(),
+                        ))
+                        .expect("sinks can only be built on items with descs")
+                        .into_owned();
                     let collection_desc = CollectionDescription {
                         // TODO(sinks): make generic once we have more than one sink type.
                         desc: KAFKA_PROGRESS_DESC.clone(),
@@ -2742,7 +2750,7 @@ impl Coordinator {
                             desc: ExportDescription {
                                 sink: StorageSinkDesc {
                                     from: sink.from,
-                                    from_desc: KAFKA_PROGRESS_DESC.clone(),
+                                    from_desc,
                                     connection: sink
                                         .connection
                                         .clone()

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -152,6 +152,7 @@ use mz_storage_types::connections::Connection as StorageConnection;
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::read_holds::ReadHold;
 use mz_storage_types::sinks::S3SinkFormat;
+use mz_storage_types::sources::kafka::KAFKA_PROGRESS_DESC;
 use mz_storage_types::sources::Timeline;
 use mz_timestamp_oracle::postgres_oracle::{
     PostgresTimestampOracle, PostgresTimestampOracleConfig,
@@ -2733,7 +2734,8 @@ impl Coordinator {
                 }
                 CatalogItem::Sink(sink) => {
                     let collection_desc = CollectionDescription {
-                        desc: RelationDesc::empty(),
+                        // TODO(sinks): make generic once we have more than one sink type.
+                        desc: KAFKA_PROGRESS_DESC.clone(),
                         data_source: DataSource::Other,
                         since: None,
                         status_collection_id: None,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2731,6 +2731,16 @@ impl Coordinator {
                         collections.push((ct.global_id(), collection_desc));
                     }
                 }
+                CatalogItem::Sink(sink) => {
+                    let collection_desc = CollectionDescription {
+                        desc: RelationDesc::empty(),
+                        data_source: DataSource::Other,
+                        since: None,
+                        status_collection_id: None,
+                        timeline: None,
+                    };
+                    collections.push((sink.global_id, collection_desc));
+                }
                 _ => (),
             }
         }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1330,6 +1330,7 @@ impl Coordinator {
             with_snapshot: sink.with_snapshot,
             version: sink.version,
             from_storage_metadata: (),
+            to_storage_metadata: (),
         };
 
         let res = self

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1320,7 +1320,7 @@ impl Coordinator {
                     storage_sink_from_entry.name(),
                     storage_sink_from_entry.conn_id(),
                 ))
-                .expect("indexes can only be built on items with descs")
+                .expect("sinks can only be built on items with descs")
                 .into_owned(),
             connection: sink
                 .connection

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3444,7 +3444,7 @@ impl Coordinator {
         ctx: ExecuteContext,
         plan: plan::AlterSinkPlan,
     ) {
-        // 1. Put a read hold on the new relation
+        // Put a read hold on the new relation
         let id_bundle = crate::CollectionIdBundle {
             storage_ids: BTreeSet::from_iter([plan.sink.from]),
             compute_ids: BTreeMap::new(),

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3576,6 +3576,7 @@ impl Coordinator {
             version: sink.version,
             partition_strategy: sink.partition_strategy,
             from_storage_metadata: (),
+            to_storage_metadata: (),
         };
 
         self.controller

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -373,7 +373,7 @@ impl<T> ShouldTerminateGracefully for StorageError<T> {
             | StorageError::ReadBeforeSince(_)
             | StorageError::InvalidUppers(_)
             | StorageError::InvalidUsage(_)
-            | StorageError::SourceIdReused(_)
+            | StorageError::CollectionIdReused(_)
             | StorageError::SinkIdReused(_)
             | StorageError::IdentifierMissing(_)
             | StorageError::IdentifierInvalid(_)

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -1614,9 +1614,9 @@ impl CatalogItem {
             CatalogItem::Table(_)
             | CatalogItem::Source(_)
             | CatalogItem::MaterializedView(_)
+            | CatalogItem::Sink(_)
             | CatalogItem::ContinualTask(_) => true,
             CatalogItem::Log(_)
-            | CatalogItem::Sink(_)
             | CatalogItem::View(_)
             | CatalogItem::Index(_)
             | CatalogItem::Type(_)

--- a/src/storage-controller/src/history.rs
+++ b/src/storage-controller/src/history.rs
@@ -406,6 +406,22 @@ mod tests {
                 ),
                 txns_shard: Default::default(),
             },
+            to_storage_metadata: CollectionMetadata {
+                persist_location: PersistLocation {
+                    blob_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
+                    consensus_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
+                },
+                remap_shard: Default::default(),
+                data_shard: Default::default(),
+                relation_desc: RelationDesc::new(
+                    RelationType {
+                        column_types: Default::default(),
+                        keys: Default::default(),
+                    },
+                    Vec::<String>::new(),
+                ),
+                txns_shard: Default::default(),
+            },
         }
     }
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1440,6 +1440,7 @@ where
             .expect("missing dependency")
             .into_element();
         let from_storage_metadata = self.storage_collections.collection_metadata(from_id)?;
+        let to_storage_metadata = self.storage_collections.collection_metadata(id)?;
 
         // Check whether the sink's write frontier is beyond the read hold we got
         let cur_export = self
@@ -1480,6 +1481,7 @@ where
                 partition_strategy: new_description.sink.partition_strategy,
                 from_storage_metadata,
                 with_snapshot: new_description.sink.with_snapshot,
+                to_storage_metadata,
             },
         };
 
@@ -1529,6 +1531,7 @@ where
             let from_storage_metadata = self
                 .storage_collections
                 .collection_metadata(new_export_description.sink.from)?;
+            let to_storage_metadata = self.storage_collections.collection_metadata(id)?;
 
             let cmd = RunSinkCommand {
                 id,
@@ -1552,6 +1555,7 @@ where
                     // TODO(petrosagg): change the controller to explicitly track dataflow executions
                     as_of: as_of.to_owned(),
                     from_storage_metadata,
+                    to_storage_metadata,
                 },
             };
 
@@ -3155,6 +3159,7 @@ where
         let from_storage_metadata = self
             .storage_collections
             .collection_metadata(description.sink.from)?;
+        let to_storage_metadata = self.storage_collections.collection_metadata(id)?;
 
         let cmd = RunSinkCommand {
             id,
@@ -3168,6 +3173,7 @@ where
                 partition_strategy: description.sink.partition_strategy.clone(),
                 from_storage_metadata,
                 with_snapshot: description.sink.with_snapshot,
+                to_storage_metadata,
             },
         };
 

--- a/src/storage-types/src/controller.rs
+++ b/src/storage-types/src/controller.rs
@@ -154,7 +154,7 @@ impl RustType<ProtoDurableCollectionMetadata> for DurableCollectionMetadata {
 pub enum StorageError<T> {
     /// The source identifier was re-created after having been dropped,
     /// or installed with a different description.
-    SourceIdReused(GlobalId),
+    CollectionIdReused(GlobalId),
     /// The sink identifier was re-created after having been dropped, or
     /// installed with a different description.
     SinkIdReused(GlobalId),
@@ -228,7 +228,7 @@ pub enum StorageError<T> {
 impl<T: Debug + Display + 'static> Error for StorageError<T> {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            Self::SourceIdReused(_) => None,
+            Self::CollectionIdReused(_) => None,
             Self::SinkIdReused(_) => None,
             Self::IdentifierMissing(_) => None,
             Self::IdentifierInvalid(_) => None,
@@ -260,7 +260,7 @@ impl<T: fmt::Display + 'static> fmt::Display for StorageError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("storage error: ")?;
         match self {
-            Self::SourceIdReused(id) => write!(
+            Self::CollectionIdReused(id) => write!(
                 f,
                 "source identifier was re-created after having been dropped: {id}"
             ),

--- a/src/storage-types/src/sinks.proto
+++ b/src/storage-types/src/sinks.proto
@@ -29,6 +29,7 @@ message ProtoStorageSinkDesc {
   ProtoStorageSinkConnection connection = 3;
   optional ProtoSinkEnvelope envelope = 4;
   optional mz_storage_types.controller.ProtoCollectionMetadata from_storage_metadata = 6;
+  optional mz_storage_types.controller.ProtoCollectionMetadata to_storage_metadata = 15;
   mz_repr.antichain.ProtoU64Antichain as_of = 11;
   bool with_snapshot = 12;
   uint64 version = 13;

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -92,7 +92,9 @@ impl<S: Debug + PartialEq, T: Debug + PartialEq + PartialOrder> AlterCompatible
                 "connection",
             ),
             (envelope == &other.envelope, "envelope"),
-            (with_snapshot == &other.with_snapshot, "with_snapshot"),
+            // This can legally change from true to false once the snapshot has been
+            // written out.
+            (*with_snapshot || !other.with_snapshot, "with_snapshot"),
             (
                 partition_strategy == &other.partition_strategy,
                 "partition_strategy",

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -76,7 +76,7 @@ impl<S: Debug + PartialEq, T: Debug + PartialEq + PartialOrder> AlterCompatible
             connection,
             envelope,
             version: _,
-            // The as of of the descriptions may differ.
+            // The as-of of the descriptions may differ.
             as_of: _,
             from_storage_metadata,
             partition_strategy,

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1001,7 +1001,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         if let Some(prev_export) = prev {
                             prev_export
                                 .alter_compatible(export.id, &export.description)
-                                .expect("only alter compatible ingestions permitted");
+                                .expect("only alter compatible exports permitted");
                         }
                     }
                 }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -5143,12 +5143,12 @@ def workflow_test_constant_sink(c: Composition) -> None:
                 > SELECT write_frontier
                   FROM mz_internal.mz_frontiers
                   JOIN mz_sinks ON id = object_id
-                  WHERE name = 'snk'
+                  WHERE name = 'snk' AND write_frontier IS NOT NULL
 
                 > SELECT status
                   FROM mz_internal.mz_sink_statuses
                   WHERE name = 'snk'
-                dropped
+                running
                 """
             )
         )
@@ -5162,12 +5162,12 @@ def workflow_test_constant_sink(c: Composition) -> None:
                 > SELECT write_frontier
                   FROM mz_internal.mz_frontiers
                   JOIN mz_sinks ON id = object_id
-                  WHERE name = 'snk'
+                  WHERE name = 'snk' AND write_frontier IS NOT NULL
 
                 > SELECT status
                   FROM mz_internal.mz_sink_statuses
                   WHERE name = 'snk'
-                dropped
+                running
                 """
             )
         )

--- a/test/testdrive-old-kafka-src-syntax/controller-frontiers.td
+++ b/test/testdrive-old-kafka-src-syntax/controller-frontiers.td
@@ -156,7 +156,7 @@ sink1 s1
     ON frontiers.object_id = sinks.id
   WHERE
     frontiers.object_id LIKE 'u%' AND
-    frontiers.read_frontier IS NULL AND
+    frontiers.read_frontier != 0 AND
     frontiers.write_frontier > 0
 sink1
 

--- a/test/testdrive-old-kafka-src-syntax/controller-frontiers.td
+++ b/test/testdrive-old-kafka-src-syntax/controller-frontiers.td
@@ -156,7 +156,7 @@ sink1 s1
     ON frontiers.object_id = sinks.id
   WHERE
     frontiers.object_id LIKE 'u%' AND
-    frontiers.read_frontier != 0 AND
+    (frontiers.read_frontier > 0 OR frontiers.read_frontier IS NULL) AND
     frontiers.write_frontier > 0
 sink1
 

--- a/test/testdrive/controller-frontiers.td
+++ b/test/testdrive/controller-frontiers.td
@@ -186,7 +186,7 @@ sink1 s1
     ON frontiers.object_id = sinks.id
   WHERE
     frontiers.object_id LIKE 'u%' AND
-    frontiers.read_frontier IS NULL AND
+    frontiers.read_frontier != 0 AND
     frontiers.write_frontier > 0
 sink1
 

--- a/test/testdrive/controller-frontiers.td
+++ b/test/testdrive/controller-frontiers.td
@@ -186,7 +186,7 @@ sink1 s1
     ON frontiers.object_id = sinks.id
   WHERE
     frontiers.object_id LIKE 'u%' AND
-    frontiers.read_frontier != 0 AND
+    (frontiers.read_frontier > 0 OR frontiers.read_frontier IS NULL) AND
     frontiers.write_frontier > 0
 sink1
 


### PR DESCRIPTION
### Motivation

Design sketch is here: https://github.com/MaterializeInc/database-issues/issues/8603#issuecomment-2611104841

Fixes https://github.com/MaterializeInc/database-issues/issues/8603

### Tips for reviewer

Adding a collection for sinks makes them much more like other types of things that the storage controller manages, which allows (and forces) us to handle them as a type of collection instead of a separate thing. Reworking this is much of the size of the diff - though the net result is slightly less / more uniform controller code, which is nice.

I've left a number of `// TODO(sinks)` todos for possible followups that I didn't want to bite off here.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
