### PR TITLE
ci: Use dedicated CPU machines for limits tests

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -365,38 +365,26 @@ steps:
     steps:
       - id: limits
         label: "Product limits"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-8cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: limits
               run: main
         timeout_in_minutes: 180
         parallelism: 2
-        # TODO(def-) Move to larger agents to prevent flakiness
-        retry:
-          automatic:
-            - exit_status: "*"
-              limit: 1
 
       - id: limits-instance-size
         label: "Instance size limits"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         agents:
-          # A larger instance is needed due to the
-          # many containers that are being created
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-8cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: limits
               run: instance-size
-        timeout_in_minutes: 50
-        # TODO(def-) Move to larger agents to prevent flakiness
-        retry:
-          automatic:
-            - exit_status: "*"
-              limit: 1
+        timeout_in_minutes: 120
 
       - id: bounded-memory
         label: "Bounded Memory"


### PR DESCRIPTION
Have been flaky before
Test run: https://buildkite.com/materialize/nightly/builds/10958
Fixes: https://github.com/MaterializeInc/database-issues/issues/8915

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
