### PR TITLE
compute/correction-v2: introduce a Stage to speed up small inserts

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -96,6 +96,7 @@ def get_default_system_parameters(
         "enable_alter_swap": "true",
         "enable_columnation_lgalloc": "true",
         "enable_compute_chunked_stack": "true",
+        "enable_compute_correction_v2": "true",
         "enable_connection_validation_syntax": "true",
         "enable_continual_task_builtins": (
             "true" if version > MzVersion.parse_mz("v0.127.0-dev") else "false"

--- a/src/timely-util/src/containers/stack.rs
+++ b/src/timely-util/src/containers/stack.rs
@@ -55,6 +55,14 @@ impl<T: Columnation> StackWrapper<T> {
         }
     }
 
+    /// Return the capacity of the local buffer.
+    pub fn capacity(&self) -> usize {
+        match self {
+            Self::Legacy(stack) => stack.capacity(),
+            Self::Chunked(stack) => stack.capacity(),
+        }
+    }
+
     /// Estimate the memory capacity in bytes.
     #[inline]
     pub fn heap_size(&self, callback: impl FnMut(usize, usize)) {


### PR DESCRIPTION
This PR extends the `CorrectionV2` data structure with a `Stage` that accumulates inserted updates before they get inserted into the sorted chains. This significantly reduces the amount of chain merges that need to be done in workloads that trickle in large amounts of updates in small batches, greatly speeding up these workloads.

For some reason, the memory tests introduced in https://github.com/MaterializeInc/materialize/pull/31267 are such a workload. Brief testing reveals that this PR speeds up the MV hydration in the `-800mb` test, when pointed against `CorrectionV2`, by roughly an order of magnitude, from ~300s to ~30s.

Note that this change doesn't have much impact when running locally on macOS. For some reason the batch sizes entering the MV sink are much smaller when running in `mzcompose`, not sure why that is.

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/database-issues/issues/8464

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
