### PR TITLE
Properly disable introspection subscribes in replica isolation test

### DIFF
--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -454,7 +454,7 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
         user="mz_system",
     )
 
-    if ArrangedIntro in disruption.compaction_checks:
+    if any(isinstance(check, ArrangedIntro) for check in disruption.compaction_checks):
         # Disable introspection subscribes because they break the
         # `ArrangedIntro` check by disabling compaction of logging indexes
         # on all replicas if one of the replicas is failing. That's because

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -504,8 +504,7 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
         disruption.disruption(c)
 
         validate(c)
-        # TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/8932 is fixed
-        # validate_introspection_compaction(c, disruption.compaction_checks)
+        validate_introspection_compaction(c, disruption.compaction_checks)
 
 
 def get_single_value_from_cursor(cursor: Cursor) -> Any:


### PR DESCRIPTION
We noticed that the check for `AllowCompaction` commands flakes. Fix an incorrect check to disable introspection subscribes.

Fixes MaterializeInc/database-issues#8932

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
