### PR TITLE
Switch to official mysql_async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -540,7 +540,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -557,7 +557,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1285,7 +1285,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1571,7 +1571,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -1742,7 +1742,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1799,7 +1799,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2192,7 +2192,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2209,7 +2209,7 @@ checksum = "928bc249a7e3cd554fd2e8e08a426e9670c50bbfc9a621653cfa9accc9641783"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2233,7 +2233,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2244,7 +2244,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2271,7 +2271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6922deacb7b9c86bb7f8ce1fb565212f4e6a9427aad6ce3bd14a2622adf520f"
 dependencies = [
  "futures",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -2479,7 +2479,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -2627,7 +2627,7 @@ checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2647,7 +2647,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2977,7 +2977,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3820,7 +3820,7 @@ dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -3835,7 +3835,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -3957,7 +3957,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tokio-tungstenite 0.23.1",
  "tokio-util",
@@ -3980,7 +3980,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -3993,7 +3993,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4018,7 +4018,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4046,7 +4046,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tokio-stream",
  "uuid",
@@ -4161,7 +4161,7 @@ dependencies = [
  "numa_maps",
  "page_size",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -4310,7 +4310,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
- "twox-hash",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -4453,7 +4453,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
@@ -4475,7 +4474,7 @@ dependencies = [
  "skeptic",
  "smallvec",
  "tagptr",
- "thiserror",
+ "thiserror 1.0.61",
  "triomphe",
  "uuid",
 ]
@@ -4494,8 +4493,9 @@ checksum = "fb585ade2549a017db2e35978b77c319214fa4b37cede841e27954dd6e8f3ca8"
 
 [[package]]
 name = "mysql_async"
-version = "0.34.1"
-source = "git+https://github.com/MaterializeInc/mysql_async#a0dbdb7c76e6ff7a27dfa2523a398ca686413737"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d14cf024116ba8fef4a7fec5abf0bd5de89b9fb29a7e55818a119ac5ec745077"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -4504,12 +4504,9 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "keyed_priority_queue",
- "lazy_static",
  "lru",
- "mio",
  "mysql_common",
  "native-tls",
- "once_cell",
  "pem",
  "percent-encoding",
  "pin-project",
@@ -4517,23 +4514,22 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2 0.5.7",
- "thiserror",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
  "tracing",
- "twox-hash",
+ "twox-hash 2.1.0",
  "url",
 ]
 
 [[package]]
 name = "mysql_common"
-version = "0.32.4"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
+checksum = "34a9141e735d5bb02414a7ac03add09522466d4db65bdd827069f76ae0850e58"
 dependencies = [
- "base64 0.21.5",
- "bindgen",
+ "base64 0.22.0",
  "bitflags 2.4.1",
  "bitvec",
  "btoi",
@@ -4554,9 +4550,8 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
- "smallvec",
  "subprocess",
- "thiserror",
+ "thiserror 1.0.61",
  "uuid",
  "zstd",
 ]
@@ -4589,7 +4584,7 @@ dependencies = [
  "serde_json",
  "tabled",
  "termcolor",
- "thiserror",
+ "thiserror 1.0.61",
  "time",
  "tokio",
  "toml",
@@ -4674,7 +4669,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.61",
  "timely",
  "tokio",
  "tokio-postgres",
@@ -4813,7 +4808,7 @@ dependencies = [
  "hyper-tls 0.5.0",
  "mz-ore",
  "pin-project",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "uuid",
  "workspace-hack",
@@ -4948,7 +4943,7 @@ dependencies = [
  "serde_plain",
  "sha2",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.61",
  "timely",
  "tokio",
  "tracing",
@@ -5042,7 +5037,7 @@ dependencies = [
  "mz-frontegg-client",
  "reqwest 0.11.24",
  "serde",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "url",
  "workspace-hack",
@@ -5235,7 +5230,7 @@ dependencies = [
  "prost-build",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "timely",
  "tokio",
  "tokio-stream",
@@ -5494,7 +5489,7 @@ dependencies = [
  "stacker",
  "sysctl",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.61",
  "timely",
  "tokio",
  "tokio-postgres",
@@ -5581,7 +5576,7 @@ dependencies = [
  "mz-ore",
  "mz-repr",
  "proc-macro2",
- "syn 2.0.63",
+ "syn 2.0.98",
  "workspace-hack",
 ]
 
@@ -5627,7 +5622,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "socket2 0.5.7",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tokio-postgres",
  "tokio-stream",
@@ -5660,7 +5655,7 @@ dependencies = [
  "reqwest-retry",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tracing",
  "uuid",
@@ -5677,7 +5672,7 @@ dependencies = [
  "reqwest 0.11.24",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "url",
  "uuid",
@@ -5792,7 +5787,7 @@ dependencies = [
  "rdkafka",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tracing",
  "url",
@@ -5883,7 +5878,7 @@ dependencies = [
  "mz-ore",
  "paste",
  "prometheus",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tracing",
  "workspace-hack",
@@ -5914,7 +5909,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "tonic-build",
  "tracing",
  "uuid",
@@ -6063,7 +6058,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tokio-postgres",
  "tower-http",
@@ -6117,7 +6112,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "stacker",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tokio-native-tls",
  "tokio-openssl",
@@ -6247,7 +6242,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.61",
  "timely",
  "tokio",
  "tokio-metrics",
@@ -6463,7 +6458,7 @@ dependencies = [
  "prost",
  "prost-build",
  "serde",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tokio-postgres",
  "tonic-build",
@@ -6601,7 +6596,7 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "strsim",
- "thiserror",
+ "thiserror 1.0.61",
  "timely",
  "tokio-postgres",
  "tracing",
@@ -6642,7 +6637,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tracing",
  "workspace-hack",
@@ -6843,7 +6838,7 @@ dependencies = [
  "serde",
  "serde_json",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -6885,7 +6880,7 @@ dependencies = [
  "phf",
  "serde",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.61",
  "tracing",
  "uncased",
  "unicode-width",
@@ -6900,7 +6895,7 @@ dependencies = [
  "mz-ore",
  "mz-sql-parser",
  "pretty",
- "thiserror",
+ "thiserror 1.0.61",
  "workspace-hack",
 ]
 
@@ -6971,7 +6966,7 @@ dependencies = [
  "serde_json",
  "ssh-key",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7047,7 +7042,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.61",
  "timely",
  "tokio",
  "tokio-postgres",
@@ -7190,7 +7185,7 @@ dependencies = [
  "sentry",
  "serde",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.61",
  "timely",
  "tokio",
  "tokio-stream",
@@ -7259,7 +7254,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "timely",
  "tokio",
  "tokio-postgres",
@@ -7419,7 +7414,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "postgres-openssl",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -7742,7 +7737,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "sha2",
- "thiserror",
+ "thiserror 1.0.61",
  "url",
 ]
 
@@ -7798,7 +7793,7 @@ dependencies = [
  "openssh-mux-client",
  "shell-escape",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tokio-pipe",
 ]
@@ -7813,7 +7808,7 @@ dependencies = [
  "sendfd",
  "serde",
  "ssh_format",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tokio-io-utility",
  "typed-builder",
@@ -7842,7 +7837,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -7884,7 +7879,7 @@ dependencies = [
  "js-sys",
  "once_cell",
  "pin-project-lite",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -7900,7 +7895,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tonic",
 ]
@@ -7933,7 +7928,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tokio-stream",
 ]
@@ -8067,7 +8062,7 @@ dependencies = [
  "snap",
  "thrift",
  "tokio",
- "twox-hash",
+ "twox-hash 1.6.3",
  "zstd",
  "zstd-sys",
 ]
@@ -8163,7 +8158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.61",
  "ucd-trie",
 ]
 
@@ -8187,7 +8182,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8267,7 +8262,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8456,7 +8451,7 @@ dependencies = [
  "smallvec",
  "symbolic-demangle",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -8532,7 +8527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8571,9 +8566,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -8589,7 +8584,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -8616,7 +8611,7 @@ checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8646,7 +8641,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.63",
+ "syn 2.0.98",
  "tempfile",
 ]
 
@@ -8660,7 +8655,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8694,7 +8689,7 @@ checksum = "58678a64de2fced2bdec6bca052a6716a0efe692d6e3f53d1bda6a1def64cfc0"
 dependencies = [
  "once_cell",
  "protobuf-support",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -8721,7 +8716,7 @@ dependencies = [
  "protobuf",
  "protobuf-support",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.61",
  "which",
 ]
 
@@ -8740,7 +8735,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1ed294a835b0f30810e13616b1cd34943c6d1e84a8f3b0dcfe466d256c3e7e7"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -9162,7 +9157,7 @@ dependencies = [
  "reqwest 0.11.24",
  "serde",
  "task-local-extensions",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -9493,7 +9488,7 @@ dependencies = [
  "reqwest 0.11.24",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "time",
 ]
 
@@ -9616,7 +9611,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "time",
  "url",
  "uuid",
@@ -9674,7 +9669,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -9727,7 +9722,7 @@ checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
 dependencies = [
  "percent-encoding",
  "serde",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -9738,7 +9733,7 @@ checksum = "6f0a21fba416426ac927b1691996e82079f8b6156e920c85345f135b2e9ba2de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -9787,7 +9782,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -9911,7 +9906,7 @@ checksum = "4a762b1c38b9b990c694b9c2f8abe3372ce6a9ceaae6bca39cfc46e054f45745"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.61",
  "time",
 ]
 
@@ -10128,9 +10123,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.63"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10159,7 +10154,7 @@ dependencies = [
  "byteorder",
  "enum-as-inner",
  "libc",
- "thiserror",
+ "thiserror 1.0.61",
  "walkdir",
 ]
 
@@ -10311,7 +10306,16 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.61",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -10322,7 +10326,18 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -10365,7 +10380,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "pretty-hex",
- "thiserror",
+ "thiserror 1.0.61",
  "tracing",
  "uuid",
 ]
@@ -10574,7 +10589,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -10798,7 +10813,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -10878,7 +10893,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -10907,7 +10922,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -11034,7 +11049,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "sha1",
- "thiserror",
+ "thiserror 1.0.61",
  "url",
  "utf-8",
 ]
@@ -11053,7 +11068,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "sha1",
- "thiserror",
+ "thiserror 1.0.61",
  "utf-8",
 ]
 
@@ -11064,9 +11079,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
  "static_assertions",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
 
 [[package]]
 name = "typed-arena"
@@ -11370,7 +11390,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -11404,7 +11424,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -11815,7 +11835,6 @@ dependencies = [
  "memchr",
  "mime_guess",
  "minimal-lexical",
- "mio",
  "mysql_async",
  "mysql_common",
  "native-tls",
@@ -11865,7 +11884,7 @@ dependencies = [
  "socket2 0.5.7",
  "subtle",
  "syn 1.0.107",
- "syn 2.0.63",
+ "syn 2.0.98",
  "time",
  "time-macros",
  "tokio",
@@ -11880,7 +11899,6 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
  "tungstenite 0.21.0",
- "twox-hash",
  "uncased",
  "unicode-bidi",
  "unicode-normalization",
@@ -11957,7 +11975,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,11 +294,6 @@ postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres" }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array" }
 
-# Waiting on a release that includes:
-# * https://github.com/blackbeam/mysql_async/pull/300
-# * https://github.com/blackbeam/mysql_async/pull/307
-mysql_async = { git = "https://github.com/MaterializeInc/mysql_async" }
-
 # Waiting on https://github.com/MaterializeInc/serde-value/pull/35.
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 

--- a/deny.toml
+++ b/deny.toml
@@ -50,7 +50,6 @@ skip = [
     # This is very Unfortunate as we don't actually use these platforms.
     { name = "hermit-abi", version = "0.2.6" },
     { name = "redox_syscall", version = "0.2.10" },
-    { name = "rustix", version = "0.38.21" },
 
     # Will require updating many crates
     { name = "indexmap", version = "1.9.1" },
@@ -129,6 +128,9 @@ skip = [
     { name = "reqwest", version = "0.11.24" },
     { name = "rustls-pemfile", version = "1.0.4" },
     { name = "winreg", version = "0.50.0" },
+    { name = "thiserror", version = "1.0.61" },
+    { name = "thiserror-impl", version = "1.0.61" },
+    { name = "twox-hash", version = "1.6.3" },
 ]
 
 # Use `tracing` instead.
@@ -167,7 +169,6 @@ wrappers = [
     "globset",
     "launchdarkly-server-sdk",
     "launchdarkly-server-sdk-evaluation",
-    "mio",
     "native-tls",
     "os_info",
     "postgres",
@@ -197,24 +198,23 @@ name = "rustls"
 [[bans.deny]]
 name = "lazy_static"
 wrappers = [
-  "bindgen",
-  "bstr",
-  "console",
-  "dynfmt",
-  "findshlibs",
-  "insta",
-  "jsonpath-rust",
-  "launchdarkly-server-sdk",
-  "launchdarkly-server-sdk-evaluation",
-  "mysql_async",
-  "mysql_common",
-  "native-tls",
-  "prometheus",
-  "proptest",
-  "rayon-core",
-  "schannel",
-  "sharded-slab",
-  "which",
+    "bindgen",
+    "bstr",
+    "console",
+    "dynfmt",
+    "findshlibs",
+    "insta",
+    "jsonpath-rust",
+    "launchdarkly-server-sdk",
+    "launchdarkly-server-sdk-evaluation",
+    "mysql_common",
+    "native-tls",
+    "prometheus",
+    "proptest",
+    "rayon-core",
+    "schannel",
+    "sharded-slab",
+    "which",
 ]
 
 # The `uncased` crate serves the same purpose as `unicase` and is more

--- a/src/mysql-util/Cargo.toml
+++ b/src/mysql-util/Cargo.toml
@@ -20,10 +20,10 @@ mz-ore = { path = "../ore", features = ["async"] }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }
 mz-ssh-util = { path = "../ssh-util" }
-mysql_common = { version = "0.32.4", default-features = false, features = [
+mysql_common = { version = "0.34.1", default-features = false, features = [
     "chrono",
 ] }
-mysql_async = { version = "0.34.1", default-features = false, features = [
+mysql_async = { version = "0.35.1", default-features = false, features = [
     "minimal",
     "tracing",
 ] }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -29,7 +29,7 @@ im = "15.1.0"
 ipnet = "2.5.0"
 itertools = "0.12.1"
 maplit = "1.0.2"
-mysql_async = { version = "0.34.1", default-features = false, features = [
+mysql_async = { version = "0.35.1", default-features = false, features = [
     "minimal",
 ] }
 mz-arrow-util = { path = "../arrow-util" }

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -29,7 +29,7 @@ differential-dataflow = "0.13.5"
 hex = "0.4.3"
 http = "1.1.0"
 itertools = { version = "0.12.1" }
-mysql_async = { version = "0.34.1", default-features = false, features = ["minimal", "native-tls-tls"] }
+mysql_async = { version = "0.35.1", default-features = false, features = ["minimal", "native-tls-tls"] }
 mz-aws-util = { path = "../aws-util" }
 mz-ccsr = { path = "../ccsr" }
 mz-cloud-resources = { path = "../cloud-resources" }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -32,8 +32,8 @@ futures = "0.3.25"
 indexmap = { version = "2.0.0", default-features = false, features = ["std"] }
 itertools = { version = "0.12.1" }
 maplit = "1.0.2"
-mysql_async = { version = "0.34.1", default-features = false, features = ["minimal", "binlog"] }
-mysql_common = { version = "0.32.4", default-features = false, features = ["chrono"] }
+mysql_async = { version = "0.35.1", default-features = false, features = ["minimal", "binlog"] }
+mysql_common = { version = "0.34.1", default-features = false, features = ["chrono"] }
 mz-build-info = { path = "../build-info" }
 mz-ccsr = { path = "../ccsr" }
 mz-dyncfg = { path = "../dyncfg" }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -31,7 +31,7 @@ itertools = "0.12.1"
 junit-report = "0.8.3"
 maplit = "1.0.2"
 md-5 = "0.10.5"
-mysql_async = { version = "0.34.1", default-features = false, features = ["minimal"] }
+mysql_async = { version = "0.35.1", default-features = false, features = ["minimal"] }
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-aws-util = { path = "../aws-util", features = ["s3"] }
 mz-build-info = { path = "../build-info" }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -77,9 +77,8 @@ lru = { version = "0.12.3" }
 memchr = { version = "2.7.4", features = ["use_std"] }
 mime_guess = { version = "2.0.5" }
 minimal-lexical = { version = "0.2.1", default-features = false, features = ["std"] }
-mio = { version = "0.8.11", features = ["net", "os-ext"] }
-mysql_async = { git = "https://github.com/MaterializeInc/mysql_async", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
-mysql_common = { version = "0.32.4", default-features = false, features = ["binlog", "chrono"] }
+mysql_async = { version = "0.35.1", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
+mysql_common = { version = "0.34.1", default-features = false, features = ["binlog", "chrono"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }
@@ -98,7 +97,7 @@ phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 predicates = { version = "2.1.4" }
-proc-macro2 = { version = "1.0.82", features = ["span-locations"] }
+proc-macro2 = { version = "1.0.93", features = ["span-locations"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit", "prost-derive"] }
 prost-reflect = { version = "0.14.5", default-features = false, features = ["serde"] }
 prost-types = { version = "0.13.2" }
@@ -118,11 +117,11 @@ serde = { version = "1.0.203", features = ["alloc", "derive", "rc"] }
 serde_json = { version = "1.0.127", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value", "unbounded_depth"] }
 sha2 = { version = "0.10.6", features = ["asm"] }
 similar = { version = "2.2.1", features = ["inline", "unicode"] }
-smallvec = { version = "1.13.2", default-features = false, features = ["const_new", "serde", "union", "write"] }
+smallvec = { version = "1.13.2", default-features = false, features = ["const_new", "serde", "union"] }
 socket2 = { version = "0.5.7", default-features = false, features = ["all"] }
 subtle = { version = "2.4.1" }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.63", features = ["extra-traits", "full", "visit", "visit-mut"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.98", features = ["extra-traits", "full", "visit", "visit-mut"] }
 time = { version = "0.3.17", features = ["local-offset", "macros", "quickcheck", "serde-well-known"] }
 tokio = { version = "1.38.0", features = ["full", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
@@ -136,7 +135,6 @@ tracing = { version = "0.1.41", features = ["log"] }
 tracing-core = { version = "0.1.33" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 tungstenite = { version = "0.21.0" }
-twox-hash = { version = "1.6.3" }
 uncased = { version = "0.9.7" }
 unicode-bidi = { version = "0.3.15" }
 unicode-normalization = { version = "0.1.23" }
@@ -212,9 +210,8 @@ lru = { version = "0.12.3" }
 memchr = { version = "2.7.4", features = ["use_std"] }
 mime_guess = { version = "2.0.5" }
 minimal-lexical = { version = "0.2.1", default-features = false, features = ["std"] }
-mio = { version = "0.8.11", features = ["net", "os-ext"] }
-mysql_async = { git = "https://github.com/MaterializeInc/mysql_async", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
-mysql_common = { version = "0.32.4", default-features = false, features = ["binlog", "chrono"] }
+mysql_async = { version = "0.35.1", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
+mysql_common = { version = "0.34.1", default-features = false, features = ["binlog", "chrono"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }
@@ -233,7 +230,7 @@ phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 predicates = { version = "2.1.4" }
-proc-macro2 = { version = "1.0.82", features = ["span-locations"] }
+proc-macro2 = { version = "1.0.93", features = ["span-locations"] }
 proptest-derive = { version = "0.5.1", default-features = false, features = ["boxed_union"] }
 prost = { version = "0.13.2", features = ["no-recursion-limit", "prost-derive"] }
 prost-reflect = { version = "0.14.5", default-features = false, features = ["serde"] }
@@ -254,11 +251,11 @@ serde = { version = "1.0.203", features = ["alloc", "derive", "rc"] }
 serde_json = { version = "1.0.127", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value", "unbounded_depth"] }
 sha2 = { version = "0.10.6", features = ["asm"] }
 similar = { version = "2.2.1", features = ["inline", "unicode"] }
-smallvec = { version = "1.13.2", default-features = false, features = ["const_new", "serde", "union", "write"] }
+smallvec = { version = "1.13.2", default-features = false, features = ["const_new", "serde", "union"] }
 socket2 = { version = "0.5.7", default-features = false, features = ["all"] }
 subtle = { version = "2.4.1" }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.63", features = ["extra-traits", "full", "visit", "visit-mut"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.98", features = ["extra-traits", "full", "visit", "visit-mut"] }
 time = { version = "0.3.17", features = ["local-offset", "macros", "quickcheck", "serde-well-known"] }
 time-macros = { version = "0.2.6", default-features = false, features = ["formatting", "parsing", "serde"] }
 tokio = { version = "1.38.0", features = ["full", "test-util", "tracing"] }
@@ -273,7 +270,6 @@ tracing = { version = "0.1.41", features = ["log"] }
 tracing-core = { version = "0.1.33" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 tungstenite = { version = "0.21.0" }
-twox-hash = { version = "1.6.3" }
 uncased = { version = "0.9.7" }
 unicode-bidi = { version = "0.3.15" }
 unicode-normalization = { version = "0.1.23" }


### PR DESCRIPTION
The released version contains our patches.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
