### PR TITLE
Update anyhow to 1.0.95

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 dependencies = [
  "backtrace",
 ]
@@ -6552,7 +6552,6 @@ dependencies = [
  "mz-ore",
  "mz-repr",
  "postgres",
- "regex",
  "workspace-hack",
 ]
 

--- a/misc/bazel/cargo-gazelle/Cargo.toml
+++ b/misc/bazel/cargo-gazelle/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 camino = "1"
 cargo_toml = "0.19.1"
 clap = { version = "4.5.23", features = ["derive", "env"] }

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 arrow = { version = "53.3.0", default-features = false }
 async-trait = "0.1.83"
 bytes = "1.3.0"

--- a/src/arrow-util/Cargo.toml
+++ b/src/arrow-util/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 arrow = { version = "53.3.0", default-features = false }
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 dec = { version = "0.4.9", features = ["num-traits"] }

--- a/src/audit-log/Cargo.toml
+++ b/src/audit-log/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 mz-ore = { path = "../ore", features = ["test"] }
 proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.5.1", features = ["boxed_union"] }

--- a/src/avro/Cargo.toml
+++ b/src/avro/Cargo.toml
@@ -15,7 +15,7 @@ autobenches = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 byteorder = { version = "1.4.3", optional = true }
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 crc32fast = { version = "1.3.2", optional = true }

--- a/src/aws-secrets-controller/Cargo.toml
+++ b/src/aws-secrets-controller/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-trait = "0.1.83"
 aws-config = { version = "1.2.0", default-features = false }
 aws-credential-types = { version = "1.1.1", features = ["hardcoded-credentials"] }

