### PR TITLE
[adapter] don't block on builtin table write in `Session` creation

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -122,6 +122,7 @@ def get_default_system_parameters(
         "unsafe_enable_table_keys": "true",
         "enable_variadic_left_join_lowering": "true",
         "enable_worker_core_affinity": "true",
+        "group_commit_batch_duration": "25ms",
         "kafka_default_metadata_fetch_interval": "1s",
         "mysql_offset_known_interval": "1s",
         "persist_record_schema_id": (

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -122,7 +122,6 @@ def get_default_system_parameters(
         "unsafe_enable_table_keys": "true",
         "enable_variadic_left_join_lowering": "true",
         "enable_worker_core_affinity": "true",
-        "group_commit_batch_duration": "25ms",
         "kafka_default_metadata_fetch_interval": "1s",
         "mysql_offset_known_interval": "1s",
         "persist_record_schema_id": (

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -117,6 +117,13 @@ pub const ENABLE_EXPRESSION_CACHE: Config<bool> = Config::new(
     "Use a cache to store optimized expressions to help speed up start times.",
 );
 
+/// Amount of time we'll wait between explict group commit triggers before running another.
+pub const GROUP_COMMIT_BATCH_DURATION: Config<Duration> = Config::new(
+    "group_commit_batch_duration",
+    Duration::from_millis(250),
+    "Amount of time we'll wait between group commit triggers to let writes batch.",
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -135,4 +142,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&DEFAULT_SINK_PARTITION_STRATEGY)
         .add(&ENABLE_CONTINUAL_TASK_BUILTINS)
         .add(&ENABLE_EXPRESSION_CACHE)
+        .add(&GROUP_COMMIT_BATCH_DURATION)
 }

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -120,7 +120,7 @@ pub const ENABLE_EXPRESSION_CACHE: Config<bool> = Config::new(
 /// Amount of time we'll wait between explict group commit triggers before running another.
 pub const GROUP_COMMIT_BATCH_DURATION: Config<Duration> = Config::new(
     "group_commit_batch_duration",
-    Duration::from_millis(250),
+    Duration::from_millis(100),
     "Amount of time we'll wait between group commit triggers to let writes batch.",
 );
 

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -120,7 +120,7 @@ pub const ENABLE_EXPRESSION_CACHE: Config<bool> = Config::new(
 /// Amount of time we'll wait between explict group commit triggers before running another.
 pub const GROUP_COMMIT_BATCH_DURATION: Config<Duration> = Config::new(
     "group_commit_batch_duration",
-    Duration::from_millis(100),
+    Duration::from_millis(25),
     "Amount of time we'll wait between group commit triggers to let writes batch.",
 );
 

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -605,15 +605,6 @@ impl SessionClient {
         outer_ctx_extra: Option<ExecuteContextExtra>,
     ) -> Result<(ExecuteResponse, Instant), AdapterError> {
         let execute_started = Instant::now();
-
-        // Before processing any queries we want to make sure our builtin tables writes that
-        // contain a record of this Session have completed.
-        //
-        // TODO(parkmycar): It would be great if we could push this waiting down a layer, after
-        // we've planned a query. This way we could only block if a query depends on a relevant
-        // internal table.
-        self.session().clear_builtin_table_updates().await;
-
         let response = self
             .send_with_cancel(
                 |tx, session| Command::Execute {

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -15,7 +15,6 @@ use std::sync::Arc;
 
 use derivative::Derivative;
 use enum_kinds::EnumKind;
-use futures::future::BoxFuture;
 use mz_adapter_types::connection::{ConnectionId, ConnectionIdType};
 use mz_compute_types::ComputeInstanceId;
 use mz_ore::collections::CollectionExt;
@@ -34,6 +33,7 @@ use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
 use crate::catalog::Catalog;
+use crate::coord::appends::BuiltinTableAppendNotify;
 use crate::coord::consistency::CoordinatorInconsistencies;
 use crate::coord::peek::PeekResponseUnary;
 use crate::coord::ExecuteContextExtra;
@@ -187,7 +187,7 @@ pub struct StartupResponse {
     pub role_id: RoleId,
     /// A future that completes when all necessary Builtin Table writes have completed.
     #[derivative(Debug = "ignore")]
-    pub write_notify: BoxFuture<'static, ()>,
+    pub write_notify: BuiltinTableAppendNotify,
     /// Map of (name, VarInput::Flat) tuples of session default variables that should be set.
     pub session_defaults: BTreeMap<String, OwnedVarInput>,
     pub catalog: Arc<Catalog>,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -176,7 +176,7 @@ use crate::client::{Client, Handle};
 use crate::command::{Command, ExecuteResponse};
 use crate::config::{SynchronizedParameters, SystemParameterFrontend, SystemParameterSyncConfig};
 use crate::coord::appends::{
-    BuiltinTableAppendNotify, DeferredWriteOp, GroupCommitPermit, PendingWriteTxn,
+    BuiltinTableAppendNotify, DeferredOp, GroupCommitPermit, PendingWriteTxn,
 };
 use crate::coord::caught_up::CaughtUpCheckContext;
 use crate::coord::cluster_scheduling::SchedulingDecision;
@@ -1678,7 +1678,7 @@ pub struct Coordinator {
     /// Locks that grant access to a specific object, populated lazily as objects are written to.
     write_locks: BTreeMap<CatalogItemId, Arc<tokio::sync::Mutex<()>>>,
     /// Plans that are currently deferred and waiting on a write lock.
-    deferred_write_ops: BTreeMap<ConnectionId, DeferredWriteOp>,
+    deferred_write_ops: BTreeMap<ConnectionId, DeferredOp>,
 
     /// Pending writes waiting for a group commit.
     pending_writes: Vec<PendingWriteTxn>,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -242,7 +242,7 @@ pub enum Message {
         /// then everything waiting on this collection will get retried causing traffic in the
         /// Coordinator's message queue.
         ///
-        /// See [`DeferredWriteOp::can_be_optimistically_retried`] for more detail.
+        /// See [`DeferredOp::can_be_optimistically_retried`] for more detail.
         acquired_lock: Option<(CatalogItemId, tokio::sync::OwnedMutexGuard<()>)>,
     },
     /// Initiates a group commit.

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -992,6 +992,9 @@ pub(crate) fn waiting_on_startup_appends(
     session: &mut Session,
     plan: &Plan,
 ) -> Option<(BTreeSet<CatalogItemId>, BoxFuture<'static, ()>)> {
+    // TODO(parkmycar): We need to check transitive uses here too if we ever move the
+    // referenced builtin tables out of mz_internal, or we allow creating views on
+    // mz_internal objects.
     let depends_on = match plan {
         Plan::Select(plan) => plan.source.depends_on(),
         Plan::ReadThenWrite(plan) => plan.selection.depends_on(),

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -99,7 +99,7 @@ impl DeferredOp {
         }
     }
 
-    /// Consumes the [`DeferredWriteOp`], returning the inner [`ExecuteContext`].
+    /// Consumes the [`DeferredOp`], returning the inner [`ExecuteContext`].
     pub fn into_ctx(self) -> ExecuteContext {
         match self {
             DeferredOp::Plan(plan) => plan.ctx,
@@ -177,7 +177,7 @@ impl Coordinator {
         self.advance_timelines_interval.reset();
     }
 
-    /// Tries to execute a previously [`DeferredWriteOp`] that requires write locks.
+    /// Tries to execute a previously [`DeferredOp`] that requires write locks.
     ///
     /// If we can't acquire all of the write locks then we'll defer the plan again and wait for
     /// the necessary locks to become available.

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -281,7 +281,7 @@ impl Coordinator {
 
                 let resp = Ok(StartupResponse {
                     role_id,
-                    write_notify: Box::pin(notify),
+                    write_notify: notify,
                     session_defaults,
                     catalog: self.owned_catalog(),
                 });

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -283,7 +283,7 @@ impl Coordinator {
                 if mz_ore::assert::soft_assertions_enabled() {
                     let required_tables: BTreeSet<_> = super::appends::REQUIRED_BUILTIN_TABLES
                         .iter()
-                        .map(|table| self.catalog().resolve_builtin_table(&*table))
+                        .map(|table| self.catalog().resolve_builtin_table(*table))
                         .collect();
                     let updates_tracked = updates
                         .iter()

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -302,7 +302,7 @@ impl Coordinator {
                     // tables is promoted out of mz_internal then we'll need to add this check.
                     mz_ore::soft_assert_or_log!(
                         all_mz_internal,
-                        "not all builtin tables are in mz_internal! need to check transitive depends".
+                        "not all builtin tables are in mz_internal! need to check transitive depends",
                     )
                 }
                 let notify = self.builtin_table_update().background(updates);

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -293,7 +293,7 @@ impl Coordinator {
                         "not tracking all required builtin table updates!"
                     );
                 }
-                let notify = self.builtin_table_update().defer(updates);
+                let notify = self.builtin_table_update().background(updates);
 
                 let resp = Ok(StartupResponse {
                     role_id,

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -849,7 +849,8 @@ impl Coordinator {
                     .resolve_builtin_table_updates(retractions);
                 updates.extend(retractions);
             }
-            self.builtin_table_update().background(updates);
+            // We don't care about when the write finishes.
+            let _notify = self.builtin_table_update().background(updates);
         }
 
         self.drop_introspection_subscribes(replica_id);

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -439,7 +439,8 @@ impl Coordinator {
                         .catalog()
                         .state()
                         .resolve_builtin_table_updates(updates);
-                    self.builtin_table_update().background(updates);
+                    // We don't care about when the write finishes.
+                    let _notify = self.builtin_table_update().background(updates);
                 }
             }
             ControllerResponse::WatchSetFinished(ws_ids) => {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -37,7 +37,7 @@ use tracing::{event, Instrument, Level, Span};
 
 use crate::catalog::Catalog;
 use crate::command::{Command, ExecuteResponse, Response};
-use crate::coord::appends::{DeferredPlan, DeferredWriteOp};
+use crate::coord::appends::{DeferredOp, DeferredPlan};
 use crate::coord::validity::PlanValidity;
 use crate::coord::{
     catalog_serving, Coordinator, DeferredPlanStatement, Message, PlanStatement, TargetCluster,
@@ -111,7 +111,7 @@ impl Coordinator {
                 // here, since the map to `None`.
                 let acquire_future = wait_future.map(|()| None);
 
-                self.defer_op(acquire_future, DeferredWriteOp::Plan(deferred_plan));
+                self.defer_op(acquire_future, DeferredOp::Plan(deferred_plan));
 
                 // Return early because our op is deferred on waiting for the builtin writes to
                 // complete.

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -96,9 +96,7 @@ use tracing::{warn, Instrument, Span};
 
 use crate::catalog::{self, Catalog, ConnCatalog, DropObjectInfo, UpdatePrivilegeVariant};
 use crate::command::{ExecuteResponse, Response};
-use crate::coord::appends::{
-    BuiltinTableAppendNotify, DeferredPlan, DeferredWriteOp, PendingWriteTxn,
-};
+use crate::coord::appends::{BuiltinTableAppendNotify, DeferredOp, DeferredPlan, PendingWriteTxn};
 use crate::coord::{
     validate_ip_with_policy_rules, AlterConnectionValidationReady, AlterSinkReadyContext,
     Coordinator, CreateConnectionValidationReady, DeferredPlanStatement, ExecuteContext,
@@ -2813,7 +2811,7 @@ impl Coordinator {
                         ),
                         requires_locks: source_ids,
                     };
-                    return self.defer_op(acquire_future, DeferredWriteOp::Plan(plan));
+                    return self.defer_op(acquire_future, DeferredOp::Plan(plan));
                 }
             };
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
-use futures::future::BoxFuture;
+use futures::future::{BoxFuture, FutureExt};
 use futures::stream::FuturesOrdered;
 use futures::{future, Future};
 use itertools::Itertools;
@@ -2800,7 +2800,7 @@ impl Coordinator {
                 Err(missing) => {
                     // Defer our write if we couldn't acquire all of the locks.
                     let role_metadata = ctx.session().role_metadata().clone();
-                    let acquire_future = self.grant_object_write_lock(missing);
+                    let acquire_future = self.grant_object_write_lock(missing).map(Option::Some);
                     let plan = DeferredPlan {
                         ctx,
                         plan: Plan::ReadThenWrite(plan),

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -42,6 +42,9 @@ pub struct Metrics {
     pub check_scheduling_policies_seconds: HistogramVec,
     pub handle_scheduling_decisions_seconds: HistogramVec,
     pub row_set_finishing_seconds: HistogramVec,
+    pub session_startup_table_writes_seconds: HistogramVec,
+    pub group_commit_trigger_count: IntCounter,
+    pub group_commit_batch_defer_seconds: HistogramVec,
 }
 
 impl Metrics {
@@ -174,6 +177,20 @@ impl Metrics {
                 help: "The time it takes to run RowSetFinishing::finish.",
                 buckets: histogram_seconds_buckets(0.000_128, 16.0),
             )),
+            session_startup_table_writes_seconds: registry.register(metric!(
+                name: "mz_session_startup_table_writes_seconds",
+                help: "If we had to wait for builtin table writes before processing a query, how long did we wait for.",
+                buckets: histogram_seconds_buckets(0.000_008, 4.0),
+            )),
+            group_commit_trigger_count: registry.register(metric!(
+                name: "mz_group_commit_trigger_count",
+                help: "How many group commits where explicitly triggered and run.",
+            )),
+            group_commit_batch_defer_seconds: registry.register(metric!(
+                name: "mz_group_commit_batch_defer_seconds",
+                help: "If we defered dropping a group commit permit, how long did we defer for.",
+                buckets: histogram_seconds_buckets(0.000_008, 1.0),
+            )),
         }
     }
 
@@ -184,6 +201,18 @@ impl Metrics {
     pub(crate) fn session_metrics(&self) -> SessionMetrics {
         SessionMetrics {
             row_set_finishing_seconds: self.row_set_finishing_seconds(),
+            session_startup_table_writes_seconds: self
+                .session_startup_table_writes_seconds
+                .with_label_values(&[]),
+        }
+    }
+
+    pub(crate) fn group_commit_metrics(&self) -> GroupCommitMetrics {
+        GroupCommitMetrics {
+            group_commit_trigger_count: self.group_commit_trigger_count.clone(),
+            group_commit_batch_defer_seconds: self
+                .group_commit_batch_defer_seconds
+                .with_label_values(&[]),
         }
     }
 }
@@ -192,12 +221,24 @@ impl Metrics {
 #[derive(Debug, Clone)]
 pub struct SessionMetrics {
     row_set_finishing_seconds: Histogram,
+    session_startup_table_writes_seconds: Histogram,
 }
 
 impl SessionMetrics {
     pub(crate) fn row_set_finishing_seconds(&self) -> &Histogram {
         &self.row_set_finishing_seconds
     }
+
+    pub(crate) fn session_startup_table_writes_seconds(&self) -> &Histogram {
+        &self.session_startup_table_writes_seconds
+    }
+}
+
+/// Metrics associated with explicitly triggering a group commit.
+#[derive(Debug, Clone)]
+pub struct GroupCommitMetrics {
+    pub(crate) group_commit_trigger_count: IntCounter,
+    pub(crate) group_commit_batch_defer_seconds: Histogram,
 }
 
 pub(crate) fn session_type_label_value(user: &User) -> &'static str {

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -872,13 +872,13 @@ impl<T: TimestampManipulation> Session<T> {
         &self.metrics
     }
 
-    /// Sets the [`BuiltinTableAppendNotify`] for this session.
+    /// Sets the `BuiltinTableAppendNotify` for this session.
     pub fn set_builtin_table_updates(&mut self, fut: BuiltinTableAppendNotify) {
         let prev = self.builtin_updates.replace(fut);
         mz_ore::soft_assert_or_log!(prev.is_none(), "replacing old builtin table notify");
     }
 
-    /// Takes the stashed [`BuiltinTableAppendNotify`] and waits for the writes to complete.
+    /// Takes the stashed `BuiltinTableAppendNotify` and waits for the writes to complete.
     pub async fn clear_builtin_table_updates(&mut self) {
         if let Some(fut) = self.builtin_updates.take() {
             // Record how long we blocked for, if we blocked at all.

--- a/src/ore/src/assert.rs
+++ b/src/ore/src/assert.rs
@@ -73,6 +73,11 @@ pub static SOFT_ASSERTIONS: AtomicBool = {
 #[cfg(any(miri, target_arch = "wasm32"))]
 pub static SOFT_ASSERTIONS: AtomicBool = AtomicBool::new(true);
 
+/// Returns if [`SOFT_ASSERTIONS`] are enabled.
+pub fn soft_assertions_enabled() -> bool {
+    SOFT_ASSERTIONS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Asserts that a condition is true if soft assertions are enabled.
 ///
 /// Soft assertions have a small runtime cost even when disabled. See

--- a/src/ore/src/assert.rs
+++ b/src/ore/src/assert.rs
@@ -73,7 +73,7 @@ pub static SOFT_ASSERTIONS: AtomicBool = {
 #[cfg(any(miri, target_arch = "wasm32"))]
 pub static SOFT_ASSERTIONS: AtomicBool = AtomicBool::new(true);
 
-/// Returns if [`SOFT_ASSERTIONS`] are enabled.
+/// Returns if soft assertions are enabled.
 pub fn soft_assertions_enabled() -> bool {
     SOFT_ASSERTIONS.load(std::sync::atomic::Ordering::Relaxed)
 }

--- a/src/ore/src/stats.rs
+++ b/src/ore/src/stats.rs
@@ -20,9 +20,9 @@
 /// see `histogram_seconds_buckets` below.
 ///
 /// Note that any changes to this range may modify buckets for existing metrics.
-const HISTOGRAM_SECOND_BUCKETS: [f64; 19] = [
-    0.000_128, 0.000_256, 0.000_512, 0.001, 0.002, 0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256,
-    0.512, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0,
+const HISTOGRAM_SECOND_BUCKETS: [f64; 23] = [
+    0.000_008, 0.000_016, 0.000_032, 0.000_064, 0.000_128, 0.000_256, 0.000_512, 0.001, 0.002,
+    0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256, 0.512, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0,
 ];
 
 /// Returns a `Vec` of time buckets that are both present in our standard


### PR DESCRIPTION
This PR does two things:

1. Changes explicitly triggered group commits (e.g. a write to `mz_sessions`) to have a minimum batching interval. Today when we trigger a group commit we only allow 1 to be in-flight at a time, this allows pending writes to naturally batch. But if the write is small there's a good chance Persist will inline it and it will take low 10s of milliseconds. Added in this PR is a dyncfg `group_commit_batch_duration` which ensures we will wait X duration before running the next group commit. The default value is 100ms.
2. When starting a `Session`/connection we have to update the `mz_sessions` table. Waiting for this write to complete has been moved to when a Session receives a query, and if that query reads from the `mz_sessions` table. This means starting a `Session` is a completely in-memory operation, and waiting for the builtin table write to complete happens concurrently with the network roundtrip of responding to the client, and them sending their request.

Theoretically it could _increase_ latency for opening a new connection, if that connection runs `SELECT ... FROM mz_sessions` because we now we might wait up to 100ms for the write to complete. But this seems like an acceptable tradeoff because it speeds up all other queries and is tune-able in LaunchDarkly if it becomes an issue.

### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/8951

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
