### PR TITLE
ci: Force-destroy terraform only in terraform tests

### DIFF
--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -146,6 +146,8 @@ run kill || true
 run rm --force -v
 run down --volumes
 
-ci_unimportant_heading "terraform: Destroying leftover state in case job was cancelled or timed out..."
-bin/ci-builder run stable terraform -chdir=test/terraform/aws destroy || true
-bin/ci-builder run stable terraform -chdir=test/terraform/gcp destroy || true
+if [[ "$BUILDKITE_LABEL" =~ Terraform\ .* ]]; then
+  ci_unimportant_heading "terraform: Destroying leftover state in case job was cancelled or timed out..."
+  bin/ci-builder run stable terraform -chdir=test/terraform/aws destroy || true
+  bin/ci-builder run stable terraform -chdir=test/terraform/gcp destroy || true
+fi


### PR DESCRIPTION
Less noisy
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
