### PR TITLE
Remove redundant types in compute

### DIFF
--- a/src/compute/src/arrangement/manager.rs
+++ b/src/compute/src/arrangement/manager.rs
@@ -14,20 +14,17 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::time::Instant;
 
-use differential_dataflow::lattice::{antichain_join, Lattice};
+use differential_dataflow::lattice::antichain_join;
 use differential_dataflow::operators::arrange::{Arranged, ShutdownButton, TraceAgent};
 use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
 use differential_dataflow::trace::TraceReader;
 use mz_repr::{Diff, GlobalId, Timestamp};
-use timely::dataflow::operators::{probe, CapabilitySet, Probe};
-use timely::dataflow::scopes::Child;
+use timely::dataflow::operators::CapabilitySet;
 use timely::dataflow::Scope;
 use timely::progress::frontier::{Antichain, AntichainRef};
-use timely::progress::timestamp::Refines;
 use timely::PartialOrder;
 
 use crate::metrics::TraceMetrics;
-use crate::render::context::MzArrangementImport;
 use crate::typedefs::{ErrAgent, RowRowAgent};
 
 /// A `TraceManager` stores maps from global identifiers to the primary arranged
@@ -102,89 +99,6 @@ impl TraceManager {
     /// Removes the trace for `id`.
     pub fn remove(&mut self, id: &GlobalId) -> Option<TraceBundle> {
         self.traces.remove(id)
-    }
-}
-
-/// An abstraction of a trace handle.
-///
-/// This type exists as an `enum` to support potential experimentation with alternate
-/// representation and layouts.
-#[derive(Clone)]
-pub enum SpecializedTraceHandle {
-    RowRow(PaddedTrace<RowRowAgent<Timestamp, Diff>>),
-}
-
-impl From<RowRowAgent<Timestamp, Diff>> for SpecializedTraceHandle {
-    fn from(trace: RowRowAgent<Timestamp, Diff>) -> Self {
-        Self::RowRow(trace.into())
-    }
-}
-
-impl SpecializedTraceHandle {
-    /// Obtains the logical compaction frontier for the underlying trace handle.
-    fn get_logical_compaction(&mut self) -> AntichainRef<Timestamp> {
-        match self {
-            SpecializedTraceHandle::RowRow(handle) => handle.get_logical_compaction(),
-        }
-    }
-
-    /// Advances the logical compaction frontier for the underlying trace handle.
-    pub fn set_logical_compaction(&mut self, frontier: AntichainRef<Timestamp>) {
-        match self {
-            SpecializedTraceHandle::RowRow(handle) => handle.set_logical_compaction(frontier),
-        }
-    }
-
-    /// Advances the physical compaction frontier for the underlying trace handle.
-    pub fn set_physical_compaction(&mut self, frontier: AntichainRef<Timestamp>) {
-        match self {
-            SpecializedTraceHandle::RowRow(handle) => handle.set_physical_compaction(frontier),
-        }
-    }
-
-    /// Reads the upper frontier of the underlying trace handle.
-    pub fn read_upper(&mut self, target: &mut Antichain<Timestamp>) {
-        match self {
-            SpecializedTraceHandle::RowRow(handle) => handle.read_upper(target),
-        }
-    }
-
-    /// Maps the underlying trace handle to a `MzArrangementImport`,
-    /// while readjusting times by `since` and `until`.
-    pub fn import_frontier<'g, G, T>(
-        &mut self,
-        scope: &Child<'g, G, T>,
-        name: &str,
-        since: Antichain<Timestamp>,
-        until: Antichain<Timestamp>,
-        input_probe: probe::Handle<Timestamp>,
-    ) -> (
-        MzArrangementImport<Child<'g, G, T>, Timestamp>,
-        ShutdownButton<CapabilitySet<Timestamp>>,
-    )
-    where
-        G: Scope<Timestamp = Timestamp>,
-        T: Lattice + Refines<G::Timestamp>,
-    {
-        match self {
-            SpecializedTraceHandle::RowRow(handle) => {
-                let (oks, oks_button) =
-                    handle.import_frontier_core(&scope.parent, name, since, until);
-                let oks = Arranged {
-                    stream: oks.stream.probe_with(&input_probe),
-                    trace: oks.trace,
-                };
-                (MzArrangementImport::RowRow(oks.enter(scope)), oks_button)
-            }
-        }
-    }
-
-    /// Turns this trace into a padded version that reports empty data for all times less than the
-    /// trace's current logical compaction frontier.
-    fn into_padded(self) -> Self {
-        match self {
-            Self::RowRow(trace) => Self::RowRow(trace.into_padded()),
-        }
     }
 }
 
