### PR TITLE
Revert "bazel: enable pipelining for the `adapter` crate (#31458)"

### DIFF
--- a/src/adapter/BUILD.bazel
+++ b/src/adapter/BUILD.bazel
@@ -24,6 +24,7 @@ rust_library(
     compile_data = [],
     crate_features = ["default"],
     data = [],
+    disable_pipelining = True,
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
     rustc_flags = [],

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -104,6 +104,11 @@ harness = false
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]
 
+[package.metadata.cargo-gazelle.lib]
+# TODO(parkmycar): No idea what, but something in this crate is non-deterministic and it breaks
+# pipelining.
+disable_pipelining = true
+
 [package.metadata.cargo-gazelle.test.sql]
 data = ["tests/testdata/sql"]
 


### PR DESCRIPTION
This reverts commit 361b5c10448a10b906af27825e96a7c245358298.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Turns out the build still isn't deterministic yet, see https://buildkite.com/materialize/test/builds/98823#_

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
