### PR TITLE
bazel: enable pipelining for the `adapter` crate

### DIFF
--- a/src/adapter/BUILD.bazel
+++ b/src/adapter/BUILD.bazel
@@ -24,7 +24,6 @@ rust_library(
     compile_data = [],
     crate_features = ["default"],
     data = [],
-    disable_pipelining = True,
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -104,11 +104,6 @@ harness = false
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]
 
-[package.metadata.cargo-gazelle.lib]
-# TODO(parkmycar): No idea what, but something in this crate is non-deterministic and it breaks
-# pipelining.
-disable_pipelining = true
-
 [package.metadata.cargo-gazelle.test.sql]
 data = ["tests/testdata/sql"]
 


### PR DESCRIPTION
I've been dogfooding this one for a while now, I think after https://github.com/MaterializeInc/materialize/pull/31016 we've removed the last source of non-determinism in the build which allows pipelining to work for the adapter crate!

### Motivation

Faster builds

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
