### PR TITLE
ci: Clean up potentially leftover state in case job was cancelled

### DIFF
--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -145,3 +145,7 @@ ci_unimportant_heading ":docker: Cleaning up after mzcompose"
 run kill || true
 run rm --force -v
 run down --volumes
+
+ci_unimportant_heading "terraform: Destroying leftover state in case job was cancelled or timed out..."
+bin/ci-builder run stable terraform -chdir=test/terraform/aws destroy || true
+bin/ci-builder run stable terraform -chdir=test/terraform/gcp destroy || true


### PR DESCRIPTION
Cancellation happened in https://buildkite.com/materialize/nightly/builds/10992#0194ae51-f610-4440-84f7-84fb30f17361 which resulted in leftover state making https://buildkite.com/materialize/nightly/builds/10995#0194ae83-c4ed-475a-8309-e8e6a5b80a02 not run

The usual cleanup logic can't be run even though it's in a `finally` block in our Python test code. The `pre-exit` hook is still being run.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
