### PR TITLE
update avro-resolution-no-publish-writer test to reference non-existent schema id

### DIFF
--- a/test/testdrive-old-kafka-src-syntax/avro-resolution-no-publish-writer.td
+++ b/test/testdrive-old-kafka-src-syntax/avro-resolution-no-publish-writer.td
@@ -38,11 +38,10 @@ GRANT CREATE, USAGE ON SCHEMA public TO materialize
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-# The value is {"f1": 123}.
+# The value is {"f1": 123}, schema_id = 0x1000000 (16777216) - that should be far beyond what the previous tests create
 # We encode it manually to avoid publishing it.
 $ kafka-ingest format=bytes topic=resolution-no-publish-writer timestamp=1
-\\x00\x00\x00\x00\x01\xf6\x01
+\\x00\x01\x00\x00\x00\xf6\x01
 
-# TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/8933 is fixed
-# ! SELECT * FROM resolution_no_publish_writer;
-# contains:to resolve
+SELECT status FROM mz_internal.mz_source_statuses WHERE source = 'resolution_no_publish_writer';
+stalled


### PR DESCRIPTION
Modifies the existing test to publish an AVRO message with a schema id that shouldn't exist (0x1000000). The schema_id is a monotonic value assigned by the schema registry, starting at 1.  It's extremely unlikely that we reach into the millions (current tests result in under 200 schema_ids).

### Motivation
fixes [8933](https://github.com/MaterializeInc/database-issues/issues/8933)


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
