### PR TITLE
upsert test: Disable another flaky source stats query

### DIFF
--- a/test/upsert/rehydration/03-after-rehydration.td
+++ b/test/upsert/rehydration/03-after-rehydration.td
@@ -92,15 +92,16 @@ SELECT
 $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
 {"key": "fish"} {"f1": "MUCHMUCHMUCHLONGERVALUE", "f2": 9000}
 
-> SELECT
-    SUM(u.bytes_indexed) > ${state-bytes},
-    SUM(u.records_indexed)
-  FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
-  WHERE t.name IN ('upsert_tbl')
-  GROUP BY t.name
-  ORDER BY t.name
-true 3
+# TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/8802 is fixed
+# > SELECT
+#     SUM(u.bytes_indexed) > ${state-bytes},
+#     SUM(u.records_indexed)
+#   FROM mz_tables t
+#   JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+#   WHERE t.name IN ('upsert_tbl')
+#   GROUP BY t.name
+#   ORDER BY t.name
+# true 3
 
 
 # Ensure deletes work.


### PR DESCRIPTION
See https://github.com/MaterializeInc/database-issues/issues/8802

Failure seen in https://buildkite.com/materialize/nightly/builds/11076#0194ddd4-9f35-4f61-b235-39905f0238cc

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
