### PR TITLE
ci: Remember failed workflows/td files and run them first in CI

### DIFF
--- a/misc/python/materialize/ci_util/__init__.py
+++ b/misc/python/materialize/ci_util/__init__.py
@@ -48,7 +48,6 @@ def upload_junit_report(suite: str, junit_report: Path) -> None:
     """
     if not buildkite.is_in_buildkite():
         return
-    ui.section(f"Uploading report for suite {suite!r} to Buildkite Test Analytics")
     suite = suite.upper().replace("-", "_")
     token = os.getenv(f"BUILDKITE_TEST_ANALYTICS_API_KEY_{suite}")
     if not token:

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -36,14 +36,14 @@ from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from inspect import Traceback, getframeinfo, getmembers, isfunction, stack
 from tempfile import TemporaryFile
-from typing import Any, TextIO, cast
+from typing import Any, TextIO, TypeVar, cast
 
 import psycopg
 import sqlparse
 import yaml
 from psycopg import Connection, Cursor
 
-from materialize import MZ_ROOT, mzbuild, spawn, ui
+from materialize import MZ_ROOT, buildkite, mzbuild, spawn, ui
 from materialize.mzcompose import cluster_replica_size_map, loader
 from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.materialized import (
@@ -1564,3 +1564,50 @@ class Composition:
         # It is necessary to append the 'https://' protocol; otherwise, urllib can't parse it correctly.
         cloud_hostname = urllib.parse.urlparse("https://" + cloud_url).hostname
         return str(cloud_hostname)
+
+    T = TypeVar("T")
+
+    def test_parts(self, parts: list[T], process_func: Callable[[T], Any]) -> None:
+        from materialize.test_analytics.config.test_analytics_db_config import (
+            create_test_analytics_config,
+        )
+        from materialize.test_analytics.test_analytics_db import TestAnalyticsDb
+
+        priority: dict[str, int] = {}
+        test_analytics: TestAnalyticsDb | None = None
+
+        if buildkite.is_in_buildkite():
+            print("~~~ Fetching part priorities")
+            test_analytics_config = create_test_analytics_config(self)
+            test_analytics = TestAnalyticsDb(test_analytics_config)
+            try:
+                priority = test_analytics.builds.get_part_priorities(timeout=15)
+                print(f"Priorities: {priority}")
+            except Exception as e:
+                print(f"Failed to fetch part priorities, using default order: {e}")
+
+        sorted_parts = sorted(
+            parts, key=lambda part: priority.get(str(part), 0), reverse=True
+        )
+        exceptions: list[Exception] = []
+
+        try:
+            for part in sorted_parts:
+                try:
+                    process_func(part)
+                except Exception as e:
+                    if buildkite.is_in_buildkite():
+                        assert test_analytics
+                        test_analytics.builds.add_build_job_failure(str(part))
+                    # raise
+                    # We could also keep running, but then runtime is still
+                    # slow when a test fails, and the annotation only shows up
+                    # after the test finished:
+                    exceptions.append(e)
+        finally:
+            if buildkite.is_in_buildkite():
+                assert test_analytics
+                test_analytics.database_connector.submit_update_statements()
+        if exceptions:
+            print(f"Further exceptions were raised:\n{exceptions[1:]}")
+            raise exceptions[0]

--- a/misc/python/materialize/test_analytics/setup/tables/03-build-job-failure.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/03-build-job-failure.sql
@@ -1,0 +1,17 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+-- part of a build job that failed, can be a testdrive file or a workflow
+CREATE TABLE build_job_failure (
+    build_job_id TEXT NOT NULL,
+    part TEXT NOT NULL
+);
+
+ALTER TABLE build_job_failure OWNER TO qa;
+GRANT SELECT, INSERT, UPDATE ON TABLE build_job_failure TO "hetzner-ci";

--- a/misc/python/materialize/test_analytics/setup/views/03-build-failure.sql
+++ b/misc/python/materialize/test_analytics/setup/views/03-build-failure.sql
@@ -1,0 +1,27 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+CREATE OR REPLACE MATERIALIZED VIEW mv_build_job_failed_on_branch AS
+SELECT build_step_key, branch, part
+FROM build
+JOIN build_job ON build.build_id = build_job.build_id
+JOIN build_job_failure ON build_job.build_job_id = build_job_failure.build_job_id;
+
+CREATE OR REPLACE MATERIALIZED VIEW mv_build_job_failed AS
+SELECT build_step_key, part
+FROM build_job
+JOIN build_job_failure ON build_job.build_job_id = build_job_failure.build_job_id;
+
+CREATE DEFAULT INDEX ON mv_build_job_failed_on_branch;
+CREATE DEFAULT INDEX ON mv_build_job_failed;
+
+ALTER MATERIALIZED VIEW mv_build_job_failed_on_branch OWNER TO qa;
+GRANT SELECT ON TABLE mv_build_job_failed_on_branch TO "hetzner-ci";
+ALTER MATERIALIZED VIEW mv_build_job_failed OWNER TO qa;
+GRANT SELECT ON TABLE mv_build_job_failed TO "hetzner-ci";

--- a/test/aws-localstack/mzcompose.py
+++ b/test/aws-localstack/mzcompose.py
@@ -25,6 +25,7 @@ from materialize.mzcompose.composition import (
 )
 from materialize.mzcompose.services.localstack import Localstack
 from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.testdrive import Testdrive
 
 ENVIRONMENT_NAME = f"environment-{DEFAULT_ORG_ID}-{DEFAULT_ORDINAL}"
@@ -43,6 +44,7 @@ AWS_ENDPOINT_URL_MZ = "http://localstack:4566"
 
 SERVICES = [
     Localstack(),
+    Mz(app_password=""),
     Materialized(
         depends_on=["localstack"],
         environment_extra=[
@@ -66,9 +68,12 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    for name in ["secrets-manager", "aws-connection", "copy-to-s3"]:
+    def process(name: str) -> None:
         with c.test_case(name):
             c.workflow(name)
+
+    workflows = ["secrets-manager", "aws-connection", "copy-to-s3"]
+    c.test_parts(workflows, process)
 
 
 def workflow_secrets_manager(c: Composition) -> None:

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -1091,15 +1091,13 @@ SCENARIOS = [
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    for name in c.workflows:
-        if name == "default":
-            continue
-
-        if name == "minimization-search":
-            continue
-
+    def process(name: str) -> None:
+        if name in ["default", "minimization-search"]:
+            return
         with c.test_case(name):
             c.workflow(name)
+
+    c.test_parts(list(c.workflows.keys()), process)
 
 
 def workflow_main(c: Composition, parser: WorkflowArgumentParser) -> None:

--- a/test/chbench/mzcompose.py
+++ b/test/chbench/mzcompose.py
@@ -19,6 +19,7 @@ from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.metabase import Metabase
 from materialize.mzcompose.services.mysql import MySql
+from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.zookeeper import Zookeeper
 
@@ -28,6 +29,7 @@ SERVICES = [
     SchemaRegistry(),
     Debezium(),
     MySql(root_password="rootpw"),
+    Mz(app_password=""),
     Materialized(),
     Metabase(),
     Service(
@@ -42,12 +44,13 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    for name in c.workflows:
+    def process(name: str) -> None:
         if name == "default":
-            continue
-
+            return
         with c.test_case(name):
             c.workflow(name)
+
+    c.test_parts(list(c.workflows.keys()), process)
 
 
 def workflow_no_load(c: Composition, parser: WorkflowArgumentParser) -> None:

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -243,7 +243,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     args = parser.parse_args()
 
-    globs = list(
+    files = list(
         itertools.chain.from_iterable(
             [
                 glob.glob(file_glob, root_dir=MZ_ROOT / "test" / "cloud-canary")
@@ -275,15 +275,18 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         # Takes about 40 min to spin up
         redpanda = (
             Redpanda(c, cleanup=args.cleanup)
-            if any(["redpanda" in filename for filename in globs])
+            if any(["redpanda" in filename for filename in files])
             else None
         )
 
         try:
             print("Running .td files ...")
             td(c, text="> CREATE CLUSTER canary_sources SIZE '25cc'")
-            for filename in globs:
+
+            def process(filename: str) -> None:
                 td(c, filename, redpanda=redpanda)
+
+            c.test_parts(files, process)
             test_failed = False
         finally:
             if args.cleanup and redpanda is not None:

--- a/test/debezium/mzcompose.py
+++ b/test/debezium/mzcompose.py
@@ -16,6 +16,7 @@ from materialize.mzcompose.services.debezium import Debezium
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mysql import MySql
+from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.sql_server import SqlServer
@@ -29,6 +30,7 @@ SERVICES = [
     Kafka(auto_create_topics=True),
     SchemaRegistry(),
     Debezium(),
+    Mz(app_password=""),
     Materialized(),
     Postgres(),
     SqlServer(),
@@ -38,12 +40,13 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    for name in c.workflows:
+    def process(name: str) -> None:
         if name == "default":
-            continue
-
+            return
         with c.test_case(name):
             c.workflow(name)
+
+    c.test_parts(list(c.workflows.keys()), process)
 
 
 def workflow_postgres(c: Composition) -> None:

--- a/test/fivetran-destination/mzcompose.py
+++ b/test/fivetran-destination/mzcompose.py
@@ -58,11 +58,13 @@ from materialize.mzcompose.services.fivetran_destination_tester import (
     FivetranDestinationTester,
 )
 from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.testdrive import Testdrive
 
 ROOT = Path(__file__).parent
 
 SERVICES = [
+    Mz(app_password=""),
     Materialized(),
     Testdrive(
         no_reset=True,

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -19,6 +19,7 @@ from materialize.mzcompose.composition import Composition, WorkflowArgumentParse
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.redpanda import Redpanda
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
@@ -30,6 +31,7 @@ SERVICES = [
     Kafka(),
     SchemaRegistry(),
     Redpanda(),
+    Mz(app_password=""),
     Materialized(),
     Clusterd(),
     Toxiproxy(),
@@ -52,11 +54,13 @@ def get_kafka_services(redpanda: bool) -> list[str]:
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    for name in c.workflows:
+    def process(name: str) -> None:
         if name == "default":
-            continue
+            return
         with c.test_case(name):
             c.workflow(name, *parser.args)
+
+    c.test_parts(list(c.workflows.keys()), process)
 
 
 #

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1829,12 +1829,13 @@ def upload_results_to_test_analytics(
 
 
 def workflow_default(c: Composition) -> None:
-    for name in c.workflows:
+    def process(name: str) -> None:
         if name == "default":
-            continue
-
+            return
         with c.test_case(name):
             c.workflow(name)
+
+    c.test_parts(list(c.workflows.keys()), process)
 
 
 def workflow_main(c: Composition, parser: WorkflowArgumentParser) -> None:

--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -23,6 +23,7 @@ from materialize.mysql_util import (
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mysql import MySql
+from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.test_certs import TestCerts
 from materialize.mzcompose.services.testdrive import Testdrive
 
@@ -45,6 +46,7 @@ def create_mysql_replica(mysql_version: str) -> MySql:
 
 
 SERVICES = [
+    Mz(app_password=""),
     Materialized(
         additional_system_parameter_defaults={
             "log_filter": "mz_storage::source::mysql=trace,info"
@@ -70,6 +72,12 @@ def get_targeted_mysql_version(parser: WorkflowArgumentParser) -> str:
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    def process(name: str) -> None:
+        if name in ("default", "large-scale"):
+            return
+        with c.test_case(name):
+            c.workflow(name, *parser.args)
+
     workflows_with_internal_sharding = ["cdc"]
     sharded_workflows = workflows_with_internal_sharding + buildkite.shard_list(
         [w for w in c.workflows if w not in workflows_with_internal_sharding],
@@ -78,12 +86,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     print(
         f"Workflows in shard with index {buildkite.get_parallelism_index()}: {sharded_workflows}"
     )
-    for name in sharded_workflows:
-        if name in ("default", "large-scale"):
-            continue
-
-        with c.test_case(name):
-            c.workflow(name, *parser.args)
+    c.test_parts(sharded_workflows, process)
 
 
 def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
@@ -113,18 +116,21 @@ def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         c.sources_and_sinks_ignored_from_validation.add("drop_table")
 
-        c.run_testdrive_files(
-            f"--var=ssl-ca={valid_ssl_context.ca}",
-            f"--var=ssl-client-cert={valid_ssl_context.client_cert}",
-            f"--var=ssl-client-key={valid_ssl_context.client_key}",
-            f"--var=ssl-wrong-ca={wrong_ssl_context.ca}",
-            f"--var=ssl-wrong-client-cert={wrong_ssl_context.client_cert}",
-            f"--var=ssl-wrong-client-key={wrong_ssl_context.client_key}",
-            f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
-            "--var=mysql-user-password=us3rp4ssw0rd",
-            f"--var=default-replica-size={Materialized.Size.DEFAULT_SIZE}-{Materialized.Size.DEFAULT_SIZE}",
-            f"--var=default-storage-size={Materialized.Size.DEFAULT_SIZE}-1",
-            *sharded_files,
+        c.test_parts(
+            sharded_files,
+            lambda file: c.run_testdrive_files(
+                f"--var=ssl-ca={valid_ssl_context.ca}",
+                f"--var=ssl-client-cert={valid_ssl_context.client_cert}",
+                f"--var=ssl-client-key={valid_ssl_context.client_key}",
+                f"--var=ssl-wrong-ca={wrong_ssl_context.ca}",
+                f"--var=ssl-wrong-client-cert={wrong_ssl_context.client_cert}",
+                f"--var=ssl-wrong-client-key={wrong_ssl_context.client_key}",
+                f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
+                "--var=mysql-user-password=us3rp4ssw0rd",
+                f"--var=default-replica-size={Materialized.Size.DEFAULT_SIZE}-{Materialized.Size.DEFAULT_SIZE}",
+                f"--var=default-storage-size={Materialized.Size.DEFAULT_SIZE}-1",
+                file,
+            ),
         )
 
 

--- a/test/mzcompose_examples/mzcompose.py
+++ b/test/mzcompose_examples/mzcompose.py
@@ -11,6 +11,7 @@ from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Minio
+from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
@@ -36,6 +37,7 @@ SERVICES = [
     *versioned_mz,
     *mz_with_options,
     Testdrive(),
+    Mz(app_password=""),
 ]
 
 
@@ -44,11 +46,14 @@ def workflow_default(c: Composition) -> None:
 
     This workflow just runs all the other ones
     """
