### PR TITLE
adapter: Fix startup parameter default values

### DIFF
--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -401,7 +401,10 @@ impl Listeners {
                 strconv::parse_bool(x).map_err(|x| x.to_string())
             })?;
             let catalog = openable_adapter_storage.get_enable_0dt_deployment().await?;
-            let computed = ld.or(catalog).or(default).unwrap_or(false);
+            let computed = ld
+                .or(catalog)
+                .or(default)
+                .unwrap_or(ENABLE_0DT_DEPLOYMENT.default().clone());
             info!(
                 %computed,
                 ?ld,
@@ -481,7 +484,10 @@ impl Listeners {
             let catalog = openable_adapter_storage
                 .get_enable_0dt_deployment_panic_after_timeout()
                 .await?;
-            let computed = ld.or(catalog).or(default).unwrap_or(false);
+            let computed = ld
+                .or(catalog)
+                .or(default)
+                .unwrap_or(ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT.default().clone());
             info!(
                 %computed,
                 ?ld,


### PR DESCRIPTION
There are some server configuration parameters that we need during
startup, before the catalog has been fully opened. To get the current
value we manually look at the current value in LaunchDarkly (which is
confusingly returned as `None` if it matches the default value in the
code), then we manually look in the catalog, then we manually look in
the server parameter default override CLI arg map.

Previously, for some of the parameters, if we weren't able to find the
value in any of those places, then we hard-code in the value false.
This is not correct, and instead we should fall back to their default
value, which is sometimes true. This commit fixes the issue by falling
back to their default values.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
