### PR TITLE
Listen on 0.0.0.0:6876 through cli

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -277,6 +277,7 @@ def main() -> int:
                 # Setting the listen addresses below to 0.0.0.0 is required
                 # to allow Prometheus running in Docker (misc/prometheus)
                 # access these services to scrape metrics.
+                "--http-listen-addr=0.0.0.0:6876",
                 "--internal-http-listen-addr=0.0.0.0:6878",
                 "--orchestrator=process",
                 f"--orchestrator-process-secrets-directory={MZDATA}/secrets",

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -275,8 +275,8 @@ def main() -> int:
             print(f"persist-blob-url: {args.blob}")
             command += [
                 # Setting the listen addresses below to 0.0.0.0 is required
-                # to allow Prometheus running in Docker (misc/prometheus)
-                # access these services to scrape metrics.
+                # to allow other services (e.g., docker containers) to
+                # access these services.
                 "--http-listen-addr=0.0.0.0:6876",
                 "--internal-http-listen-addr=0.0.0.0:6878",
                 "--orchestrator=process",


### PR DESCRIPTION
At the moment, we're exposing the default DB port 6876 only to localhost,
but the internal one to all addresses. This makes it difficult to test the
console locally because it needs access to 6876, and running it on the
host's network can cause other port collisions.

For this reason, open up connections to 6876 to all hosts. This is not a
security regression as we're already opening the internal endpoint to all
addresses.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
