### PR TITLE
tests: Fix latest version in migration tests

### DIFF
--- a/misc/python/materialize/source_table_migration.py
+++ b/misc/python/materialize/source_table_migration.py
@@ -10,6 +10,7 @@
 """Utilities for testing the source table migration"""
 from materialize.mz_version import MzVersion
 from materialize.mzcompose.composition import Composition
+from materialize.version_list import get_published_minor_mz_versions
 
 
 def verify_sources_after_source_table_migration(
@@ -61,8 +62,22 @@ def check_source_table_migration_test_sensible() -> None:
     ), "migration test probably no longer needed"
 
 
+_last_version: MzVersion | None = None
+
+
 def get_old_image_for_source_table_migration_test() -> str:
-    return "materialize/materialized:v0.131.0"
+    global _last_version
+    if _last_version is None:
+        current_version = MzVersion.parse_cargo()
+        minor_versions = [
+            v
+            for v in get_published_minor_mz_versions(
+                limit=4, exclude_current_minor_version=True
+            )
+            if v < current_version
+        ]
+        _last_version = minor_versions[0]
+    return f"materialize/materialized:{_last_version}"
 
 
 def get_new_image_for_source_table_migration_test() -> str | None:


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/30483

Failed in https://buildkite.com/materialize/nightly/builds/11022
```
pg-cdc-old-syntax-materialized-1  | environmentd: fatal: incompatible persist version 0.131.0, current: 0.133.0-dev.0, make sure to upgrade the catalog one version forward at a time
```
Test run: https://buildkite.com/materialize/nightly/builds/11029

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
