### PR TITLE
adapter: Enrich expr cache version in dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,6 +1410,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "buildid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0188344028070a23e23eebec37f4c5699db7b5a5fd088d97e6fae7727ac0dd77"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "winapi",
+]
+
+[[package]]
 name = "built"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4857,7 +4869,9 @@ dependencies = [
 name = "mz-build-info"
 version = "0.0.0"
 dependencies = [
+ "buildid",
  "compile-time-run",
+ "hex",
  "semver",
  "workspace-hack",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -160,6 +160,7 @@ name = "strum-macros"
 name = "log"
 wrappers = [
     "azure_svc_blobstorage",
+    "buildid",
     "deadpool-postgres",
     "eventsource-client",
     "fail",

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -462,8 +462,18 @@ impl Catalog {
                 )
                 .collect();
             let dyncfgs = config.persist_client.dyncfgs().clone();
+            let build_version = if config.build_info.is_dev() {
+                // A single dev version can be used for many different builds, so we need to use
+                // the build version that is also enriched with build metadata.
+                config
+                    .build_info
+                    .semver_version_build()
+                    .expect("build ID is not available on your platform!")
+            } else {
+                config.build_info.semver_version()
+            };
             let expr_cache_config = ExpressionCacheConfig {
-                build_version: config.build_info.semver_version(),
+                build_version,
                 shard_id: txn
                     .get_expression_cache_shard()
                     .expect("expression cache shard should exist for opened catalogs"),

--- a/src/build-info/Cargo.toml
+++ b/src/build-info/Cargo.toml
@@ -10,7 +10,9 @@ publish = false
 workspace = true
 
 [dependencies]
+buildid = "1.0.3"
 compile-time-run = "0.2.12"
+hex = "0.4.3"
 semver = { version = "1.0.16", optional = true }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 

--- a/src/build-info/src/lib.rs
+++ b/src/build-info/src/lib.rs
@@ -64,6 +64,18 @@ impl BuildInfo {
             .expect("build version is not valid semver")
     }
 
+    /// The same as [`Self::semver_version`], but includes build metadata in the returned version,
+    /// if build metadata is available on the compiled platform.
+    #[cfg(feature = "semver")]
+    pub fn semver_version_build(&self) -> Option<semver::Version> {
+        let build_id = buildid::build_id()?;
+        let build_id = hex::encode(build_id);
+        let version = format!("{}+{}", self.version, build_id)
+            .parse()
+            .expect("build version is not valid semver");
+        Some(version)
+    }
+
     /// Returns the version as an integer along the lines of Pg's server_version_num
     #[cfg(feature = "semver")]
     pub fn version_num(&self) -> i32 {
@@ -76,6 +88,11 @@ impl BuildInfo {
             semver.major, semver.minor, semver.patch
         );
         ver_string.parse::<i32>().unwrap()
+    }
+
+    /// Returns whether the version is a development version
+    pub fn is_dev(&self) -> bool {
+        self.version.contains("dev")
     }
 }
 


### PR DESCRIPTION
The expression cache uses the build version as part of the key to ensure that a materialize instance only tries to deserialize expressions that were serialized using the same version of the code. However, a single dev build version can be used for many different builds, which can lead to errors in deserialization when running locally. This commit fixes the issue by enriching dev build versions with build metadata containing the build ID.

Note: we could enrich all build versions with build ID metadata without any correctness issues. However, the ID is fairly long and must be stored for each expression. Since we already have the guarantee that a prod build version is only ever used with a single build, it would be wasted space for prod build versions.

Fixes #MaterializeInc/database-issues/issues/8930

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
