### PR TITLE
mz-ore: Add timestamp to panic messages

### DIFF
--- a/src/ore/src/panic.rs
+++ b/src/ore/src/panic.rs
@@ -28,6 +28,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{env, thread};
 
+use chrono::Utc;
 use itertools::Itertools;
 #[cfg(feature = "async")]
 use tokio::task_local;
@@ -85,6 +86,7 @@ pub fn install_enhanced_handler() {
             return;
         }
 
+        let timestamp = Utc::now().format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string();
         let thread = thread::current();
         let thread_name = thread.name().unwrap_or("<unnamed>");
 
@@ -139,7 +141,9 @@ pub fn install_enhanced_handler() {
         // may be writing to the stderr stream outside of the Rust runtime.
         //
         // See https://github.com/rust-lang/rust/issues/64413 for details.
-        let buf = format!("thread '{thread_name}' panicked at {location}:\n{msg}\n{backtrace}");
+        let buf = format!(
+            "{timestamp}  thread '{thread_name}' panicked at {location}:\n{msg}\n{backtrace}"
+        );
 
         // Ideal path: spawn a thread that attempts to lock the Rust-managed
         // stderr stream and write the panic message there. Acquiring the stderr


### PR DESCRIPTION
Would have been useful for https://materializeinc.slack.com/archives/C08ACQNGSQK/p1738835651328899

Example:
```
$ target/debug/environmentd --environment-id cloudtest-test-00000000-0000-0000-0000-000000000000-0 --orchestrator kubernetes --persist-blob-url http://asd --clusterd-image clusterd --bootstrap-default-cluster-replica-size 1 --cluster-replica-sizes 1
2025-02-06T15:42:23.573696Z  INFO environmentd::run: mz_environmentd::environmentd::main: startup: envd init: beginning
2025-02-06T15:42:23.573745Z  INFO environmentd::run: mz_environmentd::environmentd::main: startup: envd init: preamble beginning
2025-02-06T15:42:23.577135Z  thread 'main' panicked at src/environmentd/src/environmentd/main.rs:626:9:
environmentd: fatal: creating kubernetes orchestrator: failed to infer config: in-cluster: (failed to read an incluster environment variable: environment variable not found), kubeconfig: (failed to load current context: minikube)
   5: rust_begin_unwind
             at /rustc/9fc6b43126469e3858e2fe86cafb4f0fd5068869/library/std/src/panicking.rs:665:5
   6: core::panicking::panic_fmt
             at /rustc/9fc6b43126469e3858e2fe86cafb4f0fd5068869/library/core/src/panicking.rs:76:14
   7: mz_environmentd::environmentd::main::main
             at ./src/environmentd/src/environmentd/main.rs:626:9
   8: environmentd::main
             at ./src/environmentd/src/bin/environmentd.rs:11:5
   9: <fn() as core::ops::function::FnOnce<()>>::call_once
             at /rustc/9fc6b43126469e3858e2fe86cafb4f0fd5068869/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
zsh: IOT instruction (core dumped)  target/debug/environmentd --environment-id  --orchestrator kubernetes      1
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
