### PR TITLE
docs: kapa.ai exclude self-managed sources in cloud docs

### DIFF
--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -94,7 +94,7 @@ toCSS | fingerprint }}
   data-modal-open-on-command-k="true"
   data-modal-command-k-search-mode-default="true"
   data-search-result-link-target="_self"
-  data-search-include-source-names='["Documentation"]'
+  data-search-include-source-names='["Documentation Cloud"]'
   >
 </script>
 


### PR DESCRIPTION
https://preview.materialize.com/materialize/31202/
(the Documentation Cloud is set up on Kapa side as well so that it excludes docs/self-managed/)