@@ -329,7 +243,7 @@ where
 /// the lifetime of the bundled traces (`to_drop`).
 #[derive(Clone)]
 pub struct TraceBundle {
-    oks: SpecializedTraceHandle,
+    oks: PaddedTrace<RowRowAgent<Timestamp, Diff>>,
     errs: PaddedTrace<ErrAgent<Timestamp, Diff>>,
     to_drop: Option<Rc<dyn Any>>,
 }
@@ -338,7 +252,7 @@ impl TraceBundle {
     /// Constructs a new trace bundle out of an `oks` trace and `errs` trace.
     pub fn new<O, E>(oks: O, errs: E) -> TraceBundle
     where
-        O: Into<SpecializedTraceHandle>,
+        O: Into<PaddedTrace<RowRowAgent<Timestamp, Diff>>>,
         E: Into<PaddedTrace<ErrAgent<Timestamp, Diff>>>,
     {
         TraceBundle {
@@ -360,7 +274,7 @@ impl TraceBundle {
     }
 
     /// Returns a mutable reference to the `oks` trace.
-    pub fn oks_mut(&mut self) -> &mut SpecializedTraceHandle {
+    pub fn oks_mut(&mut self) -> &mut PaddedTrace<RowRowAgent<Timestamp, Diff>> {
         &mut self.oks
     }
 

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -62,7 +62,7 @@ use tokio::sync::{oneshot, watch};
 use tracing::{debug, error, info, span, warn, Level};
 use uuid::Uuid;
 
-use crate::arrangement::manager::{SpecializedTraceHandle, TraceBundle, TraceManager};
+use crate::arrangement::manager::{TraceBundle, TraceManager};
 use crate::logging;
 use crate::logging::compute::{CollectionLogging, ComputeEvent, PeekEvent};
 use crate::metrics::ComputeMetrics;
@@ -1334,22 +1334,7 @@ impl IndexPeek {
             cursor.step_key(&storage);
         }
 
-        self.dispatch_collect_ok_finished_data(max_result_size)
-    }
-
-    /// Dispatches peek finishing of data in the ok stream according to
-    /// arrangement key-value types.
-    fn dispatch_collect_ok_finished_data(
-        &mut self,
-        max_result_size: u64,
-    ) -> Result<Vec<(Row, NonZeroUsize)>, String> {
-        let peek = &mut self.peek;
-        let oks = self.trace_bundle.oks_mut();
-        match oks {
-            SpecializedTraceHandle::RowRow(oks_handle) => {
-                Self::collect_ok_finished_data(peek, oks_handle, max_result_size)
-            }
-        }
+        Self::collect_ok_finished_data(&mut self.peek, self.trace_bundle.oks_mut(), max_result_size)
     }
 
     /// Collects data for a known-complete peek from the ok stream.

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -391,14 +391,10 @@ where
                 let mut row_builder = binding.borrow_mut();
                 let temp_storage = RowArena::new();
 
-                let key = key.to_datum_iter();
-                let stream_row = stream_row.to_datum_iter();
-                let lookup_row = lookup_row.to_datum_iter();
-
                 let mut datums_local = datums.borrow();
-                datums_local.extend(key);
-                datums_local.extend(stream_row);
-                datums_local.extend(lookup_row);
+                datums_local.extend(key.iter());
+                datums_local.extend(stream_row.iter());
+                datums_local.extend(lookup_row.to_datum_iter());
 
                 let row = closure.apply(&mut datums_local, &temp_storage, &mut row_builder);
                 let diff = diff1.clone() * diff2.clone();
@@ -440,14 +436,10 @@ where
                 let mut row_builder = binding.borrow_mut();
                 let temp_storage = RowArena::new();
 
-                let key = key.to_datum_iter();
-                let stream_row = stream_row.to_datum_iter();
-                let lookup_row = lookup_row.to_datum_iter();
-
                 let mut datums_local = datums.borrow();
-                datums_local.extend(key);
-                datums_local.extend(stream_row);
-                datums_local.extend(lookup_row);
+                datums_local.extend(key.iter());
+                datums_local.extend(stream_row.iter());
+                datums_local.extend(lookup_row.to_datum_iter());
 
                 let row = closure
                     .apply(&mut datums_local, &temp_storage, &mut row_builder)
@@ -513,12 +505,9 @@ where
                                             let time = time.into_owned();
                                             let temp_storage = RowArena::new();
 
-                                            let key = key.to_datum_iter();
-                                            let val = val.to_datum_iter();
-
                                             let mut datums_local = datums.borrow();
-                                            datums_local.extend(key);
-                                            datums_local.extend(val);
+                                            datums_local.extend(key.to_datum_iter());
+                                            datums_local.extend(val.to_datum_iter());
 
                                             if !initial_closure.is_identity() {
                                                 match initial_closure

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -17,29 +17,25 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use columnar::Columnar;
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
-use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::cursor::IntoOwned;
 use differential_dataflow::trace::{BatchReader, Cursor, TraceReader};
-use differential_dataflow::{AsCollection, Collection, ExchangeData, Hashable};
+use differential_dataflow::{AsCollection, Collection};
 use mz_compute_types::plan::join::delta_join::{DeltaJoinPlan, DeltaPathPlan, DeltaStagePlan};
 use mz_compute_types::plan::join::JoinClosure;
 use mz_expr::MirScalarExpr;
-use mz_repr::fixed_length::{FromDatumIter, ToDatumIter};
+use mz_repr::fixed_length::ToDatumIter;
 use mz_repr::{DatumVec, Diff, Row, RowArena, SharedRow};
 use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::{CollectionExt, StreamExt};
-use timely::container::columnation::Columnation;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::{Map, OkErr};
 use timely::dataflow::Scope;
 use timely::progress::timestamp::Refines;
-use timely::progress::{Antichain, Timestamp};
+use timely::progress::Antichain;
 
-use crate::render::context::{
-    ArrangementFlavor, CollectionBundle, Context, MzArrangement, MzArrangementImport, ShutdownToken,
-};
+use crate::render::context::{ArrangementFlavor, CollectionBundle, Context, ShutdownToken};
 use crate::render::RenderTimestamp;
 use crate::typedefs::{RowRowAgent, RowRowEnter};
 
@@ -154,23 +150,25 @@ where
                     let update_stream = match val {
                         Ok(local) => {
                             let arranged = local.enter_region(region);
-                            let (update_stream, err_stream) = dispatch_build_update_stream_local(
-                                arranged,
-                                as_of,
-                                source_relation,
-                                initial_closure,
-                            );
+                            let (update_stream, err_stream) =
+                                build_update_stream::<_, RowRowAgent<_, _>>(
+                                    arranged,
+                                    as_of,
+                                    source_relation,
+                                    initial_closure,
+                                );
                             region_errs.push(err_stream);
                             update_stream
                         }
                         Err(trace) => {
                             let arranged = trace.enter_region(region);
-                            let (update_stream, err_stream) = dispatch_build_update_stream_trace(
-                                arranged,
-                                as_of,
-                                source_relation,
-                                initial_closure,
-                            );
+                            let (update_stream, err_stream) =
+                                build_update_stream::<_, RowRowEnter<_, _, _>>(
+                                    arranged,
+                                    as_of,
+                                    source_relation,
+                                    initial_closure,
+                                );
                             region_errs.push(err_stream);
                             update_stream
                         }
@@ -207,7 +205,7 @@ where
                             match arrangements.get(&(lookup_relation, lookup_key)).unwrap() {
                                 Ok(local) => {
                                     if source_relation < lookup_relation {
-                                        dispatch_build_halfjoin_local(
+                                        build_halfjoin::<_, RowRowAgent<_, _>, _>(
                                             update_stream,
                                             local.enter_region(region),
                                             stream_key,
@@ -217,7 +215,7 @@ where
                                             self.shutdown_token.clone(),
                                         )
                                     } else {
-                                        dispatch_build_halfjoin_local(
+                                        build_halfjoin::<_, RowRowAgent<_, _>, _>(
                                             update_stream,
                                             local.enter_region(region),
                                             stream_key,
@@ -230,7 +228,7 @@ where
                                 }
                                 Err(trace) => {
                                     if source_relation < lookup_relation {
-                                        dispatch_build_halfjoin_trace(
+                                        build_halfjoin::<_, RowRowEnter<_, _, _>, _>(
                                             update_stream,
                                             trace.enter_region(region),
                                             stream_key,
@@ -240,7 +238,7 @@ where
                                             self.shutdown_token.clone(),
                                         )
                                     } else {
-                                        dispatch_build_halfjoin_trace(
+                                        build_halfjoin::<_, RowRowEnter<_, _, _>, _>(
                                             update_stream,
                                             trace.enter_region(region),
                                             stream_key,
@@ -314,73 +312,6 @@ where
     }
 }
 
-/// Dispatches half-join construction according to arrangement type specialization.
-fn dispatch_build_halfjoin_local<G, CF>(
-    updates: Collection<G, (Row, G::Timestamp), Diff>,
-    trace: MzArrangement<G>,
-    prev_key: Vec<MirScalarExpr>,
-    prev_thinning: Vec<usize>,
-    comparison: CF,
-    closure: JoinClosure,
-    shutdown_token: ShutdownToken,
-) -> (
-    Collection<G, (Row, G::Timestamp), Diff>,
-    Collection<G, DataflowError, Diff>,
-)
-where
-    G: Scope,
-    G::Timestamp: RenderTimestamp,
-    <G::Timestamp as Columnar>::Container: Clone + Send,
-    for<'a> <G::Timestamp as Columnar>::Ref<'a>: Ord + Copy,
-    CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
-{
-    match trace {
-        MzArrangement::RowRow(inner) => build_halfjoin::<_, RowRowAgent<_, _>, Row, _>(
-            updates,
-            inner,
-            prev_key,
-            prev_thinning,
-            comparison,
-            closure,
-            shutdown_token,
-        ),
-    }
-}
-
-/// Dispatches half-join construction according to trace type specialization.
-fn dispatch_build_halfjoin_trace<G, T, CF>(
-    updates: Collection<G, (Row, G::Timestamp), Diff>,
-    trace: MzArrangementImport<G, T>,
-    prev_key: Vec<MirScalarExpr>,
-    prev_thinning: Vec<usize>,
-    comparison: CF,
-    closure: JoinClosure,
-    shutdown_token: ShutdownToken,
-) -> (
-    Collection<G, (Row, G::Timestamp), Diff>,
-    Collection<G, DataflowError, Diff>,
-)
-where
-    G: Scope,
-    T: Timestamp + Lattice + Columnation,
-    G::Timestamp: RenderTimestamp + Refines<T>,
-    <G::Timestamp as Columnar>::Container: Clone + Send,
-    for<'a> <G::Timestamp as Columnar>::Ref<'a>: Ord + Copy,
-    CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
-{
-    match trace {
-        MzArrangementImport::RowRow(inner) => build_halfjoin::<_, RowRowEnter<_, _, _>, Row, _>(
-            updates,
-            inner,
-            prev_key,
-            prev_thinning,
-            comparison,
-            closure,
-            shutdown_token,
-        ),
-    }
-}
-
 /// Constructs a `half_join` from supplied arguments.
 ///
 /// This method exists to factor common logic from four code paths that are generic over the type of trace.
@@ -391,7 +322,7 @@ where
 /// the time of the update. This operator may manipulate `time` as part of this pair, but will not manipulate
 /// the time of the update. This is crucial for correctness, as the total order on times of updates is used
 /// to ensure that any two updates are matched at most once.
-fn build_halfjoin<G, Tr, K, CF>(
+fn build_halfjoin<G, Tr, CF>(
     updates: Collection<G, (Row, G::Timestamp), Diff>,
     trace: Arranged<G, Tr>,
     prev_key: Vec<MirScalarExpr>,
@@ -409,8 +340,7 @@ where
     <G::Timestamp as Columnar>::Container: Clone + Send,
     for<'a> <G::Timestamp as Columnar>::Ref<'a>: Ord + Copy,
     Tr: TraceReader<Time = G::Timestamp, Diff = Diff> + Clone + 'static,
-    K: ExchangeData + Hashable + Default + FromDatumIter + ToDatumIter,
-    for<'a> Tr::Key<'a>: IntoOwned<'a, Owned = K>,
+    for<'a> Tr::Key<'a>: IntoOwned<'a, Owned = Row>,
     for<'a> Tr::Val<'a>: ToDatumIter,
     CF: Fn(Tr::TimeGat<'_>, &G::Timestamp) -> bool + 'static,
 {
@@ -419,17 +349,17 @@ where
     let (updates, errs) = updates.map_fallible::<CB<_>, CB<_>, _, _, _>(name, {
         // Reuseable allocation for unpacking.
         let mut datums = DatumVec::new();
-        let mut key_buf = K::default();
         move |(row, time)| {
             let temp_storage = RowArena::new();
             let datums_local = datums.borrow_with(&row);
-            let key = key_buf.try_from_datum_iter(
+            let binding = SharedRow::get();
+            let mut row_builder = binding.borrow_mut();
+            row_builder.packer().try_extend(
                 prev_key
                     .iter()
                     .map(|e| e.eval(&datums_local, &temp_storage)),
             )?;
-            let binding = SharedRow::get();
-            let mut row_builder = binding.borrow_mut();
+            let key = row_builder.clone();
             row_builder
                 .packer()
                 .extend(prev_thinning.iter().map(|&c| datums_local[c]));
@@ -528,53 +458,6 @@ where
         );
 
         (oks, errs)
-    }
-}
-
-/// Dispatches building of a delta path update stream by to arrangement type specialization.
-fn dispatch_build_update_stream_local<G>(
-    trace: MzArrangement<G>,
-    as_of: Antichain<mz_repr::Timestamp>,
-    source_relation: usize,
-    initial_closure: JoinClosure,
-) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
-where
-    G: Scope,
-    G::Timestamp: RenderTimestamp,
-    <G::Timestamp as Columnar>::Container: Clone + Send,
-    for<'a> <G::Timestamp as Columnar>::Ref<'a>: Ord + Copy,
-{
-    match trace {
-        MzArrangement::RowRow(inner) => build_update_stream::<_, RowRowAgent<_, _>>(
-            inner,
-            as_of,
-            source_relation,
-            initial_closure,
-        ),
-    }
-}
-
-/// Dispatches building of a delta path update stream by to trace type specialization.
-fn dispatch_build_update_stream_trace<G, T>(
-    trace: MzArrangementImport<G, T>,
-    as_of: Antichain<mz_repr::Timestamp>,
-    source_relation: usize,
-    initial_closure: JoinClosure,
-) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
-where
-    G: Scope,
-    T: Timestamp + Lattice + Columnation,
-    G::Timestamp: Lattice + RenderTimestamp + Refines<T>,
-    <G::Timestamp as Columnar>::Container: Clone + Send,
-    for<'a> <G::Timestamp as Columnar>::Ref<'a>: Ord + Copy,
-{
-    match trace {
-        MzArrangementImport::RowRow(inner) => build_update_stream::<_, RowRowEnter<_, _, _>>(
-            inner,
-            as_of,
-            source_relation,
-            initial_closure,
-        ),
     }
 }
 

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -502,14 +502,10 @@ where
                         let mut row_builder = binding.borrow_mut();
                         let temp_storage = RowArena::new();
 
-                        let key = key.to_datum_iter();
-                        let old = old.to_datum_iter();
-                        let new = new.to_datum_iter();
-
                         let mut datums_local = datums.borrow();
-                        datums_local.extend(key);
-                        datums_local.extend(old);
-                        datums_local.extend(new);
+                        datums_local.extend(key.to_datum_iter());
+                        datums_local.extend(old.to_datum_iter());
+                        datums_local.extend(new.to_datum_iter());
 
                         closure
                             .apply(&mut datums_local, &temp_storage, &mut row_builder)
@@ -537,14 +533,10 @@ where
                     let mut row_builder = binding.borrow_mut();
                     let temp_storage = RowArena::new();
 
-                    let key = key.to_datum_iter();
-                    let old = old.to_datum_iter();
-                    let new = new.to_datum_iter();
-
                     let mut datums_local = datums.borrow();
-                    datums_local.extend(key);
-                    datums_local.extend(old);
-                    datums_local.extend(new);
+                    datums_local.extend(key.to_datum_iter());
+                    datums_local.extend(old.to_datum_iter());
+                    datums_local.extend(new.to_datum_iter());
 
                     closure
                         .apply(&mut datums_local, &temp_storage, &mut row_builder)

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -36,9 +36,7 @@ use timely::dataflow::{Scope, ScopeParent};
 use timely::progress::timestamp::{Refines, Timestamp};
 
 use crate::extensions::arrange::MzArrangeCore;
-use crate::render::context::{
-    ArrangementFlavor, CollectionBundle, Context, MzArrangement, MzArrangementImport, ShutdownToken,
-};
+use crate::render::context::{ArrangementFlavor, CollectionBundle, Context, ShutdownToken};
 use crate::render::join::mz_join_core::mz_join_core;
 use crate::render::RenderTimestamp;
 use crate::row_spine::{RowRowBuilder, RowRowSpine};
@@ -199,9 +197,9 @@ where
     /// Streamed data as a collection.
     Collection(Collection<G, Row, Diff>),
     /// A dataflow-local arrangement.
-    Local(MzArrangement<G>),
+    Local(Arranged<G, RowRowAgent<G::Timestamp, Diff>>),
     /// An imported arrangement.
-    Trace(MzArrangementImport<G, T>),
+    Trace(Arranged<G, RowRowEnter<T, Diff, G::Timestamp>>),
 }
 
 impl<G, T> Context<G, T>
@@ -401,14 +399,11 @@ where
 
             errors.push(errs.as_collection());
 
-            // TODO(vmarcos): We should implement further arrangement specialization here (database-issues#6659).
-            // By knowing how types propagate through joins we could specialize intermediate
-            // arrangements as well, either in values or eventually in keys.
             let arranged = keyed
                 .mz_arrange_core::<_, Col2ValBatcher<_, _,_, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
                     ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<Row, Row, S::Timestamp, Diff>),"JoinStage"
                 );
-            joined = JoinedFlavor::Local(MzArrangement::RowRow(arranged));
+            joined = JoinedFlavor::Local(arranged);
         }
 
         // Demultiplex the four different cross products of arrangement types we might have.
@@ -416,33 +411,26 @@ where
             .arrangement(&lookup_key[..])
             .expect("Arrangement absent despite explicit construction");
 
-        use MzArrangement as A;
-        use MzArrangementImport as I;
-
         match joined {
             JoinedFlavor::Collection(_) => {
                 unreachable!("JoinedFlavor::Collection variant avoided at top of method");
             }
             JoinedFlavor::Local(local) => match arrangement {
                 ArrangementFlavor::Local(oks, errs1) => {
-                    let (oks, errs2) = match (local, oks) {
-                        (A::RowRow(prev_keyed), A::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowRowAgent<_, _>, RowRowAgent<_, _>>(
-                                prev_keyed, next_input, closure,
-                            ),
-                    };
+                    let (oks, errs2) = self
+                        .differential_join_inner::<_, RowRowAgent<_, _>, RowRowAgent<_, _>>(
+                            local, oks, closure,
+                        );
 
                     errors.push(errs1.as_collection(|k, _v| k.clone()));
                     errors.extend(errs2);
                     oks
                 }
                 ArrangementFlavor::Trace(_gid, oks, errs1) => {
-                    let (oks, errs2) = match (local, oks) {
-                        (A::RowRow(prev_keyed), I::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowRowAgent<_, _>, RowRowEnter<_, _, _>>(
-                                prev_keyed, next_input, closure,
-                            ),
-                    };
+                    let (oks, errs2) = self
+                        .differential_join_inner::<_, RowRowAgent<_, _>, RowRowEnter<_, _, _>>(
+                            local, oks, closure,
+                        );
 
                     errors.push(errs1.as_collection(|k, _v| k.clone()));
                     errors.extend(errs2);
@@ -451,24 +439,20 @@ where
             },
             JoinedFlavor::Trace(trace) => match arrangement {
                 ArrangementFlavor::Local(oks, errs1) => {
-                    let (oks, errs2) = match (trace, oks) {
-                        (I::RowRow(prev_keyed), A::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowAgent<_, _>>(
-                                prev_keyed, next_input, closure,
-                            ),
-                    };
+                    let (oks, errs2) = self
+                        .differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowAgent<_, _>>(
+                            trace, oks, closure,
+                        );
 
                     errors.push(errs1.as_collection(|k, _v| k.clone()));
                     errors.extend(errs2);
                     oks
                 }
                 ArrangementFlavor::Trace(_gid, oks, errs1) => {
-                    let (oks, errs2) = match (trace, oks) {
-                        (I::RowRow(prev_keyed), I::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowEnter<_, _, _>>(
-                                prev_keyed, next_input, closure,
-                            ),
-                    };
+                    let (oks, errs2) = self
+                        .differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowEnter<_, _, _>>(
+                            trace, oks, closure,
+                        );
 
                     errors.push(errs1.as_collection(|k, _v| k.clone()));
                     errors.extend(errs2);

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -95,7 +95,7 @@ where
                 _,
             ) = input
                 .enter_region(inner)
-                .flat_map(input_key.map(|k| (k, None)), || {
+                .flat_map(input_key.map(|k| (k, None)), {
                     // Determine the columns we'll need from the row.
                     let mut demand = Vec::new();
                     demand.extend(key_plan.demand());

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -28,9 +28,7 @@ use timely::Container;
 
 use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
 use crate::extensions::reduce::MzReduce;
-use crate::render::context::{
-    ArrangementFlavor, CollectionBundle, Context, MzArrangement, MzArrangementImport,
-};
+use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::row_spine::RowRowBuilder;
 use crate::typedefs::{ErrBatcher, ErrBuilder};
 
@@ -69,48 +67,6 @@ where
     })
 }
 
-/// Dispatches according to existing type-specialization to an appropriate threshold computation
-/// resulting in another type-specialized arrangement.
-fn dispatch_threshold_arrangement_local<G, L>(
-    oks: &MzArrangement<G>,
-    name: &str,
-    logic: L,
-) -> MzArrangement<G>
-where
-    G: Scope,
-    G::Timestamp: Lattice + Columnation,
-    L: Fn(&Diff) -> bool + 'static,
-{
-    match oks {
-        MzArrangement::RowRow(inner) => {
-            let oks =
-                threshold_arrangement::<_, _, _, _, RowRowBuilder<_, _>, _, _>(inner, name, logic);
-            MzArrangement::RowRow(oks)
-        }
-    }
-}
-
-/// Dispatches threshold computation for a trace, similarly to `dispatch_threshold_arrangement_local`.
-fn dispatch_threshold_arrangement_trace<G, T, L>(
-    oks: &MzArrangementImport<G, T>,
-    name: &str,
-    logic: L,
-) -> MzArrangement<G>
-where
-    G: Scope,
-    T: Timestamp + Lattice + Columnation,
-    G::Timestamp: Lattice + Refines<T> + Columnation,
-    L: Fn(&Diff) -> bool + 'static,
-{
-    match oks {
-        MzArrangementImport::RowRow(inner) => {
-            let oks =
-                threshold_arrangement::<_, _, _, _, RowRowBuilder<_, _>, _, _>(inner, name, logic);
-            MzArrangement::RowRow(oks)
-        }
-    }
-}
-
 /// Build a dataflow to threshold the input data.
 ///
 /// This implementation maintains rows in the output, i.e. all rows that have a count greater than
@@ -129,13 +85,19 @@ where
         .expect("Arrangement ensured to exist");
     match arrangement {
         ArrangementFlavor::Local(oks, errs) => {
-            let oks =
-                dispatch_threshold_arrangement_local(&oks, "Threshold local", |count| *count > 0);
+            let oks = threshold_arrangement::<_, _, _, _, RowRowBuilder<_, _>, _, _>(
+                &oks,
+                "Threshold local",
+                |count| *count > 0,
+            );
             CollectionBundle::from_expressions(key, ArrangementFlavor::Local(oks, errs))
         }
         ArrangementFlavor::Trace(_, oks, errs) => {
-            let oks =
-                dispatch_threshold_arrangement_trace(&oks, "Threshold trace", |count| *count > 0);
+            let oks = threshold_arrangement::<_, _, _, _, RowRowBuilder<_, _>, _, _>(
+                &oks,
+                "Threshold trace",
+                |count| *count > 0,
+            );
             let errs: KeyCollection<_, _, _> = errs.as_collection(|k, _| k.clone()).into();
             let errs = errs
                 .mz_arrange::<ErrBatcher<_, _>, ErrBuilder<_, _>, _>("Arrange threshold basic err");

--- a/src/repr/src/fixed_length.rs
+++ b/src/repr/src/fixed_length.rs
@@ -7,34 +7,30 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Provides abstractions for types that can be converted from and into `Datum` iterators.
+//! Provides abstractions for types that can be converted into `Datum` iterators.
 //! `Row` is the most obvious implementor, but other trace types that may use more advanced
 //! representations only need to commit to implementing these traits.
-
-use std::borrow::Borrow;
 
 use crate::row::DatumListIter;
 use crate::{Datum, Row};
 
-/// A helper trait to get references to `Row.
+/// A helper trait to turn a type into an iterator of datums.
 pub trait ToDatumIter: Sized {
     /// An iterator type for use in `to_datum_iter`.
     type DatumIter<'a>: IntoIterator<Item = Datum<'a>>
     where
         Self: 'a;
 
-    /// Obtains an iterator of datums out of an instance of `Self`, given a schema provided
-    /// by `types`.
-    fn to_datum_iter<'a>(&'a self) -> Self::DatumIter<'a>;
+    /// Obtains an iterator of datums out of an instance of `&Self`.
+    fn to_datum_iter(&self) -> Self::DatumIter<'_>;
 }
 
 impl<'b, T: ToDatumIter> ToDatumIter for &'b T {
     type DatumIter<'a>
         = T::DatumIter<'a>
     where
-        T: 'a,
         Self: 'a;
-    fn to_datum_iter<'a>(&'a self) -> Self::DatumIter<'a> {
+    fn to_datum_iter(&self) -> Self::DatumIter<'_> {
         (**self).to_datum_iter()
     }
 }
@@ -46,52 +42,7 @@ impl ToDatumIter for Row {
 
     /// Borrows `self` and gets an iterator from it.
     #[inline]
-    fn to_datum_iter<'a>(&'a self) -> Self::DatumIter<'a> {
+    fn to_datum_iter(&self) -> Self::DatumIter<'_> {
         self.iter()
-    }
-}
-
-/// A helper trait to construct target values from input `Row` instances.
-pub trait FromDatumIter: Sized + Default {
-    /// Obtains an instance of `Self' given an iterator of borrowed datums and a schema
-    /// provided by `types`.
-    fn from_datum_iter<'a, I, D>(&mut self, datum_iter: I) -> Self
-    where
-        I: IntoIterator<Item = D>,
-        D: Borrow<Datum<'a>>;
-
-    /// Obtains an instance of `Self' given an iterator of results of borrowed datums and a schema
-    /// provided by `types`.
-    ///
-    /// In the case the iterator produces an error, the pushing of datums is terminated and the
-    /// error returned.
-    fn try_from_datum_iter<'a, I, D, E>(&mut self, datum_iter: I) -> Result<Self, E>
-    where
-        I: IntoIterator<Item = Result<D, E>>,
-        D: Borrow<Datum<'a>>;
-}
-
-impl FromDatumIter for Row {
-    /// Packs into `self` the given iterator of datums and returns a clone.
-    #[inline]
-    fn from_datum_iter<'a, I, D>(&mut self, datum_iter: I) -> Self
-    where
-        I: IntoIterator<Item = D>,
-        D: Borrow<Datum<'a>>,
-    {
-        self.packer().extend(datum_iter);
-        self.clone()
-    }
-
-    /// Packs into `self` by using the packer's `try_extend` method on the given iterator
-    /// and returns a clone.
-    #[inline]
-    fn try_from_datum_iter<'a, I, D, E>(&mut self, datum_iter: I) -> Result<Self, E>
-    where
-        I: IntoIterator<Item = Result<D, E>>,
-        D: Borrow<Datum<'a>>,
-    {
-        self.packer().try_extend(datum_iter)?;
-        Ok(self.clone())
     }
 }


### PR DESCRIPTION
Removes the MzArrangement, MzArrangementImport, SpecializedTraceHandle, and FromDatumIter types. They were mostly boilerplate that didn't add much value, or were enums with a single variant.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
