### PR TITLE
ci: Fix typos in AWS agents, bump number of agents before considering Hetzner overloaded

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -366,7 +366,7 @@ def switch_jobs_to_aws(pipeline: Any, priority: int) -> None:
         if branch == "main" or priority < 0:
             return
 
-        # Consider Hetzner to be overloaded when at least 400 jobs exist with priority >= 0
+        # Consider Hetzner to be overloaded when at least 600 jobs exist with priority >= 0
         try:
             builds = generic_api.get_multiple(
                 "builds",
@@ -397,7 +397,7 @@ def switch_jobs_to_aws(pipeline: Any, priority: int) -> None:
                             continue
                         num_jobs += 1
             print(f"Number of high-priority jobs on Hetzner: {num_jobs}")
-            if num_jobs < 400:
+            if num_jobs < 600:
                 return
         except Exception:
             print("switch_jobs_to_aws failed, ignoring:")
@@ -418,13 +418,13 @@ def switch_jobs_to_aws(pipeline: Any, priority: int) -> None:
                 "hetzner-x86-64-2cpu-4gb",
                 "hetzner-x86-64-dedi-2cpu-8gb",
             ):
-                config["agents"]["queue"] = "linux-x86-64-small"
+                config["agents"]["queue"] = "linux-x86_64-small"
             if agent in ("hetzner-x86-64-8cpu-16gb", "hetzner-x86-64-dedi-4cpu-16gb"):
-                config["agents"]["queue"] = "linux-x86-64"
+                config["agents"]["queue"] = "linux-x86_64"
             if agent in ("hetzner-x86-64-16cpu-32gb", "hetzner-x86-64-dedi-8cpu-32gb"):
-                config["agents"]["queue"] = "linux-x86-64-medium"
+                config["agents"]["queue"] = "linux-x86_64-medium"
             if agent == "hetzner-x86-64-dedi-16cpu-64gb":
-                config["agents"]["queue"] = "linux-x86-64-large"
+                config["agents"]["queue"] = "linux-x86_64-large"
             if agent in (
                 "hetzner-x86-64-dedi-32cpu-128gb",
                 "hetzner-x86-64-dedi-48cpu-192gb",


### PR DESCRIPTION
This caused https://materializeinc.slack.com/archives/C01LKF361MZ/p1737663072464569

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
