### PR TITLE
docs: Improvements in EXPLAIN docs

### DIFF
--- a/doc/user/content/transform-data/optimization.md
+++ b/doc/user/content/transform-data/optimization.md
@@ -203,9 +203,9 @@ In this case, the index on `teachers(name)` might work better, as the `WHERE t.n
 
 #### Optimize Multi-Way Joins with Delta Joins
 
-Materialize has access to a join execution strategy we call `DeltaQuery`, a.k.a. **delta joins**, that aggressively re-uses indexes and maintains no intermediate results. Materialize considers this plan only if all the necessary indexes already exist, in which case the additional memory cost of the join is zero. This is typically possible when you index all the join keys.
+Materialize has access to a join execution strategy we call **delta joins**, which aggressively re-uses indexes and maintains no intermediate results in memory. Materialize considers this plan only if all the necessary indexes already exist, in which case the additional memory cost of the join is zero. This is typically possible when you index all the join keys (including primary keys and foreign keys that are involved in the join). Delta joins are relevant only for joins of more than 2 inputs.
 
-From the previous example, add the name of the course rather than just the course ID.
+Let us extend the previous example by also querying for the name of the course rather than just the course ID, needing a 3-input join.
 
 ```mzsql
 CREATE VIEW course_schedule AS

--- a/doc/user/data/explain_plan_operators.yml
+++ b/doc/user/data/explain_plan_operators.yml
@@ -152,7 +152,7 @@ operators:
       Performs one of `INNER` / `LEFT` / `RIGHT` / `FULL OUTER` / `CROSS` join on the two inputs, using the given predicate.
     uses_memory: True
     memory_details: |
