### PR TITLE
tests: Fix glob root dir to respect MZ_ROOT

### DIFF
--- a/test/cloudtest/test_full_testdrive.py
+++ b/test/cloudtest/test_full_testdrive.py
@@ -11,7 +11,7 @@ import glob
 
 import pytest
 
-from materialize import buildkite
+from materialize import MZ_ROOT, buildkite
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
 
 
@@ -24,7 +24,9 @@ def test_full_testdrive(mz: MaterializeApplication) -> None:
     parser.add_argument("--file-pattern", default="*.td", type=str)
     args, _ = parser.parse_known_args()
 
-    matching_files = glob.glob(f"testdrive/{args.file_pattern}", root_dir="test")
+    matching_files = glob.glob(
+        f"testdrive/{args.file_pattern}", root_dir=MZ_ROOT / "test"
+    )
 
     # TODO: database-issues#7827 (test requires fivetran running in cloudtest)
     matching_files.remove("testdrive/fivetran-destination.td")

--- a/test/mysql-cdc-old-syntax/mzcompose.py
+++ b/test/mysql-cdc-old-syntax/mzcompose.py
@@ -15,7 +15,7 @@ import glob
 import threading
 from textwrap import dedent
 
-from materialize import buildkite
+from materialize import MZ_ROOT, buildkite
 from materialize.mysql_util import (
     retrieve_invalid_ssl_context_for_mysql,
     retrieve_ssl_context_for_mysql,
@@ -112,7 +112,9 @@ def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     matching_files = []
     for filter in args.filter:
-        matching_files.extend(glob.glob(filter, root_dir="test/mysql-cdc-old-syntax"))
+        matching_files.extend(
+            glob.glob(filter, root_dir=MZ_ROOT / "test" / "mysql-cdc-old-syntax")
+        )
     sharded_files: list[str] = sorted(
         buildkite.shard_list(matching_files, lambda file: file)
     )
@@ -299,7 +301,9 @@ def workflow_migration(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     matching_files = []
     for filter in args.filter:
-        matching_files.extend(glob.glob(filter, root_dir="test/mysql-cdc-old-syntax"))
+        matching_files.extend(
+            glob.glob(filter, root_dir=MZ_ROOT / "test" / "mysql-cdc-old-syntax")
+        )
 
     sharded_files: list[str] = sorted(
         buildkite.shard_list(matching_files, lambda file: file)

--- a/test/pg-cdc-old-syntax/mzcompose.py
+++ b/test/pg-cdc-old-syntax/mzcompose.py
@@ -17,7 +17,7 @@ import time
 import pg8000
 from pg8000 import Connection
 
-from materialize import buildkite
+from materialize import MZ_ROOT, buildkite
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.service import Service, ServiceConfig
 from materialize.mzcompose.services.materialized import Materialized
@@ -303,7 +303,9 @@ def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     matching_files = []
     for filter in args.filter:
-        matching_files.extend(glob.glob(filter, root_dir="test/pg-cdc-old-syntax"))
+        matching_files.extend(
+            glob.glob(filter, root_dir=MZ_ROOT / "test" / "pg-cdc-old-syntax")
+        )
     sharded_files: list[str] = sorted(
         buildkite.shard_list(matching_files, lambda file: file)
     )
@@ -378,7 +380,9 @@ def workflow_migration(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     matching_files = []
     for filter in args.filter:
-        matching_files.extend(glob.glob(filter, root_dir="test/pg-cdc-old-syntax"))
+        matching_files.extend(
+            glob.glob(filter, root_dir=MZ_ROOT / "test" / "pg-cdc-old-syntax")
+        )
     sharded_files: list[str] = sorted(
         buildkite.shard_list(matching_files, lambda file: file)
     )

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -18,7 +18,7 @@ from textwrap import dedent
 import psycopg
 from psycopg import Connection
 
-from materialize import buildkite
+from materialize import MZ_ROOT, buildkite
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.service import Service, ServiceConfig
 from materialize.mzcompose.services.materialized import Materialized
@@ -291,7 +291,7 @@ def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     matching_files = []
     for filter in args.filter:
-        matching_files.extend(glob.glob(filter, root_dir="test/pg-cdc"))
+        matching_files.extend(glob.glob(filter, root_dir=MZ_ROOT / "test" / "pg-cdc"))
     sharded_files: list[str] = sorted(
         buildkite.shard_list(matching_files, lambda file: file)
     )

--- a/test/testdrive-old-kafka-src-syntax/mzcompose.py
+++ b/test/testdrive-old-kafka-src-syntax/mzcompose.py
@@ -15,7 +15,7 @@ retried until it produces the desired result.
 import glob
 from pathlib import Path
 
-from materialize import ci_util, spawn
+from materialize import MZ_ROOT, ci_util, spawn
 from materialize.mzcompose import get_default_system_parameters
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.azure import Azurite
@@ -304,7 +304,9 @@ def workflow_migration(c: Composition, parser: WorkflowArgumentParser) -> None:
     matching_files = []
     for filter in args.files:
         matching_files.extend(
-            glob.glob(filter, root_dir="test/testdrive-old-kafka-src-syntax")
+            glob.glob(
+                filter, root_dir=MZ_ROOT / "test" / "testdrive-old-kafka-src-syntax"
+            )
         )
     matching_files = [file for file in matching_files if file != "session.td"]
 


### PR DESCRIPTION
Noticed and fixed for one test by Marty in https://github.com/MaterializeInc/materialize/pull/31239

Nightly run to verify: https://buildkite.com/materialize/nightly/builds/11050

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
