### PR TITLE
Revert "ci: Disable bazel remote cache temporarily"

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -115,9 +115,7 @@ so it is executed.""",
     if os.environ["BUILDKITE_BRANCH"] == "main" or os.environ["BUILDKITE_TAG"]:
         bazel_remote_cache = "https://bazel-remote-pa.dev.materialize.com"
     else:
-        # TODO: Reenable when bazel remote cache is larger or cleared
-        bazel_remote_cache = ""
-        # bazel_remote_cache = "https://bazel-remote.dev.materialize.com"
+        bazel_remote_cache = "https://bazel-remote.dev.materialize.com"
     raw = raw.replace("$BAZEL_REMOTE_CACHE", bazel_remote_cache)
 
     pipeline = yaml.safe_load(raw)


### PR DESCRIPTION
This reverts commit 52e56da8cdefca71726c42f6c6734dea68d33cb2.

When remote cache is fixed

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
