### PR TITLE
[copy_from] Allow running `COPY FROM <url>` via HTTP

### DIFF
--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -1141,16 +1141,20 @@ async fn execute_request<S: ResultSender>(
         // Special-case `COPY TO` statements that are not `COPY ... TO STDOUT`, since
         // StatementKind::Copy links to several `ExecuteResponseKind`s that are not supported,
         // but this specific statement should be allowed.
-        let is_valid_copy_to = matches!(
+        let is_valid_copy = matches!(
             stmt,
             Statement::Copy(CopyStatement {
                 direction: CopyDirection::To,
                 target: CopyTarget::Expr(_),
                 ..
+            }) | Statement::Copy(CopyStatement {
+                direction: CopyDirection::From,
+                target: CopyTarget::Expr(_),
+                ..
             })
         );
 
-        if !is_valid_copy_to
+        if !is_valid_copy
             && execute_responses.iter().any(|execute_response| {
                 // Returns true if a statement or execute response are unsupported.
                 match execute_response {


### PR DESCRIPTION
Currently we prohibit all `COPY FROM` statements from running via HTTP because traditionally you need to stream data in via `stdin`. With `COPY FROM <url>` we download a file from a remote server which can be run via the HTTP protocol, and thus the web console.

### Motivation

Fixes a bug where `COPY FROM <url>` wouldn't work via the web console.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
