### PR TITLE
storage: make Kafka sources work with zero exports

### DIFF
--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -988,6 +988,14 @@ impl KafkaResumeUpperProcessor {
 impl KafkaSourceReader {
     /// Ensures that a partition queue for `pid` exists.
     fn ensure_partition(&mut self, pid: PartitionId) {
+        if self.last_offsets.is_empty() {
+            tracing::info!(
+                source_id = %self.id,
+                worker_id = %self.worker_id,
+                "kafka source does not have any outputs, not creating partition queue");
+
+            return;
+        }
         for last_offsets in self.last_offsets.values() {
             // early exit if we've already inserted this partition
             if last_offsets.contains_key(&pid) {

--- a/test/testdrive/force-source-tables.td
+++ b/test/testdrive/force-source-tables.td
@@ -368,99 +368,97 @@ contains:unknown catalog item 'mysql_table_3'
 # Kafka source using source-fed tables
 #
 
-# TODO(database-issues#8909): Re-enable when kafka sources work with force_source_table_syntax.
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key", "type": "string"}
+    ]
+  }
 
-# $ set keyschema={
-#     "type": "record",
-#     "name": "Key",
-#     "fields": [
-#         {"name": "key", "type": "string"}
-#     ]
-#   }
-#
-# $ set schema={
-#         "type" : "record",
-#         "name" : "test",
-#         "fields" : [
-#             {"name":"f1", "type":"string"},
-#             {"name":"f2", "type":"long"}
-#         ]
-#     }
-#
-# > CREATE CONNECTION kafka_conn
-#   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
-#
-# > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
-#     URL '${testdrive.schema-registry-url}'
-#   );
-#
-# $ kafka-create-topic topic=avroavro
-#
-# $ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema}
-# {"key": "fish"} {"f1": "fish", "f2": 1000}
-# {"key": "bird1"} {"f1":"goose", "f2": 1}
-# {"key": "birdmore"} {"f1":"geese", "f2": 2}
-# {"key": "mammal1"} {"f1": "moose", "f2": 1}
-# {"key": "bird1"}
-# {"key": "birdmore"} {"f1":"geese", "f2": 56}
-# {"key": "mammalmore"} {"f1": "moose", "f2": 42}
-# {"key": "mammal1"}
-# {"key": "mammalmore"} {"f1":"moose", "f2": 2}
-#
-# > CREATE SOURCE avro_source
-#   IN CLUSTER ${arg.single-replica-cluster}
-#   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-avroavro-${testdrive.seed}');
-#
-# > CREATE TABLE avro_table_upsert FROM SOURCE avro_source (REFERENCE "testdrive-avroavro-${testdrive.seed}")
-#   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-#   ENVELOPE UPSERT
-#
-# > CREATE TABLE avro_table_append FROM SOURCE avro_source (REFERENCE "testdrive-avroavro-${testdrive.seed}")
-#   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-#   ENVELOPE NONE
-#
-# > CREATE TABLE avro_table_append_cols (a, b) FROM SOURCE avro_source (REFERENCE "testdrive-avroavro-${testdrive.seed}")
-#   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-#   ENVELOPE NONE
-#
-# > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'avro_table_upsert';
-# running
-#
-# > SELECT * from avro_table_upsert
-# key           f1       f2
-# ---------------------------
-# fish          fish     1000
-# birdmore      geese    56
-# mammalmore    moose    2
-#
-# > SELECT * from avro_table_append
-# f1       f2
-# ---------------
-# fish     1000
-# geese    2
-# geese    56
-# goose    1
-# moose    1
-# moose    2
-# moose    42
-#
-# > SELECT * from avro_table_append_cols
-# a       b
-# ---------------
-# fish     1000
-# geese    2
-# geese    56
-# goose    1
-# moose    1
-# moose    2
-# moose    42
-#
-# > SHOW TABLES ON avro_source;
-# avro_table_append ""
-# avro_table_append_cols ""
-# avro_table_upsert ""
-#
-# > DROP SOURCE avro_source CASCADE
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"string"},
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+$ kafka-create-topic topic=avroavro
+
+$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "fish"} {"f1": "fish", "f2": 1000}
+{"key": "bird1"} {"f1":"goose", "f2": 1}
+{"key": "birdmore"} {"f1":"geese", "f2": 2}
+{"key": "mammal1"} {"f1": "moose", "f2": 1}
+{"key": "bird1"}
+{"key": "birdmore"} {"f1":"geese", "f2": 56}
+{"key": "mammalmore"} {"f1": "moose", "f2": 42}
+{"key": "mammal1"}
+{"key": "mammalmore"} {"f1":"moose", "f2": 2}
+
+> CREATE SOURCE avro_source
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-avroavro-${testdrive.seed}');
+
+> CREATE TABLE avro_table_upsert FROM SOURCE avro_source (REFERENCE "testdrive-avroavro-${testdrive.seed}")
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE UPSERT
+
+> CREATE TABLE avro_table_append FROM SOURCE avro_source (REFERENCE "testdrive-avroavro-${testdrive.seed}")
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+
+> CREATE TABLE avro_table_append_cols (a, b) FROM SOURCE avro_source (REFERENCE "testdrive-avroavro-${testdrive.seed}")
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+
+> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'avro_table_upsert';
+running
+
+> SELECT * from avro_table_upsert
+key           f1       f2
+---------------------------
+fish          fish     1000
+birdmore      geese    56
+mammalmore    moose    2
+
+> SELECT * from avro_table_append
+f1       f2
+---------------
+fish     1000
+geese    2
+geese    56
+goose    1
+moose    1
+moose    2
+moose    42
+
+> SELECT * from avro_table_append_cols
+a       b
+---------------
+fish     1000
+geese    2
+geese    56
+goose    1
+moose    1
+moose    2
+moose    42
+
+> SHOW TABLES ON avro_source;
+avro_table_append ""
+avro_table_append_cols ""
+avro_table_upsert ""
+
+> DROP SOURCE avro_source CASCADE
 
 #
 # Key-value load generator source using source-fed tables
@@ -535,10 +533,9 @@ contains:not supported; use CREATE TABLE .. FROM SOURCE instead
   FOR SCHEMAS (public);
 contains:not supported; use CREATE TABLE .. FROM SOURCE instead
 
-# TODO(database-issues#8909): Re-enable when kafka sources work with force_source_table_syntax.
-#! CREATE SOURCE avro_source_2
-#  IN CLUSTER ${arg.single-replica-cluster}
-#  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-avroavro-${testdrive.seed}')
-#  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-#  ENVELOPE UPSERT;
-#contains:not supported; use CREATE TABLE .. FROM SOURCE instead
+! CREATE SOURCE avro_source_2
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-avroavro-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE UPSERT;
+contains:not supported; use CREATE TABLE .. FROM SOURCE instead


### PR DESCRIPTION
Before, when we had zero outputs, we would repeatedly try and create a partition queue for the same partition, because our `self.last_offsets` is empty. The existing early exit would never trigger because it only works when there is _some_ output state.

Now, we always early exit when we know we don't have any outputs.

@jkosh44 This fixes the panic in `force-source-table.td`, which have been disabled in #31159  

Fixes MaterializeInc/database-issues#8909

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
