### PR TITLE
adapter: Remove legacy builtin item migrations

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -17,12 +17,10 @@ use std::time::{Duration, Instant};
 
 use futures::future::{BoxFuture, FutureExt};
 use itertools::{Either, Itertools};
-use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::dyncfgs::{ENABLE_CONTINUAL_TASK_BUILTINS, ENABLE_EXPRESSION_CACHE};
 use mz_catalog::builtin::{
-    Builtin, BuiltinTable, Fingerprint, BUILTINS, BUILTIN_CLUSTERS, BUILTIN_CLUSTER_REPLICAS,
-    BUILTIN_PREFIXES, BUILTIN_ROLES, MZ_STORAGE_USAGE_BY_SHARD_DESCRIPTION,
-    RUNTIME_ALTERABLE_FINGERPRINT_SENTINEL,
+    Builtin, Fingerprint, BUILTINS, BUILTIN_CLUSTERS, BUILTIN_CLUSTER_REPLICAS, BUILTIN_PREFIXES,
+    BUILTIN_ROLES, MZ_STORAGE_USAGE_BY_SHARD_DESCRIPTION, RUNTIME_ALTERABLE_FINGERPRINT_SENTINEL,
 };
 use mz_catalog::config::{ClusterReplicaSizeMap, StateConfig};
 use mz_catalog::durable::objects::{
@@ -34,35 +32,30 @@ use mz_catalog::expr_cache::{
 };
 use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
-    BootstrapStateUpdateKind, CatalogEntry, CatalogItem, CommentsMap, DefaultPrivileges,
-    StateUpdate,
+    BootstrapStateUpdateKind, CommentsMap, DefaultPrivileges, StateUpdate,
 };
 use mz_catalog::SYSTEM_CONN_ID;
-use mz_compute_client::logging::LogVariant;
 use mz_controller::clusters::{ReplicaAllocation, ReplicaLogging};
 use mz_controller_types::ClusterId;
 use mz_ore::cast::usize_to_u64;
-use mz_ore::collections::{CollectionExt, HashSet};
+use mz_ore::collections::HashSet;
 use mz_ore::now::to_datetime;
 use mz_ore::{instrument, soft_assert_no_log};
 use mz_repr::adt::mz_acl_item::PrivilegeMap;
 use mz_repr::namespaces::is_unstable_schema;
-use mz_repr::role_id::RoleId;
-use mz_repr::{CatalogItemId, Diff, GlobalId, RelationVersion, Timestamp};
+use mz_repr::{CatalogItemId, Diff, GlobalId, Timestamp};
 use mz_sql::catalog::{
-    BuiltinsConfig, CatalogError as SqlCatalogError, CatalogItem as SqlCatalogItem,
-    CatalogItemType, RoleMembership, RoleVars,
+    BuiltinsConfig, CatalogError as SqlCatalogError, CatalogItemType, RoleMembership, RoleVars,
 };
 use mz_sql::func::OP_IMPLS;
-use mz_sql::names::SchemaId;
 use mz_sql::rbac;
 use mz_sql::session::user::{MZ_SYSTEM_ROLE_ID, SYSTEM_USER};
 use mz_sql::session::vars::{SessionVars, SystemVars, VarError, VarInput};
-use mz_sql_parser::ast::display::AstDisplay;
 use mz_storage_client::storage_collections::StorageCollections;
 use timely::Container;
-use tracing::{error, info, warn, Instrument};
+use tracing::{info, warn, Instrument};
 use uuid::Uuid;
