### PR TITLE
tests: Keep source table migration tests around for now

### DIFF
--- a/misc/python/materialize/source_table_migration.py
+++ b/misc/python/materialize/source_table_migration.py
@@ -56,12 +56,6 @@ def _verify_source(
             raise e
 
 
-def check_source_table_migration_test_sensible() -> None:
-    assert MzVersion.parse_cargo() < MzVersion.parse_mz(
-        "v0.139.0"
-    ), "migration test probably no longer needed"
-
-
 _last_version: MzVersion | None = None
 
 


### PR DESCRIPTION
project is on hold

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
