### PR TITLE
sql: Valid IDs in INSPECT SHARD

### DIFF
--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -151,7 +151,8 @@ pub fn plan_inspect_shard(
     // Always inspect the shard at the latest GlobalId.
     let gid = scx
         .catalog
-        .get_item(&id)
+        .try_get_item(&id)
+        .ok_or_else(|| sql_err!("item doesn't exist"))?
         .at_version(RelationVersionSelector::Latest)
         .global_id();
     Ok(Plan::InspectShard(InspectShardPlan { id: gid }))

--- a/test/sqllogictest/shard_errors.slt
+++ b/test/sqllogictest/shard_errors.slt
@@ -41,3 +41,6 @@ INSERT INTO bar VALUES (1);
 # Make sure we get the error even if we project away all columns.
 query error division by zero
 SELECT count(*) FROM baz;
+
+query error item doesn't exist
+INSPECT SHARD 'u666'


### PR DESCRIPTION
Previously, INSPECT SHARD would panic if it was given an ID that didn't belong to any item. This commit fixes the issue by returning an error instead.

Fixes #MaterializeInc/database-issues/issues/8910

### Motivation
 This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
