### PR TITLE
logs: remove the term 'dangerous_force_compaction...'

### DIFF
--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -735,7 +735,7 @@ pub async fn dangerous_force_compaction_and_break_pushdown<K, V, T, D>(
         let (reqs, mut maintenance) = machine.spine_exert(fuel).await;
         for req in reqs {
             info!(
-                "dangerous_force_compaction_and_break_pushdown {} {} compacting {} batches in {} parts totaling {} bytes: lower={:?} upper={:?} since={:?}",
+                "force_compaction {} {} compacting {} batches in {} parts totaling {} bytes: lower={:?} upper={:?} since={:?}",
                 machine.applier.shard_metrics.name,
                 machine.applier.shard_metrics.shard_id,
                 req.inputs.len(),
@@ -757,7 +757,7 @@ pub async fn dangerous_force_compaction_and_break_pushdown<K, V, T, D>(
                 Ok(x) => x,
                 Err(err) => {
                     warn!(
-                        "dangerous_force_compaction_and_break_pushdown {} {} errored in compaction: {:?}",
+                        "force_compaction {} {} errored in compaction: {:?}",
                         machine.applier.shard_metrics.name,
                         machine.applier.shard_metrics.shard_id,
                         err
@@ -767,7 +767,7 @@ pub async fn dangerous_force_compaction_and_break_pushdown<K, V, T, D>(
             };
             machine.applier.metrics.compaction.admin_count.inc();
             info!(
-                "dangerous_force_compaction_and_break_pushdown {} {} compacted in {:?}: {:?}",
+                "force_compaction {} {} compacted in {:?}: {:?}",
                 machine.applier.shard_metrics.name,
                 machine.applier.shard_metrics.shard_id,
                 start.elapsed(),
@@ -787,7 +787,7 @@ pub async fn dangerous_force_compaction_and_break_pushdown<K, V, T, D>(
         let num_batches = machine.applier.all_batches().len();
         if num_batches < 2 {
             info!(
-                "dangerous_force_compaction_and_break_pushdown {} {} exiting with {} batches",
+                "force_compaction {} {} exiting with {} batches",
                 machine.applier.shard_metrics.name,
                 machine.applier.shard_metrics.shard_id,
                 num_batches


### PR DESCRIPTION
Was chatting with @frankmcsherry and @kay-kim, when reading through logs to debug an issue folks get misled by the "dangerous" term in this log line and it can leave folks confused as to whether or not this log line is indicative of an issue or not.

### Motivation

Make logs less misleading

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
