### PR TITLE
self-managed: Introduce script to cut releases

### DIFF
--- a/bin/cut-self-managed-release
+++ b/bin/cut-self-managed-release
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# cut-self-managed-release -- cuts a new self-managed Mz release and pushes the
+# lts-v* branch to the upstream Materialize repository.
+
+exec "$(dirname "$0")"/pyactivate -m materialize.release.cut_self_managed_release "$@"

--- a/misc/python/materialize/cli/helm_chart_version_bump.py
+++ b/misc/python/materialize/cli/helm_chart_version_bump.py
@@ -21,7 +21,12 @@ def main() -> int:
         prog="helm-chart-version-bump",
         description="Bump environmentd/orchestratord versions in helm chart.",
     )
-    parser.add_argument("version", type=str, help="Version to bump to.")
+    parser.add_argument(
+        "--helm-chart-version",
+        type=str,
+        help="Helm-chart version to bump to, no change if not set.",
+    )
+    parser.add_argument("version", type=str, help="Materialize version to bump to.")
     args = parser.parse_args()
 
     yaml = YAML()
@@ -56,6 +61,15 @@ def main() -> int:
             ),
         ),
     ]
+
+    if args.helm_chart_version:
+        mods.append(
+            (
+                MZ_ROOT / "misc" / "helm-charts" / "operator" / "Chart.yaml",
+                lambda docs: docs[0].update({"version": args.helm_chart_version}),
+            )
+        )
+
     for file, mod in mods:
         with open(file) as f:
             docs = list(yaml.load_all(f))

--- a/misc/python/materialize/release/cut_self_managed_release.py
+++ b/misc/python/materialize/release/cut_self_managed_release.py
@@ -1,0 +1,86 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Cut a new self-managed release and push the lts-v* branch to the upstream Materialize repository."""
+
+import argparse
+import re
+import sys
+
+from semver.version import Version
+
+from materialize import MZ_ROOT, spawn
+from materialize.git import checkout, commit_all_changed, fetch, get_branch_name
+
+
+def parse_version(version: str) -> Version:
+    return Version.parse(re.sub(r"^v", "", version))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="cut_self_managed_release",
+        description="Creates a new self-managed Materialize release",
+    )
+    parser.add_argument(
+        "--mz-version",
+        help="Version of Materialize, has to exist already",
+        type=parse_version,
+        required=True,
+    )
+    parser.add_argument(
+        "--helm-chart-version",
+        help="Version of Helm Chart, will be created",
+        type=parse_version,
+        required=True,
+    )
+    parser.add_argument(
+        "--remote",
+        help="Git remote name of Materialize repo",
+        type=str,
+        required=True,
+    )
+
+    args = parser.parse_args()
+    mz_version = f"v{args.mz_version}"
+    helm_chart_version = f"v{args.helm_chart_version}"
+    lts_branch = f"lts-v{args.mz_version.major}.{args.mz_version.minor}"
+    remote_lts_branch = f"{args.remote}/{lts_branch}"
+    current_branch = get_branch_name()
+
+    try:
+        fetch(args.remote)
+        print(f"Checking out LTS branch {remote_lts_branch}")
+        checkout(remote_lts_branch)
+        print(
+            f"Bumping helm-chart version to {helm_chart_version} with Materialize {mz_version}"
+        )
+        spawn.runv(
+            [
+                MZ_ROOT / "bin" / "helm-chart-version-bump",
+                f"--helm-chart-version={helm_chart_version}",
+                mz_version,
+            ]
+        )
+        print("Recreating helm-docs")
+        spawn.runv(["helm-docs", "misc/helm-charts"])
+        print("Creating commit")
+        commit_all_changed(
+            f"Bumping helm-chart version to {helm_chart_version} with Materialize {mz_version}"
+        )
+        print(f"Pushing to {remote_lts_branch}")
+        spawn.runv(["git", "push", args.remote, f"HEAD:{lts_branch}"])
+    finally:
+        # The caller may have started in a detached HEAD state.
+        if current_branch:
+            checkout(current_branch)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
To automate what I've been doing manually for v25.1.0 and v25.1.1

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
