### PR TITLE
Non-allocating YieldSpec::try_from_str

### DIFF
--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -166,8 +166,7 @@ impl YieldSpec {
         let options = s.split(',').map(|o| o.trim());
         for option in options {
             let mut iter = option.split(':').map(|p| p.trim());
-            let parts : [_; 3]= std::array::from_fn(|_| iter.next());
-            match parts {
+            match std::array::from_fn(|_| iter.next()) {
                 [Some("work"), Some(amount), None] => {
                     let amount = amount.parse().ok()?;
                     after_work = Some(amount);

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -165,13 +165,14 @@ impl YieldSpec {
 
         let options = s.split(',').map(|o| o.trim());
         for option in options {
-            let parts: Vec<_> = option.split(':').map(|p| p.trim()).collect();
-            match &parts[..] {
-                ["work", amount] => {
+            let mut iter = option.split(':').map(|p| p.trim());
+            let parts : [_; 3]= std::array::from_fn(|_| iter.next());
+            match parts {
+                [Some("work"), Some(amount), None] => {
                     let amount = amount.parse().ok()?;
                     after_work = Some(amount);
                 }
-                ["time", millis] => {
+                [Some("time"), Some(millis), None] => {
                     let millis = millis.parse().ok()?;
                     let duration = Duration::from_millis(millis);
                     after_time = Some(duration);


### PR DESCRIPTION
Change `try_from_str` to not allocate. No behavior change, just noticed this looking at related code.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
