### PR TITLE
0dt: in preflight checks, notice DDL changes and restart read-only envd

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -161,6 +161,7 @@ IGNORE_RE = re.compile(
     # For 0dt upgrades
     | halting\ process:\ (unable\ to\ confirm\ leadership|fenced\ out\ old\ deployment;\ rebooting\ as\ leader|this\ deployment\ has\ been\ fenced\ out)
     | zippy-materialized.* \| .* halting\ process:\ Server\ started\ with\ requested\ generation
+    | there\ have\ been\ DDL\ that\ we\ need\ to\ react\ to;\ rebooting\ in\ read-only\ mode
     # Don't care for ssh problems
     | fatal:\ userauth_pubkey
     # Fences without incrementing deploy generation

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -32,6 +32,12 @@ pub const WITH_0DT_DEPLOYMENT_MAX_WAIT: Config<Duration> = Config::new(
     "How long to wait at most for clusters to be hydrated, when doing a zero-downtime deployment.",
 );
 
+pub const WITH_0DT_DEPLOYMENT_DDL_CHECK_INTERVAL: Config<Duration> = Config::new(
+    "with_0dt_deployment_ddl_check_interval",
+    Duration::from_secs(5 * 60),
+    "How often to check for DDL changes during zero-downtime deployment.",
+);
+
 pub const ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT: Config<bool> = Config::new(
     "enable_0dt_deployment_panic_after_timeout",
     false,
@@ -117,6 +123,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ALLOW_USER_SESSIONS)
         .add(&ENABLE_0DT_DEPLOYMENT)
         .add(&WITH_0DT_DEPLOYMENT_MAX_WAIT)
+        .add(&WITH_0DT_DEPLOYMENT_DDL_CHECK_INTERVAL)
         .add(&ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT)
         .add(&WITH_0DT_DEPLOYMENT_CAUGHT_UP_CHECK_INTERVAL)
         .add(&ENABLE_0DT_CAUGHT_UP_CHECK)

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -17,7 +17,8 @@ use itertools::Itertools;
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::connection::ConnectionId;
 use mz_adapter_types::dyncfgs::{
-    ENABLE_0DT_DEPLOYMENT, ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT, WITH_0DT_DEPLOYMENT_MAX_WAIT,
+    ENABLE_0DT_DEPLOYMENT, ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT,
+    WITH_0DT_DEPLOYMENT_DDL_CHECK_INTERVAL, WITH_0DT_DEPLOYMENT_MAX_WAIT,
 };
 use mz_audit_log::{
     CreateOrDropClusterReplicaReasonV1, EventDetails, EventType, IdFullNameV1, IdNameV1,
@@ -2268,6 +2269,13 @@ impl Catalog {
                         Duration::parse(VarInput::Flat(&parsed_value))
                             .expect("parsing succeeded above");
                     tx.set_0dt_deployment_max_wait(with_0dt_deployment_max_wait)?;
+                } else if name == WITH_0DT_DEPLOYMENT_DDL_CHECK_INTERVAL.name() {
+                    let with_0dt_deployment_ddl_check_interval =
+                        Duration::parse(VarInput::Flat(&parsed_value))
+                            .expect("parsing succeeded above");
+                    tx.set_0dt_deployment_ddl_check_interval(
+                        with_0dt_deployment_ddl_check_interval,
+                    )?;
                 } else if name == ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT.name() {
                     let panic_after_timeout =
                         strconv::parse_bool(&parsed_value).expect("parsing succeeded above");
@@ -2297,6 +2305,8 @@ impl Catalog {
                     tx.reset_enable_0dt_deployment()?;
                 } else if name == WITH_0DT_DEPLOYMENT_MAX_WAIT.name() {
                     tx.reset_0dt_deployment_max_wait()?;
+                } else if name == WITH_0DT_DEPLOYMENT_DDL_CHECK_INTERVAL.name() {
+                    tx.reset_0dt_deployment_ddl_check_interval()?;
                 }
 
                 CatalogState::add_to_audit_log(
@@ -2314,6 +2324,7 @@ impl Catalog {
                 tx.clear_system_configs();
                 tx.reset_enable_0dt_deployment()?;
                 tx.reset_0dt_deployment_max_wait()?;
+                tx.reset_0dt_deployment_ddl_check_interval()?;
 
                 CatalogState::add_to_audit_log(
                     &state.system_configuration,

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -169,6 +169,15 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// LaunchDarkly is available.
     async fn get_0dt_deployment_max_wait(&mut self) -> Result<Option<Duration>, CatalogError>;
 
+    /// Get the `with_0dt_deployment_ddl_check_interval` config value of this instance.
+    ///
+    /// This mirrors the `with_0dt_deployment_ddl_check_interval` "system var" so that we can
+    /// toggle the flag with LaunchDarkly, but use it in boot before
+    /// LaunchDarkly is available.
+    async fn get_0dt_deployment_ddl_check_interval(
+        &mut self,
+    ) -> Result<Option<Duration>, CatalogError>;
+
     /// Get the `enable_0dt_deployment_panic_after_timeout` config value of this
     /// instance.
     ///

--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -74,6 +74,15 @@ pub(crate) const ENABLE_0DT_DEPLOYMENT: &str = "enable_0dt_deployment";
 pub(crate) const WITH_0DT_DEPLOYMENT_MAX_WAIT: &str = "with_0dt_deployment_max_wait";
 
 /// The key used within the "config" collection where we store a mirror of the
+/// `with_0dt_deployment_ddl_check_interval` "system var" value. This is
+/// mirrored so that we can toggle the flag with LaunchDarkly, but use it in
+/// boot before LaunchDarkly is available.
+///
+/// NOTE: Weird prefix because we can't start with a `0`.
+pub(crate) const WITH_0DT_DEPLOYMENT_DDL_CHECK_INTERVAL: &str =
+    "with_0dt_deployment_ddl_check_interval";
+
+/// The key used within the "config" collection where we store a mirror of the
 /// `enable_0dt_deployment_panic_after_timeout` "system var" value. This is
 /// mirrored so that we can toggle the flag with LaunchDarkly, but use it in
 /// boot before LaunchDarkly is available.

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -51,7 +51,7 @@ use crate::durable::debug::{Collection, CollectionType, DebugCatalogState, Trace
 use crate::durable::error::FenceError;
 use crate::durable::initialize::{
     ENABLE_0DT_DEPLOYMENT, ENABLE_0DT_DEPLOYMENT_PANIC_AFTER_TIMEOUT, SYSTEM_CONFIG_SYNCED_KEY,
-    USER_VERSION_KEY, WITH_0DT_DEPLOYMENT_MAX_WAIT,
+    USER_VERSION_KEY, WITH_0DT_DEPLOYMENT_DDL_CHECK_INTERVAL, WITH_0DT_DEPLOYMENT_MAX_WAIT,
 };
 use crate::durable::metrics::Metrics;
 use crate::durable::objects::state_update::{
@@ -1460,6 +1460,19 @@ impl OpenableDurableCatalogState for UnopenedPersistCatalogState {
     async fn get_0dt_deployment_max_wait(&mut self) -> Result<Option<Duration>, CatalogError> {
         let value = self
             .get_current_config(WITH_0DT_DEPLOYMENT_MAX_WAIT)
+            .await?;
+        match value {
+            None => Ok(None),
+            Some(millis) => Ok(Some(Duration::from_millis(millis))),
+        }
+    }
+
+    #[mz_ore::instrument(level = "debug")]
+    async fn get_0dt_deployment_ddl_check_interval(
+        &mut self,
+    ) -> Result<Option<Duration>, CatalogError> {
+        let value = self
+            .get_current_config(WITH_0DT_DEPLOYMENT_DDL_CHECK_INTERVAL)
             .await?;
         match value {
             None => Ok(None),

--- a/src/environmentd/src/deployment/preflight.rs
+++ b/src/environmentd/src/deployment/preflight.rs
@@ -192,6 +192,8 @@ pub async fn preflight_0dt(
             let mut should_skip_catchup = false;
             loop {
                 tokio::select! {
+                    biased;
+
                     () = &mut skip_catchup => {
                         info!("skipping waiting for deployment to catch up due to administrator request");
                         should_skip_catchup = true;

--- a/src/environmentd/src/deployment/preflight.rs
+++ b/src/environmentd/src/deployment/preflight.rs
@@ -36,6 +36,7 @@ pub struct PreflightInput {
     pub openable_adapter_storage: Box<dyn OpenableDurableCatalogState>,
     pub catalog_metrics: Arc<Metrics>,
     pub caught_up_max_wait: Duration,
+    pub ddl_check_interval: Duration,
     pub panic_after_timeout: bool,
     pub bootstrap_args: BootstrapArgs,
 }
@@ -59,6 +60,7 @@ pub async fn preflight_legacy(
         catalog_metrics,
         bootstrap_args,
         caught_up_max_wait: _,
+        ddl_check_interval: _,
         panic_after_timeout: _,
     }: PreflightInput,
 ) -> Result<Box<dyn OpenableDurableCatalogState>, CatalogError> {
@@ -135,6 +137,7 @@ pub async fn preflight_0dt(
         mut openable_adapter_storage,
         catalog_metrics,
         caught_up_max_wait,
+        ddl_check_interval,
         panic_after_timeout,
         bootstrap_args,
     }: PreflightInput,
@@ -182,7 +185,7 @@ pub async fn preflight_0dt(
 
             let mut skip_catchup = deployment_state.set_catching_up();
 
-            let mut check_ddl_changes_interval = tokio::time::interval(Duration::from_secs(5 * 60));
+            let mut check_ddl_changes_interval = tokio::time::interval(ddl_check_interval);
             check_ddl_changes_interval
                 .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -542,9 +542,6 @@ impl Listeners {
             computed
         };
 
-        // TODO(aljoscha): We have to do the same dance for
-        // `0dt_deployment_max_wait`, and pass it to the preflight check.
-
         // Perform preflight checks.
         //
         // Preflight checks determine whether to boot in read-only mode or not.

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -1505,3 +1505,506 @@ def workflow_upsert_sources(c: Composition) -> None:
 
     for thread in threads:
         thread.join()
+
+
+def workflow_ddl(c: Composition) -> None:
+    """Verify basic 0dt deployment flow with DDLs running during the 0dt deployment."""
+    c.down(destroy_volumes=True)
+    c.up("zookeeper", "kafka", "schema-registry", "postgres", "mysql", "mz_old")
+    c.up("testdrive", persistent=True)
+
+    # Make sure cluster is owned by the system so it doesn't get dropped
+    # between testdrive runs.
+    c.sql(
+        """
+        DROP CLUSTER IF EXISTS cluster CASCADE;
+        CREATE CLUSTER cluster SIZE '2-1';
+        GRANT ALL ON CLUSTER cluster TO materialize;
+        ALTER SYSTEM SET cluster = cluster;
+    """,
+        service="mz_old",
+        port=6877,
+        user="mz_system",
+    )
+
+    # Inserts should be reflected when writes are allowed.
+    c.testdrive(
+        dedent(
+            f"""
+        > SET CLUSTER = cluster;
+        > CREATE TABLE t (a int, b int);
+
+        > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${{testdrive.kafka-addr}}', SECURITY PROTOCOL = 'PLAINTEXT';
+        > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${{testdrive.schema-registry-url}}';
+        > CREATE SINK kafka_sink
+          IN CLUSTER cluster
+          FROM t
+          INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-${{testdrive.seed}}')
+          FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+          ENVELOPE DEBEZIUM;
+
+        > INSERT INTO t VALUES (1, 2);
+        > CREATE INDEX t_idx ON t (a, b);
+        > CREATE MATERIALIZED VIEW mv AS SELECT sum(a) FROM t;
+        > SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
+        > SELECT * FROM mv;
+        1
+        > SELECT max(b) FROM t;
+        2
+
+        $ kafka-create-topic topic=kafka
+        $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=kafka
+        key1A,key1B:value1A,value1B
+        > CREATE SOURCE kafka_source
+          IN CLUSTER cluster
+          FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-${{testdrive.seed}}');
+
+        > CREATE TABLE kafka_source_tbl (key1, key2, value1, value2)
+          FROM SOURCE kafka_source (REFERENCE "testdrive-kafka-${{testdrive.seed}}")
+          KEY FORMAT CSV WITH 2 COLUMNS DELIMITED BY ','
+          VALUE FORMAT CSV WITH 2 COLUMNS DELIMITED BY ','
+          ENVELOPE UPSERT;
+        > SELECT * FROM kafka_source_tbl
+        key1A key1B value1A value1B
+
+        $ postgres-execute connection=postgres://postgres:postgres@postgres
+        CREATE USER postgres1 WITH SUPERUSER PASSWORD 'postgres';
+        ALTER USER postgres1 WITH replication;
+        DROP PUBLICATION IF EXISTS postgres_source;
+        DROP TABLE IF EXISTS postgres_source_table;
+        CREATE TABLE postgres_source_table (f1 TEXT, f2 INTEGER);
+        ALTER TABLE postgres_source_table REPLICA IDENTITY FULL;
+        INSERT INTO postgres_source_table SELECT 'A', 0;
+        CREATE PUBLICATION postgres_source FOR ALL TABLES;
+
+        > CREATE SECRET pgpass AS 'postgres';
+        > CREATE CONNECTION pg FOR POSTGRES
+          HOST 'postgres',
+          DATABASE postgres,
+          USER postgres1,
+          PASSWORD SECRET pgpass;
+        > CREATE SOURCE postgres_source
+          IN CLUSTER cluster
+          FROM POSTGRES CONNECTION pg
+          (PUBLICATION 'postgres_source');
+        > CREATE TABLE postgres_source_table FROM SOURCE postgres_source (REFERENCE postgres_source_table)
+        > SELECT * FROM postgres_source_table;
+        A 0
+
+        $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+        $ mysql-execute name=mysql
+        # create the database if it does not exist yet but do not drop it
+        CREATE DATABASE IF NOT EXISTS public;
+        USE public;
+        CREATE USER mysql1 IDENTIFIED BY 'mysql';
+        GRANT REPLICATION SLAVE ON *.* TO mysql1;
+        GRANT ALL ON public.* TO mysql1;
+        CREATE TABLE mysql_source_table (f1 VARCHAR(32), f2 INTEGER);
+        INSERT INTO mysql_source_table VALUES ('A', 0);
+
+        > CREATE SECRET mysqlpass AS 'mysql';
+        > CREATE CONNECTION mysql TO MYSQL (
+          HOST 'mysql',
+          USER mysql1,
+          PASSWORD SECRET mysqlpass);
+        > CREATE SOURCE mysql_source1
+          IN CLUSTER cluster
+          FROM MYSQL CONNECTION mysql;
+        > CREATE TABLE mysql_source_table FROM SOURCE mysql_source1 (REFERENCE public.mysql_source_table);
+        > SELECT * FROM mysql_source_table;
+        A 0
+
+        $ kafka-verify-topic sink=materialize.public.kafka_sink
+
+        > CREATE SOURCE kafka_sink_source
+          IN CLUSTER cluster
+          FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-${{testdrive.seed}}')
+
+        > CREATE TABLE kafka_sink_source_tbl FROM SOURCE kafka_sink_source (REFERENCE "testdrive-kafka-sink-${{testdrive.seed}}")
+          FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+          ENVELOPE NONE
+
+        > SELECT (before).a, (before).b, (after).a, (after).b FROM kafka_sink_source_tbl
+        <null> <null> 1 2
+
+        > CREATE SOURCE webhook_source
+          IN CLUSTER cluster
+          FROM WEBHOOK BODY FORMAT TEXT
+
+        $ webhook-append database=materialize schema=public name=webhook_source
+        AAA
+        > SELECT * FROM webhook_source
+        AAA
+
+        $ set-max-tries max-tries=1
+        $ set-regex match=\\d{{13,20}} replacement=<TIMESTAMP>
+        > BEGIN
+        > DECLARE c CURSOR FOR SUBSCRIBE (SELECT a FROM t);
+        > FETCH ALL c WITH (timeout='5s');
+        <TIMESTAMP> 1 1
+        > COMMIT
+        """
+        )
+    )
+
+    # Start new Materialize in a new deploy generation, which will cause
+    # Materialize to boot in read-only mode.
+    c.up("mz_new")
+
+    # Verify against new Materialize that it is in read-only mode
+    with c.override(
+        Testdrive(
+            materialize_url="postgres://materialize@mz_new:6875",
+            materialize_url_internal="postgres://materialize@mz_new:6877",
+            mz_service="mz_new",
+            materialize_params={"cluster": "cluster"},
+            no_reset=True,
+            seed=1,
+            default_timeout=DEFAULT_TIMEOUT,
+        )
+    ):
+        c.up("testdrive", persistent=True)
+        c.testdrive(
+            dedent(
+                f"""
+            $ webhook-append database=materialize schema=public name=webhook_source status=500
+            BBB
+
+            $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=kafka
+            key2A,key2B:value2A,value2B
+
+            $ postgres-execute connection=postgres://postgres:postgres@postgres
+            INSERT INTO postgres_source_table VALUES ('B', 1);
+
+            $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+            $ mysql-execute name=mysql
+            USE public;
+            INSERT INTO mysql_source_table VALUES ('B', 1);
+
+            > SET CLUSTER = cluster;
+            > SELECT 1
+            1
+            ! INSERT INTO t VALUES (3, 4);
+            contains: cannot write in read-only mode
+            > SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
+            > SELECT * FROM mv;
+            1
+            # TODO: Currently hangs
+            # > SELECT max(b) FROM t;
+            # 2
+            > SELECT mz_unsafe.mz_sleep(5)
+            <null>
+            ! INSERT INTO t VALUES (5, 6);
+            contains: cannot write in read-only mode
+            > SELECT * FROM mv;
+            1
+            ! DROP INDEX t_idx
+            contains: cannot write in read-only mode
+            ! CREATE INDEX t_idx2 ON t (a, b)
+            contains: cannot write in read-only mode
+            ! CREATE MATERIALIZED VIEW mv2 AS SELECT sum(a) FROM t;
+            contains: cannot write in read-only mode
+
+            $ set-regex match=(s\\d+|\\d{{13}}|[ ]{{12}}0|u\\d{{1,3}}|\\(\\d+-\\d\\d-\\d\\d\\s\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d\\)) replacement=<>
+
+            > EXPLAIN TIMESTAMP FOR SELECT * FROM mv;
+            "                query timestamp: <> <>\\nlargest not in advance of upper: <> <>\\n                          upper:[<> <>]\\n                          since:[<> <>]\\n        can respond immediately: true\\n                       timeline: Some(EpochMilliseconds)\\n              session wall time: <> <>\\n\\nsource materialize.public.mv (<>, storage):\\n                  read frontier:[<> <>]\\n                 write frontier:[<> <>]\\n"
+
+            > SELECT * FROM kafka_source_tbl
+            key1A key1B value1A value1B
+            key2A key2B value2A value2B
+            > SELECT * FROM postgres_source_table
+            A 0
+            B 1
+            > SELECT * FROM mysql_source_table;
+            A 0
+            B 1
+            > SELECT (before).a, (before).b, (after).a, (after).b FROM kafka_sink_source_tbl
+            <null> <null> 1 2
+
+            > SELECT * FROM webhook_source
+            AAA
+
+            $ set-max-tries max-tries=1
+            $ set-regex match=\\d{{13,20}} replacement=<TIMESTAMP>
+            > BEGIN
+            ! DECLARE c CURSOR FOR SUBSCRIBE (SELECT a FROM t);
+            contains: cannot write in read-only mode
+            > ROLLBACK
+            # Actual subscribes without a declare still work though
+            > SUBSCRIBE (WITH a(x) AS (SELECT 'a') SELECT generate_series(1, 2), x FROM a)
+            <TIMESTAMP> 1 1 a
+            <TIMESTAMP> 1 2 a
+            """
+            )
+        )
+
+    # Run DDLs against the old Materialize, which should restart the new one
+    c.up("testdrive", persistent=True)
+    c.testdrive(
+        dedent(
+            f"""
+        > CREATE TABLE t1 (a INT);
+
+        $ webhook-append database=materialize schema=public name=webhook_source
+        CCC
+
+        $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=kafka
+        key3A,key3B:value3A,value3B
+
+        $ postgres-execute connection=postgres://postgres:postgres@postgres
+        INSERT INTO postgres_source_table VALUES ('C', 2);
+
+        $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+        $ mysql-execute name=mysql
+        USE public;
+        INSERT INTO mysql_source_table VALUES ('C', 2);
+
+        > CREATE TABLE t2 (a INT);
+
+        > SET CLUSTER = cluster;
+        > SELECT 1
+        1
+        > INSERT INTO t VALUES (3, 4);
+        > SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
+        > SELECT * FROM mv;
+        4
+        > SELECT max(b) FROM t;
+        4
+        > SELECT mz_unsafe.mz_sleep(5)
+        <null>
+        > INSERT INTO t VALUES (5, 6);
+        > SELECT * FROM mv;
+        9
+        > DROP INDEX t_idx
+        > CREATE INDEX t_idx2 ON t (a, b)
+        > CREATE MATERIALIZED VIEW mv2 AS SELECT sum(a) FROM t;
+
+        $ set-regex match=(s\\d+|\\d{{13}}|[ ]{{12}}0|u\\d{{1,3}}|\\(\\d+-\\d\\d-\\d\\d\\s\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d\\)) replacement=<>
+
+        > EXPLAIN TIMESTAMP FOR SELECT * FROM mv;
+        "                query timestamp: <> <>\\nlargest not in advance of upper: <> <>\\n                          upper:[<> <>]\\n                          since:[<> <>]\\n        can respond immediately: true\\n                       timeline: Some(EpochMilliseconds)\\n              session wall time: <> <>\\n\\nsource materialize.public.mv (<>, storage):\\n                  read frontier:[<> <>]\\n                 write frontier:[<> <>]\\n"
+
+        > SELECT * FROM kafka_source_tbl
+        key1A key1B value1A value1B
+        key2A key2B value2A value2B
+        key3A key3B value3A value3B
+        > SELECT * FROM postgres_source_table
+        A 0
+        B 1
+        C 2
+        > SELECT * FROM mysql_source_table;
+        A 0
+        B 1
+        C 2
+        > SELECT (before).a, (before).b, (after).a, (after).b FROM kafka_sink_source_tbl
+        <null> <null> 1 2
+        <null> <null> 3 4
+        <null> <null> 5 6
+        > SELECT * FROM webhook_source
+        AAA
+        CCC
+
+        > CREATE TABLE t3 (a INT);
+
+        $ set-max-tries max-tries=1
+        $ set-regex match=\\d{{13,20}} replacement=<TIMESTAMP>
+        > BEGIN
+        > DECLARE c CURSOR FOR SUBSCRIBE (SELECT a FROM t);
+        > FETCH ALL c WITH (timeout='5s');
+        <TIMESTAMP> 1 1
+        <TIMESTAMP> 1 3
+        <TIMESTAMP> 1 5
+        > COMMIT
+
+        > CREATE TABLE t4 (a INT);
+        """
+        )
+    )
+
+    with c.override(
+        Testdrive(
+            materialize_url="postgres://materialize@mz_new:6875",
+            materialize_url_internal="postgres://materialize@mz_new:6877",
+            mz_service="mz_new",
+            materialize_params={"cluster": "cluster"},
+            no_reset=True,
+            seed=1,
+            default_timeout=DEFAULT_TIMEOUT,
+        )
+    ):
+        c.up("testdrive", persistent=True)
+        c.testdrive(
+            dedent(
+                """
+            $ webhook-append database=materialize schema=public name=webhook_source status=500
+            DDD
+
+            > SET CLUSTER = cluster;
+            > SELECT 1
+            1
+            ! INSERT INTO t VALUES (3, 4);
+            contains: cannot write in read-only mode
+            > SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
+            > SELECT * FROM mv;
+            9
+            > SELECT max(b) FROM t;
+            6
+            > SELECT * FROM mv;
+            9
+            > SELECT * FROM kafka_source_tbl
+            key1A key1B value1A value1B
+            key2A key2B value2A value2B
+            key3A key3B value3A value3B
+            > SELECT * FROM postgres_source_table
+            A 0
+            B 1
+            C 2
+            > SELECT * FROM mysql_source_table;
+            A 0
+            B 1
+            C 2
+            > SELECT (before).a, (before).b, (after).a, (after).b FROM kafka_sink_source_tbl
+            <null> <null> 1 2
+            <null> <null> 3 4
+            <null> <null> 5 6
+            > SELECT * FROM webhook_source
+            AAA
+            CCC
+
+            $ set-max-tries max-tries=1
+            $ set-regex match=\\d{13,20} replacement=<TIMESTAMP>
+            > BEGIN
+            ! DECLARE c CURSOR FOR SUBSCRIBE (SELECT a FROM t);
+            contains: cannot write in read-only mode
+            > ROLLBACK
+            # Actual subscribes without a declare still work though
+            > SUBSCRIBE (WITH a(x) AS (SELECT 'a') SELECT generate_series(1, 2), x FROM a)
+            <TIMESTAMP> 1 1 a
+            <TIMESTAMP> 1 2 a
+            """
+            )
+        )
+
+        c.await_mz_deployment_status(DeploymentStatus.READY_TO_PROMOTE, "mz_new")
+        c.promote_mz("mz_new")
+
+        # Give some time for Mz to restart after promotion
+        for i in range(10):
+            try:
+                c.sql("SELECT 1", service="mz_old")
+            except OperationalError as e:
+                assert (
+                    "server closed the connection unexpectedly" in str(e)
+                    or "Can't create a connection to host" in str(e)
+                    or "Connection refused" in str(e)
+                ), f"Unexpected error: {e}"
+            except CommandFailureCausedUIError as e:
+                # service "mz_old" is not running
+                assert "running docker compose failed" in str(
+                    e
+                ), f"Unexpected error: {e}"
+                break
+            time.sleep(1)
+        else:
+            raise RuntimeError("mz_old didn't stop running within 10 seconds")
+
+        for i in range(10):
+            try:
+                c.sql("SELECT 1", service="mz_new")
+                break
+            except CommandFailureCausedUIError:
+                pass
+            except OperationalError:
+                pass
+            time.sleep(1)
+        else:
+            raise RuntimeError("mz_new didn't come up within 10 seconds")
+
+        c.await_mz_deployment_status(DeploymentStatus.IS_LEADER, "mz_new")
+
+        c.testdrive(
+            dedent(
+                f"""
+            $ webhook-append database=materialize schema=public name=webhook_source
+            EEE
+            > SET CLUSTER = cluster;
+            > SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
+            > CREATE MATERIALIZED VIEW mv3 AS SELECT sum(a) FROM t;
+            > SELECT * FROM mv;
+            9
+            > SELECT * FROM mv2;
+            9
+            > SELECT * FROM mv3;
+            9
+            > SELECT max(b) FROM t;
+            6
+            > INSERT INTO t VALUES (7, 8);
+            > SELECT * FROM mv;
+            16
+            > SELECT * FROM mv2;
+            16
+            > SELECT max(b) FROM t;
+            8
+            > SELECT * FROM kafka_source_tbl
+            key1A key1B value1A value1B
+            key2A key2B value2A value2B
+            key3A key3B value3A value3B
+            > SELECT * FROM postgres_source_table
+            A 0
+            B 1
+            C 2
+            > SELECT * FROM mysql_source_table;
+            A 0
+            B 1
+            C 2
+
+            $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=kafka
+            key4A,key4B:value4A,value4B
+
+            $ postgres-execute connection=postgres://postgres:postgres@postgres
+            INSERT INTO postgres_source_table VALUES ('D', 3);
+
+            $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+            $ mysql-execute name=mysql
+            USE public;
+            INSERT INTO mysql_source_table VALUES ('D', 3);
+
+            > SELECT * FROM kafka_source_tbl
+            key1A key1B value1A value1B
+            key2A key2B value2A value2B
+            key3A key3B value3A value3B
+            key4A key4B value4A value4B
+            > SELECT * FROM postgres_source_table
+            A 0
+            B 1
+            C 2
+            D 3
+            > SELECT * FROM mysql_source_table;
+            A 0
+            B 1
+            C 2
+            D 3
+            > SELECT (before).a, (before).b, (after).a, (after).b FROM kafka_sink_source_tbl
+            <null> <null> 1 2
+            <null> <null> 3 4
+            <null> <null> 5 6
+            <null> <null> 7 8
+            > SELECT * FROM webhook_source
+            AAA
+            CCC
+            EEE
+
+            $ set-max-tries max-tries=1
+            $ set-regex match=\\d{{13,20}} replacement=<TIMESTAMP>
+            > BEGIN
+            > DECLARE c CURSOR FOR SUBSCRIBE (SELECT a FROM t);
+            > FETCH ALL c WITH (timeout='5s');
+            <TIMESTAMP> 1 1
+            <TIMESTAMP> 1 3
+            <TIMESTAMP> 1 5
+            <TIMESTAMP> 1 7
+            > COMMIT
+            """
+            )
+        )


### PR DESCRIPTION
Before, a hydrating read-only environment would read a catalog snapshot on bootstrap and then not subscribe to further changes. This means that we would not be hydrating collections/replicas that are created in the old version that is still running, and those would then have to be hydrated after cutting over to the new version.

With this change, we periodically check if new collections/replicas where created and we also check right before announcing as ready to promote. When we _do_ notice there was relevant DDL, we halt. This will make it so we're restarted in read-only mode again, and can now read an up-to-date catalog snapshot.

It's important to note that any running clusters are not restarted, so any work that has already gone into hydration will not be lost.

I think there's no one left besides me who has seen this code, but @ParkMyCar might be best to review. @alex-hunt-materialize there's a question in there for you about what cloud can or wants to do. I'll tag you on the specific code line.

@def- We probably want more testing. The new behavior is described above, I imagine a test would be to create tables or things while hydrating, and make sure that they show up in the read-only environment.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
