### PR TITLE
mz-ore: conditional compilation for chrono

### DIFF
--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -97,7 +97,7 @@ yansi = { version = "0.5.1", optional = true }
 [dev-dependencies]
 anyhow = { version = "1.0.95" }
 criterion = { version = "0.5.1", features = ["async_tokio"] }
-mz-ore = { path = "../ore", features = ["id_gen"] }
+mz-ore = { path = "../ore", features = ["id_gen", "chrono"] }
 proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 scopeguard = "1.1.0"
 serde_json = "1.0.125"

--- a/src/ore/src/panic.rs
+++ b/src/ore/src/panic.rs
@@ -28,6 +28,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{env, thread};
 
+#[cfg(feature = "chrono")]
 use chrono::Utc;
 use itertools::Itertools;
 #[cfg(feature = "async")]
@@ -86,7 +87,12 @@ pub fn install_enhanced_handler() {
             return;
         }
 
-        let timestamp = Utc::now().format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string();
+        // can't use if cfg!() here because that will require chrono::Utc import
+        #[cfg(feature = "chrono")]
+        let timestamp = Utc::now().format("%Y-%m-%dT%H:%M:%S%.6fZ ").to_string();
+        #[cfg(not(feature = "chrono"))]
+        let timestamp = String::new();
+
         let thread = thread::current();
         let thread_name = thread.name().unwrap_or("<unnamed>");
 
@@ -142,7 +148,7 @@ pub fn install_enhanced_handler() {
         //
         // See https://github.com/rust-lang/rust/issues/64413 for details.
         let buf = format!(
-            "{timestamp}  thread '{thread_name}' panicked at {location}:\n{msg}\n{backtrace}"
+            "{timestamp}thread '{thread_name}' panicked at {location}:\n{msg}\n{backtrace}"
         );
 
         // Ideal path: spawn a thread that attempts to lock the Rust-managed

--- a/src/ore/src/panic.rs
+++ b/src/ore/src/panic.rs
@@ -89,7 +89,7 @@ pub fn install_enhanced_handler() {
 
         // can't use if cfg!() here because that will require chrono::Utc import
         #[cfg(feature = "chrono")]
-        let timestamp = Utc::now().format("%Y-%m-%dT%H:%M:%S%.6fZ ").to_string();
+        let timestamp = Utc::now().format("%Y-%m-%dT%H:%M:%S%.6fZ  ").to_string();
         #[cfg(not(feature = "chrono"))]
         let timestamp = String::new();
 


### PR DESCRIPTION
Adds conditional compilation for `chrono` in `mz-ore` crate.

### Motivation

cargo buid/test failures
```
error[E0432]: unresolved import `chrono`
  --> src/ore/src/panic.rs:31:5
   |
31 | use chrono::Utc;
   |     ^^^^^^ use of undeclared crate or module `chrono`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `mz-ore` (lib) due to 1 previous error
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