+
 // DO NOT add any more imports from `crate` outside of `crate::catalog`.
 use crate::catalog::open::builtin_item_migration::{
     migrate_builtin_items, BuiltinItemMigrationResult,
@@ -73,113 +66,9 @@ use crate::catalog::{
 };
 use crate::AdapterError;
 
-#[derive(Debug)]
-pub struct BuiltinMigrationMetadata {
-    /// Used to drop objects on STORAGE nodes.
-    ///
-    /// Note: These collections are only known by the storage controller, and not the
-    /// Catalog, thus we identify them by their [`GlobalId`].
-    pub previous_storage_collection_ids: BTreeSet<GlobalId>,
-    // Used to update persisted on disk catalog state
-    pub migrated_system_object_mappings: BTreeMap<CatalogItemId, SystemObjectMapping>,
-    pub introspection_source_index_updates:
-        BTreeMap<ClusterId, Vec<(LogVariant, String, CatalogItemId, GlobalId, u32)>>,
-    pub user_item_drop_ops: Vec<CatalogItemId>,
-    pub user_item_create_ops: Vec<CreateOp>,
-}
-
-#[derive(Debug)]
-pub struct CreateOp {
-    id: CatalogItemId,
-    oid: u32,
-    global_id: GlobalId,
-    schema_id: SchemaId,
-    name: String,
-    owner_id: RoleId,
-    privileges: PrivilegeMap,
-    item_rebuilder: CatalogItemRebuilder,
-}
-
-impl BuiltinMigrationMetadata {
-    fn new() -> BuiltinMigrationMetadata {
-        BuiltinMigrationMetadata {
-            previous_storage_collection_ids: BTreeSet::new(),
-            migrated_system_object_mappings: BTreeMap::new(),
-            introspection_source_index_updates: BTreeMap::new(),
-            user_item_drop_ops: Vec::new(),
-            user_item_create_ops: Vec::new(),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum CatalogItemRebuilder {
-    SystemSource(CatalogItem),
-    Object {
-        sql: String,
-        is_retained_metrics_object: bool,
-        custom_logical_compaction_window: Option<CompactionWindow>,
-    },
-}
-
-impl CatalogItemRebuilder {
-    fn new(
-        entry: &CatalogEntry,
-        id: CatalogItemId,
-        ancestor_ids: &BTreeMap<CatalogItemId, CatalogItemId>,
-    ) -> Self {
-        if id.is_system()
-            && (entry.is_table() || entry.is_introspection_source() || entry.is_source())
-        {
-            Self::SystemSource(entry.item().clone())
-        } else {
-            let create_sql = entry.create_sql().to_string();
-            let mut create_stmt = mz_sql::parse::parse(&create_sql)
-                .expect("invalid create sql persisted to catalog")
-                .into_element()
-                .ast;
-            mz_sql::ast::transform::create_stmt_replace_ids(&mut create_stmt, ancestor_ids);
-            Self::Object {
-                sql: create_stmt.to_ast_string_stable(),
-                is_retained_metrics_object: entry.item().is_retained_metrics_object(),
-                custom_logical_compaction_window: entry.item().custom_logical_compaction_window(),
-            }
-        }
-    }
-
-    fn build(
-        self,
-        global_id: GlobalId,
-        state: &CatalogState,
-        versions: &BTreeMap<RelationVersion, GlobalId>,
-    ) -> CatalogItem {
-        match self {
-            Self::SystemSource(item) => item,
-            Self::Object {
-                sql,
-                is_retained_metrics_object,
-                custom_logical_compaction_window,
-            } => state
-                .parse_item(
-                    global_id,
-                    &sql,
-                    versions,
-                    None,
-                    is_retained_metrics_object,
-                    custom_logical_compaction_window,
-                    &mut LocalExpressionCache::Closed,
-                    None,
-                )
-                .unwrap_or_else(|error| panic!("invalid persisted create sql ({error:?}): {sql}")),
-        }
-    }
-}
-
 pub struct InitializeStateResult {
     /// An initialized [`CatalogState`].
     pub state: CatalogState,
-    /// A set of storage collections to drop (only used by legacy migrations).
-    pub storage_collections_to_drop: BTreeSet<GlobalId>,
     /// A set of new shards that may need to be initialized (only used by 0dt migration).
     pub migrated_storage_collections_0dt: BTreeSet<CatalogItemId>,
     /// A set of new builtin items.
@@ -199,12 +88,7 @@ pub struct InitializeStateResult {
 pub struct OpenCatalogResult {
     /// An opened [`Catalog`].
     pub catalog: Catalog,
-    /// A set of storage collections to drop (only used by legacy migrations).
-    ///
-    /// Note: These Collections will not be in the Catalog, and are only known about by
-    /// the storage controller, which is why we identify them by [`GlobalId`].
-    pub storage_collections_to_drop: BTreeSet<GlobalId>,
-    /// A set of new shards that may need to be initialized (only used by 0dt migration).
+    /// A set of new shards that may need to be initialized.
     pub migrated_storage_collections_0dt: BTreeSet<CatalogItemId>,
     /// A set of new builtin items.
     pub new_builtin_collections: BTreeSet<GlobalId>,
@@ -540,7 +424,6 @@ impl Catalog {
         // Migrate builtin items.
         let BuiltinItemMigrationResult {
             builtin_table_updates: builtin_table_update,
-            storage_collections_to_drop,
             migrated_storage_collections_0dt,
             cleanup_action,
         } = migrate_builtin_items(
@@ -560,7 +443,6 @@ impl Catalog {
 
         Ok(InitializeStateResult {
             state,
-            storage_collections_to_drop,
             migrated_storage_collections_0dt,
             new_builtin_collections: new_builtin_collections.into_iter().collect(),
             builtin_table_updates,
@@ -588,7 +470,6 @@ impl Catalog {
 
             let InitializeStateResult {
                 state,
-                storage_collections_to_drop,
                 migrated_storage_collections_0dt,
                 new_builtin_collections,
                 mut builtin_table_updates,
@@ -640,7 +521,6 @@ impl Catalog {
 
             Ok(OpenCatalogResult {
                 catalog,
-                storage_collections_to_drop,
                 migrated_storage_collections_0dt,
                 new_builtin_collections,
                 builtin_table_updates,
@@ -663,7 +543,6 @@ impl Catalog {
         storage_collections: &Arc<
             dyn StorageCollections<Timestamp = mz_repr::Timestamp> + Send + Sync,
         >,
-        storage_collections_to_drop: BTreeSet<GlobalId>,
     ) -> Result<(), mz_catalog::durable::CatalogError> {
         let collections = self
             .entries()
@@ -679,7 +558,7 @@ impl Catalog {
         let mut txn = storage.transaction().await?;
 
         storage_collections
-            .initialize_state(&mut txn, collections, storage_collections_to_drop)
+            .initialize_state(&mut txn, collections)
             .await
             .map_err(mz_catalog::durable::DurableCatalogError::from)?;
 
@@ -702,7 +581,6 @@ impl Catalog {
         config: mz_controller::ControllerConfig,
         envd_epoch: core::num::NonZeroI64,
         read_only: bool,
-        storage_collections_to_drop: BTreeSet<GlobalId>,
     ) -> Result<mz_controller::Controller<mz_repr::Timestamp>, mz_catalog::durable::CatalogError>
     {
         let controller_start = Instant::now();
@@ -726,7 +604,7 @@ impl Catalog {
             mz_controller::Controller::new(config, envd_epoch, read_only, &read_only_tx).await
         };
 
-        self.initialize_storage_state(&controller.storage_collections, storage_collections_to_drop)
+        self.initialize_storage_state(&controller.storage_collections)
             .await?;
 
         info!(
@@ -735,277 +613,6 @@ impl Catalog {
         );
 
         Ok(controller)
-    }
-
-    /// The objects in the catalog form one or more DAGs (directed acyclic graph) via object
-    /// dependencies. To migrate a builtin object we must drop that object along with all of its
-    /// descendants, and then recreate that object along with all of its descendants using new
-    /// [`CatalogItemId`]s. To achieve this we perform a DFS (depth first search) on the catalog
-    /// items starting with the nodes that correspond to builtin objects that have changed schemas.
-    ///
-    /// Objects need to be dropped starting from the leafs of the DAG going up towards the roots,
-    /// and they need to be recreated starting at the roots of the DAG and going towards the leafs.
-    fn generate_builtin_migration_metadata(
-        state: &CatalogState,
-        txn: &mut Transaction<'_>,
-        migrated_ids: Vec<CatalogItemId>,
-        id_fingerprint_map: BTreeMap<CatalogItemId, String>,
-    ) -> Result<BuiltinMigrationMetadata, Error> {
-        // First obtain a topological sorting of all migrated objects and their children.
-        let mut visited_set = BTreeSet::new();
-        let mut sorted_entries = Vec::new();
-        for item_id in migrated_ids {
-            if !visited_set.contains(&item_id) {
-                let migrated_topological_sort =
-                    Catalog::topological_sort(state, item_id, &mut visited_set);
-                sorted_entries.extend(migrated_topological_sort);
-            }
-        }
-        sorted_entries.reverse();
-
-        // Then process all objects in sorted order.
-        let mut migration_metadata = BuiltinMigrationMetadata::new();
-        let mut ancestor_ids = BTreeMap::new();
-        let mut migrated_log_ids = BTreeMap::new();
-        let log_name_map: BTreeMap<_, _> = BUILTINS::logs()
-            .map(|log| (log.variant.clone(), log.name))
-            .collect();
-        for entry in sorted_entries {
-            let id = entry.id();
-
-            let (new_item_id, new_global_id) = match id {
-                CatalogItemId::System(_) => txn.allocate_system_item_ids(1)?.into_element(),
-                CatalogItemId::IntrospectionSourceIndex(id) => (
-                    CatalogItemId::IntrospectionSourceIndex(id),
-                    GlobalId::IntrospectionSourceIndex(id),
-                ),
-                CatalogItemId::User(_) => txn.allocate_user_item_ids(1)?.into_element(),
-                _ => unreachable!("can't migrate id: {id}"),
-            };
-
-            let name = state.resolve_full_name(entry.name(), None);
-            info!("migrating {name} from {id} to {new_item_id}");
-
-            // Generate value to update fingerprint and global ID persisted mapping for system objects.
-            // Not every system object has a fingerprint, like introspection source indexes.
-            if let Some(fingerprint) = id_fingerprint_map.get(&id) {
-                assert!(
-                    id.is_system(),
-                    "id_fingerprint_map should only contain builtin objects"
-                );
-                let schema_name = state
-                    .get_schema(
-                        &entry.name().qualifiers.database_spec,
-                        &entry.name().qualifiers.schema_spec,
-                        entry.conn_id().unwrap_or(&SYSTEM_CONN_ID),
-                    )
-                    .name
-                    .schema
-                    .as_str();
-                migration_metadata.migrated_system_object_mappings.insert(
-                    id,
-                    SystemObjectMapping {
-                        description: SystemObjectDescription {
-                            schema_name: schema_name.to_string(),
-                            object_type: entry.item_type(),
-                            object_name: entry.name().item.clone(),
-                        },
-                        unique_identifier: SystemObjectUniqueIdentifier {
-                            catalog_id: new_item_id,
-                            global_id: new_global_id,
-                            fingerprint: fingerprint.clone(),
-                        },
-                    },
-                );
-            }
-
-            ancestor_ids.insert(id, new_item_id);
-
-            if entry.item().is_storage_collection() {
-                migration_metadata
-                    .previous_storage_collection_ids
-                    .extend(entry.global_ids());
-            }
-
-            // Push drop commands.
-            match entry.item() {
-                CatalogItem::Log(log) => {
-                    migrated_log_ids.insert(log.global_id(), log.variant.clone());
-                }
-                CatalogItem::Index(index) => {
-                    if id.is_system() {
-                        if let Some(variant) = migrated_log_ids.get(&index.on) {
-                            migration_metadata
-                                .introspection_source_index_updates
-                                .entry(index.cluster_id)
-                                .or_default()
-                                .push((
-                                    variant.clone(),
-                                    log_name_map
-                                        .get(variant)
-                                        .expect("all variants have a name")
-                                        .to_string(),
-                                    new_item_id,
-                                    new_global_id,
-                                    entry.oid(),
-                                ));
-                        }
-                    }
-                }
-                CatalogItem::Table(_)
-                | CatalogItem::Source(_)
-                | CatalogItem::MaterializedView(_)
-                | CatalogItem::ContinualTask(_) => {
-                    // Storage objects don't have any external objects to drop.
-                }
-                CatalogItem::Sink(_) => {
-                    // Sinks don't have any external objects to drop--however,
-                    // this would change if we add a collections for sinks
-                    // database-issues#5148.
-                }
-                CatalogItem::View(_) => {
-                    // Views don't have any external objects to drop.
-                }
-                CatalogItem::Type(_)
-                | CatalogItem::Func(_)
-                | CatalogItem::Secret(_)
-                | CatalogItem::Connection(_) => unreachable!(
-                    "impossible to migrate schema for builtin {}",
-                    entry.item().typ()
-                ),
-            }
-            if id.is_user() {
-                migration_metadata.user_item_drop_ops.push(id);
-            }
-
-            // Push create commands.
-            let name = entry.name().clone();
-            if id.is_user() {
-                let schema_id = name.qualifiers.schema_spec.clone().into();
-                let item_rebuilder = CatalogItemRebuilder::new(entry, new_item_id, &ancestor_ids);
-                migration_metadata.user_item_create_ops.push(CreateOp {
-                    id: new_item_id,
-                    oid: entry.oid(),
-                    global_id: new_global_id,
-                    schema_id,
-                    name: name.item.clone(),
-                    owner_id: entry.owner_id().clone(),
-                    privileges: entry.privileges().clone(),
-                    item_rebuilder,
-                });
-            }
-        }
-
-        // Reverse drop commands.
-        migration_metadata.user_item_drop_ops.reverse();
-
-        Ok(migration_metadata)
-    }
-
-    fn topological_sort<'a, 'b>(
-        state: &'a CatalogState,
-        id: CatalogItemId,
-        visited_set: &'b mut BTreeSet<CatalogItemId>,
-    ) -> Vec<&'a CatalogEntry> {
-        let mut sorted_entries = Vec::new();
-        visited_set.insert(id);
-        let entry = state.get_entry(&id);
-        for dependant in entry.used_by() {
-            if !visited_set.contains(dependant) {
-                let child_topological_sort =
-                    Catalog::topological_sort(state, *dependant, visited_set);
-                sorted_entries.extend(child_topological_sort);
-            }
-        }
-        sorted_entries.push(entry);
-        sorted_entries
-    }
-
-    #[mz_ore::instrument]
-    async fn apply_builtin_migration(
-        state: &mut CatalogState,
-        txn: &mut Transaction<'_>,
-        migration_metadata: &mut BuiltinMigrationMetadata,
-    ) -> Result<Vec<BuiltinTableUpdate<&'static BuiltinTable>>, Error> {
-        for id in &migration_metadata.user_item_drop_ops {
-            let entry = state.get_entry(id);
-            if entry.is_sink() {
-                let full_name = state.resolve_full_name(entry.name(), None);
-                error!(
-                    "user sink {full_name} will be recreated as part of a builtin migration which \
-                    can result in duplicate data being emitted. This is a known issue, \
-                    https://github.com/MaterializeInc/database-issues/issues/5553. Please inform the \
-                    customer that their sink may produce duplicate data."
-                )
-            }
-        }
-
-        let mut builtin_table_updates = Vec::new();
-        txn.remove_items(&migration_metadata.user_item_drop_ops.drain(..).collect())?;
-        txn.update_system_object_mappings(std::mem::take(
-            &mut migration_metadata.migrated_system_object_mappings,
-        ))?;
-        txn.update_introspection_source_index_gids(
-            std::mem::take(&mut migration_metadata.introspection_source_index_updates)
-                .into_iter()
-                .map(|(cluster_id, updates)| {
-                    (
-                        cluster_id,
-                        updates
-                            .into_iter()
-                            .map(|(_variant, name, item_id, index_id, oid)| {
-                                (name, item_id, index_id, oid)
-                            }),
-                    )
-                }),
-        )?;
-        let updates = txn.get_and_commit_op_updates();
-        let builtin_table_update = state
-            .apply_updates_for_bootstrap(updates, &mut LocalExpressionCache::Closed)
-            .await;
-        builtin_table_updates.extend(builtin_table_update);
-        for CreateOp {
-            id,
-            oid,
-            global_id,
-            schema_id,
-            name,
-            owner_id,
-            privileges,
-            item_rebuilder,
-        } in migration_metadata.user_item_create_ops.drain(..)
-        {
-            // Builtin Items can't be versioned.
-            let versions = BTreeMap::new();
-            let item = item_rebuilder.build(global_id, state, &versions);
-            let (create_sql, expect_gid, expect_versions) = item.to_serialized();
-            assert_eq!(
-                global_id, expect_gid,
-                "serializing a CatalogItem changed the GlobalId"
-            );
-            assert_eq!(
-                versions, expect_versions,
-                "serializing a CatalogItem changed the Versions"
-            );
-
-            txn.insert_item(
-                id,
-                oid,
-                global_id,
-                schema_id,
-                &name,
-                create_sql,
-                owner_id.clone(),
-                privileges.all_values_owned().collect(),
-                versions,
-            )?;
-            let updates = txn.get_and_commit_op_updates();
-            let builtin_table_update = state
-                .apply_updates_for_bootstrap(updates, &mut LocalExpressionCache::Closed)
-                .await;
-            builtin_table_updates.extend(builtin_table_update);
-        }
-        Ok(builtin_table_updates)
     }
 
     /// Politely releases all external resources that can only be released in an async context.
@@ -1569,706 +1176,4 @@ fn get_dyncfg_val_from_defaults_and_remote<T: mz_dyncfg::ConfigDefault>(
         val = x;
     }
     val
-}
-
-#[cfg(test)]
-mod builtin_migration_tests {
-    use std::collections::{BTreeMap, BTreeSet};
-
-    use itertools::Itertools;
-    use mz_catalog::memory::objects::{
-        CatalogItem, Index, MaterializedView, Table, TableDataSource,
-    };
-    use mz_catalog::SYSTEM_CONN_ID;
-    use mz_controller_types::ClusterId;
-    use mz_expr::MirRelationExpr;
-    use mz_ore::id_gen::Gen;
-    use mz_repr::{
-        CatalogItemId, GlobalId, RelationDesc, RelationType, RelationVersion, ScalarType,
-        VersionedRelationDesc,
-    };
-    use mz_sql::catalog::CatalogDatabase;
-    use mz_sql::names::{
-        DependencyIds, ItemQualifiers, QualifiedItemName, ResolvedDatabaseSpecifier, ResolvedIds,
-    };
-    use mz_sql::session::user::MZ_SYSTEM_ROLE_ID;
-    use mz_sql::DEFAULT_SCHEMA;
-    use mz_sql_parser::ast::Expr;
-
-    use crate::catalog::{Catalog, Op, OptimizedMirRelationExpr};
-    use crate::session::DEFAULT_DATABASE_NAME;
-
-    enum ItemNamespace {
-        System,
-        User,
-    }
-
-    enum SimplifiedItem {
-        Table,
-        MaterializedView { referenced_names: Vec<String> },
-        Index { on: String },
-    }
-
-    struct SimplifiedCatalogEntry {
-        name: String,
-        namespace: ItemNamespace,
-        item: SimplifiedItem,
-    }
-
-    impl SimplifiedCatalogEntry {
-        // A lot of the fields here aren't actually used in the test so we can fill them in with dummy
-        // values.
-        fn to_catalog_item(
-            self,
-            item_id_mapping: &BTreeMap<String, CatalogItemId>,
-            global_id_mapping: &BTreeMap<String, GlobalId>,
-            global_id_gen: &mut Gen<u64>,
-        ) -> (String, ItemNamespace, CatalogItem, GlobalId) {
-            let global_id = GlobalId::User(global_id_gen.allocate_id());
-            let desc = RelationDesc::builder()
-                .with_column("a", ScalarType::Int32.nullable(true))
-                .with_key(vec![0])
-                .finish();
-            let item = match self.item {
-                SimplifiedItem::Table => CatalogItem::Table(Table {
-                    create_sql: Some("CREATE TABLE materialize.public.t (a INT)".to_string()),
-                    desc: VersionedRelationDesc::new(desc),
-                    collections: [(RelationVersion::root(), global_id)].into_iter().collect(),
-                    conn_id: None,
-                    resolved_ids: ResolvedIds::empty(),
-                    custom_logical_compaction_window: None,
-                    is_retained_metrics_object: false,
-                    data_source: TableDataSource::TableWrites {
-                        defaults: vec![Expr::null(); 1],
-                    },
-                }),
-                SimplifiedItem::MaterializedView { referenced_names } => {
-                    let table_list = referenced_names
-                        .iter()
-                        .map(|table| format!("materialize.public.{table}"))
-                        .join(",");
-                    let column_list = referenced_names
-                        .iter()
-                        .enumerate()
-                        .map(|(idx, _)| format!("a{idx}"))
-                        .join(",");
-                    let resolved_ids =
-                        convert_names_to_ids(referenced_names, item_id_mapping, global_id_mapping);
-
-                    CatalogItem::MaterializedView(MaterializedView {
-                        global_id,
-                        create_sql: format!(
-                            "CREATE MATERIALIZED VIEW materialize.public.mv ({column_list}) AS SELECT * FROM {table_list}"
-                        ),
-                        raw_expr: mz_sql::plan::HirRelationExpr::constant(
-                            Vec::new(),
-                            RelationType {
-                                column_types: Vec::new(),
-                                keys: Vec::new(),
-                            },
-                        ).into(),
-                        dependencies: DependencyIds(Default::default()),
-                        optimized_expr: OptimizedMirRelationExpr(MirRelationExpr::Constant {
-                            rows: Ok(Vec::new()),
-                            typ: RelationType {
-                                column_types: Vec::new(),
-                                keys: Vec::new(),
-                            },
-                        }).into(),
-                        desc: RelationDesc::builder()
-                            .with_column("a", ScalarType::Int32.nullable(true))
-                            .with_key(vec![0])
-                            .finish(),
-                        resolved_ids: resolved_ids.into_iter().collect(),
-                        cluster_id: ClusterId::user(1).expect("1 is a valid ID"),
-                        non_null_assertions: vec![],
-                        custom_logical_compaction_window: None,
-                        refresh_schedule: None,
-                        initial_as_of: None,
-                    })
-                }
-                SimplifiedItem::Index { on } => {
-                    let on_item_id = item_id_mapping[&on];
-                    let on_gid = global_id_mapping[&on];
-                    CatalogItem::Index(Index {
-                        create_sql: format!("CREATE INDEX idx ON materialize.public.{on} (a)"),
-                        global_id,
-                        on: on_gid,
-                        keys: Default::default(),
-                        conn_id: None,
-                        resolved_ids: [(on_item_id, on_gid)].into_iter().collect(),
-                        cluster_id: ClusterId::user(1).expect("1 is a valid ID"),
-                        custom_logical_compaction_window: None,
-                        is_retained_metrics_object: false,
-                    })
-                }
-            };
-            (self.name, self.namespace, item, global_id)
-        }
-    }
-
-    struct BuiltinMigrationTestCase {
-        test_name: &'static str,
-        initial_state: Vec<SimplifiedCatalogEntry>,
-        migrated_names: Vec<String>,
-        expected_previous_storage_collection_names: Vec<String>,
-        expected_migrated_system_object_mappings: Vec<String>,
-        expected_user_item_drop_ops: Vec<String>,
-        expected_user_item_create_ops: Vec<String>,
-    }
-
-    async fn add_item(
-        catalog: &mut Catalog,
-        name: String,
-        item: CatalogItem,
-        item_namespace: ItemNamespace,
-    ) -> CatalogItemId {
-        let id_ts = catalog.storage().await.current_upper().await;
-        let (item_id, _) = match item_namespace {
-            ItemNamespace::User => catalog
-                .allocate_user_id(id_ts)
-                .await
-                .expect("cannot fail to allocate user ids"),
-            ItemNamespace::System => catalog
-                .allocate_system_id(id_ts)
-                .await
-                .expect("cannot fail to allocate system ids"),
-        };
-        let database_id = catalog
-            .resolve_database(DEFAULT_DATABASE_NAME)
-            .expect("failed to resolve default database")
-            .id();
-        let database_spec = ResolvedDatabaseSpecifier::Id(database_id);
-        let schema_spec = catalog
-            .resolve_schema_in_database(&database_spec, DEFAULT_SCHEMA, &SYSTEM_CONN_ID)
-            .expect("failed to resolve default schemas")
-            .id
-            .clone();
-
-        let commit_ts = catalog.storage().await.current_upper().await;
-        catalog
-            .transact(
-                None,
-                commit_ts,
-                None,
-                vec![Op::CreateItem {
-                    id: item_id,
-                    name: QualifiedItemName {
-                        qualifiers: ItemQualifiers {
-                            database_spec,
-                            schema_spec,
-                        },
-                        item: name,
-                    },
-                    item,
-                    owner_id: MZ_SYSTEM_ROLE_ID,
-                }],
-            )
-            .await
-            .expect("failed to transact");
-
-        item_id
-    }
-
-    fn convert_names_to_ids(
-        name_vec: Vec<String>,
-        item_id_lookup: &BTreeMap<String, CatalogItemId>,
-        global_id_lookup: &BTreeMap<String, GlobalId>,
-    ) -> BTreeMap<CatalogItemId, GlobalId> {
-        name_vec
-            .into_iter()
-            .map(|name| {
-                let item_id = item_id_lookup[&name];
-                let global_id = global_id_lookup[&name];
-                (item_id, global_id)
-            })
-            .collect()
-    }
-
-    fn convert_ids_to_names<I: IntoIterator<Item = CatalogItemId>>(
-        ids: I,
-        name_lookup: &BTreeMap<CatalogItemId, String>,
-    ) -> BTreeSet<String> {
-        ids.into_iter().map(|id| name_lookup[&id].clone()).collect()
-    }
-
-    fn convert_global_ids_to_names<I: IntoIterator<Item = GlobalId>>(
-        ids: I,
-        global_id_lookup: &BTreeMap<String, GlobalId>,
-    ) -> BTreeSet<String> {
-        ids.into_iter()
-            .flat_map(|id_a| {
-                global_id_lookup
-                    .iter()
-                    .filter_map(move |(name, id_b)| (id_a == *id_b).then_some(name))
-            })
-            .cloned()
-            .collect()
-    }
-
-    async fn run_test_case(test_case: BuiltinMigrationTestCase) {
-        Catalog::with_debug_in_bootstrap(|mut catalog| async move {
-            let mut item_id_mapping = BTreeMap::new();
-            let mut name_mapping = BTreeMap::new();
-
-            let mut global_id_gen = Gen::<u64>::default();
-            let mut global_id_mapping = BTreeMap::new();
-
-            for entry in test_case.initial_state {
-                let (name, namespace, item, global_id) =
-                    entry.to_catalog_item(&item_id_mapping, &global_id_mapping, &mut global_id_gen);
-                let item_id = add_item(&mut catalog, name.clone(), item, namespace).await;
-
-                item_id_mapping.insert(name.clone(), item_id);
-                global_id_mapping.insert(name.clone(), global_id);
-                name_mapping.insert(item_id, name);
-            }
-
-            let migrated_ids = test_case
-                .migrated_names
-                .into_iter()
-                .map(|name| item_id_mapping[&name])
-                .collect();
-            let id_fingerprint_map: BTreeMap<CatalogItemId, String> = item_id_mapping
-                .iter()
-                .filter(|(_name, id)| id.is_system())
-                // We don't use the new fingerprint in this test, so we can just hard code it
-                .map(|(_name, id)| (*id, "".to_string()))
-                .collect();
-
-            let migration_metadata = {
-                // This cloning is a hacky way to appease the borrow checker. It doesn't really
-                // matter because we never look at catalog again. We could probably rewrite this
-                // test to not even need a `Catalog` which would significantly speed it up.
-                let state = catalog.state.clone();
-                let mut storage = catalog.storage().await;
-                let mut txn = storage
-                    .transaction()
-                    .await
-                    .expect("failed to create transaction");
-                Catalog::generate_builtin_migration_metadata(
-                    &state,
-                    &mut txn,
-                    migrated_ids,
-                    id_fingerprint_map,
-                )
-                .expect("failed to generate builtin migration metadata")
-            };
-
-            assert_eq!(
-                convert_global_ids_to_names(
-                    migration_metadata
-                        .previous_storage_collection_ids
-                        .into_iter(),
-                    &global_id_mapping
-                ),
-                test_case
-                    .expected_previous_storage_collection_names
-                    .into_iter()
-                    .collect(),
-                "{} test failed with wrong previous collection_names",
-                test_case.test_name
-            );
-            assert_eq!(
-                migration_metadata
-                    .migrated_system_object_mappings
-                    .values()
-                    .map(|mapping| mapping.description.object_name.clone())
-                    .collect::<BTreeSet<_>>(),
-                test_case
-                    .expected_migrated_system_object_mappings
-                    .into_iter()
-                    .collect(),
-                "{} test failed with wrong migrated system object mappings",
-                test_case.test_name
-            );
-            assert_eq!(
-                convert_ids_to_names(
-                    migration_metadata.user_item_drop_ops.into_iter(),
-                    &name_mapping
-                ),
-                test_case.expected_user_item_drop_ops.into_iter().collect(),
-                "{} test failed with wrong user drop ops",
-                test_case.test_name
-            );
-            assert_eq!(
-                migration_metadata
-                    .user_item_create_ops
-                    .into_iter()
-                    .map(|create_op| create_op.name)
-                    .collect::<BTreeSet<_>>(),
-                test_case
-                    .expected_user_item_create_ops
-                    .into_iter()
-                    .collect(),
-                "{} test failed with wrong user create ops",
-                test_case.test_name
-            );
-            catalog.expire().await;
-        })
-        .await
-    }
-
-    #[mz_ore::test(tokio::test)]
-    #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
-    async fn test_builtin_migration_no_migrations() {
-        let test_case = BuiltinMigrationTestCase {
-            test_name: "no_migrations",
-            initial_state: vec![SimplifiedCatalogEntry {
-                name: "s1".to_string(),
-                namespace: ItemNamespace::System,
-                item: SimplifiedItem::Table,
-            }],
-            migrated_names: vec![],
-            expected_previous_storage_collection_names: vec![],
-            expected_migrated_system_object_mappings: vec![],
-            expected_user_item_drop_ops: vec![],
-            expected_user_item_create_ops: vec![],
-        };
-        run_test_case(test_case).await;
-    }
-
-    #[mz_ore::test(tokio::test)]
-    #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
-    async fn test_builtin_migration_single_migrations() {
-        let test_case = BuiltinMigrationTestCase {
-            test_name: "single_migrations",
-            initial_state: vec![SimplifiedCatalogEntry {
-                name: "s1".to_string(),
-                namespace: ItemNamespace::System,
-                item: SimplifiedItem::Table,
-            }],
-            migrated_names: vec!["s1".to_string()],
-            expected_previous_storage_collection_names: vec!["s1".to_string()],
-            expected_migrated_system_object_mappings: vec!["s1".to_string()],
-            expected_user_item_drop_ops: vec![],
-            expected_user_item_create_ops: vec![],
-        };
-        run_test_case(test_case).await;
-    }
-
-    #[mz_ore::test(tokio::test)]
-    #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
-    async fn test_builtin_migration_child_migrations() {
-        let test_case = BuiltinMigrationTestCase {
-            test_name: "child_migrations",
-            initial_state: vec![
-                SimplifiedCatalogEntry {
-                    name: "s1".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::Table,
-                },
-                SimplifiedCatalogEntry {
-                    name: "u1".to_string(),
-                    namespace: ItemNamespace::User,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s1".to_string()],
-                    },
-                },
-            ],
-            migrated_names: vec!["s1".to_string()],
-            expected_previous_storage_collection_names: vec!["u1".to_string(), "s1".to_string()],
-            expected_migrated_system_object_mappings: vec!["s1".to_string()],
-            expected_user_item_drop_ops: vec!["u1".to_string()],
-            expected_user_item_create_ops: vec!["u1".to_string()],
-        };
-        run_test_case(test_case).await;
-    }
-
-    #[mz_ore::test(tokio::test)]
-    #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
-    async fn test_builtin_migration_multi_child_migrations() {
-        let test_case = BuiltinMigrationTestCase {
-            test_name: "multi_child_migrations",
-            initial_state: vec![
-                SimplifiedCatalogEntry {
-                    name: "s1".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::Table,
-                },
-                SimplifiedCatalogEntry {
-                    name: "u1".to_string(),
-                    namespace: ItemNamespace::User,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s1".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "u2".to_string(),
-                    namespace: ItemNamespace::User,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s1".to_string()],
-                    },
-                },
-            ],
-            migrated_names: vec!["s1".to_string()],
-            expected_previous_storage_collection_names: vec![
-                "u1".to_string(),
-                "u2".to_string(),
-                "s1".to_string(),
-            ],
-            expected_migrated_system_object_mappings: vec!["s1".to_string()],
-            expected_user_item_drop_ops: vec!["u1".to_string(), "u2".to_string()],
-            expected_user_item_create_ops: vec!["u2".to_string(), "u1".to_string()],
-        };
-        run_test_case(test_case).await;
-    }
-
-    #[mz_ore::test(tokio::test)]
-    #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
-    async fn test_builtin_migration_topological_sort() {
-        let test_case = BuiltinMigrationTestCase {
-            test_name: "topological_sort",
-            initial_state: vec![
-                SimplifiedCatalogEntry {
-                    name: "s1".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::Table,
-                },
-                SimplifiedCatalogEntry {
-                    name: "s2".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::Table,
-                },
-                SimplifiedCatalogEntry {
-                    name: "u1".to_string(),
-                    namespace: ItemNamespace::User,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s2".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "u2".to_string(),
-                    namespace: ItemNamespace::User,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s1".to_string(), "u1".to_string()],
-                    },
-                },
-            ],
-            migrated_names: vec!["s1".to_string(), "s2".to_string()],
-            expected_previous_storage_collection_names: vec![
-                "u2".to_string(),
-                "u1".to_string(),
-                "s1".to_string(),
-                "s2".to_string(),
-            ],
-            expected_migrated_system_object_mappings: vec!["s1".to_string(), "s2".to_string()],
-            expected_user_item_drop_ops: vec!["u2".to_string(), "u1".to_string()],
-            expected_user_item_create_ops: vec!["u1".to_string(), "u2".to_string()],
-        };
-        run_test_case(test_case).await;
-    }
-
-    #[mz_ore::test(tokio::test)]
-    #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
-    async fn test_builtin_migration_topological_sort_complex() {
-        let test_case = BuiltinMigrationTestCase {
-            test_name: "topological_sort_complex",
-            initial_state: vec![
-                SimplifiedCatalogEntry {
-                    name: "s273".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::Table,
-                },
-                SimplifiedCatalogEntry {
-                    name: "s322".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::Table,
-                },
-                SimplifiedCatalogEntry {
-                    name: "s317".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::Table,
-                },
-                SimplifiedCatalogEntry {
-                    name: "s349".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s273".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "s421".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s273".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "s295".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s273".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "s296".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s295".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "s320".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s295".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "s340".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s295".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "s318".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s295".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "s323".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s295".to_string(), "s322".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "s330".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s318".to_string(), "s317".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "s321".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s318".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "s315".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s296".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "s354".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s296".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "s327".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s296".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "s339".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s296".to_string()],
-                    },
-                },
-                SimplifiedCatalogEntry {
-                    name: "s355".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::MaterializedView {
-                        referenced_names: vec!["s315".to_string()],
-                    },
-                },
-            ],
-            migrated_names: vec![
-                "s273".to_string(),
-                "s317".to_string(),
-                "s318".to_string(),
-                "s320".to_string(),
-                "s321".to_string(),
-                "s322".to_string(),
-                "s323".to_string(),
-                "s330".to_string(),
-                "s339".to_string(),
-                "s340".to_string(),
-            ],
-            expected_previous_storage_collection_names: vec![
-                "s349".to_string(),
-                "s421".to_string(),
-                "s355".to_string(),
-                "s315".to_string(),
-                "s354".to_string(),
-                "s327".to_string(),
-                "s339".to_string(),
-                "s296".to_string(),
-                "s320".to_string(),
-                "s340".to_string(),
-                "s330".to_string(),
-                "s321".to_string(),
-                "s318".to_string(),
-                "s323".to_string(),
-                "s295".to_string(),
-                "s273".to_string(),
-                "s317".to_string(),
-                "s322".to_string(),
-            ],
-            expected_migrated_system_object_mappings: vec![
-                "s322".to_string(),
-                "s317".to_string(),
-                "s273".to_string(),
-                "s295".to_string(),
-                "s323".to_string(),
-                "s318".to_string(),
-                "s321".to_string(),
-                "s330".to_string(),
-                "s340".to_string(),
-                "s320".to_string(),
-                "s296".to_string(),
-                "s339".to_string(),
-                "s327".to_string(),
-                "s354".to_string(),
-                "s315".to_string(),
-                "s355".to_string(),
-                "s421".to_string(),
-                "s349".to_string(),
-            ],
-            expected_user_item_drop_ops: vec![],
-            expected_user_item_create_ops: vec![],
-        };
-        run_test_case(test_case).await;
-    }
-
-    #[mz_ore::test(tokio::test)]
-    #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
-    async fn test_builtin_migration_system_child_migrations() {
-        let test_case = BuiltinMigrationTestCase {
-            test_name: "system_child_migrations",
-            initial_state: vec![
-                SimplifiedCatalogEntry {
-                    name: "s1".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::Table,
-                },
-                SimplifiedCatalogEntry {
-                    name: "s2".to_string(),
-                    namespace: ItemNamespace::System,
-                    item: SimplifiedItem::Index {
-                        on: "s1".to_string(),
-                    },
-                },
-            ],
-            migrated_names: vec!["s1".to_string()],
-            expected_previous_storage_collection_names: vec!["s1".to_string()],
-            expected_migrated_system_object_mappings: vec!["s1".to_string(), "s2".to_string()],
-            expected_user_item_drop_ops: vec![],
-            expected_user_item_create_ops: vec![],
-        };
-        run_test_case(test_case).await;
-    }
 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3983,17 +3983,14 @@ pub fn serve(
             .open(controller_config.persist_location.clone())
             .await
             .context("opening persist client")?;
-        let builtin_item_migration_config = if enable_0dt_deployment {
-            BuiltinItemMigrationConfig::ZeroDownTime {
+        let builtin_item_migration_config =
+            BuiltinItemMigrationConfig {
                 persist_client: persist_client.clone(),
                 read_only: read_only_controllers,
             }
-        } else {
-            BuiltinItemMigrationConfig::Legacy
-        };
+        ;
         let OpenCatalogResult {
             mut catalog,
-            storage_collections_to_drop,
             migrated_storage_collections_0dt,
             new_builtin_collections,
             builtin_table_updates,
@@ -4158,7 +4155,6 @@ pub fn serve(
                             controller_config,
                             controller_envd_epoch,
                             read_only_controllers,
-                            storage_collections_to_drop,
                         )
                     })
                     .unwrap_or_terminate("failed to initialize storage_controller");

--- a/src/catalog/src/config.rs
+++ b/src/catalog/src/config.rs
@@ -94,12 +94,9 @@ pub struct StateConfig {
 }
 
 #[derive(Debug)]
-pub enum BuiltinItemMigrationConfig {
-    Legacy,
-    ZeroDownTime {
-        persist_client: PersistClient,
-        read_only: bool,
-    },
+pub struct BuiltinItemMigrationConfig {
+    pub persist_client: PersistClient,
+    pub read_only: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -812,7 +812,6 @@ mod tests {
             &self,
             _txn: &mut (dyn StorageTxn<Self::Timestamp> + Send),
             _init_ids: BTreeSet<GlobalId>,
-            _drop_ids: BTreeSet<GlobalId>,
         ) -> Result<(), StorageError<Self::Timestamp>> {
             unimplemented!()
         }


### PR DESCRIPTION
Previously, the adapter maintained two different implementations of the
builtin item migration framework. One that was used before 0dt and one
that was used with 0dt. The 0dt implementation still works when 0dt is
turned off, but we wanted to keep the legacy implementation around
while the 0dt implementation was still new. The 0dt implementation has
been around long enough in production to prove that it works. On the
other hand, the legacy implementation has not been tested in production
in a long time.

This commit removes the legacy implementation and always uses the new
implementation. This should reduce the maintenance burden of builtin
item migrations.

In the future, the builtin item migration framework should be
completely removed and replaced with `ALTER TABLE`.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
