### PR TITLE
Implement MzArrange for column containers

### DIFF
--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -20,18 +20,16 @@ use differential_dataflow::logging::{
 };
 use mz_ore::cast::CastFrom;
 use mz_repr::{Datum, Diff, Timestamp};
-use mz_timely_util::containers::{
-    columnar_exchange, Col2ValBatcher, ColumnBuilder, ProvidedBuilder,
-};
+use mz_timely_util::containers::{Col2ValBatcher, ColumnBuilder, ProvidedBuilder};
 use mz_timely_util::replay::MzReplay;
 use timely::communication::Allocate;
-use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
+use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::channels::pushers::buffer::Session;
 use timely::dataflow::channels::pushers::{Counter, Tee};
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::Stream;
 
-use crate::extensions::arrange::MzArrangeCore;
+use crate::extensions::arrange::MzArrange;
 use crate::logging::compute::{ArrangementHeapSizeOperatorDrop, ComputeEvent};
 use crate::logging::{
     consolidate_and_pack, DifferentialLog, EventQueue, LogCollection, LogVariant,
@@ -164,8 +162,7 @@ pub(super) fn construct<A: Allocate>(
             let variant = LogVariant::Differential(variant);
             if config.index_logs.contains_key(&variant) {
                 let trace = collection
-                    .mz_arrange_core::<_, Col2ValBatcher<_, _, _, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
-                        ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<mz_repr::Row, mz_repr::Row, Timestamp, mz_repr::Diff>),
+                    .mz_arrange::<Col2ValBatcher<_, _, _, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
                         &format!("Arrange {variant:?}"),
                     )
                     .trace;

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -17,14 +17,13 @@ use std::time::Duration;
 use columnar::Index;
 use mz_compute_client::logging::LoggingConfig;
 use mz_ore::cast::CastFrom;
-use mz_repr::{Datum, Diff, Row, Timestamp};
-use mz_timely_util::containers::{columnar_exchange, Col2ValBatcher, Column, ColumnBuilder};
+use mz_repr::{Datum, Diff, Timestamp};
+use mz_timely_util::containers::{Col2ValBatcher, Column, ColumnBuilder};
 use mz_timely_util::replay::MzReplay;
 use timely::communication::Allocate;
-use timely::dataflow::channels::pact::ExchangeCore;
 use timely::Container;
 
-use crate::extensions::arrange::MzArrangeCore;
+use crate::extensions::arrange::MzArrange;
 use crate::logging::initialize::ReachabilityEvent;
 use crate::logging::{consolidate_and_pack, EventQueue, LogCollection, LogVariant, TimelyLog};
 use crate::row_spine::RowRowBuilder;
@@ -98,8 +97,7 @@ pub(super) fn construct<A: Allocate>(
         for variant in logs_active {
             if config.index_logs.contains_key(&variant) {
                 let trace = updates
-                    .mz_arrange_core::<_, Col2ValBatcher<_, _, _, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
-                        ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<Row, Row, Timestamp, Diff>),
+                    .mz_arrange::<Col2ValBatcher<_, _, _, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
                         &format!("Arrange {variant:?}"),
                     )
                     .trace;

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -18,13 +18,11 @@ use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
 use mz_compute_client::logging::LoggingConfig;
 use mz_ore::cast::CastFrom;
 use mz_repr::{Datum, Diff, Timestamp};
-use mz_timely_util::containers::{
-    columnar_exchange, Col2ValBatcher, ColumnBuilder, ProvidedBuilder,
-};
+use mz_timely_util::containers::{Col2ValBatcher, ColumnBuilder, ProvidedBuilder};
 use mz_timely_util::replay::MzReplay;
 use timely::communication::Allocate;
 use timely::container::columnation::{Columnation, CopyRegion};
-use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
+use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::channels::pushers::buffer::Session;
 use timely::dataflow::channels::pushers::{Counter, Tee};
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
@@ -35,7 +33,7 @@ use timely::logging::{
 use timely::Container;
 use tracing::error;
 
-use crate::extensions::arrange::MzArrangeCore;
+use crate::extensions::arrange::MzArrange;
 use crate::logging::compute::{ComputeEvent, DataflowShutdown};
 use crate::logging::{consolidate_and_pack, LogCollection};
 use crate::logging::{EventQueue, LogVariant, SharedLoggingState, TimelyLog};
@@ -308,8 +306,7 @@ pub(super) fn construct<A: Allocate>(
             let variant = LogVariant::Timely(variant);
             if config.index_logs.contains_key(&variant) {
                 let trace = collection
-                    .mz_arrange_core::<_, Col2ValBatcher<_, _, _, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
-                        ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<mz_repr::Row, mz_repr::Row, Timestamp, Diff>),
+                    .mz_arrange::<Col2ValBatcher<_, _, _, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
                         &format!("Arrange {variant:?}"),
                     )
                     .trace;

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -30,11 +30,11 @@ use mz_repr::fixed_length::ToDatumIter;
 use mz_repr::{DatumVec, DatumVecBorrow, Diff, GlobalId, Row, RowArena, SharedRow};
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
-use mz_timely_util::containers::{columnar_exchange, Col2ValBatcher, ColumnBuilder};
+use mz_timely_util::containers::{Col2ValBatcher, ColumnBuilder};
 use mz_timely_util::operator::{CollectionExt, StreamExt};
 use timely::container::columnation::Columnation;
 use timely::container::CapacityContainerBuilder;
-use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
+use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::OutputHandleCore;
 use timely::dataflow::operators::Capability;
 use timely::dataflow::scopes::Child;
@@ -45,7 +45,7 @@ use timely::Container;
 use tracing::error;
 
 use crate::compute_state::{ComputeState, HydrationEvent};
-use crate::extensions::arrange::{KeyCollection, MzArrange, MzArrangeCore};
+use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::render::errors::ErrorLogger;
 use crate::render::{LinearJoinSpec, RenderTimestamp};
 use crate::row_spine::{DatumSeq, RowRowBuilder};
@@ -927,9 +927,7 @@ where
                 },
             );
         let oks = oks
-            .mz_arrange_core::<_, Col2ValBatcher<_, _,_, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
-                ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<Row, Row, S::Timestamp, Diff>),name
-            );
+            .mz_arrange::<Col2ValBatcher<_, _, _, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(name);
         (oks, errs.as_collection())
     }
 }

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -26,16 +26,16 @@ use mz_dyncfg::ConfigSet;
 use mz_repr::fixed_length::ToDatumIter;
 use mz_repr::{DatumVec, Diff, Row, RowArena, SharedRow};
 use mz_storage_types::errors::DataflowError;
