### PR TITLE
Fix EXPLAIN column names for Project

### DIFF
--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -484,7 +484,7 @@ impl MirRelationExpr {
             Project { outputs, input } => {
                 FmtNode {
                     fmt_root: |f, ctx| {
-                        let outputs = mode.seq(outputs, self.column_names(ctx));
+                        let outputs = mode.seq(outputs, input.column_names(ctx));
                         let outputs = CompactScalars(outputs);
                         write!(f, "{}Project ({})", ctx.indent, outputs)?;
                         self.fmt_analyses(f, ctx)
@@ -496,6 +496,9 @@ impl MirRelationExpr {
             Map { scalars, input } => {
                 FmtNode {
                     fmt_root: |f, ctx: &mut PlanRenderingContext<'_, MirRelationExpr>| {
+                        // Here, it's better to refer to `self.column_names(ctx)` rather than
+                        // `input.column_names(ctx)`, because then we also get humanization for refs
+                        // to cols introduced earlier by the same `Map`.
                         let scalars = mode.seq(scalars, self.column_names(ctx));
                         let scalars = CompactScalars(scalars);
                         write!(f, "{}Map ({})", ctx.indent, scalars)?;

--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -1024,7 +1024,7 @@ mod column_names {
                     typ,
                     access_strategy: _,
                 } => {
-                    // Emit ColumnName::Global instanceds for each column in the
+                    // Emit ColumnName::Global instances for each column in the
                     // `Get` type. Those can be resolved to real names later when an
                     // ExpressionHumanizer is available.
                     (0..typ.columns().len())

--- a/src/transform/tests/test_transforms/humanized_exprs.spec
+++ b/src/transform/tests/test_transforms/humanized_exprs.spec
@@ -67,7 +67,7 @@ explain with=humanized_exprs
 Project (#1, #0, #1)
   Get t0
 ----
-Project (#1{c0}, #0{c1}, #1{c0})
+Project (#1{c1}, #0{c0}, #1{c1})
   Get t0
 
 # Map

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -246,7 +246,7 @@ Explained Query:
           ReadIndex on=t t_a_idx=[*** full scan ***]
       Negate
         Distinct project=[#0{b}]
-          Project (#1)
+          Project (#1{b})
             ReadStorage materialize.public.mv
 
 Source materialize.public.mv
@@ -269,7 +269,7 @@ Explained Query:
       Project (#0{a})
         ReadIndex on=t t_a_idx=[*** full scan ***]
       Negate
-        Project (#1)
+        Project (#1{b})
           ReadStorage materialize.public.mv
 
 Source materialize.public.mv
@@ -398,10 +398,10 @@ Explained Query:
                 CrossJoin type=differential
                   ArrangeBy keys=[[]]
                     Distinct project=[#0{b}]
-                      Project (#1)
+                      Project (#1{b})
                         Get l0
                   ArrangeBy keys=[[]]
-                    Project (#1)
+                    Project (#1{b})
                       ReadStorage materialize.public.mv
 
 Source materialize.public.mv
@@ -421,7 +421,7 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
 Explained Query:
   With
     cte l0 =
-      Project (#1)
+      Project (#1{b})
         ReadIndex on=t t_a_idx=[*** full scan ***]
     cte l1 =
       Distinct project=[#0{b}]
@@ -446,7 +446,7 @@ Explained Query:
               Filter (#1{b}) IS NOT NULL
                 ReadStorage materialize.public.mv
   Return
-    Project (#2, #4)
+    Project (#2{a}, #4{a})
       Join on=(#0{b} = #1{b} = #3{b}) type=delta
         ArrangeBy keys=[[#0{b}]]
           Get l0
@@ -498,7 +498,7 @@ Explained Query:
         Get l0
     cte l2 =
       ArrangeBy keys=[[#0{b}]]
-        Project (#1)
+        Project (#1{b})
           Get l0
     cte l3 =
       Project (#0{a}..=#2{a})
@@ -516,11 +516,11 @@ Explained Query:
                 Get l2
                 ArrangeBy keys=[[#0{b}]]
                   Distinct project=[#0{b}]
-                    Project (#1)
+                    Project (#1{b})
                       Get l3
           Project ()
             ReadIndex on=t t_a_idx=[*** full scan ***]
-      Project (#0{a}, #2)
+      Project (#0{a}, #2{a})
         Get l3
 
 Used Indexes:
@@ -659,7 +659,7 @@ Explained Query:
       ArrangeBy keys=[[]]
         Get l0
     cte l2 =
-      Project (#0{a}, #1{b}, #3)
+      Project (#0{a}, #1{b}, #3{max})
         Filter (#0{a} != #3{max})
           Join on=(#0{a} = #2{a}) type=differential
             ArrangeBy keys=[[#0{a}]]
@@ -672,7 +672,7 @@ Explained Query:
                       Get l0
                   Get l1
   Return
-    Project (#0{a}..=#2{max}, #4)
+    Project (#0{a}..=#2{max}, #4{max})
       Filter (#0{a} != #4{max})
         Join on=(#0{a} = #3{a}) type=differential
           ArrangeBy keys=[[#0{a}]]
@@ -735,12 +735,12 @@ Explained Query:
       ArrangeBy keys=[[#1{b}]]
         Get l0
   Return
-    Project (#0{a}, #2)
+    Project (#0{a}, #2{a})
       Join on=(#1{b} = #3{b} = #4{b}) type=delta
         Get l1
         Get l1
         ArrangeBy keys=[[#0{b}]]
-          Project (#1)
+          Project (#1{b})
             Get l0
 
 Used Indexes:
@@ -936,10 +936,10 @@ WHERE a = 0
 GROUP BY a
 ----
 Explained Query:
-  Project (#1{max_b}, #0)
+  Project (#1, #0{max_b})
     Map (0)
       Reduce aggregates=[max(#0{b})]
-        Project (#1)
+        Project (#1{b})
           ReadIndex on=materialize.public.t t_a_idx=[lookup value=(0)]
 
 Used Indexes:

--- a/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
@@ -267,10 +267,10 @@ Explained Query:
                 CrossJoin type=differential
                   ArrangeBy keys=[[]]
                     Distinct project=[#0{b}]
-                      Project (#1)
+                      Project (#1{b})
                         Get l0
                   ArrangeBy keys=[[]]
-                    Project (#1)
+                    Project (#1{b})
                       ReadStorage materialize.public.mv
 
 Source materialize.public.mv
@@ -290,7 +290,7 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
 Explained Query:
   With
     cte l0 =
-      Project (#1)
+      Project (#1{b})
         ReadIndex on=t t_a_idx=[*** full scan ***]
     cte l1 =
       Distinct project=[#0{b}]
@@ -315,7 +315,7 @@ Explained Query:
               Filter (#1{b}) IS NOT NULL
                 ReadStorage materialize.public.mv
   Return
-    Project (#2, #4)
+    Project (#2{a}, #4{a})
       Join on=(#0{b} = #1{b} = #3{b}) type=delta
         ArrangeBy keys=[[#0{b}]]
           Get l0
@@ -367,7 +367,7 @@ Explained Query:
         Get l0
     cte l2 =
       ArrangeBy keys=[[#0{b}]]
-        Project (#1)
+        Project (#1{b})
           Get l0
     cte l3 =
       Project (#0{a}..=#2{a})
@@ -385,11 +385,11 @@ Explained Query:
                 Get l2
                 ArrangeBy keys=[[#0{b}]]
                   Distinct project=[#0{b}]
-                    Project (#1)
+                    Project (#1{b})
                       Get l3
           Project ()
             ReadIndex on=t t_a_idx=[*** full scan ***]
-      Project (#0{a}, #2)
+      Project (#0{a}, #2{a})
         Get l3
 
 Used Indexes:
@@ -408,10 +408,10 @@ WHERE a = 0
 GROUP BY a
 ----
 Explained Query:
-  Project (#1{max_b}, #0)
+  Project (#1, #0{max_b})
     Map (█)
       Reduce aggregates=[max(#0{b})]
-        Project (#1)
+        Project (#1{b})
           ReadIndex on=materialize.public.t t_a_idx=[lookup value=(█)]
 
 Used Indexes:

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -448,14 +448,14 @@ Explained Query:
             Filter (#0{creationdate} < 2010-06-11 09:21:46 UTC) // { arity: 13 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
     Return // { arity: 7 }
-      Project (#0..=#2, #4, #7, #5{sum}, #8) // { arity: 7 }
+      Project (#0..=#2, #4{count}, #7, #5{sum}, #8) // { arity: 7 }
         Map ((#5{sum} / bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end)), (bigint_to_numeric(#4{count}) / #3)) // { arity: 9 }
           Reduce group_by=[#1..=#4] aggregates=[count(*), sum(integer_to_bigint(#0{length})), count(integer_to_bigint(#0{length}))] // { arity: 7 }
             CrossJoin type=differential // { arity: 5 }
               implementation
                 %1[×]U » %0:message[×]if
               ArrangeBy keys=[[]] // { arity: 4 }
-                Project (#8, #13..=#15) // { arity: 4 }
+                Project (#8{length}, #13..=#15) // { arity: 4 }
                   Filter (#0{creationdate} < 2010-06-11 09:21:46 UTC) AND (#4{content}) IS NOT NULL // { arity: 16 }
                     Map (extract_year_tstz(#0{creationdate}), (#12{parentmessageid}) IS NOT NULL, case when (#8{length} < 40) then 0 else case when (#8{length} < 80) then 1 else case when (#8{length} < 160) then 2 else 3 end end end) // { arity: 16 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
@@ -520,7 +520,7 @@ Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0..=#3]
     With
       cte l0 =
-        Project (#5, #6) // { arity: 2 }
+        Project (#5{id}, #6{name}) // { arity: 2 }
           Join on=(#0{id} = #8{typetagclassid}) type=differential // { arity: 9 }
             implementation
               %0:tagclass[#0]KAe » %1:tag[#3]KAe
@@ -532,7 +532,7 @@ Explained Query:
         Filter (#0{id}) IS NOT NULL // { arity: 2 }
           Get l0 // { arity: 2 }
       cte l2 =
-        Project (#1{count}, #3, #4) // { arity: 3 }
+        Project (#1{name}, #3{count}, #4{count}) // { arity: 3 }
           Join on=(#0{id} = #2{id}) type=differential // { arity: 5 }
             implementation
               %1[#0]UKA » %0:l1[#0]K
@@ -540,7 +540,7 @@ Explained Query:
               Get l1 // { arity: 2 }
             ArrangeBy keys=[[#0{id}]] // { arity: 3 }
               Reduce group_by=[#0{id}] aggregates=[count(case when (#2{creationdate} < 2010-09-16 00:00:00 UTC) then #1{messageid} else null end), count(case when (#2{creationdate} >= 2010-09-16 00:00:00 UTC) then #1{messageid} else null end)] // { arity: 3 }
-                Project (#0{id}, #2{creationdate}, #4) // { arity: 3 }
+                Project (#0{id}, #2{messageid}, #4{creationdate}) // { arity: 3 }
                   Filter (#4{creationdate} < 2010-12-25 00:00:00 UTC) AND (#4{creationdate} >= 2010-06-08 00:00:00 UTC) // { arity: 17 }
                     Join on=(#0{id} = #3{tagid} AND #2{messageid} = #5{messageid}) type=delta // { arity: 17 }
                       implementation
@@ -563,7 +563,7 @@ Explained Query:
                 Negate // { arity: 1 }
                   Project (#0{name}) // { arity: 1 }
                     Get l2 // { arity: 3 }
-                Project (#1) // { arity: 1 }
+                Project (#1{name}) // { arity: 1 }
                   Get l0 // { arity: 2 }
             Get l2 // { arity: 3 }
 
@@ -616,7 +616,7 @@ LIMIT 20
 Explained Query:
   Finish order_by=[#4{count} desc nulls_first, #0{containerforumid} asc nulls_last] limit=20 output=[#0..=#4]
     Reduce group_by=[#0{containerforumid}, #2{title}, #1{creationdate}, #3{moderatorpersonid}] aggregates=[count(*)] // { arity: 5 }
-      Project (#10, #13, #15, #16) // { arity: 4 }
+      Project (#10{containerforumid}, #13{creationdate}, #15{title}, #16{moderatorpersonid}) // { arity: 4 }
         Filter (#33{name} = "China") AND (#16{moderatorpersonid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
           Join on=(#1{messageid} = #36{messageid} AND #10{containerforumid} = #14{id} AND #16{moderatorpersonid} = #18{id} AND #25{locationcityid} = #28{id} AND #31{partofcountryid} = #32{id}) type=delta // { arity: 37 }
             implementation
@@ -638,7 +638,7 @@ Explained Query:
               ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#10) // { arity: 1 }
+                Project (#10{messageid}) // { arity: 1 }
                   Join on=(#0{id} = #8{typetagclassid} AND #5{id} = #11{tagid}) type=delta // { arity: 12 }
                     implementation
                       %0:tagclass » %1:tag[#3]KA » %2:message_hastag_tag[#2]KA
@@ -745,7 +745,7 @@ Explained Query:
       cte l0 =
         Project (#0{id}) // { arity: 1 }
           TopK order_by=[#1{maxnumberofmembers} desc nulls_first, #0{id} asc nulls_last] limit=100 // { arity: 2 }
-            Project (#0{id}, #2) // { arity: 2 }
+            Project (#0{id}, #2{maxnumberofmembers}) // { arity: 2 }
               Filter (#1{creationdate} > 2010-02-12 00:00:00 UTC) // { arity: 3 }
                 ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
       cte l1 =
@@ -757,7 +757,7 @@ Explained Query:
               ReadIndex on=person person_id=[differential join] // { arity: 11 }
             ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
               Distinct project=[#0{personid}] // { arity: 1 }
-                Project (#3) // { arity: 1 }
+                Project (#3{personid}) // { arity: 1 }
                   Join on=(#0{id} = #2{forumid}) type=differential // { arity: 4 }
                     implementation
                       %1:forum_hasmember_person[#1]KA » %0:l0[#0]K
@@ -769,7 +769,7 @@ Explained Query:
         ArrangeBy keys=[[#1{id}]] // { arity: 4 }
           Get l1 // { arity: 4 }
       cte l3 =
-        Project (#0{creationdate}..=#3{lastname}, #5) // { arity: 5 }
+        Project (#0{creationdate}..=#3{lastname}, #5{messageid}) // { arity: 5 }
           Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{id}) type=delta // { arity: 18 }
             implementation
               %0:l2 » %1:message[#9]KA » %2[#0]UKA
@@ -794,7 +794,7 @@ Explained Query:
                     Get l2 // { arity: 4 }
                     ArrangeBy keys=[[#0{id}]] // { arity: 1 }
                       Distinct project=[#0{id}] // { arity: 1 }
-                        Project (#1) // { arity: 1 }
+                        Project (#1{id}) // { arity: 1 }
                           Get l3 // { arity: 5 }
               Get l1 // { arity: 4 }
           Get l3 // { arity: 5 }
@@ -846,7 +846,7 @@ Explained Query:
   Finish order_by=[#4 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0..=#4]
     With
       cte l0 =
-        Project (#1{messageid}, #5, #16) // { arity: 3 }
+        Project (#1{name}, #5{messageid}, #16{creatorpersonid}) // { arity: 3 }
           Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
             implementation
               %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
@@ -860,28 +860,28 @@ Explained Query:
               ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
       cte l1 =
         Reduce group_by=[#0{parentmessageid}] aggregates=[count(*)] // { arity: 2 }
-          Project (#12) // { arity: 1 }
+          Project (#12{parentmessageid}) // { arity: 1 }
             Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
       cte l2 =
         Reduce group_by=[#0{messageid}] aggregates=[count(*)] // { arity: 2 }
-          Project (#2) // { arity: 1 }
+          Project (#2{messageid}) // { arity: 1 }
             ReadIndex on=person_likes_message person_likes_message_personid=[*** full scan ***] // { arity: 3 }
       cte l3 =
         Distinct project=[#0{messageid}] // { arity: 1 }
-          Project (#1) // { arity: 1 }
+          Project (#1{messageid}) // { arity: 1 }
             Get l0 // { arity: 3 }
     Return // { arity: 5 }
       Map (((bigint_to_numeric((1 * #3{count})) + (2 * #1{sum})) + (10 * #2{sum}))) // { arity: 5 }
         Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(case when (#2) IS NULL then null else #1{count} end, 0)), sum(coalesce(case when (#4) IS NULL then null else #3{count} end, 0)), count(*)] // { arity: 4 }
-          Project (#1{count}, #3{count}, #4, #6, #7) // { arity: 5 }
+          Project (#1{creatorpersonid}, #3{count}, #4, #6{count}, #7) // { arity: 5 }
             Join on=(#0{messageid} = #2{parentmessageid} = #5{messageid}) type=delta // { arity: 8 }
               implementation
                 %0:l0 » %1[#0]K » %2[#0]K
                 %1 » %0:l0[#0]Kef » %2[#0]K
                 %2 » %0:l0[#0]Kef » %1[#0]K
               ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-                Project (#1{creatorpersonid}, #2) // { arity: 2 }
+                Project (#1{messageid}, #2{creatorpersonid}) // { arity: 2 }
                   Filter (#0{name} = "Sikh_Empire") // { arity: 3 }
                     Get l0 // { arity: 3 }
               ArrangeBy keys=[[#0{parentmessageid}]] // { arity: 3 }
@@ -973,7 +973,7 @@ Explained Query:
   Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
     With
       cte l0 =
-        Project (#6, #17) // { arity: 2 }
+        Project (#6{messageid}, #17{creatorpersonid}) // { arity: 2 }
           Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
             implementation
               %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
@@ -989,7 +989,7 @@ Explained Query:
         ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
           Get l0 // { arity: 2 }
       cte l2 =
-        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
+        Project (#0{messageid}, #1{creatorpersonid}, #3{personid}) // { arity: 3 }
           Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
             implementation
               %1:person_likes_message[#2]KA » %0:l1[#0]K
@@ -1002,7 +1002,7 @@ Explained Query:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#1) // { arity: 1 }
+                  Project (#1{creatorpersonid}) // { arity: 1 }
                     Join on=(#0{messageid} = #2{messageid}) type=differential // { arity: 3 }
                       implementation
                         %1[#0]UKA » %0:l1[#0]K
@@ -1011,12 +1011,12 @@ Explained Query:
                         Distinct project=[#0{messageid}] // { arity: 1 }
                           Project (#0{messageid}) // { arity: 1 }
                             Get l2 // { arity: 3 }
-                Project (#1) // { arity: 1 }
+                Project (#1{creatorpersonid}) // { arity: 1 }
                   Get l0 // { arity: 2 }
-            Project (#1{personid}, #2) // { arity: 2 }
+            Project (#1{creatorpersonid}, #2{personid}) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l4 =
-        Project (#0{creatorpersonid}, #3) // { arity: 2 }
+        Project (#0{creatorpersonid}, #3{popularityscore}) // { arity: 2 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
@@ -1079,7 +1079,7 @@ Explained Query:
   Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
     With
       cte l0 =
-        Project (#6, #17) // { arity: 2 }
+        Project (#6{messageid}, #17{creatorpersonid}) // { arity: 2 }
           Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
             implementation
               %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
@@ -1095,7 +1095,7 @@ Explained Query:
         ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
           Get l0 // { arity: 2 }
       cte l2 =
-        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
+        Project (#0{messageid}, #1{creatorpersonid}, #3{personid}) // { arity: 3 }
           Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
             implementation
               %1:person_likes_message[#2]KA » %0:l1[#0]K
@@ -1108,7 +1108,7 @@ Explained Query:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#1) // { arity: 1 }
+                  Project (#1{creatorpersonid}) // { arity: 1 }
                     Join on=(#0{messageid} = #2{messageid}) type=differential // { arity: 3 }
                       implementation
                         %1[#0]UKA » %0:l1[#0]K
@@ -1117,12 +1117,12 @@ Explained Query:
                         Distinct project=[#0{messageid}] // { arity: 1 }
                           Project (#0{messageid}) // { arity: 1 }
                             Get l2 // { arity: 3 }
-                Project (#1) // { arity: 1 }
+                Project (#1{creatorpersonid}) // { arity: 1 }
                   Get l0 // { arity: 2 }
-            Project (#1{personid}, #2) // { arity: 2 }
+            Project (#1{creatorpersonid}, #2{personid}) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l4 =
-        Project (#0{creatorpersonid}, #3) // { arity: 2 }
+        Project (#0{creatorpersonid}, #3{popularityscore}) // { arity: 2 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
@@ -1186,7 +1186,7 @@ Explained Query:
   Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
     With
       cte l0 =
-        Project (#1{messageid}, #5, #16) // { arity: 3 }
+        Project (#1{name}, #5{messageid}, #16{creatorpersonid}) // { arity: 3 }
           Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
             implementation
               %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
@@ -1199,7 +1199,7 @@ Explained Query:
             ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
               ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
       cte l1 =
-        Project (#0{name}..=#2{creatorpersonid}, #4) // { arity: 4 }
+        Project (#0{name}..=#2{creatorpersonid}, #4{personid}) // { arity: 4 }
           Join on=(#1{messageid} = #5{messageid}) type=differential // { arity: 6 }
             implementation
               %1:person_likes_message[#2]KA » %0:l0[#1]K
@@ -1216,24 +1216,24 @@ Explained Query:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#1) // { arity: 1 }
+                  Project (#1{creatorpersonid}) // { arity: 1 }
                     Join on=(#0{messageid} = #2{messageid}) type=differential // { arity: 3 }
                       implementation
                         %1[#0]UKA » %0:l2[#0]Kef
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-                        Project (#1{creatorpersonid}, #2) // { arity: 2 }
+                        Project (#1{messageid}, #2{creatorpersonid}) // { arity: 2 }
                           Get l2 // { arity: 3 }
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
                         Distinct project=[#0{messageid}] // { arity: 1 }
-                          Project (#1) // { arity: 1 }
+                          Project (#1{messageid}) // { arity: 1 }
                             Get l1 // { arity: 4 }
-                Project (#2) // { arity: 1 }
+                Project (#2{creatorpersonid}) // { arity: 1 }
                   Get l2 // { arity: 3 }
-            Project (#2, #3) // { arity: 2 }
+            Project (#2{creatorpersonid}, #3{personid}) // { arity: 2 }
               Filter (#0{name} = "Bob_Geldof") // { arity: 4 }
                 Get l1 // { arity: 4 }
       cte l4 =
-        Project (#0{creatorpersonid}, #3) // { arity: 2 }
+        Project (#0{creatorpersonid}, #3{popularityscore}) // { arity: 2 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
@@ -1303,7 +1303,7 @@ Explained Query:
   Finish order_by=[#1{count} desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0, #1]
     With
       cte l0 =
-        Project (#1) // { arity: 1 }
+        Project (#1{messageid}) // { arity: 1 }
           Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
             implementation
               %1:tag[#0]KAe » %0:message_hastag_tag[#2]KAe
@@ -1312,7 +1312,7 @@ Explained Query:
             ArrangeBy keys=[[#0{id}]] // { arity: 5 }
               ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
       cte l1 =
-        Project (#2, #18) // { arity: 2 }
+        Project (#2{messageid}, #18{name}) // { arity: 2 }
           Join on=(#0{messageid} = #13{parentmessageid} AND #2{messageid} = #15{messageid} AND #16{tagid} = #17{id}) type=delta // { arity: 21 }
             implementation
               %0:l0 » %1:message[#12]KA » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA
@@ -1333,7 +1333,7 @@ Explained Query:
             Get l1 // { arity: 2 }
     Return // { arity: 2 }
       Reduce group_by=[#0{name}] aggregates=[count(*)] // { arity: 2 }
-        Project (#1) // { arity: 1 }
+        Project (#1{name}) // { arity: 1 }
           Join on=(#0{messageid} = #2{messageid}) type=differential // { arity: 3 }
             implementation
               %0:l1[#0]K » %1[#0]K
@@ -1428,7 +1428,7 @@ Explained Query:
         ArrangeBy keys=[[#0{id}]] // { arity: 5 }
           ReadIndex on=materialize.public.tag tag_name=[lookup value=("Abbas_I_of_Persia")] // { arity: 5 }
       cte l2 =
-        Project (#1) // { arity: 1 }
+        Project (#1{id}) // { arity: 1 }
           Join on=(#1{id} = #11{personid} AND #12{tagid} = #13{id}) type=delta // { arity: 18 }
             implementation
               %0:l0 » %1:person_hasinterest_tag[#0]K » %2:l1[#0]KAe
@@ -1436,12 +1436,12 @@ Explained Query:
               %2:l1 » %1:person_hasinterest_tag[#1]KA » %0:l0[#1]KA
             Get l0 // { arity: 11 }
             ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-              Project (#1{tagid}, #2) // { arity: 2 }
+              Project (#1{personid}, #2{tagid}) // { arity: 2 }
                 ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
             Get l1 // { arity: 5 }
       cte l3 =
         Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*)] // { arity: 2 }
-          Project (#17) // { arity: 1 }
+          Project (#17{creatorpersonid}) // { arity: 1 }
             Filter (#8{creationdate} < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8{creationdate}) // { arity: 32 }
               Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid} AND #17{creatorpersonid} = #22{id}) type=delta // { arity: 32 }
                 implementation
@@ -1459,7 +1459,7 @@ Explained Query:
         ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 2 }
           Get l3 // { arity: 2 }
       cte l5 =
-        Project (#0{id}, #2) // { arity: 2 }
+        Project (#0{id}, #2{count}) // { arity: 2 }
           Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 3 }
             implementation
               %1:l4[#0]UKA » %0:l2[#0]K
@@ -1473,7 +1473,7 @@ Explained Query:
         Project (#3, #4) // { arity: 2 }
           Map (coalesce(#0{id}, #1{creatorpersonid}), (integer_to_bigint(case when (#0{id}) IS NULL then 0 else 100 end) + coalesce(#2{count}, 0))) // { arity: 5 }
             Union // { arity: 3 }
-              Project (#2{count}, #0, #1{creatorpersonid}) // { arity: 3 }
+              Project (#2, #0{creatorpersonid}, #1{count}) // { arity: 3 }
                 Map (null) // { arity: 3 }
                   Union // { arity: 2 }
                     Negate // { arity: 2 }
@@ -1491,7 +1491,7 @@ Explained Query:
                   Negate // { arity: 1 }
                     Get l6 // { arity: 1 }
                   Get l2 // { arity: 1 }
-              Project (#0{id}, #0{id}, #1{id}) // { arity: 3 }
+              Project (#0{id}, #0{id}, #1{count}) // { arity: 3 }
                 Get l5 // { arity: 2 }
     Return // { arity: 5 }
       Map (coalesce(#2{sum}, 0), (bigint_to_numeric(#1) + #3)) // { arity: 5 }
@@ -1506,14 +1506,14 @@ Explained Query:
                 Get l7 // { arity: 2 }
               ArrangeBy keys=[[#0{person1id}], [case when (#2) IS NULL then null else #1{person2id} end]] // { arity: 3 }
                 Union // { arity: 3 }
-                  Project (#1{person2id}..=#3) // { arity: 3 }
+                  Project (#1{person1id}..=#3) // { arity: 3 }
                     Map (true) // { arity: 4 }
                       ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                   Map (null, null) // { arity: 3 }
                     Threshold // { arity: 1 }
                       Union // { arity: 1 }
                         Negate // { arity: 1 }
-                          Project (#1) // { arity: 1 }
+                          Project (#1{person1id}) // { arity: 1 }
                             ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                         Distinct project=[#0] // { arity: 1 }
                           Union // { arity: 1 }
@@ -1535,7 +1535,7 @@ Explained Query:
                               Get l7 // { arity: 2 }
                         Distinct project=[#0{person2id}] // { arity: 1 }
                           Union // { arity: 1 }
-                            Project (#2) // { arity: 1 }
+                            Project (#2{person2id}) // { arity: 1 }
                               ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                             Constant // { arity: 1 }
                               - (null)
@@ -1582,7 +1582,7 @@ SELECT Person.id AS "person.id"
 Explained Query:
   Finish order_by=[#4{sum_count} desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
     Reduce group_by=[#0{id}..=#2{lastname}] aggregates=[count(*), sum(#3{count})] // { arity: 5 }
-      Project (#1{firstname}..=#3{count}, #25) // { arity: 4 }
+      Project (#1{id}..=#3{lastname}, #25{count}) // { arity: 4 }
         Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) // { arity: 26 }
           Join on=(#1{id} = #20{creatorpersonid} AND #12{messageid} = #24{rootpostid}) type=delta // { arity: 26 }
             implementation
@@ -1595,7 +1595,7 @@ Explained Query:
               ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
             ArrangeBy keys=[[#0{rootpostid}]] // { arity: 2 }
               Reduce group_by=[#0{rootpostid}] aggregates=[count(*)] // { arity: 2 }
-                Project (#2) // { arity: 1 }
+                Project (#2{rootpostid}) // { arity: 1 }
                   Filter (#0{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#0{creationdate} >= 2012-08-29 00:00:00 UTC) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
@@ -1700,9 +1700,9 @@ Explained Query:
       cte l2 =
         Distinct project=[#0{person2id}] // { arity: 1 }
           Union // { arity: 1 }
-            Project (#2) // { arity: 1 }
+            Project (#2{person2id}) // { arity: 1 }
               Get l1 // { arity: 4 }
-            Project (#6) // { arity: 1 }
+            Project (#6{person2id}) // { arity: 1 }
               Join on=(#2{person2id} = #5{person1id}) type=differential // { arity: 7 }
                 implementation
                   %0:l1[#2]KAe » %1:l0[#1]KAe
@@ -1711,7 +1711,7 @@ Explained Query:
                 Get l0 // { arity: 3 }
     Return // { arity: 3 }
       Reduce group_by=[#0{person2id}, #1{name}] aggregates=[count(*)] // { arity: 3 }
-        Project (#0{person2id}, #9) // { arity: 2 }
+        Project (#0{person2id}, #9{name}) // { arity: 2 }
           Join on=(#0{person2id} = #1{id} = #2{creatorpersonid} AND #3{messageid} = #4{messageid} = #6{messageid} AND #7{tagid} = #8{id}) type=delta // { arity: 12 }
             implementation
               %0 » %1[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
@@ -1725,7 +1725,7 @@ Explained Query:
                 Threshold // { arity: 1 }
                   Union // { arity: 1 }
                     Distinct project=[#0{person2id}] // { arity: 1 }
-                      Project (#6) // { arity: 1 }
+                      Project (#6{person2id}) // { arity: 1 }
                         Join on=(#0{person2id} = #2{person1id} AND #3{person2id} = #5{person1id}) type=delta // { arity: 7 }
                           implementation
                             %0:l2 » %1:person_knows_person[#1]KA » %2:l0[#1]KA
@@ -1740,7 +1740,7 @@ Explained Query:
                       Get l2 // { arity: 1 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
+                Project (#1{id}) // { arity: 1 }
                   Filter (#16{name} = "Italy") AND (#1{id}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 19 }
                     Join on=(#8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 19 }
                       implementation
@@ -1755,11 +1755,11 @@ Explained Query:
                         ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
             ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1{creatorpersonid}, #9) // { arity: 2 }
+                Project (#1{messageid}, #9{creatorpersonid}) // { arity: 2 }
                   ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
+                Project (#1{messageid}) // { arity: 1 }
                   Join on=(#2{tagid} = #3{id} AND #6{typetagclassid} = #7{id}) type=delta // { arity: 12 }
                     implementation
                       %0:message_hastag_tag » %1:tag[#0]KA » %2:tagclass[#0]KAe
@@ -1835,7 +1835,7 @@ SELECT count(*)
 Explained Query:
   With
     cte l0 =
-      Project (#1{person2id}, #21) // { arity: 2 }
+      Project (#1{id}, #21{person2id}) // { arity: 2 }
         Filter (#16{name} = "India") AND (#19{creationdate} <= 2013-01-10 00:00:00 UTC) AND (2012-09-28 00:00:00 UTC <= #19{creationdate}) AND (#14{partofcountryid}) IS NOT NULL // { arity: 22 }
           Join on=(#1{id} = #20{person1id} AND #8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 22 }
             implementation
@@ -1932,7 +1932,7 @@ Explained Query:
         ArrangeBy keys=[[#1{id}]] // { arity: 11 }
           ReadIndex on=person person_id=[differential join] // { arity: 11 }
       cte l1 =
-        Project (#1{messageid}, #12) // { arity: 2 }
+        Project (#1{id}, #12{messageid}) // { arity: 2 }
           Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#15{content}) IS NOT NULL // { arity: 25 }
             Join on=(#1{id} = #20{creatorpersonid}) type=differential // { arity: 25 }
               implementation
@@ -1942,13 +1942,13 @@ Explained Query:
                 ReadIndex on=materialize.public.message message_rootpostlanguage=[lookup values=[("es"); ("pt"); ("ta")]] // { arity: 14 }
     Return // { arity: 2 }
       Reduce group_by=[#0{count_messageid}] aggregates=[count(*)] // { arity: 2 }
-        Project (#1) // { arity: 1 }
+        Project (#1{count_messageid}) // { arity: 1 }
           Reduce group_by=[#0{id}] aggregates=[count(#1{messageid})] // { arity: 2 }
             Union // { arity: 2 }
               Map (null) // { arity: 2 }
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
-                    Project (#1) // { arity: 1 }
+                    Project (#1{id}) // { arity: 1 }
                       Join on=(#1{id} = #11{id}) type=differential // { arity: 12 }
                         implementation
                           %1[#0]UKA » %0:l0[#1]KA
@@ -1957,7 +1957,7 @@ Explained Query:
                           Distinct project=[#0{id}] // { arity: 1 }
                             Project (#0{id}) // { arity: 1 }
                               Get l1 // { arity: 2 }
-                  Project (#1) // { arity: 1 }
+                  Project (#1{id}) // { arity: 1 }
                     ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
               Get l1 // { arity: 2 }
 
@@ -2003,7 +2003,7 @@ Explained Query:
           ArrangeBy keys=[[]] // { arity: 11 }
             ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
           ArrangeBy keys=[[]] // { arity: 6 }
-            Project (#0{creationdate}, #1{messageid}, #3{content}, #4{length}, #8, #9) // { arity: 6 }
+            Project (#0{creationdate}, #1{messageid}, #3{rootpostlanguage}, #4{content}, #8{length}, #9{creatorpersonid}) // { arity: 6 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
       cte l1 =
         Project (#0{creationdate}..=#11{messageid}) // { arity: 12 }
@@ -2011,7 +2011,7 @@ Explained Query:
             implementation
               %1[#0]UKA » %0:l0[#12]Kiif
             ArrangeBy keys=[[#12{rootpostlanguage}]] // { arity: 13 }
-              Project (#0{creationdate}..=#10{email}, #12{rootpostlanguage}, #13) // { arity: 13 }
+              Project (#0{creationdate}..=#10{email}, #12{messageid}, #13{rootpostlanguage}) // { arity: 13 }
                 Filter (#15{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#14{content}) IS NOT NULL AND (#1{id} = #16{creatorpersonid}) // { arity: 17 }
                   Get l0 // { arity: 17 }
             ArrangeBy keys=[[#0{rootpostlanguage}]] // { arity: 1 }
@@ -2020,16 +2020,16 @@ Explained Query:
                   Filter (#0{rootpostlanguage} = varchar_to_text(#1)) // { arity: 2 }
                     FlatMap unnest_array({"es", "ta", "pt"}) // { arity: 2 }
                       Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
-                        Project (#13) // { arity: 1 }
+                        Project (#13{rootpostlanguage}) // { arity: 1 }
                           Get l0 // { arity: 17 }
     Return // { arity: 2 }
       Reduce group_by=[#0{count_messageid}] aggregates=[count(*)] // { arity: 2 }
-        Project (#1) // { arity: 1 }
+        Project (#1{count_messageid}) // { arity: 1 }
           Reduce group_by=[#0{id}] aggregates=[count(#1{messageid})] // { arity: 2 }
             Union // { arity: 2 }
-              Project (#1{messageid}, #11) // { arity: 2 }
+              Project (#1{id}, #11{messageid}) // { arity: 2 }
                 Get l1 // { arity: 12 }
-              Project (#1, #22) // { arity: 2 }
+              Project (#1{id}, #22) // { arity: 2 }
                 Map (null) // { arity: 23 }
                   Join on=(#0{creationdate} = #11{creationdate} AND #1{id} = #12{id} AND #2{firstname} = #13{firstname} AND #3{lastname} = #14{lastname} AND #4{gender} = #15{gender} AND #5{birthday} = #16{birthday} AND #6{locationip} = #17{locationip} AND #7{browserused} = #18{browserused} AND #8{locationcityid} = #19{locationcityid} AND #9{speaks} = #20{speaks} AND #10{email} = #21{email}) type=differential // { arity: 22 }
                     implementation
@@ -2097,7 +2097,7 @@ Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#3]
     With
       cte l0 =
-        Project (#0{id}, #2{partofcontinentid}..=#6{creationdate}, #8{firstname}..=#15{email}, #17, #18) // { arity: 16 }
+        Project (#0{id}, #2{url}..=#6{url}, #8{creationdate}..=#15{browserused}, #17{speaks}, #18{email}) // { arity: 16 }
           Filter (#1{name} = "India") AND (#8{creationdate} < 2012-11-09 00:00:00 UTC) AND (#0{id}) IS NOT NULL // { arity: 19 }
             Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid}) type=delta // { arity: 19 }
               implementation
@@ -2111,7 +2111,7 @@ Explained Query:
               ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
                 ReadIndex on=person person_locationcityid=[delta join lookup] // { arity: 11 }
       cte l1 =
-        Project (#0{id}..=#15{email}, #17) // { arity: 17 }
+        Project (#0{id}..=#15{email}, #17{messageid}) // { arity: 17 }
           Filter (#16{creationdate} <= 2012-11-09 00:00:00 UTC) AND (#16{creationdate} >= #6{creationdate}) // { arity: 29 }
             Join on=(#7{id} = #25{creatorpersonid}) type=differential // { arity: 29 }
               implementation
@@ -2126,9 +2126,9 @@ Explained Query:
           Filter (bigint_to_numeric(#2{count_messageid}) < ((24155 - ((12 * extract_year_tstz(#1{creationdate})) + extract_month_tstz(#1{creationdate}))) + 1)) // { arity: 3 }
             Reduce group_by=[#1{id}, #0{creationdate}] aggregates=[count(#2{messageid})] // { arity: 3 }
               Union // { arity: 3 }
-                Project (#6, #7, #16) // { arity: 3 }
+                Project (#6{creationdate}, #7{id}, #16{messageid}) // { arity: 3 }
                   Get l1 // { arity: 17 }
-                Project (#6, #7, #32) // { arity: 3 }
+                Project (#6{creationdate}, #7{id}, #32) // { arity: 3 }
                   Map (null) // { arity: 33 }
                     Join on=(#0{id} = #16{id} AND #1{url} = #17{url} AND #2{partofcontinentid} = #18{partofcontinentid} AND #3{id} = #19{id} AND #4{name} = #20{name} AND #5{url} = #21{url} AND #6{creationdate} = #22{creationdate} AND #7{id} = #23{id} AND #8{firstname} = #24{firstname} AND #9{lastname} = #25{lastname} AND #10{gender} = #26{gender} AND #11{birthday} = #27{birthday} AND #12{locationip} = #28{locationip} AND #13{browserused} = #29{browserused} AND #14{speaks} = #30{speaks} AND #15{email} = #31{email}) type=differential // { arity: 32 }
                       implementation
@@ -2152,7 +2152,7 @@ Explained Query:
         ArrangeBy keys=[[#0{id}]] // { arity: 1 }
           Get l3 // { arity: 1 }
       cte l5 =
-        Project (#1{creatorpersonid}, #23) // { arity: 2 }
+        Project (#1{id}, #23{creatorpersonid}) // { arity: 2 }
           Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) // { arity: 28 }
             Join on=(#1{id} = #12{personid} AND #13{messageid} = #15{messageid} AND #23{creatorpersonid} = #27{id}) type=delta // { arity: 28 }
               implementation
@@ -2182,14 +2182,14 @@ Explained Query:
               Distinct project=[#0{id}] // { arity: 1 }
                 Get l3 // { arity: 1 }
       cte l8 =
-        Project (#0{id}, #2{sum}, #3) // { arity: 3 }
+        Project (#0{id}, #2{count}, #3{sum}) // { arity: 3 }
           Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 4 }
             implementation
               %1[#0]UKA » %0:l4[#0]K
             Get l4 // { arity: 1 }
             ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 3 }
               Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*), sum(case when #1 then 1 else 0 end)] // { arity: 3 }
-                Project (#1, #3) // { arity: 2 }
+                Project (#1{creatorpersonid}, #3) // { arity: 2 }
                   Join on=(#0{id} = #2{id}) type=differential // { arity: 4 }
                     implementation
                       %0:l5[#0]K » %1[#0]K
@@ -2310,7 +2310,7 @@ Explained Query:
         ArrangeBy keys=[[#1{id}], [#8{locationcityid}]] // { arity: 11 }
           ReadIndex on=person person_id=[delta join lookup] person_locationcityid=[delta join lookup] // { arity: 11 }
       cte l3 =
-        Project (#4, #5, #9, #21) // { arity: 4 }
+        Project (#4{id}, #5{name}, #9{id}, #21{person2id}) // { arity: 4 }
           Filter (#1{name} = "Philippines") AND (#38{name} = "Taiwan") AND (#0{id}) IS NOT NULL AND (#36{partofcountryid}) IS NOT NULL // { arity: 41 }
             Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid} AND #9{id} = #20{person1id} AND #21{person2id} = #23{id} AND #30{locationcityid} = #33{id} AND #36{partofcountryid} = #37{id}) type=delta // { arity: 41 }
               implementation
@@ -2332,10 +2332,10 @@ Explained Query:
       cte l4 =
         Map (case when #2 then #1{person2id} else #0{id} end, case when #2 then #0{id} else #1{person2id} end) // { arity: 5 }
           Union // { arity: 3 }
-            Project (#2..=#4) // { arity: 3 }
+            Project (#2{id}..=#4) // { arity: 3 }
               Map (false) // { arity: 5 }
                 Get l3 // { arity: 4 }
-            Project (#3, #2, #4) // { arity: 3 }
+            Project (#3{person2id}, #2{id}, #4) // { arity: 3 }
               Map (true) // { arity: 5 }
                 Get l3 // { arity: 4 }
       cte l5 =
@@ -2354,7 +2354,7 @@ Explained Query:
               Get l5 // { arity: 2 }
             ArrangeBy keys=[[#0{creatorpersonid}, #1{creatorpersonid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{creatorpersonid}] // { arity: 2 }
-                Project (#9, #22) // { arity: 2 }
+                Project (#9{creatorpersonid}, #22{creatorpersonid}) // { arity: 2 }
                   Join on=(#1{messageid} = #25{parentmessageid}) type=differential // { arity: 26 }
                     implementation
                       %0:l6[#1]KA » %1:message[#12]KA
@@ -2390,7 +2390,7 @@ Explained Query:
               Get l9 // { arity: 2 }
             ArrangeBy keys=[[#0{personid}, #1{creatorpersonid}]] // { arity: 2 }
               Distinct project=[#1{personid}, #0{creatorpersonid}] // { arity: 2 }
-                Project (#9, #14) // { arity: 2 }
+                Project (#9{creatorpersonid}, #14{personid}) // { arity: 2 }
                   Join on=(#1{messageid} = #15{messageid}) type=differential // { arity: 16 }
                     implementation
                       %0:l6[#1]KA » %1:person_likes_message[#2]KA
@@ -2398,7 +2398,7 @@ Explained Query:
                     ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
                       ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l11 =
-        Project (#0{id}..=#3{person2id}, #6) // { arity: 5 }
+        Project (#0{id}..=#3{person2id}, #6{sum}) // { arity: 5 }
           Join on=(#2{id} = #4 AND #3{person2id} = #5) type=differential // { arity: 7 }
             implementation
               %1[#0, #1]UKKA » %0:l3[#2, #3]KK
@@ -2422,17 +2422,17 @@ Explained Query:
                               Get l10 // { arity: 2 }
                             Get l9 // { arity: 2 }
     Return // { arity: 4 }
-      Project (#0{id}, #1{person2id}, #3{sum}, #4) // { arity: 4 }
+      Project (#0{id}, #1{person2id}, #3{name}, #4{sum}) // { arity: 4 }
         TopK group_by=[#2{id}] order_by=[#4{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=1 // { arity: 5 }
           Union // { arity: 5 }
             Map (null) // { arity: 5 }
               Union // { arity: 4 }
                 Negate // { arity: 4 }
-                  Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
+                  Project (#2{id}, #3{person2id}, #0{id}, #1{name}) // { arity: 4 }
                     Get l11 // { arity: 5 }
-                Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
+                Project (#2{id}, #3{person2id}, #0{id}, #1{name}) // { arity: 4 }
                   Get l3 // { arity: 4 }
-            Project (#2{id}, #3{name}, #0{id}, #1{person2id}, #4{sum}) // { arity: 5 }
+            Project (#2{id}, #3{person2id}, #0{id}, #1{name}, #4{sum}) // { arity: 5 }
               Get l11 // { arity: 5 }
 
 Used Indexes:
@@ -2519,7 +2519,7 @@ Explained Query:
   Finish order_by=[#1{min} asc nulls_last] limit=20 output=[#2]
     With Mutually Recursive
       cte l0 =
-        Project (#1{person2id}, #2) // { arity: 2 }
+        Project (#1{person1id}, #2{person2id}) // { arity: 2 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
       cte l1 =
         ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
@@ -2527,7 +2527,7 @@ Explained Query:
       cte l2 =
         ArrangeBy keys=[[#0{id}]] // { arity: 1 }
           Distinct project=[#0{id}] // { arity: 1 }
-            Project (#1) // { arity: 1 }
+            Project (#1{id}) // { arity: 1 }
               Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                 ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
       cte l3 =
@@ -2537,7 +2537,7 @@ Explained Query:
           Get l1 // { arity: 2 }
           ArrangeBy keys=[[#1, #0]] // { arity: 3 }
             Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-              Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+              Project (#1{person1id}, #2{person2id}, #6{parentmessageid}) // { arity: 3 }
                 Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                   implementation
                     %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
@@ -2548,27 +2548,27 @@ Explained Query:
                   ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
                     ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                   ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                    Project (#1{messageid}, #9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 4 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                   ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                    Project (#9, #10, #12) // { arity: 3 }
+                    Project (#9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 3 }
                       Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                         ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                   Get l2 // { arity: 1 }
                   Get l2 // { arity: 1 }
       cte l4 =
-        Project (#2{min}, #0, #1{person2id}) // { arity: 3 }
+        Project (#2, #0{person2id}, #1{min}) // { arity: 3 }
           Map (1450) // { arity: 3 }
             Reduce group_by=[#0{person2id}] aggregates=[min(#1)] // { arity: 2 }
               Distinct project=[#0{person2id}, #1] // { arity: 2 }
                 Union // { arity: 2 }
-                  Project (#3, #5) // { arity: 2 }
+                  Project (#3{person2id}, #5) // { arity: 2 }
                     Map ((#1 + #4)) // { arity: 6 }
                       Join on=(#0 = #2{person1id}) type=differential // { arity: 5 }
                         implementation
                           %0:l4[#0]UK » %1[#0]K
                         ArrangeBy keys=[[#0]] // { arity: 2 }
-                          Project (#1, #2) // { arity: 2 }
+                          Project (#1{person2id}, #2{min}) // { arity: 2 }
                             Get l4 // { arity: 3 }
                         ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
                           Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
@@ -2587,12 +2587,12 @@ Explained Query:
                                               Project (#2, #3) // { arity: 2 }
                                                 Get l3 // { arity: 5 }
                                     Get l0 // { arity: 2 }
-                                Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
+                                Project (#0{person1id}, #1{person2id}, #4{sum}) // { arity: 3 }
                                   Get l3 // { arity: 5 }
                   Constant // { arity: 2 }
                     - (1450, 0)
     Return // { arity: 3 }
-      Project (#1{min}, #2{min}, #2{min}) // { arity: 3 }
+      Project (#1{person2id}, #2{min}, #2{min}) // { arity: 3 }
         Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
           Get l4 // { arity: 3 }
 
@@ -2715,7 +2715,7 @@ SELECT coalesce(min(w), -1) FROM results
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#1{person2id}, #2) // { arity: 2 }
+      Project (#1{person1id}, #2{person2id}) // { arity: 2 }
         ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
     cte l1 =
       ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
@@ -2723,7 +2723,7 @@ Explained Query:
     cte l2 =
       ArrangeBy keys=[[#0{id}]] // { arity: 1 }
         Distinct project=[#0{id}] // { arity: 1 }
-          Project (#1) // { arity: 1 }
+          Project (#1{id}) // { arity: 1 }
             Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
               ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
     cte l3 =
@@ -2733,7 +2733,7 @@ Explained Query:
         Get l1 // { arity: 2 }
         ArrangeBy keys=[[#1, #0]] // { arity: 3 }
           Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-            Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+            Project (#1{person1id}, #2{person2id}, #6{parentmessageid}) // { arity: 3 }
               Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                 implementation
                   %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
@@ -2744,10 +2744,10 @@ Explained Query:
                 ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
                   ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                 ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                  Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                  Project (#1{messageid}, #9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 4 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                 ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                  Project (#9, #10, #12) // { arity: 3 }
+                  Project (#9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 3 }
                     Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                 Get l2 // { arity: 1 }
@@ -2769,10 +2769,10 @@ Explained Query:
                           Project (#2, #3) // { arity: 2 }
                             Get l3 // { arity: 5 }
                 Get l0 // { arity: 2 }
-            Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
+            Project (#0{person1id}, #1{person2id}, #4{sum}) // { arity: 3 }
               Get l3 // { arity: 5 }
     cte l5 =
-      Project (#1{person2id}, #3) // { arity: 2 }
+      Project (#1, #3{person2id}) // { arity: 2 }
         Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
           implementation
             %0:l8[#0]K » %1:l4[#0]K
@@ -2783,7 +2783,7 @@ Explained Query:
               Get l4 // { arity: 3 }
     cte l6 =
       Union // { arity: 2 }
-        Project (#1, #0{person2id}) // { arity: 2 }
+        Project (#1{person2id}, #0) // { arity: 2 }
           Get l5 // { arity: 2 }
         Get l8 // { arity: 2 }
     cte l7 =
@@ -2803,7 +2803,7 @@ Explained Query:
     cte l8 =
       Distinct project=[#0{person2id}, #1] // { arity: 2 }
         Union // { arity: 2 }
-          Project (#1, #0{person2id}) // { arity: 2 }
+          Project (#1{person2id}, #0) // { arity: 2 }
             CrossJoin type=differential // { arity: 2 }
               implementation
                 %0:l5[×] » %1[×]
@@ -2828,7 +2828,7 @@ Explained Query:
             Get l17 // { arity: 6 }
     cte l10 =
       Distinct project=[#0..=#2] // { arity: 3 }
-        Project (#0..=#2) // { arity: 3 }
+        Project (#0..=#2{person2id}) // { arity: 3 }
           Get l17 // { arity: 6 }
     cte l11 =
       ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
@@ -2846,7 +2846,7 @@ Explained Query:
     cte l13 =
       TopK group_by=[#0, #1, #2{person2id}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
         Union // { arity: 5 }
-          Project (#3, #4, #1, #7, #8) // { arity: 5 }
+          Project (#3, #4, #1{person2id}, #7, #8) // { arity: 5 }
             Map ((#6 + #2), false) // { arity: 9 }
               Join on=(#0{person1id} = #5) type=differential // { arity: 7 }
                 implementation
@@ -2886,11 +2886,11 @@ Explained Query:
             implementation
               %0:l13[#0]Kef » %1:l13[#0]Kef
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              Project (#2, #3) // { arity: 2 }
+              Project (#2{person2id}, #3) // { arity: 2 }
                 Filter (#0 = false) // { arity: 5 }
                   Get l13 // { arity: 5 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              Project (#2, #3) // { arity: 2 }
+              Project (#2{person2id}, #3) // { arity: 2 }
                 Filter (#0 = true) // { arity: 5 }
                   Get l13 // { arity: 5 }
     cte l15 =
@@ -2959,18 +2959,18 @@ Explained Query:
                   Get l17 // { arity: 6 }
       cte l19 =
         Reduce aggregates=[min(#0{min})] // { arity: 1 }
-          Project (#2) // { arity: 1 }
+          Project (#2{min}) // { arity: 1 }
             Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0, #2, #3, #5) // { arity: 4 }
                 Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
                   implementation
                     %0:l18[#1]Kef » %1:l18[#1]Kef
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1{person2id}..=#3) // { arity: 3 }
+                    Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
                         Get l18 // { arity: 4 }
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1{person2id}..=#3) // { arity: 3 }
+                    Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
                         Get l18 // { arity: 4 }
     Return // { arity: 1 }
@@ -3076,7 +3076,7 @@ Explained Query:
       cte l0 =
         ArrangeBy keys=[[#0{id}]] // { arity: 1 }
           Distinct project=[#0{id}] // { arity: 1 }
-            Project (#1) // { arity: 1 }
+            Project (#1{id}) // { arity: 1 }
               Filter (#1{id}) IS NOT NULL // { arity: 11 }
                 ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
       cte l1 =
@@ -3086,7 +3086,7 @@ Explained Query:
         ArrangeBy keys=[[#1{name}]] // { arity: 4 }
           ReadIndex on=tag tag_name=[lookup] // { arity: 4 }
       cte l3 =
-        Project (#0{id}, #2) // { arity: 2 }
+        Project (#0{id}, #2{messageid}) // { arity: 2 }
           Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
             implementation
               %0:l0 » %1[#0]K » %2[#0]UKA
@@ -3095,12 +3095,12 @@ Explained Query:
             Get l0 // { arity: 1 }
             ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1{creatorpersonid}, #9) // { arity: 2 }
+                Project (#1{messageid}, #9{creatorpersonid}) // { arity: 2 }
                   Filter (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
+                Project (#1{messageid}) // { arity: 1 }
                   Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
                     implementation
                       %1:tag[#0]KAe » %0:l1[#2]KAe
@@ -3111,7 +3111,7 @@ Explained Query:
         ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
       cte l5 =
-        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
+        Project (#0{id}, #1{messageid}, #4{person2id}) // { arity: 3 }
           Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
             implementation
               %0:l3 » %1:l4[#1]KA » %2[#0]UKA
@@ -3125,7 +3125,7 @@ Explained Query:
                 Project (#0{id}) // { arity: 1 }
                   Get l3 // { arity: 2 }
       cte l6 =
-        Project (#0{id}, #2) // { arity: 2 }
+        Project (#0{id}, #2{messageid}) // { arity: 2 }
           Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
             implementation
               %0:l0 » %1[#0]K » %2[#0]UKA
@@ -3134,12 +3134,12 @@ Explained Query:
             Get l0 // { arity: 1 }
             ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1{creatorpersonid}, #9) // { arity: 2 }
+                Project (#1{messageid}, #9{creatorpersonid}) // { arity: 2 }
                   Filter (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
+                Project (#1{messageid}) // { arity: 1 }
                   Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
                     implementation
                       %1:tag[#0]KAe » %0:l1[#2]KAe
@@ -3147,7 +3147,7 @@ Explained Query:
                     ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                       ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
       cte l7 =
-        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
+        Project (#0{id}, #1{messageid}, #4{person2id}) // { arity: 3 }
           Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
             implementation
               %0:l6 » %1:l4[#1]KA » %2[#0]UKA
@@ -3249,7 +3249,7 @@ Explained Query:
   Finish order_by=[#1{count_messageid} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=10 output=[#0, #1]
     With
       cte l0 =
-        Project (#0{creationdate}, #1{messageid}, #9, #10, #12) // { arity: 5 }
+        Project (#0{creationdate}, #1{messageid}, #9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 5 }
           Join on=(#1{messageid} = #13{messageid}) type=differential // { arity: 14 }
             implementation
               %1[#0]UKA » %0:message[#1]KA
@@ -3257,7 +3257,7 @@ Explained Query:
               ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
+                Project (#1{messageid}) // { arity: 1 }
                   Join on=(#2{tagid} = #3{id}) type=differential // { arity: 4 }
                     implementation
                       %1[#0]UKA » %0:message_hastag_tag[#2]KA
@@ -3272,7 +3272,7 @@ Explained Query:
         ArrangeBy keys=[[#1{forumid}], [#2{personid}]] // { arity: 3 }
           ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[delta join lookup] forum_hasmember_person_personid=[delta join lookup] // { arity: 3 }
       cte l2 =
-        Project (#1{messageid}, #4, #6) // { arity: 3 }
+        Project (#1{creatorpersonid}, #4{messageid}, #6{containerforumid}) // { arity: 3 }
           Filter (#2{containerforumid} != #6{containerforumid}) AND (#5{creatorpersonid} != #7{creatorpersonid}) AND ((#0{creationdate} + 12:00:00) < #3{creationdate}) // { arity: 15 }
             Join on=(#2{containerforumid} = #10{forumid} = #13{forumid} AND #4{messageid} = #8{parentmessageid} AND #5{creatorpersonid} = #14{personid} AND #7{creatorpersonid} = #11{personid}) type=delta // { arity: 15 }
               implementation
@@ -3282,20 +3282,20 @@ Explained Query:
                 %3:l1 » %4:l1[#1]KA » %0:l0[#2]K » %1:l0[#2]K » %2:l0[#0, #1]KK
                 %4:l1 » %3:l1[#1]KA » %0:l0[#2]K » %1:l0[#2]K » %2:l0[#0, #1]KK
               ArrangeBy keys=[[#2{containerforumid}]] // { arity: 3 }
-                Project (#0{creationdate}, #2{containerforumid}, #3) // { arity: 3 }
+                Project (#0{creationdate}, #2{creatorpersonid}, #3{containerforumid}) // { arity: 3 }
                   Get l0 // { arity: 5 }
               ArrangeBy keys=[[#1{messageid}, #2{creatorpersonid}], [#2{creatorpersonid}]] // { arity: 4 }
                 Project (#0{creationdate}..=#3{containerforumid}) // { arity: 4 }
                   Get l0 // { arity: 5 }
               ArrangeBy keys=[[#0{creatorpersonid}, #1{parentmessageid}]] // { arity: 2 }
-                Project (#2, #4) // { arity: 2 }
+                Project (#2{creatorpersonid}, #4{parentmessageid}) // { arity: 2 }
                   Filter (#4{parentmessageid}) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
               Get l1 // { arity: 3 }
               Get l1 // { arity: 3 }
       cte l3 =
         Distinct project=[#0{creatorpersonid}, #1{containerforumid}] // { arity: 2 }
-          Project (#0{creatorpersonid}, #2) // { arity: 2 }
+          Project (#0{creatorpersonid}, #2{containerforumid}) // { arity: 2 }
             Get l2 // { arity: 3 }
     Return // { arity: 2 }
       Reduce group_by=[#0{creatorpersonid}] aggregates=[count(distinct #1{messageid})] // { arity: 2 }
@@ -3316,7 +3316,7 @@ Explained Query:
                         Get l3 // { arity: 2 }
                       ArrangeBy keys=[[#0{personid}, #1{forumid}]] // { arity: 2 }
                         Distinct project=[#1{personid}, #0{forumid}] // { arity: 2 }
-                          Project (#1{personid}, #2) // { arity: 2 }
+                          Project (#1{forumid}, #2{personid}) // { arity: 2 }
                             ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[*** full scan ***] // { arity: 3 }
                 Get l3 // { arity: 2 }
 
@@ -3369,21 +3369,21 @@ Explained Query:
     With
       cte l0 =
         ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
-          Project (#0{personid}, #9) // { arity: 2 }
+          Project (#0{personid}, #9{person2id}) // { arity: 2 }
             Join on=(#0{personid} = #8{person1id} AND #1{tagid} = #2{id}) type=delta // { arity: 10 }
               implementation
                 %0:person_hasinterest_tag » %1:tag[#0]KAe » %2:person_knows_person[#1]KA
                 %1:tag » %0:person_hasinterest_tag[#1]KA » %2:person_knows_person[#1]KA
                 %2:person_knows_person » %0:person_hasinterest_tag[#0]K » %1:tag[#0]KAe
               ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-                Project (#1{tagid}, #2) // { arity: 2 }
+                Project (#1{personid}, #2{tagid}) // { arity: 2 }
                   ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
               ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                 ReadIndex on=materialize.public.tag tag_name=[lookup value=("Fyodor_Dostoyevsky")] // { arity: 5 }
               ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
                 ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] // { arity: 3 }
       cte l1 =
-        Project (#0{personid}, #2) // { arity: 2 }
+        Project (#0{personid}, #2{personid}) // { arity: 2 }
           Filter (#0{personid} != #2{personid}) // { arity: 4 }
             Join on=(#1{person2id} = #3{person2id}) type=differential // { arity: 4 }
               implementation
@@ -3412,7 +3412,7 @@ Explained Query:
                         Get l2 // { arity: 2 }
                       ArrangeBy keys=[[#0{person2id}, #1{person1id}]] // { arity: 2 }
                         Distinct project=[#1{person2id}, #0{person1id}] // { arity: 2 }
-                          Project (#1{person2id}, #2) // { arity: 2 }
+                          Project (#1{person1id}, #2{person2id}) // { arity: 2 }
                             ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                 Get l2 // { arity: 2 }
 
@@ -3467,7 +3467,7 @@ materialize.public.pathq19:
       Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
         Map (greatest(f64toi64(roundf64((40 - sqrtf64(bigint_to_double(#2{count}))))), 1)) // { arity: 4 }
           Reduce group_by=[#0{person1id}, #1{person2id}] aggregates=[count(*)] // { arity: 3 }
-            Project (#16, #17) // { arity: 2 }
+            Project (#16{person1id}, #17{person2id}) // { arity: 2 }
               Filter (#0{creatorpersonid} != #11{creatorpersonid}) AND (#16{person1id} < #17{person2id}) // { arity: 18 }
                 Join on=(#1{parentmessageid} = #3{messageid} AND #16{person1id} = least(#0{creatorpersonid}, #11{creatorpersonid}) AND #17{person2id} = greatest(#0{creatorpersonid}, #11{creatorpersonid})) type=delta // { arity: 18 }
                   implementation
@@ -3475,7 +3475,7 @@ materialize.public.pathq19:
                     %1:message » %0:message[#1]KA » %2:person_knows_person[#1, #2]KKAf
                     %2:person_knows_person » %0:message[×] » %1:message[#1]KA
                   ArrangeBy keys=[[], [#1{parentmessageid}]] // { arity: 2 }
-                    Project (#9, #12) // { arity: 2 }
+                    Project (#9{creatorpersonid}, #12{parentmessageid}) // { arity: 2 }
                       Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                         ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                   ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
@@ -3485,7 +3485,7 @@ materialize.public.pathq19:
   Return // { arity: 3 }
     Union // { arity: 3 }
       Get l0 // { arity: 3 }
-      Project (#1{person1id}, #0{person2id}, #2) // { arity: 3 }
+      Project (#1{person2id}, #0{person1id}, #2) // { arity: 3 }
         Get l0 // { arity: 3 }
 
 Used Indexes:
@@ -3569,7 +3569,7 @@ Explained Query:
             Project (#1{id}, #1{id}, #12) // { arity: 3 }
               Map (0) // { arity: 13 }
                 ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
-            Project (#0, #4, #6) // { arity: 3 }
+            Project (#0, #4{dst}, #6) // { arity: 3 }
               Map ((#2 + bigint_to_double(#5{w}))) // { arity: 7 }
                 Join on=(#1 = #3{src}) type=differential // { arity: 6 }
                   implementation
@@ -3591,7 +3591,7 @@ Explained Query:
                 Get l0 // { arity: 3 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
+                Project (#1{id}) // { arity: 1 }
                   Filter (#1{id}) IS NOT NULL // { arity: 12 }
                     ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
     Return // { arity: 3 }
@@ -3603,7 +3603,7 @@ Explained Query:
             Get l1 // { arity: 3 }
           ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
             Reduce aggregates=[min(#0{min})] // { arity: 1 }
-              Project (#2) // { arity: 1 }
+              Project (#2{min}) // { arity: 1 }
                 Get l1 // { arity: 3 }
 
 Used Indexes:
@@ -3696,7 +3696,7 @@ Explained Query:
           Project (#1{id}, #1{id}, #12) // { arity: 3 }
             Map (0) // { arity: 13 }
               ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
-          Project (#0, #5, #7) // { arity: 3 }
+          Project (#0, #5{dst}, #7) // { arity: 3 }
             Filter coalesce((#2 < #3), true) // { arity: 8 }
               Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
                 Join on=(#1 = #4{src}) type=delta // { arity: 7 }
@@ -3715,7 +3715,7 @@ Explained Query:
           Project (#1{id}, #1{id}, #12) // { arity: 3 }
             Map (0) // { arity: 13 }
               ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
-          Project (#0, #5, #7) // { arity: 3 }
+          Project (#0, #5{dst}, #7) // { arity: 3 }
             Filter coalesce((#2 < #3), true) // { arity: 8 }
               Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
                 Join on=(#1 = #4{src}) type=delta // { arity: 7 }
@@ -3730,7 +3730,7 @@ Explained Query:
                   Get l2 // { arity: 3 }
     cte l5 =
       Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-        Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
+        Project (#0{id}, #2, #3{id}, #5) // { arity: 4 }
           Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
             implementation
               %0:l3[#1]K » %1:l4[#1]K
@@ -3742,7 +3742,7 @@ Explained Query:
                 Get l4 // { arity: 3 }
     cte l6 =
       Reduce aggregates=[min(#0{min})] // { arity: 1 }
-        Project (#2) // { arity: 1 }
+        Project (#2{min}) // { arity: 1 }
           Get l5 // { arity: 3 }
     cte l7 =
       Union // { arity: 1 }
@@ -3763,7 +3763,7 @@ Explained Query:
           Get l5 // { arity: 3 }
         ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
           Reduce aggregates=[min(#0{min})] // { arity: 1 }
-            Project (#2) // { arity: 1 }
+            Project (#2{min}) // { arity: 1 }
               Get l5 // { arity: 3 }
 
 Used Indexes:
@@ -3837,7 +3837,7 @@ Explained Query:
               Get l7 // { arity: 6 }
       cte l1 =
         Distinct project=[#0..=#2] // { arity: 3 }
-          Project (#0..=#2) // { arity: 3 }
+          Project (#0..=#2{id}) // { arity: 3 }
             Get l7 // { arity: 6 }
       cte l2 =
         Project (#0..=#2) // { arity: 3 }
@@ -3856,7 +3856,7 @@ Explained Query:
         TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
           Distinct project=[#0..=#4] // { arity: 5 }
             Union // { arity: 5 }
-              Project (#3, #4, #1, #7, #8) // { arity: 5 }
+              Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
                 Map ((#6 + bigint_to_double(#2{w})), false) // { arity: 9 }
                   Join on=(#0{src} = #5) type=differential // { arity: 7 }
                     implementation
@@ -3898,11 +3898,11 @@ Explained Query:
               implementation
                 %0:l3[#0]Kef » %1:l3[#0]Kef
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
+                Project (#2{dst}, #3) // { arity: 2 }
                   Filter (#0 = false) AND (#2{dst}) IS NOT NULL // { arity: 5 }
                     Get l3 // { arity: 5 }
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
+                Project (#2{dst}, #3) // { arity: 2 }
                   Filter (#0 = true) AND (#2{dst}) IS NOT NULL // { arity: 5 }
                     Get l3 // { arity: 5 }
       cte l5 =
@@ -3923,13 +3923,13 @@ Explained Query:
       cte l7 =
         Distinct project=[#0..=#5] // { arity: 6 }
           Union // { arity: 6 }
-            Project (#1{id}, #0, #0, #2{id}..=#4) // { arity: 6 }
+            Project (#1, #0{id}, #0{id}, #2..=#4) // { arity: 6 }
               Map (0, false, 0) // { arity: 5 }
                 Union // { arity: 2 }
-                  Project (#1, #12) // { arity: 2 }
+                  Project (#1{id}, #12) // { arity: 2 }
                     Map (false) // { arity: 13 }
                       ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
-                  Project (#1, #12) // { arity: 2 }
+                  Project (#1{id}, #12) // { arity: 2 }
                     Map (true) // { arity: 13 }
                       ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
             Project (#0..=#3, #7, #8) // { arity: 6 }
@@ -3972,7 +3972,7 @@ Explained Query:
                     Get l7 // { arity: 6 }
         cte l9 =
           Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-            Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
+            Project (#0{id}, #2, #3{id}, #5) // { arity: 4 }
               Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
                 implementation
                   %0:l8[#1]Kef » %1:l8[#1]Kef
@@ -3993,7 +3993,7 @@ Explained Query:
               Get l9 // { arity: 3 }
             ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
               Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                Project (#2) // { arity: 1 }
+                Project (#2{min}) // { arity: 1 }
                   Get l9 // { arity: 3 }
 
 Used Indexes:
@@ -4061,18 +4061,18 @@ Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0, #1]
     With Mutually Recursive
       cte l0 =
-        Project (#2{min}, #0, #1{dst}) // { arity: 3 }
+        Project (#2, #0{dst}, #1{min}) // { arity: 3 }
           Map (10995116285979) // { arity: 3 }
             Reduce group_by=[#0{dst}] aggregates=[min(#1)] // { arity: 2 }
               Distinct project=[#0{dst}, #1] // { arity: 2 }
                 Union // { arity: 2 }
-                  Project (#3, #5) // { arity: 2 }
+                  Project (#3{dst}, #5) // { arity: 2 }
                     Map ((#1 + integer_to_bigint(#4{w}))) // { arity: 6 }
                       Join on=(#0 = #2{src}) type=differential // { arity: 5 }
                         implementation
                           %0:l0[#0]UK » %1:pathq20[#0]KA
                         ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                          Project (#1{min}, #2) // { arity: 2 }
+                          Project (#1{dst}, #2{min}) // { arity: 2 }
                             Get l0 // { arity: 3 }
                         ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                           ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
@@ -4086,11 +4086,11 @@ Explained Query:
               implementation
                 %1[#0]UKA » %0:l0[#0]UK
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#1{min}, #2) // { arity: 2 }
+                Project (#1{dst}, #2{min}) // { arity: 2 }
                   Get l0 // { arity: 3 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
+                  Project (#1{personid}) // { arity: 1 }
                     Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
                       Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
                         implementation
@@ -4100,7 +4100,7 @@ Explained Query:
                         ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
         cte l2 =
-          Project (#1) // { arity: 1 }
+          Project (#1{min}) // { arity: 1 }
             Get l1 // { arity: 2 }
       Return // { arity: 2 }
         Project (#0{dst}, #1{min}) // { arity: 2 }
@@ -4172,7 +4172,7 @@ Explained Query:
         Reduce group_by=[#0{dst}] aggregates=[min(#1)] // { arity: 2 }
           Distinct project=[#0{dst}, #1] // { arity: 2 }
             Union // { arity: 2 }
-              Project (#3, #5) // { arity: 2 }
+              Project (#3{dst}, #5) // { arity: 2 }
                 Map ((#1 + integer_to_bigint(#4{w}))) // { arity: 6 }
                   Join on=(#0 = #2{src}) type=differential // { arity: 5 }
                     implementation
@@ -4194,7 +4194,7 @@ Explained Query:
                 Get l0 // { arity: 2 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
+                  Project (#1{personid}) // { arity: 1 }
                     Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
                       Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
                         implementation
@@ -4204,7 +4204,7 @@ Explained Query:
                         ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
         cte l2 =
-          Project (#1) // { arity: 1 }
+          Project (#1{min}) // { arity: 1 }
             Get l1 // { arity: 2 }
       Return // { arity: 2 }
         Project (#0{dst}, #1{min}) // { arity: 2 }
@@ -4278,19 +4278,19 @@ Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0..=#2]
     With Mutually Recursive
       cte l0 =
-        Project (#3{min}, #0..=#2{min}) // { arity: 4 }
+        Project (#3, #0{dst}..=#2{min}) // { arity: 4 }
           Map (10995116285979) // { arity: 4 }
             Reduce group_by=[#0{dst}, #2{min}] aggregates=[min(#1)] // { arity: 3 }
               Reduce group_by=[#0{dst}, #2] aggregates=[min(#1)] // { arity: 3 }
                 Distinct project=[#0{dst}..=#2] // { arity: 3 }
                   Union // { arity: 3 }
-                    Project (#4, #6, #7) // { arity: 3 }
+                    Project (#4{dst}, #6, #7) // { arity: 3 }
                       Map ((#1 + integer_to_bigint(#5{w})), (#2 + 1)) // { arity: 8 }
                         Join on=(#0 = #3{src}) type=differential // { arity: 6 }
                           implementation
                             %1:pathq20[#0]KA » %0:l0[#0]K
                           ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
-                            Project (#1{min}..=#3) // { arity: 3 }
+                            Project (#1{dst}..=#3{min}) // { arity: 3 }
                               Get l0 // { arity: 4 }
                           ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                             ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
@@ -4304,11 +4304,11 @@ Explained Query:
               implementation
                 %1[#0]UKA » %0:l0[#0]K
               ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
-                Project (#1{min}..=#3) // { arity: 3 }
+                Project (#1{dst}..=#3{min}) // { arity: 3 }
                   Get l0 // { arity: 4 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
+                  Project (#1{personid}) // { arity: 1 }
                     Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
                       Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
                         implementation
@@ -4318,7 +4318,7 @@ Explained Query:
                         ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
         cte l2 =
-          Project (#1) // { arity: 1 }
+          Project (#1{min}) // { arity: 1 }
             Get l1 // { arity: 3 }
       Return // { arity: 3 }
         Project (#0{dst}..=#2{min}) // { arity: 3 }
@@ -4429,7 +4429,7 @@ Explained Query:
   Finish order_by=[#0{personid} asc nulls_last] limit=20 output=[#0, #1]
     With Mutually Recursive
       cte l0 =
-        Project (#1) // { arity: 1 }
+        Project (#1{personid}) // { arity: 1 }
           Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
             Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
               implementation
@@ -4447,7 +4447,7 @@ Explained Query:
       cte l3 =
         Distinct project=[#0{dst}] // { arity: 1 }
           Union // { arity: 1 }
-            Project (#2) // { arity: 1 }
+            Project (#2{dst}) // { arity: 1 }
               Join on=(#0 = #1{src}) type=delta // { arity: 4 }
                 implementation
                   %0:l3 » %1:l1[#0]KA » %2[×]
@@ -4478,7 +4478,7 @@ Explained Query:
               Get l12 // { arity: 6 }
       cte l5 =
         Distinct project=[#0..=#2] // { arity: 3 }
-          Project (#0..=#2) // { arity: 3 }
+          Project (#0..=#2{personid}) // { arity: 3 }
             Get l12 // { arity: 6 }
       cte l6 =
         ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
@@ -4496,7 +4496,7 @@ Explained Query:
       cte l8 =
         TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
           Union // { arity: 5 }
-            Project (#3, #4, #1, #7, #8) // { arity: 5 }
+            Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
               Map ((#6 + integer_to_bigint(#2{w})), false) // { arity: 9 }
                 Join on=(#0{src} = #5) type=differential // { arity: 7 }
                   implementation
@@ -4535,11 +4535,11 @@ Explained Query:
               implementation
                 %0:l8[#0]Kef » %1:l8[#0]Kef
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
+                Project (#2{dst}, #3) // { arity: 2 }
                   Filter (#0 = false) // { arity: 5 }
                     Get l8 // { arity: 5 }
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
+                Project (#2{dst}, #3) // { arity: 2 }
                   Filter (#0 = true) // { arity: 5 }
                     Get l8 // { arity: 5 }
       cte l10 =
@@ -4573,7 +4573,7 @@ Explained Query:
                     Project (#1, #0, #0) // { arity: 3 }
                       Map (10995116285979, false) // { arity: 2 }
                         Get l11 // { arity: 0 }
-                    Project (#1{personid}, #0, #0) // { arity: 3 }
+                    Project (#1, #0{personid}, #0{personid}) // { arity: 3 }
                       Map (true) // { arity: 2 }
                         CrossJoin type=differential // { arity: 1 }
                           implementation
@@ -4620,9 +4620,9 @@ Explained Query:
                   Project (#5) // { arity: 1 }
                     Get l12 // { arity: 6 }
         cte l14 =
-          Project (#1{min}, #2) // { arity: 2 }
+          Project (#1{personid}, #2{min}) // { arity: 2 }
             Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1 + #3))] // { arity: 3 }
-              Project (#0{personid}, #2{personid}, #3, #5) // { arity: 4 }
+              Project (#0{personid}, #2, #3{personid}, #5) // { arity: 4 }
                 Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
                   implementation
                     %0:l13[#1]Kef » %1:l13[#1]Kef
@@ -4643,7 +4643,7 @@ Explained Query:
               Get l14 // { arity: 2 }
             ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
               Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                Project (#1) // { arity: 1 }
+                Project (#1{min}) // { arity: 1 }
                   Get l14 // { arity: 2 }
 
 Used Indexes:

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -455,14 +455,14 @@ Explained Query:
             Filter (#0{creationdate} < 2010-06-11 09:21:46 UTC) // { arity: 13 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
     Return // { arity: 7 }
-      Project (#0..=#2, #4, #7, #5{sum}, #8) // { arity: 7 }
+      Project (#0..=#2, #4{count}, #7, #5{sum}, #8) // { arity: 7 }
         Map ((#5{sum} / bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end)), (bigint_to_numeric(#4{count}) / #3)) // { arity: 9 }
           Reduce group_by=[#1..=#4] aggregates=[count(*), sum(integer_to_bigint(#0{length})), count(integer_to_bigint(#0{length}))] // { arity: 7 }
             CrossJoin type=differential // { arity: 5 }
               implementation
                 %1[×]U » %0:message[×]if
               ArrangeBy keys=[[]] // { arity: 4 }
-                Project (#8, #13..=#15) // { arity: 4 }
+                Project (#8{length}, #13..=#15) // { arity: 4 }
                   Filter (#0{creationdate} < 2010-06-11 09:21:46 UTC) AND (#4{content}) IS NOT NULL // { arity: 16 }
                     Map (extract_year_tstz(#0{creationdate}), (#12{parentmessageid}) IS NOT NULL, case when (#8{length} < 40) then 0 else case when (#8{length} < 80) then 1 else case when (#8{length} < 160) then 2 else 3 end end end) // { arity: 16 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
@@ -527,7 +527,7 @@ Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0..=#3]
     With
       cte l0 =
-        Project (#5, #6) // { arity: 2 }
+        Project (#5{id}, #6{name}) // { arity: 2 }
           Join on=(#0{id} = #8{typetagclassid}) type=differential // { arity: 9 }
             implementation
               %0:tagclass[#0]KAe » %1:tag[#3]KAe
@@ -539,7 +539,7 @@ Explained Query:
         Filter (#0{id}) IS NOT NULL // { arity: 2 }
           Get l0 // { arity: 2 }
       cte l2 =
-        Project (#1{count}, #3, #4) // { arity: 3 }
+        Project (#1{name}, #3{count}, #4{count}) // { arity: 3 }
           Join on=(#0{id} = #2{id}) type=differential // { arity: 5 }
             implementation
               %1[#0]UKA » %0:l1[#0]K
@@ -547,7 +547,7 @@ Explained Query:
               Get l1 // { arity: 2 }
             ArrangeBy keys=[[#0{id}]] // { arity: 3 }
               Reduce group_by=[#0{id}] aggregates=[count(case when (#2{creationdate} < 2010-09-16 00:00:00 UTC) then #1{messageid} else null end), count(case when (#2{creationdate} >= 2010-09-16 00:00:00 UTC) then #1{messageid} else null end)] // { arity: 3 }
-                Project (#0{id}, #2{creationdate}, #4) // { arity: 3 }
+                Project (#0{id}, #2{messageid}, #4{creationdate}) // { arity: 3 }
                   Filter (#4{creationdate} < 2010-12-25 00:00:00 UTC) AND (#4{creationdate} >= 2010-06-08 00:00:00 UTC) // { arity: 17 }
                     Join on=(#0{id} = #3{tagid} AND #2{messageid} = #5{messageid}) type=delta // { arity: 17 }
                       implementation
@@ -570,7 +570,7 @@ Explained Query:
                 Negate // { arity: 1 }
                   Project (#0{name}) // { arity: 1 }
                     Get l2 // { arity: 3 }
-                Project (#1) // { arity: 1 }
+                Project (#1{name}) // { arity: 1 }
                   Get l0 // { arity: 2 }
             Get l2 // { arity: 3 }
 
@@ -623,7 +623,7 @@ LIMIT 20
 Explained Query:
   Finish order_by=[#4{count} desc nulls_first, #0{containerforumid} asc nulls_last] limit=20 output=[#0..=#4]
     Reduce group_by=[#0{containerforumid}, #2{title}, #1{creationdate}, #3{moderatorpersonid}] aggregates=[count(*)] // { arity: 5 }
-      Project (#10, #13, #15, #16) // { arity: 4 }
+      Project (#10{containerforumid}, #13{creationdate}, #15{title}, #16{moderatorpersonid}) // { arity: 4 }
         Filter (#33{name} = "China") AND (#16{moderatorpersonid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
           Join on=(#1{messageid} = #36{messageid} AND #10{containerforumid} = #14{id} AND #16{moderatorpersonid} = #18{id} AND #25{locationcityid} = #28{id} AND #31{partofcountryid} = #32{id}) type=delta // { arity: 37 }
             implementation
@@ -645,7 +645,7 @@ Explained Query:
               ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#10) // { arity: 1 }
+                Project (#10{messageid}) // { arity: 1 }
                   Join on=(#0{id} = #8{typetagclassid} AND #5{id} = #11{tagid}) type=delta // { arity: 12 }
                     implementation
                       %0:tagclass » %1:tag[#3]KA » %2:message_hastag_tag[#2]KA
@@ -752,7 +752,7 @@ Explained Query:
       cte l0 =
         Project (#0{id}) // { arity: 1 }
           TopK order_by=[#1{maxnumberofmembers} desc nulls_first, #0{id} asc nulls_last] limit=100 // { arity: 2 }
-            Project (#0{id}, #2) // { arity: 2 }
+            Project (#0{id}, #2{maxnumberofmembers}) // { arity: 2 }
               Filter (#1{creationdate} > 2010-02-12 00:00:00 UTC) // { arity: 3 }
                 ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
       cte l1 =
@@ -764,7 +764,7 @@ Explained Query:
               ReadIndex on=person person_id=[differential join] // { arity: 11 }
             ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
               Distinct project=[#0{personid}] // { arity: 1 }
-                Project (#3) // { arity: 1 }
+                Project (#3{personid}) // { arity: 1 }
                   Join on=(#0{id} = #2{forumid}) type=differential // { arity: 4 }
                     implementation
                       %1:forum_hasmember_person[#1]KA » %0:l0[#0]K
@@ -776,7 +776,7 @@ Explained Query:
         ArrangeBy keys=[[#1{id}]] // { arity: 4 }
           Get l1 // { arity: 4 }
       cte l3 =
-        Project (#0{creationdate}..=#3{lastname}, #5) // { arity: 5 }
+        Project (#0{creationdate}..=#3{lastname}, #5{messageid}) // { arity: 5 }
           Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{id}) type=delta // { arity: 18 }
             implementation
               %0:l2 » %1:message[#9]KA » %2[#0]UKA
@@ -801,7 +801,7 @@ Explained Query:
                     Get l2 // { arity: 4 }
                     ArrangeBy keys=[[#0{id}]] // { arity: 1 }
                       Distinct project=[#0{id}] // { arity: 1 }
-                        Project (#1) // { arity: 1 }
+                        Project (#1{id}) // { arity: 1 }
                           Get l3 // { arity: 5 }
               Get l1 // { arity: 4 }
           Get l3 // { arity: 5 }
@@ -853,7 +853,7 @@ Explained Query:
   Finish order_by=[#4 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0..=#4]
     With
       cte l0 =
-        Project (#1{messageid}, #5, #16) // { arity: 3 }
+        Project (#1{name}, #5{messageid}, #16{creatorpersonid}) // { arity: 3 }
           Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
             implementation
               %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
@@ -867,28 +867,28 @@ Explained Query:
               ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
       cte l1 =
         Reduce group_by=[#0{parentmessageid}] aggregates=[count(*)] // { arity: 2 }
-          Project (#12) // { arity: 1 }
+          Project (#12{parentmessageid}) // { arity: 1 }
             Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
       cte l2 =
         Reduce group_by=[#0{messageid}] aggregates=[count(*)] // { arity: 2 }
-          Project (#2) // { arity: 1 }
+          Project (#2{messageid}) // { arity: 1 }
             ReadIndex on=person_likes_message person_likes_message_personid=[*** full scan ***] // { arity: 3 }
       cte l3 =
         Distinct project=[#0{messageid}] // { arity: 1 }
-          Project (#1) // { arity: 1 }
+          Project (#1{messageid}) // { arity: 1 }
             Get l0 // { arity: 3 }
     Return // { arity: 5 }
       Map (((bigint_to_numeric((1 * #3{count})) + (2 * #1{sum})) + (10 * #2{sum}))) // { arity: 5 }
         Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(case when (#2) IS NULL then null else #1{count} end, 0)), sum(coalesce(case when (#4) IS NULL then null else #3{count} end, 0)), count(*)] // { arity: 4 }
-          Project (#1{count}, #3{count}, #4, #6, #7) // { arity: 5 }
+          Project (#1{creatorpersonid}, #3{count}, #4, #6{count}, #7) // { arity: 5 }
             Join on=(#0{messageid} = #2{parentmessageid} = #5{messageid}) type=delta // { arity: 8 }
               implementation
                 %0:l0 » %1[#0]K » %2[#0]K
                 %1 » %0:l0[#0]Kef » %2[#0]K
                 %2 » %0:l0[#0]Kef » %1[#0]K
               ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-                Project (#1{creatorpersonid}, #2) // { arity: 2 }
+                Project (#1{messageid}, #2{creatorpersonid}) // { arity: 2 }
                   Filter (#0{name} = "Sikh_Empire") // { arity: 3 }
                     Get l0 // { arity: 3 }
               ArrangeBy keys=[[#0{parentmessageid}]] // { arity: 3 }
@@ -980,7 +980,7 @@ Explained Query:
   Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
     With
       cte l0 =
-        Project (#6, #17) // { arity: 2 }
+        Project (#6{messageid}, #17{creatorpersonid}) // { arity: 2 }
           Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
             implementation
               %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
@@ -996,7 +996,7 @@ Explained Query:
         ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
           Get l0 // { arity: 2 }
       cte l2 =
-        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
+        Project (#0{messageid}, #1{creatorpersonid}, #3{personid}) // { arity: 3 }
           Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
             implementation
               %1:person_likes_message[#2]KA » %0:l1[#0]K
@@ -1009,7 +1009,7 @@ Explained Query:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#1) // { arity: 1 }
+                  Project (#1{creatorpersonid}) // { arity: 1 }
                     Join on=(#0{messageid} = #2{messageid}) type=differential // { arity: 3 }
                       implementation
                         %1[#0]UKA » %0:l1[#0]K
@@ -1018,12 +1018,12 @@ Explained Query:
                         Distinct project=[#0{messageid}] // { arity: 1 }
                           Project (#0{messageid}) // { arity: 1 }
                             Get l2 // { arity: 3 }
-                Project (#1) // { arity: 1 }
+                Project (#1{creatorpersonid}) // { arity: 1 }
                   Get l0 // { arity: 2 }
-            Project (#1{personid}, #2) // { arity: 2 }
+            Project (#1{creatorpersonid}, #2{personid}) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l4 =
-        Project (#0{creatorpersonid}, #3) // { arity: 2 }
+        Project (#0{creatorpersonid}, #3{popularityscore}) // { arity: 2 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
@@ -1086,7 +1086,7 @@ Explained Query:
   Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
     With
       cte l0 =
-        Project (#6, #17) // { arity: 2 }
+        Project (#6{messageid}, #17{creatorpersonid}) // { arity: 2 }
           Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
             implementation
               %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
@@ -1102,7 +1102,7 @@ Explained Query:
         ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
           Get l0 // { arity: 2 }
       cte l2 =
-        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
+        Project (#0{messageid}, #1{creatorpersonid}, #3{personid}) // { arity: 3 }
           Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
             implementation
               %1:person_likes_message[#2]KA » %0:l1[#0]K
@@ -1115,7 +1115,7 @@ Explained Query:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#1) // { arity: 1 }
+                  Project (#1{creatorpersonid}) // { arity: 1 }
                     Join on=(#0{messageid} = #2{messageid}) type=differential // { arity: 3 }
                       implementation
                         %1[#0]UKA » %0:l1[#0]K
@@ -1124,12 +1124,12 @@ Explained Query:
                         Distinct project=[#0{messageid}] // { arity: 1 }
                           Project (#0{messageid}) // { arity: 1 }
                             Get l2 // { arity: 3 }
-                Project (#1) // { arity: 1 }
+                Project (#1{creatorpersonid}) // { arity: 1 }
                   Get l0 // { arity: 2 }
-            Project (#1{personid}, #2) // { arity: 2 }
+            Project (#1{creatorpersonid}, #2{personid}) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l4 =
-        Project (#0{creatorpersonid}, #3) // { arity: 2 }
+        Project (#0{creatorpersonid}, #3{popularityscore}) // { arity: 2 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
@@ -1193,7 +1193,7 @@ Explained Query:
   Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
     With
       cte l0 =
-        Project (#1{messageid}, #5, #16) // { arity: 3 }
+        Project (#1{name}, #5{messageid}, #16{creatorpersonid}) // { arity: 3 }
           Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
             implementation
               %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
@@ -1206,7 +1206,7 @@ Explained Query:
             ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
               ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
       cte l1 =
-        Project (#0{name}..=#2{creatorpersonid}, #4) // { arity: 4 }
+        Project (#0{name}..=#2{creatorpersonid}, #4{personid}) // { arity: 4 }
           Join on=(#1{messageid} = #5{messageid}) type=differential // { arity: 6 }
             implementation
               %1:person_likes_message[#2]KA » %0:l0[#1]K
@@ -1223,24 +1223,24 @@ Explained Query:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#1) // { arity: 1 }
+                  Project (#1{creatorpersonid}) // { arity: 1 }
                     Join on=(#0{messageid} = #2{messageid}) type=differential // { arity: 3 }
                       implementation
                         %1[#0]UKA » %0:l2[#0]Kef
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-                        Project (#1{creatorpersonid}, #2) // { arity: 2 }
+                        Project (#1{messageid}, #2{creatorpersonid}) // { arity: 2 }
                           Get l2 // { arity: 3 }
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
                         Distinct project=[#0{messageid}] // { arity: 1 }
-                          Project (#1) // { arity: 1 }
+                          Project (#1{messageid}) // { arity: 1 }
                             Get l1 // { arity: 4 }
-                Project (#2) // { arity: 1 }
+                Project (#2{creatorpersonid}) // { arity: 1 }
                   Get l2 // { arity: 3 }
-            Project (#2, #3) // { arity: 2 }
+            Project (#2{creatorpersonid}, #3{personid}) // { arity: 2 }
               Filter (#0{name} = "Bob_Geldof") // { arity: 4 }
                 Get l1 // { arity: 4 }
       cte l4 =
-        Project (#0{creatorpersonid}, #3) // { arity: 2 }
+        Project (#0{creatorpersonid}, #3{popularityscore}) // { arity: 2 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
@@ -1310,7 +1310,7 @@ Explained Query:
   Finish order_by=[#1{count} desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0, #1]
     With
       cte l0 =
-        Project (#1) // { arity: 1 }
+        Project (#1{messageid}) // { arity: 1 }
           Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
             implementation
               %1:tag[#0]KAe » %0:message_hastag_tag[#2]KAe
@@ -1319,7 +1319,7 @@ Explained Query:
             ArrangeBy keys=[[#0{id}]] // { arity: 5 }
               ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
       cte l1 =
-        Project (#2, #18) // { arity: 2 }
+        Project (#2{messageid}, #18{name}) // { arity: 2 }
           Join on=(#0{messageid} = #13{parentmessageid} AND #2{messageid} = #15{messageid} AND #16{tagid} = #17{id}) type=delta // { arity: 21 }
             implementation
               %0:l0 » %1:message[#12]KA » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA
@@ -1340,7 +1340,7 @@ Explained Query:
             Get l1 // { arity: 2 }
     Return // { arity: 2 }
       Reduce group_by=[#0{name}] aggregates=[count(*)] // { arity: 2 }
-        Project (#1) // { arity: 1 }
+        Project (#1{name}) // { arity: 1 }
           Join on=(#0{messageid} = #2{messageid}) type=differential // { arity: 3 }
             implementation
               %0:l1[#0]K » %1[#0]K
@@ -1435,7 +1435,7 @@ Explained Query:
         ArrangeBy keys=[[#0{id}]] // { arity: 5 }
           ReadIndex on=materialize.public.tag tag_name=[lookup value=("Abbas_I_of_Persia")] // { arity: 5 }
       cte l2 =
-        Project (#1) // { arity: 1 }
+        Project (#1{id}) // { arity: 1 }
           Join on=(#1{id} = #11{personid} AND #12{tagid} = #13{id}) type=delta // { arity: 18 }
             implementation
               %0:l0 » %1:person_hasinterest_tag[#0]K » %2:l1[#0]KAe
@@ -1443,12 +1443,12 @@ Explained Query:
               %2:l1 » %1:person_hasinterest_tag[#1]KA » %0:l0[#1]KA
             Get l0 // { arity: 11 }
             ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-              Project (#1{tagid}, #2) // { arity: 2 }
+              Project (#1{personid}, #2{tagid}) // { arity: 2 }
                 ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
             Get l1 // { arity: 5 }
       cte l3 =
         Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*)] // { arity: 2 }
-          Project (#17) // { arity: 1 }
+          Project (#17{creatorpersonid}) // { arity: 1 }
             Filter (#8{creationdate} < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8{creationdate}) // { arity: 32 }
               Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid} AND #17{creatorpersonid} = #22{id}) type=delta // { arity: 32 }
                 implementation
@@ -1466,7 +1466,7 @@ Explained Query:
         ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 2 }
           Get l3 // { arity: 2 }
       cte l5 =
-        Project (#0{id}, #2) // { arity: 2 }
+        Project (#0{id}, #2{count}) // { arity: 2 }
           Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 3 }
             implementation
               %1:l4[#0]UKA » %0:l2[#0]K
@@ -1480,7 +1480,7 @@ Explained Query:
         Project (#3, #4) // { arity: 2 }
           Map (coalesce(#0{id}, #1{creatorpersonid}), (integer_to_bigint(case when (#0{id}) IS NULL then 0 else 100 end) + coalesce(#2{count}, 0))) // { arity: 5 }
             Union // { arity: 3 }
-              Project (#2{count}, #0, #1{creatorpersonid}) // { arity: 3 }
+              Project (#2, #0{creatorpersonid}, #1{count}) // { arity: 3 }
                 Map (null) // { arity: 3 }
                   Union // { arity: 2 }
                     Negate // { arity: 2 }
@@ -1498,7 +1498,7 @@ Explained Query:
                   Negate // { arity: 1 }
                     Get l6 // { arity: 1 }
                   Get l2 // { arity: 1 }
-              Project (#0{id}, #0{id}, #1{id}) // { arity: 3 }
+              Project (#0{id}, #0{id}, #1{count}) // { arity: 3 }
                 Get l5 // { arity: 2 }
     Return // { arity: 5 }
       Map (coalesce(#2{sum}, 0), (bigint_to_numeric(#1) + #3)) // { arity: 5 }
@@ -1513,14 +1513,14 @@ Explained Query:
                 Get l7 // { arity: 2 }
               ArrangeBy keys=[[#0{person1id}], [case when (#2) IS NULL then null else #1{person2id} end]] // { arity: 3 }
                 Union // { arity: 3 }
-                  Project (#1{person2id}..=#3) // { arity: 3 }
+                  Project (#1{person1id}..=#3) // { arity: 3 }
                     Map (true) // { arity: 4 }
                       ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                   Map (null, null) // { arity: 3 }
                     Threshold // { arity: 1 }
                       Union // { arity: 1 }
                         Negate // { arity: 1 }
-                          Project (#1) // { arity: 1 }
+                          Project (#1{person1id}) // { arity: 1 }
                             ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                         Distinct project=[#0] // { arity: 1 }
                           Union // { arity: 1 }
@@ -1542,7 +1542,7 @@ Explained Query:
                               Get l7 // { arity: 2 }
                         Distinct project=[#0{person2id}] // { arity: 1 }
                           Union // { arity: 1 }
-                            Project (#2) // { arity: 1 }
+                            Project (#2{person2id}) // { arity: 1 }
                               ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                             Constant // { arity: 1 }
                               - (null)
@@ -1589,7 +1589,7 @@ SELECT Person.id AS "person.id"
 Explained Query:
   Finish order_by=[#4{sum_count} desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
     Reduce group_by=[#0{id}..=#2{lastname}] aggregates=[count(*), sum(#3{count})] // { arity: 5 }
-      Project (#1{firstname}..=#3{count}, #25) // { arity: 4 }
+      Project (#1{id}..=#3{lastname}, #25{count}) // { arity: 4 }
         Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) // { arity: 26 }
           Join on=(#1{id} = #20{creatorpersonid} AND #12{messageid} = #24{rootpostid}) type=delta // { arity: 26 }
             implementation
@@ -1602,7 +1602,7 @@ Explained Query:
               ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
             ArrangeBy keys=[[#0{rootpostid}]] // { arity: 2 }
               Reduce group_by=[#0{rootpostid}] aggregates=[count(*)] // { arity: 2 }
-                Project (#2) // { arity: 1 }
+                Project (#2{rootpostid}) // { arity: 1 }
                   Filter (#0{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#0{creationdate} >= 2012-08-29 00:00:00 UTC) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
@@ -1707,9 +1707,9 @@ Explained Query:
       cte l2 =
         Distinct project=[#0{person2id}] // { arity: 1 }
           Union // { arity: 1 }
-            Project (#2) // { arity: 1 }
+            Project (#2{person2id}) // { arity: 1 }
               Get l1 // { arity: 4 }
-            Project (#6) // { arity: 1 }
+            Project (#6{person2id}) // { arity: 1 }
               Join on=(#2{person2id} = #5{person1id}) type=differential // { arity: 7 }
                 implementation
                   %0:l1[#2]KAe » %1:l0[#1]KAe
@@ -1718,7 +1718,7 @@ Explained Query:
                 Get l0 // { arity: 3 }
     Return // { arity: 3 }
       Reduce group_by=[#0{person2id}, #1{name}] aggregates=[count(*)] // { arity: 3 }
-        Project (#0{person2id}, #9) // { arity: 2 }
+        Project (#0{person2id}, #9{name}) // { arity: 2 }
           Join on=(#0{person2id} = #1{id} = #2{creatorpersonid} AND #3{messageid} = #4{messageid} = #6{messageid} AND #7{tagid} = #8{id}) type=delta // { arity: 12 }
             implementation
               %0 » %1[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
@@ -1732,7 +1732,7 @@ Explained Query:
                 Threshold // { arity: 1 }
                   Union // { arity: 1 }
                     Distinct project=[#0{person2id}] // { arity: 1 }
-                      Project (#6) // { arity: 1 }
+                      Project (#6{person2id}) // { arity: 1 }
                         Join on=(#0{person2id} = #2{person1id} AND #3{person2id} = #5{person1id}) type=delta // { arity: 7 }
                           implementation
                             %0:l2 » %1:person_knows_person[#1]KA » %2:l0[#1]KA
@@ -1747,7 +1747,7 @@ Explained Query:
                       Get l2 // { arity: 1 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
+                Project (#1{id}) // { arity: 1 }
                   Filter (#16{name} = "Italy") AND (#1{id}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 19 }
                     Join on=(#8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 19 }
                       implementation
@@ -1762,11 +1762,11 @@ Explained Query:
                         ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
             ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1{creatorpersonid}, #9) // { arity: 2 }
+                Project (#1{messageid}, #9{creatorpersonid}) // { arity: 2 }
                   ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
+                Project (#1{messageid}) // { arity: 1 }
                   Join on=(#2{tagid} = #3{id} AND #6{typetagclassid} = #7{id}) type=delta // { arity: 12 }
                     implementation
                       %0:message_hastag_tag » %1:tag[#0]KA » %2:tagclass[#0]KAe
@@ -1842,7 +1842,7 @@ SELECT count(*)
 Explained Query:
   With
     cte l0 =
-      Project (#1{person2id}, #21) // { arity: 2 }
+      Project (#1{id}, #21{person2id}) // { arity: 2 }
         Filter (#16{name} = "India") AND (#19{creationdate} <= 2013-01-10 00:00:00 UTC) AND (2012-09-28 00:00:00 UTC <= #19{creationdate}) AND (#14{partofcountryid}) IS NOT NULL // { arity: 22 }
           Join on=(#1{id} = #20{person1id} AND #8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 22 }
             implementation
@@ -1939,7 +1939,7 @@ Explained Query:
         ArrangeBy keys=[[#1{id}]] // { arity: 11 }
           ReadIndex on=person person_id=[differential join] // { arity: 11 }
       cte l1 =
-        Project (#1{messageid}, #12) // { arity: 2 }
+        Project (#1{id}, #12{messageid}) // { arity: 2 }
           Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#15{content}) IS NOT NULL // { arity: 25 }
             Join on=(#1{id} = #20{creatorpersonid}) type=differential // { arity: 25 }
               implementation
@@ -1949,13 +1949,13 @@ Explained Query:
                 ReadIndex on=materialize.public.message message_rootpostlanguage=[lookup values=[("es"); ("pt"); ("ta")]] // { arity: 14 }
     Return // { arity: 2 }
       Reduce group_by=[#0{count_messageid}] aggregates=[count(*)] // { arity: 2 }
-        Project (#1) // { arity: 1 }
+        Project (#1{count_messageid}) // { arity: 1 }
           Reduce group_by=[#0{id}] aggregates=[count(#1{messageid})] // { arity: 2 }
             Union // { arity: 2 }
               Map (null) // { arity: 2 }
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
-                    Project (#1) // { arity: 1 }
+                    Project (#1{id}) // { arity: 1 }
                       Join on=(#1{id} = #11{id}) type=differential // { arity: 12 }
                         implementation
                           %1[#0]UKA » %0:l0[#1]KA
@@ -1964,7 +1964,7 @@ Explained Query:
                           Distinct project=[#0{id}] // { arity: 1 }
                             Project (#0{id}) // { arity: 1 }
                               Get l1 // { arity: 2 }
-                  Project (#1) // { arity: 1 }
+                  Project (#1{id}) // { arity: 1 }
                     ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
               Get l1 // { arity: 2 }
 
@@ -2010,7 +2010,7 @@ Explained Query:
           ArrangeBy keys=[[]] // { arity: 11 }
             ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
           ArrangeBy keys=[[]] // { arity: 6 }
-            Project (#0{creationdate}, #1{messageid}, #3{content}, #4{length}, #8, #9) // { arity: 6 }
+            Project (#0{creationdate}, #1{messageid}, #3{rootpostlanguage}, #4{content}, #8{length}, #9{creatorpersonid}) // { arity: 6 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
       cte l1 =
         Project (#0{creationdate}..=#11{messageid}) // { arity: 12 }
@@ -2018,7 +2018,7 @@ Explained Query:
             implementation
               %1[#0]UKA » %0:l0[#12]Kiif
             ArrangeBy keys=[[#12{rootpostlanguage}]] // { arity: 13 }
-              Project (#0{creationdate}..=#10{email}, #12{rootpostlanguage}, #13) // { arity: 13 }
+              Project (#0{creationdate}..=#10{email}, #12{messageid}, #13{rootpostlanguage}) // { arity: 13 }
                 Filter (#15{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#14{content}) IS NOT NULL AND (#1{id} = #16{creatorpersonid}) // { arity: 17 }
                   Get l0 // { arity: 17 }
             ArrangeBy keys=[[#0{rootpostlanguage}]] // { arity: 1 }
@@ -2027,16 +2027,16 @@ Explained Query:
                   Filter (#0{rootpostlanguage} = varchar_to_text(#1)) // { arity: 2 }
                     FlatMap unnest_array({"es", "ta", "pt"}) // { arity: 2 }
                       Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
-                        Project (#13) // { arity: 1 }
+                        Project (#13{rootpostlanguage}) // { arity: 1 }
                           Get l0 // { arity: 17 }
     Return // { arity: 2 }
       Reduce group_by=[#0{count_messageid}] aggregates=[count(*)] // { arity: 2 }
-        Project (#1) // { arity: 1 }
+        Project (#1{count_messageid}) // { arity: 1 }
           Reduce group_by=[#0{id}] aggregates=[count(#1{messageid})] // { arity: 2 }
             Union // { arity: 2 }
-              Project (#1{messageid}, #11) // { arity: 2 }
+              Project (#1{id}, #11{messageid}) // { arity: 2 }
                 Get l1 // { arity: 12 }
-              Project (#1, #22) // { arity: 2 }
+              Project (#1{id}, #22) // { arity: 2 }
                 Map (null) // { arity: 23 }
                   Join on=(#0{creationdate} = #11{creationdate} AND #1{id} = #12{id} AND #2{firstname} = #13{firstname} AND #3{lastname} = #14{lastname} AND #4{gender} = #15{gender} AND #5{birthday} = #16{birthday} AND #6{locationip} = #17{locationip} AND #7{browserused} = #18{browserused} AND #8{locationcityid} = #19{locationcityid} AND #9{speaks} = #20{speaks} AND #10{email} = #21{email}) type=differential // { arity: 22 }
                     implementation
@@ -2104,7 +2104,7 @@ Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#3]
     With
       cte l0 =
-        Project (#0{id}, #2{partofcontinentid}..=#6{creationdate}, #8{firstname}..=#15{email}, #17, #18) // { arity: 16 }
+        Project (#0{id}, #2{url}..=#6{url}, #8{creationdate}..=#15{browserused}, #17{speaks}, #18{email}) // { arity: 16 }
           Filter (#1{name} = "India") AND (#8{creationdate} < 2012-11-09 00:00:00 UTC) AND (#0{id}) IS NOT NULL // { arity: 19 }
             Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid}) type=delta // { arity: 19 }
               implementation
@@ -2118,7 +2118,7 @@ Explained Query:
               ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
                 ReadIndex on=person person_locationcityid=[delta join lookup] // { arity: 11 }
       cte l1 =
-        Project (#0{id}..=#15{email}, #17) // { arity: 17 }
+        Project (#0{id}..=#15{email}, #17{messageid}) // { arity: 17 }
           Filter (#16{creationdate} <= 2012-11-09 00:00:00 UTC) AND (#16{creationdate} >= #6{creationdate}) // { arity: 29 }
             Join on=(#7{id} = #25{creatorpersonid}) type=differential // { arity: 29 }
               implementation
@@ -2133,9 +2133,9 @@ Explained Query:
           Filter (bigint_to_numeric(#2{count_messageid}) < ((24155 - ((12 * extract_year_tstz(#1{creationdate})) + extract_month_tstz(#1{creationdate}))) + 1)) // { arity: 3 }
             Reduce group_by=[#1{id}, #0{creationdate}] aggregates=[count(#2{messageid})] // { arity: 3 }
               Union // { arity: 3 }
-                Project (#6, #7, #16) // { arity: 3 }
+                Project (#6{creationdate}, #7{id}, #16{messageid}) // { arity: 3 }
                   Get l1 // { arity: 17 }
-                Project (#6, #7, #32) // { arity: 3 }
+                Project (#6{creationdate}, #7{id}, #32) // { arity: 3 }
                   Map (null) // { arity: 33 }
                     Join on=(#0{id} = #16{id} AND #1{url} = #17{url} AND #2{partofcontinentid} = #18{partofcontinentid} AND #3{id} = #19{id} AND #4{name} = #20{name} AND #5{url} = #21{url} AND #6{creationdate} = #22{creationdate} AND #7{id} = #23{id} AND #8{firstname} = #24{firstname} AND #9{lastname} = #25{lastname} AND #10{gender} = #26{gender} AND #11{birthday} = #27{birthday} AND #12{locationip} = #28{locationip} AND #13{browserused} = #29{browserused} AND #14{speaks} = #30{speaks} AND #15{email} = #31{email}) type=differential // { arity: 32 }
                       implementation
@@ -2159,7 +2159,7 @@ Explained Query:
         ArrangeBy keys=[[#0{id}]] // { arity: 1 }
           Get l3 // { arity: 1 }
       cte l5 =
-        Project (#1{creatorpersonid}, #23) // { arity: 2 }
+        Project (#1{id}, #23{creatorpersonid}) // { arity: 2 }
           Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) // { arity: 28 }
             Join on=(#1{id} = #12{personid} AND #13{messageid} = #15{messageid} AND #23{creatorpersonid} = #27{id}) type=delta // { arity: 28 }
               implementation
@@ -2189,14 +2189,14 @@ Explained Query:
               Distinct project=[#0{id}] // { arity: 1 }
                 Get l3 // { arity: 1 }
       cte l8 =
-        Project (#0{id}, #2{sum}, #3) // { arity: 3 }
+        Project (#0{id}, #2{count}, #3{sum}) // { arity: 3 }
           Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 4 }
             implementation
               %1[#0]UKA » %0:l4[#0]K
             Get l4 // { arity: 1 }
             ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 3 }
               Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*), sum(case when #1 then 1 else 0 end)] // { arity: 3 }
-                Project (#1, #3) // { arity: 2 }
+                Project (#1{creatorpersonid}, #3) // { arity: 2 }
                   Join on=(#0{id} = #2{id}) type=differential // { arity: 4 }
                     implementation
                       %0:l5[#0]K » %1[#0]K
@@ -2317,7 +2317,7 @@ Explained Query:
         ArrangeBy keys=[[#1{id}], [#8{locationcityid}]] // { arity: 11 }
           ReadIndex on=person person_id=[delta join lookup] person_locationcityid=[delta join lookup] // { arity: 11 }
       cte l3 =
-        Project (#4, #5, #9, #21) // { arity: 4 }
+        Project (#4{id}, #5{name}, #9{id}, #21{person2id}) // { arity: 4 }
           Filter (#1{name} = "Philippines") AND (#38{name} = "Taiwan") AND (#0{id}) IS NOT NULL AND (#36{partofcountryid}) IS NOT NULL // { arity: 41 }
             Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid} AND #9{id} = #20{person1id} AND #21{person2id} = #23{id} AND #30{locationcityid} = #33{id} AND #36{partofcountryid} = #37{id}) type=delta // { arity: 41 }
               implementation
@@ -2339,10 +2339,10 @@ Explained Query:
       cte l4 =
         Map (case when #2 then #1{person2id} else #0{id} end, case when #2 then #0{id} else #1{person2id} end) // { arity: 5 }
           Union // { arity: 3 }
-            Project (#2..=#4) // { arity: 3 }
+            Project (#2{id}..=#4) // { arity: 3 }
               Map (false) // { arity: 5 }
                 Get l3 // { arity: 4 }
-            Project (#3, #2, #4) // { arity: 3 }
+            Project (#3{person2id}, #2{id}, #4) // { arity: 3 }
               Map (true) // { arity: 5 }
                 Get l3 // { arity: 4 }
       cte l5 =
@@ -2361,7 +2361,7 @@ Explained Query:
               Get l5 // { arity: 2 }
             ArrangeBy keys=[[#0{creatorpersonid}, #1{creatorpersonid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{creatorpersonid}] // { arity: 2 }
-                Project (#9, #22) // { arity: 2 }
+                Project (#9{creatorpersonid}, #22{creatorpersonid}) // { arity: 2 }
                   Join on=(#1{messageid} = #25{parentmessageid}) type=differential // { arity: 26 }
                     implementation
                       %0:l6[#1]KA » %1:message[#12]KA
@@ -2397,7 +2397,7 @@ Explained Query:
               Get l9 // { arity: 2 }
             ArrangeBy keys=[[#0{personid}, #1{creatorpersonid}]] // { arity: 2 }
               Distinct project=[#1{personid}, #0{creatorpersonid}] // { arity: 2 }
-                Project (#9, #14) // { arity: 2 }
+                Project (#9{creatorpersonid}, #14{personid}) // { arity: 2 }
                   Join on=(#1{messageid} = #15{messageid}) type=differential // { arity: 16 }
                     implementation
                       %0:l6[#1]KA » %1:person_likes_message[#2]KA
@@ -2405,7 +2405,7 @@ Explained Query:
                     ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
                       ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l11 =
-        Project (#0{id}..=#3{person2id}, #6) // { arity: 5 }
+        Project (#0{id}..=#3{person2id}, #6{sum}) // { arity: 5 }
           Join on=(#2{id} = #4 AND #3{person2id} = #5) type=differential // { arity: 7 }
             implementation
               %1[#0, #1]UKKA » %0:l3[#2, #3]KK
@@ -2429,17 +2429,17 @@ Explained Query:
                               Get l10 // { arity: 2 }
                             Get l9 // { arity: 2 }
     Return // { arity: 4 }
-      Project (#0{id}, #1{person2id}, #3{sum}, #4) // { arity: 4 }
+      Project (#0{id}, #1{person2id}, #3{name}, #4{sum}) // { arity: 4 }
         TopK group_by=[#2{id}] order_by=[#4{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=1 // { arity: 5 }
           Union // { arity: 5 }
             Map (null) // { arity: 5 }
               Union // { arity: 4 }
                 Negate // { arity: 4 }
-                  Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
+                  Project (#2{id}, #3{person2id}, #0{id}, #1{name}) // { arity: 4 }
                     Get l11 // { arity: 5 }
-                Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
+                Project (#2{id}, #3{person2id}, #0{id}, #1{name}) // { arity: 4 }
                   Get l3 // { arity: 4 }
-            Project (#2{id}, #3{name}, #0{id}, #1{person2id}, #4{sum}) // { arity: 5 }
+            Project (#2{id}, #3{person2id}, #0{id}, #1{name}, #4{sum}) // { arity: 5 }
               Get l11 // { arity: 5 }
 
 Used Indexes:
@@ -2526,7 +2526,7 @@ Explained Query:
   Finish order_by=[#1{min} asc nulls_last] limit=20 output=[#2]
     With Mutually Recursive
       cte l0 =
-        Project (#1{person2id}, #2) // { arity: 2 }
+        Project (#1{person1id}, #2{person2id}) // { arity: 2 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
       cte l1 =
         ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
@@ -2534,7 +2534,7 @@ Explained Query:
       cte l2 =
         ArrangeBy keys=[[#0{id}]] // { arity: 1 }
           Distinct project=[#0{id}] // { arity: 1 }
-            Project (#1) // { arity: 1 }
+            Project (#1{id}) // { arity: 1 }
               Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                 ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
       cte l3 =
@@ -2544,7 +2544,7 @@ Explained Query:
           Get l1 // { arity: 2 }
           ArrangeBy keys=[[#1, #0]] // { arity: 3 }
             Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-              Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+              Project (#1{person1id}, #2{person2id}, #6{parentmessageid}) // { arity: 3 }
                 Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                   implementation
                     %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
@@ -2555,27 +2555,27 @@ Explained Query:
                   ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
                     ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                   ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                    Project (#1{messageid}, #9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 4 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                   ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                    Project (#9, #10, #12) // { arity: 3 }
+                    Project (#9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 3 }
                       Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                         ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                   Get l2 // { arity: 1 }
                   Get l2 // { arity: 1 }
       cte l4 =
-        Project (#2{min}, #0, #1{person2id}) // { arity: 3 }
+        Project (#2, #0{person2id}, #1{min}) // { arity: 3 }
           Map (1450) // { arity: 3 }
             Reduce group_by=[#0{person2id}] aggregates=[min(#1)] // { arity: 2 }
               Distinct project=[#0{person2id}, #1] // { arity: 2 }
                 Union // { arity: 2 }
-                  Project (#3, #5) // { arity: 2 }
+                  Project (#3{person2id}, #5) // { arity: 2 }
                     Map ((#1 + #4)) // { arity: 6 }
                       Join on=(#0 = #2{person1id}) type=differential // { arity: 5 }
                         implementation
                           %0:l4[#0]UK » %1[#0]K
                         ArrangeBy keys=[[#0]] // { arity: 2 }
-                          Project (#1, #2) // { arity: 2 }
+                          Project (#1{person2id}, #2{min}) // { arity: 2 }
                             Get l4 // { arity: 3 }
                         ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
                           Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
@@ -2594,12 +2594,12 @@ Explained Query:
                                               Project (#2, #3) // { arity: 2 }
                                                 Get l3 // { arity: 5 }
                                     Get l0 // { arity: 2 }
-                                Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
+                                Project (#0{person1id}, #1{person2id}, #4{sum}) // { arity: 3 }
                                   Get l3 // { arity: 5 }
                   Constant // { arity: 2 }
                     - (1450, 0)
     Return // { arity: 3 }
-      Project (#1{min}, #2{min}, #2{min}) // { arity: 3 }
+      Project (#1{person2id}, #2{min}, #2{min}) // { arity: 3 }
         Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
           Get l4 // { arity: 3 }
 
@@ -2722,7 +2722,7 @@ SELECT coalesce(min(w), -1) FROM results
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#1{person2id}, #2) // { arity: 2 }
+      Project (#1{person1id}, #2{person2id}) // { arity: 2 }
         ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
     cte l1 =
       ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
@@ -2730,7 +2730,7 @@ Explained Query:
     cte l2 =
       ArrangeBy keys=[[#0{id}]] // { arity: 1 }
         Distinct project=[#0{id}] // { arity: 1 }
-          Project (#1) // { arity: 1 }
+          Project (#1{id}) // { arity: 1 }
             Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
               ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
     cte l3 =
@@ -2740,7 +2740,7 @@ Explained Query:
         Get l1 // { arity: 2 }
         ArrangeBy keys=[[#1, #0]] // { arity: 3 }
           Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-            Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+            Project (#1{person1id}, #2{person2id}, #6{parentmessageid}) // { arity: 3 }
               Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                 implementation
                   %0:person_knows_person » %1:message[#1]KA » %3:l2[#0]UK » %2:message[#0, #2]KK » %4:l2[#0]UK
@@ -2751,10 +2751,10 @@ Explained Query:
                 ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
                   ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
                 ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                  Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                  Project (#1{messageid}, #9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 4 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                 ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                  Project (#9, #10, #12) // { arity: 3 }
+                  Project (#9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 3 }
                     Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                 Get l2 // { arity: 1 }
@@ -2776,10 +2776,10 @@ Explained Query:
                           Project (#2, #3) // { arity: 2 }
                             Get l3 // { arity: 5 }
                 Get l0 // { arity: 2 }
-            Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
+            Project (#0{person1id}, #1{person2id}, #4{sum}) // { arity: 3 }
               Get l3 // { arity: 5 }
     cte l5 =
-      Project (#1{person2id}, #3) // { arity: 2 }
+      Project (#1, #3{person2id}) // { arity: 2 }
         Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
           implementation
             %0:l8[#0]K » %1:l4[#0]K
@@ -2790,7 +2790,7 @@ Explained Query:
               Get l4 // { arity: 3 }
     cte l6 =
       Union // { arity: 2 }
-        Project (#1, #0{person2id}) // { arity: 2 }
+        Project (#1{person2id}, #0) // { arity: 2 }
           Get l5 // { arity: 2 }
         Get l8 // { arity: 2 }
     cte l7 =
@@ -2810,7 +2810,7 @@ Explained Query:
     cte l8 =
       Distinct project=[#0{person2id}, #1] // { arity: 2 }
         Union // { arity: 2 }
-          Project (#1, #0{person2id}) // { arity: 2 }
+          Project (#1{person2id}, #0) // { arity: 2 }
             CrossJoin type=differential // { arity: 2 }
               implementation
                 %0:l5[×] » %1[×]
@@ -2835,7 +2835,7 @@ Explained Query:
             Get l17 // { arity: 6 }
     cte l10 =
       Distinct project=[#0..=#2] // { arity: 3 }
-        Project (#0..=#2) // { arity: 3 }
+        Project (#0..=#2{person2id}) // { arity: 3 }
           Get l17 // { arity: 6 }
     cte l11 =
       ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
@@ -2853,7 +2853,7 @@ Explained Query:
     cte l13 =
       TopK group_by=[#0, #1, #2{person2id}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
         Union // { arity: 5 }
-          Project (#3, #4, #1, #7, #8) // { arity: 5 }
+          Project (#3, #4, #1{person2id}, #7, #8) // { arity: 5 }
             Map ((#6 + #2), false) // { arity: 9 }
               Join on=(#0{person1id} = #5) type=differential // { arity: 7 }
                 implementation
@@ -2893,11 +2893,11 @@ Explained Query:
             implementation
               %0:l13[#0]Kef » %1:l13[#0]Kef
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              Project (#2, #3) // { arity: 2 }
+              Project (#2{person2id}, #3) // { arity: 2 }
                 Filter (#0 = false) // { arity: 5 }
                   Get l13 // { arity: 5 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-              Project (#2, #3) // { arity: 2 }
+              Project (#2{person2id}, #3) // { arity: 2 }
                 Filter (#0 = true) // { arity: 5 }
                   Get l13 // { arity: 5 }
     cte l15 =
@@ -2966,18 +2966,18 @@ Explained Query:
                   Get l17 // { arity: 6 }
       cte l19 =
         Reduce aggregates=[min(#0{min})] // { arity: 1 }
-          Project (#2) // { arity: 1 }
+          Project (#2{min}) // { arity: 1 }
             Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0, #2, #3, #5) // { arity: 4 }
                 Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
                   implementation
                     %0:l18[#1]Kef » %1:l18[#1]Kef
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1{person2id}..=#3) // { arity: 3 }
+                    Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
                         Get l18 // { arity: 4 }
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1{person2id}..=#3) // { arity: 3 }
+                    Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
                         Get l18 // { arity: 4 }
     Return // { arity: 1 }
@@ -3083,7 +3083,7 @@ Explained Query:
       cte l0 =
         ArrangeBy keys=[[#0{id}]] // { arity: 1 }
           Distinct project=[#0{id}] // { arity: 1 }
-            Project (#1) // { arity: 1 }
+            Project (#1{id}) // { arity: 1 }
               Filter (#1{id}) IS NOT NULL // { arity: 11 }
                 ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
       cte l1 =
@@ -3093,7 +3093,7 @@ Explained Query:
         ArrangeBy keys=[[#1{name}]] // { arity: 4 }
           ReadIndex on=tag tag_name=[lookup] // { arity: 4 }
       cte l3 =
-        Project (#0{id}, #2) // { arity: 2 }
+        Project (#0{id}, #2{messageid}) // { arity: 2 }
           Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
             implementation
               %0:l0 » %1[#0]K » %2[#0]UKA
@@ -3102,12 +3102,12 @@ Explained Query:
             Get l0 // { arity: 1 }
             ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1{creatorpersonid}, #9) // { arity: 2 }
+                Project (#1{messageid}, #9{creatorpersonid}) // { arity: 2 }
                   Filter (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
+                Project (#1{messageid}) // { arity: 1 }
                   Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
                     implementation
                       %1:tag[#0]KAe » %0:l1[#2]KAe
@@ -3118,7 +3118,7 @@ Explained Query:
         ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
       cte l5 =
-        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
+        Project (#0{id}, #1{messageid}, #4{person2id}) // { arity: 3 }
           Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
             implementation
               %0:l3 » %1:l4[#1]KA » %2[#0]UKA
@@ -3132,7 +3132,7 @@ Explained Query:
                 Project (#0{id}) // { arity: 1 }
                   Get l3 // { arity: 2 }
       cte l6 =
-        Project (#0{id}, #2) // { arity: 2 }
+        Project (#0{id}, #2{messageid}) // { arity: 2 }
           Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
             implementation
               %0:l0 » %1[#0]K » %2[#0]UKA
@@ -3141,12 +3141,12 @@ Explained Query:
             Get l0 // { arity: 1 }
             ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1{creatorpersonid}, #9) // { arity: 2 }
+                Project (#1{messageid}, #9{creatorpersonid}) // { arity: 2 }
                   Filter (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
+                Project (#1{messageid}) // { arity: 1 }
                   Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
                     implementation
                       %1:tag[#0]KAe » %0:l1[#2]KAe
@@ -3154,7 +3154,7 @@ Explained Query:
                     ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                       ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
       cte l7 =
-        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
+        Project (#0{id}, #1{messageid}, #4{person2id}) // { arity: 3 }
           Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
             implementation
               %0:l6 » %1:l4[#1]KA » %2[#0]UKA
@@ -3256,7 +3256,7 @@ Explained Query:
   Finish order_by=[#1{count_messageid} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=10 output=[#0, #1]
     With
       cte l0 =
-        Project (#0{creationdate}, #1{messageid}, #9, #10, #12) // { arity: 5 }
+        Project (#0{creationdate}, #1{messageid}, #9{creatorpersonid}, #10{containerforumid}, #12{parentmessageid}) // { arity: 5 }
           Join on=(#1{messageid} = #13{messageid}) type=differential // { arity: 14 }
             implementation
               %1[#0]UKA » %0:message[#1]KA
@@ -3264,7 +3264,7 @@ Explained Query:
               ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
+                Project (#1{messageid}) // { arity: 1 }
                   Join on=(#2{tagid} = #3{id}) type=differential // { arity: 4 }
                     implementation
                       %1[#0]UKA » %0:message_hastag_tag[#2]KA
@@ -3279,7 +3279,7 @@ Explained Query:
         ArrangeBy keys=[[#1{forumid}], [#2{personid}]] // { arity: 3 }
           ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[delta join lookup] forum_hasmember_person_personid=[delta join lookup] // { arity: 3 }
       cte l2 =
-        Project (#1{messageid}, #4, #6) // { arity: 3 }
+        Project (#1{creatorpersonid}, #4{messageid}, #6{containerforumid}) // { arity: 3 }
           Filter (#2{containerforumid} != #6{containerforumid}) AND (#5{creatorpersonid} != #7{creatorpersonid}) AND ((#0{creationdate} + 12:00:00) < #3{creationdate}) // { arity: 15 }
             Join on=(#2{containerforumid} = #10{forumid} = #13{forumid} AND #4{messageid} = #8{parentmessageid} AND #5{creatorpersonid} = #14{personid} AND #7{creatorpersonid} = #11{personid}) type=delta // { arity: 15 }
               implementation
@@ -3289,20 +3289,20 @@ Explained Query:
                 %3:l1 » %4:l1[#1]KA » %0:l0[#2]K » %1:l0[#2]K » %2:l0[#0, #1]KK
                 %4:l1 » %3:l1[#1]KA » %0:l0[#2]K » %1:l0[#2]K » %2:l0[#0, #1]KK
               ArrangeBy keys=[[#2{containerforumid}]] // { arity: 3 }
-                Project (#0{creationdate}, #2{containerforumid}, #3) // { arity: 3 }
+                Project (#0{creationdate}, #2{creatorpersonid}, #3{containerforumid}) // { arity: 3 }
                   Get l0 // { arity: 5 }
               ArrangeBy keys=[[#1{messageid}, #2{creatorpersonid}], [#2{creatorpersonid}]] // { arity: 4 }
                 Project (#0{creationdate}..=#3{containerforumid}) // { arity: 4 }
                   Get l0 // { arity: 5 }
               ArrangeBy keys=[[#0{creatorpersonid}, #1{parentmessageid}]] // { arity: 2 }
-                Project (#2, #4) // { arity: 2 }
+                Project (#2{creatorpersonid}, #4{parentmessageid}) // { arity: 2 }
                   Filter (#4{parentmessageid}) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
               Get l1 // { arity: 3 }
               Get l1 // { arity: 3 }
       cte l3 =
         Distinct project=[#0{creatorpersonid}, #1{containerforumid}] // { arity: 2 }
-          Project (#0{creatorpersonid}, #2) // { arity: 2 }
+          Project (#0{creatorpersonid}, #2{containerforumid}) // { arity: 2 }
             Get l2 // { arity: 3 }
     Return // { arity: 2 }
       Reduce group_by=[#0{creatorpersonid}] aggregates=[count(distinct #1{messageid})] // { arity: 2 }
@@ -3323,7 +3323,7 @@ Explained Query:
                         Get l3 // { arity: 2 }
                       ArrangeBy keys=[[#0{personid}, #1{forumid}]] // { arity: 2 }
                         Distinct project=[#1{personid}, #0{forumid}] // { arity: 2 }
-                          Project (#1{personid}, #2) // { arity: 2 }
+                          Project (#1{forumid}, #2{personid}) // { arity: 2 }
                             ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[*** full scan ***] // { arity: 3 }
                 Get l3 // { arity: 2 }
 
@@ -3376,21 +3376,21 @@ Explained Query:
     With
       cte l0 =
         ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
-          Project (#0{personid}, #9) // { arity: 2 }
+          Project (#0{personid}, #9{person2id}) // { arity: 2 }
             Join on=(#0{personid} = #8{person1id} AND #1{tagid} = #2{id}) type=delta // { arity: 10 }
               implementation
                 %0:person_hasinterest_tag » %1:tag[#0]KAe » %2:person_knows_person[#1]KA
                 %1:tag » %0:person_hasinterest_tag[#1]KA » %2:person_knows_person[#1]KA
                 %2:person_knows_person » %0:person_hasinterest_tag[#0]K » %1:tag[#0]KAe
               ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-                Project (#1{tagid}, #2) // { arity: 2 }
+                Project (#1{personid}, #2{tagid}) // { arity: 2 }
                   ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
               ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                 ReadIndex on=materialize.public.tag tag_name=[lookup value=("Fyodor_Dostoyevsky")] // { arity: 5 }
               ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
                 ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] // { arity: 3 }
       cte l1 =
-        Project (#0{personid}, #2) // { arity: 2 }
+        Project (#0{personid}, #2{personid}) // { arity: 2 }
           Filter (#0{personid} != #2{personid}) // { arity: 4 }
             Join on=(#1{person2id} = #3{person2id}) type=differential // { arity: 4 }
               implementation
@@ -3419,7 +3419,7 @@ Explained Query:
                         Get l2 // { arity: 2 }
                       ArrangeBy keys=[[#0{person2id}, #1{person1id}]] // { arity: 2 }
                         Distinct project=[#1{person2id}, #0{person1id}] // { arity: 2 }
-                          Project (#1{person2id}, #2) // { arity: 2 }
+                          Project (#1{person1id}, #2{person2id}) // { arity: 2 }
                             ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                 Get l2 // { arity: 2 }
 
@@ -3474,7 +3474,7 @@ materialize.public.pathq19:
       Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
         Map (greatest(f64toi64(roundf64((40 - sqrtf64(bigint_to_double(#2{count}))))), 1)) // { arity: 4 }
           Reduce group_by=[#0{person1id}, #1{person2id}] aggregates=[count(*)] // { arity: 3 }
-            Project (#16, #17) // { arity: 2 }
+            Project (#16{person1id}, #17{person2id}) // { arity: 2 }
               Filter (#0{creatorpersonid} != #11{creatorpersonid}) AND (#16{person1id} < #17{person2id}) // { arity: 18 }
                 Join on=(#1{parentmessageid} = #3{messageid} AND #16{person1id} = least(#0{creatorpersonid}, #11{creatorpersonid}) AND #17{person2id} = greatest(#0{creatorpersonid}, #11{creatorpersonid})) type=delta // { arity: 18 }
                   implementation
@@ -3482,7 +3482,7 @@ materialize.public.pathq19:
                     %1:message » %0:message[#1]KA » %2:person_knows_person[#1, #2]KKAf
                     %2:person_knows_person » %0:message[×] » %1:message[#1]KA
                   ArrangeBy keys=[[], [#1{parentmessageid}]] // { arity: 2 }
-                    Project (#9, #12) // { arity: 2 }
+                    Project (#9{creatorpersonid}, #12{parentmessageid}) // { arity: 2 }
                       Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                         ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
                   ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
@@ -3492,7 +3492,7 @@ materialize.public.pathq19:
   Return // { arity: 3 }
     Union // { arity: 3 }
       Get l0 // { arity: 3 }
-      Project (#1{person1id}, #0{person2id}, #2) // { arity: 3 }
+      Project (#1{person2id}, #0{person1id}, #2) // { arity: 3 }
         Get l0 // { arity: 3 }
 
 Used Indexes:
@@ -3576,7 +3576,7 @@ Explained Query:
             Project (#1{id}, #1{id}, #12) // { arity: 3 }
               Map (0) // { arity: 13 }
                 ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
-            Project (#0, #4, #6) // { arity: 3 }
+            Project (#0, #4{dst}, #6) // { arity: 3 }
               Map ((#2 + bigint_to_double(#5{w}))) // { arity: 7 }
                 Join on=(#1 = #3{src}) type=differential // { arity: 6 }
                   implementation
@@ -3598,7 +3598,7 @@ Explained Query:
                 Get l0 // { arity: 3 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
+                Project (#1{id}) // { arity: 1 }
                   Filter (#1{id}) IS NOT NULL // { arity: 12 }
                     ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
     Return // { arity: 3 }
@@ -3610,7 +3610,7 @@ Explained Query:
             Get l1 // { arity: 3 }
           ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
             Reduce aggregates=[min(#0{min})] // { arity: 1 }
-              Project (#2) // { arity: 1 }
+              Project (#2{min}) // { arity: 1 }
                 Get l1 // { arity: 3 }
 
 Used Indexes:
@@ -3703,7 +3703,7 @@ Explained Query:
           Project (#1{id}, #1{id}, #12) // { arity: 3 }
             Map (0) // { arity: 13 }
               ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
-          Project (#0, #5, #7) // { arity: 3 }
+          Project (#0, #5{dst}, #7) // { arity: 3 }
             Filter coalesce((#2 < #3), true) // { arity: 8 }
               Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
                 Join on=(#1 = #4{src}) type=delta // { arity: 7 }
@@ -3722,7 +3722,7 @@ Explained Query:
           Project (#1{id}, #1{id}, #12) // { arity: 3 }
             Map (0) // { arity: 13 }
               ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
-          Project (#0, #5, #7) // { arity: 3 }
+          Project (#0, #5{dst}, #7) // { arity: 3 }
             Filter coalesce((#2 < #3), true) // { arity: 8 }
               Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
                 Join on=(#1 = #4{src}) type=delta // { arity: 7 }
@@ -3737,7 +3737,7 @@ Explained Query:
                   Get l2 // { arity: 3 }
     cte l5 =
       Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-        Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
+        Project (#0{id}, #2, #3{id}, #5) // { arity: 4 }
           Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
             implementation
               %0:l3[#1]K » %1:l4[#1]K
@@ -3749,7 +3749,7 @@ Explained Query:
                 Get l4 // { arity: 3 }
     cte l6 =
       Reduce aggregates=[min(#0{min})] // { arity: 1 }
-        Project (#2) // { arity: 1 }
+        Project (#2{min}) // { arity: 1 }
           Get l5 // { arity: 3 }
     cte l7 =
       Union // { arity: 1 }
@@ -3770,7 +3770,7 @@ Explained Query:
           Get l5 // { arity: 3 }
         ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
           Reduce aggregates=[min(#0{min})] // { arity: 1 }
-            Project (#2) // { arity: 1 }
+            Project (#2{min}) // { arity: 1 }
               Get l5 // { arity: 3 }
 
 Used Indexes:
@@ -3844,7 +3844,7 @@ Explained Query:
               Get l7 // { arity: 6 }
       cte l1 =
         Distinct project=[#0..=#2] // { arity: 3 }
-          Project (#0..=#2) // { arity: 3 }
+          Project (#0..=#2{id}) // { arity: 3 }
             Get l7 // { arity: 6 }
       cte l2 =
         Project (#0..=#2) // { arity: 3 }
@@ -3863,7 +3863,7 @@ Explained Query:
         TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
           Distinct project=[#0..=#4] // { arity: 5 }
             Union // { arity: 5 }
-              Project (#3, #4, #1, #7, #8) // { arity: 5 }
+              Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
                 Map ((#6 + bigint_to_double(#2{w})), false) // { arity: 9 }
                   Join on=(#0{src} = #5) type=differential // { arity: 7 }
                     implementation
@@ -3905,11 +3905,11 @@ Explained Query:
               implementation
                 %0:l3[#0]Kef » %1:l3[#0]Kef
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
+                Project (#2{dst}, #3) // { arity: 2 }
                   Filter (#0 = false) AND (#2{dst}) IS NOT NULL // { arity: 5 }
                     Get l3 // { arity: 5 }
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
+                Project (#2{dst}, #3) // { arity: 2 }
                   Filter (#0 = true) AND (#2{dst}) IS NOT NULL // { arity: 5 }
                     Get l3 // { arity: 5 }
       cte l5 =
@@ -3930,13 +3930,13 @@ Explained Query:
       cte l7 =
         Distinct project=[#0..=#5] // { arity: 6 }
           Union // { arity: 6 }
-            Project (#1{id}, #0, #0, #2{id}..=#4) // { arity: 6 }
+            Project (#1, #0{id}, #0{id}, #2..=#4) // { arity: 6 }
               Map (0, false, 0) // { arity: 5 }
                 Union // { arity: 2 }
-                  Project (#1, #12) // { arity: 2 }
+                  Project (#1{id}, #12) // { arity: 2 }
                     Map (false) // { arity: 13 }
                       ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
-                  Project (#1, #12) // { arity: 2 }
+                  Project (#1{id}, #12) // { arity: 2 }
                     Map (true) // { arity: 13 }
                       ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
             Project (#0..=#3, #7, #8) // { arity: 6 }
@@ -3979,7 +3979,7 @@ Explained Query:
                     Get l7 // { arity: 6 }
         cte l9 =
           Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-            Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
+            Project (#0{id}, #2, #3{id}, #5) // { arity: 4 }
               Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
                 implementation
                   %0:l8[#1]Kef » %1:l8[#1]Kef
@@ -4000,7 +4000,7 @@ Explained Query:
               Get l9 // { arity: 3 }
             ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
               Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                Project (#2) // { arity: 1 }
+                Project (#2{min}) // { arity: 1 }
                   Get l9 // { arity: 3 }
 
 Used Indexes:
@@ -4068,18 +4068,18 @@ Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0, #1]
     With Mutually Recursive
       cte l0 =
-        Project (#2{min}, #0, #1{dst}) // { arity: 3 }
+        Project (#2, #0{dst}, #1{min}) // { arity: 3 }
           Map (10995116285979) // { arity: 3 }
             Reduce group_by=[#0{dst}] aggregates=[min(#1)] // { arity: 2 }
               Distinct project=[#0{dst}, #1] // { arity: 2 }
                 Union // { arity: 2 }
-                  Project (#3, #5) // { arity: 2 }
+                  Project (#3{dst}, #5) // { arity: 2 }
                     Map ((#1 + integer_to_bigint(#4{w}))) // { arity: 6 }
                       Join on=(#0 = #2{src}) type=differential // { arity: 5 }
                         implementation
                           %0:l0[#0]UK » %1:pathq20[#0]KA
                         ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                          Project (#1{min}, #2) // { arity: 2 }
+                          Project (#1{dst}, #2{min}) // { arity: 2 }
                             Get l0 // { arity: 3 }
                         ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                           ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
@@ -4093,11 +4093,11 @@ Explained Query:
               implementation
                 %1[#0]UKA » %0:l0[#0]UK
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#1{min}, #2) // { arity: 2 }
+                Project (#1{dst}, #2{min}) // { arity: 2 }
                   Get l0 // { arity: 3 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
+                  Project (#1{personid}) // { arity: 1 }
                     Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
                       Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
                         implementation
@@ -4107,7 +4107,7 @@ Explained Query:
                         ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
         cte l2 =
-          Project (#1) // { arity: 1 }
+          Project (#1{min}) // { arity: 1 }
             Get l1 // { arity: 2 }
       Return // { arity: 2 }
         Project (#0{dst}, #1{min}) // { arity: 2 }
@@ -4179,7 +4179,7 @@ Explained Query:
         Reduce group_by=[#0{dst}] aggregates=[min(#1)] // { arity: 2 }
           Distinct project=[#0{dst}, #1] // { arity: 2 }
             Union // { arity: 2 }
-              Project (#3, #5) // { arity: 2 }
+              Project (#3{dst}, #5) // { arity: 2 }
                 Map ((#1 + integer_to_bigint(#4{w}))) // { arity: 6 }
                   Join on=(#0 = #2{src}) type=differential // { arity: 5 }
                     implementation
@@ -4201,7 +4201,7 @@ Explained Query:
                 Get l0 // { arity: 2 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
+                  Project (#1{personid}) // { arity: 1 }
                     Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
                       Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
                         implementation
@@ -4211,7 +4211,7 @@ Explained Query:
                         ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
         cte l2 =
-          Project (#1) // { arity: 1 }
+          Project (#1{min}) // { arity: 1 }
             Get l1 // { arity: 2 }
       Return // { arity: 2 }
         Project (#0{dst}, #1{min}) // { arity: 2 }
@@ -4285,19 +4285,19 @@ Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0..=#2]
     With Mutually Recursive
       cte l0 =
-        Project (#3{min}, #0..=#2{min}) // { arity: 4 }
+        Project (#3, #0{dst}..=#2{min}) // { arity: 4 }
           Map (10995116285979) // { arity: 4 }
             Reduce group_by=[#0{dst}, #2{min}] aggregates=[min(#1)] // { arity: 3 }
               Reduce group_by=[#0{dst}, #2] aggregates=[min(#1)] // { arity: 3 }
                 Distinct project=[#0{dst}..=#2] // { arity: 3 }
                   Union // { arity: 3 }
-                    Project (#4, #6, #7) // { arity: 3 }
+                    Project (#4{dst}, #6, #7) // { arity: 3 }
                       Map ((#1 + integer_to_bigint(#5{w})), (#2 + 1)) // { arity: 8 }
                         Join on=(#0 = #3{src}) type=differential // { arity: 6 }
                           implementation
                             %1:pathq20[#0]KA » %0:l0[#0]K
                           ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
-                            Project (#1{min}..=#3) // { arity: 3 }
+                            Project (#1{dst}..=#3{min}) // { arity: 3 }
                               Get l0 // { arity: 4 }
                           ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                             ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
@@ -4311,11 +4311,11 @@ Explained Query:
               implementation
                 %1[#0]UKA » %0:l0[#0]K
               ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
-                Project (#1{min}..=#3) // { arity: 3 }
+                Project (#1{dst}..=#3{min}) // { arity: 3 }
                   Get l0 // { arity: 4 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
+                  Project (#1{personid}) // { arity: 1 }
                     Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
                       Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
                         implementation
@@ -4325,7 +4325,7 @@ Explained Query:
                         ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
         cte l2 =
-          Project (#1) // { arity: 1 }
+          Project (#1{min}) // { arity: 1 }
             Get l1 // { arity: 3 }
       Return // { arity: 3 }
         Project (#0{dst}..=#2{min}) // { arity: 3 }
@@ -4436,7 +4436,7 @@ Explained Query:
   Finish order_by=[#0{personid} asc nulls_last] limit=20 output=[#0, #1]
     With Mutually Recursive
       cte l0 =
-        Project (#1) // { arity: 1 }
+        Project (#1{personid}) // { arity: 1 }
           Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
             Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
               implementation
@@ -4454,7 +4454,7 @@ Explained Query:
       cte l3 =
         Distinct project=[#0{dst}] // { arity: 1 }
           Union // { arity: 1 }
-            Project (#2) // { arity: 1 }
+            Project (#2{dst}) // { arity: 1 }
               Join on=(#0 = #1{src}) type=delta // { arity: 4 }
                 implementation
                   %0:l3 » %1:l1[#0]KA » %2[×]
@@ -4485,7 +4485,7 @@ Explained Query:
               Get l12 // { arity: 6 }
       cte l5 =
         Distinct project=[#0..=#2] // { arity: 3 }
-          Project (#0..=#2) // { arity: 3 }
+          Project (#0..=#2{personid}) // { arity: 3 }
             Get l12 // { arity: 6 }
       cte l6 =
         ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
@@ -4503,7 +4503,7 @@ Explained Query:
       cte l8 =
         TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
           Union // { arity: 5 }
-            Project (#3, #4, #1, #7, #8) // { arity: 5 }
+            Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
               Map ((#6 + integer_to_bigint(#2{w})), false) // { arity: 9 }
                 Join on=(#0{src} = #5) type=differential // { arity: 7 }
                   implementation
@@ -4542,11 +4542,11 @@ Explained Query:
               implementation
                 %0:l8[#0]Kef » %1:l8[#0]Kef
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
+                Project (#2{dst}, #3) // { arity: 2 }
                   Filter (#0 = false) // { arity: 5 }
                     Get l8 // { arity: 5 }
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#2, #3) // { arity: 2 }
+                Project (#2{dst}, #3) // { arity: 2 }
                   Filter (#0 = true) // { arity: 5 }
                     Get l8 // { arity: 5 }
       cte l10 =
@@ -4580,7 +4580,7 @@ Explained Query:
                     Project (#1, #0, #0) // { arity: 3 }
                       Map (10995116285979, false) // { arity: 2 }
                         Get l11 // { arity: 0 }
-                    Project (#1{personid}, #0, #0) // { arity: 3 }
+                    Project (#1, #0{personid}, #0{personid}) // { arity: 3 }
                       Map (true) // { arity: 2 }
                         CrossJoin type=differential // { arity: 1 }
                           implementation
@@ -4627,9 +4627,9 @@ Explained Query:
                   Project (#5) // { arity: 1 }
                     Get l12 // { arity: 6 }
         cte l14 =
-          Project (#1{min}, #2) // { arity: 2 }
+          Project (#1{personid}, #2{min}) // { arity: 2 }
             Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1 + #3))] // { arity: 3 }
-              Project (#0{personid}, #2{personid}, #3, #5) // { arity: 4 }
+              Project (#0{personid}, #2, #3{personid}, #5) // { arity: 4 }
                 Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
                   implementation
                     %0:l13[#1]Kef » %1:l13[#1]Kef
@@ -4650,7 +4650,7 @@ Explained Query:
               Get l14 // { arity: 2 }
             ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
               Reduce aggregates=[min(#0{min})] // { arity: 1 }
-                Project (#1) // { arity: 1 }
+                Project (#1{min}) // { arity: 1 }
                   Get l14 // { arity: 2 }
 
 Used Indexes:

--- a/test/sqllogictest/limit_expr.slt
+++ b/test/sqllogictest/limit_expr.slt
@@ -113,17 +113,17 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#1{first_name} asc nulls_last, #4{preference} asc nulls_last] output=[#1, #3]
-    Project (#0{id}..=#2{allowance}, #5, #6) // { arity: 5 }
+    Project (#0{id}..=#2{allowance}, #5{fruit}, #6{preference}) // { arity: 5 }
       Join on=(#0{id} = #3{id} AND #2{allowance} = #4{allowance}) type=differential // { arity: 7 }
         ArrangeBy keys=[[#0{id}, #2{allowance}]] // { arity: 3 }
           ReadStorage materialize.public.people // { arity: 3 }
         ArrangeBy keys=[[#0{id}, #1{allowance}]] // { arity: 4 }
           TopK group_by=[#0{id}, #1{allowance}] order_by=[#3{preference} asc nulls_last] limit=integer_to_bigint(#1{allowance}) offset=1 // { arity: 4 }
-            Project (#0{id}, #1{allowance}, #3{preference}, #4) // { arity: 4 }
+            Project (#0{id}, #1{allowance}, #3{fruit}, #4{preference}) // { arity: 4 }
               Join on=(#0{id} = #2{person_id}) type=differential // { arity: 5 }
                 ArrangeBy keys=[[#0{id}]] // { arity: 2 }
                   Distinct project=[#0{id}, #1{allowance}] // { arity: 2 }
-                    Project (#0{id}, #2) // { arity: 2 }
+                    Project (#0{id}, #2{allowance}) // { arity: 2 }
                       Filter (#0{id}) IS NOT NULL // { arity: 3 }
                         ReadStorage materialize.public.people // { arity: 3 }
                 ArrangeBy keys=[[#0{person_id}]] // { arity: 3 }
@@ -168,10 +168,10 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#1 asc nulls_last, #4{preference} asc nulls_last] output=[#1, #3]
-    Project (#2..=#4{preference}, #0, #1) // { arity: 5 }
+    Project (#2..=#4, #0{fruit}, #1{preference}) // { arity: 5 }
       Map (1, "frank", -4) // { arity: 5 }
         TopK order_by=[#1{preference} asc nulls_last] limit=-4 offset=1 // { arity: 2 }
-          Project (#1{preference}, #2) // { arity: 2 }
+          Project (#1{fruit}, #2{preference}) // { arity: 2 }
             Filter (#0{person_id} = 1) // { arity: 3 }
               ReadStorage materialize.public.preferred_fruits // { arity: 3 }
 
@@ -208,7 +208,7 @@ LIMIT 3;
 Explained Query:
   Finish order_by=[#0{state} asc nulls_last, #1{name} asc nulls_last] limit=3 output=[#0, #1]
     TopK group_by=[#0{state}] limit=integer_to_bigint((ascii(substr(#0{state}, 1, 1)) - 64)) // { arity: 2 }
-      Project (#1{name}, #0{state}) // { arity: 2 }
+      Project (#1{state}, #0{name}) // { arity: 2 }
         ReadStorage materialize.public.cities // { arity: 3 }
 
 Source materialize.public.cities
@@ -259,10 +259,10 @@ Explained Query:
     With
       cte l0 =
         Distinct project=[#0{state}] // { arity: 1 }
-          Project (#1) // { arity: 1 }
+          Project (#1{state}) // { arity: 1 }
             ReadStorage materialize.public.cities // { arity: 3 }
       cte l1 =
-        Project (#0{state}, #2) // { arity: 2 }
+        Project (#0{state}, #2{l}) // { arity: 2 }
           Join on=(#1{sl} = substr(#0{state}, 1, 1)) type=differential // { arity: 3 }
             ArrangeBy keys=[[substr(#0{state}, 1, 1)]] // { arity: 1 }
               Get l0 // { arity: 1 }
@@ -279,9 +279,9 @@ Explained Query:
                   Project (#0{state}) // { arity: 1 }
                     Get l1 // { arity: 2 }
     Return // { arity: 2 }
-      Project (#1{name}, #0{state}) // { arity: 2 }
+      Project (#1{state}, #0{name}) // { arity: 2 }
         TopK group_by=[#1{state}, #2{l}] order_by=[#0{name} asc nulls_last] limit=integer_to_bigint(#2{l}) // { arity: 3 }
-          Project (#0{name}, #1{state}, #3) // { arity: 3 }
+          Project (#0{name}, #1{state}, #3{l}) // { arity: 3 }
             Join on=(#1{state} = #2{state}) type=differential // { arity: 4 }
               ArrangeBy keys=[[#1{state}]] // { arity: 2 }
                 Project (#0{name}, #1{state}) // { arity: 2 }
@@ -330,7 +330,7 @@ Explained Query:
   CrossJoin type=differential // { arity: 2 }
     ArrangeBy keys=[[]] // { arity: 1 }
       Distinct project=[#0{state}] // { arity: 1 }
-        Project (#1) // { arity: 1 }
+        Project (#1{state}) // { arity: 1 }
           ReadStorage materialize.public.cities // { arity: 3 }
     ArrangeBy keys=[[]] // { arity: 1 }
       TopK limit=1 // { arity: 1 }
@@ -386,7 +386,7 @@ Explained Query:
       TopK group_by=[#1{state}] limit=integer_to_bigint((char_length(#1{state}) % 3)) // { arity: 2 }
         Get l0 // { arity: 2 }
   Return // { arity: 3 }
-    Project (#1{name}, #0{state}, #3) // { arity: 3 }
+    Project (#1{state}, #0{name}, #3{name}) // { arity: 3 }
       Join on=(#1{state} = #2{state}) type=differential // { arity: 4 }
         ArrangeBy keys=[[#1{state}]] // { arity: 2 }
           Get l1 // { arity: 2 }
@@ -396,7 +396,7 @@ Explained Query:
               Join on=(#0{state} = #2{state}) type=differential // { arity: 3 }
                 ArrangeBy keys=[[#0{state}]] // { arity: 1 }
                   Distinct project=[#0{state}] // { arity: 1 }
-                    Project (#1) // { arity: 1 }
+                    Project (#1{state}) // { arity: 1 }
                       Get l1 // { arity: 2 }
                 ArrangeBy keys=[[#1{state}]] // { arity: 2 }
                   Get l0 // { arity: 2 }
@@ -504,7 +504,7 @@ Explained Query:
   CrossJoin type=differential // { arity: 2 }
     ArrangeBy keys=[[]] // { arity: 1 }
       Distinct project=[#0{state}] // { arity: 1 }
-        Project (#1) // { arity: 1 }
+        Project (#1{state}) // { arity: 1 }
           ReadStorage materialize.public.cities // { arity: 3 }
     ArrangeBy keys=[[]] // { arity: 1 }
       Project (#0{name}) // { arity: 1 }

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -121,7 +121,7 @@ With
               - ()
             Get materialize.left_joins_raw.dim01 // { arity: 6 }
 Return // { arity: 4 }
-  Project (#0{facts_k01}, #4, #1{facts_d01}, #10) // { arity: 4 }
+  Project (#0{facts_k01}, #4{facts_d01}, #1{dim01_k01}, #10{dim01_d01}) // { arity: 4 }
     Union // { arity: 15 }
       Get l1 // { arity: 15 }
       CrossJoin // { arity: 15 }
@@ -180,7 +180,7 @@ With
               - ()
             Get materialize.left_joins_raw.dim01 // { arity: 6 }
 Return // { arity: 4 }
-  Project (#0{facts_k01}, #4, #1{facts_d01}, #10) // { arity: 4 }
+  Project (#0{facts_k01}, #4{facts_d01}, #1{dim01_k01}, #10{dim01_d01}) // { arity: 4 }
     Union // { arity: 15 }
       Map (null, null, null, null, null, null) // { arity: 15 }
         Union // { arity: 9 }
@@ -190,7 +190,7 @@ Return // { arity: 4 }
                 Filter (#1{dim01_k01}) IS NOT NULL // { arity: 9 }
                   Get l0 // { arity: 9 }
                 Distinct project=[#0{dim01_k01}] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
+                  Project (#1{dim01_k01}) // { arity: 1 }
                     Get l1 // { arity: 15 }
           Get l0 // { arity: 9 }
       Get l1 // { arity: 15 }
@@ -229,17 +229,17 @@ With
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l3 =
     Filter ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
-      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
+      Project (#0{x}..=#10{facts_d05}, #13{dim01_k01}..=#18{dim01_d05}) // { arity: 17 }
         Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
           Get l2 // { arity: 11 }
           CrossJoin // { arity: 8 }
             Get l1 // { arity: 2 }
             Get materialize.left_joins_raw.dim01 // { arity: 6 }
 Return // { arity: 6 }
-  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
+  Project (#0{x}, #1{y}, #4{facts_k01}..=#7{dim01_d01}) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
       Get l0 // { arity: 2 }
-      Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
+      Project (#0{x}..=#2{facts_k01}, #6{facts_d01}, #3{dim01_k01}, #12{dim01_d01}) // { arity: 6 }
         Union // { arity: 17 }
           Get l3 // { arity: 17 }
           CrossJoin // { arity: 17 }
@@ -289,17 +289,17 @@ With
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l3 =
     Filter ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
-      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
+      Project (#0{x}..=#10{facts_d05}, #13{dim01_k01}..=#18{dim01_d05}) // { arity: 17 }
         Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
           Get l2 // { arity: 11 }
           CrossJoin // { arity: 8 }
             Get l1 // { arity: 2 }
             Get materialize.left_joins_raw.dim01 // { arity: 6 }
 Return // { arity: 6 }
-  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
+  Project (#0{x}, #1{y}, #4{facts_k01}..=#7{dim01_d01}) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
       Get l0 // { arity: 2 }
-      Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
+      Project (#0{x}..=#2{facts_k01}, #6{facts_d01}, #3{dim01_k01}, #12{dim01_d01}) // { arity: 6 }
         Union // { arity: 17 }
           Map (null, null, null, null, null, null) // { arity: 17 }
             Union // { arity: 11 }
@@ -309,7 +309,7 @@ Return // { arity: 6 }
                     Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL // { arity: 11 }
                       Get l2 // { arity: 11 }
                     Distinct project=[#0{x}..=#2] // { arity: 3 }
-                      Project (#17..=#19) // { arity: 3 }
+                      Project (#17{x}..=#19) // { arity: 3 }
                         Map (#0{x}, #1{y}, (#3{dim01_k01} + #0{x})) // { arity: 20 }
                           Get l3 // { arity: 17 }
               Get l2 // { arity: 11 }
@@ -349,19 +349,19 @@ With
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l3 =
     Filter ((#2{dim01_k01} + #1{y}) = (#9{dim01_k01} + #0{x})) // { arity: 17 }
-      Project (#0{x}..=#7{dim01_d05}, #10{dim02_k01}..=#18) // { arity: 17 }
+      Project (#0{x}..=#7{dim01_d05}, #10{facts_k01}..=#18{facts_d05}) // { arity: 17 }
         Join on=(#0{x} = #8{x} AND #1{y} = #9{y}) // { arity: 19 }
           CrossJoin // { arity: 8 }
             Get l1 // { arity: 2 }
             Get materialize.left_joins_raw.dim01 // { arity: 6 }
           Get l2 // { arity: 11 }
 Return // { arity: 6 }
-  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
+  Project (#0{x}, #1{y}, #4{facts_k01}..=#7{dim01_d01}) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
       Get l0 // { arity: 2 }
-      Project (#0{x}, #1{y}, #8, #12, #9, #3{facts_d01}) // { arity: 6 }
+      Project (#0{x}, #1{y}, #8{facts_k01}, #12{facts_d01}, #9{dim01_k01}, #3{dim01_d01}) // { arity: 6 }
         Union // { arity: 17 }
-          Project (#0{x}, #1{y}, #11{dim03_k01}..=#16{facts_d05}, #2..=#10{dim02_k01}) // { arity: 17 }
+          Project (#0{x}, #1{y}, #11..=#16, #2{facts_k01}..=#10{facts_d05}) // { arity: 17 }
             Map (null, null, null, null, null, null) // { arity: 17 }
               Union // { arity: 11 }
                 Negate // { arity: 11 }
@@ -370,7 +370,7 @@ Return // { arity: 6 }
                       Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL // { arity: 11 }
                         Get l2 // { arity: 11 }
                       Distinct project=[#0{x}..=#2] // { arity: 3 }
-                        Project (#17..=#19) // { arity: 3 }
+                        Project (#17{x}..=#19) // { arity: 3 }
                           Map (#0{x}, #1{y}, (#2{dim01_k01} + #1{y})) // { arity: 20 }
                             Get l3 // { arity: 17 }
                 Get l2 // { arity: 11 }
@@ -414,17 +414,17 @@ With
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l3 =
     Filter ((((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) AND (#7{facts_d02} = 42)) AND (#13{dim01_d02} = 24)) // { arity: 17 }
-      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
+      Project (#0{x}..=#10{facts_d05}, #13{dim01_k01}..=#18{dim01_d05}) // { arity: 17 }
         Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
           Get l2 // { arity: 11 }
           CrossJoin // { arity: 8 }
             Get l1 // { arity: 2 }
             Get materialize.left_joins_raw.dim01 // { arity: 6 }
 Return // { arity: 6 }
-  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
+  Project (#0{x}, #1{y}, #4{facts_k01}..=#7{dim01_d01}) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
       Get l0 // { arity: 2 }
-      Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
+      Project (#0{x}..=#2{facts_k01}, #6{facts_d01}, #3{dim01_k01}, #12{dim01_d01}) // { arity: 6 }
         Union // { arity: 17 }
           Get l3 // { arity: 17 }
           CrossJoin // { arity: 17 }
@@ -478,17 +478,17 @@ With
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l3 =
     Filter (#7{facts_d02} = 42) AND (#13{dim01_d02} = 24) AND ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
-      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
+      Project (#0{x}..=#10{facts_d05}, #13{dim01_k01}..=#18{dim01_d05}) // { arity: 17 }
         Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
           Get l2 // { arity: 11 }
           CrossJoin // { arity: 8 }
             Get l1 // { arity: 2 }
             Get materialize.left_joins_raw.dim01 // { arity: 6 }
 Return // { arity: 6 }
-  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
+  Project (#0{x}, #1{y}, #4{facts_k01}..=#7{dim01_d01}) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
       Get l0 // { arity: 2 }
-      Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
+      Project (#0{x}..=#2{facts_k01}, #6{facts_d01}, #3{dim01_k01}, #12{dim01_d01}) // { arity: 6 }
         Union // { arity: 17 }
           Map (null, null, null, null, null, null) // { arity: 17 }
             Union // { arity: 11 }
@@ -498,7 +498,7 @@ Return // { arity: 6 }
                     Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL AND (#7{facts_d02} = 42) // { arity: 11 }
                       Get l2 // { arity: 11 }
                     Distinct project=[#0{x}..=#2] // { arity: 3 }
-                      Project (#17..=#19) // { arity: 3 }
+                      Project (#17{x}..=#19) // { arity: 3 }
                         Map (#0{x}, #1{y}, (#3{dim01_k01} + #0{x})) // { arity: 20 }
                           Get l3 // { arity: 17 }
               Get l2 // { arity: 11 }
@@ -542,19 +542,19 @@ With
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l3 =
     Filter (#4{dim01_d02} = 24) AND (#13{facts_d02} = 42) AND ((#2{dim01_k01} + #1{y}) = (#9{dim01_k01} + #0{x})) // { arity: 17 }
-      Project (#0{x}..=#7{dim01_d05}, #10{dim02_k01}..=#18) // { arity: 17 }
+      Project (#0{x}..=#7{dim01_d05}, #10{facts_k01}..=#18{facts_d05}) // { arity: 17 }
         Join on=(#0{x} = #8{x} AND #1{y} = #9{y}) // { arity: 19 }
           CrossJoin // { arity: 8 }
             Get l1 // { arity: 2 }
             Get materialize.left_joins_raw.dim01 // { arity: 6 }
           Get l2 // { arity: 11 }
 Return // { arity: 6 }
-  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
+  Project (#0{x}, #1{y}, #4{facts_k01}..=#7{dim01_d01}) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
       Get l0 // { arity: 2 }
-      Project (#0{x}, #1{y}, #8, #12, #9, #3{facts_d01}) // { arity: 6 }
+      Project (#0{x}, #1{y}, #8{facts_k01}, #12{facts_d01}, #9{dim01_k01}, #3{dim01_d01}) // { arity: 6 }
         Union // { arity: 17 }
-          Project (#0{x}, #1{y}, #11{dim03_k01}..=#16{facts_d05}, #2..=#10{dim02_k01}) // { arity: 17 }
+          Project (#0{x}, #1{y}, #11..=#16, #2{facts_k01}..=#10{facts_d05}) // { arity: 17 }
             Map (null, null, null, null, null, null) // { arity: 17 }
               Union // { arity: 11 }
                 Negate // { arity: 11 }
@@ -563,7 +563,7 @@ Return // { arity: 6 }
                       Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL AND (#7{facts_d02} = 42) // { arity: 11 }
                         Get l2 // { arity: 11 }
                       Distinct project=[#0{x}..=#2] // { arity: 3 }
-                        Project (#17..=#19) // { arity: 3 }
+                        Project (#17{x}..=#19) // { arity: 3 }
                           Map (#0{x}, #1{y}, (#2{dim01_k01} + #1{y})) // { arity: 20 }
                             Get l3 // { arity: 17 }
                 Get l2 // { arity: 11 }
@@ -610,22 +610,22 @@ With
       Get materialize.left_joins_raw.dim02 // { arity: 6 }
   cte l4 =
     Filter (coalesce(#2{dim01_k01}, #0{x}) = coalesce(#8{dim02_k01}, #1{y})) AND (#11{dim02_d03} < 24) AND (#5{dim01_d03} > 42) // { arity: 14 }
-      Project (#0{x}..=#7{dim01_d05}, #10{dim02_d02}..=#15) // { arity: 14 }
+      Project (#0{x}..=#7{dim01_d05}, #10{dim02_k01}..=#15{dim02_d05}) // { arity: 14 }
         Join on=(#0{x} = #8{x} AND #1{y} = #9{y}) // { arity: 16 }
           Get l2 // { arity: 8 }
           Get l3 // { arity: 8 }
   cte l5 =
     Distinct project=[#0{x}..=#2] // { arity: 3 }
-      Project (#14..=#16) // { arity: 3 }
+      Project (#14{x}..=#16) // { arity: 3 }
         Map (#0{x}, #1{y}, coalesce(#2{dim01_k01}, #0{x})) // { arity: 17 }
           Get l4 // { arity: 14 }
 Return // { arity: 6 }
-  Project (#0{x}, #1{y}, #4{dim02_d02}..=#7) // { arity: 6 }
+  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7{dim02_d02}) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
       Get l0 // { arity: 2 }
-      Project (#0{x}..=#2{dim01_k01}, #2{dim01_k01}, #10, #10) // { arity: 6 }
+      Project (#0{x}..=#2{dim01_k01}, #2{dim01_k01}, #10{dim02_d02}, #10{dim02_d02}) // { arity: 6 }
         Union // { arity: 14 }
-          Project (#0{x}, #1{y}, #8{dim02_k01}..=#13{dim02_d05}, #2..=#7) // { arity: 14 }
+          Project (#0{x}, #1{y}, #8..=#13, #2{dim02_k01}..=#7{dim02_d05}) // { arity: 14 }
             Map (null, null, null, null, null, null) // { arity: 14 }
               Union // { arity: 8 }
                 Negate // { arity: 8 }
@@ -683,7 +683,7 @@ With
       Get l1 // { arity: 2 }
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l3 =
-    Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
+    Project (#0{x}..=#10{facts_d05}, #13{dim01_k01}..=#18{dim01_d05}) // { arity: 17 }
       Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
         Get l2 // { arity: 11 }
         CrossJoin // { arity: 8 }
@@ -722,7 +722,7 @@ With
   cte l8 =
     Project (#0{x}..=#16{dim01_d05}) // { arity: 17 }
       Filter ((((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) AND (#7{facts_d02} = 42)) AND #17{any}) // { arity: 18 }
-        Project (#0{x}..=#16{dim01_d05}, #18) // { arity: 18 }
+        Project (#0{x}..=#16{dim01_d05}, #18{any}) // { arity: 18 }
           Join on=(#12{dim01_d01} = #17{dim01_d01}) // { arity: 19 }
             Get l3 // { arity: 17 }
             Union // { arity: 2 }
@@ -740,10 +740,10 @@ With
                 Constant // { arity: 1 }
                   - (null)
 Return // { arity: 6 }
-  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
+  Project (#0{x}, #1{y}, #4{facts_k01}..=#7{dim01_d01}) // { arity: 6 }
     Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
       Get l0 // { arity: 2 }
-      Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
+      Project (#0{x}..=#2{facts_k01}, #6{facts_d01}, #3{dim01_k01}, #12{dim01_d01}) // { arity: 6 }
         Union // { arity: 17 }
           Get l8 // { arity: 17 }
           CrossJoin // { arity: 17 }
@@ -791,7 +791,7 @@ Explained Query:
   With
     cte l0 =
       ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4{facts_d01}, #5{facts_d02}) // { arity: 4 }
           Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
     cte l1 =
@@ -806,16 +806,16 @@ Explained Query:
       Map (null, null, null) // { arity: 6 }
         Union // { arity: 3 }
           Negate // { arity: 3 }
-            Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
+            Project (#0{facts_k01}, #2{facts_d01}, #3{facts_d02}) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
-                    Project (#1) // { arity: 1 }
+                    Project (#1{dim01_k01}) // { arity: 1 }
                       Get l1 // { arity: 7 }
-          Project (#0{facts_k01}, #4, #5) // { arity: 3 }
+          Project (#0{facts_k01}, #4{facts_d01}, #5{facts_d02}) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-      Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
+      Project (#0{facts_k01}, #2{facts_d01}..=#6{dim01_d02}) // { arity: 6 }
         Get l1 // { arity: 7 }
 
 Source materialize.left_joins_raw.facts
@@ -852,7 +852,7 @@ Explained Query:
   With
     cte l0 =
       ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4{facts_d01}, #5{facts_d02}) // { arity: 4 }
           Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
     cte l1 =
@@ -867,16 +867,16 @@ Explained Query:
       Map (null, null, null) // { arity: 6 }
         Union // { arity: 3 }
           Negate // { arity: 3 }
-            Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
+            Project (#0{facts_k01}, #2{facts_d01}, #3{facts_d02}) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
-                    Project (#1) // { arity: 1 }
+                    Project (#1{dim01_k01}) // { arity: 1 }
                       Get l1 // { arity: 7 }
-          Project (#0{facts_k01}, #4, #5) // { arity: 3 }
+          Project (#0{facts_k01}, #4{facts_d01}, #5{facts_d02}) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-      Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
+      Project (#0{facts_k01}, #2{facts_d01}..=#6{dim01_d02}) // { arity: 6 }
         Get l1 // { arity: 7 }
 
 Source materialize.left_joins_raw.facts
@@ -900,7 +900,7 @@ materialize.public.v:
   With
     cte l0 =
       ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4{facts_d01}, #5{facts_d02}) // { arity: 4 }
           Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
     cte l1 =
@@ -915,16 +915,16 @@ materialize.public.v:
       Map (null, null, null) // { arity: 6 }
         Union // { arity: 3 }
           Negate // { arity: 3 }
-            Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
+            Project (#0{facts_k01}, #2{facts_d01}, #3{facts_d02}) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
-                    Project (#1) // { arity: 1 }
+                    Project (#1{dim01_k01}) // { arity: 1 }
                       Get l1 // { arity: 7 }
-          Project (#0{facts_k01}, #4, #5) // { arity: 3 }
+          Project (#0{facts_k01}, #4{facts_d01}, #5{facts_d02}) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-      Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
+      Project (#0{facts_k01}, #2{facts_d01}..=#6{dim01_d02}) // { arity: 6 }
         Get l1 // { arity: 7 }
 
 Source materialize.left_joins_raw.facts
@@ -957,7 +957,7 @@ materialize.public.mv:
   With
     cte l0 =
       ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4{facts_d01}, #5{facts_d02}) // { arity: 4 }
           Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
     cte l1 =
@@ -972,16 +972,16 @@ materialize.public.mv:
       Map (null, null, null) // { arity: 6 }
         Union // { arity: 3 }
           Negate // { arity: 3 }
-            Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
+            Project (#0{facts_k01}, #2{facts_d01}, #3{facts_d02}) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
-                    Project (#1) // { arity: 1 }
+                    Project (#1{dim01_k01}) // { arity: 1 }
                       Get l1 // { arity: 7 }
-          Project (#0{facts_k01}, #4, #5) // { arity: 3 }
+          Project (#0{facts_k01}, #4{facts_d01}, #5{facts_d02}) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-      Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
+      Project (#0{facts_k01}, #2{facts_d01}..=#6{dim01_d02}) // { arity: 6 }
         Get l1 // { arity: 7 }
 
 Source materialize.left_joins_raw.facts

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -197,10 +197,10 @@ materialize.public.q01_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q01 // { arity: 10 }
 
 materialize.public.q01:
-  Project (#0{l_returnflag}..=#5{sum}, #9{count}..=#11, #6) // { arity: 10 }
+  Project (#0{l_returnflag}..=#5{sum}, #9..=#11, #6{count}) // { arity: 10 }
     Map (bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end), (#2{sum_l_quantity} / #8), (#3{sum_l_extendedprice} / #8), (#7{sum_l_discount} / #8)) // { arity: 12 }
       Reduce group_by=[#4{l_returnflag}, #5{l_linestatus}] aggregates=[sum(#0{l_quantity}), sum(#1{l_extendedprice}), sum((#1{l_extendedprice} * (1 - #2{l_discount}))), sum(((#1{l_extendedprice} * (1 - #2{l_discount})) * (1 + #3{l_tax}))), count(*), sum(#2{l_discount})] // { arity: 8 }
-        Project (#4{l_returnflag}..=#9) // { arity: 6 }
+        Project (#4{l_quantity}..=#9{l_linestatus}) // { arity: 6 }
           Filter (date_to_timestamp(#10{l_shipdate}) <= 1998-10-02 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
@@ -281,7 +281,7 @@ materialize.public.q02:
       ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
         ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
     cte l4 =
-      Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
+      Project (#0{p_partkey}, #2{p_mfgr}, #10{s_name}, #11{s_address}, #13{s_phone}..=#15{s_comment}, #19{ps_supplycost}, #22{n_name}) // { arity: 9 }
         Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
           Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
             implementation
@@ -297,7 +297,7 @@ materialize.public.q02:
             Get l2 // { arity: 4 }
             Get l3 // { arity: 3 }
   Return // { arity: 8 }
-    Project (#5{s_address}, #2{n_name}, #8, #0{s_acctbal}, #1{s_name}, #3{p_partkey}, #4{p_mfgr}, #6{s_phone}) // { arity: 8 }
+    Project (#5{s_acctbal}, #2{s_name}, #8{n_name}, #0{p_partkey}, #1{p_mfgr}, #3{s_address}, #4{s_phone}, #6{s_comment}) // { arity: 8 }
       Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10{min_ps_supplycost}) type=differential // { arity: 11 }
         implementation
           %1[#0, #1]UKK » %0:l4[#0, #7]KK
@@ -305,7 +305,7 @@ materialize.public.q02:
           Get l4 // { arity: 9 }
         ArrangeBy keys=[[#0{p_partkey}, #1{min_ps_supplycost}]] // { arity: 2 }
           Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
-            Project (#0{p_partkey}, #4) // { arity: 2 }
+            Project (#0{p_partkey}, #4{ps_supplycost}) // { arity: 2 }
               Filter (#18{r_name} = "EUROPE") // { arity: 20 }
                 Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
                   implementation
@@ -375,9 +375,9 @@ materialize.public.q03_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q03 // { arity: 4 }
 
 materialize.public.q03:
-  Project (#0{o_orderkey}, #3{o_shippriority}, #1{sum}, #2{o_orderdate}) // { arity: 4 }
+  Project (#0{o_orderkey}, #3{sum}, #1{o_orderdate}, #2{o_shippriority}) // { arity: 4 }
     Reduce group_by=[#0{o_orderkey}..=#2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
-      Project (#8, #12, #15, #22, #23) // { arity: 5 }
+      Project (#8{o_orderkey}, #12{o_orderdate}, #15{o_shippriority}, #22{l_extendedprice}, #23{l_discount}) // { arity: 5 }
         Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) // { arity: 33 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
             implementation
@@ -439,7 +439,7 @@ materialize.public.q04_primary_idx:
 
 materialize.public.q04:
   Reduce group_by=[#0{o_orderpriority}] aggregates=[count(*)] // { arity: 2 }
-    Project (#5) // { arity: 1 }
+    Project (#5{o_orderpriority}) // { arity: 1 }
       Filter (#4{o_orderdate} >= 1993-07-01) AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 10 }
         Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 10 }
           implementation
@@ -501,7 +501,7 @@ materialize.public.q05_primary_idx:
 
 materialize.public.q05:
   Reduce group_by=[#2{n_name}] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
-    Project (#19, #20, #24) // { arity: 3 }
+    Project (#19{l_extendedprice}, #20{l_discount}, #24{n_name}) // { arity: 3 }
       Filter (#28{r_name} = "ASIA") AND (#12{o_orderdate} < 1995-01-01) AND (#12{o_orderdate} >= 1994-01-01) // { arity: 30 }
         Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #22{s_nationkey} = #23{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey} AND #18{l_suppkey} = #21{s_suppkey} AND #25{n_regionkey} = #27{r_regionkey}) type=delta // { arity: 30 }
           implementation
@@ -516,10 +516,10 @@ materialize.public.q05:
           ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
             ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
           ArrangeBy keys=[[#0{l_orderkey}], [#0{l_orderkey}, #1{l_suppkey}]] // { arity: 4 }
-            Project (#0{l_orderkey}, #2{l_extendedprice}, #5, #6) // { arity: 4 }
+            Project (#0{l_orderkey}, #2{l_suppkey}, #5{l_extendedprice}, #6{l_discount}) // { arity: 4 }
               ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
           ArrangeBy keys=[[#0{s_suppkey}, #1{s_nationkey}]] // { arity: 2 }
-            Project (#0{s_suppkey}, #3) // { arity: 2 }
+            Project (#0{s_suppkey}, #3{s_nationkey}) // { arity: 2 }
               Filter (#0{s_suppkey}) IS NOT NULL // { arity: 7 }
                 ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
           ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
@@ -570,7 +570,7 @@ materialize.public.q06:
   With
     cte l0 =
       Reduce aggregates=[sum((#0{l_extendedprice} * #1{l_discount}))] // { arity: 1 }
-        Project (#5, #6) // { arity: 2 }
+        Project (#5{l_extendedprice}, #6{l_discount}) // { arity: 2 }
           Filter (#4{l_quantity} < 24) AND (#6{l_discount} <= 0.07) AND (#6{l_discount} >= 0.05) AND (#10{l_shipdate} >= 1994-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-01-01 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
   Return // { arity: 1 }
@@ -652,7 +652,7 @@ materialize.public.q07:
         ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
   Return // { arity: 4 }
     Reduce group_by=[#3{n_name}, #4{n_name}, extract_year_d(#2{l_shipdate})] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 4 }
-      Project (#12, #13, #17, #41, #45) // { arity: 5 }
+      Project (#12{l_extendedprice}, #13{l_discount}, #17{l_shipdate}, #41{n_name}, #45{n_name}) // { arity: 5 }
         Filter (#17{l_shipdate} <= 1996-12-31) AND (#17{l_shipdate} >= 1995-01-01) AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
           Map ((#41{n_name} = "FRANCE"), (#41{n_name} = "GERMANY"), (#45{n_name} = "FRANCE"), (#45{n_name} = "GERMANY")) // { arity: 52 }
             Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #40{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey} AND #24{o_custkey} = #32{c_custkey} AND #35{c_nationkey} = #44{n_nationkey}) type=delta // { arity: 48 }
@@ -745,7 +745,7 @@ materialize.public.q08:
   Project (#0, #3) // { arity: 2 }
     Map ((#1{sum} / #2{sum})) // { arity: 4 }
       Reduce group_by=[extract_year_d(#2{o_orderdate})] aggregates=[sum(case when (#3{n_name} = "BRAZIL") then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 3 }
-        Project (#21, #22, #36, #54) // { arity: 4 }
+        Project (#21{l_extendedprice}, #22{l_discount}, #36{o_orderdate}, #54{n_name}) // { arity: 4 }
           Filter (#58{r_name} = "AMERICA") AND (#36{o_orderdate} <= 1996-12-31) AND (#36{o_orderdate} >= 1995-01-01) AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4{p_type})) // { arity: 60 }
             Join on=(#0{p_partkey} = #17{l_partkey} AND #9{s_suppkey} = #18{l_suppkey} AND #12{s_nationkey} = #53{n_nationkey} AND #16{l_orderkey} = #32{o_orderkey} AND #33{o_custkey} = #41{c_custkey} AND #44{c_nationkey} = #49{n_nationkey} AND #51{n_regionkey} = #57{r_regionkey}) type=delta // { arity: 60 }
               implementation
@@ -842,7 +842,7 @@ materialize.public.q09_primary_idx:
 
 materialize.public.q09:
   Reduce group_by=[#5{n_name}, extract_year_d(#4{o_orderdate})] aggregates=[sum(((#1{l_extendedprice} * (1 - #2{l_discount})) - (#3{ps_supplycost} * #0{l_quantity})))] // { arity: 3 }
-    Project (#20..=#22, #35, #41, #47) // { arity: 6 }
+    Project (#20{l_quantity}..=#22{l_discount}, #35{ps_supplycost}, #41{o_orderdate}, #47{n_name}) // { arity: 6 }
       Filter like["%green%"](varchar_to_text(#1{p_name})) // { arity: 50 }
         Join on=(#0{p_partkey} = #17{l_partkey} = #32{ps_partkey} AND #9{s_suppkey} = #18{l_suppkey} = #33{ps_suppkey} AND #12{s_nationkey} = #46{n_nationkey} AND #16{l_orderkey} = #37{o_orderkey}) type=delta // { arity: 50 }
           implementation
@@ -929,9 +929,9 @@ materialize.public.q10_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q10 // { arity: 8 }
 
 materialize.public.q10:
-  Project (#0{c_custkey}, #1{c_name}, #7{c_comment}, #2{sum}, #4{n_name}, #5{c_address}, #3{c_acctbal}, #6{c_phone}) // { arity: 8 }
+  Project (#0{c_custkey}, #1{c_name}, #7{sum}, #2{c_acctbal}, #4{n_name}, #5{c_address}, #3{c_phone}, #6{c_comment}) // { arity: 8 }
     Reduce group_by=[#0{c_custkey}, #1{c_name}, #4{c_acctbal}, #3{c_phone}, #8{n_name}, #2{c_address}, #5{c_comment}] aggregates=[sum((#6{l_extendedprice} * (1 - #7{l_discount})))] // { arity: 8 }
-      Project (#0{c_custkey}..=#2{c_address}, #4{c_acctbal}, #5{c_comment}, #7{l_discount}, #22, #23, #34) // { arity: 9 }
+      Project (#0{c_custkey}..=#2{c_address}, #4{c_phone}, #5{c_acctbal}, #7{c_comment}, #22{l_extendedprice}, #23{l_discount}, #34{n_name}) // { arity: 9 }
         Filter (#25{l_returnflag} = "R") AND (#12{o_orderdate} < 1994-01-01) AND (#12{o_orderdate} >= 1993-10-01) AND (date_to_timestamp(#12{o_orderdate}) < 1994-01-01 00:00:00) // { arity: 37 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #33{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 37 }
             implementation
@@ -1005,7 +1005,7 @@ materialize.public.q11_primary_idx:
 materialize.public.q11:
   With
     cte l0 =
-      Project (#0{ps_partkey}, #2{ps_supplycost}, #3) // { arity: 3 }
+      Project (#0{ps_partkey}, #2{ps_availqty}, #3{ps_supplycost}) // { arity: 3 }
         Filter (#13{n_name} = "GERMANY") // { arity: 16 }
           Join on=(#1{ps_suppkey} = #5{s_suppkey} AND #8{s_nationkey} = #12{n_nationkey}) type=delta // { arity: 16 }
             implementation
@@ -1029,7 +1029,7 @@ materialize.public.q11:
               Get l0 // { arity: 3 }
           ArrangeBy keys=[[]] // { arity: 1 }
             Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
-              Project (#1{ps_supplycost}, #2) // { arity: 2 }
+              Project (#1{ps_availqty}, #2{ps_supplycost}) // { arity: 2 }
                 Get l0 // { arity: 3 }
 
 Used Indexes:
@@ -1087,7 +1087,7 @@ materialize.public.q12_primary_idx:
 
 materialize.public.q12:
   Reduce group_by=[#1{l_shipmode}] aggregates=[sum(case when ((#0{o_orderpriority} = "2-HIGH") OR (#0{o_orderpriority} = "1-URGENT")) then 1 else 0 end), sum(case when ((#0{o_orderpriority} != "2-HIGH") AND (#0{o_orderpriority} != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
-    Project (#5, #23) // { arity: 2 }
+    Project (#5{o_orderpriority}, #23{l_shipmode}) // { arity: 2 }
       Filter (#21{l_receiptdate} >= 1994-01-01) AND (#19{l_shipdate} < #20{l_commitdate}) AND (#20{l_commitdate} < #21{l_receiptdate}) AND (date_to_timestamp(#21{l_receiptdate}) < 1995-01-01 00:00:00) AND ((#23{l_shipmode} = "MAIL") OR (#23{l_shipmode} = "SHIP")) // { arity: 25 }
         Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 25 }
           implementation
@@ -1146,7 +1146,7 @@ materialize.public.q13:
       ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
         ReadIndex on=customer pk_customer_custkey=[differential join] // { arity: 8 }
     cte l1 =
-      Project (#0{c_custkey}, #8) // { arity: 2 }
+      Project (#0{c_custkey}, #8{o_orderkey}) // { arity: 2 }
         Filter NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
           Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
             implementation
@@ -1156,7 +1156,7 @@ materialize.public.q13:
               ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
   Return // { arity: 2 }
     Reduce group_by=[#0{count_o_orderkey}] aggregates=[count(*)] // { arity: 2 }
-      Project (#1) // { arity: 1 }
+      Project (#1{count_o_orderkey}) // { arity: 1 }
         Reduce group_by=[#0{c_custkey}] aggregates=[count(#1{o_orderkey})] // { arity: 2 }
           Union // { arity: 2 }
             Map (null) // { arity: 2 }
@@ -1215,7 +1215,7 @@ materialize.public.q14:
   With
     cte l0 =
       Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(#2{p_type})) then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
-        Project (#5, #6, #20) // { arity: 3 }
+        Project (#5{l_extendedprice}, #6{l_discount}, #20{p_type}) // { arity: 3 }
           Filter (#10{l_shipdate} >= 1995-09-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-10-01 00:00:00) // { arity: 25 }
             Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
               implementation
@@ -1296,11 +1296,11 @@ materialize.public.q15:
   With
     cte l0 =
       Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
-        Project (#2{l_discount}, #5, #6) // { arity: 3 }
+        Project (#2{l_suppkey}, #5{l_extendedprice}, #6{l_discount}) // { arity: 3 }
           Filter (#10{l_shipdate} >= 1996-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1996-04-01 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
   Return // { arity: 5 }
-    Project (#0{s_suppkey}..=#2{s_address}, #4{sum}, #8) // { arity: 5 }
+    Project (#0{s_suppkey}..=#2{s_address}, #4{s_phone}, #8{sum}) // { arity: 5 }
       Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
         implementation
           %0:supplier » %1:l0[#0]UKA » %2[#0]UK
@@ -1312,7 +1312,7 @@ materialize.public.q15:
           Get l0 // { arity: 2 }
         ArrangeBy keys=[[#0{max_sum}]] // { arity: 1 }
           Reduce aggregates=[max(#0{sum})] // { arity: 1 }
-            Project (#1) // { arity: 1 }
+            Project (#1{sum}) // { arity: 1 }
               Get l0 // { arity: 2 }
 
 Used Indexes:
@@ -1371,7 +1371,7 @@ materialize.public.q16_primary_idx:
 materialize.public.q16:
   With
     cte l0 =
-      Project (#1{p_brand}, #8..=#10) // { arity: 4 }
+      Project (#1{ps_suppkey}, #8{p_brand}..=#10{p_size}) // { arity: 4 }
         Filter (#8{p_brand} != "Brand#45") AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
           Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
             implementation
@@ -1456,7 +1456,7 @@ materialize.public.q17:
       ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
     cte l1 =
-      Project (#1{l_quantity}, #4, #5) // { arity: 3 }
+      Project (#1{l_partkey}, #4{l_quantity}, #5{l_extendedprice}) // { arity: 3 }
         Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") // { arity: 25 }
           Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
             implementation
@@ -1466,7 +1466,7 @@ materialize.public.q17:
               ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
     cte l2 =
       Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
-        Project (#2) // { arity: 1 }
+        Project (#2{l_extendedprice}) // { arity: 1 }
           Filter (#1{l_quantity} < (0.2 * (#4{sum_l_quantity} / bigint_to_numeric(case when (#5{count} = 0) then null else #5{count} end)))) // { arity: 6 }
             Join on=(#0{l_partkey} = #3{l_partkey}) type=differential // { arity: 6 }
               implementation
@@ -1475,7 +1475,7 @@ materialize.public.q17:
                 Get l1 // { arity: 3 }
               ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
                 Reduce group_by=[#0{l_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
-                  Project (#0{l_partkey}, #5) // { arity: 2 }
+                  Project (#0{l_partkey}, #5{l_quantity}) // { arity: 2 }
                     Join on=(#0{l_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
                       implementation
                         %0[#0]UKA » %1:l0[#1]KA
@@ -1558,7 +1558,7 @@ materialize.public.q18:
       ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
     cte l1 =
-      Project (#0{c_custkey}, #1{c_name}, #8, #11, #12, #21) // { arity: 6 }
+      Project (#0{c_custkey}, #1{c_name}, #8{o_orderkey}, #11{o_totalprice}, #12{o_orderdate}, #21{l_quantity}) // { arity: 6 }
         Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
           implementation
             %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
@@ -1580,13 +1580,13 @@ materialize.public.q18:
               Get l1 // { arity: 6 }
             ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 2 }
               Reduce group_by=[#0{o_orderkey}] aggregates=[sum(#1{l_quantity})] // { arity: 2 }
-                Project (#0{o_orderkey}, #5) // { arity: 2 }
+                Project (#0{o_orderkey}, #5{l_quantity}) // { arity: 2 }
                   Join on=(#0{o_orderkey} = #1{l_orderkey}) type=differential // { arity: 17 }
                     implementation
                       %0[#0]UKA » %1:l0[#0]KA
                     ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
                       Distinct project=[#0{o_orderkey}] // { arity: 1 }
-                        Project (#2) // { arity: 1 }
+                        Project (#2{o_orderkey}) // { arity: 1 }
                           Get l1 // { arity: 6 }
                     Get l0 // { arity: 16 }
 
@@ -1654,7 +1654,7 @@ materialize.public.q19:
   With
     cte l0 =
       Reduce aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 1 }
-        Project (#5, #6) // { arity: 2 }
+        Project (#5{l_extendedprice}, #6{l_discount}) // { arity: 2 }
           Filter (#13{l_shipinstruct} = "DELIVER IN PERSON") AND (#21{p_size} >= 1) AND ((#14{l_shipmode} = "AIR") OR (#14{l_shipmode} = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
             Map ((#4{l_quantity} <= 20), (#4{l_quantity} >= 10), (#4{l_quantity} <= 30), (#4{l_quantity} >= 20), (#4{l_quantity} <= 11), (#4{l_quantity} >= 1), (#19{p_brand} = "Brand#12"), (#21{p_size} <= 5), ((#22{p_container} = "SM BOX") OR (#22{p_container} = "SM PKG") OR (#22{p_container} = "SM CASE") OR (#22{p_container} = "SM PACK")), (#19{p_brand} = "Brand#23"), (#21{p_size} <= 10), ((#22{p_container} = "MED BAG") OR (#22{p_container} = "MED BOX") OR (#22{p_container} = "MED PKG") OR (#22{p_container} = "MED PACK")), (#19{p_brand} = "Brand#34"), (#21{p_size} <= 15), ((#22{p_container} = "LG BOX") OR (#22{p_container} = "LG PKG") OR (#22{p_container} = "LG CASE") OR (#22{p_container} = "LG PACK"))) // { arity: 40 }
               Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
@@ -1767,7 +1767,7 @@ materialize.public.q20:
                 Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
   Return // { arity: 2 }
-    Project (#1{s_address}, #2) // { arity: 2 }
+    Project (#1{s_name}, #2{s_address}) // { arity: 2 }
       Join on=(#0{s_suppkey} = #3{s_suppkey}) type=differential // { arity: 4 }
         implementation
           %1[#0]UKA » %0:l0[#0]K
@@ -1781,21 +1781,21 @@ materialize.public.q20:
                   implementation
                     %1[#1, #0]UKK » %0:l1[#0, #1]KKf
                   ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}]] // { arity: 3 }
-                    Project (#0{s_suppkey}, #1{ps_partkey}, #3) // { arity: 3 }
+                    Project (#0{s_suppkey}, #1{ps_partkey}, #3{ps_availqty}) // { arity: 3 }
                       Filter (#0{s_suppkey} = #2{ps_suppkey}) // { arity: 4 }
                         Get l1 // { arity: 4 }
                   ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
                     Project (#0{ps_partkey}, #1{ps_suppkey}, #3) // { arity: 3 }
                       Map ((0.5 * #2{sum_l_quantity})) // { arity: 4 }
                         Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
-                          Project (#0{ps_partkey}, #1{ps_suppkey}, #6) // { arity: 3 }
+                          Project (#0{ps_partkey}, #1{ps_suppkey}, #6{l_quantity}) // { arity: 3 }
                             Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
                               Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
                                 implementation
                                   %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
                                 ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
                                   Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
-                                    Project (#1{ps_suppkey}, #2) // { arity: 2 }
+                                    Project (#1{ps_partkey}, #2{ps_suppkey}) // { arity: 2 }
                                       Get l1 // { arity: 4 }
                                 ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
                                   ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
@@ -1868,7 +1868,7 @@ materialize.public.q21_primary_idx:
 materialize.public.q21:
   With
     cte l0 =
-      Project (#0{s_suppkey}, #1{s_name}, #7) // { arity: 3 }
+      Project (#0{s_suppkey}, #1{s_name}, #7{l_orderkey}) // { arity: 3 }
         Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
           Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
             implementation
@@ -1903,16 +1903,16 @@ materialize.public.q21:
                       %1:l1[#0]KA » %0[#0]K
                     ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
                       Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-                        Project (#0{s_suppkey}, #2) // { arity: 2 }
+                        Project (#0{s_suppkey}, #2{l_orderkey}) // { arity: 2 }
                           Get l0 // { arity: 3 }
                     Get l1 // { arity: 16 }
     cte l3 =
       Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-        Project (#0{s_suppkey}, #2) // { arity: 2 }
+        Project (#0{s_suppkey}, #2{l_orderkey}) // { arity: 2 }
           Get l2 // { arity: 3 }
   Return // { arity: 2 }
     Reduce group_by=[#0{s_name}] aggregates=[count(*)] // { arity: 2 }
-      Project (#1) // { arity: 1 }
+      Project (#1{s_name}) // { arity: 1 }
         Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
           implementation
             %0:l2[#2, #0]KK » %1[#0, #1]KK
@@ -2018,12 +2018,12 @@ materialize.public.q22:
             implementation
               %1[×]UA » %0:l0[×]ef
             ArrangeBy keys=[[]] // { arity: 3 }
-              Project (#0{c_custkey}, #4, #5) // { arity: 3 }
+              Project (#0{c_custkey}, #4{c_phone}, #5{c_acctbal}) // { arity: 3 }
                 Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                   Get l0 // { arity: 9 }
             ArrangeBy keys=[[]] // { arity: 2 }
               Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
-                Project (#5) // { arity: 1 }
+                Project (#5{c_acctbal}) // { arity: 1 }
                   Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                     Get l0 // { arity: 9 }
     cte l2 =
@@ -2032,7 +2032,7 @@ materialize.public.q22:
           Get l1 // { arity: 3 }
   Return // { arity: 3 }
     Reduce group_by=[substr(char_to_text(#0{c_phone}), 1, 2)] aggregates=[count(*), sum(#1{c_acctbal})] // { arity: 3 }
-      Project (#1{c_acctbal}, #2) // { arity: 2 }
+      Project (#1{c_phone}, #2{c_acctbal}) // { arity: 2 }
         Join on=(#0{c_custkey} = #3{c_custkey}) type=differential // { arity: 4 }
           implementation
             %0:l1[#0]K » %1[#0]K
@@ -2049,7 +2049,7 @@ materialize.public.q22:
                       Get l2 // { arity: 1 }
                     ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
                       Distinct project=[#0{o_custkey}] // { arity: 1 }
-                        Project (#1) // { arity: 1 }
+                        Project (#1{o_custkey}) // { arity: 1 }
                           ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
               Get l2 // { arity: 1 }
 

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -191,10 +191,10 @@ ORDER BY
 	l_linestatus;
 ----
 materialize.public.q01:
-  Project (#0{l_returnflag}..=#5{sum}, #9{count}..=#11, #6) // { arity: 10 }
+  Project (#0{l_returnflag}..=#5{sum}, #9..=#11, #6{count}) // { arity: 10 }
     Map (bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end), (#2{sum_l_quantity} / #8), (#3{sum_l_extendedprice} / #8), (#7{sum_l_discount} / #8)) // { arity: 12 }
       Reduce group_by=[#4{l_returnflag}, #5{l_linestatus}] aggregates=[sum(#0{l_quantity}), sum(#1{l_extendedprice}), sum((#1{l_extendedprice} * (1 - #2{l_discount}))), sum(((#1{l_extendedprice} * (1 - #2{l_discount})) * (1 + #3{l_tax}))), count(*), sum(#2{l_discount})] // { arity: 8 }
-        Project (#4{l_returnflag}..=#9) // { arity: 6 }
+        Project (#4{l_quantity}..=#9{l_linestatus}) // { arity: 6 }
           Filter (date_to_timestamp(#10{l_shipdate}) <= 1998-10-02 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
@@ -260,7 +260,7 @@ materialize.public.q02:
       ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
         ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
     cte l4 =
-      Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
+      Project (#0{p_partkey}, #2{p_mfgr}, #10{s_name}, #11{s_address}, #13{s_phone}..=#15{s_comment}, #19{ps_supplycost}, #22{n_name}) // { arity: 9 }
         Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
           Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
             implementation
@@ -276,7 +276,7 @@ materialize.public.q02:
             Get l2 // { arity: 4 }
             Get l3 // { arity: 3 }
   Return // { arity: 8 }
-    Project (#5{s_address}, #2{n_name}, #8, #0{s_acctbal}, #1{s_name}, #3{p_partkey}, #4{p_mfgr}, #6{s_phone}) // { arity: 8 }
+    Project (#5{s_acctbal}, #2{s_name}, #8{n_name}, #0{p_partkey}, #1{p_mfgr}, #3{s_address}, #4{s_phone}, #6{s_comment}) // { arity: 8 }
       Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10{min_ps_supplycost}) type=differential // { arity: 11 }
         implementation
           %1[#0, #1]UKK » %0:l4[#0, #7]KK
@@ -284,7 +284,7 @@ materialize.public.q02:
           Get l4 // { arity: 9 }
         ArrangeBy keys=[[#0{p_partkey}, #1{min_ps_supplycost}]] // { arity: 2 }
           Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
-            Project (#0{p_partkey}, #4) // { arity: 2 }
+            Project (#0{p_partkey}, #4{ps_supplycost}) // { arity: 2 }
               Filter (#18{r_name} = "EUROPE") // { arity: 20 }
                 Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
                   implementation
@@ -345,9 +345,9 @@ ORDER BY
     o_orderdate;
 ----
 materialize.public.q03:
-  Project (#0{o_orderkey}, #3{o_shippriority}, #1{sum}, #2{o_orderdate}) // { arity: 4 }
+  Project (#0{o_orderkey}, #3{sum}, #1{o_orderdate}, #2{o_shippriority}) // { arity: 4 }
     Reduce group_by=[#0{o_orderkey}..=#2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
-      Project (#8, #12, #15, #22, #23) // { arity: 5 }
+      Project (#8{o_orderkey}, #12{o_orderdate}, #15{o_shippriority}, #22{l_extendedprice}, #23{l_discount}) // { arity: 5 }
         Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) // { arity: 33 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
             implementation
@@ -400,7 +400,7 @@ ORDER BY
 ----
 materialize.public.q04:
   Reduce group_by=[#0{o_orderpriority}] aggregates=[count(*)] // { arity: 2 }
-    Project (#5) // { arity: 1 }
+    Project (#5{o_orderpriority}) // { arity: 1 }
       Filter (#4{o_orderdate} >= 1993-07-01) AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 10 }
         Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 10 }
           implementation
@@ -453,7 +453,7 @@ ORDER BY
 ----
 materialize.public.q05:
   Reduce group_by=[#2{n_name}] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
-    Project (#19, #20, #24) // { arity: 3 }
+    Project (#19{l_extendedprice}, #20{l_discount}, #24{n_name}) // { arity: 3 }
       Filter (#28{r_name} = "ASIA") AND (#12{o_orderdate} < 1995-01-01) AND (#12{o_orderdate} >= 1994-01-01) // { arity: 30 }
         Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #22{s_nationkey} = #23{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey} AND #18{l_suppkey} = #21{s_suppkey} AND #25{n_regionkey} = #27{r_regionkey}) type=delta // { arity: 30 }
           implementation
@@ -468,10 +468,10 @@ materialize.public.q05:
           ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
             ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
           ArrangeBy keys=[[#0{l_orderkey}], [#0{l_orderkey}, #1{l_suppkey}]] // { arity: 4 }
-            Project (#0{l_orderkey}, #2{l_extendedprice}, #5, #6) // { arity: 4 }
+            Project (#0{l_orderkey}, #2{l_suppkey}, #5{l_extendedprice}, #6{l_discount}) // { arity: 4 }
               ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
           ArrangeBy keys=[[#0{s_suppkey}, #1{s_nationkey}]] // { arity: 2 }
-            Project (#0{s_suppkey}, #3) // { arity: 2 }
+            Project (#0{s_suppkey}, #3{s_nationkey}) // { arity: 2 }
               Filter (#0{s_suppkey}) IS NOT NULL // { arity: 7 }
                 ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
           ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
@@ -513,7 +513,7 @@ materialize.public.q06:
   With
     cte l0 =
       Reduce aggregates=[sum((#0{l_extendedprice} * #1{l_discount}))] // { arity: 1 }
-        Project (#5, #6) // { arity: 2 }
+        Project (#5{l_extendedprice}, #6{l_discount}) // { arity: 2 }
           Filter (#4{l_quantity} < 24) AND (#6{l_discount} <= 0.07) AND (#6{l_discount} >= 0.05) AND (#10{l_shipdate} >= 1994-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-01-01 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
   Return // { arity: 1 }
@@ -586,7 +586,7 @@ materialize.public.q07:
         ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
   Return // { arity: 4 }
     Reduce group_by=[#3{n_name}, #4{n_name}, extract_year_d(#2{l_shipdate})] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 4 }
-      Project (#12, #13, #17, #41, #45) // { arity: 5 }
+      Project (#12{l_extendedprice}, #13{l_discount}, #17{l_shipdate}, #41{n_name}, #45{n_name}) // { arity: 5 }
         Filter (#17{l_shipdate} <= 1996-12-31) AND (#17{l_shipdate} >= 1995-01-01) AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
           Map ((#41{n_name} = "FRANCE"), (#41{n_name} = "GERMANY"), (#45{n_name} = "FRANCE"), (#45{n_name} = "GERMANY")) // { arity: 52 }
             Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #40{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey} AND #24{o_custkey} = #32{c_custkey} AND #35{c_nationkey} = #44{n_nationkey}) type=delta // { arity: 48 }
@@ -670,7 +670,7 @@ materialize.public.q08:
   Project (#0, #3) // { arity: 2 }
     Map ((#1{sum} / #2{sum})) // { arity: 4 }
       Reduce group_by=[extract_year_d(#2{o_orderdate})] aggregates=[sum(case when (#3{n_name} = "BRAZIL") then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 3 }
-        Project (#21, #22, #36, #54) // { arity: 4 }
+        Project (#21{l_extendedprice}, #22{l_discount}, #36{o_orderdate}, #54{n_name}) // { arity: 4 }
           Filter (#58{r_name} = "AMERICA") AND (#36{o_orderdate} <= 1996-12-31) AND (#36{o_orderdate} >= 1995-01-01) AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4{p_type})) // { arity: 60 }
             Join on=(#0{p_partkey} = #17{l_partkey} AND #9{s_suppkey} = #18{l_suppkey} AND #12{s_nationkey} = #53{n_nationkey} AND #16{l_orderkey} = #32{o_orderkey} AND #33{o_custkey} = #41{c_custkey} AND #44{c_nationkey} = #49{n_nationkey} AND #51{n_regionkey} = #57{r_regionkey}) type=delta // { arity: 60 }
               implementation
@@ -758,7 +758,7 @@ ORDER BY
 ----
 materialize.public.q09:
   Reduce group_by=[#5{n_name}, extract_year_d(#4{o_orderdate})] aggregates=[sum(((#1{l_extendedprice} * (1 - #2{l_discount})) - (#3{ps_supplycost} * #0{l_quantity})))] // { arity: 3 }
-    Project (#20..=#22, #35, #41, #47) // { arity: 6 }
+    Project (#20{l_quantity}..=#22{l_discount}, #35{ps_supplycost}, #41{o_orderdate}, #47{n_name}) // { arity: 6 }
       Filter like["%green%"](varchar_to_text(#1{p_name})) // { arity: 50 }
         Join on=(#0{p_partkey} = #17{l_partkey} = #32{ps_partkey} AND #9{s_suppkey} = #18{l_suppkey} = #33{ps_suppkey} AND #12{s_nationkey} = #46{n_nationkey} AND #16{l_orderkey} = #37{o_orderkey}) type=delta // { arity: 50 }
           implementation
@@ -836,9 +836,9 @@ ORDER BY
     revenue DESC;
 ----
 materialize.public.q10:
-  Project (#0{c_custkey}, #1{c_name}, #7{c_comment}, #2{sum}, #4{n_name}, #5{c_address}, #3{c_acctbal}, #6{c_phone}) // { arity: 8 }
+  Project (#0{c_custkey}, #1{c_name}, #7{sum}, #2{c_acctbal}, #4{n_name}, #5{c_address}, #3{c_phone}, #6{c_comment}) // { arity: 8 }
     Reduce group_by=[#0{c_custkey}, #1{c_name}, #4{c_acctbal}, #3{c_phone}, #8{n_name}, #2{c_address}, #5{c_comment}] aggregates=[sum((#6{l_extendedprice} * (1 - #7{l_discount})))] // { arity: 8 }
-      Project (#0{c_custkey}..=#2{c_address}, #4{c_acctbal}, #5{c_comment}, #7{l_discount}, #22, #23, #34) // { arity: 9 }
+      Project (#0{c_custkey}..=#2{c_address}, #4{c_phone}, #5{c_acctbal}, #7{c_comment}, #22{l_extendedprice}, #23{l_discount}, #34{n_name}) // { arity: 9 }
         Filter (#25{l_returnflag} = "R") AND (#12{o_orderdate} < 1994-01-01) AND (#12{o_orderdate} >= 1993-10-01) AND (date_to_timestamp(#12{o_orderdate}) < 1994-01-01 00:00:00) // { arity: 37 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #33{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 37 }
             implementation
@@ -903,7 +903,7 @@ ORDER BY
 materialize.public.q11:
   With
     cte l0 =
-      Project (#0{ps_partkey}, #2{ps_supplycost}, #3) // { arity: 3 }
+      Project (#0{ps_partkey}, #2{ps_availqty}, #3{ps_supplycost}) // { arity: 3 }
         Filter (#13{n_name} = "GERMANY") // { arity: 16 }
           Join on=(#1{ps_suppkey} = #5{s_suppkey} AND #8{s_nationkey} = #12{n_nationkey}) type=delta // { arity: 16 }
             implementation
@@ -927,7 +927,7 @@ materialize.public.q11:
               Get l0 // { arity: 3 }
           ArrangeBy keys=[[]] // { arity: 1 }
             Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
-              Project (#1{ps_supplycost}, #2) // { arity: 2 }
+              Project (#1{ps_availqty}, #2{ps_supplycost}) // { arity: 2 }
                 Get l0 // { arity: 3 }
 
 Used Indexes:
@@ -976,7 +976,7 @@ ORDER BY
 ----
 materialize.public.q12:
   Reduce group_by=[#1{l_shipmode}] aggregates=[sum(case when ((#0{o_orderpriority} = "2-HIGH") OR (#0{o_orderpriority} = "1-URGENT")) then 1 else 0 end), sum(case when ((#0{o_orderpriority} != "2-HIGH") AND (#0{o_orderpriority} != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
-    Project (#5, #23) // { arity: 2 }
+    Project (#5{o_orderpriority}, #23{l_shipmode}) // { arity: 2 }
       Filter (#21{l_receiptdate} >= 1994-01-01) AND (#19{l_shipdate} < #20{l_commitdate}) AND (#20{l_commitdate} < #21{l_receiptdate}) AND (date_to_timestamp(#21{l_receiptdate}) < 1995-01-01 00:00:00) AND ((#23{l_shipmode} = "MAIL") OR (#23{l_shipmode} = "SHIP")) // { arity: 25 }
         Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 25 }
           implementation
@@ -1026,7 +1026,7 @@ materialize.public.q13:
       ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
         ReadIndex on=customer pk_customer_custkey=[differential join] // { arity: 8 }
     cte l1 =
-      Project (#0{c_custkey}, #8) // { arity: 2 }
+      Project (#0{c_custkey}, #8{o_orderkey}) // { arity: 2 }
         Filter NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
           Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
             implementation
@@ -1036,7 +1036,7 @@ materialize.public.q13:
               ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
   Return // { arity: 2 }
     Reduce group_by=[#0{count_o_orderkey}] aggregates=[count(*)] // { arity: 2 }
-      Project (#1) // { arity: 1 }
+      Project (#1{count_o_orderkey}) // { arity: 1 }
         Reduce group_by=[#0{c_custkey}] aggregates=[count(#1{o_orderkey})] // { arity: 2 }
           Union // { arity: 2 }
             Map (null) // { arity: 2 }
@@ -1086,7 +1086,7 @@ materialize.public.q14:
   With
     cte l0 =
       Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(#2{p_type})) then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
-        Project (#5, #6, #20) // { arity: 3 }
+        Project (#5{l_extendedprice}, #6{l_discount}, #20{p_type}) // { arity: 3 }
           Filter (#10{l_shipdate} >= 1995-09-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-10-01 00:00:00) // { arity: 25 }
             Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
               implementation
@@ -1158,11 +1158,11 @@ materialize.public.q15:
   With
     cte l0 =
       Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
-        Project (#2{l_discount}, #5, #6) // { arity: 3 }
+        Project (#2{l_suppkey}, #5{l_extendedprice}, #6{l_discount}) // { arity: 3 }
           Filter (#10{l_shipdate} >= 1996-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1996-04-01 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
   Return // { arity: 5 }
-    Project (#0{s_suppkey}..=#2{s_address}, #4{sum}, #8) // { arity: 5 }
+    Project (#0{s_suppkey}..=#2{s_address}, #4{s_phone}, #8{sum}) // { arity: 5 }
       Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
         implementation
           %0:supplier » %1:l0[#0]UKA » %2[#0]UK
@@ -1174,7 +1174,7 @@ materialize.public.q15:
           Get l0 // { arity: 2 }
         ArrangeBy keys=[[#0{max_sum}]] // { arity: 1 }
           Reduce aggregates=[max(#0{sum})] // { arity: 1 }
-            Project (#1) // { arity: 1 }
+            Project (#1{sum}) // { arity: 1 }
               Get l0 // { arity: 2 }
 
 Used Indexes:
@@ -1227,7 +1227,7 @@ ORDER BY
 materialize.public.q16:
   With
     cte l0 =
-      Project (#1{p_brand}, #8..=#10) // { arity: 4 }
+      Project (#1{ps_suppkey}, #8{p_brand}..=#10{p_size}) // { arity: 4 }
         Filter (#8{p_brand} != "Brand#45") AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
           Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
             implementation
@@ -1303,7 +1303,7 @@ materialize.public.q17:
       ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
     cte l1 =
-      Project (#1{l_quantity}, #4, #5) // { arity: 3 }
+      Project (#1{l_partkey}, #4{l_quantity}, #5{l_extendedprice}) // { arity: 3 }
         Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") // { arity: 25 }
           Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
             implementation
@@ -1313,7 +1313,7 @@ materialize.public.q17:
               ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
     cte l2 =
       Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
-        Project (#2) // { arity: 1 }
+        Project (#2{l_extendedprice}) // { arity: 1 }
           Filter (#1{l_quantity} < (0.2 * (#4{sum_l_quantity} / bigint_to_numeric(case when (#5{count} = 0) then null else #5{count} end)))) // { arity: 6 }
             Join on=(#0{l_partkey} = #3{l_partkey}) type=differential // { arity: 6 }
               implementation
@@ -1322,7 +1322,7 @@ materialize.public.q17:
                 Get l1 // { arity: 3 }
               ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
                 Reduce group_by=[#0{l_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
-                  Project (#0{l_partkey}, #5) // { arity: 2 }
+                  Project (#0{l_partkey}, #5{l_quantity}) // { arity: 2 }
                     Join on=(#0{l_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
                       implementation
                         %0[#0]UKA » %1:l0[#1]KA
@@ -1396,7 +1396,7 @@ materialize.public.q18:
       ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
     cte l1 =
-      Project (#0{c_custkey}, #1{c_name}, #8, #11, #12, #21) // { arity: 6 }
+      Project (#0{c_custkey}, #1{c_name}, #8{o_orderkey}, #11{o_totalprice}, #12{o_orderdate}, #21{l_quantity}) // { arity: 6 }
         Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
           implementation
             %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
@@ -1418,13 +1418,13 @@ materialize.public.q18:
               Get l1 // { arity: 6 }
             ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 2 }
               Reduce group_by=[#0{o_orderkey}] aggregates=[sum(#1{l_quantity})] // { arity: 2 }
-                Project (#0{o_orderkey}, #5) // { arity: 2 }
+                Project (#0{o_orderkey}, #5{l_quantity}) // { arity: 2 }
                   Join on=(#0{o_orderkey} = #1{l_orderkey}) type=differential // { arity: 17 }
                     implementation
                       %0[#0]UKA » %1:l0[#0]KA
                     ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
                       Distinct project=[#0{o_orderkey}] // { arity: 1 }
-                        Project (#2) // { arity: 1 }
+                        Project (#2{o_orderkey}) // { arity: 1 }
                           Get l1 // { arity: 6 }
                     Get l0 // { arity: 16 }
 
@@ -1483,7 +1483,7 @@ materialize.public.q19:
   With
     cte l0 =
       Reduce aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 1 }
-        Project (#5, #6) // { arity: 2 }
+        Project (#5{l_extendedprice}, #6{l_discount}) // { arity: 2 }
           Filter (#13{l_shipinstruct} = "DELIVER IN PERSON") AND (#21{p_size} >= 1) AND ((#14{l_shipmode} = "AIR") OR (#14{l_shipmode} = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
             Map ((#4{l_quantity} <= 20), (#4{l_quantity} >= 10), (#4{l_quantity} <= 30), (#4{l_quantity} >= 20), (#4{l_quantity} <= 11), (#4{l_quantity} >= 1), (#19{p_brand} = "Brand#12"), (#21{p_size} <= 5), ((#22{p_container} = "SM BOX") OR (#22{p_container} = "SM PKG") OR (#22{p_container} = "SM CASE") OR (#22{p_container} = "SM PACK")), (#19{p_brand} = "Brand#23"), (#21{p_size} <= 10), ((#22{p_container} = "MED BAG") OR (#22{p_container} = "MED BOX") OR (#22{p_container} = "MED PKG") OR (#22{p_container} = "MED PACK")), (#19{p_brand} = "Brand#34"), (#21{p_size} <= 15), ((#22{p_container} = "LG BOX") OR (#22{p_container} = "LG PKG") OR (#22{p_container} = "LG CASE") OR (#22{p_container} = "LG PACK"))) // { arity: 40 }
               Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
@@ -1587,7 +1587,7 @@ materialize.public.q20:
                 Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
   Return // { arity: 2 }
-    Project (#1{s_address}, #2) // { arity: 2 }
+    Project (#1{s_name}, #2{s_address}) // { arity: 2 }
       Join on=(#0{s_suppkey} = #3{s_suppkey}) type=differential // { arity: 4 }
         implementation
           %1[#0]UKA » %0:l0[#0]K
@@ -1601,21 +1601,21 @@ materialize.public.q20:
                   implementation
                     %1[#1, #0]UKK » %0:l1[#0, #1]KKf
                   ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}]] // { arity: 3 }
-                    Project (#0{s_suppkey}, #1{ps_partkey}, #3) // { arity: 3 }
+                    Project (#0{s_suppkey}, #1{ps_partkey}, #3{ps_availqty}) // { arity: 3 }
                       Filter (#0{s_suppkey} = #2{ps_suppkey}) // { arity: 4 }
                         Get l1 // { arity: 4 }
                   ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
                     Project (#0{ps_partkey}, #1{ps_suppkey}, #3) // { arity: 3 }
                       Map ((0.5 * #2{sum_l_quantity})) // { arity: 4 }
                         Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
-                          Project (#0{ps_partkey}, #1{ps_suppkey}, #6) // { arity: 3 }
+                          Project (#0{ps_partkey}, #1{ps_suppkey}, #6{l_quantity}) // { arity: 3 }
                             Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
                               Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
                                 implementation
                                   %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
                                 ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
                                   Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
-                                    Project (#1{ps_suppkey}, #2) // { arity: 2 }
+                                    Project (#1{ps_partkey}, #2{ps_suppkey}) // { arity: 2 }
                                       Get l1 // { arity: 4 }
                                 ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
                                   ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
@@ -1679,7 +1679,7 @@ ORDER BY
 materialize.public.q21:
   With
     cte l0 =
-      Project (#0{s_suppkey}, #1{s_name}, #7) // { arity: 3 }
+      Project (#0{s_suppkey}, #1{s_name}, #7{l_orderkey}) // { arity: 3 }
         Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
           Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
             implementation
@@ -1714,16 +1714,16 @@ materialize.public.q21:
                       %1:l1[#0]KA » %0[#0]K
                     ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
                       Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-                        Project (#0{s_suppkey}, #2) // { arity: 2 }
+                        Project (#0{s_suppkey}, #2{l_orderkey}) // { arity: 2 }
                           Get l0 // { arity: 3 }
                     Get l1 // { arity: 16 }
     cte l3 =
       Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-        Project (#0{s_suppkey}, #2) // { arity: 2 }
+        Project (#0{s_suppkey}, #2{l_orderkey}) // { arity: 2 }
           Get l2 // { arity: 3 }
   Return // { arity: 2 }
     Reduce group_by=[#0{s_name}] aggregates=[count(*)] // { arity: 2 }
-      Project (#1) // { arity: 1 }
+      Project (#1{s_name}) // { arity: 1 }
         Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
           implementation
             %0:l2[#2, #0]KK » %1[#0, #1]KK
@@ -1820,12 +1820,12 @@ materialize.public.q22:
             implementation
               %1[×]UA » %0:l0[×]ef
             ArrangeBy keys=[[]] // { arity: 3 }
-              Project (#0{c_custkey}, #4, #5) // { arity: 3 }
+              Project (#0{c_custkey}, #4{c_phone}, #5{c_acctbal}) // { arity: 3 }
                 Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                   Get l0 // { arity: 9 }
             ArrangeBy keys=[[]] // { arity: 2 }
               Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
-                Project (#5) // { arity: 1 }
+                Project (#5{c_acctbal}) // { arity: 1 }
                   Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                     Get l0 // { arity: 9 }
     cte l2 =
@@ -1834,7 +1834,7 @@ materialize.public.q22:
           Get l1 // { arity: 3 }
   Return // { arity: 3 }
     Reduce group_by=[substr(char_to_text(#0{c_phone}), 1, 2)] aggregates=[count(*), sum(#1{c_acctbal})] // { arity: 3 }
-      Project (#1{c_acctbal}, #2) // { arity: 2 }
+      Project (#1{c_phone}, #2{c_acctbal}) // { arity: 2 }
         Join on=(#0{c_custkey} = #3{c_custkey}) type=differential // { arity: 4 }
           implementation
             %0:l1[#0]K » %1[#0]K
@@ -1851,7 +1851,7 @@ materialize.public.q22:
                       Get l2 // { arity: 1 }
                     ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
                       Distinct project=[#0{o_custkey}] // { arity: 1 }
-                        Project (#1) // { arity: 1 }
+                        Project (#1{o_custkey}) // { arity: 1 }
                           ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
               Get l2 // { arity: 1 }
 

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -190,10 +190,10 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#0{l_returnflag} asc nulls_last, #1{l_linestatus} asc nulls_last] output=[#0..=#9]
-    Project (#0{l_returnflag}..=#5{sum}, #9{count}..=#11, #6) // { arity: 10 }
+    Project (#0{l_returnflag}..=#5{sum}, #9..=#11, #6{count}) // { arity: 10 }
       Map (bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end), (#2{sum_l_quantity} / #8), (#3{sum_l_extendedprice} / #8), (#7{sum_l_discount} / #8)) // { arity: 12 }
         Reduce group_by=[#4{l_returnflag}, #5{l_linestatus}] aggregates=[sum(#0{l_quantity}), sum(#1{l_extendedprice}), sum((#1{l_extendedprice} * (1 - #2{l_discount}))), sum(((#1{l_extendedprice} * (1 - #2{l_discount})) * (1 + #3{l_tax}))), count(*), sum(#2{l_discount})] // { arity: 8 }
-          Project (#4{l_returnflag}..=#9) // { arity: 6 }
+          Project (#4{l_quantity}..=#9{l_linestatus}) // { arity: 6 }
             Filter (date_to_timestamp(#10{l_shipdate}) <= 1998-10-02 00:00:00) // { arity: 16 }
               ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
@@ -259,7 +259,7 @@ Explained Query:
         ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
           ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
       cte l4 =
-        Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
+        Project (#0{p_partkey}, #2{p_mfgr}, #10{s_name}, #11{s_address}, #13{s_phone}..=#15{s_comment}, #19{ps_supplycost}, #22{n_name}) // { arity: 9 }
           Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
             Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
               implementation
@@ -275,7 +275,7 @@ Explained Query:
               Get l2 // { arity: 4 }
               Get l3 // { arity: 3 }
     Return // { arity: 8 }
-      Project (#5{s_address}, #2{n_name}, #8, #0{s_acctbal}, #1{s_name}, #3{p_partkey}, #4{p_mfgr}, #6{s_phone}) // { arity: 8 }
+      Project (#5{s_acctbal}, #2{s_name}, #8{n_name}, #0{p_partkey}, #1{p_mfgr}, #3{s_address}, #4{s_phone}, #6{s_comment}) // { arity: 8 }
         Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10{min_ps_supplycost}) type=differential // { arity: 11 }
           implementation
             %1[#0, #1]UKK » %0:l4[#0, #7]KK
@@ -283,7 +283,7 @@ Explained Query:
             Get l4 // { arity: 9 }
           ArrangeBy keys=[[#0{p_partkey}, #1{min_ps_supplycost}]] // { arity: 2 }
             Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
-              Project (#0{p_partkey}, #4) // { arity: 2 }
+              Project (#0{p_partkey}, #4{ps_supplycost}) // { arity: 2 }
                 Filter (#18{r_name} = "EUROPE") // { arity: 20 }
                   Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
                     implementation
@@ -344,9 +344,9 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#1{sum} desc nulls_first, #2{o_orderdate} asc nulls_last] output=[#0..=#3]
-    Project (#0{o_orderkey}, #3{o_shippriority}, #1{sum}, #2{o_orderdate}) // { arity: 4 }
+    Project (#0{o_orderkey}, #3{sum}, #1{o_orderdate}, #2{o_shippriority}) // { arity: 4 }
       Reduce group_by=[#0{o_orderkey}..=#2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
-        Project (#8, #12, #15, #22, #23) // { arity: 5 }
+        Project (#8{o_orderkey}, #12{o_orderdate}, #15{o_shippriority}, #22{l_extendedprice}, #23{l_discount}) // { arity: 5 }
           Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) // { arity: 33 }
             Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
               implementation
@@ -399,7 +399,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#0{o_orderpriority} asc nulls_last] output=[#0, #1]
     Reduce group_by=[#0{o_orderpriority}] aggregates=[count(*)] // { arity: 2 }
-      Project (#5) // { arity: 1 }
+      Project (#5{o_orderpriority}) // { arity: 1 }
         Filter (#4{o_orderdate} >= 1993-07-01) AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 10 }
           Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 10 }
             implementation
@@ -452,7 +452,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#1{sum} desc nulls_first] output=[#0, #1]
     Reduce group_by=[#2{n_name}] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
-      Project (#19, #20, #24) // { arity: 3 }
+      Project (#19{l_extendedprice}, #20{l_discount}, #24{n_name}) // { arity: 3 }
         Filter (#28{r_name} = "ASIA") AND (#12{o_orderdate} < 1995-01-01) AND (#12{o_orderdate} >= 1994-01-01) // { arity: 30 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #22{s_nationkey} = #23{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey} AND #18{l_suppkey} = #21{s_suppkey} AND #25{n_regionkey} = #27{r_regionkey}) type=delta // { arity: 30 }
             implementation
@@ -467,10 +467,10 @@ Explained Query:
             ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
             ArrangeBy keys=[[#0{l_orderkey}], [#0{l_orderkey}, #1{l_suppkey}]] // { arity: 4 }
-              Project (#0{l_orderkey}, #2{l_extendedprice}, #5, #6) // { arity: 4 }
+              Project (#0{l_orderkey}, #2{l_suppkey}, #5{l_extendedprice}, #6{l_discount}) // { arity: 4 }
                 ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
             ArrangeBy keys=[[#0{s_suppkey}, #1{s_nationkey}]] // { arity: 2 }
-              Project (#0{s_suppkey}, #3) // { arity: 2 }
+              Project (#0{s_suppkey}, #3{s_nationkey}) // { arity: 2 }
                 Filter (#0{s_suppkey}) IS NOT NULL // { arity: 7 }
                   ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
             ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
@@ -511,7 +511,7 @@ Explained Query:
   With
     cte l0 =
       Reduce aggregates=[sum((#0{l_extendedprice} * #1{l_discount}))] // { arity: 1 }
-        Project (#5, #6) // { arity: 2 }
+        Project (#5{l_extendedprice}, #6{l_discount}) // { arity: 2 }
           Filter (#4{l_quantity} < 24) AND (#6{l_discount} <= 0.07) AND (#6{l_discount} >= 0.05) AND (#10{l_shipdate} >= 1994-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-01-01 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
   Return // { arity: 1 }
@@ -584,7 +584,7 @@ Explained Query:
           ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
     Return // { arity: 4 }
       Reduce group_by=[#3{n_name}, #4{n_name}, extract_year_d(#2{l_shipdate})] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 4 }
-        Project (#12, #13, #17, #41, #45) // { arity: 5 }
+        Project (#12{l_extendedprice}, #13{l_discount}, #17{l_shipdate}, #41{n_name}, #45{n_name}) // { arity: 5 }
           Filter (#17{l_shipdate} <= 1996-12-31) AND (#17{l_shipdate} >= 1995-01-01) AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
             Map ((#41{n_name} = "FRANCE"), (#41{n_name} = "GERMANY"), (#45{n_name} = "FRANCE"), (#45{n_name} = "GERMANY")) // { arity: 52 }
               Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #40{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey} AND #24{o_custkey} = #32{c_custkey} AND #35{c_nationkey} = #44{n_nationkey}) type=delta // { arity: 48 }
@@ -668,7 +668,7 @@ Explained Query:
     Project (#0, #3) // { arity: 2 }
       Map ((#1{sum} / #2{sum})) // { arity: 4 }
         Reduce group_by=[extract_year_d(#2{o_orderdate})] aggregates=[sum(case when (#3{n_name} = "BRAZIL") then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 3 }
-          Project (#21, #22, #36, #54) // { arity: 4 }
+          Project (#21{l_extendedprice}, #22{l_discount}, #36{o_orderdate}, #54{n_name}) // { arity: 4 }
             Filter (#58{r_name} = "AMERICA") AND (#36{o_orderdate} <= 1996-12-31) AND (#36{o_orderdate} >= 1995-01-01) AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4{p_type})) // { arity: 60 }
               Join on=(#0{p_partkey} = #17{l_partkey} AND #9{s_suppkey} = #18{l_suppkey} AND #12{s_nationkey} = #53{n_nationkey} AND #16{l_orderkey} = #32{o_orderkey} AND #33{o_custkey} = #41{c_custkey} AND #44{c_nationkey} = #49{n_nationkey} AND #51{n_regionkey} = #57{r_regionkey}) type=delta // { arity: 60 }
                 implementation
@@ -756,7 +756,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#0{n_name} asc nulls_last, #1 desc nulls_first] output=[#0..=#2]
     Reduce group_by=[#5{n_name}, extract_year_d(#4{o_orderdate})] aggregates=[sum(((#1{l_extendedprice} * (1 - #2{l_discount})) - (#3{ps_supplycost} * #0{l_quantity})))] // { arity: 3 }
-      Project (#20..=#22, #35, #41, #47) // { arity: 6 }
+      Project (#20{l_quantity}..=#22{l_discount}, #35{ps_supplycost}, #41{o_orderdate}, #47{n_name}) // { arity: 6 }
         Filter like["%green%"](varchar_to_text(#1{p_name})) // { arity: 50 }
           Join on=(#0{p_partkey} = #17{l_partkey} = #32{ps_partkey} AND #9{s_suppkey} = #18{l_suppkey} = #33{ps_suppkey} AND #12{s_nationkey} = #46{n_nationkey} AND #16{l_orderkey} = #37{o_orderkey}) type=delta // { arity: 50 }
             implementation
@@ -834,9 +834,9 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#2{sum} desc nulls_first] output=[#0..=#7]
-    Project (#0{c_custkey}, #1{c_name}, #7{c_comment}, #2{sum}, #4{n_name}, #5{c_address}, #3{c_acctbal}, #6{c_phone}) // { arity: 8 }
+    Project (#0{c_custkey}, #1{c_name}, #7{sum}, #2{c_acctbal}, #4{n_name}, #5{c_address}, #3{c_phone}, #6{c_comment}) // { arity: 8 }
       Reduce group_by=[#0{c_custkey}, #1{c_name}, #4{c_acctbal}, #3{c_phone}, #8{n_name}, #2{c_address}, #5{c_comment}] aggregates=[sum((#6{l_extendedprice} * (1 - #7{l_discount})))] // { arity: 8 }
-        Project (#0{c_custkey}..=#2{c_address}, #4{c_acctbal}, #5{c_comment}, #7{l_discount}, #22, #23, #34) // { arity: 9 }
+        Project (#0{c_custkey}..=#2{c_address}, #4{c_phone}, #5{c_acctbal}, #7{c_comment}, #22{l_extendedprice}, #23{l_discount}, #34{n_name}) // { arity: 9 }
           Filter (#25{l_returnflag} = "R") AND (#12{o_orderdate} < 1994-01-01) AND (#12{o_orderdate} >= 1993-10-01) AND (date_to_timestamp(#12{o_orderdate}) < 1994-01-01 00:00:00) // { arity: 37 }
             Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #33{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 37 }
               implementation
@@ -901,7 +901,7 @@ Explained Query:
   Finish order_by=[#1{sum} desc nulls_first] output=[#0, #1]
     With
       cte l0 =
-        Project (#0{ps_partkey}, #2{ps_supplycost}, #3) // { arity: 3 }
+        Project (#0{ps_partkey}, #2{ps_availqty}, #3{ps_supplycost}) // { arity: 3 }
           Filter (#13{n_name} = "GERMANY") // { arity: 16 }
             Join on=(#1{ps_suppkey} = #5{s_suppkey} AND #8{s_nationkey} = #12{n_nationkey}) type=delta // { arity: 16 }
               implementation
@@ -925,7 +925,7 @@ Explained Query:
                 Get l0 // { arity: 3 }
             ArrangeBy keys=[[]] // { arity: 1 }
               Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
-                Project (#1{ps_supplycost}, #2) // { arity: 2 }
+                Project (#1{ps_availqty}, #2{ps_supplycost}) // { arity: 2 }
                   Get l0 // { arity: 3 }
 
 Used Indexes:
@@ -974,7 +974,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#0{l_shipmode} asc nulls_last] output=[#0..=#2]
     Reduce group_by=[#1{l_shipmode}] aggregates=[sum(case when ((#0{o_orderpriority} = "2-HIGH") OR (#0{o_orderpriority} = "1-URGENT")) then 1 else 0 end), sum(case when ((#0{o_orderpriority} != "2-HIGH") AND (#0{o_orderpriority} != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
-      Project (#5, #23) // { arity: 2 }
+      Project (#5{o_orderpriority}, #23{l_shipmode}) // { arity: 2 }
         Filter (#21{l_receiptdate} >= 1994-01-01) AND (#19{l_shipdate} < #20{l_commitdate}) AND (#20{l_commitdate} < #21{l_receiptdate}) AND (date_to_timestamp(#21{l_receiptdate}) < 1995-01-01 00:00:00) AND ((#23{l_shipmode} = "MAIL") OR (#23{l_shipmode} = "SHIP")) // { arity: 25 }
           Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 25 }
             implementation
@@ -1024,7 +1024,7 @@ Explained Query:
         ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
           ReadIndex on=customer pk_customer_custkey=[differential join] // { arity: 8 }
       cte l1 =
-        Project (#0{c_custkey}, #8) // { arity: 2 }
+        Project (#0{c_custkey}, #8{o_orderkey}) // { arity: 2 }
           Filter NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
             Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
               implementation
@@ -1034,7 +1034,7 @@ Explained Query:
                 ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
     Return // { arity: 2 }
       Reduce group_by=[#0{count_o_orderkey}] aggregates=[count(*)] // { arity: 2 }
-        Project (#1) // { arity: 1 }
+        Project (#1{count_o_orderkey}) // { arity: 1 }
           Reduce group_by=[#0{c_custkey}] aggregates=[count(#1{o_orderkey})] // { arity: 2 }
             Union // { arity: 2 }
               Map (null) // { arity: 2 }
@@ -1083,7 +1083,7 @@ Explained Query:
   With
     cte l0 =
       Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(#2{p_type})) then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
-        Project (#5, #6, #20) // { arity: 3 }
+        Project (#5{l_extendedprice}, #6{l_discount}, #20{p_type}) // { arity: 3 }
           Filter (#10{l_shipdate} >= 1995-09-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-10-01 00:00:00) // { arity: 25 }
             Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
               implementation
@@ -1155,11 +1155,11 @@ Explained Query:
     With
       cte l0 =
         Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
-          Project (#2{l_discount}, #5, #6) // { arity: 3 }
+          Project (#2{l_suppkey}, #5{l_extendedprice}, #6{l_discount}) // { arity: 3 }
             Filter (#10{l_shipdate} >= 1996-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1996-04-01 00:00:00) // { arity: 16 }
               ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
     Return // { arity: 5 }
-      Project (#0{s_suppkey}..=#2{s_address}, #4{sum}, #8) // { arity: 5 }
+      Project (#0{s_suppkey}..=#2{s_address}, #4{s_phone}, #8{sum}) // { arity: 5 }
         Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
           implementation
             %0:supplier » %1:l0[#0]UKA » %2[#0]UK
@@ -1171,7 +1171,7 @@ Explained Query:
             Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0{max_sum}]] // { arity: 1 }
             Reduce aggregates=[max(#0{sum})] // { arity: 1 }
-              Project (#1) // { arity: 1 }
+              Project (#1{sum}) // { arity: 1 }
                 Get l0 // { arity: 2 }
 
 Used Indexes:
@@ -1224,7 +1224,7 @@ Explained Query:
   Finish order_by=[#3{count_ps_suppkey} desc nulls_first, #0{p_brand} asc nulls_last, #1{p_type} asc nulls_last, #2{p_size} asc nulls_last] output=[#0..=#3]
     With
       cte l0 =
-        Project (#1{p_brand}, #8..=#10) // { arity: 4 }
+        Project (#1{ps_suppkey}, #8{p_brand}..=#10{p_size}) // { arity: 4 }
           Filter (#8{p_brand} != "Brand#45") AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
             Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
               implementation
@@ -1299,7 +1299,7 @@ Explained Query:
       ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
     cte l1 =
-      Project (#1{l_quantity}, #4, #5) // { arity: 3 }
+      Project (#1{l_partkey}, #4{l_quantity}, #5{l_extendedprice}) // { arity: 3 }
         Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") // { arity: 25 }
           Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
             implementation
@@ -1309,7 +1309,7 @@ Explained Query:
               ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
     cte l2 =
       Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
-        Project (#2) // { arity: 1 }
+        Project (#2{l_extendedprice}) // { arity: 1 }
           Filter (#1{l_quantity} < (0.2 * (#4{sum_l_quantity} / bigint_to_numeric(case when (#5{count} = 0) then null else #5{count} end)))) // { arity: 6 }
             Join on=(#0{l_partkey} = #3{l_partkey}) type=differential // { arity: 6 }
               implementation
@@ -1318,7 +1318,7 @@ Explained Query:
                 Get l1 // { arity: 3 }
               ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
                 Reduce group_by=[#0{l_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
-                  Project (#0{l_partkey}, #5) // { arity: 2 }
+                  Project (#0{l_partkey}, #5{l_quantity}) // { arity: 2 }
                     Join on=(#0{l_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
                       implementation
                         %0[#0]UKA » %1:l0[#1]KA
@@ -1392,7 +1392,7 @@ Explained Query:
         ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
           ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
       cte l1 =
-        Project (#0{c_custkey}, #1{c_name}, #8, #11, #12, #21) // { arity: 6 }
+        Project (#0{c_custkey}, #1{c_name}, #8{o_orderkey}, #11{o_totalprice}, #12{o_orderdate}, #21{l_quantity}) // { arity: 6 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
             implementation
               %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
@@ -1414,13 +1414,13 @@ Explained Query:
                 Get l1 // { arity: 6 }
               ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 2 }
                 Reduce group_by=[#0{o_orderkey}] aggregates=[sum(#1{l_quantity})] // { arity: 2 }
-                  Project (#0{o_orderkey}, #5) // { arity: 2 }
+                  Project (#0{o_orderkey}, #5{l_quantity}) // { arity: 2 }
                     Join on=(#0{o_orderkey} = #1{l_orderkey}) type=differential // { arity: 17 }
                       implementation
                         %0[#0]UKA » %1:l0[#0]KA
                       ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
                         Distinct project=[#0{o_orderkey}] // { arity: 1 }
-                          Project (#2) // { arity: 1 }
+                          Project (#2{o_orderkey}) // { arity: 1 }
                             Get l1 // { arity: 6 }
                       Get l0 // { arity: 16 }
 
@@ -1478,7 +1478,7 @@ Explained Query:
   With
     cte l0 =
       Reduce aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 1 }
-        Project (#5, #6) // { arity: 2 }
+        Project (#5{l_extendedprice}, #6{l_discount}) // { arity: 2 }
           Filter (#13{l_shipinstruct} = "DELIVER IN PERSON") AND (#21{p_size} >= 1) AND ((#14{l_shipmode} = "AIR") OR (#14{l_shipmode} = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
             Map ((#4{l_quantity} <= 20), (#4{l_quantity} >= 10), (#4{l_quantity} <= 30), (#4{l_quantity} >= 20), (#4{l_quantity} <= 11), (#4{l_quantity} >= 1), (#19{p_brand} = "Brand#12"), (#21{p_size} <= 5), ((#22{p_container} = "SM BOX") OR (#22{p_container} = "SM PKG") OR (#22{p_container} = "SM CASE") OR (#22{p_container} = "SM PACK")), (#19{p_brand} = "Brand#23"), (#21{p_size} <= 10), ((#22{p_container} = "MED BAG") OR (#22{p_container} = "MED BOX") OR (#22{p_container} = "MED PKG") OR (#22{p_container} = "MED PACK")), (#19{p_brand} = "Brand#34"), (#21{p_size} <= 15), ((#22{p_container} = "LG BOX") OR (#22{p_container} = "LG PKG") OR (#22{p_container} = "LG CASE") OR (#22{p_container} = "LG PACK"))) // { arity: 40 }
               Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
@@ -1582,7 +1582,7 @@ Explained Query:
                   Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
                     ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
     Return // { arity: 2 }
-      Project (#1{s_address}, #2) // { arity: 2 }
+      Project (#1{s_name}, #2{s_address}) // { arity: 2 }
         Join on=(#0{s_suppkey} = #3{s_suppkey}) type=differential // { arity: 4 }
           implementation
             %1[#0]UKA » %0:l0[#0]K
@@ -1596,21 +1596,21 @@ Explained Query:
                     implementation
                       %1[#1, #0]UKK » %0:l1[#0, #1]KKf
                     ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}]] // { arity: 3 }
-                      Project (#0{s_suppkey}, #1{ps_partkey}, #3) // { arity: 3 }
+                      Project (#0{s_suppkey}, #1{ps_partkey}, #3{ps_availqty}) // { arity: 3 }
                         Filter (#0{s_suppkey} = #2{ps_suppkey}) // { arity: 4 }
                           Get l1 // { arity: 4 }
                     ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
                       Project (#0{ps_partkey}, #1{ps_suppkey}, #3) // { arity: 3 }
                         Map ((0.5 * #2{sum_l_quantity})) // { arity: 4 }
                           Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
-                            Project (#0{ps_partkey}, #1{ps_suppkey}, #6) // { arity: 3 }
+                            Project (#0{ps_partkey}, #1{ps_suppkey}, #6{l_quantity}) // { arity: 3 }
                               Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
                                 Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
                                   implementation
                                     %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
                                   ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
                                     Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
-                                      Project (#1{ps_suppkey}, #2) // { arity: 2 }
+                                      Project (#1{ps_partkey}, #2{ps_suppkey}) // { arity: 2 }
                                         Get l1 // { arity: 4 }
                                   ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
                                     ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
@@ -1674,7 +1674,7 @@ Explained Query:
   Finish order_by=[#1{count} desc nulls_first, #0{s_name} asc nulls_last] output=[#0, #1]
     With
       cte l0 =
-        Project (#0{s_suppkey}, #1{s_name}, #7) // { arity: 3 }
+        Project (#0{s_suppkey}, #1{s_name}, #7{l_orderkey}) // { arity: 3 }
           Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
             Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
               implementation
@@ -1709,16 +1709,16 @@ Explained Query:
                         %1:l1[#0]KA » %0[#0]K
                       ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
                         Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-                          Project (#0{s_suppkey}, #2) // { arity: 2 }
+                          Project (#0{s_suppkey}, #2{l_orderkey}) // { arity: 2 }
                             Get l0 // { arity: 3 }
                       Get l1 // { arity: 16 }
       cte l3 =
         Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-          Project (#0{s_suppkey}, #2) // { arity: 2 }
+          Project (#0{s_suppkey}, #2{l_orderkey}) // { arity: 2 }
             Get l2 // { arity: 3 }
     Return // { arity: 2 }
       Reduce group_by=[#0{s_name}] aggregates=[count(*)] // { arity: 2 }
-        Project (#1) // { arity: 1 }
+        Project (#1{s_name}) // { arity: 1 }
           Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
             implementation
               %0:l2[#2, #0]KK » %1[#0, #1]KK
@@ -1815,12 +1815,12 @@ Explained Query:
               implementation
                 %1[×]UA » %0:l0[×]ef
               ArrangeBy keys=[[]] // { arity: 3 }
-                Project (#0{c_custkey}, #4, #5) // { arity: 3 }
+                Project (#0{c_custkey}, #4{c_phone}, #5{c_acctbal}) // { arity: 3 }
                   Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                     Get l0 // { arity: 9 }
               ArrangeBy keys=[[]] // { arity: 2 }
                 Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
-                  Project (#5) // { arity: 1 }
+                  Project (#5{c_acctbal}) // { arity: 1 }
                     Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                       Get l0 // { arity: 9 }
       cte l2 =
@@ -1829,7 +1829,7 @@ Explained Query:
             Get l1 // { arity: 3 }
     Return // { arity: 3 }
       Reduce group_by=[substr(char_to_text(#0{c_phone}), 1, 2)] aggregates=[count(*), sum(#1{c_acctbal})] // { arity: 3 }
-        Project (#1{c_acctbal}, #2) // { arity: 2 }
+        Project (#1{c_phone}, #2{c_acctbal}) // { arity: 2 }
           Join on=(#0{c_custkey} = #3{c_custkey}) type=differential // { arity: 4 }
             implementation
               %0:l1[#0]K » %1[#0]K
@@ -1846,7 +1846,7 @@ Explained Query:
                         Get l2 // { arity: 1 }
                       ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
                         Distinct project=[#0{o_custkey}] // { arity: 1 }
-                          Project (#1) // { arity: 1 }
+                          Project (#1{o_custkey}) // { arity: 1 }
                             ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
                 Get l2 // { arity: 1 }
 


### PR DESCRIPTION
1-liner fix for https://github.com/MaterializeInc/database-issues/issues/8094, correcting column name printing for Project. When looking up a column name from a column number, the code used to refer to the column names of the _output_ of Project, but we actually want to refer to the column names of the input to the Project, because the column numbers make sense only in that context.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/8094

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
