### PR TITLE
build: Use the `min` CI builder image for Tag Docker Images

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -141,7 +141,7 @@ steps:
 
       - id: devel-docker-tags
         label: Tag development docker images
-        command: bin/ci-builder run stable bin/pyactivate -m ci.test.dev_tag
+        command: bin/ci-builder run min bin/pyactivate -m ci.test.dev_tag
         inputs:
           - "*"
         depends_on:

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -107,3 +107,7 @@ pub mod __private {
     #[cfg(feature = "tracing_")]
     pub use tracing;
 }
+
+// Epoch: 1
+//
+// Bump this whenever we need to change the hash of a build without changing any code.


### PR DESCRIPTION
I've been iterating on some changes in Staging recently and realized the step to tag developer Docker images uses the 'full' CI builder image meanwhile it could use the 'min' builder.

### Motivation

Save ~2 minutes when getting Docker images pushed

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
