### PR TITLE
doc/user: remove maintenance window

### DIFF
--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -10,7 +10,7 @@ menu:
 ---
 
 We are continually improving Materialize with new features and bug fixes. We
-periodically release these improvements to your Materialize account. This page
+release these improvements to your Materialize account weekly. This page
 describes the changes in each release and the process by which they are
 deployed.
 
@@ -24,29 +24,19 @@ and [documentation](https://materialize.com/docs/lts/).
 
 ## Schedule
 
-Materialize upgrades all regions to the latest release each week according to
-the following schedule:
+Materialize upgrades all regions to the latest release each week. Materialize
+may occasionally deploy additional releases to fix urgent bugs as well.
 
-Region        | Day of week | Time
---------------|-------------|-----------------------------
-aws/eu-west-1 | Wednesday   | 2100-2300 [Europe/Dublin]
-aws/us-east-1 | Thursday    | 0500-0700 [America/New_York]
-aws/us-west-2 | Thursday    | 0500-0700 [America/New_York]
+When your region is upgraded, clients connected to the region will experience a
+short period of unavailability. During this period, connection requests may fail
+and queries may stall. Most regions experience less than 10 seconds of
+unavailability. Regions with a large number of database objects (i.e., sources,
+views, indexes, etc.) may experience a longer period of unavailability, but
+typically less than 30 seconds.
 
-{{< note >}}
-Upgrade windows follow any daylight saving time or summer time rules
-for their indicated time zone.
-{{< /note >}}
-
-Upgrade windows were chosen to be outside of business hours in the most
-representative time zone for the region.
-
-Materialize may occasionally deploy unscheduled releases to fix urgent bugs as well.
-
-You can find details about upcoming and current maintenance on the [status
-page](https://status.materialize.com). You can also use the [status page API](https://status.materialize.com/api) to programmatically access this information.
-
-When your region is upgraded, you’ll experience just a few minutes of downtime. After the initial downtime, the new version of Materialize will begin rehydrating your indexes and materialized views. This takes time proportional to data volume and query complexity. Indexes and materialized views with large amounts of data will take longer to rehydrate than indexes and materialized views with small amounts of data. Similarly, indexes and materialized views for complex queries will take longer to rehydrate than indexes and materialized views for simple queries.
+We do not currently make public commitments about the precise timing of region
+upgrades. If you have specific needs around the timing of upgrades, please [file
+a support ticket](/support).
 
 ## Versioning
 


### PR DESCRIPTION
Now that we have zero-downtime deployments, we no longer need to publish the maintenance window timing. Instead, document the small period of unavailability that occurs during the weekly upgrade.

Part of MaterializeInc/database-issues#8095.