--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 aws-config = { version = "1.2.0", default-features = false }
 aws-sdk-s3 = { version = "1.23.0", default-features = false, features = [
     "rt-tokio",

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = { version = "1.0.66", features = ["backtrace"] }
+anyhow = { version = "1.0.95", features = ["backtrace"] }
 async-trait = "0.1.83"
 axum = "0.7.5"
 bytes = "1.3.0"

--- a/src/catalog-debug/Cargo.toml
+++ b/src/catalog-debug/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 clap = { version = "4.5.23", features = ["derive", "env"] }
 futures = "0.3.25"
 mz-adapter = { path = "../adapter" }

--- a/src/catalog-protos/Cargo.toml
+++ b/src/catalog-protos/Cargo.toml
@@ -31,7 +31,7 @@ proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 similar-asserts = "1.4"
 
 [build-dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 md-5 = "0.10.5"
 mz-build-tools = { path = "../build-tools", default-features = false }
 prost-build = "0.13.2"

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-trait = "0.1.83"
 bincode = { version = "1.3.3" }
 bytes = { version = "1.3.0", features = ["serde"] }

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 native-tls = "0.2.11"
 openssl = { version = "0.10.48", features = ["vendored"] }
 reqwest = { version = "0.11.13", features = [

--- a/src/cloud-api/Cargo.toml
+++ b/src/cloud-api/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.44"
+anyhow = "1.0.95"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 reqwest = { version = "0.11.4", features = ["json"] }
 serde = { version = "1.0.130", features = ["derive"] }

--- a/src/cloud-resources/Cargo.toml
+++ b/src/cloud-resources/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 chrono = { version = "0.4.35", default-features = false }
 futures = "0.3.25"
 k8s-openapi = { version = "0.22.0", features = ["schemars", "v1_29"] }

--- a/src/cluster-client/Cargo.toml
+++ b/src/cluster-client/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 http = "1.1.0"
 mz-ore = { path = "../ore", features = ["tracing_"] }
 mz-proto = { path = "../proto" }

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-trait = "0.1.83"
 crossbeam-channel = "0.5.8"
 differential-dataflow = "0.13.5"

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 axum = "0.7.5"
 clap = { version = "4.5.23", features = ["derive", "env"] }
 fail = { version = "0.5.1", features = ["failpoints"] }

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-trait = "0.1.83"
 bytesize = "1.1.0"
 crossbeam-channel = "0.5.8"

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-stream = "0.3.3"
 bytesize = "1.1.0"
 columnar = "0.2.2"

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 futures = "0.3.25"
 mz-build-info = { path = "../build-info" }

--- a/src/dyncfg-launchdarkly/Cargo.toml
+++ b/src/dyncfg-launchdarkly/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = { version = "1.0.66", features = ["backtrace"] }
+anyhow = { version = "1.0.95", features = ["backtrace"] }
 humantime = "2.1.0"
 launchdarkly-server-sdk = { version = "1.0.0", default-features = false, features = [
   "hypertls",

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 askama = { version = "0.12.1", default-features = false, features = ["config", "serde-json"] }
 async-trait = "0.1.83"
 axum = { version = "0.7.5", features = ["ws"] }
@@ -149,7 +149,7 @@ timely = "0.17.1"
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4"] }
 
 [build-dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 cc = "1.0.78"
 mz-npm = { path = "../npm" }
 

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -19,7 +19,7 @@ harness = false
 
 [dependencies]
 aho-corasick = "1.1.3"
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 bytes = "1.3.0"
 bytesize = "1.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 base64 = "0.13.1"
 clap = { version = "4.5.23", features = ["wrap_help", "env", "derive"] }
 derivative = "2.2.0"

--- a/src/frontegg-mock/Cargo.toml
+++ b/src/frontegg-mock/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = { version = "1.0.66", features = ["backtrace"] }
+anyhow = { version = "1.0.95", features = ["backtrace"] }
 axum = "0.7.5"
 axum-extra = { version = "0.9.3", features = ["typed-header"] }
 base64 = "0.22.0"

--- a/src/http-util/Cargo.toml
+++ b/src/http-util/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 askama = { version = "0.12.1", default-features = false, features = ["config", "serde-json"] }
 axum = "0.7.5"
 axum-extra = { version = "0.9.3", features = ["typed-header"] }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -15,7 +15,7 @@ path = "benches/benches.rs"
 harness = false
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 byteorder = "1.4.3"
 bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 aws-config = { version = "1.2.0", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.1.1" }
 aws-sigv4 = { version = "1.2.0" }

--- a/src/lowertest/Cargo.toml
+++ b/src/lowertest/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1.0.125"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 datadriven = "0.8.0"
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/mysql-util/Cargo.toml
+++ b/src/mysql-util/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 itertools = "0.12.1"

--- a/src/npm/Cargo.toml
+++ b/src/npm/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 flate2 = "1.0.24"
 hex = "0.4.3"
 hex-literal = "0.3.4"

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-trait = "0.1.83"
 chrono = { version = "0.4.35", default-features = false }
 clap = { version = "4.5.23", features = ["derive"] }

--- a/src/orchestrator-process/Cargo.toml
+++ b/src/orchestrator-process/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-stream = "0.3.3"
 async-trait = "0.1.83"
 chrono = { version = "0.4.35", default-features = false, features = ["clock"] }

--- a/src/orchestrator-tracing/Cargo.toml
+++ b/src/orchestrator-tracing/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-trait = "0.1.83"
 clap = { version = "4.5.23", features = ["env", "derive"] }
 derivative = "2.2.0"

--- a/src/orchestrator/Cargo.toml
+++ b/src/orchestrator/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-trait = "0.1.83"
 bytesize = "1.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["serde"] }

--- a/src/orchestratord/Cargo.toml
+++ b/src/orchestratord/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-trait = "0.1.83"
 axum = "0.7.5"
 chrono = { version = "0.4.35", default-features = false }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Materialize, Inc."]
 workspace = true
 
 [dependencies]
-anyhow = { version = "1.0.66", optional = true }
+anyhow = { version = "1.0.95", optional = true }
 # NB: ore is meant to be an extension of the Rust stdlib. To keep it
 # lightweight, dependencies on external crates should be avoided if possible. If
 # an external crate is required, it must be optional and feature-gated.
@@ -95,7 +95,7 @@ sentry-tracing = { version = "0.29.1", optional = true }
 yansi = { version = "0.5.1", optional = true }
 
 [dev-dependencies]
-anyhow = { version = "1.0.66" }
+anyhow = { version = "1.0.95" }
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 mz-ore = { path = "../ore", features = ["id_gen"] }
 proptest = { version = "1.6.0", default-features = false, features = ["std"] }

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -17,7 +17,7 @@ name = "persistcli"
 bench = false
 
 [dependencies]
-anyhow = { version = "1.0.66", features = ["backtrace"] }
+anyhow = { version = "1.0.95", features = ["backtrace"] }
 arrow = { version = "53.3.0", default-features = false }
 async-trait = "0.1.83"
 axum = "0.7.5"

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -28,7 +28,7 @@ name = "benches"
 harness = false
 
 [dependencies]
-anyhow = { version = "1.0.66", features = ["backtrace"] }
+anyhow = { version = "1.0.95", features = ["backtrace"] }
 arrayvec = "0.7.4"
 arrow = { version = "53.3.0", default-features = false }
 async-stream = "0.3.3"

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 # NB: This is meant to be a strong, independent abstraction boundary. Please
 # don't leak in dependencies on other Materialize packages.
 [dependencies]
-anyhow = { version = "1.0.66", features = ["backtrace"] }
+anyhow = { version = "1.0.95", features = ["backtrace"] }
 arrow = { version = "53.3.0", default-features = false }
 bytes = { version = "1.3.0", features = ["serde"] }
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -22,7 +22,7 @@ bench = false
 # NB: This is meant to be a strong, independent abstraction boundary. Please
 # don't leak in dependencies on other Materialize packages.
 [dependencies]
-anyhow = { version = "1.0.66", features = ["backtrace"] }
+anyhow = { version = "1.0.95", features = ["backtrace"] }
 arrow = { version = "53.3.0", default-features = false }
 async-trait = "0.1.83"
 async-stream = "0.3.3"

--- a/src/pgtest/Cargo.toml
+++ b/src/pgtest/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 bytes = "1.3.0"
 clap = { version = "4.5.23", features = ["derive"] }
 datadriven = "0.8.0"

--- a/src/pgtz/Cargo.toml
+++ b/src/pgtz/Cargo.toml
@@ -24,7 +24,7 @@ uncased = "0.9.7"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [build-dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
 mz-build-tools = { path = "../build-tools", default-features = false }
 mz-ore-build = { path = "../ore-build", default-features = false }

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-trait = "0.1.83"
 byteorder = "1.4.3"
 bytes = "1.3.0"

--- a/src/postgres-client/Cargo.toml
+++ b/src/postgres-client/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = { version = "1.0.66", features = ["backtrace"] }
+anyhow = { version = "1.0.95", features = ["backtrace"] }
 deadpool-postgres = "0.10.3"
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async", "bytes_"] }
 mz-tls-util = { path = "../tls-util" }

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 mz-cloud-resources = { path = "../cloud-resources", optional = true }
 mz-ore = { path = "../ore", features = ["async"], optional = true }
 mz-proto = { path = "../proto", optional = true }

--- a/src/prof-http/Cargo.toml
+++ b/src/prof-http/Cargo.toml
@@ -32,7 +32,7 @@ tracing = { version = "0.1.37", optional = true }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [build-dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 mz-npm = { path = "../npm", default-features = false }
 
 [features]

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 backtrace = "0.3.66"
 flate2 = "1.0.24"
 jemalloc_pprof = { version = "0.6", optional = true }
@@ -25,7 +25,7 @@ tokio = { version = "1.38.0", features = ["time"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [build-dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 mz-build-tools = { path = "../build-tools", default-features = false }
 prost-build = "0.13.2"
 

--- a/src/proto/Cargo.toml
+++ b/src/proto/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 chrono = { version = "0.4.35", default-features = false, features = ["serde", "std"], optional = true }
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"], optional = true }
 globset = "0.4.14"

--- a/src/regexp/Cargo.toml
+++ b/src/regexp/Cargo.toml
@@ -11,11 +11,10 @@ workspace = true
 
 [dependencies]
 mz-repr = { path = "../repr" }
-regex = "1.7.0"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 mz-ore = { path = "../ore", features = ["cli"] }
 postgres = "0.19.5"
 

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -26,7 +26,7 @@ name = "data_types"
 harness = false
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 arrow = { version = "53.3.0", default-features = false }
 bitflags = "1.3.2"
 bytes = "1.3.0"

--- a/src/rocksdb-types/Cargo.toml
+++ b/src/rocksdb-types/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 mz-ore = { path = "../ore", features = ["async", "metrics", "test"] }
 mz-proto = { path = "../proto" }
 prost = { version = "0.13.2", features = ["no-recursion-limit"] }

--- a/src/rocksdb/Cargo.toml
+++ b/src/rocksdb/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 bincode = { version = "1.3.3" }
 derivative = "2.2.0"
 itertools = { version = "0.12.1" }

--- a/src/s3-datagen/Cargo.toml
+++ b/src/s3-datagen/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 aws-config = { version = "1.2.0", default-features = false }
 aws-sdk-s3 = { version = "1.23.0", default-features = false, features = ["rt-tokio"] }
 bytefmt = "0.1.7"

--- a/src/secrets/Cargo.toml
+++ b/src/secrets/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-trait = "0.1.83"
 mz-repr = { path = "../repr", default-features = false }
 tracing = "0.1.37"

--- a/src/server-core/Cargo.toml
+++ b/src/server-core/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-trait = { version = "0.1.83" }
 clap = { version = "4.5.23", features = ["derive", "env"] }
 openssl = { version = "0.10.48", features = ["vendored"] }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-stream = "0.3.3"
 async-trait = "0.1.83"
 clap = { version = "4.5.23", features = ["env", "derive"] }

--- a/src/sql-lexer/Cargo.toml
+++ b/src/sql-lexer/Cargo.toml
@@ -21,7 +21,7 @@ datadriven = "0.8.0"
 mz-ore = { path = "../ore", default-features = false, features = ["test"] }
 
 [build-dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 mz-ore-build = { path = "../ore-build", default-features = false }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_codegen = "0.11.1"

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -31,7 +31,7 @@ mz-ore = { path = "../ore", default-features = false, features = ["test"] }
 mz-sql-parser = { path = ".", default-features = false, features = ["test"] }
 
 [build-dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 mz-ore-build = { path = "../ore-build", default-features = false }
 mz-walkabout = { path = "../walkabout", default-features = false }
 

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 array-concat = "0.5.2"
 aws-sdk-sts = { version = "1.7.0", default-features = false, features = [
     "rt-tokio",

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 clap = { version = "4.5.23", features = ["derive"] }

--- a/src/ssh-util/Cargo.toml
+++ b/src/ssh-util/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = { version = "1.0.66" }
+anyhow = { version = "1.0.95" }
 mz-ore = { path = "../ore", features = ["test"] }
 openssh = { version = "0.9.8", default-features = false, features = ["native-mux"] }
 openssh-mux-client = "0.15.5"

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-trait = "0.1.83"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 differential-dataflow = "0.13.5"

--- a/src/storage-controller/Cargo.toml
+++ b/src/storage-controller/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-trait = "0.1.83"
 bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 arrow = { version = "53.3.0", default-features = false }
 async-compression = { version = "0.4.5", features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
 async-stream = "0.3.3"

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -14,7 +14,7 @@ name = "row"
 harness = false
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 arrow = { version = "53.3.0", default-features = false }
 async-trait = "0.1.83"
 aws-config = { version = "1.2.0", default-features = false, features = ["sso"] }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -14,7 +14,7 @@ name = "upsert_open_loop"
 bench = false
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-stream = "0.3.3"
 async-trait = "0.1.83"
 bytes = { version = "1.3.0", features = ["serde"] }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-compression = { version = "0.4.5", features = ["tokio", "gzip"] }
 async-trait = "0.1.83"
 aws-credential-types = { version = "1.1.1", features = ["hardcoded-credentials"] }

--- a/src/timestamp-oracle/Cargo.toml
+++ b/src/timestamp-oracle/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 async-trait = "0.1.83"
 dec = "0.4.8"
 deadpool-postgres = "0.10.3"

--- a/src/tls-util/Cargo.toml
+++ b/src/tls-util/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = { version = "1.0.66", features = ["backtrace"] }
+anyhow = { version = "1.0.95", features = ["backtrace"] }
 openssl = { version = "0.10.48", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
 postgres-openssl = { version = "0.5.0" }

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -27,7 +27,7 @@ tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 datadriven = "0.8.0"
 mz-expr-parser = { path = "../expr-parser" }
 mz-expr-test-util = { path = "../expr-test-util" }

--- a/src/walkabout/Cargo.toml
+++ b/src/walkabout/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 itertools = "0.12.1"
 mz-ore-build = { path = "../ore-build", default-features = false }
 quote = "1.0.23"

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 [dependencies]
 ahash = { version = "0.8.11" }
 aho-corasick = { version = "1.1.3" }
-anyhow = { version = "1.0.66", features = ["backtrace"] }
+anyhow = { version = "1.0.95", features = ["backtrace"] }
 async-compression = { version = "0.4.5", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
 aws-config = { version = "1.2.1", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.2.0", default-features = false, features = ["hardcoded-credentials", "test-util"] }
@@ -150,7 +150,7 @@ zstd-sys = { version = "2.0.9", features = ["std"] }
 [build-dependencies]
 ahash = { version = "0.8.11" }
 aho-corasick = { version = "1.1.3" }
-anyhow = { version = "1.0.66", features = ["backtrace"] }
+anyhow = { version = "1.0.95", features = ["backtrace"] }
 async-compression = { version = "0.4.5", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
 aws-config = { version = "1.2.1", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.2.0", default-features = false, features = ["hardcoded-credentials", "test-util"] }

--- a/test/metabase/smoketest/Cargo.toml
+++ b/test/metabase/smoketest/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 itertools = "0.12.1"
 mz-metabase = { path = "../../../src/metabase" }
 mz-ore = { path = "../../../src/ore", features = ["network", "async", "test"] }

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.95"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 mz-kafka-util = { path = "../../src/kafka-util" }
 mz-ore = { path = "../../src/ore", features = ["async"] }


### PR DESCRIPTION
As it says on the box, update the anyhow dependency to 1.0.95.

Also removes an unused regex dependency from mz-regexp.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