-use mz_timely_util::containers::{columnar_exchange, Col2ValBatcher, ColumnBuilder};
+use mz_timely_util::containers::{Col2ValBatcher, ColumnBuilder};
 use mz_timely_util::operator::{CollectionExt, StreamExt};
 use timely::container::columnation::Columnation;
-use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
+use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::OkErr;
 use timely::dataflow::scopes::Child;
 use timely::dataflow::{Scope, ScopeParent};
 use timely::progress::timestamp::{Refines, Timestamp};
 
-use crate::extensions::arrange::MzArrangeCore;
+use crate::extensions::arrange::MzArrange;
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context, ShutdownToken};
 use crate::render::join::mz_join_core::mz_join_core;
 use crate::render::RenderTimestamp;
@@ -400,8 +400,8 @@ where
             errors.push(errs.as_collection());
 
             let arranged = keyed
-                .mz_arrange_core::<_, Col2ValBatcher<_, _,_, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
-                    ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<Row, Row, S::Timestamp, Diff>),"JoinStage"
+                .mz_arrange::<Col2ValBatcher<_, _, _, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+                    "JoinStage",
                 );
             joined = JoinedFlavor::Local(arranged);
         }

--- a/src/timely-util/src/containers.rs
+++ b/src/timely-util/src/containers.rs
@@ -9,11 +9,7 @@
 
 //! Reusable containers.
 
-use std::hash::Hash;
-
-use columnar::Columnar;
 use differential_dataflow::trace::implementations::merge_batcher::{ColMerger, MergeBatcher};
-use differential_dataflow::Hashable;
 use timely::container::columnation::TimelyStack;
 
 pub mod array;
@@ -288,21 +284,6 @@ pub type Col2ValBatcher<K, V, T, R> = MergeBatcher<
     ColMerger<(K, V), T, R>,
 >;
 pub type Col2KeyBatcher<K, T, R> = Col2ValBatcher<K, (), T, R>;
-
-/// An exchange function for columnar tuples of the form `((K, V), T, D)`. Rust has a hard
-/// time to figure out the lifetimes of the elements when specified as a closure, so we rather
-/// specify it as a function.
-#[inline(always)]
-pub fn columnar_exchange<K, V, T, D>(((k, _), _, _): &<((K, V), T, D) as Columnar>::Ref<'_>) -> u64
-where
-    K: Columnar,
-    for<'a> K::Ref<'a>: Hash,
-    V: Columnar,
-    D: Columnar,
-    T: Columnar,
-{
-    k.hashed()
-}
 
 /// Types for consolidating, merging, and extracting columnar update collections.
 pub mod batcher {


### PR DESCRIPTION
Provide an implementation for MzArrange for collections and streams backed
by Column. This is strictly better than calling `mz_exchange_core`
wherever we need to arrange columnar data.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
