### PR TITLE
test: add memory tests for MV hydration

### DIFF
--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -1087,6 +1087,62 @@ SCENARIOS = [
         materialized_memory="4.5Gb",
         clusterd_memory="3.5Gb",
     ),
+    Scenario(
+        name="mv-hydration-800mb",
+        pre_restart=dedent(
+            """
+            > CREATE SOURCE tpch
+              FROM LOAD GENERATOR TPCH (SCALE FACTOR 1, TICK INTERVAL '1s')
+              FOR TABLES (lineitem)
+
+            > SELECT count(*) > 0 FROM lineitem
+            true
+
+            > CREATE MATERIALIZED VIEW mv
+              IN CLUSTER clusterd AS
+              SELECT * FROM lineitem
+
+            > SELECT count(*) > 0 FROM mv
+            true
+            """
+        ),
+        post_restart=dedent(
+            """
+            > SELECT count(*) > 0 FROM mv
+            true
+            """
+        ),
+        materialized_memory="2Gb",
+        clusterd_memory="1.5Gb",
+    ),
+    Scenario(
+        name="mv-hydration-4gb",
+        pre_restart=dedent(
+            """
+            > CREATE SOURCE tpch
+              FROM LOAD GENERATOR TPCH (SCALE FACTOR 5, TICK INTERVAL '1s')
+              FOR TABLES (lineitem)
+
+            > SELECT count(*) > 0 FROM lineitem
+            true
+
+            > CREATE MATERIALIZED VIEW mv
+              IN CLUSTER clusterd AS
+              SELECT * FROM lineitem
+
+            > SELECT count(*) > 0 FROM mv
+            true
+            """
+        ),
+        post_restart=dedent(
+            """
+            > SELECT count(*) > 0 FROM mv
+            true
+            """
+        ),
+        materialized_memory="2Gb",
+        clusterd_memory="7Gb",
+    ),
 ]
 
 


### PR DESCRIPTION
This PR adds bounded-memory tests for MV hydration. The largest MV is limited to 4GB, because the test would be too slow otherwise. Afaict, the slowness comes from the fact that the `clusterd` used for the test only has a single worker.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