-      Uses memory proportional to the input sizes, unless [the inputs have appropriate indexes](/transform-data/optimization/#join). Certain joins with more than 2 inputs use additional memory, see in the optimized plan.
+      Uses memory proportional to the input sizes, unless [the inputs have appropriate indexes](/transform-data/optimization/#join). Certain joins with more than 2 inputs use additional memory, see details in the optimized plan.
     expansive: True
     expansive_details: |
       For `CrossJoin`s, Cartesian product of the inputs (|N| x |M|). Note that, in many cases, a join that shows up as a cross join in the RAW PLAN will actually be turned into an inner join in the OPTIMIZED PLAN, by making use of an equality WHERE condition.
@@ -210,8 +210,8 @@ operators:
       Groups the input rows by some scalar expressions, reduces each group using some aggregate functions, and produces rows containing the group key and aggregate outputs.
     uses_memory: True
     memory_details: |
-      `SUM`, `COUNT`, and some other aggregations use a moderate amount of memory. `MIN` and `MAX` aggregates can use
-      significantly more memory. This can be improved by including group size hints in the query, see
+      `SUM`, `COUNT`, and most other aggregations use a moderate amount of memory (proportional either to twice the output size or to input size + output size).
+      `MIN` and `MAX` aggregates can use significantly more memory. This can be improved by including group size hints in the query, see
       [`mz_introspection.mz_expected_group_size_advice`](/sql/system-catalog/mz_introspection/#mz_expected_group_size_advice).
     expansive: False
     example: "`Reduce group_by=[#0] aggregates=[max((#0 * #1))]`"
@@ -233,13 +233,15 @@ operators:
 
       4. `Reduce::Collation` corresponds to an arbitrary mix of reductions of different types, which will be performed separately and then joined together.
 
-      5. `Reduce::Basic` (e.g., window functions, `list_agg`) corresponds to a single hard-to-incrementalize aggregation.
+      5. `Reduce::Basic` (e.g., window functions, `list_agg`) corresponds to a single non-incremental aggregation.
 
     uses_memory: True
     memory_details: |
-      Can use significant amount as the operator can significantly overestimate
-      the size. For `MIN` and `MAX` aggregates, consult
+      `Distinct` and `Accumulable` aggregates use a moderate amount of memory (proportional to twice the output size).
+      `MIN` and `MAX` aggregates can use significantly more memory. This can be improved by including group size hints in the query, see
       [`mz_introspection.mz_expected_group_size_advice`](/sql/system-catalog/mz_introspection/#mz_expected_group_size_advice).
+      `Basic` aggregates use memory proportional to the input + output size.
+      `Collation` aggregates use memory that is the sum of their constituents, plus some memory for the join at the end.
     expansive: False
     example: "`Reduce::Accumulable 8`"
 
@@ -253,8 +255,8 @@ operators:
       empty input collection.
     uses_memory: True
     memory_details: |
-      Can use significant amount as the operator can significantly overestimate
-      the size. For `MIN` and `MAX` aggregates, consult
+      `SUM`, `COUNT`, and most other aggregations use a moderate amount of memory (proportional either to twice the output size or to input size + output size).
+      `MIN` and `MAX` aggregates can use significantly more memory. This can be improved by including group size hints in the query, see
       [`mz_introspection.mz_expected_group_size_advice`](/sql/system-catalog/mz_introspection/#mz_expected_group_size_advice).
     expansive: False
     example: "`Reduce group_by=[#0] aggregates=[max((#0 * #1))]`"
@@ -265,7 +267,7 @@ operators:
       Alias for a `Reduce` with an empty aggregate list.
     uses_memory: True
     memory_details: |
-      Uses memory proportional to the input and output size.
+      Uses memory proportional to twice the output size.
     expansive: False
     example: "`Distinct`"
 
@@ -275,7 +277,7 @@ operators:
       Removes duplicate copies of input rows.
     uses_memory: True
     memory_details: |
-      Uses memory proportional to the input and output size, twice.
+      Uses memory proportional to twice the output size.
     expansive: False
     example: "`Distinct`"
 
@@ -286,7 +288,7 @@ operators:
     uses_memory: True
     memory_details: |
       Can use significant amount as the operator can significantly overestimate
-      the size. Consult
+      the group sizes. Consult
       [`mz_introspection.mz_expected_group_size_advice`](/sql/system-catalog/mz_introspection/#mz_expected_group_size_advice).
     expansive: False
     example: "`TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5`"
@@ -305,8 +307,8 @@ operators:
       3. `TopK::Basic`, a generic `TopK` plan.
     uses_memory: True
     memory_details: |
-      Can use significant amount as the operator can significantly overestimate
-      the size. Consult
+      `MonotonicTop1` or `MonotonicTopK` uses a moderate amount of memory. Other TopKs use significantly more memory as the operator can significantly overestimate
+      the group sizes. Consult
       [`mz_introspection.mz_expected_group_size_advice`](/sql/system-catalog/mz_introspection/#mz_expected_group_size_advice).
     expansive: False
     example: "`TopK::Basic 10`"

--- a/doc/user/data/explain_plan_operators.yml
+++ b/doc/user/data/explain_plan_operators.yml
@@ -30,8 +30,8 @@ operators:
   - operator: Get
     plan_types: "optimized,raw"
     description: |
-      Produces rows from either an existing source/view or from a previous
-      operator in the same plan.
+      Produces rows from either an existing relation (source/view/materialized view/table) or from a previous
+      CTE in the same plan.
     uses_memory: False
     memory_details: ""
     expansive: False
@@ -41,14 +41,14 @@ operators:
   - operator: Get::~
     plan_types: "LIR"
     description: |
-      Produces rows from either an existing source/view or
-      from a previous operator in the same plan. There may be a
-      `MapFilterProject` included in the lookup.
+      Produces rows from either an existing relation (source/view/materialized view/table) or from a previous
+      CTE in the same plan.
+      There may be a `MapFilterProject` included in the lookup.
 
       There are three types of `Get`.
 
       1. `Get::PassArrangements`, which means the plan will use an
-         existing arrangement.
+         existing [arrangement](/get-started/arrangements/#arrangements).
 
       2. `Get::Arrangement`, which means that the results will be
          _looked up_ in an existing arrangement.
@@ -152,12 +152,12 @@ operators:
       Performs one of `INNER` / `LEFT` / `RIGHT` / `FULL OUTER` / `CROSS` join on the two inputs, using the given predicate.
     uses_memory: True
     memory_details: |
-      Uses memory for 3-way or more differential joins.
+      Uses memory proportional to the input sizes, unless [the inputs have appropriate indexes](/transform-data/optimization/#join). Certain joins with more than 2 inputs use additional memory, see in the optimized plan.
     expansive: True
     expansive_details: |
-      For `CROSSJOINS`, Cartesian product of the inputs (|N| x |M|).
+      For `CrossJoin`s, Cartesian product of the inputs (|N| x |M|). Note that, in many cases, a join that shows up as a cross join in the RAW PLAN will actually be turned into an inner join in the OPTIMIZED PLAN, by making use of an equality WHERE condition.
       For other join types, depends on the join order and facts about the joined collections.
-    example: "`Join on=(#1 = #2) type=delta`"
+    example: "`InnerJoin (#0 = #2)`"
 
   - operator: Join
     plan_types: "optimized"
@@ -165,7 +165,9 @@ operators:
       Returns combinations of rows from each input whenever some equality predicates are `true`.
     uses_memory: True
     memory_details: |
-      Uses memory for 3-way or more differential joins.
+      The `Join` operator itself uses memory only for `type=differential` with more than 2 inputs.
+      However, `Join` operators need [arrangements](/get-started/arrangements/#arrangements) on their inputs (shown by the `ArrangeBy` operator).
+      These arrangements use memory proportional to the input sizes. If an input has an [appropriate index](/transform-data/optimization/#join), then the arrangement of the index will be reused.
     expansive: True
     expansive_details: |
       Depends on the join order and facts about the joined collections.
@@ -178,7 +180,7 @@ operators:
 
       Returns combinations of rows from each input whenever some equality predicates are `true`.
 
-      There are two types of `Join`: `Join::Differential` and `Join::Delta`, with [documented differences](/transform-data/optimization/#join).
+      There are two types of `Join`: `Join::Differential` (also called linear join) and `Join::Delta`, with [documented differences](/transform-data/optimization/#join).
     uses_memory: True
     memory_details: |
       Uses memory for 3-way or more differential joins.
@@ -191,7 +193,9 @@ operators:
   - operator: CrossJoin
     plan_types: "optimized"
     description: |
-      An alias for a `Join` with an empty predicate (emits all combinations).
+      An alias for a `Join` with an empty predicate (emits all combinations). Note that not all cross joins are marked
+      as `CrossJoin`: In a join with more than 2 inputs, it can happen that there is a cross join between some of the inputs.
+      You can recognize this case by `ArrangeBy` operators having empty keys, i.e., `ArrangeBy keys=[[]]`.
     uses_memory: True
     memory_details: |
       Uses memory for 3-way or more differential joins.
@@ -206,8 +210,8 @@ operators:
       Groups the input rows by some scalar expressions, reduces each group using some aggregate functions, and produces rows containing the group key and aggregate outputs.
     uses_memory: True
     memory_details: |
-      Can use significant amount as the operator can significantly overestimate
-      the size. For `MIN` and `MAX` aggregates, consult
+      `SUM`, `COUNT`, and some other aggregations use a moderate amount of memory. `MIN` and `MAX` aggregates can use
+      significantly more memory. This can be improved by including group size hints in the query, see
       [`mz_introspection.mz_expected_group_size_advice`](/sql/system-catalog/mz_introspection/#mz_expected_group_size_advice).
     expansive: False
     example: "`Reduce group_by=[#0] aggregates=[max((#0 * #1))]`"
@@ -223,13 +227,13 @@ operators:
 
       1. `Reduce::Distinct` corresponds to the SQL `DISTINCT` operator.
 
-      2. `Reduce::Accumulable` corresponds to several easy to implement aggregations that can be done simultaneously.
+      2. `Reduce::Accumulable` (e.g., `SUM`, `COUNT`) corresponds to several easy to implement aggregations that can be executed simultaneously and efficiently.
 
-      3. `Reduce::Hierarchical` corresponds to an aggregation requiring a tower of arrangements. These can be either monotonic (more efficient) or bucketed. These may benefit from a hint; [see `mz_introspection.mz_expected_group_size_advice`](/sql/system-catalog/mz_introspection/#mz_expected_group_size_advice).
+      3. `Reduce::Hierarchical` (e.g., `MIN`, `MAX`) corresponds to an aggregation requiring a tower of arrangements. These can be either monotonic (more efficient) or bucketed. These may benefit from a hint; [see `mz_introspection.mz_expected_group_size_advice`](/sql/system-catalog/mz_introspection/#mz_expected_group_size_advice).
 
-      4. `Reduce::Collation` corresponds to an arbitrary mix of reductions, which will be performed separately and then joined together.
+      4. `Reduce::Collation` corresponds to an arbitrary mix of reductions of different types, which will be performed separately and then joined together.
 
-      5. `Reduce::Basic` corresponds to a single hard-to-incrementalize aggregation.
+      5. `Reduce::Basic` (e.g., window functions, `list_agg`) corresponds to a single hard-to-incrementalize aggregation.
 
     uses_memory: True
     memory_details: |
@@ -261,7 +265,7 @@ operators:
       Alias for a `Reduce` with an empty aggregate list.
     uses_memory: True
     memory_details: |
-      Uses memory proportional to the number of input updates, twice.
+      Uses memory proportional to the input and output size.
     expansive: False
     example: "`Distinct`"
 
@@ -271,7 +275,7 @@ operators:
       Removes duplicate copies of input rows.
     uses_memory: True
     memory_details: |
-      Uses memory proportional to the number of input updates, twice.
+      Uses memory proportional to the input and output size, twice.
     expansive: False
     example: "`Distinct`"
 
@@ -332,7 +336,7 @@ operators:
       Removes any rows with negative counts.
     uses_memory: True
     memory_details: |
-      Uses memory proportional to the number of input updates, twice.
+      Uses memory proportional to the input and output size, twice.
     expansive: False
     example: "`Threshold`"
 
@@ -342,24 +346,24 @@ operators:
       Removes any rows with negative counts.
     uses_memory: True
     memory_details: |
-      Uses memory proportional to the number of input updates, twice.
+      Uses memory proportional to the input and output size, twice.
     expansive: False
     example: "`Threshold 47`"
 
   - operator: Union
     plan_types: "optimized,raw"
     description: |
-      Sums the counts of each row of all inputs.
+      Sums the counts of each row of all inputs. (Corresponds to `UNION ALL` rather than `UNION`/`UNION DISTINCT`.)
     uses_memory: True
     memory_details: |
-      Moderate use of memory. Union stages force consolidation, which results in a memory spike, largely at hydration time.
+      Moderate use of memory. Some union operators force consolidation, which results in a memory spike, largely at hydration time.
     expansive: False
     example: "`Union`"
 
   - operator: Union
     plan_types: "LIR"
     description: |
-      Combines its inputs into a unified output, emitting one row for each row on any input.
+      Combines its inputs into a unified output, emitting one row for each row on any input. (Corresponds to `UNION ALL` rather than `UNION`/`UNION DISTINCT`.)
     uses_memory: True
     memory_details: |
       If the union "consolidates output", it will make moderate use of memory, particularly at hydration time. If the union is not marked with "consolidates output", it will not consume memory.
@@ -369,27 +373,27 @@ operators:
   - operator: ArrangeBy
     plan_types: "optimized"
     description: |
-      Indicates a point that will become an arrangement in the dataflow engine (each `keys` element will be a different arrangement). Note that if the output of the previous operator is already arranged with a key that is also requested here, then this operator will just pass on that existing arrangement instead of creating a new one.
+      Indicates a point that will become an [arrangement](/get-started/arrangements/#arrangements) in the dataflow engine (each `keys` element will be a different arrangement). Note that if an appropriate index already exists on the input or the output of the previous operator is already arranged with a key that is also requested here, then this operator will just pass on that existing arrangement instead of creating a new one.
     uses_memory: True
     memory_details: |
-      Depends. When it does, uses memory proportional to the number of input updates.
+      Depends. If arrangements need to be created, they use memory proportional to the input size.
     expansive: False
     example: "`ArrangeBy keys=[[#0]]`"
 
   - operator: Arrange
     plan_types: "LIR"
     description: |
-      Indicates a point that will become an arrangement in the dataflow engine, i.e., it will consume memory to cache results.
+      Indicates a point that will become an [arrangement](/get-started/arrangements/#arrangements) in the dataflow engine, i.e., it will consume memory to cache results.
     uses_memory: True
     memory_details: |
-      Depends. When it does, uses memory proportional to the number of input updates.
+      Uses memory proportional to the input size. Note that in the LIR / physical plan, `Arrange`/`ArrangeBy` almost always means that an arrangement will actually be created. (This is in contrast to the "optimized" plan, where an `ArrangeBy` being present in the plan often does not mean that an arrangement will actually be created.)
     expansive: False
     example: "`Arrange 12`"
 
-  - operator: Return ... With ...
+  - operator: With ... Return ...
     plan_types: "optimized,raw"
     description: |
-      Binds sub-plans consumed multiple times by downstream operators.
+      Introduces CTEs, i.e., makes it possible for sub-plans to be consumed multiple times by downstream operators.
     uses_memory: False
     memory_details: ""
     expansive: False


### PR DESCRIPTION
- Update example output for fast path EXPLAIN
- CTE correspondence
- MIR Union text tweak:
  - Only _some_ Union stages force consolidation.
  - Eliminate "stage" terminology, because this is an internal-only terminology (coming from the dataflow world). Also, it's easy to confuse it with "EXPLAIN stages", which is a completely different thing, referring to the stages of compiling a query.
  - Note that it corresponds to UNION DISTINCT.
- Join
  - Correct mem usage, and link to the Optimization page.
  - Correct RAW PLAN example.
- Various tweaks for Reduce.
- Change the order of the "Plan operators" table, to have the default EXPLAIN first.
- I removed the "**Private preview**" marker from "filter pushdown". I'm pretty sure this is enabled globally for everybody, and is turned on by default.
- Various operators had the following: "Uses memory proportional to the number of input updates" This might be misleading in multiple ways:
  - The reader might think that this grows without bound, if there are new updates coming in continuously.
  - The reader might think that the initial snapshot is not included. I think we should simply say "Uses memory proportional to the input size"
- Flipped `Return ... With ...` to `With ... Return ...`, to follow https://github.com/MaterializeInc/materialize/pull/30983 and https://github.com/MaterializeInc/materialize/pull/31132 (And tweaked the text.)
- And many other minor tweaks.

Additionally, in the Optimization page, tweak the Delta join section: Eliminate the `DeltaQuery` terminology, as it is not used externally in other parts of the docs. Plus some minor tweaks in the text.

cc @ala2134 

### Motivation

https://www.notion.so/materialize/EXPLAIN-PLAN-Usability-17613f48d37b80139742d8c3ee710640

### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