-    for name in c.workflows:
+
+    def process(name: str) -> None:
         if name == "default":
-            continue
+            return
         with c.test_case(name):
             c.workflow(name)
+
+    c.test_parts(list(c.workflows.keys()), process)
 
 
 def workflow_start_confluents(c: Composition) -> None:

--- a/test/pg-cdc-resumption/mzcompose.py
+++ b/test/pg-cdc-resumption/mzcompose.py
@@ -21,12 +21,14 @@ from materialize import buildkite
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.alpine import Alpine
 from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.toxiproxy import Toxiproxy
 
 SERVICES = [
     Alpine(),
+    Mz(app_password=""),
     Materialized(),
     Postgres(),
     Toxiproxy(),
@@ -35,9 +37,9 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    for name in c.workflows:
+    def process(name: str) -> None:
         if name == "default":
-            continue
+            return
 
         # clear to avoid issues
         c.kill("postgres")
@@ -45,6 +47,8 @@ def workflow_default(c: Composition) -> None:
 
         with c.test_case(name):
             c.workflow(name)
+
+    c.test_parts(list(c.workflows.keys()), process)
 
 
 def workflow_disruptions(c: Composition) -> None:

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -26,6 +26,7 @@ from psycopg.errors import (
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.postgres import CockroachOrPostgresMetadata
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
@@ -38,6 +39,7 @@ SERVICES = [
     Zookeeper(),
     Kafka(auto_create_topics=True),
     SchemaRegistry(),
+    Mz(app_password=""),
     Materialized(),
     Testdrive(
         entrypoint_extra=[
@@ -864,8 +866,11 @@ def workflow_index_compute_dependencies(c: Composition) -> None:
 
 
 def workflow_default(c: Composition) -> None:
-    for name in c.workflows:
+    def process(name: str) -> None:
         if name == "default":
-            continue
+            return
+
         with c.test_case(name):
             c.workflow(name)
+
+    c.test_parts(list(c.workflows.keys()), process)

--- a/test/skip-version-upgrade/mzcompose.py
+++ b/test/skip-version-upgrade/mzcompose.py
@@ -15,6 +15,7 @@ from materialize.mz_version import MzVersion
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.ui import UIError
 from materialize.version_list import (
@@ -25,17 +26,21 @@ mz_options: dict[MzVersion, str] = {}
 
 SERVICES = [
     Cockroach(setup_materialize=True),
+    Mz(app_password=""),
     Materialized(external_metadata_store=True, metadata_store="cockroach"),
     Testdrive(no_reset=True, metadata_store="cockroach"),
 ]
 
 
 def workflow_default(c: Composition) -> None:
-    for i, name in enumerate(c.workflows):
+    def process(name: str) -> None:
         if name == "default":
-            continue
+            return
+
         with c.test_case(name):
             c.workflow(name)
+
+    c.test_parts(list(c.workflows.keys()), process)
 
 
 def workflow_test_version_skips(c: Composition) -> None:

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -13,9 +13,10 @@ the expected-result/actual-result (aka golden testing) paradigm. A query is
 retried until it produces the desired result.
 """
 
+import glob
 from pathlib import Path
 
-from materialize import ci_util
+from materialize import MZ_ROOT, buildkite, ci_util
 from materialize.mzcompose import get_default_system_parameters
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.azure import Azurite
@@ -24,6 +25,7 @@ from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Minio
 from materialize.mzcompose.services.mysql import MySql
+from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.redpanda import Redpanda
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
@@ -38,6 +40,7 @@ SERVICES = [
     Postgres(),
     MySql(),
     Azurite(),
+    Mz(app_password=""),
     Minio(setup_materialize=True, additional_directories=["copytos3"]),
     Materialized(external_blob_store=True),
     FivetranDestination(volumes_extra=["tmp:/share/tmp"]),
@@ -137,7 +140,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
 
     testdrive = Testdrive(
-        forward_buildkite_shard=True,
         kafka_default_partitions=args.kafka_default_partitions,
         aws_region=args.aws_region,
         validate_catalog_store=True,
@@ -207,14 +209,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 f"--var=default-storage-size={materialized.default_storage_size}"
             )
 
-        junit_report = ci_util.junit_report_filename(c.name)
+        print(f"Passing through arguments to testdrive {passthrough_args}\n")
+        # do not set default args, they should be set in the td file using set-arg-default to easen the execution
+        # without mzcompose
 
-        try:
-            junit_report = ci_util.junit_report_filename(c.name)
-            print(f"Passing through arguments to testdrive {passthrough_args}\n")
-            # do not set default args, they should be set in the td file using set-arg-default to easen the execution
-            # without mzcompose
-            for file in args.files:
+        def process(file: str) -> None:
+            junit_report = ci_util.junit_report_filename(f"{c.name}_{file}")
+            try:
                 c.run_testdrive_files(
                     (
                         "--rewrite-results"
@@ -225,8 +226,18 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     *passthrough_args,
                     file,
                 )
-                c.sanity_restart_mz()
-        finally:
-            ci_util.upload_junit_report(
-                "testdrive", Path(__file__).parent / junit_report
-            )
+            finally:
+                ci_util.upload_junit_report(
+                    "testdrive", Path(__file__).parent / junit_report
+                )
+
+        files = buildkite.shard_list(
+            [
+                file
+                for pattern in args.files
+                for file in glob.glob(pattern, root_dir=MZ_ROOT / "test" / "testdrive")
+            ],
+            lambda file: file,
+        )
+        c.test_parts(files, process)
+        c.sanity_restart_mz()

--- a/test/tracing/mzcompose.py
+++ b/test/tracing/mzcompose.py
@@ -17,10 +17,12 @@ import requests
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.mz import Mz
 
 SENTRY_DSN = os.getenv("BUILDKITE_SENTRY_DSN")
 
 SERVICES = [
+    Mz(app_password=""),
     Materialized(
         options=[
             "--opentelemetry-endpoint=whatever:7777",
@@ -33,10 +35,14 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    for name in c.workflows:
-        if name != "default":
-            with c.test_case(name):
-                c.workflow(name)
+    def process(name: str) -> None:
+        if name == "default":
+            return
+
+        with c.test_case(name):
+            c.workflow(name)
+
+    c.test_parts(list(c.workflows.keys()), process)
 
 
 def workflow_with_everything(c: Composition) -> None:


### PR DESCRIPTION
We have three priorities to determine the order of parts (workflows, td/slt files):
- 2: Parts that failed in this PR in previous runs
- 1: Parts that failed before on main or any PR
- 0: Parts that haven't failed
When fetching the order fails (timeout 15 seconds), we just run in the same order as before.

This uses the Materialize Production Analytics database, so also another nice use case for dog fooding

Fixes: https://github.com/MaterializeInc/database-issues/issues/8935

Verification runs:
https://buildkite.com/materialize/test/builds/98151
https://buildkite.com/materialize/nightly/builds/11053
https://buildkite.com/materialize/nightly/builds/11051
https://buildkite.com/materialize/release-qualification/builds/739

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
