### PR TITLE
ci: Disable some tests and work around recent flakes

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1144,6 +1144,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: persist
               args: [--node-count=4, --consensus=cockroach, --blob=maelstrom, --time-limit=300, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
+        skip: "reenable when https://github.com/MaterializeInc/database-issues/issues/8637 is fixed"
 
       - id: txn-wal-maelstrom
         label: Maelstrom coverage of txn-wal

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -496,7 +496,8 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
         disruption.disruption(c)
 
         validate(c)
-        validate_introspection_compaction(c, disruption.compaction_checks)
+        # TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/8932 is fixed
+        # validate_introspection_compaction(c, disruption.compaction_checks)
 
 
 def get_single_value_from_cursor(cursor: Cursor) -> Any:

--- a/test/testdrive/alter-sink.td
+++ b/test/testdrive/alter-sink.td
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/8636 is fixed
+$ skip-if
+SELECT true
+
 $ set-arg-default single-replica-cluster=quickstart
 
 > CREATE CONNECTION kafka_conn
@@ -126,10 +130,6 @@ contains:canceling statement due to user request
 $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=10s
 
 > INSERT INTO created_post_alter VALUES ('hundred', 99);
-
-# TODO: Reenable when database-issues#8636 is fixed
-$ skip-if
-SELECT true
 
 $ kafka-verify-data format=json sink=materialize.public.sink key=false
 {"before": null, "after": {"created_post_name": "hundred", "created_post_value": 99}}

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -117,7 +117,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
   SELECT true
   FROM mz_introspection.mz_compute_frontiers f, mz_internal.mz_subscriptions s
   WHERE f.export_id = s.id AND time > 0)
-> FETCH 1 c WITH (timeout='5s')
+> FETCH 1 c WITH (timeout='20s')
 <TIMESTAMP> 1 true
 > COMMIT
 


### PR DESCRIPTION
From Nightly failures today and yesterday.

We have too many flakes currently, making Nightly annoying to use. The fact that I'm disabling some tests now is also pretty bad since we have reduced test coverage, I'd appreciate any progress on:
- https://github.com/MaterializeInc/database-issues/issues/8637 @bkirwi 
- https://github.com/MaterializeInc/database-issues/issues/8932 Already pinged in https://materializeinc.slack.com/archives/C08ACQNGSQK/p1738168087934519
- https://github.com/MaterializeInc/database-issues/issues/8636 @petrosagg 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
