### PR TITLE
Adapt comment in ci builder to consult testing, not Nikhil

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -67,7 +67,7 @@ This makes from-scratch compilation on a fresh agent *much* faster.
 ## macOS agent
 
 We run two macOS agents on Buildkite, via [MacStadium], to produce our macOS
-binaries. These agents are manually configured. Ask Nikhil for access if you
+binaries. These agents are manually configured. Ask @testing for access if you
 need it.
 
 The basic configuration is as follows:

--- a/ci/builder/requirements-core.txt
+++ b/ci/builder/requirements-core.txt
@@ -1,7 +1,7 @@
 # Packages required to install *other* packages.
 #
 # It is extremely unlikely that we'll ever need additional packages here. Do not
-# add to this list without consulting with @benesch!
+# add to this list without consulting with @testing!
 
 pip==24.3.1
 setuptools==75.7.0


### PR DESCRIPTION

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
