### PR TITLE
pg-cdc test: Reduce size for large scale workflow

### DIFF
--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -370,7 +370,7 @@ def workflow_large_scale(c: Composition, parser: WorkflowArgumentParser) -> None
             ),
         )
 
-    num_rows = 300_000  # out of disk with 400_000 rows
+    num_rows = 100_000  # out of memory with 200_000 rows
     batch_size = 10_000
     for i in range(0, num_rows, batch_size):
         batch_num = min(batch_size, num_rows - i)


### PR DESCRIPTION
OoM seen in https://buildkite.com/materialize/release-qualification/builds/739#0194d56a-9bde-4ca9-9ed4-836dc886ad44

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
