### PR TITLE
Consolidate produces batch of data

### DIFF
--- a/src/compute/src/logging.rs
+++ b/src/compute/src/logging.rs
@@ -236,7 +236,7 @@ where
     CB: ContainerBuilder,
     L: Into<LogVariant>,
     F: for<'a> FnMut(
-            <B::Output as Container>::Item<'a>,
+            <B::Output as Container>::ItemRef<'a>,
             &mut PermutedRowPacker,
             &mut OutputSession<CB>,
         ) + 'static,
@@ -251,7 +251,7 @@ where
         move |input, output| {
             while let Some((time, data)) = input.next() {
                 let mut session = output.session_with_builder(&time);
-                for item in data.drain() {
+                for item in data.iter().flatten().flat_map(|chunk| chunk.iter()) {
                     logic(item, &mut packer, &mut session);
                 }
             }


### PR DESCRIPTION
Instead of flattening the outputs of consolidate, provide the output as a
whole batch, encoded as an `Stream<_, Vec<C>>`. This allows downstream operators
to act on a whole batch at once, without relying on undocumented properties
of how Timely channels behave. For operators that need to flatten the
output need slightly different logic.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
