### PR TITLE
ci: Lower priority for dependabot

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -317,6 +317,7 @@ def prioritize_pipeline(pipeline: Any, priority: int) -> None:
 
     tag = os.environ["BUILDKITE_TAG"]
     branch = os.getenv("BUILDKITE_BRANCH")
+    build_author = os.getenv("BUILDKITE_BUILD_AUTHOR")
     # use the base priority of the entire pipeline
     priority += pipeline.get("priority", 0)
 
@@ -327,6 +328,10 @@ def prioritize_pipeline(pipeline: Any, priority: int) -> None:
     # main branch is less time sensitive than results on PRs
     if branch == "main":
         priority -= 50
+
+    # Dependabot is less urgent than manual PRs
+    if build_author == "Dependabot":
+        priority -= 40
 
     def visit(config: Any) -> None:
         # Increase priority for larger Hetzner-based tests so that they get


### PR DESCRIPTION
Priority becomes high again if someone manually adds a commit to a dependabot PR
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
