### PR TITLE
ci: Move macOS clippy to Tests, but don't run on PRs

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -62,26 +62,6 @@ steps:
           queue: hetzner-aarch64-8cpu-16gb
         sanitizer: skip
 
-      # TODO(def-) Move this back to tests pipeline if we start having
-      # macOS-only failures, or once we have more reliable macOS agents
-      - id: lint-macos
-        label: ":rust: macOS Clippy"
-        command: cargo clippy --all-targets -- -D warnings
-        env:
-          CARGO_INCREMENTAL: "0"
-          RUSTUP_TOOLCHAIN: $RUST_VERSION
-        inputs:
-          - Cargo.lock
-          - Cargo.toml
-          - "**/Cargo.toml"
-          - "**/*.rs"
-        depends_on: []
-        timeout_in_minutes: 30
-        agents:
-          queue: mac
-        coverage: skip
-        sanitizer: skip
-
   - id: miri-test
     label: ":rust: Miri test (full)"
     depends_on: []

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -191,6 +191,25 @@ steps:
         coverage: skip
         sanitizer: skip
 
+      - id: lint-macos
+        label: ":rust: macOS Clippy"
+        command: cargo clippy --all-targets -- -D warnings
+        env:
+          CARGO_INCREMENTAL: "0"
+          RUSTUP_TOOLCHAIN: $RUST_VERSION
+        inputs:
+          - Cargo.lock
+          - Cargo.toml
+          - "**/Cargo.toml"
+          - "**/*.rs"
+        depends_on: []
+        timeout_in_minutes: 30
+        agents:
+          queue: mac
+        coverage: skip
+        sanitizer: skip
+        branches: "main v*.* lts-v*"
+
       - id: lint-deps
         label: Lint dependencies
         command: bin/ci-builder run stable ci/test/lint-deps.sh


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/31404

This gives us a faster signal without costing any extra resources. With nightly we might have broken main for 1 day, the Mac agent is idling anyway.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
