### PR TITLE
Fix a minor EXPLAIN bug around `count(*)`

### DIFF
--- a/src/adapter/src/explain/insights.rs
+++ b/src/adapter/src/explain/insights.rs
@@ -14,10 +14,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use mz_compute_types::dataflows::{BuildDesc, DataflowDescription};
-use mz_expr::{
-    AccessStrategy, AggregateExpr, AggregateFunc, Id, MirRelationExpr, OptimizedMirRelationExpr,
-    RowSetFinishing,
-};
+use mz_expr::{AccessStrategy, Id, MirRelationExpr, OptimizedMirRelationExpr, RowSetFinishing};
 use mz_ore::num::NonNeg;
 use mz_repr::explain::ExprHumanizer;
 use mz_repr::{GlobalId, Timestamp};
@@ -266,15 +263,7 @@ fn global_insights(
             let [aggregate] = aggregates.as_slice() else {
                 return;
             };
-            let AggregateExpr {
-                func: AggregateFunc::Count,
-                distinct: false,
-                expr,
-            } = aggregate
-            else {
-                return;
-            };
-            if !expr.is_literal_true() {
+            if !aggregate.is_count_asterisk() {
                 return;
             }
             let name = structured_name(humanizer, *id);

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -3340,16 +3340,9 @@ impl AggregateExpr {
         match self {
             AggregateExpr {
                 func: AggregateFunc::Count,
-                expr:
-                    MirScalarExpr::Literal(
-                        Ok(row),
-                        mz_repr::ColumnType {
-                            scalar_type: mz_repr::ScalarType::Bool,
-                            nullable: false,
-                        },
-                    ),
+                expr,
                 distinct: false,
-            } => row.unpack_first() == mz_repr::Datum::True,
+            } => expr.is_literal_true(),
             _ => false,
         }
     }

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -3348,7 +3348,7 @@ impl AggregateExpr {
                             nullable: false,
                         },
                     ),
-                ..
+                distinct: false,
             } => row.unpack_first() == mz_repr::Datum::True,
             _ => false,
         }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3046,6 +3046,8 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
         "count" => Aggregate {
             params!() => Operation::nullary(|_ecx| {
                 // COUNT(*) is equivalent to COUNT(true).
+                // This is mirrored in `AggregateExpr::is_count_asterisk`, so if you modify this,
+                // then attend to that code also.
                 Ok((HirScalarExpr::literal_true(), AggregateFunc::Count))
             }) => Int64, 2803;
             params!(Any) => AggregateFunc::Count => Int64, 2147;

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -1623,3 +1623,96 @@ Source materialize.public.t6
 Target cluster: no_replicas
 
 EOF
+
+# `count(*)` is planned as `count(true)`. We take care in EXPLAIN to show `count(true)` as `count(*)` to avoid confusing
+# users.
+query T multiline
+EXPLAIN OPTIMIZED PLAN AS TEXT FOR
+SELECT count(*)
+FROM t5;
+----
+Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[count(*)]
+        Project ()
+          ReadStorage materialize.public.t5
+  Return
+    Union
+      Get l0
+      Map (0)
+        Union
+          Negate
+            Project ()
+              Get l0
+          Constant
+            - ()
+
+Source materialize.public.t5
+
+Target cluster: no_replicas
+
+EOF
+
+query error DISTINCT \* not supported as function args
+EXPLAIN OPTIMIZED PLAN AS TEXT FOR
+SELECT count(distinct *)
+FROM t5;
+
+# `count(true)` is currently also printed as `count(*)` in EXPLAIN, which I'd say is fine.
+query T multiline
+EXPLAIN OPTIMIZED PLAN AS TEXT FOR
+SELECT count(true)
+FROM t5;
+----
+Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[count(*)]
+        Project ()
+          ReadStorage materialize.public.t5
+  Return
+    Union
+      Get l0
+      Map (0)
+        Union
+          Negate
+            Project ()
+              Get l0
+          Constant
+            - ()
+
+Source materialize.public.t5
+
+Target cluster: no_replicas
+
+EOF
+
+# But `count(DISTINCT true)` means an entirely different thing, so EXPLAIN shouldn't conflate it with `count(*)`.
+query T multiline
+EXPLAIN OPTIMIZED PLAN AS TEXT FOR
+SELECT count(DISTINCT true)
+FROM t5;
+----
+Explained Query:
+  With
+    cte l0 =
+      Reduce aggregates=[count(distinct true)]
+        Project ()
+          ReadStorage materialize.public.t5
+  Return
+    Union
+      Get l0
+      Map (0)
+        Union
+          Negate
+            Project ()
+              Get l0
+          Constant
+            - ()
+
+Source materialize.public.t5
+
+Target cluster: no_replicas
+
+EOF


### PR DESCRIPTION
See https://github.com/MaterializeInc/database-issues/issues/8831#issuecomment-2643526472

The first commit is just a 1-liner fix for the bug (and adding tests), while the second commit is a bit of refactoring to simplify some related code.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/8831#issuecomment-2643526472

### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
