### PR TITLE
ci: improve aws terraform module test s3 bucket deletion

### DIFF
--- a/test/terraform/aws/main.tf
+++ b/test/terraform/aws/main.tf
@@ -36,9 +36,12 @@ module "materialize_infrastructure" {
   node_group_capacity_type  = "ON_DEMAND"
 
   # Storage Configuration
-  enable_bucket_versioning = true
-  enable_bucket_encryption = true
-  bucket_force_destroy     = true
+  bucket_force_destroy = true
+
+  # For testing purposes, we are disabling encryption and versioning to allow for easier cleanup
+  # This should be enabled in production environments for security and data integrity
+  enable_bucket_versioning = false
+  enable_bucket_encryption = false
 
   # Database Configuration
   database_password    = "someRANDOMpasswordNOTsecure"


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

As per the suggestion [here](https://github.com/MaterializeInc/terraform-aws-materialize/issues/17#issuecomment-2632764448), disabling S3 bucket versioning and encryption to improve the S3 bucket deletion time in tests.