### PR TITLE
dependabot: group updates for minor and patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
     time: "22:00"
   open-pull-requests-limit: 50
   labels: [A-dependencies]
+  groups:
+    simple:
+      applies-to: version-updates
+      update-types:
+        - minor
+        - patch
 - package-ecosystem: cargo
   directory: /misc/wasm
   schedule:
@@ -16,6 +22,12 @@ updates:
     time: "22:00"
   open-pull-requests-limit: 50
   labels: [A-dependencies]
+  groups:
+    simple:
+      applies-to: version-updates
+      update-types:
+        - minor
+        - patch
 - package-ecosystem: pip
   directory: /misc/dbt-materialize
   schedule:
@@ -24,6 +36,12 @@ updates:
     # dbt drops.
     interval: daily
   labels: [A-dependencies]
+  groups:
+    simple:
+      applies-to: version-updates
+      update-types:
+        - minor
+        - patch
 - package-ecosystem: docker
   directory: /misc/images/ubuntu-base
   schedule:
@@ -32,6 +50,12 @@ updates:
     time: "22:00"
   open-pull-requests-limit: 50
   labels: [A-dependencies]
+  groups:
+    simple:
+      applies-to: version-updates
+      update-types:
+        - minor
+        - patch
 - package-ecosystem: docker
   directory: /ci/builder
   schedule:
@@ -40,6 +64,12 @@ updates:
     time: "22:00"
   open-pull-requests-limit: 50
   labels: [A-dependencies]
+  groups:
+    simple:
+      applies-to: version-updates
+      update-types:
+        - minor
+        - patch
 - package-ecosystem: pip
   directory: /ci/builder
   schedule:
@@ -48,3 +78,9 @@ updates:
     time: "22:00"
   open-pull-requests-limit: 50
   labels: [A-dependencies]
+  groups:
+    simple:
+      applies-to: version-updates
+      update-types:
+        - minor
+        - patch


### PR DESCRIPTION
to have fewer open PRs at a time. Suggested by @doy-materialize : https://materializeinc.slack.com/archives/C08ACQNGSQK/p1738940883162109?thread_ts=1738871426.623379&cid=C08ACQNGSQK

Let's see how this goes, might require more manual work in case one dependency causes errors/lint failures, but doesn't overload our CI as much.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
