### PR TITLE
[adapter] Stream BuiltinTable retractions at bootstrap

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -46,6 +46,7 @@ use mz_expr::MirScalarExpr;
 use mz_orchestrator::{CpuLimit, DiskLimit, MemoryLimit, ServiceProcessMetrics};
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
+use mz_persist_client::batch::ProtoBatch;
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::interval::Interval;
 use mz_repr::adt::jsonb::Jsonb;
@@ -67,6 +68,7 @@ use mz_sql::plan::{ClusterSchedule, ConnectionDetails, SshKey};
 use mz_sql::session::user::SYSTEM_USER;
 use mz_sql::session::vars::SessionVars;
 use mz_sql_parser::ast::display::AstDisplay;
+use mz_storage_client::client::TableData;
 use mz_storage_types::connections::aws::{AwsAuth, AwsConnection};
 use mz_storage_types::connections::inline::ReferencedConnection;
 use mz_storage_types::connections::string_or_secret::StringOrSecret;
@@ -75,6 +77,7 @@ use mz_storage_types::sinks::{KafkaSinkConnection, StorageSinkConnection};
 use mz_storage_types::sources::{
     GenericSourceConnection, KafkaSourceConnection, PostgresSourceConnection, SourceConnection,
 };
+use smallvec::smallvec;
 
 // DO NOT add any more imports from `crate` outside of `crate::catalog`.
 use crate::active_compute_sink::ActiveSubscribe;
@@ -82,14 +85,29 @@ use crate::catalog::CatalogState;
 use crate::coord::ConnMeta;
 
 /// An update to a built-in table.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct BuiltinTableUpdate<T = CatalogItemId> {
     /// The reference of the table to update.
     pub id: T,
     /// The data to put into the table.
