### PR TITLE
storage: make loadgens export a progress stream

### DIFF
--- a/src/storage/src/source/generator/key_value.rs
+++ b/src/storage/src/source/generator/key_value.rs
@@ -44,7 +44,7 @@ pub fn render<G: Scope<Timestamp = MzOffset>>(
     output_map: BTreeMap<LoadGeneratorOutput, Vec<usize>>,
 ) -> (
     BTreeMap<GlobalId, StackedCollection<G, Result<SourceMessage, DataflowError>>>,
-    Option<Stream<G, Infallible>>,
+    Stream<G, Infallible>,
     Stream<G, HealthStatusMessage>,
     Stream<G, ProgressStatisticsUpdate>,
     Vec<PressOnDropButton>,
@@ -235,7 +235,7 @@ pub fn render<G: Scope<Timestamp = MzOffset>>(
 
     (
         data_collections,
-        Some(progress_stream),
+        progress_stream,
         status,
         stats_stream,
         vec![button.press_on_drop(), stats_button],

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -188,7 +188,7 @@ impl SourceRender for KafkaSourceConnection {
         start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
         BTreeMap<GlobalId, StackedCollection<G, Result<SourceMessage, DataflowError>>>,
-        Option<Stream<G, Infallible>>,
+        Stream<G, Infallible>,
         Stream<G, HealthStatusMessage>,
         Stream<G, ProgressStatisticsUpdate>,
         Option<Stream<G, Probe<KafkaTimestamp>>>,
@@ -224,7 +224,7 @@ impl SourceRender for KafkaSourceConnection {
 
         (
             data_collections,
-            Some(progress),
+            progress,
             health,
             stats,
             Some(probes),

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -109,7 +109,7 @@ impl SourceRender for MySqlSourceConnection {
         _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
         BTreeMap<GlobalId, StackedCollection<G, Result<SourceMessage, DataflowError>>>,
-        Option<Stream<G, Infallible>>,
+        Stream<G, Infallible>,
         Stream<G, HealthStatusMessage>,
         Stream<G, ProgressStatisticsUpdate>,
         Option<Stream<G, Probe<GtidPartition>>>,
@@ -231,7 +231,7 @@ impl SourceRender for MySqlSourceConnection {
 
         (
             data_collections,
-            Some(uppers),
+            uppers,
             health,
             stats_stream,
             Some(probe_stream),

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -131,7 +131,7 @@ impl SourceRender for PostgresSourceConnection {
         _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
         BTreeMap<GlobalId, StackedCollection<G, Result<SourceMessage, DataflowError>>>,
-        Option<Stream<G, Infallible>>,
+        Stream<G, Infallible>,
         Stream<G, HealthStatusMessage>,
         Stream<G, ProgressStatisticsUpdate>,
         Option<Stream<G, Probe<MzOffset>>>,
@@ -256,7 +256,7 @@ impl SourceRender for PostgresSourceConnection {
 
         (
             data_collections,
-            Some(uppers),
+            uppers,
             health,
             stats_stream,
             probe_stream,

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -76,10 +76,8 @@ pub trait SourceRender {
     /// First, a source must produce a collection that is produced by the rendered dataflow and
     /// must contain *definite*[^1] data for all times beyond the resumption frontier.
     ///
-    /// Second, a source may produce an optional progress stream that will be used to drive
-    /// reclocking. This is useful for sources that can query the highest offsets of the external
-    /// source before reading the data for those offsets. In those cases it is preferable to
-    /// produce this additional stream.
+    /// Second, a source must produce a progress stream that will be used to drive reclocking.
+    /// The frontier of this stream decides for which upstream offsets bindings can be minted.
     ///
     /// Third, a source must produce a stream of health status updates.
     ///
@@ -95,7 +93,7 @@ pub trait SourceRender {
         start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
         BTreeMap<GlobalId, StackedCollection<G, Result<SourceMessage, DataflowError>>>,
-        Option<Stream<G, Infallible>>,
+        Stream<G, Infallible>,
         Stream<G, HealthStatusMessage>,
         Stream<G, ProgressStatisticsUpdate>,
         Option<Stream<G, Probe<Self::Time>>>,


### PR DESCRIPTION
This PR makes the simple load generators export a progress stream, giving the remap operator the ability to mint bindings earlier, thus allowing the reclock operator to pass through snapshot updates instead of stashing them all. The effect of this that load generators now need constant memory during hydration, instead of memory proportional to the snapshot size.

Before this PR, an SF10 TPCH load generator required a `200cc` instance to successfully hydrate. With this PR it hydrates on a `25cc`.

This PR also makes the progress-stream non-optional in source rendering, to avoid pitfalls like this in the future.

### Motivation

  * This PR fixes a previously unreported bug.

Hydrating load generators requires memory proportional to their snapshot size.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
