### PR TITLE
test: fix another flake in source statistics tests

### DIFF
--- a/test/testdrive/source-statistics.td
+++ b/test/testdrive/source-statistics.td
@@ -65,6 +65,34 @@ goofus,gallant
   FORMAT CSV WITH 2 COLUMNS
   INCLUDE OFFSET
 
+> SELECT * FROM metrics_test_source_tbl
+jack   jill    0
+goofus gallant 1
+
+# The `CREATE TABLE ... FROM SOURCE` command caused a recreation of the source
+# dataflow, during which we might have lost the statistics about committed
+# updates from the snapshot. Ingest some more data to ensure we see some
+# `updates_committed`.
+$ kafka-ingest topic=metrics-test format=bytes
+calvin,hobbes
+
+> SELECT
+      s.name,
+      bool_and(u.snapshot_committed),
+      SUM(u.messages_received) >= 4,
+      SUM(u.updates_staged) > 0,
+      SUM(u.updates_committed) > 0,
+      SUM(u.bytes_received) > 0,
+      bool_and(u.rehydration_latency IS NOT NULL)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('metrics_test_source')
+  GROUP BY s.name
+  ORDER BY s.name
+metrics_test_source true true true true true true
+
+> DROP SOURCE metrics_test_source CASCADE
+
 > CREATE SOURCE upsert
   IN CLUSTER ${arg.single-replica-cluster}
   FROM KAFKA CONNECTION kafka_conn (TOPIC
@@ -98,23 +126,6 @@ mammalmore    moosemoose   2
 > CREATE TABLE bids FROM SOURCE auction_house_in_source_statistics_td (REFERENCE bids);
 > CREATE TABLE organizations FROM SOURCE auction_house_in_source_statistics_td (REFERENCE organizations);
 > CREATE TABLE users FROM SOURCE auction_house_in_source_statistics_td (REFERENCE users);
-
-> SELECT
-      s.name,
-      bool_and(u.snapshot_committed),
-      SUM(u.messages_received) >= 4,
-      SUM(u.updates_staged) > 0,
-      SUM(u.updates_committed) > 0,
-      SUM(u.bytes_received) > 0,
-      bool_and(u.rehydration_latency IS NOT NULL)
-  FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
-  WHERE s.name IN ('metrics_test_source')
-  GROUP BY s.name
-  ORDER BY s.name
-metrics_test_source true true true true true true
-
-> DROP SOURCE metrics_test_source CASCADE
 
 # Note that only the base-source has `messages_received`, but the sub-sources have `messages_committed`.
 # Committed will usually, for auction sources, add up to received, but we don't test this (right now) because of


### PR DESCRIPTION
Same cause as [previous flakes](https://github.com/MaterializeInc/database-issues/issues/8848) in `updates_committed` counts, same fix as well.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8943

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