-    pub row: Row,
-    /// The diff of the data.
-    pub diff: Diff,
+    pub data: TableData,
+}
+
+impl<T> BuiltinTableUpdate<T> {
+    /// Create a [`BuiltinTableUpdate`] from a [`Row`].
+    pub fn row(id: T, row: Row, diff: Diff) -> BuiltinTableUpdate<T> {
+        BuiltinTableUpdate {
+            id,
+            data: TableData::Rows(vec![(row, diff)]),
+        }
+    }
+
+    pub fn batch(id: T, batch: ProtoBatch) -> BuiltinTableUpdate<T> {
+        BuiltinTableUpdate {
+            id,
+            data: TableData::Batches(smallvec![batch]),
+        }
+    }
 }
 
 impl CatalogState {
@@ -105,10 +123,10 @@ impl CatalogState {
 
     pub fn resolve_builtin_table_update(
         &self,
-        BuiltinTableUpdate { id, row, diff }: BuiltinTableUpdate<&'static BuiltinTable>,
+        BuiltinTableUpdate { id, data }: BuiltinTableUpdate<&'static BuiltinTable>,
     ) -> BuiltinTableUpdate<CatalogItemId> {
         let id = self.resolve_builtin_table(id);
-        BuiltinTableUpdate { id, row, diff }
+        BuiltinTableUpdate { id, data }
     }
 
     pub fn pack_depends_update(
@@ -117,14 +135,11 @@ impl CatalogState {
         dependee: CatalogItemId,
         diff: Diff,
     ) -> BuiltinTableUpdate<&'static BuiltinTable> {
-        BuiltinTableUpdate {
-            id: &*MZ_OBJECT_DEPENDENCIES,
-            row: Row::pack_slice(&[
-                Datum::String(&depender.to_string()),
-                Datum::String(&dependee.to_string()),
-            ]),
-            diff,
-        }
+        let row = Row::pack_slice(&[
+            Datum::String(&depender.to_string()),
+            Datum::String(&dependee.to_string()),
+        ]);
+        BuiltinTableUpdate::row(&*MZ_OBJECT_DEPENDENCIES, row, diff)
     }
 
     pub(super) fn pack_database_update(
@@ -135,9 +150,9 @@ impl CatalogState {
         let database = self.get_database(database_id);
         let row = self.pack_privilege_array_row(database.privileges());
         let privileges = row.unpack_first();
-        BuiltinTableUpdate {
-            id: &*MZ_DATABASES,
-            row: Row::pack_slice(&[
+        BuiltinTableUpdate::row(
+            &*MZ_DATABASES,
+            Row::pack_slice(&[
                 Datum::String(&database.id.to_string()),
                 Datum::UInt32(database.oid),
                 Datum::String(database.name()),
@@ -145,7 +160,7 @@ impl CatalogState {
                 privileges,
             ]),
             diff,
-        }
+        )
     }
 
     pub(super) fn pack_schema_update(
@@ -163,9 +178,9 @@ impl CatalogState {
         };
         let row = self.pack_privilege_array_row(schema.privileges());
         let privileges = row.unpack_first();
-        BuiltinTableUpdate {
-            id: &*MZ_SCHEMAS,
-            row: Row::pack_slice(&[
+        BuiltinTableUpdate::row(
+            &*MZ_SCHEMAS,
+            Row::pack_slice(&[
                 Datum::String(&schema_id.to_string()),
                 Datum::UInt32(schema.oid),
                 Datum::from(database_id.as_deref()),
@@ -174,7 +189,7 @@ impl CatalogState {
                 privileges,
             ]),
             diff,
-        }
+        )
     }
 
     pub(super) fn pack_role_update(
@@ -187,16 +202,16 @@ impl CatalogState {
             RoleId::Public => vec![],
             id => {
                 let role = self.get_role(&id);
-                let role_update = BuiltinTableUpdate {
-                    id: &*MZ_ROLES,
-                    row: Row::pack_slice(&[
+                let role_update = BuiltinTableUpdate::row(
+                    &*MZ_ROLES,
+                    Row::pack_slice(&[
                         Datum::String(&role.id.to_string()),
                         Datum::UInt32(role.oid),
                         Datum::String(&role.name),
                         Datum::from(role.attributes.inherit),
                     ]),
                     diff,
-                };
+                );
                 let mut updates = vec![role_update];
 
                 // HACK/TODO(parkmycar): Creating an empty SessionVars like this is pretty hacky,
@@ -218,15 +233,15 @@ impl CatalogState {
                         continue;
                     };
 
-                    let role_var_update = BuiltinTableUpdate {
-                        id: &*MZ_ROLE_PARAMETERS,
-                        row: Row::pack_slice(&[
+                    let role_var_update = BuiltinTableUpdate::row(
+                        &*MZ_ROLE_PARAMETERS,
+                        Row::pack_slice(&[
                             Datum::String(&role.id.to_string()),
                             Datum::String(name),
                             Datum::String(&formatted_val),
                         ]),
                         diff,
-                    };
+                    );
                     updates.push(role_var_update);
                 }
 
@@ -247,15 +262,15 @@ impl CatalogState {
             .map
             .get(&role_id)
             .expect("catalog out of sync");
-        BuiltinTableUpdate {
-            id: &*MZ_ROLE_MEMBERS,
-            row: Row::pack_slice(&[
+        BuiltinTableUpdate::row(
+            &*MZ_ROLE_MEMBERS,
+            Row::pack_slice(&[
                 Datum::String(&role_id.to_string()),
                 Datum::String(&member_id.to_string()),
                 Datum::String(&grantor_id.to_string()),
             ]),
             diff,
-        }
+        )
     }
 
     pub(super) fn pack_cluster_update(
@@ -309,11 +324,7 @@ impl CatalogState {
 
         let mut updates = Vec::new();
 
-        updates.push(BuiltinTableUpdate {
-            id: &*MZ_CLUSTERS,
-            row,
-            diff,
-        });
+        updates.push(BuiltinTableUpdate::row(&*MZ_CLUSTERS, row, diff));
 
         if let ClusterVariant::Managed(managed_config) = &cluster.config.variant {
             let row = match managed_config.schedule {
@@ -333,21 +344,17 @@ impl CatalogState {
                     ),
                 ]),
             };
-            updates.push(BuiltinTableUpdate {
-                id: &*MZ_CLUSTER_SCHEDULES,
-                row,
-                diff,
-            });
+            updates.push(BuiltinTableUpdate::row(&*MZ_CLUSTER_SCHEDULES, row, diff));
         }
 
-        updates.push(BuiltinTableUpdate {
-            id: &*MZ_CLUSTER_WORKLOAD_CLASSES,
-            row: Row::pack_slice(&[
+        updates.push(BuiltinTableUpdate::row(
+            &*MZ_CLUSTER_WORKLOAD_CLASSES,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::from(cluster.config.workload_class.as_deref()),
             ]),
             diff,
-        });
+        ));
 
         updates
     }
@@ -392,9 +399,9 @@ impl CatalogState {
             _ => (None, None, None, false, false),
         };
 
-        let cluster_replica_update = BuiltinTableUpdate {
-            id: &*MZ_CLUSTER_REPLICAS,
-            row: Row::pack_slice(&[
+        let cluster_replica_update = BuiltinTableUpdate::row(
+            &*MZ_CLUSTER_REPLICAS,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::String(name),
                 Datum::String(&cluster_id.to_string()),
@@ -404,25 +411,25 @@ impl CatalogState {
                 Datum::from(disk),
             ]),
             diff,
-        };
+        );
 
         let mut updates = vec![cluster_replica_update];
 
         if internal {
-            let update = BuiltinTableUpdate {
-                id: &*MZ_INTERNAL_CLUSTER_REPLICAS,
-                row: Row::pack_slice(&[Datum::String(&id.to_string())]),
+            let update = BuiltinTableUpdate::row(
+                &*MZ_INTERNAL_CLUSTER_REPLICAS,
+                Row::pack_slice(&[Datum::String(&id.to_string())]),
                 diff,
-            };
+            );
             updates.push(update);
         }
 
         if pending {
-            let update = BuiltinTableUpdate {
-                id: &*MZ_PENDING_CLUSTER_REPLICAS,
-                row: Row::pack_slice(&[Datum::String(&id.to_string())]),
+            let update = BuiltinTableUpdate::row(
+                &*MZ_PENDING_CLUSTER_REPLICAS,
+                Row::pack_slice(&[Datum::String(&id.to_string())]),
                 diff,
-            };
+            );
             updates.push(update);
         }
 
@@ -445,9 +452,9 @@ impl CatalogState {
             ClusterStatus::Offline(Some(reason)) => Some(reason.to_string()),
         };
 
-        BuiltinTableUpdate {
-            id: &*MZ_CLUSTER_REPLICA_STATUSES,
-            row: Row::pack_slice(&[
+        BuiltinTableUpdate::row(
+            &*MZ_CLUSTER_REPLICA_STATUSES,
+            Row::pack_slice(&[
                 Datum::String(&replica_id.to_string()),
                 Datum::UInt64(process_id),
                 Datum::String(status),
@@ -455,7 +462,7 @@ impl CatalogState {
                 Datum::TimestampTz(event.time.try_into().expect("must fit")),
             ]),
             diff,
-        }
+        )
     }
 
     pub(crate) fn pack_network_policy_update(
@@ -468,9 +475,9 @@ impl CatalogState {
         let privileges = row.unpack_first();
         let mut updates = Vec::new();
         for ref rule in policy.rules.clone() {
-            updates.push(BuiltinTableUpdate {
-                id: &*MZ_NETWORK_POLICY_RULES,
-                row: Row::pack_slice(&[
+            updates.push(BuiltinTableUpdate::row(
+                &*MZ_NETWORK_POLICY_RULES,
+                Row::pack_slice(&[
                     Datum::String(&rule.name),
                     Datum::String(&policy.id.to_string()),
                     Datum::String(&rule.action.to_string()),
@@ -478,11 +485,11 @@ impl CatalogState {
                     Datum::String(&rule.direction.to_string()),
                 ]),
                 diff,
-            });
+            ));
         }
-        updates.push(BuiltinTableUpdate {
-            id: &*MZ_NETWORK_POLICIES,
-            row: Row::pack_slice(&[
+        updates.push(BuiltinTableUpdate::row(
+            &*MZ_NETWORK_POLICIES,
+            Row::pack_slice(&[
                 Datum::String(&policy.id.to_string()),
                 Datum::String(&policy.name),
                 Datum::String(&policy.owner_id.to_string()),
@@ -490,7 +497,7 @@ impl CatalogState {
                 Datum::UInt32(policy.oid.clone()),
             ]),
             diff,
-        });
+        ));
 
         Ok(updates)
     }
@@ -788,9 +795,9 @@ impl CatalogState {
                     }
                     _ => (pgtype.name(), pgtype.oid()),
                 };
-                updates.push(BuiltinTableUpdate {
-                    id: &*MZ_COLUMNS,
-                    row: Row::pack_slice(&[
+                updates.push(BuiltinTableUpdate::row(
+                    &*MZ_COLUMNS,
+                    Row::pack_slice(&[
                         Datum::String(&id.to_string()),
                         Datum::String(column_name.as_str()),
                         Datum::UInt64(u64::cast_from(i + 1)),
@@ -801,7 +808,7 @@ impl CatalogState {
                         Datum::Int32(pgtype.typmod()),
                     ]),
                     diff,
-                });
+                ));
             }
         }
 
@@ -830,16 +837,16 @@ impl CatalogState {
         let cw: u64 = cw.comparable_timestamp().into();
         let cw = Jsonb::from_serde_json(serde_json::Value::Number(serde_json::Number::from(cw)))
             .expect("must serialize");
-        BuiltinTableUpdate {
-            id: &*MZ_HISTORY_RETENTION_STRATEGIES,
-            row: Row::pack_slice(&[
+        BuiltinTableUpdate::row(
+            &*MZ_HISTORY_RETENTION_STRATEGIES,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 // FOR is the only strategy at the moment. We may introduce FROM or others later.
                 Datum::String("FOR"),
                 cw.into_row().into_element(),
             ]),
             diff,
-        }
+        )
     }
 
     fn pack_table_update(
@@ -870,9 +877,9 @@ impl CatalogState {
             None
         };
 
-        vec![BuiltinTableUpdate {
-            id: &*MZ_TABLES,
-            row: Row::pack_slice(&[
+        vec![BuiltinTableUpdate::row(
+            &*MZ_TABLES,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::UInt32(oid),
                 Datum::String(&schema_id.to_string()),
@@ -896,7 +903,7 @@ impl CatalogState {
                 },
             ]),
             diff,
-        }]
+        )]
     }
 
     fn pack_source_update(
@@ -923,9 +930,9 @@ impl CatalogState {
                 .ast;
             create_stmt.to_ast_string_redacted()
         });
-        vec![BuiltinTableUpdate {
-            id: &*MZ_SOURCES,
-            row: Row::pack_slice(&[
+        vec![BuiltinTableUpdate::row(
+            &*MZ_SOURCES,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::UInt32(oid),
                 Datum::String(&schema_id.to_string()),
@@ -953,7 +960,7 @@ impl CatalogState {
                 },
             ]),
             diff,
-        }]
+        )]
     }
 
     fn pack_postgres_source_update(
@@ -962,15 +969,15 @@ impl CatalogState {
         postgres: &PostgresSourceConnection<ReferencedConnection>,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
-        vec![BuiltinTableUpdate {
-            id: &*MZ_POSTGRES_SOURCES,
-            row: Row::pack_slice(&[
+        vec![BuiltinTableUpdate::row(
+            &*MZ_POSTGRES_SOURCES,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::String(&postgres.publication_details.slot),
                 Datum::from(postgres.publication_details.timeline_id),
             ]),
             diff,
-        }]
+        )]
     }
 
     fn pack_kafka_source_update(
@@ -980,15 +987,15 @@ impl CatalogState {
         kafka: &KafkaSourceConnection<ReferencedConnection>,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
-        vec![BuiltinTableUpdate {
-            id: &*MZ_KAFKA_SOURCES,
-            row: Row::pack_slice(&[
+        vec![BuiltinTableUpdate::row(
+            &*MZ_KAFKA_SOURCES,
+            Row::pack_slice(&[
                 Datum::String(&item_id.to_string()),
                 Datum::String(&kafka.group_id(&self.config.connection_context, collection_id)),
                 Datum::String(&kafka.topic),
             ]),
             diff,
-        }]
+        )]
     }
 
     fn pack_postgres_source_tables_update(
@@ -998,15 +1005,15 @@ impl CatalogState {
         table_name: &str,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
-        vec![BuiltinTableUpdate {
-            id: &*MZ_POSTGRES_SOURCE_TABLES,
-            row: Row::pack_slice(&[
+        vec![BuiltinTableUpdate::row(
+            &*MZ_POSTGRES_SOURCE_TABLES,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::String(schema_name),
                 Datum::String(table_name),
             ]),
             diff,
-        }]
+        )]
     }
 
     fn pack_mysql_source_tables_update(
@@ -1016,15 +1023,15 @@ impl CatalogState {
         table_name: &str,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
-        vec![BuiltinTableUpdate {
-            id: &*MZ_MYSQL_SOURCE_TABLES,
-            row: Row::pack_slice(&[
+        vec![BuiltinTableUpdate::row(
+            &*MZ_MYSQL_SOURCE_TABLES,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::String(schema_name),
                 Datum::String(table_name),
             ]),
             diff,
-        }]
+        )]
     }
 
     fn pack_kafka_source_tables_update(
@@ -1036,9 +1043,9 @@ impl CatalogState {
         value_format: Option<&str>,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
-        vec![BuiltinTableUpdate {
-            id: &*MZ_KAFKA_SOURCE_TABLES,
-            row: Row::pack_slice(&[
+        vec![BuiltinTableUpdate::row(
+            &*MZ_KAFKA_SOURCE_TABLES,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::String(topic),
                 Datum::from(envelope),
@@ -1046,7 +1053,7 @@ impl CatalogState {
                 Datum::from(value_format),
             ]),
             diff,
-        }]
+        )]
     }
 
     fn pack_connection_update(
@@ -1064,9 +1071,9 @@ impl CatalogState {
             .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", connection.create_sql))
             .into_element()
             .ast;
-        let mut updates = vec![BuiltinTableUpdate {
-            id: &*MZ_CONNECTIONS,
-            row: Row::pack_slice(&[
+        let mut updates = vec![BuiltinTableUpdate::row(
+            &*MZ_CONNECTIONS,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::UInt32(oid),
                 Datum::String(&schema_id.to_string()),
@@ -1086,7 +1093,7 @@ impl CatalogState {
                 Datum::String(&create_stmt.to_ast_string_redacted()),
             ]),
             diff,
-        }];
+        )];
         match connection.details {
             ConnectionDetails::Kafka(ref kafka) => {
                 updates.extend(self.pack_kafka_connection_update(id, kafka, diff));
@@ -1133,15 +1140,15 @@ impl CatalogState {
         key_2: &SshKey,
         diff: Diff,
     ) -> BuiltinTableUpdate<&'static BuiltinTable> {
-        BuiltinTableUpdate {
-            id: &*MZ_SSH_TUNNEL_CONNECTIONS,
-            row: Row::pack_slice(&[
+        BuiltinTableUpdate::row(
+            &*MZ_SSH_TUNNEL_CONNECTIONS,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::String(key_1.public_key().as_str()),
                 Datum::String(key_2.public_key().as_str()),
             ]),
             diff,
-        }
+        )
     }
 
     fn pack_kafka_connection_update(
@@ -1165,15 +1172,15 @@ impl CatalogState {
             )
             .expect("kafka.brokers is 1 dimensional, and its length is used for the array length");
         let brokers = row.unpack_first();
-        vec![BuiltinTableUpdate {
-            id: &*MZ_KAFKA_CONNECTIONS,
-            row: Row::pack_slice(&[
+        vec![BuiltinTableUpdate::row(
+            &*MZ_KAFKA_CONNECTIONS,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 brokers,
                 Datum::String(&progress_topic),
             ]),
             diff,
-        }]
+        )]
     }
 
     pub fn pack_aws_privatelink_connection_update(
@@ -1187,7 +1194,7 @@ impl CatalogState {
             Datum::String(&connection_id.to_string()),
             Datum::String(&aws_principal_context.to_principal_string(connection_id)),
         ]);
-        BuiltinTableUpdate { id, row, diff }
+        BuiltinTableUpdate::row(id, row, diff)
     }
 
     pub fn pack_aws_connection_update(
@@ -1258,7 +1265,7 @@ impl CatalogState {
             Datum::from(example_trust_policy.as_ref().map(|p| p.into_element())),
         ]);
 
-        Ok(BuiltinTableUpdate { id, row, diff })
+        Ok(BuiltinTableUpdate::row(id, row, diff))
     }
 
     fn pack_view_update(
@@ -1291,9 +1298,9 @@ impl CatalogState {
         // do the same for compatibility's sake.
         query_string.push(';');
 
-        vec![BuiltinTableUpdate {
-            id: &*MZ_VIEWS,
-            row: Row::pack_slice(&[
+        vec![BuiltinTableUpdate::row(
+            &*MZ_VIEWS,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::UInt32(oid),
                 Datum::String(&schema_id.to_string()),
@@ -1305,7 +1312,7 @@ impl CatalogState {
                 Datum::String(&create_stmt.to_ast_string_redacted()),
             ]),
             diff,
-        }]
+        )]
     }
 
     fn pack_materialized_view_update(
@@ -1341,9 +1348,9 @@ impl CatalogState {
 
         let mut updates = Vec::new();
 
-        updates.push(BuiltinTableUpdate {
-            id: &*MZ_MATERIALIZED_VIEWS,
-            row: Row::pack_slice(&[
+        updates.push(BuiltinTableUpdate::row(
+            &*MZ_MATERIALIZED_VIEWS,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::UInt32(oid),
                 Datum::String(&schema_id.to_string()),
@@ -1356,7 +1363,7 @@ impl CatalogState {
                 Datum::String(&create_stmt.to_ast_string_redacted()),
             ]),
             diff,
-        });
+        ));
 
         if let Some(refresh_schedule) = &mview.refresh_schedule {
             // This can't be `ON COMMIT`, because that is represented by a `None` instead of an
@@ -1370,9 +1377,9 @@ impl CatalogState {
                 let aligned_to_dt = mz_ore::now::to_datetime(
                     <&Timestamp as TryInto<u64>>::try_into(aligned_to).expect("undoes planning"),
                 );
-                updates.push(BuiltinTableUpdate {
-                    id: &*MZ_MATERIALIZED_VIEW_REFRESH_STRATEGIES,
-                    row: Row::pack_slice(&[
+                updates.push(BuiltinTableUpdate::row(
+                    &*MZ_MATERIALIZED_VIEW_REFRESH_STRATEGIES,
+                    Row::pack_slice(&[
                         Datum::String(&id.to_string()),
                         Datum::String("every"),
                         Datum::Interval(
@@ -1384,15 +1391,15 @@ impl CatalogState {
                         Datum::Null,
                     ]),
                     diff,
-                });
+                ));
             }
             for at in refresh_schedule.ats.iter() {
                 let at_dt = mz_ore::now::to_datetime(
                     <&Timestamp as TryInto<u64>>::try_into(at).expect("undoes planning"),
                 );
-                updates.push(BuiltinTableUpdate {
-                    id: &*MZ_MATERIALIZED_VIEW_REFRESH_STRATEGIES,
-                    row: Row::pack_slice(&[
+                updates.push(BuiltinTableUpdate::row(
+                    &*MZ_MATERIALIZED_VIEW_REFRESH_STRATEGIES,
+                    Row::pack_slice(&[
                         Datum::String(&id.to_string()),
                         Datum::String("at"),
                         Datum::Null,
@@ -1400,12 +1407,12 @@ impl CatalogState {
                         Datum::TimestampTz(at_dt.try_into().expect("undoes planning")),
                     ]),
                     diff,
-                });
+                ));
             }
         } else {
-            updates.push(BuiltinTableUpdate {
-                id: &*MZ_MATERIALIZED_VIEW_REFRESH_STRATEGIES,
-                row: Row::pack_slice(&[
+            updates.push(BuiltinTableUpdate::row(
+                &*MZ_MATERIALIZED_VIEW_REFRESH_STRATEGIES,
+                Row::pack_slice(&[
                     Datum::String(&id.to_string()),
                     Datum::String("on-commit"),
                     Datum::Null,
@@ -1413,7 +1420,7 @@ impl CatalogState {
                     Datum::Null,
                 ]),
                 diff,
-            });
+            ));
         }
 
         updates
@@ -1459,9 +1466,9 @@ impl CatalogState {
             _ => unreachable!(),
         };
 
-        vec![BuiltinTableUpdate {
-            id: &*MZ_CONTINUAL_TASKS,
-            row: Row::pack_slice(&[
+        vec![BuiltinTableUpdate::row(
+            &*MZ_CONTINUAL_TASKS,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::UInt32(oid),
                 Datum::String(&schema_id.to_string()),
@@ -1474,7 +1481,7 @@ impl CatalogState {
                 Datum::String(&create_stmt.to_ast_string_redacted()),
             ]),
             diff,
-        }]
+        )]
     }
 
     fn pack_sink_update(
@@ -1492,14 +1499,14 @@ impl CatalogState {
             StorageSinkConnection::Kafka(KafkaSinkConnection {
                 topic: topic_name, ..
             }) => {
-                updates.push(BuiltinTableUpdate {
-                    id: &*MZ_KAFKA_SINKS,
-                    row: Row::pack_slice(&[
+                updates.push(BuiltinTableUpdate::row(
+                    &*MZ_KAFKA_SINKS,
+                    Row::pack_slice(&[
                         Datum::String(&id.to_string()),
                         Datum::String(topic_name.as_str()),
                     ]),
                     diff,
-                });
+                ));
             }
         };
 
@@ -1514,9 +1521,9 @@ impl CatalogState {
         let combined_format = sink.combined_format();
         let (key_format, value_format) = sink.formats();
 
-        updates.push(BuiltinTableUpdate {
-            id: &*MZ_SINKS,
-            row: Row::pack_slice(&[
+        updates.push(BuiltinTableUpdate::row(
+            &*MZ_SINKS,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::UInt32(oid),
                 Datum::String(&schema_id.to_string()),
@@ -1535,7 +1542,7 @@ impl CatalogState {
                 Datum::String(&create_stmt.to_ast_string_redacted()),
             ]),
             diff,
-        });
+        ));
 
         updates
     }
@@ -1569,9 +1576,9 @@ impl CatalogState {
         };
         let on_item_id = self.get_entry_by_global_id(&index.on).id();
 
-        updates.push(BuiltinTableUpdate {
-            id: &*MZ_INDEXES,
-            row: Row::pack_slice(&[
+        updates.push(BuiltinTableUpdate::row(
+            &*MZ_INDEXES,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::UInt32(oid),
                 Datum::String(name),
@@ -1582,7 +1589,7 @@ impl CatalogState {
                 Datum::String(&create_stmt.to_ast_string_redacted()),
             ]),
             diff,
-        });
+        ));
 
         for (i, key) in index.keys.iter().enumerate() {
             let on_entry = self.get_entry_by_global_id(&index.on);
@@ -1606,9 +1613,9 @@ impl CatalogState {
                 }
                 _ => (Datum::Null, Datum::String(&key_sql)),
             };
-            updates.push(BuiltinTableUpdate {
-                id: &*MZ_INDEX_COLUMNS,
-                row: Row::pack_slice(&[
+            updates.push(BuiltinTableUpdate::row(
+                &*MZ_INDEX_COLUMNS,
+                Row::pack_slice(&[
                     Datum::String(&id.to_string()),
                     Datum::UInt64(seq_in_index),
                     field_number,
@@ -1616,7 +1623,7 @@ impl CatalogState {
                     Datum::from(nullable),
                 ]),
                 diff,
-            });
+            ));
         }
 
         updates
@@ -1643,9 +1650,9 @@ impl CatalogState {
                 .to_ast_string_redacted()
         });
 
-        out.push(BuiltinTableUpdate {
-            id: &*MZ_TYPES,
-            row: Row::pack_slice(&[
+        out.push(BuiltinTableUpdate::row(
+            &*MZ_TYPES,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::UInt32(oid),
                 Datum::String(&schema_id.to_string()),
@@ -1665,7 +1672,7 @@ impl CatalogState {
                 },
             ]),
             diff,
-        });
+        ));
 
         let mut row = Row::default();
         let mut packer = row.packer();
@@ -1717,22 +1724,18 @@ impl CatalogState {
                 &MZ_BASE_TYPES
             }
         };
-        out.push(BuiltinTableUpdate {
-            id: index_id,
-            row,
-            diff,
-        });
+        out.push(BuiltinTableUpdate::row(index_id, row, diff));
 
         if let Some(pg_metadata) = &typ.details.pg_metadata {
-            out.push(BuiltinTableUpdate {
-                id: &*MZ_TYPE_PG_METADATA,
-                row: Row::pack_slice(&[
+            out.push(BuiltinTableUpdate::row(
+                &*MZ_TYPE_PG_METADATA,
+                Row::pack_slice(&[
                     Datum::String(&id.to_string()),
                     Datum::UInt32(pg_metadata.typinput_oid),
                     Datum::UInt32(pg_metadata.typreceive_oid),
                 ]),
                 diff,
-            });
+            ));
         }
 
         out
@@ -1769,9 +1772,9 @@ impl CatalogState {
                 );
             let arg_type_ids = row.unpack_first();
 
-            updates.push(BuiltinTableUpdate {
-                id: &*MZ_FUNCTIONS,
-                row: Row::pack_slice(&[
+            updates.push(BuiltinTableUpdate::row(
+                &*MZ_FUNCTIONS,
+                Row::pack_slice(&[
                     Datum::String(&id.to_string()),
                     Datum::UInt32(func_impl_details.oid),
                     Datum::String(&schema_id.to_string()),
@@ -1793,19 +1796,19 @@ impl CatalogState {
                     Datum::String(&owner_id.to_string()),
                 ]),
                 diff,
-            });
+            ));
 
             if let mz_sql::func::Func::Aggregate(_) = func.inner {
-                updates.push(BuiltinTableUpdate {
-                    id: &*MZ_AGGREGATES,
-                    row: Row::pack_slice(&[
+                updates.push(BuiltinTableUpdate::row(
+                    &*MZ_AGGREGATES,
+                    Row::pack_slice(&[
                         Datum::UInt32(func_impl_details.oid),
                         // TODO(database-issues#1064): Support ordered-set aggregate functions.
                         Datum::String("n"),
                         Datum::Int16(0),
                     ]),
                     diff,
-                });
+                ));
             }
         }
         updates
@@ -1835,9 +1838,9 @@ impl CatalogState {
             .expect("arg_type_ids is 1 dimensional, and its length is used for the array length");
         let arg_type_ids = row.unpack_first();
 
-        BuiltinTableUpdate {
-            id: &*MZ_OPERATORS,
-            row: Row::pack_slice(&[
+        BuiltinTableUpdate::row(
+            &*MZ_OPERATORS,
+            Row::pack_slice(&[
                 Datum::UInt32(func_impl_details.oid),
                 Datum::String(operator),
                 arg_type_ids,
@@ -1849,7 +1852,7 @@ impl CatalogState {
                 ),
             ]),
             diff,
-        }
+        )
     }
 
     fn pack_secret_update(
@@ -1862,9 +1865,9 @@ impl CatalogState {
         privileges: Datum,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
-        vec![BuiltinTableUpdate {
-            id: &*MZ_SECRETS,
-            row: Row::pack_slice(&[
+        vec![BuiltinTableUpdate::row(
+            &*MZ_SECRETS,
+            Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::UInt32(oid),
                 Datum::String(&schema_id.to_string()),
@@ -1873,7 +1876,7 @@ impl CatalogState {
                 privileges,
             ]),
             diff,
-        }]
+        )]
     }
 
     pub fn pack_audit_log_update(
@@ -1910,9 +1913,9 @@ impl CatalogState {
             .expect("details created above with a single jsonb column");
         let dt = mz_ore::now::to_datetime(occurred_at);
         let id = event.sortable_id();
-        Ok(BuiltinTableUpdate {
-            id: &*MZ_AUDIT_EVENTS,
-            row: Row::pack_slice(&[
+        Ok(BuiltinTableUpdate::row(
+            &*MZ_AUDIT_EVENTS,
+            Row::pack_slice(&[
                 Datum::UInt64(id),
                 Datum::String(&format!("{}", event_type)),
                 Datum::String(&format!("{}", object_type)),
@@ -1924,7 +1927,7 @@ impl CatalogState {
                 Datum::TimestampTz(dt.try_into().expect("must fit")),
             ]),
             diff,
-        })
+        ))
     }
 
     pub fn pack_storage_usage_update(
@@ -1943,7 +1946,7 @@ impl CatalogState {
                     .expect("must fit"),
             ),
         ]);
-        BuiltinTableUpdate { id, row, diff }
+        BuiltinTableUpdate::row(id, row, diff)
     }
 
     pub fn pack_egress_ip_update(
@@ -1957,7 +1960,7 @@ impl CatalogState {
             Datum::Int32(ip.prefix_len().into()),
             Datum::String(&format!("{}/{}", addr, ip.prefix_len())),
         ]);
-        Ok(BuiltinTableUpdate { id, row, diff: 1 })
+        Ok(BuiltinTableUpdate::row(id, row, 1))
     }
 
     pub fn pack_replica_metric_updates(
@@ -1986,7 +1989,7 @@ impl CatalogState {
             },
         );
         let updates = rows
-            .map(|row| BuiltinTableUpdate { id, row, diff })
+            .map(|row| BuiltinTableUpdate::row(id, row, diff))
             .collect();
         updates
     }
@@ -2031,7 +2034,7 @@ impl CatalogState {
                         disk_bytes.into(),
                         (*credits_per_hour).into(),
                     ]);
-                    BuiltinTableUpdate { id, row, diff: 1 }
+                    BuiltinTableUpdate::row(id, row, 1)
                 },
             )
             .collect();
@@ -2060,11 +2063,7 @@ impl CatalogState {
             .collect();
         packer.push_list(depends_on.iter().map(|s| Datum::String(s)));
 
-        BuiltinTableUpdate {
-            id: &*MZ_SUBSCRIPTIONS,
-            row,
-            diff,
-        }
+        BuiltinTableUpdate::row(&*MZ_SUBSCRIPTIONS, row, diff)
     }
 
     pub fn pack_session_update(
@@ -2073,9 +2072,9 @@ impl CatalogState {
         diff: Diff,
     ) -> BuiltinTableUpdate<&'static BuiltinTable> {
         let connect_dt = mz_ore::now::to_datetime(conn.connected_at());
-        BuiltinTableUpdate {
-            id: &*MZ_SESSIONS,
-            row: Row::pack_slice(&[
+        BuiltinTableUpdate::row(
+            &*MZ_SESSIONS,
+            Row::pack_slice(&[
                 Datum::Uuid(conn.uuid()),
                 Datum::UInt32(conn.conn_id().unhandled()),
                 Datum::String(&conn.authenticated_role_id().to_string()),
@@ -2083,7 +2082,7 @@ impl CatalogState {
                 Datum::TimestampTz(connect_dt.try_into().expect("must fit")),
             ]),
             diff,
-        }
+        )
     }
 
     pub fn pack_default_privileges_update(
@@ -2093,9 +2092,9 @@ impl CatalogState {
         acl_mode: &AclMode,
         diff: Diff,
     ) -> BuiltinTableUpdate<&'static BuiltinTable> {
-        BuiltinTableUpdate {
-            id: &*MZ_DEFAULT_PRIVILEGES,
-            row: Row::pack_slice(&[
+        BuiltinTableUpdate::row(
+            &*MZ_DEFAULT_PRIVILEGES,
+            Row::pack_slice(&[
                 default_privilege_object.role_id.to_string().as_str().into(),
                 default_privilege_object
                     .database_id
@@ -2117,7 +2116,7 @@ impl CatalogState {
                 acl_mode.to_string().as_str().into(),
             ]),
             diff,
-        }
+        )
     }
 
     pub fn pack_system_privileges_update(
@@ -2125,11 +2124,11 @@ impl CatalogState {
         privileges: MzAclItem,
         diff: Diff,
     ) -> BuiltinTableUpdate<&'static BuiltinTable> {
-        BuiltinTableUpdate {
-            id: &*MZ_SYSTEM_PRIVILEGES,
-            row: Row::pack_slice(&[privileges.into()]),
+        BuiltinTableUpdate::row(
+            &*MZ_SYSTEM_PRIVILEGES,
+            Row::pack_slice(&[privileges.into()]),
             diff,
-        }
+        )
     }
 
     fn pack_privilege_array_row(&self, privileges: &PrivilegeMap) -> Row {
@@ -2190,16 +2189,16 @@ impl CatalogState {
             None => Datum::Null,
         };
 
-        BuiltinTableUpdate {
-            id: &*MZ_COMMENTS,
-            row: Row::pack_slice(&[
+        BuiltinTableUpdate::row(
+            &*MZ_COMMENTS,
+            Row::pack_slice(&[
                 Datum::String(&object_id_str),
                 Datum::String(&object_type_str),
                 column_pos_datum,
                 Datum::String(comment),
             ]),
             diff,
-        }
+        )
     }
 
     pub fn pack_webhook_source_update(
@@ -2214,15 +2213,15 @@ impl CatalogState {
         let name = &self.get_entry(&item_id).name().item;
         let id_str = item_id.to_string();
 
-        BuiltinTableUpdate {
-            id: &*MZ_WEBHOOKS_SOURCES,
-            row: Row::pack_slice(&[
+        BuiltinTableUpdate::row(
+            &*MZ_WEBHOOKS_SOURCES,
+            Row::pack_slice(&[
                 Datum::String(&id_str),
                 Datum::String(name),
                 Datum::String(&url),
             ]),
             diff,
-        }
+        )
     }
 
     pub fn pack_source_references_update(
@@ -2268,11 +2267,7 @@ impl CatalogState {
                     packer.push(Datum::Null);
                 }
 
-                BuiltinTableUpdate {
-                    id: &*MZ_SOURCE_REFERENCES,
-                    row,
-                    diff,
-                }
+                BuiltinTableUpdate::row(&*MZ_SOURCE_REFERENCES, row, diff)
             })
             .collect()
     }

--- a/src/adapter/src/catalog/builtin_table_updates/notice.rs
+++ b/src/adapter/src/catalog/builtin_table_updates/notice.rs
@@ -174,11 +174,11 @@ impl CatalogState {
             // push `created_at` column
             packer.push(Datum::TimestampTz(created_at));
 
-            updates.push(BuiltinTableUpdate {
-                id: self.resolve_builtin_table(&MZ_OPTIMIZER_NOTICES),
-                row: row.clone(),
+            updates.push(BuiltinTableUpdate::row(
+                self.resolve_builtin_table(&MZ_OPTIMIZER_NOTICES),
+                row.clone(),
                 diff,
-            });
+            ));
         }
     }
 }

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -591,7 +591,7 @@ impl Catalog {
 
         let updates = txn.get_and_commit_op_updates();
         let builtin_updates = state.apply_updates(updates)?;
-        assert_eq!(builtin_updates, Vec::new());
+        assert!(builtin_updates.is_empty());
         let commit_ts = txn.upper();
         txn.commit(commit_ts).await?;
         drop(storage);

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -484,8 +484,7 @@ impl Coordinator {
                 }
                 PendingWriteTxn::System { updates, source } => {
                     for update in updates {
-                        let data = TableData::Rows(vec![(update.row, update.diff)]);
-                        appends.entry(update.id).or_default().push(data);
+                        appends.entry(update.id).or_default().push(update.data);
                     }
                     // Once the write completes we notify any waiters.
                     if let BuiltinTableUpdateSource::Internal(tx) = source {

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -768,6 +768,7 @@ mod tests {
     use async_trait::async_trait;
     use differential_dataflow::lattice::Lattice;
     use futures::future::BoxFuture;
+    use futures::stream::BoxStream;
     use mz_compute_types::dataflows::{IndexDesc, IndexImport};
     use mz_compute_types::sinks::ComputeSinkConnection;
     use mz_compute_types::sinks::ComputeSinkDesc;
@@ -778,14 +779,15 @@ mod tests {
     use mz_persist_types::{Codec64, ShardId};
     use mz_repr::Timestamp;
     use mz_repr::{Diff, RelationDesc, RelationType, RelationVersion, Row};
+    use mz_storage_client::client::TimestamplessUpdateBuilder;
     use mz_storage_client::controller::{CollectionDescription, StorageMetadata, StorageTxn};
     use mz_storage_client::storage_collections::{CollectionFrontiers, SnapshotCursor};
     use mz_storage_types::connections::inline::InlinedConnection;
     use mz_storage_types::controller::{CollectionMetadata, StorageError};
     use mz_storage_types::parameters::StorageParameters;
     use mz_storage_types::read_holds::ReadHoldError;
-    use mz_storage_types::sources::SourceExportDataConfig;
     use mz_storage_types::sources::{GenericSourceConnection, SourceDesc};
+    use mz_storage_types::sources::{SourceData, SourceExportDataConfig};
     use mz_storage_types::time_dependence::{TimeDependence, TimeDependenceError};
     use timely::progress::Timestamp as TimelyTimestamp;
 
@@ -895,6 +897,38 @@ mod tests {
         ) -> Result<SnapshotCursor<Self::Timestamp>, StorageError<Self::Timestamp>>
         where
             Self::Timestamp: TimelyTimestamp + Lattice + Codec64,
+        {
+            unimplemented!()
+        }
+
+        fn snapshot_and_stream(
+            &self,
+            _id: GlobalId,
+            _as_of: Self::Timestamp,
+        ) -> BoxFuture<
+            'static,
+            Result<
+                BoxStream<'static, (SourceData, Self::Timestamp, Diff)>,
+                StorageError<Self::Timestamp>,
+            >,
+        > {
+            unimplemented!()
+        }
+
+        /// Create a [`TimestamplessUpdateBuilder`] that can be used to stage
+        /// updates for the provided [`GlobalId`].
+        fn create_update_builder(
+            &self,
+            _id: GlobalId,
+        ) -> BoxFuture<
+            'static,
+            Result<
+                TimestamplessUpdateBuilder<SourceData, (), Self::Timestamp, Diff>,
+                StorageError<Self::Timestamp>,
+            >,
+        >
+        where
+            Self::Timestamp: Lattice + Codec64,
         {
             unimplemented!()
         }

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -1028,7 +1028,7 @@ where
     /// Add a `(K, V, D)` to the staged batch.
     pub async fn add(&mut self, k: &K, v: &V, d: &D) {
         self.builder
-            .add(&k, &v, &self.initial_ts, d)
+            .add(k, v, &self.initial_ts, d)
             .await
             .expect("invalid Persist usage");
     }

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -63,6 +63,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::time::MissedTickBehavior;
 use tracing::{debug, info, trace, warn};
 
+use crate::client::TimestamplessUpdateBuilder;
 use crate::controller::{
     CollectionDescription, DataSource, PersistEpoch, StorageMetadata, StorageTxn,
 };
@@ -188,6 +189,37 @@ pub trait StorageCollections: Debug {
     ) -> Result<SnapshotCursor<Self::Timestamp>, StorageError<Self::Timestamp>>
     where
         Self::Timestamp: Codec64 + TimelyTimestamp + Lattice;
+
+    /// Generates a snapshot of the contents of collection `id` at `as_of` and
+    /// streams out all of the updates in bounded memory.
+    ///
+    /// The output is __not__ consolidated.
+    fn snapshot_and_stream(
+        &self,
+        id: GlobalId,
+        as_of: Self::Timestamp,
+    ) -> BoxFuture<
+        'static,
+        Result<
+            BoxStream<'static, (SourceData, Self::Timestamp, Diff)>,
+            StorageError<Self::Timestamp>,
+        >,
+    >;
+
+    /// Create a [`TimestamplessUpdateBuilder`] that can be used to stage
+    /// updates for the provided [`GlobalId`].
+    fn create_update_builder(
+        &self,
+        id: GlobalId,
+    ) -> BoxFuture<
+        'static,
+        Result<
+            TimestamplessUpdateBuilder<SourceData, (), Self::Timestamp, Diff>,
+            StorageError<Self::Timestamp>,
+        >,
+    >
+    where
+        Self::Timestamp: Lattice + Codec64;
 
     /// Update the given [`StorageTxn`] with the appropriate metadata given the
     /// IDs to add and drop.
@@ -1071,58 +1103,61 @@ where
         .boxed()
     }
 
-    // TODO: This appears to have become unused at some point. Figure out if the
-    // caller is coming back or if we should delete it.
-    #[allow(dead_code)]
-    async fn snapshot_and_stream(
+    fn snapshot_and_stream(
         &self,
         id: GlobalId,
         as_of: T,
-    ) -> Result<BoxStream<(SourceData, T, Diff)>, StorageError<T>> {
+        txns_read: &TxnsRead<T>,
+    ) -> BoxFuture<'static, Result<BoxStream<'static, (SourceData, T, Diff)>, StorageError<T>>>
+    {
         use futures::stream::StreamExt;
 
-        let metadata = &self.collection_metadata(id)?;
+        let metadata = match self.collection_metadata(id) {
+            Ok(metadata) => metadata.clone(),
+            Err(e) => return async { Err(e) }.boxed(),
+        };
+        let txns_read = metadata.txns_shard.as_ref().map(|txns_id| {
+            assert_eq!(txns_id, txns_read.txns_id());
+            txns_read.clone()
+        });
+        let persist = Arc::clone(&self.persist);
 
-        // See the comments in Self::snapshot for what's going on here.
-        match metadata.txns_shard.as_ref() {
-            None => {
-                let as_of = Antichain::from_elem(as_of);
-                let persist = Arc::clone(&self.persist);
-                let mut read_handle = Self::read_handle_for_snapshot(persist, metadata, id).await?;
-                let contents = read_handle.snapshot_and_stream(as_of).await;
-                match contents {
-                    Ok(contents) => {
-                        Ok(Box::pin(contents.map(|((result_k, result_v), t, diff)| {
-                            let () = result_v.expect("invalid empty value");
-                            let data = result_k.expect("invalid key data");
-                            (data, t, diff)
-                        })))
-                    }
-                    Err(_) => Err(StorageError::ReadBeforeSince(id)),
+        async move {
+            let mut read_handle = Self::read_handle_for_snapshot(persist, &metadata, id).await?;
+            let stream = match txns_read {
+                None => {
+                    // We're not using txn-wal for tables, so we can take a snapshot directly.
+                    read_handle
+                        .snapshot_and_stream(Antichain::from_elem(as_of))
+                        .await
+                        .map_err(|_| StorageError::ReadBeforeSince(id))?
+                        .boxed()
                 }
-            }
-            Some(txns_id) => {
-                assert_eq!(txns_id, self.txns_read.txns_id());
-                self.txns_read.update_gt(as_of.clone()).await;
-                let data_snapshot = self
-                    .txns_read
-                    .data_snapshot(metadata.data_shard, as_of.clone())
-                    .await;
-                let persist = Arc::clone(&self.persist);
-                let mut handle = Self::read_handle_for_snapshot(persist, metadata, id).await?;
-                let contents = data_snapshot.snapshot_and_stream(&mut handle).await;
-                match contents {
-                    Ok(contents) => {
-                        Ok(Box::pin(contents.map(|((result_k, result_v), t, diff)| {
-                            let () = result_v.expect("invalid empty value");
-                            let data = result_k.expect("invalid key data");
-                            (data, t, diff)
-                        })))
-                    }
-                    Err(_) => Err(StorageError::ReadBeforeSince(id)),
+                Some(txns_read) => {
+                    txns_read.update_gt(as_of.clone()).await;
+                    let data_snapshot = txns_read
+                        .data_snapshot(metadata.data_shard, as_of.clone())
+                        .await;
+                    data_snapshot
+                        .snapshot_and_stream(&mut read_handle)
+                        .await
+                        .map_err(|_| StorageError::ReadBeforeSince(id))?
+                        .boxed()
                 }
-            }
+            };
+
+            // Map our stream, unwrapping Persist internal errors.
+            let stream = stream
+                .map(|((k, _v), t, d)| {
+                    // TODO(parkmycar): We should accumulate the errors and pass them on to the
+                    // caller.
+                    let data = k.expect("error while streaming from Persist");
+                    (data, t, d)
+                })
+                .boxed();
+            Ok(stream)
         }
+        .boxed()
     }
 
     fn set_read_policies_inner(
@@ -1595,6 +1630,63 @@ where
         };
 
         Ok(cursor)
+    }
+
+    fn snapshot_and_stream(
+        &self,
+        id: GlobalId,
+        as_of: Self::Timestamp,
+    ) -> BoxFuture<
+        'static,
+        Result<
+            BoxStream<'static, (SourceData, Self::Timestamp, Diff)>,
+            StorageError<Self::Timestamp>,
+        >,
+    >
+    where
+        Self::Timestamp: TimelyTimestamp + Lattice + Codec64 + 'static,
+    {
+        self.snapshot_and_stream(id, as_of, &self.txns_read)
+    }
+
+    fn create_update_builder(
+        &self,
+        id: GlobalId,
+    ) -> BoxFuture<
+        'static,
+        Result<
+            TimestamplessUpdateBuilder<SourceData, (), Self::Timestamp, Diff>,
+            StorageError<Self::Timestamp>,
+        >,
+    > {
+        let metadata = match self.collection_metadata(id) {
+            Ok(m) => m,
+            Err(e) => return Box::pin(async move { Err(e) }),
+        };
+        let persist = Arc::clone(&self.persist);
+
+        async move {
+            let persist_client = persist
+                .open(metadata.persist_location.clone())
+                .await
+                .expect("invalid persist usage");
+            let write_handle = persist_client
+                .open_writer::<SourceData, (), Self::Timestamp, Diff>(
+                    metadata.data_shard,
+                    Arc::new(metadata.relation_desc.clone()),
+                    Arc::new(UnitSchema),
+                    Diagnostics {
+                        shard_name: id.to_string(),
+                        handle_purpose: format!("create write batch {}", id),
+                    },
+                )
+                .await
+                .expect("invalid persist usage");
+            let builder = TimestamplessUpdateBuilder::new(&write_handle);
+
+            Ok(builder)
+        }
+        .boxed()
     }
 
     fn check_exists(&self, id: GlobalId) -> Result<(), StorageError<Self::Timestamp>> {

--- a/src/txn-wal/src/txn_cache.rs
+++ b/src/txn-wal/src/txn_cache.rs
@@ -560,7 +560,13 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync> TxnsCac
             let times = self.datas.get_mut(&data_id).expect("data is initialized");
             // Sanity check that shard is registered.
             assert_eq!(times.last_reg().forget_ts, None);
-            times.writes.push_back(ts);
+
+            // Only add the timestamp if it's not already in the deque. We don't
+            // track all writes in this but track at what timestamps we have
+            // _any_ writes.
+            if times.writes.back() != Some(&ts) {
+                times.writes.push_back(ts);
+            }
         } else if diff == -1 {
             debug!(
                 "cache learned {:.9} applied t={:?} b={}",


### PR DESCRIPTION
This PR refactors Coordinator startup, specifically `bootstrap_tables()` to stream our retractions into a Persist `BatchBuilder` instead of buffering them in-memory. It also makes two `txn-wal` related fixes that were required to get this passing. A more detailed explanation of them is in a comment below.

### Motivation

Fix/reduce a memory spike we've seen at startup.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
