### PR TITLE
Fix botched release docs

### DIFF
--- a/doc/user/content/releases/v0.131.md
+++ b/doc/user/content/releases/v0.131.md
@@ -2,7 +2,6 @@
 title: "Materialize v0.131"
 date: 2025-01-29
 released: true
-patch: 0
 patch: 1
 _build:
   render: never

--- a/doc/user/content/releases/v0.132.md
+++ b/doc/user/content/releases/v0.132.md
@@ -1,8 +1,7 @@
 ---
 title: "Materialize v0.132"
-date: 2025-02-05
-released: true
-patch: v0.131.0
+date: 2025-02-12
+released: false
 _build:
   render: never
 ---

--- a/doc/user/content/releases/v0.133.md
+++ b/doc/user/content/releases/v0.133.md
@@ -1,7 +1,0 @@
----
-title: "Materialize v0.133"
-date: 2025-02-12
-released: false
-_build:
-  render: never
----


### PR DESCRIPTION
Because we have moved the release to a week later, but the automatic script still ran and broke things: https://github.com/MaterializeInc/materialize/commit/06f1447ba69ae38df36ca8024d6d245476e09eab

Seen failing in https://buildkite.com/materialize/test/builds/98190#0194d8ea-f70a-4d6d-9379-5b2080ffe748

Related to https://github.com/MaterializeInc/release/pull/138

This code is wrong:

https://github.com/MaterializeInc/release/blob/2ac7a35bce12c13f3a6f464650aa48a2a3320534/release/scripts/complete_release.py#L52

It should fail when the prefix is not what it expects, I'll provide a fix. Edit: https://github.com/MaterializeInc/release/pull/139

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
