### PR TITLE
compute/correction-v2: introduce a Stage to speed up small inserts (`ConsolidatingContainerBuilder` version)

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -96,6 +96,7 @@ def get_default_system_parameters(
         "enable_alter_swap": "true",
         "enable_columnation_lgalloc": "true",
         "enable_compute_chunked_stack": "true",
+        "enable_compute_correction_v2": "true",
         "enable_connection_validation_syntax": "true",
         "enable_continual_task_builtins": (
             "true" if version > MzVersion.parse_mz("v0.127.0-dev") else "false"


### PR DESCRIPTION
This PR extends the `CorrectionV2` data structure with a `Stage` that accumulates inserted updates before they get inserted into the sorted chains. This significantly reduces the amount of chain merges that need to be done in workloads that trickle in large amounts of updates in small batches, greatly speeding up these workloads.

This is an alternative implementation of https://github.com/MaterializeInc/materialize/pull/31401, trying out the use of a `ConsolidatingContainerBuilder`.

Unfortunately, performance isn't great. Running the `800mb` mzcompose test from https://github.com/MaterializeInc/materialize/pull/31267, this version needs more than 3 times as much time to hydrate the MV as the hand-rolled version (165s vs 50s). It's not clear to me what causes the slowdown. The `ConsolidatingContainerBuilder` version needs to do more work, due to the re-sorting, but I don't think that explains this much of a regression?

Apart from performance, the `ConsolidatingContainerBuilder` version has two other drawbacks compared to the hand-rolled version: It doesn't count the contents of the `stage` against the correction metrics, and it cannot advance times in the `stage`, so it potentially misses out on early consolidation opportunities. Both are caused by limitations in the `ConsolidatingContainerBuilder` API that could be removed.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
