### PR TITLE
[persist] Remove the "gone to sleep" panics

### DIFF
--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1061,14 +1061,6 @@ where
                 Err(seqno) => seqno,
             };
 
-            // There might be some holdup in the next batch being
-            // produced. Perhaps we've quiesced a table or maybe a
-            // dataflow is taking a long time to start up because it has
-            // to read a lot of data. Heartbeat ourself so we don't
-            // accidentally lose our lease while we wait for things to
-            // resume.
-            // self.maybe_heartbeat_reader().await;
-
             // Wait a bit and try again. Intentionally don't ever log
             // this at info level.
             match wake {

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1660,7 +1660,14 @@ where
             return Break(NoOpStateTransition(Since(Antichain::new())));
         }
 
-        let reader_state = self.leased_reader(reader_id);
+        // The only way to have a missing reader in state is if it's been expired... and in that
+        // case, we behave the same as though that reader had been downgraded to the empty antichain.
+        let Some(reader_state) = self.leased_reader(reader_id) else {
+            tracing::warn!(
+                "Leased reader {reader_id} was expired due to inactivity. Did the machine go to sleep?",
+            );
+            return Break(NoOpStateTransition(Since(Antichain::new())));
+        };
 
         // Also use this as an opportunity to heartbeat the reader and downgrade
         // the seqno capability.
@@ -1856,20 +1863,8 @@ where
         Continue(existed)
     }
 
-    fn leased_reader(&mut self, id: &LeasedReaderId) -> &mut LeasedReaderState<T> {
-        self.leased_readers
-            .get_mut(id)
-            // The only (tm) ways to hit this are (1) inventing a LeasedReaderId
-            // instead of getting it from Register or (2) if a lease expired.
-            // (1) is a gross mis-use and (2) may happen if a reader did not get
-            // to heartbeat for a long time. Readers are expected to
-            // heartbeat/downgrade their since regularly.
-            .unwrap_or_else(|| {
-                panic!(
-                    "LeasedReaderId({}) was expired due to inactivity. Did the machine go to sleep?",
-                    id
-                )
-            })
+    fn leased_reader(&mut self, id: &LeasedReaderId) -> Option<&mut LeasedReaderState<T>> {
+        self.leased_readers.get_mut(id)
     }
 
     fn critical_reader(&mut self, id: &CriticalReaderId) -> &mut CriticalReaderState<T> {

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -798,16 +798,9 @@ where
     /// A rate-limited version of [Self::downgrade_since].
     ///
     /// This is an internally rate limited helper, designed to allow users to
-    /// call it as frequently as they like. Call this [Self::downgrade_since],
-    /// or Self::maybe_heartbeat_reader on some interval that is "frequent"
-    /// compared to PersistConfig::FAKE_READ_LEASE_DURATION.
-    ///
-    /// This is communicating actual progress information, so is given
-    /// preferential treatment compared to Self::maybe_heartbeat_reader.
+    /// call it as frequently as they like. Call this or [Self::downgrade_since],
+    /// on some interval that is "frequent" compared to the read lease duration.
     pub async fn maybe_downgrade_since(&mut self, new_since: &Antichain<T>) {
-        // NB: min_elapsed is intentionally smaller than the one in
-        // maybe_heartbeat_reader (this is the preferential treatment mentioned
-        // above).
         let min_elapsed = READER_LEASE_DURATION.get(&self.cfg) / 4;
         let elapsed_since_last_heartbeat =
             Duration::from_millis((self.cfg.now)().saturating_sub(self.last_heartbeat));


### PR DESCRIPTION
- Include more debugging info in the handle-expiry message.
- Remove a panic when attempting to downgrade the since of a handle that is expired.

### Motivation

https://github.com/MaterializeInc/incidents-and-escalations/issues/170

### Tips for reviewer

Silencing the error here might be controversial? My thinking is roughly:
- In theory: semantically, we generally treat an expired handle as one that has had its frontier advanced all the way, so this is in line with some existing behaviour.
- In practice: this should never lead to incorrectness that wasn't already possible, because extending the lease never guaranteed that it would be present for any particular future operation... just more likely. It does increase the risk that we'll hit some other panic down the line, but that should only happen in cases where this would have panicked anyways... so this should be a net stability benefit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
