### PR TITLE
as-of-selection: downgrade the log emitted on soft constraint violation

### DIFF
--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -91,7 +91,7 @@ use mz_storage_types::read_holds::ReadHold;
 use mz_storage_types::read_policy::ReadPolicy;
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
-use tracing::{info, warn};
+use tracing::info;
 
 /// Runs as-of selection for the given dataflows.
 ///
@@ -395,7 +395,7 @@ impl<'a, T: TimestampManipulation> Context<'a, T> {
                         );
                     }
                     ConstraintType::Soft => {
-                        warn!(%id, %bounds, ?constraint, "failed to apply soft as-of constraint");
+                        info!(%id, %bounds, ?constraint, "failed to apply soft as-of constraint");
                     }
                 }
                 changed


### PR DESCRIPTION
Failing to apply soft constraints is quite common, particularly with new envs that don't yet have 30 days worth of retained metrics, making it impossible to apply the 30-day compaction windows. It's unhelpful and quite noisy to log a warning in this case, so downgrade the log to info level.

### Motivation

   * This PR removes noise from our logging.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
