### PR TITLE
platform-checks: Bump minimum version for invisible columns

### DIFF
--- a/misc/python/materialize/checks/all_checks/mysql_cdc.py
+++ b/misc/python/materialize/checks/all_checks/mysql_cdc.py
@@ -483,7 +483,7 @@ class MySqlBitType(Check):
 @externally_idempotent(False)
 class MySqlInvisibleColumn(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version > MzVersion.parse_mz("v0.132.0-dev")
+        return self.base_version > MzVersion.parse_mz("v0.133.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/11061#0194d7d7-4721-4741-8e43-668699fa5696

Should have rebased the original PR before adding this, then we would have noticed on the PR's run already.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
