### PR TITLE
migration test: Skip invisible columns in old version

### DIFF
--- a/test/mysql-cdc-old-syntax/invisible-columns.td
+++ b/test/mysql-cdc-old-syntax/invisible-columns.td
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ skip-if
+SELECT mz_version_num() < 13300;
+
 $ set-sql-timeout duration=1s
 $ set-max-tries max-tries=20
 


### PR DESCRIPTION
The newly introduced migration tests run from the previous Mz version and test that we can migrate the source when running a new version. (Does this even make sense or can we just use a new version for both? Unfortunately Joe left so I can't ask him what the original motivation for that was)

For now we can skip the td file when it's starting in an older version.

Failure seen in https://buildkite.com/materialize/nightly/builds/11076#0194ddd4-9f47-4888-bbaa-89ddfbc86da8

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
