### PR TITLE
Tweak aoc slts to use more EXPLAIN options

### DIFF
--- a/test/sqllogictest/advent-of-code/2023/aoc_1201.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1201.slt
@@ -38,7 +38,8 @@ FROM (
 278
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR SELECT SUM(LEFT(r, 1)::int * 10 + RIGHT(r, 1)::int) AS part1
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+SELECT SUM(LEFT(r, 1)::int * 10 + RIGHT(r, 1)::int) AS part1
 FROM (
 	SELECT regexp_replace(input, '[^\d]', '', 'g') AS r
 	FROM aoc_1201
@@ -47,17 +48,17 @@ FROM (
 Explained Query:
   With
     cte l0 =
-      Reduce aggregates=[sum(((text_to_integer(left(regexp_replace["[^\d]", case_insensitive=false, limit=0](#0, ""), 1)) * 10) + text_to_integer(right(regexp_replace["[^\d]", case_insensitive=false, limit=0](#0, ""), 1))))]
-        ReadStorage materialize.public.aoc_1201
-  Return
-    Union
-      Get l0
-      Map (null)
-        Union
-          Negate
-            Project ()
-              Get l0
-          Constant
+      Reduce aggregates=[sum(((text_to_integer(left(regexp_replace["[^\d]", case_insensitive=false, limit=0](#0{input}, ""), 1)) * 10) + text_to_integer(right(regexp_replace["[^\d]", case_insensitive=false, limit=0](#0{input}, ""), 1))))] // { arity: 1 }
+        ReadStorage materialize.public.aoc_1201 // { arity: 1 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l0 // { arity: 1 }
+          Constant // { arity: 0 }
             - ()
 
 Source materialize.public.aoc_1201
@@ -97,7 +98,8 @@ WHERE first.line = last.line
 391
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH
     lines AS (
         SELECT regexp_split_to_table(input, '\n') AS line
         FROM aoc_1201
@@ -127,23 +129,27 @@ WHERE first.line = last.line
 Explained Query:
   With
     cte l0 =
-      Project (#0, #1, #4)
-        Join on=(#3 = substr(#0, #1, #2)) type=delta
-          ArrangeBy keys=[[]]
-            FlatMap generate_series(1, char_length(#0), 1)
-              Project (#1)
-                Filter (#1) IS NOT NULL
-                  FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-                    ReadStorage materialize.public.aoc_1201
-          ArrangeBy keys=[[]]
-            Constant
+      Project (#0, #1, #4) // { arity: 3 }
+        Join on=(#3 = substr(#0, #1, #2)) type=delta // { arity: 5 }
+          implementation
+            %0 » %1[×] » %2[#0]UK
+            %1 » %0[×] » %2[#0]UK
+            %2 » %0[×] » %1[×]
+          ArrangeBy keys=[[]] // { arity: 2 }
+            FlatMap generate_series(1, char_length(#0), 1) // { arity: 2 }
+              Project (#1) // { arity: 1 }
+                Filter (#1) IS NOT NULL // { arity: 2 }
+                  FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0{input})) // { arity: 2 }
+                    ReadStorage materialize.public.aoc_1201 // { arity: 1 }
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Constant // { arity: 1 }
               - (1)
               - (2)
               - (3)
               - (4)
               - (5)
-          ArrangeBy keys=[[#0]]
-            Constant
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Constant // { arity: 2 }
               - ("0", 0)
               - ("1", 1)
               - ("2", 2)
@@ -165,26 +171,28 @@ Explained Query:
               - ("seven", 7)
               - ("three", 3)
     cte l1 =
-      Reduce aggregates=[sum(((#0 * 10) + #1))]
-        Project (#1, #3)
-          Join on=(#0 = #2) type=differential
-            ArrangeBy keys=[[#0]]
-              Project (#0, #2)
-                TopK group_by=[#0] order_by=[#1 asc nulls_last] limit=1
-                  Get l0
-            ArrangeBy keys=[[#0]]
-              Project (#0, #2)
-                TopK group_by=[#0] order_by=[#1 desc nulls_first] limit=1
-                  Get l0
-  Return
-    Union
-      Get l1
-      Map (null)
-        Union
-          Negate
-            Project ()
-              Get l1
-          Constant
+      Reduce aggregates=[sum(((#0 * 10) + #1))] // { arity: 1 }
+        Project (#1, #3) // { arity: 2 }
+          Join on=(#0 = #2) type=differential // { arity: 4 }
+            implementation
+              %0[#0]UK » %1[#0]UK
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Project (#0, #2) // { arity: 2 }
+                TopK group_by=[#0] order_by=[#1 asc nulls_last] limit=1 // { arity: 3 }
+                  Get l0 // { arity: 3 }
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Project (#0, #2) // { arity: 2 }
+                TopK group_by=[#0] order_by=[#1 desc nulls_first] limit=1 // { arity: 3 }
+                  Get l0 // { arity: 3 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l1 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l1 // { arity: 1 }
+          Constant // { arity: 0 }
             - ()
 
 Source materialize.public.aoc_1201

--- a/test/sqllogictest/advent-of-code/2023/aoc_1202.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1202.slt
@@ -60,7 +60,8 @@ SELECT SUM(game_id) FROM game_cnt WHERE total_set_cnt = possible_set_cnt;
 8
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH game_cnt AS (
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH game_cnt AS (
         SELECT split_part(game_id,' ', 2)::int AS game_id,
                COUNT(set_id) AS total_set_cnt,
                COUNT(set_id) FILTER (WHERE (green_cnt <= 13) AND (red_cnt <= 12) AND (blue_cnt <= 14)) AS possible_set_cnt
@@ -72,20 +73,20 @@ EXPLAIN OPTIMIZED PLAN FOR WITH game_cnt AS (
 Explained Query:
   With
     cte l0 =
-      Reduce aggregates=[sum(text_to_integer(split_string(#0, " ", 2)))]
-        Project (#0)
-          Filter (#1 = #2)
-            Reduce group_by=[#0] aggregates=[count(#1), count(case when ((#2 <= 13) AND (#3 <= 12) AND (#4 <= 14)) then #1 else null end)]
-              ReadStorage materialize.public.aoc_1202
-  Return
-    Union
-      Get l0
-      Map (null)
-        Union
-          Negate
-            Project ()
-              Get l0
-          Constant
+      Reduce aggregates=[sum(text_to_integer(split_string(#0{game_id}, " ", 2)))] // { arity: 1 }
+        Project (#0{game_id}) // { arity: 1 }
+          Filter (#1{count_set_id} = #2{count}) // { arity: 3 }
+            Reduce group_by=[#0{game_id}] aggregates=[count(#1{set_id}), count(case when ((#2{green_cnt} <= 13) AND (#3{red_cnt} <= 12) AND (#4{blue_cnt} <= 14)) then #1{set_id} else null end)] // { arity: 3 }
+              ReadStorage materialize.public.aoc_1202 // { arity: 5 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l0 // { arity: 1 }
+          Constant // { arity: 0 }
             - ()
 
 Source materialize.public.aoc_1202
@@ -108,7 +109,8 @@ SELECT SUM(green_min*red_min*blue_min) FROM game_min;
 2567
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH game_min AS (
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH game_min AS (
 SELECT split_part(game_id,' ', 2)::int AS game_id,
        MAX(green_cnt) AS green_min,
        MAX(red_cnt) AS red_min,
@@ -121,20 +123,20 @@ SELECT SUM(green_min*red_min*blue_min) FROM game_min;
 Explained Query:
   With
     cte l0 =
-      Reduce aggregates=[sum(((#0 * #1) * #2))]
-        Project (#1..=#3)
-          Reduce group_by=[text_to_integer(split_string(#0, " ", 2))] aggregates=[max(#1), max(#2), max(#3)]
-            Project (#0, #2..=#4)
-              ReadStorage materialize.public.aoc_1202
-  Return
-    Union
-      Get l0
-      Map (null)
-        Union
-          Negate
-            Project ()
-              Get l0
-          Constant
+      Reduce aggregates=[sum(((#0{max_green_cnt} * #1{max_red_cnt}) * #2{max_blue_cnt}))] // { arity: 1 }
+        Project (#1{max_green_cnt}..=#3{max_blue_cnt}) // { arity: 3 }
+          Reduce group_by=[text_to_integer(split_string(#0{game_id}, " ", 2))] aggregates=[max(#1{green_cnt}), max(#2{red_cnt}), max(#3{blue_cnt})] // { arity: 4 }
+            Project (#0{game_id}, #2{green_cnt}..=#4{blue_cnt}) // { arity: 4 }
+              ReadStorage materialize.public.aoc_1202 // { arity: 5 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l0 // { arity: 1 }
+          Constant // { arity: 0 }
             - ()
 
 Source materialize.public.aoc_1202
@@ -179,7 +181,8 @@ select * from part1, part2;
 8  2567
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR with mutually recursive
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+with mutually recursive
     -- Parse the input up
     lines(line TEXT) as (select regexp_split_to_table(input, '\n') as line from input),
     games(game TEXT, report TEXT) as (select regexp_split_to_array(line, ':')[1], regexp_split_to_array(line, ':')[2] from lines),
@@ -214,96 +217,108 @@ select * from part1, part2;
 Explained Query:
   With
     cte l0 =
-      Project (#3, #5, #6)
-        Map (text_to_integer(substr(#0, 5)), regexp_split_to_array[" ", case_insensitive=false](#2), array_index(#4, 3), text_to_integer(array_index(#4, 2)))
-          FlatMap unnest_array(regexp_split_to_array[",", case_insensitive=false](#1))
-            Project (#0, #2)
-              FlatMap unnest_array(regexp_split_to_array[";", case_insensitive=false](#1))
-                Project (#3, #4)
-                  Map (regexp_split_to_array[":", case_insensitive=false](#1), array_index(#2, 1), array_index(#2, 2))
-                    FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-                      ReadStorage materialize.public.input
+      Project (#3, #5, #6) // { arity: 3 }
+        Map (text_to_integer(substr(#0, 5)), regexp_split_to_array[" ", case_insensitive=false](#2), array_index(#4, 3), text_to_integer(array_index(#4, 2))) // { arity: 7 }
+          FlatMap unnest_array(regexp_split_to_array[",", case_insensitive=false](#1)) // { arity: 3 }
+            Project (#0, #2) // { arity: 2 }
+              FlatMap unnest_array(regexp_split_to_array[";", case_insensitive=false](#1)) // { arity: 3 }
+                Project (#3, #4) // { arity: 2 }
+                  Map (regexp_split_to_array[":", case_insensitive=false](#1), array_index(#2, 1), array_index(#2, 2)) // { arity: 5 }
+                    FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0{input})) // { arity: 2 }
+                      ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Filter (#0) IS NOT NULL
-        Get l0
+      Filter (#0) IS NOT NULL // { arity: 3 }
+        Get l0 // { arity: 3 }
     cte l2 =
-      ArrangeBy keys=[[#0]]
-        Project (#0)
-          Get l1
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l1 // { arity: 3 }
     cte l3 =
-      Reduce aggregates=[sum(#0)]
-        Distinct project=[#0]
-          Union
-            Negate
-              Project (#0)
-                Join on=(#0 = #1) type=differential
-                  Get l2
-                  ArrangeBy keys=[[#0]]
-                    Distinct project=[#0]
-                      Project (#0)
-                        Filter (#3 > #5)
-                          Join on=(#0 = #1 AND #2 = #4) type=delta
-                            Get l2
-                            ArrangeBy keys=[[#0], [#1]]
-                              Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-                                Get l0
-                            ArrangeBy keys=[[#0]]
-                              Constant
+      Reduce aggregates=[sum(#0)] // { arity: 1 }
+        Distinct project=[#0] // { arity: 1 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Join on=(#0 = #1) type=differential // { arity: 2 }
+                  implementation
+                    %1[#0]UKA » %0:l2[#0]K
+                  Get l2 // { arity: 1 }
+                  ArrangeBy keys=[[#0]] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Filter (#3 > #5) // { arity: 6 }
+                          Join on=(#0 = #1 AND #2 = #4) type=delta // { arity: 6 }
+                            implementation
+                              %0:l2 » %1:l0[#0]K » %2[#0]UK
+                              %1:l0 » %2[#0]UK » %0:l2[#0]K
+                              %2 » %1:l0[#1]K » %0:l2[#0]K
+                            Get l2 // { arity: 1 }
+                            ArrangeBy keys=[[#0], [#1]] // { arity: 3 }
+                              Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 3 }
+                                Get l0 // { arity: 3 }
+                            ArrangeBy keys=[[#0]] // { arity: 2 }
+                              Constant // { arity: 2 }
                                 - ("red", 12)
                                 - ("blue", 14)
                                 - ("green", 13)
-            Project (#0)
-              Get l0
+            Project (#0) // { arity: 1 }
+              Get l0 // { arity: 3 }
     cte l4 =
-      Reduce group_by=[#0, #1] aggregates=[max(#2)]
-        Get l1
+      Reduce group_by=[#0, #1] aggregates=[max(#2)] // { arity: 3 }
+        Get l1 // { arity: 3 }
     cte l5 =
-      Reduce aggregates=[sum(#0)]
-        Project (#1)
-          Reduce group_by=[#0] aggregates=[count(*)]
-            Project (#0)
-              Join on=(#0 = #1 = #2) type=delta
-                ArrangeBy keys=[[#0]]
-                  Project (#0)
-                    FlatMap generate_series(1, #1, 1)
-                      Project (#0, #2)
-                        Filter (#1 = "red")
-                          Get l4
-                ArrangeBy keys=[[#0]]
-                  Project (#0)
-                    FlatMap generate_series(1, #1, 1)
-                      Project (#0, #2)
-                        Filter (#1 = "blue")
-                          Get l4
-                ArrangeBy keys=[[#0]]
-                  Project (#0)
-                    FlatMap generate_series(1, #1, 1)
-                      Project (#0, #2)
-                        Filter (#1 = "green")
-                          Get l4
-  Return
-    CrossJoin type=differential
-      ArrangeBy keys=[[]]
-        Union
-          Get l3
-          Map (null)
-            Union
-              Negate
-                Project ()
-                  Get l3
-              Constant
+      Reduce aggregates=[sum(#0{count})] // { arity: 1 }
+        Project (#1{count}) // { arity: 1 }
+          Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              Join on=(#0 = #1 = #2) type=delta // { arity: 3 }
+                implementation
+                  %0 » %1[#0]K » %2[#0]K
+                  %1 » %0[#0]K » %2[#0]K
+                  %2 » %0[#0]K » %1[#0]K
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Project (#0) // { arity: 1 }
+                    FlatMap generate_series(1, #1{max}, 1) // { arity: 3 }
+                      Project (#0, #2{max}) // { arity: 2 }
+                        Filter (#1 = "red") // { arity: 3 }
+                          Get l4 // { arity: 3 }
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Project (#0) // { arity: 1 }
+                    FlatMap generate_series(1, #1{max}, 1) // { arity: 3 }
+                      Project (#0, #2{max}) // { arity: 2 }
+                        Filter (#1 = "blue") // { arity: 3 }
+                          Get l4 // { arity: 3 }
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Project (#0) // { arity: 1 }
+                    FlatMap generate_series(1, #1{max}, 1) // { arity: 3 }
+                      Project (#0, #2{max}) // { arity: 2 }
+                        Filter (#1 = "green") // { arity: 3 }
+                          Get l4 // { arity: 3 }
+  Return // { arity: 2 }
+    CrossJoin type=differential // { arity: 2 }
+      implementation
+        %0[×]U » %1[×]U
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Union // { arity: 1 }
+          Get l3 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l3 // { arity: 1 }
+              Constant // { arity: 0 }
                 - ()
-      ArrangeBy keys=[[]]
-        Project (#1)
-          Map (numeric_to_bigint(#0))
-            Union
-              Get l5
-              Map (null)
-                Union
-                  Negate
-                    Project ()
-                      Get l5
-                  Constant
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Map (numeric_to_bigint(#0{sum_count})) // { arity: 2 }
+            Union // { arity: 1 }
+              Get l5 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l5 // { arity: 1 }
+                  Constant // { arity: 0 }
                     - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1203.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1203.slt
@@ -128,7 +128,8 @@ SELECT * FROM part1, part2;
 11374  1587570
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
     -- PART 0
     -- Parse the input as lines of text with line numbers.
     lines(line TEXT, row_idx INT) AS (
@@ -230,205 +231,239 @@ SELECT * FROM part1, part2;
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Reduce aggregates=[count(*)]
-        Project ()
-          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-            ReadStorage materialize.public.input
+      Reduce aggregates=[count(*)] // { arity: 1 }
+        Project () // { arity: 0 }
+          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0{input})) // { arity: 2 }
+            ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Project (#0, #2, #3)
-        Filter (#3 != ".")
-          Map (substr(#1, #2, 1))
-            FlatMap generate_series(1, char_length(#1), 1)
-              Project (#1, #2)
-                Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                  CrossJoin type=differential
-                    ArrangeBy keys=[[]]
-                      ReadStorage materialize.public.input
-                    ArrangeBy keys=[[]]
-                      Project (#1)
-                        FlatMap generate_series(1, #0, 1)
-                          Project (#1)
-                            Map (bigint_to_integer(#0))
-                              Union
-                                Get l0
-                                Map (0)
-                                  Union
-                                    Negate
-                                      Project ()
-                                        Get l0
-                                    Constant
+      Project (#0, #2, #3) // { arity: 3 }
+        Filter (#3 != ".") // { arity: 4 }
+          Map (substr(#1, #2, 1)) // { arity: 4 }
+            FlatMap generate_series(1, char_length(#1), 1) // { arity: 3 }
+              Project (#1, #2) // { arity: 2 }
+                Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
+                  CrossJoin type=differential // { arity: 2 }
+                    implementation
+                      %0:input[×] » %1[×]
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      ReadStorage materialize.public.input // { arity: 1 }
+                    ArrangeBy keys=[[]] // { arity: 1 }
+                      Project (#1) // { arity: 1 }
+                        FlatMap generate_series(1, #0, 1) // { arity: 2 }
+                          Project (#1) // { arity: 1 }
+                            Map (bigint_to_integer(#0{count})) // { arity: 2 }
+                              Union // { arity: 1 }
+                                Get l0 // { arity: 1 }
+                                Map (0) // { arity: 1 }
+                                  Union // { arity: 0 }
+                                    Negate // { arity: 0 }
+                                      Project () // { arity: 0 }
+                                        Get l0 // { arity: 1 }
+                                    Constant // { arity: 0 }
                                       - ()
     cte l2 =
-      Distinct project=[#0]
-        Project (#2)
-          Get l1
+      Distinct project=[#0] // { arity: 1 }
+        Project (#2) // { arity: 1 }
+          Get l1 // { arity: 3 }
     cte l3 =
-      Distinct project=[#0]
-        Project (#0)
-          Filter (#0 = #1)
-            FlatMap wrap1("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
-              Get l2
+      Distinct project=[#0] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#0 = #1) // { arity: 2 }
+            FlatMap wrap1("0", "1", "2", "3", "4", "5", "6", "7", "8", "9") // { arity: 2 }
+              Get l2 // { arity: 1 }
     cte l4 =
-      ArrangeBy keys=[[#2]]
-        Get l1
+      ArrangeBy keys=[[#2]] // { arity: 3 }
+        Get l1 // { arity: 3 }
     cte l5 =
-      Project (#0..=#2)
-        Join on=(#2 = #3) type=differential
-          Get l4
-          ArrangeBy keys=[[#0]]
-            Get l3
+      Project (#0..=#2) // { arity: 3 }
+        Join on=(#2 = #3) type=differential // { arity: 4 }
+          implementation
+            %1:l3[#0]UK » %0:l4[#2]K
+          Get l4 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l3 // { arity: 1 }
     cte l6 =
-      Project (#0..=#2)
-        Join on=(#2 = #3) type=differential
-          Get l4
-          ArrangeBy keys=[[#0]]
-            Union
-              Negate
-                Get l3
-              Get l2
+      Project (#0..=#2) // { arity: 3 }
+        Join on=(#2 = #3) type=differential // { arity: 4 }
+          implementation
+            %0:l4[#2]K » %1[#0]K
+          Get l4 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Union // { arity: 1 }
+              Negate // { arity: 1 }
+                Get l3 // { arity: 1 }
+              Get l2 // { arity: 1 }
     cte l7 =
-      ArrangeBy keys=[[]]
-        Constant
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Constant // { arity: 1 }
           - (0)
           - (-1)
           - (1)
     cte l8 =
-      ArrangeBy keys=[[#0, #1]]
-        Get l5
+      ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+        Get l5 // { arity: 3 }
     cte l9 =
-      Distinct project=[#0..=#3]
-        Union
-          Distinct project=[#0..=#3]
-            Union
-              Project (#2, #0, #1, #7)
-                Map (1)
-                  Join on=(#0 = (#3 + #5) AND #1 = (#4 + #6)) type=delta
-                    ArrangeBy keys=[[]]
-                      Get l5
-                    ArrangeBy keys=[[]]
-                      Project (#0, #1)
-                        Get l6
-                    Get l7
-                    Get l7
-              Project (#7, #0, #1, #8)
-                Map ((#2 || #3), (#6 + 1))
-                  Join on=(#0 = #4 AND #1 = (#5 - 1)) type=differential
-                    Get l8
-                    ArrangeBy keys=[[#1, (#2 - 1)]]
-                      Get l9
-          Project (#7, #0, #5, #8)
-            Map ((#3 || #2), (#6 + 1))
-              Join on=(#0 = #4 AND #1 = (#5 + #6)) type=differential
-                Get l8
-                ArrangeBy keys=[[#1, (#2 + #3)]]
-                  Get l9
-  Return
+      Distinct project=[#0..=#3] // { arity: 4 }
+        Union // { arity: 4 }
+          Distinct project=[#0..=#3] // { arity: 4 }
+            Union // { arity: 4 }
+              Project (#2, #0, #1, #7) // { arity: 4 }
+                Map (1) // { arity: 8 }
+                  Join on=(#0 = (#3 + #5) AND #1 = (#4 + #6)) type=delta // { arity: 7 }
+                    implementation
+                      %0:l5 » %1:l6[×] » %2:l7[×] » %3:l7[×]
+                      %1:l6 » %0:l5[×] » %2:l7[×] » %3:l7[×]
+                      %2:l7 » %0:l5[×] » %1:l6[×] » %3:l7[×]
+                      %3:l7 » %0:l5[×] » %1:l6[×] » %2:l7[×]
+                    ArrangeBy keys=[[]] // { arity: 3 }
+                      Get l5 // { arity: 3 }
+                    ArrangeBy keys=[[]] // { arity: 2 }
+                      Project (#0, #1) // { arity: 2 }
+                        Get l6 // { arity: 3 }
+                    Get l7 // { arity: 1 }
+                    Get l7 // { arity: 1 }
+              Project (#7, #0, #1, #8) // { arity: 4 }
+                Map ((#2 || #3), (#6 + 1)) // { arity: 9 }
+                  Join on=(#0 = #4 AND #1 = (#5 - 1)) type=differential // { arity: 7 }
+                    implementation
+                      %0:l8[#0, #1]KK » %1:l9[#1, (#2 - 1)]KK
+                    Get l8 // { arity: 3 }
+                    ArrangeBy keys=[[#1, (#2 - 1)]] // { arity: 4 }
+                      Get l9 // { arity: 4 }
+          Project (#7, #0, #5, #8) // { arity: 4 }
+            Map ((#3 || #2), (#6 + 1)) // { arity: 9 }
+              Join on=(#0 = #4 AND #1 = (#5 + #6)) type=differential // { arity: 7 }
+                implementation
+                  %0:l8[#0, #1]KK » %1:l9[#1, (#2 + #3)]KK
+                Get l8 // { arity: 3 }
+                ArrangeBy keys=[[#1, (#2 + #3)]] // { arity: 4 }
+                  Get l9 // { arity: 4 }
+  Return // { arity: 2 }
     With
       cte l10 =
-        Distinct project=[#0, #1]
-          Project (#1, #2)
-            Get l9
+        Distinct project=[#0, #1] // { arity: 2 }
+          Project (#1, #2) // { arity: 2 }
+            Get l9 // { arity: 4 }
       cte l11 =
-        ArrangeBy keys=[[#0, #1]]
-          Project (#0, #1)
-            Get l5
+        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            Get l5 // { arity: 3 }
       cte l12 =
-        Project (#0..=#3)
-          Join on=(#1 = #4 AND #2 = #5) type=differential
-            ArrangeBy keys=[[#1, #2]]
-              Get l9
-            ArrangeBy keys=[[#0, #1]]
-              Union
-                Negate
-                  Distinct project=[#0, #1]
-                    Project (#0, #1)
-                      Join on=(#0 = #2 AND #3 = (#1 - 1)) type=differential
-                        ArrangeBy keys=[[#0, (#1 - 1)]]
-                          Get l10
-                        Get l11
-                Get l10
+        Project (#0..=#3) // { arity: 4 }
+          Join on=(#1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+            implementation
+              %0:l9[#1, #2]KK » %1[#0, #1]KK
+            ArrangeBy keys=[[#1, #2]] // { arity: 4 }
+              Get l9 // { arity: 4 }
+            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+              Union // { arity: 2 }
+                Negate // { arity: 2 }
+                  Distinct project=[#0, #1] // { arity: 2 }
+                    Project (#0, #1) // { arity: 2 }
+                      Join on=(#0 = #2 AND #3 = (#1 - 1)) type=differential // { arity: 4 }
+                        implementation
+                          %0:l10[#0, (#1 - 1)]KK » %1:l11[#0, #1]KK
+                        ArrangeBy keys=[[#0, (#1 - 1)]] // { arity: 2 }
+                          Get l10 // { arity: 2 }
+                        Get l11 // { arity: 2 }
+                Get l10 // { arity: 2 }
       cte l13 =
-        Distinct project=[#0..=#2]
-          Project (#1..=#3)
-            Get l12
+        Distinct project=[#0..=#2] // { arity: 3 }
+          Project (#1..=#3) // { arity: 3 }
+            Get l12 // { arity: 4 }
       cte l14 =
-        Project (#1..=#3, #7)
-          Map (text_to_integer(#0))
-            Join on=(#1 = #4 AND #2 = #5 AND #3 = #6) type=differential
-              ArrangeBy keys=[[#1..=#3]]
-                Get l12
-              ArrangeBy keys=[[#0..=#2]]
-                Union
-                  Negate
-                    Distinct project=[#0..=#2]
-                      Project (#0..=#2)
-                        Join on=(#0 = #3 AND #4 = (#1 + #2)) type=differential
-                          ArrangeBy keys=[[#0, (#1 + #2)]]
-                            Get l13
-                          Get l11
-                  Get l13
+        Project (#1..=#3, #7) // { arity: 4 }
+          Map (text_to_integer(#0)) // { arity: 8 }
+            Join on=(#1 = #4 AND #2 = #5 AND #3 = #6) type=differential // { arity: 7 }
+              implementation
+                %0:l12[#1..=#3]KKK » %1[#0..=#2]KKK
+              ArrangeBy keys=[[#1..=#3]] // { arity: 4 }
+                Get l12 // { arity: 4 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                Union // { arity: 3 }
+                  Negate // { arity: 3 }
+                    Distinct project=[#0..=#2] // { arity: 3 }
+                      Project (#0..=#2) // { arity: 3 }
+                        Join on=(#0 = #3 AND #4 = (#1 + #2)) type=differential // { arity: 5 }
+                          implementation
+                            %0:l13[#0, (#1 + #2)]KK » %1:l11[#0, #1]KK
+                          ArrangeBy keys=[[#0, (#1 + #2)]] // { arity: 3 }
+                            Get l13 // { arity: 3 }
+                          Get l11 // { arity: 2 }
+                  Get l13 // { arity: 3 }
       cte l15 =
-        Reduce aggregates=[sum(#0)]
-          Project (#3)
-            Get l14
+        Reduce aggregates=[sum(#0)] // { arity: 1 }
+          Project (#3) // { arity: 1 }
+            Get l14 // { arity: 4 }
       cte l16 =
-        ArrangeBy keys=[[]]
-          Constant
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Constant // { arity: 1 }
             - (0)
             - (-1)
             - (1)
       cte l17 =
-        Distinct project=[#0, #1, #4, #2, #3]
-          Project (#0, #1, #3, #4, #6)
-            Filter (#7 = (#1 + #2))
-              FlatMap generate_series(#4, ((#4 + #5) - 1), 1)
-                Project (#0, #1, #3..=#7)
-                  Join on=(#4 = (#0 + #2)) type=delta
-                    ArrangeBy keys=[[]]
-                      Project (#0, #1)
-                        Filter (#2 = "*")
-                          Get l6
-                    Get l16
-                    Get l16
-                    ArrangeBy keys=[[#0]]
-                      Get l14
+        Distinct project=[#0, #1, #4, #2, #3] // { arity: 5 }
+          Project (#0, #1, #3, #4, #6) // { arity: 5 }
+            Filter (#7 = (#1 + #2)) // { arity: 8 }
+              FlatMap generate_series(#4, ((#4 + #5) - 1), 1) // { arity: 8 }
+                Project (#0, #1, #3..=#7) // { arity: 7 }
+                  Join on=(#4 = (#0 + #2)) type=delta // { arity: 8 }
+                    implementation
+                      %0:l6 » %1:l16[×] » %3:l14[#0]K » %2:l16[×]
+                      %1:l16 » %0:l6[×]ef » %3:l14[#0]K » %2:l16[×]
+                      %2:l16 » %0:l6[×]ef » %1:l16[×] » %3:l14[#0]K
+                      %3:l14 » %0:l6[×]ef » %1:l16[×] » %2:l16[×]
+                    ArrangeBy keys=[[]] // { arity: 2 }
+                      Project (#0, #1) // { arity: 2 }
+                        Filter (#2 = "*") // { arity: 3 }
+                          Get l6 // { arity: 3 }
+                    Get l16 // { arity: 1 }
+                    Get l16 // { arity: 1 }
+                    ArrangeBy keys=[[#0]] // { arity: 4 }
+                      Get l14 // { arity: 4 }
       cte l18 =
-        ArrangeBy keys=[[#0, #1]]
-          Get l17
+        ArrangeBy keys=[[#0, #1]] // { arity: 5 }
+          Get l17 // { arity: 5 }
       cte l19 =
-        Reduce aggregates=[sum(#0)]
-          Project (#2)
-            Distinct project=[#0, #1, (#2 * #3)]
-              Project (#0, #1, #5, #10)
-                Filter (#2 = 2) AND ((#6 != #11) OR (#7 != #12))
-                  Join on=(#0 = #3 = #8 AND #1 = #4 = #9) type=delta
-                    ArrangeBy keys=[[#0, #1]]
-                      Reduce group_by=[#0, #1] aggregates=[count(*)]
-                        Project (#0, #1)
-                          Get l17
-                    Get l18
-                    Get l18
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Union
-            Get l15
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l15
-                Constant
+        Reduce aggregates=[sum(#0)] // { arity: 1 }
+          Project (#2) // { arity: 1 }
+            Distinct project=[#0, #1, (#2 * #3)] // { arity: 3 }
+              Project (#0, #1, #5, #10) // { arity: 4 }
+                Filter (#2{count} = 2) AND ((#6 != #11) OR (#7 != #12)) // { arity: 13 }
+                  Join on=(#0 = #3 = #8 AND #1 = #4 = #9) type=delta // { arity: 13 }
+                    implementation
+                      %0 » %1:l18[#0, #1]KK » %2:l18[#0, #1]KK
+                      %1:l18 » %0[#0, #1]UKKAef » %2:l18[#0, #1]KK
+                      %2:l18 » %0[#0, #1]UKKAef » %1:l18[#0, #1]KK
+                    ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+                      Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+                        Project (#0, #1) // { arity: 2 }
+                          Get l17 // { arity: 5 }
+                    Get l18 // { arity: 5 }
+                    Get l18 // { arity: 5 }
+    Return // { arity: 2 }
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0[×]U » %1[×]U
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l15 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l15 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
-        ArrangeBy keys=[[]]
-          Union
-            Get l19
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l19
-                Constant
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l19 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l19 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1204.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1204.slt
@@ -64,7 +64,8 @@ FROM winning_points;
 184
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH parsed AS (
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH parsed AS (
   SELECT regexp_split_to_table(input, '\n') AS line FROM aoc_1204
 ),
 numbers AS (
@@ -97,30 +98,30 @@ FROM winning_points;
 Explained Query:
   With
     cte l0 =
-      Reduce aggregates=[sum(roundf64(expf64(#0)))]
-        Project (#1)
-          Reduce group_by=[record_get[0](record_get[1](#0))] aggregates=[sum(lnf64(bigint_to_double(case when (1 = record_get[0](#0)) then record_get[0](#0) else 2 end)))]
-            Project (#1)
-              FlatMap unnest_list(#0)
-                Project (#1)
-                  Reduce group_by=[#0] aggregates=[row_number[order_by=[]](row(list[row(#0, #1, #2)]))]
-                    Filter (#2 > 1)
-                      Reduce group_by=[#0, #1] aggregates=[count(*)]
-                        Project (#0, #2)
-                          FlatMap unnest_array(array_remove(#1, ""))
-                            Project (#2, #3)
-                              Map (split_string(#1, ":", 1), regexp_split_to_array["\s", case_insensitive=false](ltrim(rtrim(replace(split_string(#1, ":", 2), "|", "")))))
-                                FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-                                  ReadStorage materialize.public.aoc_1204
-  Return
-    Union
-      Get l0
-      Map (null)
-        Union
-          Negate
-            Project ()
-              Get l0
-          Constant
+      Reduce aggregates=[sum(roundf64(expf64(#0{sum})))] // { arity: 1 }
+        Project (#1{sum}) // { arity: 1 }
+          Reduce group_by=[record_get[0](record_get[1](#0))] aggregates=[sum(lnf64(bigint_to_double(case when (1 = record_get[0](#0)) then record_get[0](#0) else 2 end)))] // { arity: 2 }
+            Project (#1) // { arity: 1 }
+              FlatMap unnest_list(#0{row_number}) // { arity: 2 }
+                Project (#1{row_number}) // { arity: 1 }
+                  Reduce group_by=[#0] aggregates=[row_number[order_by=[]](row(list[row(#0, #1, #2{count})]))] // { arity: 2 }
+                    Filter (#2{count} > 1) // { arity: 3 }
+                      Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+                        Project (#0, #2) // { arity: 2 }
+                          FlatMap unnest_array(array_remove(#1, "")) // { arity: 3 }
+                            Project (#2, #3) // { arity: 2 }
+                              Map (split_string(#1, ":", 1), regexp_split_to_array["\s", case_insensitive=false](ltrim(rtrim(replace(split_string(#1, ":", 2), "|", ""))))) // { arity: 4 }
+                                FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0{input})) // { arity: 2 }
+                                  ReadStorage materialize.public.aoc_1204 // { arity: 1 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l0 // { arity: 1 }
+          Constant // { arity: 0 }
             - ()
 
 Source materialize.public.aoc_1204
@@ -206,7 +207,8 @@ FROM
 978
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
 lines(line string) AS (
     SELECT
         regexp_split_to_table(input, '\n') AS line
@@ -282,91 +284,97 @@ FROM
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#3, #4)
-        Map (regexp_match["Card +(\d+): (.*)", case_insensitive=false](#1), text_to_integer(array_index(#2, 1)), regexp_split_to_array[" \| ", case_insensitive=false](array_index(#2, 2)))
-          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-            ReadStorage materialize.public.aoc_1204
+      Project (#3, #4) // { arity: 2 }
+        Map (regexp_match["Card +(\d+): (.*)", case_insensitive=false](#1), text_to_integer(array_index(#2, 1)), regexp_split_to_array[" \| ", case_insensitive=false](array_index(#2, 2))) // { arity: 5 }
+          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0{input})) // { arity: 2 }
+            ReadStorage materialize.public.aoc_1204 // { arity: 1 }
     cte l1 =
-      Project (#0, #3)
-        Map (text_to_integer(#2))
-          FlatMap unnest_array(regexp_split_to_array["\s+", case_insensitive=false](btrim(array_index(#1, 2))))
-            Get l0
+      Project (#0, #3) // { arity: 2 }
+        Map (text_to_integer(#2)) // { arity: 4 }
+          FlatMap unnest_array(regexp_split_to_array["\s+", case_insensitive=false](btrim(array_index(#1, 2)))) // { arity: 3 }
+            Get l0 // { arity: 2 }
     cte l2 =
-      ArrangeBy keys=[[#0, #1]]
-        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-          Get l1
+      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
+          Get l1 // { arity: 2 }
     cte l3 =
-      Project (#0, #1)
-        Join on=(#0 = #2 AND #1 = #3) type=differential
-          Get l2
-          ArrangeBy keys=[[#0, #1]]
-            Project (#0, #3)
-              Filter (#2) IS NOT NULL
-                Map (text_to_integer(#2))
-                  FlatMap unnest_array(regexp_split_to_array["\s+", case_insensitive=false](btrim(array_index(#1, 1))))
-                    Filter (#0) IS NOT NULL
-                      Get l0
+      Project (#0, #1) // { arity: 2 }
+        Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+          implementation
+            %0:l2[#0, #1]KK » %1[#0, #1]KK
+          Get l2 // { arity: 2 }
+          ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+            Project (#0, #3) // { arity: 2 }
+              Filter (#2) IS NOT NULL // { arity: 4 }
+                Map (text_to_integer(#2)) // { arity: 4 }
+                  FlatMap unnest_array(regexp_split_to_array["\s+", case_insensitive=false](btrim(array_index(#1, 1)))) // { arity: 3 }
+                    Filter (#0) IS NOT NULL // { arity: 2 }
+                      Get l0 // { arity: 2 }
     cte l4 =
-      Distinct project=[#0, #1]
-        Union
-          Project (#0, #2)
-            FlatMap generate_series((#0 + 1), (#0 + #1), 1)
-              Project (#0, #2)
-                Map (bigint_to_integer(#1))
-                  Reduce group_by=[#0] aggregates=[count(#1)]
-                    Union
-                      Map (null)
-                        Union
-                          Negate
-                            Project (#0)
-                              Join on=(#0 = #2 AND #1 = #3) type=differential
-                                Get l2
-                                ArrangeBy keys=[[#0, #1]]
-                                  Distinct project=[#0, #1]
-                                    Get l3
-                          Project (#0)
-                            Get l1
-                      Get l3
-          Project (#2, #0)
-            Map (0)
-              Get l1
+      Distinct project=[#0, #1] // { arity: 2 }
+        Union // { arity: 2 }
+          Project (#0, #2) // { arity: 2 }
+            FlatMap generate_series((#0 + 1), (#0 + #1), 1) // { arity: 3 }
+              Project (#0, #2) // { arity: 2 }
+                Map (bigint_to_integer(#1{count})) // { arity: 3 }
+                  Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
+                    Union // { arity: 2 }
+                      Map (null) // { arity: 2 }
+                        Union // { arity: 1 }
+                          Negate // { arity: 1 }
+                            Project (#0) // { arity: 1 }
+                              Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                                implementation
+                                  %1[#0, #1]UKKA » %0:l2[#0, #1]KK
+                                Get l2 // { arity: 2 }
+                                ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                                  Distinct project=[#0, #1] // { arity: 2 }
+                                    Get l3 // { arity: 2 }
+                          Project (#0) // { arity: 1 }
+                            Get l1 // { arity: 2 }
+                      Get l3 // { arity: 2 }
+          Project (#2, #0) // { arity: 2 }
+            Map (0) // { arity: 3 }
+              Get l1 // { arity: 2 }
     cte l5 =
-      Project (#1, #3)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Filter (#0) IS NOT NULL
-              Get l4
-          ArrangeBy keys=[[#0]]
-            Filter (#0) IS NOT NULL
-              Get l6
+      Project (#1, #3) // { arity: 2 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %1:l6[#0]UK » %0:l4[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              Get l4 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              Get l6 // { arity: 2 }
     cte l6 =
-      Project (#0, #2)
-        Map (bigint_to_integer(#1))
-          Reduce group_by=[#0] aggregates=[sum(coalesce(#1, 1))]
-            Union
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l5
-                  Project (#1)
-                    Get l4
-              Get l5
-  Return
+      Project (#0, #2) // { arity: 2 }
+        Map (bigint_to_integer(#1{sum})) // { arity: 3 }
+          Reduce group_by=[#0] aggregates=[sum(coalesce(#1, 1))] // { arity: 2 }
+            Union // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l5 // { arity: 2 }
+                  Project (#1) // { arity: 1 }
+                    Get l4 // { arity: 2 }
+              Get l5 // { arity: 2 }
+  Return // { arity: 1 }
     With
       cte l7 =
-        Reduce aggregates=[sum(#0)]
-          Project (#1)
-            Get l6
-    Return
-      Union
-        Get l7
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l7
-            Constant
+        Reduce aggregates=[sum(#0)] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Get l6 // { arity: 2 }
+    Return // { arity: 1 }
+      Union // { arity: 1 }
+        Get l7 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l7 // { arity: 1 }
+            Constant // { arity: 0 }
               - ()
 
 Source materialize.public.aoc_1204
@@ -442,7 +450,8 @@ select * from part1, part2;
 23  314
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
     -- PART 0
     -- Parse the input as lines of text with line numbers.
     lines(line TEXT) AS (
@@ -508,126 +517,138 @@ select * from part1, part2;
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#3..=#5)
-        Map (regexp_split_to_array["(:|\|)", case_insensitive=false](#1), text_to_integer(array_index(regexp_match["[0-9]+", case_insensitive=false](btrim(array_index(#2, 1))), 1)), regexp_split_to_array[" ", case_insensitive=false](btrim(array_index(#2, 2))), regexp_split_to_array[" ", case_insensitive=false](btrim(array_index(#2, 3))))
-          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-            ReadStorage materialize.public.aoc_1204
+      Project (#3..=#5) // { arity: 3 }
+        Map (regexp_split_to_array["(:|\|)", case_insensitive=false](#1), text_to_integer(array_index(regexp_match["[0-9]+", case_insensitive=false](btrim(array_index(#2, 1))), 1)), regexp_split_to_array[" ", case_insensitive=false](btrim(array_index(#2, 2))), regexp_split_to_array[" ", case_insensitive=false](btrim(array_index(#2, 3)))) // { arity: 6 }
+          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0{input})) // { arity: 2 }
+            ReadStorage materialize.public.aoc_1204 // { arity: 1 }
     cte l1 =
-      Distinct project=[#0..=#2]
-        Get l0
+      Distinct project=[#0..=#2] // { arity: 3 }
+        Get l0 // { arity: 3 }
     cte l2 =
-      Distinct project=[#0, #1]
-        Project (#1, #2)
-          Get l1
+      Distinct project=[#0, #1] // { arity: 2 }
+        Project (#1, #2) // { arity: 2 }
+          Get l1 // { arity: 3 }
     cte l3 =
-      Filter (#2 != "")
-        FlatMap unnest_array(#0)
-          Get l2
+      Filter (#2 != "") // { arity: 3 }
+        FlatMap unnest_array(#0) // { arity: 3 }
+          Get l2 // { arity: 2 }
     cte l4 =
-      Reduce group_by=[#0, #1] aggregates=[count(*)]
-        Project (#0, #1)
-          Distinct project=[#0..=#2]
-            Union
-              Get l3
-              Negate
-                Threshold
-                  Union
-                    Get l3
-                    Negate
-                      Filter (#2 != "")
-                        FlatMap unnest_array(#1)
-                          Get l2
+      Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+        Project (#0, #1) // { arity: 2 }
+          Distinct project=[#0..=#2] // { arity: 3 }
+            Union // { arity: 3 }
+              Get l3 // { arity: 3 }
+              Negate // { arity: 3 }
+                Threshold // { arity: 3 }
+                  Union // { arity: 3 }
+                    Get l3 // { arity: 3 }
+                    Negate // { arity: 3 }
+                      Filter (#2 != "") // { arity: 3 }
+                        FlatMap unnest_array(#1) // { arity: 3 }
+                          Get l2 // { arity: 2 }
     cte l5 =
-      ArrangeBy keys=[[#0, #1]]
-        Get l2
+      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+        Get l2 // { arity: 2 }
     cte l6 =
-      Union
-        Get l4
-        Project (#0, #1, #4)
-          Map (0)
-            Join on=(#0 = #2 AND #1 = #3) type=differential
-              ArrangeBy keys=[[#0, #1]]
-                Union
-                  Negate
-                    Project (#0, #1)
-                      Get l4
-                  Get l2
-              Get l5
+      Union // { arity: 3 }
+        Get l4 // { arity: 3 }
+        Project (#0, #1, #4) // { arity: 3 }
+          Map (0) // { arity: 5 }
+            Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+              implementation
+                %1:l5[#0, #1]UKK » %0[#0, #1]KK
+              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                Union // { arity: 2 }
+                  Negate // { arity: 2 }
+                    Project (#0, #1) // { arity: 2 }
+                      Get l4 // { arity: 3 }
+                  Get l2 // { arity: 2 }
+              Get l5 // { arity: 2 }
     cte l7 =
-      Union
-        Get l6
-        Map (error("more than one record produced in subquery"))
-          Project (#0, #1)
-            Filter (#2 > 1)
-              Reduce group_by=[#0, #1] aggregates=[count(*)]
-                Project (#0, #1)
-                  Get l6
+      Union // { arity: 3 }
+        Get l6 // { arity: 3 }
+        Map (error("more than one record produced in subquery")) // { arity: 3 }
+          Project (#0, #1) // { arity: 2 }
+            Filter (#2{count} > 1) // { arity: 3 }
+              Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+                Project (#0, #1) // { arity: 2 }
+                  Get l6 // { arity: 3 }
     cte l8 =
-      Project (#0, #8)
-        Join on=(#0 = #3 AND #1 = #4 = #6 AND #2 = #5 = #7) type=delta
-          ArrangeBy keys=[[#0..=#2], [#1, #2]]
-            Get l0
-          ArrangeBy keys=[[#0..=#2]]
-            Get l1
-          ArrangeBy keys=[[#0, #1]]
-            Union
-              Get l7
-              Project (#0, #1, #4)
-                Map (null)
-                  Join on=(#0 = #2 AND #1 = #3) type=differential
-                    ArrangeBy keys=[[#0, #1]]
-                      Union
-                        Negate
-                          Distinct project=[#0, #1]
-                            Project (#0, #1)
-                              Get l7
-                        Get l2
-                    Get l5
+      Project (#0, #8{count}) // { arity: 2 }
+        Join on=(#0 = #3 AND #1 = #4 = #6 AND #2 = #5 = #7) type=delta // { arity: 9 }
+          implementation
+            %0:l0 » %1:l1[#0..=#2]UKKK » %2[#0, #1]KK
+            %1:l1 » %0:l0[#0..=#2]KKK » %2[#0, #1]KK
+            %2 » %0:l0[#1, #2]KK » %1:l1[#0..=#2]UKKK
+          ArrangeBy keys=[[#0..=#2], [#1, #2]] // { arity: 3 }
+            Get l0 // { arity: 3 }
+          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+            Get l1 // { arity: 3 }
+          ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+            Union // { arity: 3 }
+              Get l7 // { arity: 3 }
+              Project (#0, #1, #4) // { arity: 3 }
+                Map (null) // { arity: 5 }
+                  Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                    implementation
+                      %1:l5[#0, #1]UKK » %0[#0, #1]KK
+                    ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                      Union // { arity: 2 }
+                        Negate // { arity: 2 }
+                          Distinct project=[#0, #1] // { arity: 2 }
+                            Project (#0, #1) // { arity: 2 }
+                              Get l7 // { arity: 3 }
+                        Get l2 // { arity: 2 }
+                    Get l5 // { arity: 2 }
     cte l9 =
-      Reduce aggregates=[sum(power(2, bigint_to_double((#0 - 1))))]
-        Project (#1)
-          Filter (#1 > 0)
-            Get l8
+      Reduce aggregates=[sum(power(2, bigint_to_double((#0{count} - 1))))] // { arity: 1 }
+        Project (#1{count}) // { arity: 1 }
+          Filter (#1{count} > 0) // { arity: 2 }
+            Get l8 // { arity: 2 }
     cte l10 =
-      Union
-        Get l8
-        Project (#2, #3)
-          Filter (integer_to_bigint(#2) = (integer_to_bigint(#0) + #4))
-            FlatMap generate_series(1, #1, 1)
-              CrossJoin type=differential
-                ArrangeBy keys=[[]]
-                  Get l10
-                ArrangeBy keys=[[]]
-                  Get l8
-  Return
+      Union // { arity: 2 }
+        Get l8 // { arity: 2 }
+        Project (#2, #3{count}) // { arity: 2 }
+          Filter (integer_to_bigint(#2) = (integer_to_bigint(#0) + #4)) // { arity: 5 }
+            FlatMap generate_series(1, #1, 1) // { arity: 5 }
+              CrossJoin type=differential // { arity: 4 }
+                implementation
+                  %0:l10[×] » %1:l8[×]
+                ArrangeBy keys=[[]] // { arity: 2 }
+                  Get l10 // { arity: 2 }
+                ArrangeBy keys=[[]] // { arity: 2 }
+                  Get l8 // { arity: 2 }
+  Return // { arity: 2 }
     With
       cte l11 =
-        Reduce aggregates=[count(*)]
-          Project ()
-            Get l10
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Project (#1)
-            Map (double_to_numeric(#0))
-              Union
-                Get l9
-                Map (null)
-                  Union
-                    Negate
-                      Project ()
-                        Get l9
-                    Constant
+        Reduce aggregates=[count(*)] // { arity: 1 }
+          Project () // { arity: 0 }
+            Get l10 // { arity: 2 }
+    Return // { arity: 2 }
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0[×]U » %1[×]U
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Map (double_to_numeric(#0{sum})) // { arity: 2 }
+              Union // { arity: 1 }
+                Get l9 // { arity: 1 }
+                Map (null) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l9 // { arity: 1 }
+                    Constant // { arity: 0 }
                       - ()
-        ArrangeBy keys=[[]]
-          Union
-            Get l11
-            Map (0)
-              Union
-                Negate
-                  Project ()
-                    Get l11
-                Constant
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l11 // { arity: 1 }
+            Map (0) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l11 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
 
 Source materialize.public.aoc_1204

--- a/test/sqllogictest/advent-of-code/2023/aoc_1205.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1205.slt
@@ -465,7 +465,8 @@ FROM
 2364832465
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH seeds AS (
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH seeds AS (
             SELECT
                 regexp_split_to_table(
                     regexp_split_to_array(
@@ -744,88 +745,102 @@ EXPLAIN OPTIMIZED PLAN FOR WITH seeds AS (
 Explained Query:
   With
     cte l0 =
-      Reduce aggregates=[min(coalesce(#1, #0))]
-        Reduce group_by=[#0] aggregates=[max(case when ((#0 < (#2 + #3)) AND (#0 >= #2)) then (#1 + (#0 - #2)) else null end)]
-          CrossJoin type=differential
-            ArrangeBy keys=[[]]
-              Project (#2)
-                Map (coalesce(#1, #0))
-                  Reduce group_by=[#0] aggregates=[max(case when ((#0 < (#2 + #3)) AND (#0 >= #2)) then (#1 + (#0 - #2)) else null end)]
-                    CrossJoin type=differential
-                      ArrangeBy keys=[[]]
-                        Project (#2)
-                          Map (coalesce(#1, #0))
-                            Reduce group_by=[#0] aggregates=[max(case when ((#0 < (#2 + #3)) AND (#0 >= #2)) then (#1 + (#0 - #2)) else null end)]
-                              CrossJoin type=differential
-                                ArrangeBy keys=[[]]
-                                  Project (#2)
-                                    Map (coalesce(#1, #0))
-                                      Reduce group_by=[#0] aggregates=[max(case when ((#0 < (#2 + #3)) AND (#0 >= #2)) then (#1 + (#0 - #2)) else null end)]
-                                        CrossJoin type=differential
-                                          ArrangeBy keys=[[]]
-                                            Project (#2)
-                                              Map (coalesce(#1, #0))
-                                                Reduce group_by=[#0] aggregates=[max(case when ((#0 < (#2 + #3)) AND (#0 >= #2)) then (#1 + (#0 - #2)) else null end)]
-                                                  CrossJoin type=differential
-                                                    ArrangeBy keys=[[]]
-                                                      Project (#2)
-                                                        Map (coalesce(#1, #0))
-                                                          Reduce group_by=[#0] aggregates=[max(case when ((#0 < (#2 + #3)) AND (#0 >= #2)) then (#1 + (#0 - #2)) else null end)]
-                                                            CrossJoin type=differential
-                                                              ArrangeBy keys=[[]]
-                                                                Project (#2)
-                                                                  Map (coalesce(#1, #0))
-                                                                    Reduce group_by=[#0] aggregates=[max(case when ((#0 < (#2 + #3)) AND (#0 >= #2)) then (#1 + (#0 - #2)) else null end)]
-                                                                      CrossJoin type=differential
-                                                                        ArrangeBy keys=[[]]
-                                                                          Project (#2)
-                                                                            Map (text_to_bigint(#1))
-                                                                              FlatMap unnest_array(regexp_split_to_array[" ", case_insensitive=false](array_index(regexp_split_to_array[": ", case_insensitive=false](array_index(regexp_split_to_array["\n", case_insensitive=false](#0), 1)), 2)))
-                                                                                ReadStorage materialize.public.input
-                                                                        ArrangeBy keys=[[]]
-                                                                          Project (#3..=#5)
-                                                                            Map (arraytoarray(regexp_split_to_array[" ", case_insensitive=false](#1)), array_index(#2, 1), array_index(#2, 2), array_index(#2, 3))
-                                                                              FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](array_index(regexp_match["seed-to-soil map:\n([0-9 \n]*?)\n\n", case_insensitive=false](#0), 1)))
-                                                                                ReadStorage materialize.public.input
-                                                              ArrangeBy keys=[[]]
-                                                                Project (#3..=#5)
-                                                                  Map (arraytoarray(regexp_split_to_array[" ", case_insensitive=false](#1)), array_index(#2, 1), array_index(#2, 2), array_index(#2, 3))
-                                                                    FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](array_index(regexp_match["soil-to-fertilizer map:\n([0-9 \n]*?)\n\n", case_insensitive=false](#0), 1)))
-                                                                      ReadStorage materialize.public.input
-                                                    ArrangeBy keys=[[]]
-                                                      Project (#3..=#5)
-                                                        Map (arraytoarray(regexp_split_to_array[" ", case_insensitive=false](#1)), array_index(#2, 1), array_index(#2, 2), array_index(#2, 3))
-                                                          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](array_index(regexp_match["fertilizer-to-water map:\n([0-9 \n]*?)\n\n", case_insensitive=false](#0), 1)))
-                                                            ReadStorage materialize.public.input
-                                          ArrangeBy keys=[[]]
-                                            Project (#3..=#5)
-                                              Map (arraytoarray(regexp_split_to_array[" ", case_insensitive=false](#1)), array_index(#2, 1), array_index(#2, 2), array_index(#2, 3))
-                                                FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](array_index(regexp_match["water-to-light map:\n([0-9 \n]*?)\n\n", case_insensitive=false](#0), 1)))
-                                                  ReadStorage materialize.public.input
-                                ArrangeBy keys=[[]]
-                                  Project (#3..=#5)
-                                    Map (arraytoarray(regexp_split_to_array[" ", case_insensitive=false](#1)), array_index(#2, 1), array_index(#2, 2), array_index(#2, 3))
-                                      FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](array_index(regexp_match["light-to-temperature map:\n([0-9 \n]*?)\n\n", case_insensitive=false](#0), 1)))
-                                        ReadStorage materialize.public.input
-                      ArrangeBy keys=[[]]
-                        Project (#3..=#5)
-                          Map (arraytoarray(regexp_split_to_array[" ", case_insensitive=false](#1)), array_index(#2, 1), array_index(#2, 2), array_index(#2, 3))
-                            FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](array_index(regexp_match["temperature-to-humidity map:\n([0-9 \n]*?)\n\n", case_insensitive=false](#0), 1)))
-                              ReadStorage materialize.public.input
-            ArrangeBy keys=[[]]
-              Project (#3..=#5)
-                Map (arraytoarray(regexp_split_to_array[" ", case_insensitive=false](#1)), array_index(#2, 1), array_index(#2, 2), array_index(#2, 3))
-                  FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](array_index(regexp_match["humidity-to-location map:\n([0-9 \n]*)", case_insensitive=false](#0), 1)))
-                    ReadStorage materialize.public.input
-  Return
-    Union
-      Get l0
-      Map (null)
-        Union
-          Negate
-            Project ()
-              Get l0
-          Constant
+      Reduce aggregates=[min(coalesce(#1{max}, #0))] // { arity: 1 }
+        Reduce group_by=[#0] aggregates=[max(case when ((#0 < (#2 + #3)) AND (#0 >= #2)) then (#1 + (#0 - #2)) else null end)] // { arity: 2 }
+          CrossJoin type=differential // { arity: 4 }
+            implementation
+              %0[×] » %1[×]
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Project (#2) // { arity: 1 }
+                Map (coalesce(#1{max}, #0)) // { arity: 3 }
+                  Reduce group_by=[#0] aggregates=[max(case when ((#0 < (#2 + #3)) AND (#0 >= #2)) then (#1 + (#0 - #2)) else null end)] // { arity: 2 }
+                    CrossJoin type=differential // { arity: 4 }
+                      implementation
+                        %0[×] » %1[×]
+                      ArrangeBy keys=[[]] // { arity: 1 }
+                        Project (#2) // { arity: 1 }
+                          Map (coalesce(#1{max}, #0)) // { arity: 3 }
+                            Reduce group_by=[#0] aggregates=[max(case when ((#0 < (#2 + #3)) AND (#0 >= #2)) then (#1 + (#0 - #2)) else null end)] // { arity: 2 }
+                              CrossJoin type=differential // { arity: 4 }
+                                implementation
+                                  %0[×] » %1[×]
+                                ArrangeBy keys=[[]] // { arity: 1 }
+                                  Project (#2) // { arity: 1 }
+                                    Map (coalesce(#1{max}, #0)) // { arity: 3 }
+                                      Reduce group_by=[#0] aggregates=[max(case when ((#0 < (#2 + #3)) AND (#0 >= #2)) then (#1 + (#0 - #2)) else null end)] // { arity: 2 }
+                                        CrossJoin type=differential // { arity: 4 }
+                                          implementation
+                                            %0[×] » %1[×]
+                                          ArrangeBy keys=[[]] // { arity: 1 }
+                                            Project (#2) // { arity: 1 }
+                                              Map (coalesce(#1{max}, #0)) // { arity: 3 }
+                                                Reduce group_by=[#0] aggregates=[max(case when ((#0 < (#2 + #3)) AND (#0 >= #2)) then (#1 + (#0 - #2)) else null end)] // { arity: 2 }
+                                                  CrossJoin type=differential // { arity: 4 }
+                                                    implementation
+                                                      %0[×] » %1[×]
+                                                    ArrangeBy keys=[[]] // { arity: 1 }
+                                                      Project (#2) // { arity: 1 }
+                                                        Map (coalesce(#1{max}, #0)) // { arity: 3 }
+                                                          Reduce group_by=[#0] aggregates=[max(case when ((#0 < (#2 + #3)) AND (#0 >= #2)) then (#1 + (#0 - #2)) else null end)] // { arity: 2 }
+                                                            CrossJoin type=differential // { arity: 4 }
+                                                              implementation
+                                                                %0[×] » %1[×]
+                                                              ArrangeBy keys=[[]] // { arity: 1 }
+                                                                Project (#2) // { arity: 1 }
+                                                                  Map (coalesce(#1{max}, #0)) // { arity: 3 }
+                                                                    Reduce group_by=[#0] aggregates=[max(case when ((#0 < (#2 + #3)) AND (#0 >= #2)) then (#1 + (#0 - #2)) else null end)] // { arity: 2 }
+                                                                      CrossJoin type=differential // { arity: 4 }
+                                                                        implementation
+                                                                          %0[×] » %1[×]
+                                                                        ArrangeBy keys=[[]] // { arity: 1 }
+                                                                          Project (#2) // { arity: 1 }
+                                                                            Map (text_to_bigint(#1)) // { arity: 3 }
+                                                                              FlatMap unnest_array(regexp_split_to_array[" ", case_insensitive=false](array_index(regexp_split_to_array[": ", case_insensitive=false](array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), 1)), 2))) // { arity: 2 }
+                                                                                ReadStorage materialize.public.input // { arity: 1 }
+                                                                        ArrangeBy keys=[[]] // { arity: 3 }
+                                                                          Project (#3..=#5) // { arity: 3 }
+                                                                            Map (arraytoarray(regexp_split_to_array[" ", case_insensitive=false](#1)), array_index(#2, 1), array_index(#2, 2), array_index(#2, 3)) // { arity: 6 }
+                                                                              FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](array_index(regexp_match["seed-to-soil map:\n([0-9 \n]*?)\n\n", case_insensitive=false](#0{input}), 1))) // { arity: 2 }
+                                                                                ReadStorage materialize.public.input // { arity: 1 }
+                                                              ArrangeBy keys=[[]] // { arity: 3 }
+                                                                Project (#3..=#5) // { arity: 3 }
+                                                                  Map (arraytoarray(regexp_split_to_array[" ", case_insensitive=false](#1)), array_index(#2, 1), array_index(#2, 2), array_index(#2, 3)) // { arity: 6 }
+                                                                    FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](array_index(regexp_match["soil-to-fertilizer map:\n([0-9 \n]*?)\n\n", case_insensitive=false](#0{input}), 1))) // { arity: 2 }
+                                                                      ReadStorage materialize.public.input // { arity: 1 }
+                                                    ArrangeBy keys=[[]] // { arity: 3 }
+                                                      Project (#3..=#5) // { arity: 3 }
+                                                        Map (arraytoarray(regexp_split_to_array[" ", case_insensitive=false](#1)), array_index(#2, 1), array_index(#2, 2), array_index(#2, 3)) // { arity: 6 }
+                                                          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](array_index(regexp_match["fertilizer-to-water map:\n([0-9 \n]*?)\n\n", case_insensitive=false](#0{input}), 1))) // { arity: 2 }
+                                                            ReadStorage materialize.public.input // { arity: 1 }
+                                          ArrangeBy keys=[[]] // { arity: 3 }
+                                            Project (#3..=#5) // { arity: 3 }
+                                              Map (arraytoarray(regexp_split_to_array[" ", case_insensitive=false](#1)), array_index(#2, 1), array_index(#2, 2), array_index(#2, 3)) // { arity: 6 }
+                                                FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](array_index(regexp_match["water-to-light map:\n([0-9 \n]*?)\n\n", case_insensitive=false](#0{input}), 1))) // { arity: 2 }
+                                                  ReadStorage materialize.public.input // { arity: 1 }
+                                ArrangeBy keys=[[]] // { arity: 3 }
+                                  Project (#3..=#5) // { arity: 3 }
+                                    Map (arraytoarray(regexp_split_to_array[" ", case_insensitive=false](#1)), array_index(#2, 1), array_index(#2, 2), array_index(#2, 3)) // { arity: 6 }
+                                      FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](array_index(regexp_match["light-to-temperature map:\n([0-9 \n]*?)\n\n", case_insensitive=false](#0{input}), 1))) // { arity: 2 }
+                                        ReadStorage materialize.public.input // { arity: 1 }
+                      ArrangeBy keys=[[]] // { arity: 3 }
+                        Project (#3..=#5) // { arity: 3 }
+                          Map (arraytoarray(regexp_split_to_array[" ", case_insensitive=false](#1)), array_index(#2, 1), array_index(#2, 2), array_index(#2, 3)) // { arity: 6 }
+                            FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](array_index(regexp_match["temperature-to-humidity map:\n([0-9 \n]*?)\n\n", case_insensitive=false](#0{input}), 1))) // { arity: 2 }
+                              ReadStorage materialize.public.input // { arity: 1 }
+            ArrangeBy keys=[[]] // { arity: 3 }
+              Project (#3..=#5) // { arity: 3 }
+                Map (arraytoarray(regexp_split_to_array[" ", case_insensitive=false](#1)), array_index(#2, 1), array_index(#2, 2), array_index(#2, 3)) // { arity: 6 }
+                  FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](array_index(regexp_match["humidity-to-location map:\n([0-9 \n]*)", case_insensitive=false](#0{input}), 1))) // { arity: 2 }
+                    ReadStorage materialize.public.input // { arity: 1 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l0 // { arity: 1 }
+          Constant // { arity: 0 }
             - ()
 
 Source materialize.public.input
@@ -992,7 +1007,8 @@ SELECT * FROM part1, part2;
 60602459  5
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
     blocks(head TEXT, body TEXT) AS (
         SELECT
             split_part(regexp_split_to_table(input, '\n\n'), ':', 1),
@@ -1147,223 +1163,251 @@ SELECT * FROM part1, part2;
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#2, #3)
-        Map (split_string(#1, ":", 1), split_string(#1, ":", 2))
-          FlatMap unnest_array(regexp_split_to_array["\n\n", case_insensitive=false](#0))
-            ReadStorage materialize.public.input
+      Project (#2, #3) // { arity: 2 }
+        Map (split_string(#1, ":", 1), split_string(#1, ":", 2)) // { arity: 4 }
+          FlatMap unnest_array(regexp_split_to_array["\n\n", case_insensitive=false](#0{input})) // { arity: 2 }
+            ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Project (#5..=#9)
-        Filter (#3 != "")
-          Map (split_string(#2, " ", 2), split_string(#0, " ", 1), split_string(#4, "-", 1), split_string(#4, "-", 3), text_to_bigint(#3), text_to_bigint(split_string(#2, " ", 1)), text_to_bigint(split_string(#2, " ", 3)))
-            FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#1))
-              Filter (#0 != "seeds")
-                Get l0
+      Project (#5..=#9) // { arity: 5 }
+        Filter (#3 != "") // { arity: 10 }
+          Map (split_string(#2, " ", 2), split_string(#0, " ", 1), split_string(#4, "-", 1), split_string(#4, "-", 3), text_to_bigint(#3), text_to_bigint(split_string(#2, " ", 1)), text_to_bigint(split_string(#2, " ", 3))) // { arity: 10 }
+            FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#1)) // { arity: 3 }
+              Filter (#0 != "seeds") // { arity: 2 }
+                Get l0 // { arity: 2 }
     cte l2 =
-      ArrangeBy keys=[[#0, #1]]
-        Get l1
+      ArrangeBy keys=[[#0, #1]] // { arity: 5 }
+        Get l1 // { arity: 5 }
     cte l3 =
-      Project (#0..=#2, #5, #6)
-        Filter (#2 >= #5) AND (#2 <= ((#5 + #7) - 1))
-          Join on=(#0 = #3 AND #1 = #4) type=differential
-            ArrangeBy keys=[[#0, #1]]
-              Get l7
-            Get l2
+      Project (#0..=#2, #5, #6) // { arity: 5 }
+        Filter (#2 >= #5) AND (#2 <= ((#5 + #7) - 1)) // { arity: 8 }
+          Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 8 }
+            implementation
+              %0:l7[#0, #1]KK » %1:l2[#0, #1]KK
+            ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+              Get l7 // { arity: 3 }
+            Get l2 // { arity: 5 }
     cte l4 =
-      Project (#1)
-        Filter (#0 = "seeds")
-          Get l0
+      Project (#1) // { arity: 1 }
+        Filter (#0 = "seeds") // { arity: 2 }
+          Get l0 // { arity: 2 }
     cte l5 =
-      Union
-        Project (#3, #2)
-          Map (text_to_bigint(#1), "seed")
-            FlatMap unnest_array(regexp_split_to_array[" ", case_insensitive=false](btrim(#0)))
-              Get l4
-        Project (#0, #4)
-          Map (coalesce((#1 + (#3 - #2)), #1))
-            Union
-              Project (#1..=#4)
-                Get l3
-              Project (#1, #2, #6, #7)
-                Map (null, null)
-                  Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential
-                    ArrangeBy keys=[[#0..=#2]]
-                      Union
-                        Negate
-                          Distinct project=[#0..=#2]
-                            Project (#0..=#2)
-                              Get l3
-                        Get l7
-                    ArrangeBy keys=[[#0..=#2]]
-                      Get l7
+      Union // { arity: 2 }
+        Project (#3, #2) // { arity: 2 }
+          Map (text_to_bigint(#1), "seed") // { arity: 4 }
+            FlatMap unnest_array(regexp_split_to_array[" ", case_insensitive=false](btrim(#0))) // { arity: 2 }
+              Get l4 // { arity: 1 }
+        Project (#0, #4) // { arity: 2 }
+          Map (coalesce((#1 + (#3 - #2)), #1)) // { arity: 5 }
+            Union // { arity: 4 }
+              Project (#1..=#4) // { arity: 4 }
+                Get l3 // { arity: 5 }
+              Project (#1, #2, #6, #7) // { arity: 4 }
+                Map (null, null) // { arity: 8 }
+                  Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                    implementation
+                      %0[#0..=#2]KKK » %1:l7[#0..=#2]KKK
+                    ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                      Union // { arity: 3 }
+                        Negate // { arity: 3 }
+                          Distinct project=[#0..=#2] // { arity: 3 }
+                            Project (#0..=#2) // { arity: 3 }
+                              Get l3 // { arity: 5 }
+                        Get l7 // { arity: 3 }
+                    ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                      Get l7 // { arity: 3 }
     cte l6 =
-      ArrangeBy keys=[[#0]]
-        Distinct project=[#0, #1]
-          Project (#0, #1)
-            Get l1
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Distinct project=[#0, #1] // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            Get l1 // { arity: 5 }
     cte l7 =
-      Project (#0, #3, #1)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Distinct project=[#0, #1]
-              Get l5
-          Get l6
+      Project (#0, #3, #1) // { arity: 3 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %0[#0]K » %1:l6[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Distinct project=[#0, #1] // { arity: 2 }
+              Get l5 // { arity: 2 }
+          Get l6 // { arity: 2 }
     cte l8 =
-      Reduce aggregates=[min(#0)]
-        Project (#1)
-          Filter (#0 = "location")
-            Get l5
+      Reduce aggregates=[min(#0)] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Filter (#0 = "location") // { arity: 2 }
+            Get l5 // { arity: 2 }
     cte l9 =
-      Distinct project=[#0..=#2]
-        Union
-          Project (#6, #4, #5)
-            Map (regexp_split_to_array[" ", case_insensitive=false](btrim(#0)), (2 * #1), text_to_bigint(array_index(#2, integer_to_bigint((#3 - 1)))), (#4 + text_to_bigint(array_index(#2, integer_to_bigint(#3)))), "seed")
-              FlatMap generate_series(1, ((regexp_split_to_array[" ", case_insensitive=false](btrim(#0)) array_length 1) / 2), 1)
-                Get l4
-          Project (#1, #10, #11)
-            Map ((#8 - #4), (#6 + #9), (#7 + #9))
-              Get l11
-          Get l19
+      Distinct project=[#0..=#2] // { arity: 3 }
+        Union // { arity: 3 }
+          Project (#6, #4, #5) // { arity: 3 }
+            Map (regexp_split_to_array[" ", case_insensitive=false](btrim(#0)), (2 * #1), text_to_bigint(array_index(#2, integer_to_bigint((#3 - 1)))), (#4 + text_to_bigint(array_index(#2, integer_to_bigint(#3)))), "seed") // { arity: 7 }
+              FlatMap generate_series(1, ((regexp_split_to_array[" ", case_insensitive=false](btrim(#0)) array_length 1) / 2), 1) // { arity: 2 }
+                Get l4 // { arity: 1 }
+          Project (#1, #10, #11) // { arity: 3 }
+            Map ((#8 - #4), (#6 + #9), (#7 + #9)) // { arity: 12 }
+              Get l11 // { arity: 9 }
+          Get l19 // { arity: 3 }
     cte l10 =
-      Project (#0..=#2, #4)
-        Join on=(#0 = #3) type=differential
-          ArrangeBy keys=[[#0]]
-            Get l9
-          Get l6
+      Project (#0..=#2, #4) // { arity: 4 }
+        Join on=(#0 = #3) type=differential // { arity: 5 }
+          implementation
+            %0:l9[#0]K » %1:l6[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 3 }
+            Get l9 // { arity: 3 }
+          Get l6 // { arity: 2 }
     cte l11 =
-      Project (#0, #3, #1, #2, #6, #10, #9, #11, #7)
-        Filter (#9 < #11)
-          Map (greatest(#1, #6), (#6 + #8), least(#2, #10))
-            Join on=(#0 = #4 AND #3 = #5) type=differential
-              ArrangeBy keys=[[#0, #3]]
-                Get l10
-              Get l2
+      Project (#0, #3, #1, #2, #6, #10, #9, #11, #7) // { arity: 9 }
+        Filter (#9 < #11) // { arity: 12 }
+          Map (greatest(#1, #6), (#6 + #8), least(#2, #10)) // { arity: 12 }
+            Join on=(#0 = #4 AND #3 = #5) type=differential // { arity: 9 }
+              implementation
+                %0:l10[#0, #3]KK » %1:l2[#0, #1]KK
+              ArrangeBy keys=[[#0, #3]] // { arity: 4 }
+                Get l10 // { arity: 4 }
+              Get l2 // { arity: 5 }
     cte l12 =
-      Distinct project=[#0..=#8]
-        Get l11
+      Distinct project=[#0..=#8] // { arity: 9 }
+        Get l11 // { arity: 9 }
     cte l13 =
-      Distinct project=[#0..=#4]
-        Project (#0..=#3, #7)
-          Get l12
+      Distinct project=[#0..=#4] // { arity: 5 }
+        Project (#0..=#3, #7) // { arity: 5 }
+          Get l12 // { arity: 9 }
     cte l14 =
-      Reduce group_by=[#0..=#4] aggregates=[min(#5)]
-        Project (#0..=#4, #9)
-          Filter (#9 >= #4)
-            Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8) type=differential
-              ArrangeBy keys=[[#0..=#3]]
-                Filter (#2) IS NOT NULL AND (#3) IS NOT NULL
-                  Get l13
-              ArrangeBy keys=[[#0..=#3]]
-                Project (#0..=#3, #6)
-                  Filter (#2) IS NOT NULL AND (#6 < #3)
-                    Get l11
+      Reduce group_by=[#0..=#4] aggregates=[min(#5)] // { arity: 6 }
+        Project (#0..=#4, #9) // { arity: 6 }
+          Filter (#9 >= #4) // { arity: 10 }
+            Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8) type=differential // { arity: 10 }
+              implementation
+                %1:l11[#0..=#3]KKKKf » %0:l13[#0..=#3]KKKKf
+              ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
+                Filter (#2) IS NOT NULL AND (#3) IS NOT NULL // { arity: 5 }
+                  Get l13 // { arity: 5 }
+              ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
+                Project (#0..=#3, #6) // { arity: 5 }
+                  Filter (#2) IS NOT NULL AND (#6 < #3) // { arity: 9 }
+                    Get l11 // { arity: 9 }
     cte l15 =
-      Project (#0..=#4, #6)
-        Map (coalesce(#5, #3))
-          Union
-            Get l14
-            Project (#0..=#4, #10)
-              Map (null)
-                Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8 AND #4 = #9) type=differential
-                  ArrangeBy keys=[[#0..=#4]]
-                    Union
-                      Negate
-                        Project (#0..=#4)
-                          Get l14
-                      Get l13
-                  ArrangeBy keys=[[#0..=#4]]
-                    Get l13
+      Project (#0..=#4, #6) // { arity: 6 }
+        Map (coalesce(#5{min}, #3)) // { arity: 7 }
+          Union // { arity: 6 }
+            Get l14 // { arity: 6 }
+            Project (#0..=#4, #10) // { arity: 6 }
+              Map (null) // { arity: 11 }
+                Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8 AND #4 = #9) type=differential // { arity: 10 }
+                  implementation
+                    %1:l13[#0..=#4]UKKKKK » %0[#0..=#4]KKKKK
+                  ArrangeBy keys=[[#0..=#4]] // { arity: 5 }
+                    Union // { arity: 5 }
+                      Negate // { arity: 5 }
+                        Project (#0..=#4) // { arity: 5 }
+                          Get l14 // { arity: 6 }
+                      Get l13 // { arity: 5 }
+                  ArrangeBy keys=[[#0..=#4]] // { arity: 5 }
+                    Get l13 // { arity: 5 }
     cte l16 =
-      Reduce group_by=[#0, #3, #1, #2] aggregates=[min(#4)]
-        Project (#0..=#3, #8)
-          Join on=(#0 = #4 AND #1 = #6 AND #2 = #7 AND #3 = #5) type=differential
-            ArrangeBy keys=[[#0..=#3]]
-              Filter (#1) IS NOT NULL AND (#2) IS NOT NULL
-                Get l10
-            ArrangeBy keys=[[#0, #2, #3, #1]]
-              Project (#0..=#3, #6)
-                Filter (#6 < #3) AND (#6 >= #2)
-                  Get l11
+      Reduce group_by=[#0, #3, #1, #2] aggregates=[min(#4)] // { arity: 5 }
+        Project (#0..=#3, #8) // { arity: 5 }
+          Join on=(#0 = #4 AND #1 = #6 AND #2 = #7 AND #3 = #5) type=differential // { arity: 9 }
+            implementation
+              %1:l11[#0, #2, #3, #1]KKKKf » %0:l10[#0..=#3]KKKKf
+            ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+              Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 4 }
+                Get l10 // { arity: 4 }
+            ArrangeBy keys=[[#0, #2, #3, #1]] // { arity: 5 }
+              Project (#0..=#3, #6) // { arity: 5 }
+                Filter (#6 < #3) AND (#6 >= #2) // { arity: 9 }
+                  Get l11 // { arity: 9 }
     cte l17 =
-      ArrangeBy keys=[[#0..=#3]]
-        Get l10
+      ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+        Get l10 // { arity: 4 }
     cte l18 =
-      Project (#0..=#3, #5)
-        Map (coalesce(#4, #3))
-          Union
-            Get l16
-            Project (#0..=#3, #8)
-              Map (null)
-                Join on=(#0 = #4 AND #1 = #7 AND #2 = #5 AND #3 = #6) type=differential
-                  ArrangeBy keys=[[#0, #2, #3, #1]]
-                    Union
-                      Negate
-                        Project (#0..=#3)
-                          Get l16
-                      Project (#0, #3, #1, #2)
-                        Get l10
-                  Get l17
+      Project (#0..=#3, #5) // { arity: 5 }
+        Map (coalesce(#4{min}, #3)) // { arity: 6 }
+          Union // { arity: 5 }
+            Get l16 // { arity: 5 }
+            Project (#0..=#3, #8) // { arity: 5 }
+              Map (null) // { arity: 9 }
+                Join on=(#0 = #4 AND #1 = #7 AND #2 = #5 AND #3 = #6) type=differential // { arity: 8 }
+                  implementation
+                    %0[#0, #2, #3, #1]KKKK » %1:l17[#0..=#3]KKKK
+                  ArrangeBy keys=[[#0, #2, #3, #1]] // { arity: 4 }
+                    Union // { arity: 4 }
+                      Negate // { arity: 4 }
+                        Project (#0..=#3) // { arity: 4 }
+                          Get l16 // { arity: 5 }
+                      Project (#0, #3, #1, #2) // { arity: 4 }
+                        Get l10 // { arity: 4 }
+                  Get l17 // { arity: 4 }
     cte l19 =
-      Distinct project=[#0..=#2]
-        Union
-          Project (#1, #7, #23)
-            Join on=(#0 = #9 = #18 AND #1 = #10 = #19 AND #2 = #11 = #20 AND #3 = #12 = #21 AND #4 = #13 AND #5 = #14 AND #6 = #15 AND #7 = #16 = #22 AND #8 = #17) type=delta
-              ArrangeBy keys=[[#0..=#8], [#0..=#3, #7]]
-                Get l11
-              ArrangeBy keys=[[#0..=#8]]
-                Get l12
-              ArrangeBy keys=[[#0..=#4]]
-                Union
-                  Filter (#4 < #5)
-                    Get l15
-                  Map (error("more than one record produced in subquery"))
-                    Project (#0..=#4)
-                      Filter error("more than one record produced in subquery") AND (#5 > 1)
-                        Reduce group_by=[#0..=#4] aggregates=[count(*)]
-                          Project (#0..=#4)
-                            Get l15
-          Distinct project=[#1, #0, #2]
-            Project (#1, #3, #12)
-              Join on=(#0 = #4 = #8 AND #1 = #5 = #10 AND #2 = #6 = #11 AND #3 = #7 = #9) type=delta
-                Get l17
-                Get l17
-                ArrangeBy keys=[[#0..=#3]]
-                  Union
-                    Filter (#2 < #4)
-                      Get l18
-                    Map (error("more than one record produced in subquery"))
-                      Project (#0..=#3)
-                        Filter error("more than one record produced in subquery") AND (#4 > 1)
-                          Reduce group_by=[#0..=#3] aggregates=[count(*)]
-                            Project (#0..=#3)
-                              Get l18
-  Return
+      Distinct project=[#0..=#2] // { arity: 3 }
+        Union // { arity: 3 }
+          Project (#1, #7, #23) // { arity: 3 }
+            Join on=(#0 = #9 = #18 AND #1 = #10 = #19 AND #2 = #11 = #20 AND #3 = #12 = #21 AND #4 = #13 AND #5 = #14 AND #6 = #15 AND #7 = #16 = #22 AND #8 = #17) type=delta // { arity: 24 }
+              implementation
+                %0:l11 » %1:l12[#0..=#8]UKKKKKKKKK » %2[#0..=#4]KKKKK
+                %1:l12 » %0:l11[#0..=#8]KKKKKKKKK » %2[#0..=#4]KKKKK
+                %2 » %0:l11[#0..=#3, #7]KKKKK » %1:l12[#0..=#8]UKKKKKKKKK
+              ArrangeBy keys=[[#0..=#8], [#0..=#3, #7]] // { arity: 9 }
+                Get l11 // { arity: 9 }
+              ArrangeBy keys=[[#0..=#8]] // { arity: 9 }
+                Get l12 // { arity: 9 }
+              ArrangeBy keys=[[#0..=#4]] // { arity: 6 }
+                Union // { arity: 6 }
+                  Filter (#4 < #5) // { arity: 6 }
+                    Get l15 // { arity: 6 }
+                  Map (error("more than one record produced in subquery")) // { arity: 6 }
+                    Project (#0..=#4) // { arity: 5 }
+                      Filter error("more than one record produced in subquery") AND (#5{count} > 1) // { arity: 6 }
+                        Reduce group_by=[#0..=#4] aggregates=[count(*)] // { arity: 6 }
+                          Project (#0..=#4) // { arity: 5 }
+                            Get l15 // { arity: 6 }
+          Distinct project=[#1, #0, #2] // { arity: 3 }
+            Project (#1, #3, #12) // { arity: 3 }
+              Join on=(#0 = #4 = #8 AND #1 = #5 = #10 AND #2 = #6 = #11 AND #3 = #7 = #9) type=delta // { arity: 13 }
+                implementation
+                  %0:l17 » %1:l17[#0..=#3]KKKK » %2[#0..=#3]KKKK
+                  %1:l17 » %0:l17[#0..=#3]KKKK » %2[#0..=#3]KKKK
+                  %2 » %0:l17[#0..=#3]KKKK » %1:l17[#0..=#3]KKKK
+                Get l17 // { arity: 4 }
+                Get l17 // { arity: 4 }
+                ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
+                  Union // { arity: 5 }
+                    Filter (#2 < #4) // { arity: 5 }
+                      Get l18 // { arity: 5 }
+                    Map (error("more than one record produced in subquery")) // { arity: 5 }
+                      Project (#0..=#3) // { arity: 4 }
+                        Filter error("more than one record produced in subquery") AND (#4{count} > 1) // { arity: 5 }
+                          Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
+                            Project (#0..=#3) // { arity: 4 }
+                              Get l18 // { arity: 5 }
+  Return // { arity: 2 }
     With
       cte l20 =
-        Reduce aggregates=[min(#0)]
-          Project (#1)
-            Filter (#0 = "location")
-              Get l9
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Union
-            Get l8
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l8
-                Constant
+        Reduce aggregates=[min(#0)] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = "location") // { arity: 3 }
+              Get l9 // { arity: 3 }
+    Return // { arity: 2 }
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0[×]U » %1[×]U
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l8 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l8 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
-        ArrangeBy keys=[[]]
-          Union
-            Get l20
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l20
-                Constant
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l20 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l20 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1206.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1206.slt
@@ -46,7 +46,8 @@ FROM options;
 1180707298
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH options AS
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH options AS
 (
 	SELECT
 	  (floor((time - sqrt(time * time - 4 * distance)) / 2) + 1)::int low,
@@ -59,19 +60,19 @@ FROM options;
 Explained Query:
   With
     cte l0 =
-      Reduce aggregates=[sum(lnf64(integer_to_double(((double_to_integer((ceilf64(((integer_to_double(#0) + sqrtf64(integer_to_double(((#0 * #0) - (4 * #1))))) / 2)) - 1)) - double_to_integer((floorf64(((integer_to_double(#0) - sqrtf64(integer_to_double(((#0 * #0) - (4 * #1))))) / 2)) + 1))) + 1))))]
-        ReadStorage materialize.public.input
-  Return
-    Project (#1)
-      Map (double_to_integer(expf64(#0)))
-        Union
-          Get l0
-          Map (null)
-            Union
-              Negate
-                Project ()
-                  Get l0
-              Constant
+      Reduce aggregates=[sum(lnf64(integer_to_double(((double_to_integer((ceilf64(((integer_to_double(#0{time}) + sqrtf64(integer_to_double(((#0{time} * #0{time}) - (4 * #1{distance}))))) / 2)) - 1)) - double_to_integer((floorf64(((integer_to_double(#0{time}) - sqrtf64(integer_to_double(((#0{time} * #0{time}) - (4 * #1{distance}))))) / 2)) + 1))) + 1))))] // { arity: 1 }
+        ReadStorage materialize.public.input // { arity: 2 }
+  Return // { arity: 1 }
+    Project (#1) // { arity: 1 }
+      Map (double_to_integer(expf64(#0{sum}))) // { arity: 2 }
+        Union // { arity: 1 }
+          Get l0 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l0 // { arity: 1 }
+              Constant // { arity: 0 }
                 - ()
 
 Source materialize.public.input
@@ -100,7 +101,8 @@ SELECT * FROM part12;
 1180707528
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
     ties(slower NUMERIC, faster NUMERIC) AS (
         SELECT
             (time + sqrt(time * time - 4 * distance)) / 2 as slower,
@@ -118,19 +120,19 @@ SELECT * FROM part12;
 Explained Query:
   With
     cte l0 =
-      Reduce aggregates=[sum(log10numeric(((1 + floornumeric(double_to_numeric(((integer_to_double(#0) + sqrtf64(integer_to_double(((#0 * #0) - (4 * #1))))) / 2)))) - ceilnumeric(double_to_numeric(((integer_to_double(#0) - sqrtf64(integer_to_double(((#0 * #0) - (4 * #1))))) / 2))))))]
-        ReadStorage materialize.public.input
-  Return
-    Project (#1)
-      Map (power_numeric(10, #0))
-        Union
-          Get l0
-          Map (null)
-            Union
-              Negate
-                Project ()
-                  Get l0
-              Constant
+      Reduce aggregates=[sum(log10numeric(((1 + floornumeric(double_to_numeric(((integer_to_double(#0{time}) + sqrtf64(integer_to_double(((#0{time} * #0{time}) - (4 * #1{distance}))))) / 2)))) - ceilnumeric(double_to_numeric(((integer_to_double(#0{time}) - sqrtf64(integer_to_double(((#0{time} * #0{time}) - (4 * #1{distance}))))) / 2))))))] // { arity: 1 }
+        ReadStorage materialize.public.input // { arity: 2 }
+  Return // { arity: 1 }
+    Project (#1) // { arity: 1 }
+      Map (power_numeric(10, #0{sum})) // { arity: 2 }
+        Union // { arity: 1 }
+          Get l0 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l0 // { arity: 1 }
+              Constant // { arity: 0 }
                 - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1207.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1207.slt
@@ -161,7 +161,8 @@ SELECT * FROM part1, part2;
 340665  332531
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
     lines(line TEXT) AS ( SELECT regexp_split_to_table(input, '\n') FROM input ),
     hands(hand TEXT, bid INT) as (
         SELECT regexp_split_to_array(line, ' ')[1],
@@ -270,726 +271,802 @@ SELECT * FROM part1, part2;
 Explained Query:
   With
     cte l0 =
-      Project (#3, #4)
-        Map (regexp_split_to_array[" ", case_insensitive=false](#1), array_index(#2, 1), text_to_integer(array_index(#2, 2)))
-          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-            ReadStorage materialize.public.input
+      Project (#3, #4) // { arity: 2 }
+        Map (regexp_split_to_array[" ", case_insensitive=false](#1), array_index(#2, 1), text_to_integer(array_index(#2, 2))) // { arity: 5 }
+          FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0{input})) // { arity: 2 }
+            ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Project (#0)
-        Get l0
+      Project (#0) // { arity: 1 }
+        Get l0 // { arity: 2 }
     cte l2 =
-      ArrangeBy keys=[[]]
-        Constant
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Constant // { arity: 1 }
           - (1)
           - (2)
           - (3)
           - (4)
           - (5)
     cte l3 =
-      Map (substr(#0, #1, 1))
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l1
-          Get l2
+      Map (substr(#0, #1, 1)) // { arity: 3 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0:l1[×] » %1:l2[×]
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l1 // { arity: 1 }
+          Get l2 // { arity: 1 }
     cte l4 =
-      Project (#0, #3)
-        Map (bigint_to_integer(#2))
-          Reduce group_by=[#0, #1] aggregates=[count(*)]
-            Project (#0, #2)
-              Get l3
+      Project (#0, #3) // { arity: 2 }
+        Map (bigint_to_integer(#2{count})) // { arity: 4 }
+          Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+            Project (#0, #2) // { arity: 2 }
+              Get l3 // { arity: 3 }
     cte l5 =
-      Distinct project=[#0]
-        Get l1
+      Distinct project=[#0] // { arity: 1 }
+        Get l1 // { arity: 1 }
     cte l6 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l5
-          ArrangeBy keys=[[]]
-            Project (#0)
-              Filter (#1 = 5)
-                Get l4
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %1:l4[×]ef » %0:l5[×]ef
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l5 // { arity: 1 }
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#1 = 5) // { arity: 2 }
+                Get l4 // { arity: 2 }
     cte l7 =
-      Union
-        Get l6
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l6
-            Get l5
+      Union // { arity: 2 }
+        Get l6 // { arity: 2 }
+        Map (false) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l6 // { arity: 2 }
+            Get l5 // { arity: 1 }
     cte l8 =
-      Project (#0, #1, #3)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Get l0
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l7
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l7
-                  Get l5
+      Project (#0, #1, #3{any}) // { arity: 3 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UK » %0:l0[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l7 // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l7 // { arity: 2 }
+                  Get l5 // { arity: 1 }
     cte l9 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l8
+      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+        Get l8 // { arity: 3 }
     cte l10 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l9
+      Distinct project=[#0] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l9 // { arity: 3 }
     cte l11 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l10
-          ArrangeBy keys=[[]]
-            Project (#0)
-              Filter (#1 = 4)
-                Get l4
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %1:l4[×]ef » %0:l10[×]ef
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l10 // { arity: 1 }
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#1 = 4) // { arity: 2 }
+                Get l4 // { arity: 2 }
     cte l12 =
-      Union
-        Get l11
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l11
-            Get l10
+      Union // { arity: 2 }
+        Get l11 // { arity: 2 }
+        Map (false) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l11 // { arity: 2 }
+            Get l10 // { arity: 1 }
     cte l13 =
-      Project (#0, #1, #3)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Project (#0, #1)
-              Get l9
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l12
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l12
-                  Get l10
+      Project (#0, #1, #3{any}) // { arity: 3 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UK » %0:l9[#0]Kenf
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Get l9 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l12 // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l12 // { arity: 2 }
+                  Get l10 // { arity: 1 }
     cte l14 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l13
+      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+        Get l13 // { arity: 3 }
     cte l15 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l14
+      Distinct project=[#0] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l14 // { arity: 3 }
     cte l16 =
-      ArrangeBy keys=[[]]
-        Project (#0)
-          Filter (#1 = 3)
-            Get l4
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#1 = 3) // { arity: 2 }
+            Get l4 // { arity: 2 }
     cte l17 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l15
-          Get l16
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %1:l16[×]ef » %0:l15[×]ef
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l15 // { arity: 1 }
+          Get l16 // { arity: 1 }
     cte l18 =
-      Union
-        Get l17
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l17
-            Get l15
+      Union // { arity: 2 }
+        Get l17 // { arity: 2 }
+        Map (false) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l17 // { arity: 2 }
+            Get l15 // { arity: 1 }
     cte l19 =
-      Project (#0, #1, #3)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Project (#0, #1)
-              Get l14
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l18
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l18
-                  Get l15
+      Project (#0, #1, #3{any}) // { arity: 3 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UK » %0:l14[#0]Kenf
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Get l14 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l18 // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l18 // { arity: 2 }
+                  Get l15 // { arity: 1 }
     cte l20 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l19
+      Distinct project=[#0] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l19 // { arity: 3 }
     cte l21 =
-      ArrangeBy keys=[[]]
-        Project (#0)
-          Filter (#1 = 2)
-            Get l4
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#1 = 2) // { arity: 2 }
+            Get l4 // { arity: 2 }
     cte l22 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l20
-          Get l21
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %1:l21[×]ef » %0:l20[×]ef
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l20 // { arity: 1 }
+          Get l21 // { arity: 1 }
     cte l23 =
-      Union
-        Get l22
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l22
-            Get l20
+      Union // { arity: 2 }
+        Get l22 // { arity: 2 }
+        Map (false) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l22 // { arity: 2 }
+            Get l20 // { arity: 1 }
     cte l24 =
-      Project (#0..=#2, #4)
-        Join on=(#0 = #3) type=differential
-          ArrangeBy keys=[[#0]]
-            Get l19
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l23
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l23
-                  Get l20
+      Project (#0..=#2{any}, #4{any}) // { arity: 4 }
+        Join on=(#0 = #3) type=differential // { arity: 5 }
+          implementation
+            %1[#0]UK » %0:l19[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 3 }
+            Get l19 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l23 // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l23 // { arity: 2 }
+                  Get l20 // { arity: 1 }
     cte l25 =
-      Filter ((#4) IS NULL OR (#4 = false))
-        Map ((#2 AND #3))
-          Get l24
+      Filter ((#4) IS NULL OR (#4 = false)) // { arity: 5 }
+        Map ((#2{any} AND #3{any})) // { arity: 5 }
+          Get l24 // { arity: 4 }
     cte l26 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l25
+      Distinct project=[#0] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l25 // { arity: 5 }
     cte l27 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l26
-          Get l16
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %1:l16[×]ef » %0:l26[×]ef
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l26 // { arity: 1 }
+          Get l16 // { arity: 1 }
     cte l28 =
-      Union
-        Get l27
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l27
-            Get l26
+      Union // { arity: 2 }
+        Get l27 // { arity: 2 }
+        Map (false) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l27 // { arity: 2 }
+            Get l26 // { arity: 1 }
     cte l29 =
-      Project (#0, #1, #3)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Project (#0, #1)
-              Get l25
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l28
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l28
-                  Get l26
+      Project (#0, #1, #3{any}) // { arity: 3 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UK » %0:l25[#0]Kenf
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Get l25 // { arity: 5 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l28 // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l28 // { arity: 2 }
+                  Get l26 // { arity: 1 }
     cte l30 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l29
+      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+        Get l29 // { arity: 3 }
     cte l31 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l30
+      Distinct project=[#0] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l30 // { arity: 3 }
     cte l32 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        Project (#0, #1)
-          Filter (#2 = 2)
-            Reduce group_by=[#0, #1] aggregates=[count(*)]
-              CrossJoin type=differential
-                ArrangeBy keys=[[]]
-                  Get l31
-                Get l21
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        Project (#0, #1) // { arity: 2 }
+          Filter (#2{count} = 2) // { arity: 3 }
+            Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+              CrossJoin type=differential // { arity: 2 }
+                implementation
+                  %1:l21[×]ef » %0:l31[×]ef
+                ArrangeBy keys=[[]] // { arity: 1 }
+                  Get l31 // { arity: 1 }
+                Get l21 // { arity: 1 }
     cte l33 =
-      Union
-        Get l32
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l32
-            Get l31
+      Union // { arity: 2 }
+        Get l32 // { arity: 2 }
+        Map (false) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l32 // { arity: 2 }
+            Get l31 // { arity: 1 }
     cte l34 =
-      Project (#0, #1, #3)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Project (#0, #1)
-              Get l30
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l33
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l33
-                  Get l31
+      Project (#0, #1, #3{any}) // { arity: 3 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UK » %0:l30[#0]Kenf
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Get l30 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l33 // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l33 // { arity: 2 }
+                  Get l31 // { arity: 1 }
     cte l35 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l34
+      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+        Get l34 // { arity: 3 }
     cte l36 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l35
+      Distinct project=[#0] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l35 // { arity: 3 }
     cte l37 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l36
-          Get l21
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %1:l21[×]ef » %0:l36[×]ef
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l36 // { arity: 1 }
+          Get l21 // { arity: 1 }
     cte l38 =
-      Union
-        Get l37
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l37
-            Get l36
+      Union // { arity: 2 }
+        Get l37 // { arity: 2 }
+        Map (false) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l37 // { arity: 2 }
+            Get l36 // { arity: 1 }
     cte l39 =
-      Project (#1..=#3)
-        Map (translate(#0, "AKQJT98765432", "ABCDEFGHIJKLM"))
-          Union
-            Project (#0, #1, #3)
-              Filter #2
-                Map (1)
-                  Get l8
-            Project (#0, #1, #3)
-              Filter #2
-                Map (2)
-                  Get l13
-            Project (#0, #1, #4)
-              Filter #2 AND #3
-                Map (3)
-                  Get l24
-            Project (#0, #1, #3)
-              Filter #2
-                Map (4)
-                  Get l29
-            Project (#0, #1, #3)
-              Filter #2
-                Map (5)
-                  Get l34
-            Project (#0, #1, #4)
-              Map (case when #3 then 6 else 7 end)
-                Join on=(#0 = #2) type=differential
-                  ArrangeBy keys=[[#0]]
-                    Project (#0, #1)
-                      Get l35
-                  ArrangeBy keys=[[#0]]
-                    Union
-                      Get l38
-                      Map (null)
-                        Union
-                          Negate
-                            Project (#0)
-                              Get l38
-                          Get l36
+      Project (#1..=#3) // { arity: 3 }
+        Map (translate(#0, "AKQJT98765432", "ABCDEFGHIJKLM")) // { arity: 4 }
+          Union // { arity: 3 }
+            Project (#0, #1, #3) // { arity: 3 }
+              Filter #2{any} // { arity: 4 }
+                Map (1) // { arity: 4 }
+                  Get l8 // { arity: 3 }
+            Project (#0, #1, #3) // { arity: 3 }
+              Filter #2{any} // { arity: 4 }
+                Map (2) // { arity: 4 }
+                  Get l13 // { arity: 3 }
+            Project (#0, #1, #4) // { arity: 3 }
+              Filter #2{any} AND #3{any} // { arity: 5 }
+                Map (3) // { arity: 5 }
+                  Get l24 // { arity: 4 }
+            Project (#0, #1, #3) // { arity: 3 }
+              Filter #2{any} // { arity: 4 }
+                Map (4) // { arity: 4 }
+                  Get l29 // { arity: 3 }
+            Project (#0, #1, #3) // { arity: 3 }
+              Filter #2{any} // { arity: 4 }
+                Map (5) // { arity: 4 }
+                  Get l34 // { arity: 3 }
+            Project (#0, #1, #4) // { arity: 3 }
+              Map (case when #3{any} then 6 else 7 end) // { arity: 5 }
+                Join on=(#0 = #2) type=differential // { arity: 4 }
+                  implementation
+                    %1[#0]UK » %0:l35[#0]Kenf
+                  ArrangeBy keys=[[#0]] // { arity: 2 }
+                    Project (#0, #1) // { arity: 2 }
+                      Get l35 // { arity: 3 }
+                  ArrangeBy keys=[[#0]] // { arity: 2 }
+                    Union // { arity: 2 }
+                      Get l38 // { arity: 2 }
+                      Map (null) // { arity: 2 }
+                        Union // { arity: 1 }
+                          Negate // { arity: 1 }
+                            Project (#0) // { arity: 1 }
+                              Get l38 // { arity: 2 }
+                          Get l36 // { arity: 1 }
     cte l40 =
-      Reduce aggregates=[sum(#0)]
-        Project (#0)
-          Filter ((#1 < #3) OR ((#1 = #3) AND (#2 <= #4)))
-            CrossJoin type=differential
-              ArrangeBy keys=[[]]
-                Get l39
-              ArrangeBy keys=[[]]
-                Project (#1, #2)
-                  Get l39
+      Reduce aggregates=[sum(#0)] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter ((#1 < #3) OR ((#1 = #3) AND (#2 <= #4))) // { arity: 5 }
+            CrossJoin type=differential // { arity: 5 }
+              implementation
+                %0:l39[×] » %1:l39[×]
+              ArrangeBy keys=[[]] // { arity: 3 }
+                Get l39 // { arity: 3 }
+              ArrangeBy keys=[[]] // { arity: 2 }
+                Project (#1, #2) // { arity: 2 }
+                  Get l39 // { arity: 3 }
     cte l41 =
-      Filter (#0) IS NOT NULL
-        Get l3
+      Filter (#0) IS NOT NULL // { arity: 3 }
+        Get l3 // { arity: 3 }
     cte l42 =
-      Distinct project=[#0..=#2]
-        Union
-          Project (#0, #2, #1)
-            Get l41
-          Project (#0, #3, #1)
-            Join on=(#0 = #2) type=differential
-              ArrangeBy keys=[[#0]]
-                Project (#0, #1)
-                  Filter (#2 = "J") AND (#0) IS NOT NULL
-                    Get l3
-              ArrangeBy keys=[[#0]]
-                Project (#0, #2)
-                  Get l41
+      Distinct project=[#0..=#2] // { arity: 3 }
+        Union // { arity: 3 }
+          Project (#0, #2, #1) // { arity: 3 }
+            Get l41 // { arity: 3 }
+          Project (#0, #3, #1) // { arity: 3 }
+            Join on=(#0 = #2) type=differential // { arity: 4 }
+              implementation
+                %0:l3[#0]Kef » %1:l41[#0]Kef
+              ArrangeBy keys=[[#0]] // { arity: 2 }
+                Project (#0, #1) // { arity: 2 }
+                  Filter (#2 = "J") AND (#0) IS NOT NULL // { arity: 3 }
+                    Get l3 // { arity: 3 }
+              ArrangeBy keys=[[#0]] // { arity: 2 }
+                Project (#0, #2) // { arity: 2 }
+                  Get l41 // { arity: 3 }
     cte l43 =
-      Distinct project=[#0, ((((#1 || #2) || #3) || #4) || #5)]
-        Project (#0, #1, #3, #5, #7, #9)
-          Join on=(#0 = #2 = #4 = #6 = #8) type=delta
-            ArrangeBy keys=[[#0]]
-              Project (#0, #1)
-                Filter (#2 = 1)
-                  Get l42
-            ArrangeBy keys=[[#0]]
-              Project (#0, #1)
-                Filter (#2 = 2)
-                  Get l42
-            ArrangeBy keys=[[#0]]
-              Project (#0, #1)
-                Filter (#2 = 3)
-                  Get l42
-            ArrangeBy keys=[[#0]]
-              Project (#0, #1)
-                Filter (#2 = 4)
-                  Get l42
-            ArrangeBy keys=[[#0]]
-              Project (#0, #1)
-                Filter (#2 = 5)
-                  Get l42
+      Distinct project=[#0, ((((#1 || #2) || #3) || #4) || #5)] // { arity: 2 }
+        Project (#0, #1, #3, #5, #7, #9) // { arity: 6 }
+          Join on=(#0 = #2 = #4 = #6 = #8) type=delta // { arity: 10 }
+            implementation
+              %0:l42 » %1:l42[#0]Kef » %2:l42[#0]Kef » %3:l42[#0]Kef » %4:l42[#0]Kef
+              %1:l42 » %0:l42[#0]Kef » %2:l42[#0]Kef » %3:l42[#0]Kef » %4:l42[#0]Kef
+              %2:l42 » %0:l42[#0]Kef » %1:l42[#0]Kef » %3:l42[#0]Kef » %4:l42[#0]Kef
+              %3:l42 » %0:l42[#0]Kef » %1:l42[#0]Kef » %2:l42[#0]Kef » %4:l42[#0]Kef
+              %4:l42 » %0:l42[#0]Kef » %1:l42[#0]Kef » %2:l42[#0]Kef » %3:l42[#0]Kef
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Filter (#2 = 1) // { arity: 3 }
+                  Get l42 // { arity: 3 }
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Filter (#2 = 2) // { arity: 3 }
+                  Get l42 // { arity: 3 }
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Filter (#2 = 3) // { arity: 3 }
+                  Get l42 // { arity: 3 }
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Filter (#2 = 4) // { arity: 3 }
+                  Get l42 // { arity: 3 }
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Filter (#2 = 5) // { arity: 3 }
+                  Get l42 // { arity: 3 }
     cte l44 =
-      Project (#1)
-        Get l43
+      Project (#1) // { arity: 1 }
+        Get l43 // { arity: 2 }
     cte l45 =
-      Project (#0, #3)
-        Map (bigint_to_integer(#2))
-          Reduce group_by=[#0, #1] aggregates=[count(*)]
-            Project (#0, #1)
-              Distinct project=[#0, substr(#0, #1, 1), #1]
-                CrossJoin type=differential
-                  ArrangeBy keys=[[]]
-                    Get l44
-                  Get l2
+      Project (#0, #3) // { arity: 2 }
+        Map (bigint_to_integer(#2{count})) // { arity: 4 }
+          Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+            Project (#0, #1) // { arity: 2 }
+              Distinct project=[#0, substr(#0, #1, 1), #1] // { arity: 3 }
+                CrossJoin type=differential // { arity: 2 }
+                  implementation
+                    %0:l44[×] » %1:l2[×]
+                  ArrangeBy keys=[[]] // { arity: 1 }
+                    Get l44 // { arity: 1 }
+                  Get l2 // { arity: 1 }
     cte l46 =
-      Distinct project=[#0]
-        Get l44
+      Distinct project=[#0] // { arity: 1 }
+        Get l44 // { arity: 1 }
     cte l47 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l46
-          ArrangeBy keys=[[]]
-            Project (#0)
-              Filter (#1 = 5)
-                Get l45
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %1:l45[×]ef » %0:l46[×]ef
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l46 // { arity: 1 }
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#1 = 5) // { arity: 2 }
+                Get l45 // { arity: 2 }
     cte l48 =
-      Union
-        Get l47
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l47
-            Get l46
+      Union // { arity: 2 }
+        Get l47 // { arity: 2 }
+        Map (false) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l47 // { arity: 2 }
+            Get l46 // { arity: 1 }
     cte l49 =
-      Project (#0, #1, #3)
-        Join on=(#1 = #2) type=differential
-          ArrangeBy keys=[[#1]]
-            Get l43
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l48
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l48
-                  Get l46
+      Project (#0, #1, #3{any}) // { arity: 3 }
+        Join on=(#1 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UK » %0:l43[#1]K
+          ArrangeBy keys=[[#1]] // { arity: 2 }
+            Get l43 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l48 // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l48 // { arity: 2 }
+                  Get l46 // { arity: 1 }
     cte l50 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l49
+      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+        Get l49 // { arity: 3 }
     cte l51 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l50
+      Distinct project=[#0] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Get l50 // { arity: 3 }
     cte l52 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l51
-          ArrangeBy keys=[[]]
-            Project (#0)
-              Filter (#1 = 4)
-                Get l45
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %1:l45[×]ef » %0:l51[×]ef
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l51 // { arity: 1 }
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#1 = 4) // { arity: 2 }
+                Get l45 // { arity: 2 }
     cte l53 =
-      Union
-        Get l52
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l52
-            Get l51
+      Union // { arity: 2 }
+        Get l52 // { arity: 2 }
+        Map (false) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l52 // { arity: 2 }
+            Get l51 // { arity: 1 }
     cte l54 =
-      Project (#0, #1, #3)
-        Join on=(#1 = #2) type=differential
-          ArrangeBy keys=[[#1]]
-            Project (#0, #1)
-              Get l50
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l53
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l53
-                  Get l51
+      Project (#0, #1, #3{any}) // { arity: 3 }
+        Join on=(#1 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UK » %0:l50[#1]Kenf
+          ArrangeBy keys=[[#1]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Get l50 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l53 // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l53 // { arity: 2 }
+                  Get l51 // { arity: 1 }
     cte l55 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l54
+      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+        Get l54 // { arity: 3 }
     cte l56 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l55
+      Distinct project=[#0] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Get l55 // { arity: 3 }
     cte l57 =
-      ArrangeBy keys=[[]]
-        Project (#0)
-          Filter (#1 = 3)
-            Get l45
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#1 = 3) // { arity: 2 }
+            Get l45 // { arity: 2 }
     cte l58 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l56
-          Get l57
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %1:l57[×]ef » %0:l56[×]ef
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l56 // { arity: 1 }
+          Get l57 // { arity: 1 }
     cte l59 =
-      Union
-        Get l58
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l58
-            Get l56
+      Union // { arity: 2 }
+        Get l58 // { arity: 2 }
+        Map (false) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l58 // { arity: 2 }
+            Get l56 // { arity: 1 }
     cte l60 =
-      Project (#0, #1, #3)
-        Join on=(#1 = #2) type=differential
-          ArrangeBy keys=[[#1]]
-            Project (#0, #1)
-              Get l55
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l59
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l59
-                  Get l56
+      Project (#0, #1, #3{any}) // { arity: 3 }
+        Join on=(#1 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UK » %0:l55[#1]Kenf
+          ArrangeBy keys=[[#1]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Get l55 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l59 // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l59 // { arity: 2 }
+                  Get l56 // { arity: 1 }
     cte l61 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l60
+      Distinct project=[#0] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Get l60 // { arity: 3 }
     cte l62 =
-      ArrangeBy keys=[[]]
-        Project (#0)
-          Filter (#1 = 2)
-            Get l45
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#1 = 2) // { arity: 2 }
+            Get l45 // { arity: 2 }
     cte l63 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l61
-          Get l62
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %1:l62[×]ef » %0:l61[×]ef
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l61 // { arity: 1 }
+          Get l62 // { arity: 1 }
     cte l64 =
-      Union
-        Get l63
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l63
-            Get l61
+      Union // { arity: 2 }
+        Get l63 // { arity: 2 }
+        Map (false) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l63 // { arity: 2 }
+            Get l61 // { arity: 1 }
     cte l65 =
-      Project (#0..=#2, #4)
-        Join on=(#1 = #3) type=differential
-          ArrangeBy keys=[[#1]]
-            Get l60
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l64
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l64
-                  Get l61
+      Project (#0..=#2{any}, #4{any}) // { arity: 4 }
+        Join on=(#1 = #3) type=differential // { arity: 5 }
+          implementation
+            %1[#0]UK » %0:l60[#1]K
+          ArrangeBy keys=[[#1]] // { arity: 3 }
+            Get l60 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l64 // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l64 // { arity: 2 }
+                  Get l61 // { arity: 1 }
     cte l66 =
-      Filter ((#4) IS NULL OR (#4 = false))
-        Map ((#2 AND #3))
-          Get l65
+      Filter ((#4) IS NULL OR (#4 = false)) // { arity: 5 }
+        Map ((#2{any} AND #3{any})) // { arity: 5 }
+          Get l65 // { arity: 4 }
     cte l67 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l66
+      Distinct project=[#0] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Get l66 // { arity: 5 }
     cte l68 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l67
-          Get l57
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %1:l57[×]ef » %0:l67[×]ef
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l67 // { arity: 1 }
+          Get l57 // { arity: 1 }
     cte l69 =
-      Union
-        Get l68
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l68
-            Get l67
+      Union // { arity: 2 }
+        Get l68 // { arity: 2 }
+        Map (false) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l68 // { arity: 2 }
+            Get l67 // { arity: 1 }
     cte l70 =
-      Project (#0, #1, #3)
-        Join on=(#1 = #2) type=differential
-          ArrangeBy keys=[[#1]]
-            Project (#0, #1)
-              Get l66
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l69
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l69
-                  Get l67
+      Project (#0, #1, #3{any}) // { arity: 3 }
+        Join on=(#1 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UK » %0:l66[#1]Kenf
+          ArrangeBy keys=[[#1]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Get l66 // { arity: 5 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l69 // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l69 // { arity: 2 }
+                  Get l67 // { arity: 1 }
     cte l71 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l70
+      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+        Get l70 // { arity: 3 }
     cte l72 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l71
+      Distinct project=[#0] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Get l71 // { arity: 3 }
     cte l73 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        Project (#0, #1)
-          Filter (#2 = 2)
-            Reduce group_by=[#0, #1] aggregates=[count(*)]
-              CrossJoin type=differential
-                ArrangeBy keys=[[]]
-                  Get l72
-                Get l62
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        Project (#0, #1) // { arity: 2 }
+          Filter (#2{count} = 2) // { arity: 3 }
+            Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+              CrossJoin type=differential // { arity: 2 }
+                implementation
+                  %1:l62[×]ef » %0:l72[×]ef
+                ArrangeBy keys=[[]] // { arity: 1 }
+                  Get l72 // { arity: 1 }
+                Get l62 // { arity: 1 }
     cte l74 =
-      Union
-        Get l73
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l73
-            Get l72
+      Union // { arity: 2 }
+        Get l73 // { arity: 2 }
+        Map (false) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l73 // { arity: 2 }
+            Get l72 // { arity: 1 }
     cte l75 =
-      Project (#0, #1, #3)
-        Join on=(#1 = #2) type=differential
-          ArrangeBy keys=[[#1]]
-            Project (#0, #1)
-              Get l71
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l74
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l74
-                  Get l72
+      Project (#0, #1, #3{any}) // { arity: 3 }
+        Join on=(#1 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UK » %0:l71[#1]Kenf
+          ArrangeBy keys=[[#1]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Get l71 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l74 // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l74 // { arity: 2 }
+                  Get l72 // { arity: 1 }
     cte l76 =
-      Filter ((#2) IS NULL OR (#2 = false))
-        Get l75
+      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+        Get l75 // { arity: 3 }
     cte l77 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l76
+      Distinct project=[#0] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Get l76 // { arity: 3 }
     cte l78 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l77
-          Get l62
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %1:l62[×]ef » %0:l77[×]ef
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l77 // { arity: 1 }
+          Get l62 // { arity: 1 }
     cte l79 =
-      Union
-        Get l78
-        Map (false)
-          Union
-            Negate
-              Project (#0)
-                Get l78
-            Get l77
+      Union // { arity: 2 }
+        Get l78 // { arity: 2 }
+        Map (false) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l78 // { arity: 2 }
+            Get l77 // { arity: 1 }
     cte l80 =
-      Project (#1, #3, #4)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Filter (#0) IS NOT NULL
-              Get l0
-          ArrangeBy keys=[[#0]]
-            TopK group_by=[#0] order_by=[#1 asc nulls_last, #2 asc nulls_last] limit=1
-              Map (translate(#0, "AKQT98765432J", "ABCDEFGHIJKLM"))
-                Union
-                  Project (#0, #3)
-                    Filter #2
-                      Map (1)
-                        Get l49
-                  Project (#0, #3)
-                    Filter #2
-                      Map (2)
-                        Get l54
-                  Project (#0, #4)
-                    Filter #2 AND #3
-                      Map (3)
-                        Get l65
-                  Project (#0, #3)
-                    Filter #2
-                      Map (4)
-                        Get l70
-                  Project (#0, #3)
-                    Filter #2
-                      Map (5)
-                        Get l75
-                  Project (#0, #4)
-                    Map (case when #3 then 6 else 7 end)
-                      Join on=(#1 = #2) type=differential
-                        ArrangeBy keys=[[#1]]
-                          Project (#0, #1)
-                            Get l76
-                        ArrangeBy keys=[[#0]]
-                          Union
-                            Get l79
-                            Map (null)
-                              Union
-                                Negate
-                                  Project (#0)
-                                    Get l79
-                                Get l77
+      Project (#1, #3, #4) // { arity: 3 }
+        Join on=(#0 = #2) type=differential // { arity: 5 }
+          implementation
+            %1[#0]UK » %0:l0[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 3 }
+            TopK group_by=[#0] order_by=[#1 asc nulls_last, #2 asc nulls_last] limit=1 // { arity: 3 }
+              Map (translate(#0, "AKQT98765432J", "ABCDEFGHIJKLM")) // { arity: 3 }
+                Union // { arity: 2 }
+                  Project (#0, #3) // { arity: 2 }
+                    Filter #2{any} // { arity: 4 }
+                      Map (1) // { arity: 4 }
+                        Get l49 // { arity: 3 }
+                  Project (#0, #3) // { arity: 2 }
+                    Filter #2{any} // { arity: 4 }
+                      Map (2) // { arity: 4 }
+                        Get l54 // { arity: 3 }
+                  Project (#0, #4) // { arity: 2 }
+                    Filter #2{any} AND #3{any} // { arity: 5 }
+                      Map (3) // { arity: 5 }
+                        Get l65 // { arity: 4 }
+                  Project (#0, #3) // { arity: 2 }
+                    Filter #2{any} // { arity: 4 }
+                      Map (4) // { arity: 4 }
+                        Get l70 // { arity: 3 }
+                  Project (#0, #3) // { arity: 2 }
+                    Filter #2{any} // { arity: 4 }
+                      Map (5) // { arity: 4 }
+                        Get l75 // { arity: 3 }
+                  Project (#0, #4) // { arity: 2 }
+                    Map (case when #3{any} then 6 else 7 end) // { arity: 5 }
+                      Join on=(#1 = #2) type=differential // { arity: 4 }
+                        implementation
+                          %1[#0]UK » %0:l76[#1]Kenf
+                        ArrangeBy keys=[[#1]] // { arity: 2 }
+                          Project (#0, #1) // { arity: 2 }
+                            Get l76 // { arity: 3 }
+                        ArrangeBy keys=[[#0]] // { arity: 2 }
+                          Union // { arity: 2 }
+                            Get l79 // { arity: 2 }
+                            Map (null) // { arity: 2 }
+                              Union // { arity: 1 }
+                                Negate // { arity: 1 }
+                                  Project (#0) // { arity: 1 }
+                                    Get l79 // { arity: 2 }
+                                Get l77 // { arity: 1 }
     cte l81 =
-      Reduce aggregates=[sum(#0)]
-        Project (#0)
-          Filter ((#1 < #3) OR ((#1 = #3) AND (#2 <= #4)))
-            CrossJoin type=differential
-              ArrangeBy keys=[[]]
-                Get l80
-              ArrangeBy keys=[[]]
-                Project (#1, #2)
-                  Get l80
-  Return
-    CrossJoin type=differential
-      ArrangeBy keys=[[]]
-        Project (#1)
-          Map (bigint_to_integer(#0))
-            Union
-              Get l40
-              Map (null)
-                Union
-                  Negate
-                    Project ()
-                      Get l40
-                  Constant
+      Reduce aggregates=[sum(#0)] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter ((#1 < #3) OR ((#1 = #3) AND (#2 <= #4))) // { arity: 5 }
+            CrossJoin type=differential // { arity: 5 }
+              implementation
+                %0:l80[×] » %1:l80[×]
+              ArrangeBy keys=[[]] // { arity: 3 }
+                Get l80 // { arity: 3 }
+              ArrangeBy keys=[[]] // { arity: 2 }
+                Project (#1, #2) // { arity: 2 }
+                  Get l80 // { arity: 3 }
+  Return // { arity: 2 }
+    CrossJoin type=differential // { arity: 2 }
+      implementation
+        %0[×]U » %1[×]U
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Map (bigint_to_integer(#0{sum})) // { arity: 2 }
+            Union // { arity: 1 }
+              Get l40 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l40 // { arity: 1 }
+                  Constant // { arity: 0 }
                     - ()
-      ArrangeBy keys=[[]]
-        Project (#1)
-          Map (bigint_to_integer(#0))
-            Union
-              Get l81
-              Map (null)
-                Union
-                  Negate
-                    Project ()
-                      Get l81
-                  Constant
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Map (bigint_to_integer(#0{sum})) // { arity: 2 }
+            Union // { arity: 1 }
+              Get l81 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l81 // { arity: 1 }
+                  Constant // { arity: 0 }
                     - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1208.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1208.slt
@@ -20,7 +20,8 @@ CREATE TABLE paths (state TEXT, left TEXT, right TEXT);
 # no data
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
     route(step TEXT, steps INT) AS (
         SELECT substring(input, steps, 1), steps
         FROM steps_input, generate_series(1, length(input)) steps
@@ -68,28 +69,32 @@ SELECT * FROM pos2 WHERE substring(state, 3, 1) = 'Z';
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Union
-        Project (#0, #0, #3)
-          Filter ("A" = substr(#0, 3, 1))
-            Map (0)
-              ReadStorage materialize.public.paths
-        Project (#3, #8, #9)
-          Map (case when (#7 = "L") then #1 else case when (#7 = "R") then #2 else "???" end end, (#5 + 1))
-            Join on=(#0 = #4 AND #6 = (1 + (#5 % 263))) type=delta
-              ArrangeBy keys=[[#0]]
-                Filter ("Z" != substr(#0, 3, 1))
-                  ReadStorage materialize.public.paths
-              ArrangeBy keys=[[#1], [(1 + (#2 % 263))]]
-                Filter ("Z" != substr(#1, 3, 1))
-                  Get l0
-              ArrangeBy keys=[[#0]]
-                Project (#1, #2)
-                  Map (substr(#0, #1, 1))
-                    FlatMap generate_series(1, char_length(#0), 1)
-                      ReadStorage materialize.public.steps_input
-  Return
-    Filter ("Z" = substr(#1, 3, 1))
-      Get l0
+      Union // { arity: 3 }
+        Project (#0{state}, #0{state}, #3) // { arity: 3 }
+          Filter ("A" = substr(#0{state}, 3, 1)) // { arity: 4 }
+            Map (0) // { arity: 4 }
+              ReadStorage materialize.public.paths // { arity: 3 }
+        Project (#3, #8, #9) // { arity: 3 }
+          Map (case when (#7 = "L") then #1{"left"} else case when (#7 = "R") then #2{"right"} else "???" end end, (#5 + 1)) // { arity: 10 }
+            Join on=(#0{state} = #4 AND #6 = (1 + (#5 % 263))) type=delta // { arity: 8 }
+              implementation
+                %0:paths » %1:l0[#1]Kf » %2[#0]K
+                %1:l0 » %0:paths[#0]Kf » %2[#0]K
+                %2 » %1:l0[(1 + (#2 % 263))]Kf » %0:paths[#0]Kf
+              ArrangeBy keys=[[#0{state}]] // { arity: 3 }
+                Filter ("Z" != substr(#0{state}, 3, 1)) // { arity: 3 }
+                  ReadStorage materialize.public.paths // { arity: 3 }
+              ArrangeBy keys=[[#1], [(1 + (#2 % 263))]] // { arity: 3 }
+                Filter ("Z" != substr(#1{state}, 3, 1)) // { arity: 3 }
+                  Get l0 // { arity: 3 }
+              ArrangeBy keys=[[#0]] // { arity: 2 }
+                Project (#1, #2) // { arity: 2 }
+                  Map (substr(#0{input}, #1, 1)) // { arity: 3 }
+                    FlatMap generate_series(1, char_length(#0{input}), 1) // { arity: 2 }
+                      ReadStorage materialize.public.steps_input // { arity: 1 }
+  Return // { arity: 3 }
+    Filter ("Z" = substr(#1{state}, 3, 1)) // { arity: 3 }
+      Get l0 // { arity: 3 }
 
 Source materialize.public.steps_input
 Source materialize.public.paths

--- a/test/sqllogictest/advent-of-code/2023/aoc_1209.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1209.slt
@@ -17,7 +17,8 @@ CREATE TABLE input (input TEXT);
 # no data
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 30)
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 30)
 
     lines (line TEXT, line_no INT) AS (
         SELECT regexp_split_to_array(input, '\n')[i], i
@@ -65,100 +66,108 @@ SELECT * FROM part1, part2;
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Map ((#2 + 1))
-        Get l3
+      Map ((#2 + 1)) // { arity: 5 }
+        Get l3 // { arity: 4 }
     cte l1 =
-      Project (#0..=#4, #6)
-        Join on=(#1 = #5 AND #3 = #7 AND #6 = (#2 + 1)) type=differential
-          ArrangeBy keys=[[#1, (#2 + 1), #3]]
-            Project (#0..=#3)
-              Filter (#4 <= 21) AND (#1) IS NOT NULL AND (#4 > #3)
-                Get l0
-          ArrangeBy keys=[[#1..=#3]]
-            Filter (#2 <= 21) AND (#1) IS NOT NULL AND (#2 > #3)
-              Get l3
+      Project (#0..=#4, #6) // { arity: 6 }
+        Join on=(#1 = #5 AND #3 = #7 AND #6 = (#2 + 1)) type=differential // { arity: 8 }
+          implementation
+            %0:l0[#1, (#2 + 1), #3]KKKif » %1:l3[#1..=#3]KKKiif
+          ArrangeBy keys=[[#1, (#2 + 1), #3]] // { arity: 4 }
+            Project (#0..=#3) // { arity: 4 }
+              Filter (#4 <= 21) AND (#1) IS NOT NULL AND (#4 > #3) // { arity: 5 }
+                Get l0 // { arity: 5 }
+          ArrangeBy keys=[[#1..=#3]] // { arity: 4 }
+            Filter (#2 <= 21) AND (#1) IS NOT NULL AND (#2 > #3) // { arity: 4 }
+              Get l3 // { arity: 4 }
     cte l2 =
-      Distinct project=[#0..=#2]
-        Project (#1, #3, #5)
-          Get l1
+      Distinct project=[#0..=#2] // { arity: 3 }
+        Project (#1, #3, #5) // { arity: 3 }
+          Get l1 // { arity: 6 }
     cte [recursion_limit=30, return_at_limit] l3 =
-      Distinct project=[#0..=#3]
-        Union
-          Project (#3, #0, #2, #4)
-            Map (text_to_integer(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), integer_to_bigint(#2))), 1)
-              FlatMap generate_series(1, (regexp_split_to_array[" ", case_insensitive=false](#1) array_length 1), 1)
-                Project (#1, #2)
-                  Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                    FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-                      ReadStorage materialize.public.input
-          Project (#8..=#11)
-            Map ((coalesce(#4, 0) - coalesce(#0, 0)), coalesce(#1, #5), coalesce((#2 + 1), #6), (coalesce(#3, #7) + 1))
-              Union
-                Project (#4..=#7, #0..=#3)
-                  Map (null, null, null, null)
-                    Union
-                      Negate
-                        Project (#0..=#3)
-                          Join on=(#1 = #4 AND #2 = #6 AND #3 = #5) type=differential
-                            ArrangeBy keys=[[#1..=#3]]
-                              Filter (#2 <= 21) AND (#1) IS NOT NULL AND (#2 > #3) AND (0 != (coalesce(#0, 0) - 0))
-                                Get l3
-                            ArrangeBy keys=[[#0, #2, #1]]
-                              Get l2
-                      Filter (#2 <= 21) AND (#2 > #3) AND (0 != (coalesce(#0, 0) - 0))
-                        Get l3
-                Map (null, null, null, null)
-                  Union
-                    Negate
-                      Project (#0..=#3)
-                        Join on=(#1 = #4 AND #3 = #5 AND #6 = (#2 + 1)) type=differential
-                          ArrangeBy keys=[[#1, #3, (#2 + 1)]]
-                            Project (#0..=#3)
-                              Filter (#4 <= 21) AND (#1) IS NOT NULL AND (#4 > #3) AND (0 != (0 - coalesce(#0, 0)))
-                                Get l0
-                          ArrangeBy keys=[[#0..=#2]]
-                            Get l2
-                    Project (#0..=#3)
-                      Filter (#4 <= 21) AND (#4 > #3) AND (0 != (0 - coalesce(#0, 0)))
-                        Get l0
-                Project (#0..=#4, #1, #5, #3)
-                  Filter (0 != (coalesce(#4, 0) - coalesce(#0, 0)))
-                    Get l1
-  Return
+      Distinct project=[#0..=#3] // { arity: 4 }
+        Union // { arity: 4 }
+          Project (#3, #0, #2, #4) // { arity: 4 }
+            Map (text_to_integer(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), integer_to_bigint(#2))), 1) // { arity: 5 }
+              FlatMap generate_series(1, (regexp_split_to_array[" ", case_insensitive=false](#1) array_length 1), 1) // { arity: 3 }
+                Project (#1, #2) // { arity: 2 }
+                  Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
+                    FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
+                      ReadStorage materialize.public.input // { arity: 1 }
+          Project (#8..=#11) // { arity: 4 }
+            Map ((coalesce(#4, 0) - coalesce(#0, 0)), coalesce(#1, #5), coalesce((#2 + 1), #6), (coalesce(#3, #7) + 1)) // { arity: 12 }
+              Union // { arity: 8 }
+                Project (#4..=#7, #0..=#3) // { arity: 8 }
+                  Map (null, null, null, null) // { arity: 8 }
+                    Union // { arity: 4 }
+                      Negate // { arity: 4 }
+                        Project (#0..=#3) // { arity: 4 }
+                          Join on=(#1 = #4 AND #2 = #6 AND #3 = #5) type=differential // { arity: 7 }
+                            implementation
+                              %1:l2[#0, #2, #1]UKKK » %0:l3[#1..=#3]KKKif
+                            ArrangeBy keys=[[#1..=#3]] // { arity: 4 }
+                              Filter (#2 <= 21) AND (#1) IS NOT NULL AND (#2 > #3) AND (0 != (coalesce(#0, 0) - 0)) // { arity: 4 }
+                                Get l3 // { arity: 4 }
+                            ArrangeBy keys=[[#0, #2, #1]] // { arity: 3 }
+                              Get l2 // { arity: 3 }
+                      Filter (#2 <= 21) AND (#2 > #3) AND (0 != (coalesce(#0, 0) - 0)) // { arity: 4 }
+                        Get l3 // { arity: 4 }
+                Map (null, null, null, null) // { arity: 8 }
+                  Union // { arity: 4 }
+                    Negate // { arity: 4 }
+                      Project (#0..=#3) // { arity: 4 }
+                        Join on=(#1 = #4 AND #3 = #5 AND #6 = (#2 + 1)) type=differential // { arity: 7 }
+                          implementation
+                            %1:l2[#0..=#2]UKKK » %0:l0[#1, #3, (#2 + 1)]KKKif
+                          ArrangeBy keys=[[#1, #3, (#2 + 1)]] // { arity: 4 }
+                            Project (#0..=#3) // { arity: 4 }
+                              Filter (#4 <= 21) AND (#1) IS NOT NULL AND (#4 > #3) AND (0 != (0 - coalesce(#0, 0))) // { arity: 5 }
+                                Get l0 // { arity: 5 }
+                          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                            Get l2 // { arity: 3 }
+                    Project (#0..=#3) // { arity: 4 }
+                      Filter (#4 <= 21) AND (#4 > #3) AND (0 != (0 - coalesce(#0, 0))) // { arity: 5 }
+                        Get l0 // { arity: 5 }
+                Project (#0..=#4, #1, #5, #3) // { arity: 8 }
+                  Filter (0 != (coalesce(#4, 0) - coalesce(#0, 0))) // { arity: 6 }
+                    Get l1 // { arity: 6 }
+  Return // { arity: 2 }
     With
       cte l4 =
-        Reduce aggregates=[sum(#0)]
-          Project (#0)
-            Filter (#2 = 21)
-              Get l3
+        Reduce aggregates=[sum(#0)] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Filter (#2 = 21) // { arity: 4 }
+              Get l3 // { arity: 4 }
       cte l5 =
-        Reduce aggregates=[sum((power(-1, integer_to_double((#1 + 1))) * integer_to_double(#0)))]
-          Project (#0, #2)
-            Filter (#2 = #3)
-              Get l3
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Union
-            Get l4
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l4
-                Constant
+        Reduce aggregates=[sum((power(-1, integer_to_double((#1 + 1))) * integer_to_double(#0)))] // { arity: 1 }
+          Project (#0, #2) // { arity: 2 }
+            Filter (#2 = #3) // { arity: 4 }
+              Get l3 // { arity: 4 }
+    Return // { arity: 2 }
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0[×]U » %1[×]U
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l4 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l4 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
-        ArrangeBy keys=[[]]
-          Project (#1)
-            Map (f64toi64(#0))
-              Union
-                Get l5
-                Map (null)
-                  Union
-                    Negate
-                      Project ()
-                        Get l5
-                    Constant
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Map (f64toi64(#0{sum})) // { arity: 2 }
+              Union // { arity: 1 }
+                Get l5 // { arity: 1 }
+                Map (null) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l5 // { arity: 1 }
+                    Constant // { arity: 0 }
                       - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1210.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1210.slt
@@ -223,7 +223,8 @@ SELECT * FROM part1, part2;
 1439  2073
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
 
     lines(line TEXT, row_no INT) AS (
         SELECT regexp_split_to_array(input, '\n')[i], i
@@ -372,225 +373,249 @@ SELECT * FROM part1, part2;
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#0, #2, #3)
-        Map (substr(#1, #2, 1))
-          FlatMap generate_series(1, char_length(#1), 1)
-            Project (#1, #2)
-              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-                  ReadStorage materialize.public.input
+      Project (#0, #2, #3) // { arity: 3 }
+        Map (substr(#1, #2, 1)) // { arity: 4 }
+          FlatMap generate_series(1, char_length(#1), 1) // { arity: 3 }
+            Project (#1, #2) // { arity: 2 }
+              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
+                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
+                  ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Map ((#2 = "-"), case when #3 then #0 else case when (#2 = "|") then (#0 - 1) else case when (#2 = "F") then (#0 + 1) else case when (#2 = "L") then (#0 - 1) else case when (#2 = "J") then #0 else case when (#2 = "7") then #0 else null end end end end end end, case when #3 then (#1 - 1) else case when (#2 = "|") then #1 else case when (#2 = "F") then #1 else case when (#2 = "L") then #1 else case when (#2 = "J") then (#1 - 1) else case when (#2 = "7") then (#1 - 1) else null end end end end end end)
-        Get l0
+      Map ((#2 = "-"), case when #3 then #0 else case when (#2 = "|") then (#0 - 1) else case when (#2 = "F") then (#0 + 1) else case when (#2 = "L") then (#0 - 1) else case when (#2 = "J") then #0 else case when (#2 = "7") then #0 else null end end end end end end, case when #3 then (#1 - 1) else case when (#2 = "|") then #1 else case when (#2 = "F") then #1 else case when (#2 = "L") then #1 else case when (#2 = "J") then (#1 - 1) else case when (#2 = "7") then (#1 - 1) else null end end end end end end) // { arity: 6 }
+        Get l0 // { arity: 3 }
     cte l2 =
-      Map ((#2 = "-"), case when #3 then #0 else case when (#2 = "|") then (#0 + 1) else case when (#2 = "F") then #0 else case when (#2 = "L") then #0 else case when (#2 = "J") then (#0 - 1) else case when (#2 = "7") then (#0 + 1) else null end end end end end end, case when #3 then (#1 + 1) else case when (#2 = "|") then #1 else case when (#2 = "F") then (#1 + 1) else case when (#2 = "L") then (#1 + 1) else case when (#2 = "J") then #1 else case when (#2 = "7") then #1 else null end end end end end end)
-        Get l0
+      Map ((#2 = "-"), case when #3 then #0 else case when (#2 = "|") then (#0 + 1) else case when (#2 = "F") then #0 else case when (#2 = "L") then #0 else case when (#2 = "J") then (#0 - 1) else case when (#2 = "7") then (#0 + 1) else null end end end end end end, case when #3 then (#1 + 1) else case when (#2 = "|") then #1 else case when (#2 = "F") then (#1 + 1) else case when (#2 = "L") then (#1 + 1) else case when (#2 = "J") then #1 else case when (#2 = "7") then #1 else null end end end end end end) // { arity: 6 }
+        Get l0 // { arity: 3 }
     cte l3 =
-      Project (#0..=#3)
-        Filter (#4 = 2)
-          Reduce group_by=[#0..=#3] aggregates=[count(*)]
-            Union
-              Project (#0, #1, #4, #5)
-                Filter (#2 != ".") AND (#2 != "S")
-                  Get l1
-              Project (#0, #1, #4, #5)
-                Filter (#2 != ".") AND (#2 != "S")
-                  Get l2
-              Project (#4, #5, #0, #1)
-                Filter (#2 != ".") AND (#2 != "S") AND (#4) IS NOT NULL AND (#5) IS NOT NULL
-                  Get l1
-              Project (#4, #5, #0, #1)
-                Filter (#2 != ".") AND (#2 != "S") AND (#4) IS NOT NULL AND (#5) IS NOT NULL
-                  Get l2
-              Project (#0, #1, #3, #1)
-                Filter (#2 = "S")
-                  Map ((#0 + 1))
-                    Get l0
-              Project (#0, #1, #0, #3)
-                Filter (#2 = "S")
-                  Map ((#1 + 1))
-                    Get l0
-              Project (#0, #1, #3, #1)
-                Filter (#2 = "S")
-                  Map ((#0 - 1))
-                    Get l0
-              Project (#0, #1, #0, #3)
-                Filter (#2 = "S")
-                  Map ((#1 - 1))
-                    Get l0
+      Project (#0..=#3) // { arity: 4 }
+        Filter (#4{count} = 2) // { arity: 5 }
+          Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
+            Union // { arity: 4 }
+              Project (#0, #1, #4, #5) // { arity: 4 }
+                Filter (#2 != ".") AND (#2 != "S") // { arity: 6 }
+                  Get l1 // { arity: 6 }
+              Project (#0, #1, #4, #5) // { arity: 4 }
+                Filter (#2 != ".") AND (#2 != "S") // { arity: 6 }
+                  Get l2 // { arity: 6 }
+              Project (#4, #5, #0, #1) // { arity: 4 }
+                Filter (#2 != ".") AND (#2 != "S") AND (#4) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
+                  Get l1 // { arity: 6 }
+              Project (#4, #5, #0, #1) // { arity: 4 }
+                Filter (#2 != ".") AND (#2 != "S") AND (#4) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
+                  Get l2 // { arity: 6 }
+              Project (#0, #1, #3, #1) // { arity: 4 }
+                Filter (#2 = "S") // { arity: 4 }
+                  Map ((#0 + 1)) // { arity: 4 }
+                    Get l0 // { arity: 3 }
+              Project (#0, #1, #0, #3) // { arity: 4 }
+                Filter (#2 = "S") // { arity: 4 }
+                  Map ((#1 + 1)) // { arity: 4 }
+                    Get l0 // { arity: 3 }
+              Project (#0, #1, #3, #1) // { arity: 4 }
+                Filter (#2 = "S") // { arity: 4 }
+                  Map ((#0 - 1)) // { arity: 4 }
+                    Get l0 // { arity: 3 }
+              Project (#0, #1, #0, #3) // { arity: 4 }
+                Filter (#2 = "S") // { arity: 4 }
+                  Map ((#1 - 1)) // { arity: 4 }
+                    Get l0 // { arity: 3 }
     cte l4 =
-      Project (#0, #1)
-        Filter (#2 = "S")
-          Get l0
+      Project (#0, #1) // { arity: 2 }
+        Filter (#2 = "S") // { arity: 3 }
+          Get l0 // { arity: 3 }
     cte l5 =
-      ArrangeBy keys=[[#0, #1]]
-        Get l3
+      ArrangeBy keys=[[#0, #1]] // { arity: 4 }
+        Get l3 // { arity: 4 }
     cte l6 =
-      Distinct project=[#0, #1]
-        Union
-          Get l4
-          Project (#4, #5)
-            Join on=(#0 = #2 AND #1 = #3) type=differential
-              ArrangeBy keys=[[#0, #1]]
-                Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-                  Get l6
-              Get l5
+      Distinct project=[#0, #1] // { arity: 2 }
+        Union // { arity: 2 }
+          Get l4 // { arity: 2 }
+          Project (#4, #5) // { arity: 2 }
+            Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 6 }
+              implementation
+                %0:l6[#0, #1]UKK » %1:l5[#0, #1]KK
+              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
+                  Get l6 // { arity: 2 }
+              Get l5 // { arity: 4 }
     cte l7 =
-      Reduce aggregates=[count(*)]
-        Project ()
-          Get l6
+      Reduce aggregates=[count(*)] // { arity: 1 }
+        Project () // { arity: 0 }
+          Get l6 // { arity: 2 }
     cte l8 =
-      Distinct project=[#0..=#2]
-        Union
-          Project (#0, #1, #4)
-            Join on=(#0 = #2 AND #1 = #3) type=differential
-              ArrangeBy keys=[[#0, #1]]
-                Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-                  Get l6
-              ArrangeBy keys=[[#0, #1]]
-                Filter (#2 != "S")
-                  Get l0
-          Project (#0, #1, #8)
-            Map (case when ((#0 = #0) AND (#0 = (#6 + 1)) AND (#1 = #7) AND (#1 = (#1 + 1))) then "J" else case when ((#0 = #0) AND (#0 = #6) AND (#1 = (#1 + 1)) AND (#1 = (#7 - 1))) then "-" else case when ((#0 = #0) AND (#0 = (#6 - 1)) AND (#1 = #7) AND (#1 = (#1 + 1))) then "7" else case when ((#0 = #6) AND (#0 = (#0 + 1)) AND (#1 = #1) AND (#1 = (#7 - 1))) then "L" else case when ((#0 = (#0 + 1)) AND (#0 = (#6 - 1)) AND (#1 = #1) AND (#1 = #7)) then "|" else case when ((#0 = #0) AND (#0 = #6) AND (#1 = (#1 - 1)) AND (#1 = (#7 - 1))) then "F" else "???" end end end end end end)
-              Join on=(#0 = #2 = #4 AND #1 = #3 = #5) type=delta
-                ArrangeBy keys=[[#0, #1]]
-                  Get l4
-                ArrangeBy keys=[[#0, #1]]
-                  Project (#0, #1)
-                    Get l3
-                Get l5
+      Distinct project=[#0..=#2] // { arity: 3 }
+        Union // { arity: 3 }
+          Project (#0, #1, #4) // { arity: 3 }
+            Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 5 }
+              implementation
+                %0:l6[#0, #1]UKK » %1:l0[#0, #1]KKf
+              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
+                  Get l6 // { arity: 2 }
+              ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+                Filter (#2 != "S") // { arity: 3 }
+                  Get l0 // { arity: 3 }
+          Project (#0, #1, #8) // { arity: 3 }
+            Map (case when ((#0 = #0) AND (#0 = (#6 + 1)) AND (#1 = #7) AND (#1 = (#1 + 1))) then "J" else case when ((#0 = #0) AND (#0 = #6) AND (#1 = (#1 + 1)) AND (#1 = (#7 - 1))) then "-" else case when ((#0 = #0) AND (#0 = (#6 - 1)) AND (#1 = #7) AND (#1 = (#1 + 1))) then "7" else case when ((#0 = #6) AND (#0 = (#0 + 1)) AND (#1 = #1) AND (#1 = (#7 - 1))) then "L" else case when ((#0 = (#0 + 1)) AND (#0 = (#6 - 1)) AND (#1 = #1) AND (#1 = #7)) then "|" else case when ((#0 = #0) AND (#0 = #6) AND (#1 = (#1 - 1)) AND (#1 = (#7 - 1))) then "F" else "???" end end end end end end) // { arity: 9 }
+              Join on=(#0 = #2 = #4 AND #1 = #3 = #5) type=delta // { arity: 8 }
+                implementation
+                  %0:l4 » %1:l3[#0, #1]KK » %2:l5[#0, #1]KK
+                  %1:l3 » %0:l4[#0, #1]KKef » %2:l5[#0, #1]KK
+                  %2:l5 » %0:l4[#0, #1]KKef » %1:l3[#0, #1]KK
+                ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                  Get l4 // { arity: 2 }
+                ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                  Project (#0, #1) // { arity: 2 }
+                    Get l3 // { arity: 4 }
+                Get l5 // { arity: 4 }
     cte l9 =
-      ArrangeBy keys=[[#0, #1]]
-        Get l17
+      ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+        Get l17 // { arity: 3 }
     cte l10 =
-      Project (#0..=#2, #5)
-        Join on=(#0 = #3 AND #1 = #4) type=differential
-          Get l9
-          ArrangeBy keys=[[#0, #1]]
-            Get l8
+      Project (#0..=#2, #5) // { arity: 4 }
+        Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 6 }
+          implementation
+            %0:l9[#0, #1]KK » %1:l8[#0, #1]KK
+          Get l9 // { arity: 3 }
+          ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+            Get l8 // { arity: 3 }
     cte l11 =
-      Project (#2, #3, #6, #7)
-        Map ((#0 + 1), (#1 + 1))
-          Join on=(#0 = #4 AND #1 = #5) type=differential
-            ArrangeBy keys=[[#0, #1]]
-              Union
-                Map (null)
-                  Union
-                    Negate
-                      Project (#0..=#2)
-                        Join on=(#0 = #3 AND #1 = #4) type=differential
-                          Get l9
-                          ArrangeBy keys=[[#0, #1]]
-                            Distinct project=[#0, #1]
-                              Project (#0, #1)
-                                Get l10
-                    Get l17
-                Get l10
-            ArrangeBy keys=[[#0, #1]]
-              Project (#0, #1)
-                Get l0
+      Project (#2, #3, #6, #7) // { arity: 4 }
+        Map ((#0 + 1), (#1 + 1)) // { arity: 8 }
+          Join on=(#0 = #4 AND #1 = #5) type=differential // { arity: 6 }
+            implementation
+              %0[#0, #1]KK » %1:l0[#0, #1]KK
+            ArrangeBy keys=[[#0, #1]] // { arity: 4 }
+              Union // { arity: 4 }
+                Map (null) // { arity: 4 }
+                  Union // { arity: 3 }
+                    Negate // { arity: 3 }
+                      Project (#0..=#2) // { arity: 3 }
+                        Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 5 }
+                          implementation
+                            %1[#0, #1]UKKA » %0:l9[#0, #1]KK
+                          Get l9 // { arity: 3 }
+                          ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                            Distinct project=[#0, #1] // { arity: 2 }
+                              Project (#0, #1) // { arity: 2 }
+                                Get l10 // { arity: 4 }
+                    Get l17 // { arity: 3 }
+                Get l10 // { arity: 4 }
+            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Get l0 // { arity: 3 }
     cte l12 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l11
+      Distinct project=[#0] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Get l11 // { arity: 4 }
     cte l13 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        FlatMap wrap1("J", "-", "|", "F")
-          Get l12
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        FlatMap wrap1("J", "-", "|", "F") // { arity: 2 }
+          Get l12 // { arity: 1 }
     cte l14 =
-      ArrangeBy keys=[[#0]]
-        Get l12
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Get l12 // { arity: 1 }
     cte l15 =
-      Union
-        Get l13
-        Project (#0, #2)
-          Map (false)
-            Join on=(#0 = #1) type=differential
-              ArrangeBy keys=[[#0]]
-                Union
-                  Negate
-                    Project (#0)
-                      Get l13
-                  Get l12
-              Get l14
+      Union // { arity: 2 }
+        Get l13 // { arity: 2 }
+        Project (#0, #2) // { arity: 2 }
+          Map (false) // { arity: 3 }
+            Join on=(#0 = #1) type=differential // { arity: 2 }
+              implementation
+                %1:l14[#0]UK » %0[#0]K
+              ArrangeBy keys=[[#0]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l13 // { arity: 2 }
+                  Get l12 // { arity: 1 }
+              Get l14 // { arity: 1 }
     cte l16 =
-      Union
-        Get l15
-        Map (error("more than one record produced in subquery"))
-          Project (#0)
-            Filter (#1 > 1)
-              Reduce group_by=[#0] aggregates=[count(*)]
-                Project (#0)
-                  Get l15
+      Union // { arity: 2 }
+        Get l15 // { arity: 2 }
+        Map (error("more than one record produced in subquery")) // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Filter (#1{count} > 1) // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                Project (#0) // { arity: 1 }
+                  Get l15 // { arity: 2 }
     cte l17 =
-      Distinct project=[#0..=#2]
-        Union
-          Project (#0, #1, #3)
-            Filter ((#0 = 1) OR (#1 = 1))
-              Map (false)
-                Get l0
-          Project (#2, #3, #6)
-            Map (case when #5 then NOT(#0) else #0 end)
-              Join on=(#1 = #4) type=differential
-                ArrangeBy keys=[[#1]]
-                  Get l11
-                ArrangeBy keys=[[#0]]
-                  Union
-                    Get l16
-                    Project (#0, #2)
-                      Map (null)
-                        Join on=(#0 = #1) type=differential
-                          ArrangeBy keys=[[#0]]
-                            Union
-                              Negate
-                                Distinct project=[#0]
-                                  Project (#0)
-                                    Get l16
-                              Get l12
-                          Get l14
-  Return
+      Distinct project=[#0..=#2] // { arity: 3 }
+        Union // { arity: 3 }
+          Project (#0, #1, #3) // { arity: 3 }
+            Filter ((#0 = 1) OR (#1 = 1)) // { arity: 4 }
+              Map (false) // { arity: 4 }
+                Get l0 // { arity: 3 }
+          Project (#2, #3, #6) // { arity: 3 }
+            Map (case when #5{any} then NOT(#0) else #0 end) // { arity: 7 }
+              Join on=(#1 = #4) type=differential // { arity: 6 }
+                implementation
+                  %0:l11[#1]K » %1[#0]K
+                ArrangeBy keys=[[#1]] // { arity: 4 }
+                  Get l11 // { arity: 4 }
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Union // { arity: 2 }
+                    Get l16 // { arity: 2 }
+                    Project (#0, #2) // { arity: 2 }
+                      Map (null) // { arity: 3 }
+                        Join on=(#0 = #1) type=differential // { arity: 2 }
+                          implementation
+                            %1:l14[#0]UK » %0[#0]K
+                          ArrangeBy keys=[[#0]] // { arity: 1 }
+                            Union // { arity: 1 }
+                              Negate // { arity: 1 }
+                                Distinct project=[#0] // { arity: 1 }
+                                  Project (#0) // { arity: 1 }
+                                    Get l16 // { arity: 2 }
+                              Get l12 // { arity: 1 }
+                          Get l14 // { arity: 1 }
+  Return // { arity: 2 }
     With
       cte l18 =
-        Filter (#2 = true)
-          Get l17
+        Filter (#2 = true) // { arity: 3 }
+          Get l17 // { arity: 3 }
       cte l19 =
-        Reduce aggregates=[count(*)]
-          Union
-            Negate
-              Project ()
-                Join on=(#0 = #2 AND #1 = #3) type=differential
-                  ArrangeBy keys=[[#0, #1]]
-                    Project (#0, #1)
-                      Get l18
-                  ArrangeBy keys=[[#0, #1]]
-                    Distinct project=[#0, #1]
-                      Project (#0, #1)
-                        Get l8
-            Project ()
-              Get l18
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Project (#1)
-            Map ((#0 / 2))
-              Union
-                Get l7
-                Map (0)
-                  Union
-                    Negate
-                      Project ()
-                        Get l7
-                    Constant
+        Reduce aggregates=[count(*)] // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                  implementation
+                    %1[#0, #1]UKKA » %0:l18[#0, #1]UKKef
+                  ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                    Project (#0, #1) // { arity: 2 }
+                      Get l18 // { arity: 3 }
+                  ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                    Distinct project=[#0, #1] // { arity: 2 }
+                      Project (#0, #1) // { arity: 2 }
+                        Get l8 // { arity: 3 }
+            Project () // { arity: 0 }
+              Get l18 // { arity: 3 }
+    Return // { arity: 2 }
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0[×]U » %1[×]U
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Map ((#0{count} / 2)) // { arity: 2 }
+              Union // { arity: 1 }
+                Get l7 // { arity: 1 }
+                Map (0) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l7 // { arity: 1 }
+                    Constant // { arity: 0 }
                       - ()
-        ArrangeBy keys=[[]]
-          Union
-            Get l19
-            Map (0)
-              Union
-                Negate
-                  Project ()
-                    Get l19
-                Constant
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l19 // { arity: 1 }
+            Map (0) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l19 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1211.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1211.slt
@@ -138,7 +138,8 @@ SELECT * FROM part1, part2;
 129655908  129655908
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
 
     lines(line TEXT, r INT) AS (
         SELECT regexp_split_to_array(input, '\n')[i], i
@@ -201,138 +202,152 @@ SELECT * FROM part1, part2;
 Explained Query:
   With
     cte l0 =
-      Project (#0, #2, #3)
-        Map (substr(#1, #2, 1))
-          FlatMap generate_series(1, char_length(#1), 1)
-            Project (#1, #2)
-              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-                  ReadStorage materialize.public.input
+      Project (#0, #2, #3) // { arity: 3 }
+        Map (substr(#1, #2, 1)) // { arity: 4 }
+          FlatMap generate_series(1, char_length(#1), 1) // { arity: 3 }
+            Project (#1, #2) // { arity: 2 }
+              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
+                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
+                  ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Project (#0, #1)
-        Filter (#2 = "#")
-          Get l0
+      Project (#0, #1) // { arity: 2 }
+        Filter (#2 = "#") // { arity: 3 }
+          Get l0 // { arity: 3 }
     cte l2 =
-      Distinct project=[#0, #1]
-        Get l1
+      Distinct project=[#0, #1] // { arity: 2 }
+        Get l1 // { arity: 2 }
     cte l3 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l2
+      Distinct project=[#0] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l2 // { arity: 2 }
     cte l4 =
-      Reduce group_by=[#0] aggregates=[count(*)]
-        Project (#0)
-          Filter (#1 < #0)
-            CrossJoin type=differential
-              ArrangeBy keys=[[]]
-                Get l3
-              ArrangeBy keys=[[]]
-                Project (#0)
-                  Filter (#1 = 0)
-                    Reduce group_by=[#0] aggregates=[count((null OR ((#1) IS NOT NULL AND (#1 = "#"))))]
-                      Project (#0, #2)
-                        Get l0
+      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+        Project (#0) // { arity: 1 }
+          Filter (#1 < #0) // { arity: 2 }
+            CrossJoin type=differential // { arity: 2 }
+              implementation
+                %1[×]ef » %0:l3[×]ef
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Get l3 // { arity: 1 }
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Project (#0) // { arity: 1 }
+                  Filter (#1{count} = 0) // { arity: 2 }
+                    Reduce group_by=[#0] aggregates=[count((null OR ((#1) IS NOT NULL AND (#1 = "#"))))] // { arity: 2 }
+                      Project (#0, #2) // { arity: 2 }
+                        Get l0 // { arity: 3 }
     cte l5 =
-      Union
-        Get l4
-        Map (0)
-          Union
-            Negate
-              Project (#0)
-                Get l4
-            Get l3
+      Union // { arity: 2 }
+        Get l4 // { arity: 2 }
+        Map (0) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l4 // { arity: 2 }
+            Get l3 // { arity: 1 }
     cte l6 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l2
+      Distinct project=[#0] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Get l2 // { arity: 2 }
     cte l7 =
-      Reduce group_by=[#0] aggregates=[count(*)]
-        Project (#0)
-          Filter (#1 < #0)
-            CrossJoin type=differential
-              ArrangeBy keys=[[]]
-                Get l6
-              ArrangeBy keys=[[]]
-                Project (#0)
-                  Filter (#1 = 0)
-                    Reduce group_by=[#0] aggregates=[count((null OR ((#1) IS NOT NULL AND (#1 = "#"))))]
-                      Project (#1, #2)
-                        Get l0
+      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+        Project (#0) // { arity: 1 }
+          Filter (#1 < #0) // { arity: 2 }
+            CrossJoin type=differential // { arity: 2 }
+              implementation
+                %1[×]ef » %0:l6[×]ef
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Get l6 // { arity: 1 }
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Project (#0) // { arity: 1 }
+                  Filter (#1{count} = 0) // { arity: 2 }
+                    Reduce group_by=[#0] aggregates=[count((null OR ((#1) IS NOT NULL AND (#1 = "#"))))] // { arity: 2 }
+                      Project (#1, #2) // { arity: 2 }
+                        Get l0 // { arity: 3 }
     cte l8 =
-      Union
-        Get l7
-        Map (0)
-          Union
-            Negate
-              Project (#0)
-                Get l7
-            Get l6
+      Union // { arity: 2 }
+        Get l7 // { arity: 2 }
+        Map (0) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l7 // { arity: 2 }
+            Get l6 // { arity: 1 }
     cte l9 =
-      Project (#0, #1, #3, #5)
-        Join on=(#0 = #2 AND #1 = #4) type=delta
-          ArrangeBy keys=[[#0], [#1]]
-            Get l1
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l5
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l5
-                  Get l3
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l8
-              Map (null)
-                Union
-                  Negate
-                    Project (#0)
-                      Get l8
-                  Get l6
+      Project (#0, #1, #3{count}, #5{count}) // { arity: 4 }
+        Join on=(#0 = #2 AND #1 = #4) type=delta // { arity: 6 }
+          implementation
+            %0:l1 » %1[#0]UK » %2[#0]UK
+            %1 » %0:l1[#0]Kef » %2[#0]UK
+            %2 » %0:l1[#1]Kef » %1[#0]UK
+          ArrangeBy keys=[[#0], [#1]] // { arity: 2 }
+            Get l1 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l5 // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l5 // { arity: 2 }
+                  Get l3 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l8 // { arity: 2 }
+              Map (null) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l8 // { arity: 2 }
+                  Get l6 // { arity: 1 }
     cte l10 =
-      ArrangeBy keys=[[]]
-        Project (#4, #5)
-          Map (bigint_to_integer((integer_to_bigint(#0) + #2)), bigint_to_integer((integer_to_bigint(#1) + #3)))
-            Get l9
+      ArrangeBy keys=[[]] // { arity: 2 }
+        Project (#4, #5) // { arity: 2 }
+          Map (bigint_to_integer((integer_to_bigint(#0) + #2{count})), bigint_to_integer((integer_to_bigint(#1) + #3{count}))) // { arity: 6 }
+            Get l9 // { arity: 4 }
     cte l11 =
-      Reduce aggregates=[sum((abs((#0 - #2)) + abs((#1 - #3))))]
-        Filter ((#0 < #2) OR ((#0 = #2) AND (#1 < #3)))
-          CrossJoin type=differential
-            Get l10
-            Get l10
+      Reduce aggregates=[sum((abs((#0 - #2)) + abs((#1 - #3))))] // { arity: 1 }
+        Filter ((#0 < #2) OR ((#0 = #2) AND (#1 < #3))) // { arity: 4 }
+          CrossJoin type=differential // { arity: 4 }
+            implementation
+              %0:l10[×] » %1:l10[×]
+            Get l10 // { arity: 2 }
+            Get l10 // { arity: 2 }
     cte l12 =
-      ArrangeBy keys=[[]]
-        Project (#4, #5)
-          Map (bigint_to_integer((integer_to_bigint(#0) + (999999 * #2))), bigint_to_integer((integer_to_bigint(#1) + (999999 * #3))))
-            Get l9
+      ArrangeBy keys=[[]] // { arity: 2 }
+        Project (#4, #5) // { arity: 2 }
+          Map (bigint_to_integer((integer_to_bigint(#0) + (999999 * #2{count}))), bigint_to_integer((integer_to_bigint(#1) + (999999 * #3{count})))) // { arity: 6 }
+            Get l9 // { arity: 4 }
     cte l13 =
-      Reduce aggregates=[sum((abs((#0 - #2)) + abs((#1 - #3))))]
-        Filter ((#0 < #2) OR ((#0 = #2) AND (#1 < #3)))
-          CrossJoin type=differential
-            Get l12
-            Get l12
-  Return
-    CrossJoin type=differential
-      ArrangeBy keys=[[]]
-        Union
-          Get l11
-          Map (null)
-            Union
-              Negate
-                Project ()
-                  Get l11
-              Constant
+      Reduce aggregates=[sum((abs((#0 - #2)) + abs((#1 - #3))))] // { arity: 1 }
+        Filter ((#0 < #2) OR ((#0 = #2) AND (#1 < #3))) // { arity: 4 }
+          CrossJoin type=differential // { arity: 4 }
+            implementation
+              %0:l12[×] » %1:l12[×]
+            Get l12 // { arity: 2 }
+            Get l12 // { arity: 2 }
+  Return // { arity: 2 }
+    CrossJoin type=differential // { arity: 2 }
+      implementation
+        %0[×]U » %1[×]U
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Union // { arity: 1 }
+          Get l11 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l11 // { arity: 1 }
+              Constant // { arity: 0 }
                 - ()
-      ArrangeBy keys=[[]]
-        Union
-          Get l13
-          Map (null)
-            Union
-              Negate
-                Project ()
-                  Get l13
-              Constant
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Union // { arity: 1 }
+          Get l13 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l13 // { arity: 1 }
+              Constant // { arity: 0 }
                 - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1212.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1212.slt
@@ -17,7 +17,8 @@ CREATE TABLE input (input TEXT);
 # no input data
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
 
     lines(r INT, characters TEXT, springs TEXT) AS (
         SELECT
@@ -93,84 +94,94 @@ SELECT SUM(count) FROM counts;
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#1, #3, #4)
-        Map (regexp_split_to_array[" ", case_insensitive=false](array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1))), (array_index(#2, 1) || "."), array_index(#2, 2))
-          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-            ReadStorage materialize.public.input
+      Project (#1, #3, #4) // { arity: 3 }
+        Map (regexp_split_to_array[" ", case_insensitive=false](array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))), (array_index(#2, 1) || "."), array_index(#2, 2)) // { arity: 5 }
+          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
+            ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Project (#0, #2, #3)
-        Map (substr(#1, #2, 1))
-          FlatMap generate_series(1, char_length(#1), 1)
-            Project (#0, #1)
-              Get l0
+      Project (#0, #2, #3) // { arity: 3 }
+        Map (substr(#1, #2, 1)) // { arity: 4 }
+          FlatMap generate_series(1, char_length(#1), 1) // { arity: 3 }
+            Project (#0, #1) // { arity: 2 }
+              Get l0 // { arity: 3 }
     cte l2 =
-      ArrangeBy keys=[[#0, #1]]
-        Project (#0, #1)
-          Filter (#2 != "#")
-            Get l1
+      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+        Project (#0, #1) // { arity: 2 }
+          Filter (#2 != "#") // { arity: 3 }
+            Get l1 // { arity: 3 }
     cte l3 =
-      Project (#0..=#2, #5)
-        Join on=(#0 = #3 = #6 AND #4 = (#2 + 1) AND #7 = ((#1 + #5) + 1)) type=delta
-          ArrangeBy keys=[[#0], [#0, (#2 + 1)]]
-            Get l5
-          ArrangeBy keys=[[#0, #1]]
-            Project (#0, #2, #3)
-              Map (text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2))))
-                FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#1) array_length 1), 1)
-                  Project (#0, #2)
-                    Get l0
-          Get l2
+      Project (#0..=#2, #5) // { arity: 4 }
+        Join on=(#0 = #3 = #6 AND #4 = (#2 + 1) AND #7 = ((#1 + #5) + 1)) type=delta // { arity: 8 }
+          implementation
+            %0:l5 » %1[#0, #1]KK » %2:l2[#0, #1]KKf
+            %1 » %0:l5[#0, (#2 + 1)]KK » %2:l2[#0, #1]KKf
+            %2:l2 » %0:l5[#0]K » %1[#0, #1]KK
+          ArrangeBy keys=[[#0], [#0, (#2 + 1)]] // { arity: 3 }
+            Get l5 // { arity: 3 }
+          ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+            Project (#0, #2, #3) // { arity: 3 }
+              Map (text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2)))) // { arity: 4 }
+                FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#1) array_length 1), 1) // { arity: 3 }
+                  Project (#0, #2) // { arity: 2 }
+                    Get l0 // { arity: 3 }
+          Get l2 // { arity: 2 }
     cte l4 =
-      Distinct project=[#0..=#2]
-        Project (#0, #1, #3)
-          Get l3
+      Distinct project=[#0..=#2] // { arity: 3 }
+        Project (#0, #1, #3) // { arity: 3 }
+          Get l3 // { arity: 4 }
     cte l5 =
-      Union
-        Project (#0, #3, #4)
-          Map (0, 0)
-            Get l0
-        Project (#0, #5, #2)
-          Map ((#1 + 1))
-            Join on=(#0 = #3 AND #4 = (#1 + 1)) type=differential
-              ArrangeBy keys=[[#0, (#1 + 1)]]
-                Get l5
-              Get l2
-        Project (#0, #7, #8)
-          Map (((#1 + #3) + 1), (#2 + 1))
-            Join on=(#0 = #4 AND #1 = #5 AND #3 = #6) type=differential
-              ArrangeBy keys=[[#0, #1, #3]]
-                Get l3
-              ArrangeBy keys=[[#0..=#2]]
-                Union
-                  Negate
-                    Distinct project=[#0..=#2]
-                      Project (#0..=#2)
-                        Filter (#4 >= (#1 + 1)) AND (#4 <= (#1 + #2))
-                          Join on=(#0 = #3) type=differential
-                            ArrangeBy keys=[[#0]]
-                              Get l4
-                            ArrangeBy keys=[[#0]]
-                              Project (#0, #1)
-                                Filter (#2 = ".")
-                                  Get l1
-                  Get l4
-  Return
+      Union // { arity: 3 }
+        Project (#0, #3, #4) // { arity: 3 }
+          Map (0, 0) // { arity: 5 }
+            Get l0 // { arity: 3 }
+        Project (#0, #5, #2) // { arity: 3 }
+          Map ((#1 + 1)) // { arity: 6 }
+            Join on=(#0 = #3 AND #4 = (#1 + 1)) type=differential // { arity: 5 }
+              implementation
+                %1:l2[#0, #1]KKf » %0:l5[#0, (#1 + 1)]KKf
+              ArrangeBy keys=[[#0, (#1 + 1)]] // { arity: 3 }
+                Get l5 // { arity: 3 }
+              Get l2 // { arity: 2 }
+        Project (#0, #7, #8) // { arity: 3 }
+          Map (((#1 + #3) + 1), (#2 + 1)) // { arity: 9 }
+            Join on=(#0 = #4 AND #1 = #5 AND #3 = #6) type=differential // { arity: 7 }
+              implementation
+                %0:l3[#0, #1, #3]KKK » %1[#0..=#2]KKK
+              ArrangeBy keys=[[#0, #1, #3]] // { arity: 4 }
+                Get l3 // { arity: 4 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                Union // { arity: 3 }
+                  Negate // { arity: 3 }
+                    Distinct project=[#0..=#2] // { arity: 3 }
+                      Project (#0..=#2) // { arity: 3 }
+                        Filter (#4 >= (#1 + 1)) AND (#4 <= (#1 + #2)) // { arity: 5 }
+                          Join on=(#0 = #3) type=differential // { arity: 5 }
+                            implementation
+                              %1:l1[#0]Kef » %0:l4[#0]Kef
+                            ArrangeBy keys=[[#0]] // { arity: 3 }
+                              Get l4 // { arity: 3 }
+                            ArrangeBy keys=[[#0]] // { arity: 2 }
+                              Project (#0, #1) // { arity: 2 }
+                                Filter (#2 = ".") // { arity: 3 }
+                                  Get l1 // { arity: 3 }
+                  Get l4 // { arity: 3 }
+  Return // { arity: 1 }
     With
       cte l6 =
-        Reduce aggregates=[sum(#0)]
-          Project (#3)
-            TopK group_by=[#0] order_by=[#1 desc nulls_first, #2 desc nulls_first] limit=1
-              Reduce group_by=[#0..=#2] aggregates=[count(*)]
-                Get l5
-    Return
-      Union
-        Get l6
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l6
-            Constant
+        Reduce aggregates=[sum(#0{count})] // { arity: 1 }
+          Project (#3{count}) // { arity: 1 }
+            TopK group_by=[#0] order_by=[#1 desc nulls_first, #2 desc nulls_first] limit=1 // { arity: 4 }
+              Reduce group_by=[#0..=#2] aggregates=[count(*)] // { arity: 4 }
+                Get l5 // { arity: 3 }
+    Return // { arity: 1 }
+      Union // { arity: 1 }
+        Get l6 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l6 // { arity: 1 }
+            Constant // { arity: 0 }
               - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1213.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1213.slt
@@ -226,7 +226,8 @@ SELECT * FROM part1, part2;
 100  16
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
 
     blocks(b INT, block TEXT) AS (
         SELECT b, regexp_split_to_array(input, '\n\n')[b] as block
@@ -317,174 +318,191 @@ SELECT * FROM part1, part2;
 Explained Query:
   With
     cte l0 =
-      Project (#0, #2, #3)
-        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#1), integer_to_bigint(#2)))
-          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#1) array_length 1), 1)
-            Project (#1, #2)
-              Map (array_index(regexp_split_to_array["\n\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                FlatMap generate_series(1, (regexp_split_to_array["\n\n", case_insensitive=false](#0) array_length 1), 1)
-                  ReadStorage materialize.public.input
+      Project (#0, #2, #3) // { arity: 3 }
+        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#1), integer_to_bigint(#2))) // { arity: 4 }
+          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#1) array_length 1), 1) // { arity: 3 }
+            Project (#1, #2) // { arity: 2 }
+              Map (array_index(regexp_split_to_array["\n\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
+                FlatMap generate_series(1, (regexp_split_to_array["\n\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
+                  ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Project (#0, #1, #3, #4)
-        Map (substr(#2, #3, 1))
-          FlatMap generate_series(1, char_length(#2), 1)
-            Get l0
+      Project (#0, #1, #3, #4) // { arity: 4 }
+        Map (substr(#2, #3, 1)) // { arity: 5 }
+          FlatMap generate_series(1, char_length(#2), 1) // { arity: 4 }
+            Get l0 // { arity: 3 }
     cte l2 =
-      Distinct project=[#0, #1]
-        Project (#0, #1)
-          Get l1
+      Distinct project=[#0, #1] // { arity: 2 }
+        Project (#0, #1) // { arity: 2 }
+          Get l1 // { arity: 4 }
     cte l3 =
-      Distinct project=[#0, #1]
-        Project (#0, #2)
-          Get l1
+      Distinct project=[#0, #1] // { arity: 2 }
+        Project (#0, #2) // { arity: 2 }
+          Get l1 // { arity: 4 }
     cte l4 =
-      ArrangeBy keys=[[#0]]
-        Get l2
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Get l2 // { arity: 2 }
     cte l5 =
-      Reduce aggregates=[sum((#0 - 1))]
-        Union
-          Negate
-            Project (#1)
-              Distinct project=[#0, #1]
-                Project (#0, #1)
-                  Filter (#3 > 1)
-                    Reduce group_by=[#0, #1, abs(((2 * #2) - ((2 * #1) - 1)))] aggregates=[count(distinct #3)]
-                      Project (#0, #1, #3, #4)
-                        Join on=(#0 = #2) type=differential
-                          Get l4
-                          ArrangeBy keys=[[#0]]
-                            Get l0
-          Project (#1)
-            Get l2
+      Reduce aggregates=[sum((#0 - 1))] // { arity: 1 }
+        Union // { arity: 1 }
+          Negate // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Distinct project=[#0, #1] // { arity: 2 }
+                Project (#0, #1) // { arity: 2 }
+                  Filter (#3{count} > 1) // { arity: 4 }
+                    Reduce group_by=[#0, #1, abs(((2 * #2) - ((2 * #1) - 1)))] aggregates=[count(distinct #3)] // { arity: 4 }
+                      Project (#0, #1, #3, #4) // { arity: 4 }
+                        Join on=(#0 = #2) type=differential // { arity: 5 }
+                          implementation
+                            %0:l4[#0]K » %1:l0[#0]K
+                          Get l4 // { arity: 2 }
+                          ArrangeBy keys=[[#0]] // { arity: 3 }
+                            Get l0 // { arity: 3 }
+          Project (#1) // { arity: 1 }
+            Get l2 // { arity: 2 }
     cte l6 =
-      Union
-        Get l5
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l5
-            Constant
+      Union // { arity: 1 }
+        Get l5 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l5 // { arity: 1 }
+            Constant // { arity: 0 }
               - ()
     cte l7 =
-      ArrangeBy keys=[[#0]]
-        Get l3
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Get l3 // { arity: 2 }
     cte l8 =
-      Reduce aggregates=[sum((#0 - 1))]
-        Union
-          Negate
-            Project (#1)
-              Distinct project=[#0, #1]
-                Project (#0, #1)
-                  Filter (#3 > 1)
-                    Reduce group_by=[#0, #1, abs(((2 * #2) - ((2 * #1) - 1)))] aggregates=[count(distinct #3)]
-                      Project (#0, #1, #3, #4)
-                        Join on=(#0 = #2) type=differential
-                          Get l7
-                          ArrangeBy keys=[[#0]]
-                            Reduce group_by=[#0, #2] aggregates=[string_agg[order_by=[#0 asc nulls_last]](row(row(#3, ""), #1))]
-                              Get l1
-          Project (#1)
-            Get l3
+      Reduce aggregates=[sum((#0 - 1))] // { arity: 1 }
+        Union // { arity: 1 }
+          Negate // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Distinct project=[#0, #1] // { arity: 2 }
+                Project (#0, #1) // { arity: 2 }
+                  Filter (#3{count_string_agg} > 1) // { arity: 4 }
+                    Reduce group_by=[#0, #1, abs(((2 * #2) - ((2 * #1) - 1)))] aggregates=[count(distinct #3{string_agg})] // { arity: 4 }
+                      Project (#0, #1, #3, #4{string_agg}) // { arity: 4 }
+                        Join on=(#0 = #2) type=differential // { arity: 5 }
+                          implementation
+                            %0:l7[#0]K » %1[#0]K
+                          Get l7 // { arity: 2 }
+                          ArrangeBy keys=[[#0]] // { arity: 3 }
+                            Reduce group_by=[#0, #2] aggregates=[string_agg[order_by=[#0 asc nulls_last]](row(row(#3, ""), #1))] // { arity: 3 }
+                              Get l1 // { arity: 4 }
+          Project (#1) // { arity: 1 }
+            Get l3 // { arity: 2 }
     cte l9 =
-      Union
-        Get l8
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l8
-            Constant
+      Union // { arity: 1 }
+        Get l8 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l8 // { arity: 1 }
+            Constant // { arity: 0 }
               - ()
     cte l10 =
-      Reduce aggregates=[sum((#0 - 1))]
-        Project (#1)
-          Filter (#2 = 1)
-            Reduce group_by=[#0, #1] aggregates=[count(*)]
-              Project (#0, #1)
-                Filter (#5 != #9) AND (#3 < #7)
-                  Join on=(#0 = #2 = #6 AND #4 = #8 AND abs(((2 * #3) - ((2 * #1) - 1))) = abs(((2 * #7) - ((2 * #1) - 1)))) type=delta
-                    Get l4
-                    ArrangeBy keys=[[#0], [#0, #2]]
-                      Get l1
-                    ArrangeBy keys=[[#0, #2]]
-                      Get l1
+      Reduce aggregates=[sum((#0 - 1))] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Filter (#2{count} = 1) // { arity: 3 }
+            Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+              Project (#0, #1) // { arity: 2 }
+                Filter (#5 != #9) AND (#3 < #7) // { arity: 10 }
+                  Join on=(#0 = #2 = #6 AND #4 = #8 AND abs(((2 * #3) - ((2 * #1) - 1))) = abs(((2 * #7) - ((2 * #1) - 1)))) type=delta // { arity: 10 }
+                    implementation
+                      %0:l4 » %1:l1[#0]K » %2:l1[#0, #2]KK
+                      %1:l1 » %2:l1[#0, #2]KK » %0:l4[#0]K
+                      %2:l1 » %1:l1[#0, #2]KK » %0:l4[#0]K
+                    Get l4 // { arity: 2 }
+                    ArrangeBy keys=[[#0], [#0, #2]] // { arity: 4 }
+                      Get l1 // { arity: 4 }
+                    ArrangeBy keys=[[#0, #2]] // { arity: 4 }
+                      Get l1 // { arity: 4 }
     cte l11 =
-      Union
-        Get l10
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l10
-            Constant
+      Union // { arity: 1 }
+        Get l10 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l10 // { arity: 1 }
+            Constant // { arity: 0 }
               - ()
     cte l12 =
-      Reduce aggregates=[sum((#0 - 1))]
-        Project (#1)
-          Filter (#2 = 1)
-            Reduce group_by=[#0, #1] aggregates=[count(*)]
-              Project (#0, #1)
-                Filter (#5 != #9) AND (#4 < #8)
-                  Join on=(#0 = #2 = #6 AND #3 = #7 AND abs(((2 * #4) - ((2 * #1) - 1))) = abs(((2 * #8) - ((2 * #1) - 1)))) type=delta
-                    Get l7
-                    ArrangeBy keys=[[#0], [#0, #1]]
-                      Get l1
-                    ArrangeBy keys=[[#0, #1]]
-                      Get l1
+      Reduce aggregates=[sum((#0 - 1))] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Filter (#2{count} = 1) // { arity: 3 }
+            Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+              Project (#0, #1) // { arity: 2 }
+                Filter (#5 != #9) AND (#4 < #8) // { arity: 10 }
+                  Join on=(#0 = #2 = #6 AND #3 = #7 AND abs(((2 * #4) - ((2 * #1) - 1))) = abs(((2 * #8) - ((2 * #1) - 1)))) type=delta // { arity: 10 }
+                    implementation
+                      %0:l7 » %1:l1[#0]K » %2:l1[#0, #1]KK
+                      %1:l1 » %2:l1[#0, #1]KK » %0:l7[#0]K
+                      %2:l1 » %1:l1[#0, #1]KK » %0:l7[#0]K
+                    Get l7 // { arity: 2 }
+                    ArrangeBy keys=[[#0], [#0, #1]] // { arity: 4 }
+                      Get l1 // { arity: 4 }
+                    ArrangeBy keys=[[#0, #1]] // { arity: 4 }
+                      Get l1 // { arity: 4 }
     cte l13 =
-      Union
-        Get l12
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l12
-            Constant
+      Union // { arity: 1 }
+        Get l12 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l12 // { arity: 1 }
+            Constant // { arity: 0 }
               - ()
-  Return
-    Project (#4, #5)
-      Map (((coalesce(#0, 0) * 100) + coalesce(#1, 0)), ((coalesce(#2, 0) * 100) + coalesce(#3, 0)))
-        CrossJoin type=delta
-          ArrangeBy keys=[[]]
-            Union
-              Get l6
-              Map (null)
-                Union
-                  Negate
-                    Project ()
-                      Get l6
-                  Constant
+  Return // { arity: 2 }
+    Project (#4, #5) // { arity: 2 }
+      Map (((coalesce(#0{sum}, 0) * 100) + coalesce(#1{sum}, 0)), ((coalesce(#2{sum}, 0) * 100) + coalesce(#3{sum}, 0))) // { arity: 6 }
+        CrossJoin type=delta // { arity: 4 }
+          implementation
+            %0 » %1[×]U » %2[×]U » %3[×]U
+            %1 » %0[×]U » %2[×]U » %3[×]U
+            %2 » %0[×]U » %1[×]U » %3[×]U
+            %3 » %0[×]U » %1[×]U » %2[×]U
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l6 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l6 // { arity: 1 }
+                  Constant // { arity: 0 }
                     - ()
-          ArrangeBy keys=[[]]
-            Union
-              Get l9
-              Map (null)
-                Union
-                  Negate
-                    Project ()
-                      Get l9
-                  Constant
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l9 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l9 // { arity: 1 }
+                  Constant // { arity: 0 }
                     - ()
-          ArrangeBy keys=[[]]
-            Union
-              Get l11
-              Map (null)
-                Union
-                  Negate
-                    Project ()
-                      Get l11
-                  Constant
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l11 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l11 // { arity: 1 }
+                  Constant // { arity: 0 }
                     - ()
-          ArrangeBy keys=[[]]
-            Union
-              Get l13
-              Map (null)
-                Union
-                  Negate
-                    Project ()
-                      Get l13
-                  Constant
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l13 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l13 // { arity: 1 }
+                  Constant // { arity: 0 }
                     - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1214.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1214.slt
@@ -77,7 +77,8 @@ SELECT * FROM part1;
 146
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
 
     lines(r INT, line TEXT) AS (
         SELECT r, regexp_split_to_array(input, '\n')[r] as block
@@ -129,92 +130,96 @@ SELECT * FROM part1;
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#1, #2)
-        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-            ReadStorage materialize.public.input
+      Project (#1, #2) // { arity: 2 }
+        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
+          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
+            ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Project (#0, #2, #3)
-        Map (substr(#1, #2, 1))
-          FlatMap generate_series(1, char_length(#1), 1)
-            Get l0
+      Project (#0, #2, #3) // { arity: 3 }
+        Map (substr(#1, #2, 1)) // { arity: 4 }
+          FlatMap generate_series(1, char_length(#1), 1) // { arity: 3 }
+            Get l0 // { arity: 2 }
     cte l2 =
-      Threshold
-        Union
-          Threshold
-            Union
-              Threshold
-                Union
-                  Get l2
-                  Project (#2, #1, #3)
-                    Map ((#0 - 1), "O")
-                      Get l4
-                  Negate
-                    Project (#2, #1, #3)
-                      Map ((#0 - 1), ".")
-                        Get l4
-              Map (".")
-                Get l4
-              Negate
-                Map ("O")
-                  Get l4
-          Get l1
-          Negate
-            Get l8
+      Threshold // { arity: 3 }
+        Union // { arity: 3 }
+          Threshold // { arity: 3 }
+            Union // { arity: 3 }
+              Threshold // { arity: 3 }
+                Union // { arity: 3 }
+                  Get l2 // { arity: 3 }
+                  Project (#2, #1, #3) // { arity: 3 }
+                    Map ((#0 - 1), "O") // { arity: 4 }
+                      Get l4 // { arity: 2 }
+                  Negate // { arity: 3 }
+                    Project (#2, #1, #3) // { arity: 3 }
+                      Map ((#0 - 1), ".") // { arity: 4 }
+                        Get l4 // { arity: 2 }
+              Map (".") // { arity: 3 }
+                Get l4 // { arity: 2 }
+              Negate // { arity: 3 }
+                Map ("O") // { arity: 3 }
+                  Get l4 // { arity: 2 }
+          Get l1 // { arity: 3 }
+          Negate // { arity: 3 }
+            Get l8 // { arity: 3 }
     cte l3 =
-      Filter (#2 = "O")
-        Get l2
+      Filter (#2 = "O") // { arity: 3 }
+        Get l2 // { arity: 3 }
     cte l4 =
-      Project (#0, #1)
-        Join on=(#0 = (#2 + 1) AND #1 = #3) type=differential
-          ArrangeBy keys=[[#1, #0]]
-            Project (#0, #1)
-              Get l3
-          ArrangeBy keys=[[#1, (#0 + 1)]]
-            Project (#0, #1)
-              Filter (#2 = ".")
-                Get l2
+      Project (#0, #1) // { arity: 2 }
+        Join on=(#0 = (#2 + 1) AND #1 = #3) type=differential // { arity: 4 }
+          implementation
+            %0:l3[#1, #0]KKef » %1:l2[#1, (#0 + 1)]KKef
+          ArrangeBy keys=[[#1, #0]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Get l3 // { arity: 3 }
+          ArrangeBy keys=[[#1, (#0 + 1)]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Filter (#2 = ".") // { arity: 3 }
+                Get l2 // { arity: 3 }
     cte l5 =
-      Reduce aggregates=[max(#0)]
-        Project (#0)
-          Get l0
+      Reduce aggregates=[max(#0)] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l0 // { arity: 2 }
     cte l6 =
-      Union
-        Get l5
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l5
-            Constant
+      Union // { arity: 1 }
+        Get l5 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l5 // { arity: 1 }
+            Constant // { arity: 0 }
               - ()
     cte l7 =
-      Reduce aggregates=[sum(((1 + #1) - #0))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Project (#0)
-              Get l3
-          ArrangeBy keys=[[]]
-            Union
-              Get l6
-              Map (null)
-                Union
-                  Negate
-                    Project ()
-                      Get l6
-                  Constant
+      Reduce aggregates=[sum(((1 + #1{max}) - #0))] // { arity: 1 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %1[×]U » %0:l3[×]ef
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Get l3 // { arity: 3 }
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l6 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l6 // { arity: 1 }
+                  Constant // { arity: 0 }
                     - ()
     cte l8 =
-      Get l1
-  Return
-    Union
-      Get l7
-      Map (null)
-        Union
-          Negate
-            Project ()
-              Get l7
-          Constant
+      Get l1 // { arity: 3 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l7 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l7 // { arity: 1 }
+          Constant // { arity: 0 }
             - ()
 
 Source materialize.public.input
@@ -397,7 +402,8 @@ SELECT * FROM part2;
 105
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 142)
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 142)
 
     lines(r INT, line TEXT) AS (
         SELECT r, regexp_split_to_array(input, '\n')[r] as block
@@ -570,224 +576,234 @@ SELECT * FROM part2;
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#1, #2)
-        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-            ReadStorage materialize.public.input
+      Project (#1, #2) // { arity: 2 }
+        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
+          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
+            ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Project (#0, #2, #3)
-        Map (substr(#1, #2, 1))
-          FlatMap generate_series(1, char_length(#1), 1)
-            Get l0
+      Project (#0, #2, #3) // { arity: 3 }
+        Map (substr(#1, #2, 1)) // { arity: 4 }
+          FlatMap generate_series(1, char_length(#1), 1) // { arity: 3 }
+            Get l0 // { arity: 2 }
     cte [recursion_limit=142, return_at_limit] l2 =
-      Threshold
-        Union
-          Get l18
-          Get l1
-          Negate
-            Get l22
+      Threshold // { arity: 3 }
+        Union // { arity: 3 }
+          Get l18 // { arity: 3 }
+          Get l1 // { arity: 3 }
+          Negate // { arity: 3 }
+            Get l22 // { arity: 3 }
     cte l6 =
       With Mutually Recursive
         cte l3 =
-          Threshold
-            Union
-              Threshold
-                Union
-                  Threshold
-                    Union
-                      Get l3
-                      Project (#2, #1, #3)
-                        Map ((#0 - 1), "O")
-                          Get l4
-                      Negate
-                        Project (#2, #1, #3)
-                          Map ((#0 - 1), ".")
-                            Get l4
-                  Map (".")
-                    Get l4
-                  Negate
-                    Map ("O")
-                      Get l4
-              Get l2
-              Negate
-                Get l5
+          Threshold // { arity: 3 }
+            Union // { arity: 3 }
+              Threshold // { arity: 3 }
+                Union // { arity: 3 }
+                  Threshold // { arity: 3 }
+                    Union // { arity: 3 }
+                      Get l3 // { arity: 3 }
+                      Project (#2, #1, #3) // { arity: 3 }
+                        Map ((#0 - 1), "O") // { arity: 4 }
+                          Get l4 // { arity: 2 }
+                      Negate // { arity: 3 }
+                        Project (#2, #1, #3) // { arity: 3 }
+                          Map ((#0 - 1), ".") // { arity: 4 }
+                            Get l4 // { arity: 2 }
+                  Map (".") // { arity: 3 }
+                    Get l4 // { arity: 2 }
+                  Negate // { arity: 3 }
+                    Map ("O") // { arity: 3 }
+                      Get l4 // { arity: 2 }
+              Get l2 // { arity: 3 }
+              Negate // { arity: 3 }
+                Get l5 // { arity: 3 }
         cte l4 =
-          Project (#0, #1)
-            Join on=(#0 = (#2 + 1) AND #1 = #3) type=differential
-              ArrangeBy keys=[[#1, #0]]
-                Project (#0, #1)
-                  Filter (#2 = "O")
-                    Get l3
-              ArrangeBy keys=[[#1, (#0 + 1)]]
-                Project (#0, #1)
-                  Filter (#2 = ".")
-                    Get l3
+          Project (#0, #1) // { arity: 2 }
+            Join on=(#0 = (#2 + 1) AND #1 = #3) type=differential // { arity: 4 }
+              implementation
+                %0:l3[#1, #0]KKef » %1:l3[#1, (#0 + 1)]KKef
+              ArrangeBy keys=[[#1, #0]] // { arity: 2 }
+                Project (#0, #1) // { arity: 2 }
+                  Filter (#2 = "O") // { arity: 3 }
+                    Get l3 // { arity: 3 }
+              ArrangeBy keys=[[#1, (#0 + 1)]] // { arity: 2 }
+                Project (#0, #1) // { arity: 2 }
+                  Filter (#2 = ".") // { arity: 3 }
+                    Get l3 // { arity: 3 }
         cte l5 =
-          Get l2
-      Return
-        Get l3
+          Get l2 // { arity: 3 }
+      Return // { arity: 3 }
+        Get l3 // { arity: 3 }
     cte l10 =
       With Mutually Recursive
         cte l7 =
-          Threshold
-            Union
-              Threshold
-                Union
-                  Threshold
-                    Union
-                      Get l7
-                      Project (#0, #2, #3)
-                        Map ((#1 - 1), "O")
-                          Get l8
-                      Negate
-                        Project (#0, #2, #3)
-                          Map ((#1 - 1), ".")
-                            Get l8
-                  Map (".")
-                    Get l8
-                  Negate
-                    Map ("O")
-                      Get l8
-              Get l6
-              Negate
-                Get l9
+          Threshold // { arity: 3 }
+            Union // { arity: 3 }
+              Threshold // { arity: 3 }
+                Union // { arity: 3 }
+                  Threshold // { arity: 3 }
+                    Union // { arity: 3 }
+                      Get l7 // { arity: 3 }
+                      Project (#0, #2, #3) // { arity: 3 }
+                        Map ((#1 - 1), "O") // { arity: 4 }
+                          Get l8 // { arity: 2 }
+                      Negate // { arity: 3 }
+                        Project (#0, #2, #3) // { arity: 3 }
+                          Map ((#1 - 1), ".") // { arity: 4 }
+                            Get l8 // { arity: 2 }
+                  Map (".") // { arity: 3 }
+                    Get l8 // { arity: 2 }
+                  Negate // { arity: 3 }
+                    Map ("O") // { arity: 3 }
+                      Get l8 // { arity: 2 }
+              Get l6 // { arity: 3 }
+              Negate // { arity: 3 }
+                Get l9 // { arity: 3 }
         cte l8 =
-          Project (#0, #1)
-            Join on=(#0 = #2 AND #1 = (#3 + 1)) type=differential
-              ArrangeBy keys=[[#0, #1]]
-                Project (#0, #1)
-                  Filter (#2 = "O")
-                    Get l7
-              ArrangeBy keys=[[#0, (#1 + 1)]]
-                Project (#0, #1)
-                  Filter (#2 = ".")
-                    Get l7
+          Project (#0, #1) // { arity: 2 }
+            Join on=(#0 = #2 AND #1 = (#3 + 1)) type=differential // { arity: 4 }
+              implementation
+                %0:l7[#0, #1]KKef » %1:l7[#0, (#1 + 1)]KKef
+              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                Project (#0, #1) // { arity: 2 }
+                  Filter (#2 = "O") // { arity: 3 }
+                    Get l7 // { arity: 3 }
+              ArrangeBy keys=[[#0, (#1 + 1)]] // { arity: 2 }
+                Project (#0, #1) // { arity: 2 }
+                  Filter (#2 = ".") // { arity: 3 }
+                    Get l7 // { arity: 3 }
         cte l9 =
-          Get l6
-      Return
-        Get l7
+          Get l6 // { arity: 3 }
+      Return // { arity: 3 }
+        Get l7 // { arity: 3 }
     cte l14 =
       With Mutually Recursive
         cte l11 =
-          Threshold
-            Union
-              Threshold
-                Union
-                  Threshold
-                    Union
-                      Get l11
-                      Project (#2, #1, #3)
-                        Map ((#0 + 1), "O")
-                          Get l12
-                      Negate
-                        Project (#2, #1, #3)
-                          Map ((#0 + 1), ".")
-                            Get l12
-                  Map (".")
-                    Get l12
-                  Negate
-                    Map ("O")
-                      Get l12
-              Get l10
-              Negate
-                Get l13
+          Threshold // { arity: 3 }
+            Union // { arity: 3 }
+              Threshold // { arity: 3 }
+                Union // { arity: 3 }
+                  Threshold // { arity: 3 }
+                    Union // { arity: 3 }
+                      Get l11 // { arity: 3 }
+                      Project (#2, #1, #3) // { arity: 3 }
+                        Map ((#0 + 1), "O") // { arity: 4 }
+                          Get l12 // { arity: 2 }
+                      Negate // { arity: 3 }
+                        Project (#2, #1, #3) // { arity: 3 }
+                          Map ((#0 + 1), ".") // { arity: 4 }
+                            Get l12 // { arity: 2 }
+                  Map (".") // { arity: 3 }
+                    Get l12 // { arity: 2 }
+                  Negate // { arity: 3 }
+                    Map ("O") // { arity: 3 }
+                      Get l12 // { arity: 2 }
+              Get l10 // { arity: 3 }
+              Negate // { arity: 3 }
+                Get l13 // { arity: 3 }
         cte l12 =
-          Project (#0, #1)
-            Join on=(#0 = (#2 - 1) AND #1 = #3) type=differential
-              ArrangeBy keys=[[#1, #0]]
-                Project (#0, #1)
-                  Filter (#2 = "O")
-                    Get l11
-              ArrangeBy keys=[[#1, (#0 - 1)]]
-                Project (#0, #1)
-                  Filter (#2 = ".")
-                    Get l11
+          Project (#0, #1) // { arity: 2 }
+            Join on=(#0 = (#2 - 1) AND #1 = #3) type=differential // { arity: 4 }
+              implementation
+                %0:l11[#1, #0]KKef » %1:l11[#1, (#0 - 1)]KKef
+              ArrangeBy keys=[[#1, #0]] // { arity: 2 }
+                Project (#0, #1) // { arity: 2 }
+                  Filter (#2 = "O") // { arity: 3 }
+                    Get l11 // { arity: 3 }
+              ArrangeBy keys=[[#1, (#0 - 1)]] // { arity: 2 }
+                Project (#0, #1) // { arity: 2 }
+                  Filter (#2 = ".") // { arity: 3 }
+                    Get l11 // { arity: 3 }
         cte l13 =
-          Get l10
-      Return
-        Get l11
+          Get l10 // { arity: 3 }
+      Return // { arity: 3 }
+        Get l11 // { arity: 3 }
     cte [recursion_limit=142, return_at_limit] l18 =
       With Mutually Recursive
         cte l15 =
-          Threshold
-            Union
-              Threshold
-                Union
-                  Threshold
-                    Union
-                      Get l15
-                      Project (#0, #2, #3)
-                        Map ((#1 + 1), "O")
-                          Get l16
-                      Negate
-                        Project (#0, #2, #3)
-                          Map ((#1 + 1), ".")
-                            Get l16
-                  Map (".")
-                    Get l16
-                  Negate
-                    Map ("O")
-                      Get l16
-              Get l14
-              Negate
-                Get l17
+          Threshold // { arity: 3 }
+            Union // { arity: 3 }
+              Threshold // { arity: 3 }
+                Union // { arity: 3 }
+                  Threshold // { arity: 3 }
+                    Union // { arity: 3 }
+                      Get l15 // { arity: 3 }
+                      Project (#0, #2, #3) // { arity: 3 }
+                        Map ((#1 + 1), "O") // { arity: 4 }
+                          Get l16 // { arity: 2 }
+                      Negate // { arity: 3 }
+                        Project (#0, #2, #3) // { arity: 3 }
+                          Map ((#1 + 1), ".") // { arity: 4 }
+                            Get l16 // { arity: 2 }
+                  Map (".") // { arity: 3 }
+                    Get l16 // { arity: 2 }
+                  Negate // { arity: 3 }
+                    Map ("O") // { arity: 3 }
+                      Get l16 // { arity: 2 }
+              Get l14 // { arity: 3 }
+              Negate // { arity: 3 }
+                Get l17 // { arity: 3 }
         cte l16 =
-          Project (#0, #1)
-            Join on=(#0 = #2 AND #1 = (#3 - 1)) type=differential
-              ArrangeBy keys=[[#0, #1]]
-                Project (#0, #1)
-                  Filter (#2 = "O")
-                    Get l15
-              ArrangeBy keys=[[#0, (#1 - 1)]]
-                Project (#0, #1)
-                  Filter (#2 = ".")
-                    Get l15
+          Project (#0, #1) // { arity: 2 }
+            Join on=(#0 = #2 AND #1 = (#3 - 1)) type=differential // { arity: 4 }
+              implementation
+                %0:l15[#0, #1]KKef » %1:l15[#0, (#1 - 1)]KKef
+              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                Project (#0, #1) // { arity: 2 }
+                  Filter (#2 = "O") // { arity: 3 }
+                    Get l15 // { arity: 3 }
+              ArrangeBy keys=[[#0, (#1 - 1)]] // { arity: 2 }
+                Project (#0, #1) // { arity: 2 }
+                  Filter (#2 = ".") // { arity: 3 }
+                    Get l15 // { arity: 3 }
         cte l17 =
-          Get l14
-      Return
-        Get l15
+          Get l14 // { arity: 3 }
+      Return // { arity: 3 }
+        Get l15 // { arity: 3 }
     cte l19 =
-      Reduce aggregates=[max(#0)]
-        Project (#0)
-          Get l0
+      Reduce aggregates=[max(#0)] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l0 // { arity: 2 }
     cte l20 =
-      Union
-        Get l19
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l19
-            Constant
+      Union // { arity: 1 }
+        Get l19 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l19 // { arity: 1 }
+            Constant // { arity: 0 }
               - ()
     cte l21 =
-      Reduce aggregates=[sum(((1 + #1) - #0))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Project (#0)
-              Filter (#2 = "O")
-                Get l18
-          ArrangeBy keys=[[]]
-            Union
-              Get l20
-              Map (null)
-                Union
-                  Negate
-                    Project ()
-                      Get l20
-                  Constant
+      Reduce aggregates=[sum(((1 + #1{max}) - #0))] // { arity: 1 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %1[×]U » %0:l18[×]ef
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#2 = "O") // { arity: 3 }
+                Get l18 // { arity: 3 }
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l20 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l20 // { arity: 1 }
+                  Constant // { arity: 0 }
                     - ()
     cte [recursion_limit=142, return_at_limit] l22 =
-      Get l1
-  Return
-    Union
-      Get l21
-      Map (null)
-        Union
-          Negate
-            Project ()
-              Get l21
-          Constant
+      Get l1 // { arity: 3 }
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l21 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l21 // { arity: 1 }
+          Constant // { arity: 0 }
             - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1215.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1215.slt
@@ -109,7 +109,8 @@ SELECT * FROM part1, part2;
 2021  6155
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 10)
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 10)
 
     strings(r INT, string TEXT) AS (
         SELECT r, regexp_split_to_array(input, ',')[r]
@@ -199,241 +200,267 @@ SELECT * FROM part1, part2;
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#1, #2)
-        Map (array_index(regexp_split_to_array[",", case_insensitive=false](#0), integer_to_bigint(#1)))
-          FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#0) array_length 1), 1)
-            ReadStorage materialize.public.input
+      Project (#1, #2) // { arity: 2 }
+        Map (array_index(regexp_split_to_array[",", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
+          FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
+            ReadStorage materialize.public.input // { arity: 1 }
     cte [recursion_limit=10, return_at_limit] l1 =
-      Union
-        Project (#1, #2)
-          Map (0)
-            Get l0
-        Project (#2, #3)
-          Filter (char_length(#0) > 0)
-            Map (substr(#0, 2), (((#1 + integer_to_bigint(ascii(substr(#0, 1, 1)))) * 17) % 256))
-              Get l1
+      Union // { arity: 2 }
+        Project (#1, #2) // { arity: 2 }
+          Map (0) // { arity: 3 }
+            Get l0 // { arity: 2 }
+        Project (#2, #3) // { arity: 2 }
+          Filter (char_length(#0) > 0) // { arity: 4 }
+            Map (substr(#0, 2), (((#1 + integer_to_bigint(ascii(substr(#0, 1, 1)))) * 17) % 256)) // { arity: 4 }
+              Get l1 // { arity: 2 }
     cte l2 =
-      Reduce aggregates=[sum(#0)]
-        Project (#1)
-          Filter (#0 = "")
-            Get l1
+      Reduce aggregates=[sum(#0)] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Filter (#0 = "") // { arity: 2 }
+            Get l1 // { arity: 2 }
     cte l3 =
-      Distinct project=[#0]
-        Project (#2)
-          Map (case when ("-" = substr(#1, char_length(#1))) then substr(#1, 1, (char_length(#1) - 1)) else substr(#1, 1, (char_length(#1) - 2)) end)
-            Get l0
+      Distinct project=[#0] // { arity: 1 }
+        Project (#2) // { arity: 1 }
+          Map (case when ("-" = substr(#1, char_length(#1))) then substr(#1, 1, (char_length(#1) - 1)) else substr(#1, 1, (char_length(#1) - 2)) end) // { arity: 3 }
+            Get l0 // { arity: 2 }
     cte l4 =
-      Reduce group_by=[#0] aggregates=[max(#1)]
-        Project (#0, #1)
-          Join on=(#0 = #2) type=differential
-            ArrangeBy keys=[[#0]]
-              Filter (#0) IS NOT NULL
-                Get l3
-            ArrangeBy keys=[[#1]]
-              Project (#0, #3)
-                Filter (#3) IS NOT NULL AND (0 = case when #2 then 0 else text_to_integer(substr(#1, char_length(#1))) end)
-                  Map (("-" = substr(#1, char_length(#1))), case when #2 then substr(#1, 1, (char_length(#1) - 1)) else substr(#1, 1, (char_length(#1) - 2)) end)
-                    Get l0
+      Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+        Project (#0, #1) // { arity: 2 }
+          Join on=(#0 = #2) type=differential // { arity: 3 }
+            implementation
+              %0:l3[#0]UK » %1:l0[#1]Kef
+            ArrangeBy keys=[[#0]] // { arity: 1 }
+              Filter (#0) IS NOT NULL // { arity: 1 }
+                Get l3 // { arity: 1 }
+            ArrangeBy keys=[[#1]] // { arity: 2 }
+              Project (#0, #3) // { arity: 2 }
+                Filter (#3) IS NOT NULL AND (0 = case when #2 then 0 else text_to_integer(substr(#1, char_length(#1))) end) // { arity: 4 }
+                  Map (("-" = substr(#1, char_length(#1))), case when #2 then substr(#1, 1, (char_length(#1) - 1)) else substr(#1, 1, (char_length(#1) - 2)) end) // { arity: 4 }
+                    Get l0 // { arity: 2 }
     cte l5 =
-      ArrangeBy keys=[[#0]]
-        Get l3
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Get l3 // { arity: 1 }
     cte l6 =
-      Union
-        Get l4
-        Project (#0, #2)
-          Map (null)
-            Join on=(#0 = #1) type=differential
-              ArrangeBy keys=[[#0]]
-                Union
-                  Negate
-                    Project (#0)
-                      Get l4
-                  Get l3
-              Get l5
+      Union // { arity: 2 }
+        Get l4 // { arity: 2 }
+        Project (#0, #2) // { arity: 2 }
+          Map (null) // { arity: 3 }
+            Join on=(#0 = #1) type=differential // { arity: 2 }
+              implementation
+                %1:l5[#0]UK » %0[#0]K
+              ArrangeBy keys=[[#0]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l4 // { arity: 2 }
+                  Get l3 // { arity: 1 }
+              Get l5 // { arity: 1 }
     cte l7 =
-      Union
-        Get l6
-        Map (error("more than one record produced in subquery"))
-          Project (#0)
-            Filter (#1 > 1)
-              Reduce group_by=[#0] aggregates=[count(*)]
-                Project (#0)
-                  Get l6
+      Union // { arity: 2 }
+        Get l6 // { arity: 2 }
+        Map (error("more than one record produced in subquery")) // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Filter (#1{count} > 1) // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                Project (#0) // { arity: 1 }
+                  Get l6 // { arity: 2 }
     cte l8 =
-      Project (#0..=#2)
-        Filter (#0 > coalesce(#4, 0))
-          Join on=(#1 = #3) type=differential
-            ArrangeBy keys=[[#1]]
-              Project (#0, #3, #4)
-                Map (("-" = substr(#1, char_length(#1))), case when #2 then substr(#1, 1, (char_length(#1) - 1)) else substr(#1, 1, (char_length(#1) - 2)) end, case when #2 then 0 else text_to_integer(substr(#1, char_length(#1))) end)
-                  Get l0
-            ArrangeBy keys=[[#0]]
-              Union
-                Get l7
-                Project (#0, #2)
-                  Map (null)
-                    Join on=(#0 = #1) type=differential
-                      ArrangeBy keys=[[#0]]
-                        Union
-                          Negate
-                            Distinct project=[#0]
-                              Project (#0)
-                                Get l7
-                          Get l3
-                      Get l5
+      Project (#0..=#2) // { arity: 3 }
+        Filter (#0 > coalesce(#4{max}, 0)) // { arity: 5 }
+          Join on=(#1 = #3) type=differential // { arity: 5 }
+            implementation
+              %0:l0[#1]K » %1[#0]K
+            ArrangeBy keys=[[#1]] // { arity: 3 }
+              Project (#0, #3, #4) // { arity: 3 }
+                Map (("-" = substr(#1, char_length(#1))), case when #2 then substr(#1, 1, (char_length(#1) - 1)) else substr(#1, 1, (char_length(#1) - 2)) end, case when #2 then 0 else text_to_integer(substr(#1, char_length(#1))) end) // { arity: 5 }
+                  Get l0 // { arity: 2 }
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Union // { arity: 2 }
+                Get l7 // { arity: 2 }
+                Project (#0, #2) // { arity: 2 }
+                  Map (null) // { arity: 3 }
+                    Join on=(#0 = #1) type=differential // { arity: 2 }
+                      implementation
+                        %1:l5[#0]UK » %0[#0]K
+                      ArrangeBy keys=[[#0]] // { arity: 1 }
+                        Union // { arity: 1 }
+                          Negate // { arity: 1 }
+                            Distinct project=[#0] // { arity: 1 }
+                              Project (#0) // { arity: 1 }
+                                Get l7 // { arity: 2 }
+                          Get l3 // { arity: 1 }
+                      Get l5 // { arity: 1 }
     cte l9 =
-      Distinct project=[#0..=#2]
-        Get l8
+      Distinct project=[#0..=#2] // { arity: 3 }
+        Get l8 // { arity: 3 }
     cte l10 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l9
+      Distinct project=[#0] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Get l9 // { arity: 3 }
     cte l11 =
-      Reduce group_by=[#0] aggregates=[min(#1)]
-        Project (#0, #1)
-          Join on=(#0 = #2) type=differential
-            ArrangeBy keys=[[#0]]
-              Filter (#0) IS NOT NULL
-                Get l10
-            ArrangeBy keys=[[#1]]
-              Project (#0, #1)
-                Filter (#1) IS NOT NULL
-                  Get l8
+      Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
+        Project (#0, #1) // { arity: 2 }
+          Join on=(#0 = #2) type=differential // { arity: 3 }
+            implementation
+              %0:l10[#0]UK » %1:l8[#1]K
+            ArrangeBy keys=[[#0]] // { arity: 1 }
+              Filter (#0) IS NOT NULL // { arity: 1 }
+                Get l10 // { arity: 1 }
+            ArrangeBy keys=[[#1]] // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Filter (#1) IS NOT NULL // { arity: 3 }
+                  Get l8 // { arity: 3 }
     cte l12 =
-      ArrangeBy keys=[[#0]]
-        Get l10
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Get l10 // { arity: 1 }
     cte l13 =
-      Union
-        Get l11
-        Project (#0, #2)
-          Map (null)
-            Join on=(#0 = #1) type=differential
-              ArrangeBy keys=[[#0]]
-                Union
-                  Negate
-                    Project (#0)
-                      Get l11
-                  Get l10
-              Get l12
+      Union // { arity: 2 }
+        Get l11 // { arity: 2 }
+        Project (#0, #2) // { arity: 2 }
+          Map (null) // { arity: 3 }
+            Join on=(#0 = #1) type=differential // { arity: 2 }
+              implementation
+                %1:l12[#0]UK » %0[#0]K
+              ArrangeBy keys=[[#0]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l11 // { arity: 2 }
+                  Get l10 // { arity: 1 }
+              Get l12 // { arity: 1 }
     cte l14 =
-      Union
-        Get l13
-        Map (error("more than one record produced in subquery"))
-          Project (#0)
-            Filter (#1 > 1)
-              Reduce group_by=[#0] aggregates=[count(*)]
-                Project (#0)
-                  Get l13
+      Union // { arity: 2 }
+        Get l13 // { arity: 2 }
+        Map (error("more than one record produced in subquery")) // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Filter (#1{count} > 1) // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                Project (#0) // { arity: 1 }
+                  Get l13 // { arity: 2 }
     cte l15 =
-      Project (#1..=#4)
-        TopK group_by=[#1] order_by=[#0 desc nulls_first, #2 asc nulls_last] limit=1
-          Project (#0..=#2, #7, #8)
-            Map ((#1) IS NULL)
-              Join on=(#0 = #3 AND #1 = #4 = #6 AND #2 = #5) type=delta
-                ArrangeBy keys=[[#0..=#2], [#1]]
-                  Get l8
-                ArrangeBy keys=[[#0..=#2]]
-                  Get l9
-                ArrangeBy keys=[[#0]]
-                  Union
-                    Get l14
-                    Project (#0, #2)
-                      Map (null)
-                        Join on=(#0 = #1) type=differential
-                          ArrangeBy keys=[[#0]]
-                            Union
-                              Negate
-                                Distinct project=[#0]
-                                  Project (#0)
-                                    Get l14
-                              Get l10
-                          Get l12
+      Project (#1..=#4) // { arity: 4 }
+        TopK group_by=[#1] order_by=[#0 desc nulls_first, #2 asc nulls_last] limit=1 // { arity: 5 }
+          Project (#0..=#2, #7{min}, #8) // { arity: 5 }
+            Map ((#1) IS NULL) // { arity: 9 }
+              Join on=(#0 = #3 AND #1 = #4 = #6 AND #2 = #5) type=delta // { arity: 8 }
+                implementation
+                  %0:l8 » %1:l9[#0..=#2]UKKK » %2[#0]K
+                  %1:l9 » %0:l8[#0..=#2]KKK » %2[#0]K
+                  %2 » %0:l8[#1]K » %1:l9[#0..=#2]UKKK
+                ArrangeBy keys=[[#0..=#2], [#1]] // { arity: 3 }
+                  Get l8 // { arity: 3 }
+                ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                  Get l9 // { arity: 3 }
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Union // { arity: 2 }
+                    Get l14 // { arity: 2 }
+                    Project (#0, #2) // { arity: 2 }
+                      Map (null) // { arity: 3 }
+                        Join on=(#0 = #1) type=differential // { arity: 2 }
+                          implementation
+                            %1:l12[#0]UK » %0[#0]K
+                          ArrangeBy keys=[[#0]] // { arity: 1 }
+                            Union // { arity: 1 }
+                              Negate // { arity: 1 }
+                                Distinct project=[#0] // { arity: 1 }
+                                  Project (#0) // { arity: 1 }
+                                    Get l14 // { arity: 2 }
+                              Get l10 // { arity: 1 }
+                          Get l12 // { arity: 1 }
     cte [recursion_limit=10, return_at_limit] l16 =
-      Union
-        Project (#0, #0, #4)
-          Map (0)
-            Get l15
-        Project (#0, #3, #4)
-          Filter (char_length(#1) > 0)
-            Map (substr(#1, 2), (((#2 + integer_to_bigint(ascii(substr(#1, 1, 1)))) * 17) % 256))
-              Get l16
-  Return
+      Union // { arity: 3 }
+        Project (#0, #0, #4) // { arity: 3 }
+          Map (0) // { arity: 5 }
+            Get l15 // { arity: 4 }
+        Project (#0, #3, #4) // { arity: 3 }
+          Filter (char_length(#1) > 0) // { arity: 5 }
+            Map (substr(#1, 2), (((#2 + integer_to_bigint(ascii(substr(#1, 1, 1)))) * 17) % 256)) // { arity: 5 }
+              Get l16 // { arity: 3 }
+  Return // { arity: 2 }
     With
       cte l17 =
-        Project (#1, #3, #4)
-          Join on=(#0 = #2) type=differential
-            ArrangeBy keys=[[#0]]
-              Project (#0, #2)
-                Filter (#1 = "") AND (#0) IS NOT NULL
-                  Get l16
-            ArrangeBy keys=[[#0]]
-              Project (#0..=#2)
-                Filter NOT(#3)
-                  Get l15
+        Project (#1, #3, #4{min}) // { arity: 3 }
+          Join on=(#0 = #2) type=differential // { arity: 5 }
+            implementation
+              %1:l15[#0]UKf » %0:l16[#0]Kef
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Project (#0, #2) // { arity: 2 }
+                Filter (#1 = "") AND (#0) IS NOT NULL // { arity: 3 }
+                  Get l16 // { arity: 3 }
+            ArrangeBy keys=[[#0]] // { arity: 3 }
+              Project (#0..=#2{min}) // { arity: 3 }
+                Filter NOT(#3) // { arity: 4 }
+                  Get l15 // { arity: 4 }
       cte l18 =
-        Project (#0, #2)
-          Get l17
+        Project (#0, #2{min}) // { arity: 2 }
+          Get l17 // { arity: 3 }
       cte l19 =
-        Distinct project=[#0, #1]
-          Get l18
+        Distinct project=[#0, #1{min}] // { arity: 2 }
+          Get l18 // { arity: 2 }
       cte l20 =
-        Reduce group_by=[#0, #1] aggregates=[count(*)]
-          Project (#0, #1)
-            Filter (#1 >= #3)
-              Join on=(#0 = #2) type=differential
-                ArrangeBy keys=[[#0]]
-                  Get l19
-                ArrangeBy keys=[[#0]]
-                  Get l18
+        Reduce group_by=[#0, #1{min}] aggregates=[count(*)] // { arity: 3 }
+          Project (#0, #1{min}) // { arity: 2 }
+            Filter (#1{min} >= #3{min}) // { arity: 4 }
+              Join on=(#0 = #2) type=differential // { arity: 4 }
+                implementation
+                  %0:l19[#0]K » %1:l18[#0]K
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Get l19 // { arity: 2 }
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Get l18 // { arity: 2 }
       cte l21 =
-        Union
-          Get l20
-          Map (0)
-            Union
-              Negate
-                Project (#0, #1)
-                  Get l20
-              Get l19
+        Union // { arity: 3 }
+          Get l20 // { arity: 3 }
+          Map (0) // { arity: 3 }
+            Union // { arity: 2 }
+              Negate // { arity: 2 }
+                Project (#0, #1{min}) // { arity: 2 }
+                  Get l20 // { arity: 3 }
+              Get l19 // { arity: 2 }
       cte l22 =
-        Reduce aggregates=[sum((((1 + #0) * #2) * integer_to_bigint(#1)))]
-          Project (#0, #1, #5)
-            Join on=(#0 = #3 AND #2 = #4) type=differential
-              ArrangeBy keys=[[#0, #2]]
-                Get l17
-              ArrangeBy keys=[[#0, #1]]
-                Union
-                  Get l21
-                  Map (null)
-                    Union
-                      Negate
-                        Project (#0, #1)
-                          Get l21
-                      Get l19
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Project (#1)
-            Map (numeric_to_bigint(#0))
-              Union
-                Get l2
-                Map (null)
-                  Union
-                    Negate
-                      Project ()
-                        Get l2
-                    Constant
+        Reduce aggregates=[sum((((1 + #0) * #2{count}) * integer_to_bigint(#1)))] // { arity: 1 }
+          Project (#0, #1, #5{count}) // { arity: 3 }
+            Join on=(#0 = #3 AND #2{min} = #4{min}) type=differential // { arity: 6 }
+              implementation
+                %1[#0, #1]UKK » %0:l17[#0, #2]KK
+              ArrangeBy keys=[[#0, #2{min}]] // { arity: 3 }
+                Get l17 // { arity: 3 }
+              ArrangeBy keys=[[#0, #1{min}]] // { arity: 3 }
+                Union // { arity: 3 }
+                  Get l21 // { arity: 3 }
+                  Map (null) // { arity: 3 }
+                    Union // { arity: 2 }
+                      Negate // { arity: 2 }
+                        Project (#0, #1{min}) // { arity: 2 }
+                          Get l21 // { arity: 3 }
+                      Get l19 // { arity: 2 }
+    Return // { arity: 2 }
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0[×]U » %1[×]U
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Map (numeric_to_bigint(#0{sum})) // { arity: 2 }
+              Union // { arity: 1 }
+                Get l2 // { arity: 1 }
+                Map (null) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l2 // { arity: 1 }
+                    Constant // { arity: 0 }
                       - ()
-        ArrangeBy keys=[[]]
-          Project (#1)
-            Map (numeric_to_bigint(#0))
-              Union
-                Get l22
-                Map (null)
-                  Union
-                    Negate
-                      Project ()
-                        Get l22
-                    Constant
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Map (numeric_to_bigint(#0{sum})) // { arity: 2 }
+              Union // { arity: 1 }
+                Get l22 // { arity: 1 }
+                Map (null) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l22 // { arity: 1 }
+                    Constant // { arity: 0 }
                       - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1216.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1216.slt
@@ -134,7 +134,8 @@ SELECT * FROM part1, part2;
 15  613
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
 
     lines(r INT, line TEXT) AS (
         SELECT r, regexp_split_to_array(input, '\n')[r] as block
@@ -225,20 +226,20 @@ SELECT * FROM part1, part2;
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#0, #2, #3)
-        Map (substr(#1, #2, 1))
-          FlatMap generate_series(1, char_length(#1), 1)
-            Project (#1, #2)
-              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-                  ReadStorage materialize.public.input
+      Project (#0, #2, #3) // { arity: 3 }
+        Map (substr(#1, #2, 1)) // { arity: 4 }
+          FlatMap generate_series(1, char_length(#1), 1) // { arity: 3 }
+            Project (#1, #2) // { arity: 2 }
+              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
+                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
+                  ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      ArrangeBy keys=[[#0, #1]]
-        Filter (#2) IS NOT NULL
-          Get l0
+      ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+        Filter (#2) IS NOT NULL // { arity: 3 }
+          Get l0 // { arity: 3 }
     cte l2 =
-      ArrangeBy keys=[[#0, #1]]
-        Constant
+      ArrangeBy keys=[[#0, #1]] // { arity: 5 }
+        Constant // { arity: 5 }
           total_rows (diffs absed): 24
           first_rows:
             - ("d", "-", 0, -1, "l")
@@ -262,175 +263,191 @@ Explained Query:
             - ("r", "-", 0, 1, "r")
             - ("r", ".", 0, 1, "r")
     cte l3 =
-      Distinct project=[#0..=#2]
-        Union
-          Project (#11, #12, #10)
-            Map ((#0 + #8), (#1 + #9))
-              Join on=(#0 = #3 AND #1 = #4 AND #2 = #6 AND #5 = #7) type=differential
-                ArrangeBy keys=[[#0, #1]]
-                  Get l3
-                Get l1
-                Get l2
-          Constant
+      Distinct project=[#0..=#2] // { arity: 3 }
+        Union // { arity: 3 }
+          Project (#11, #12, #10) // { arity: 3 }
+            Map ((#0 + #8), (#1 + #9)) // { arity: 13 }
+              Join on=(#0 = #3 AND #1 = #4 AND #2 = #6 AND #5 = #7) type=differential // { arity: 11 }
+                implementation
+                  %0:l3[#0, #1]KK » %1:l1[#0, #1]KK » %2:l2[#0, #1]KK
+                ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+                  Get l3 // { arity: 3 }
+                Get l1 // { arity: 3 }
+                Get l2 // { arity: 5 }
+          Constant // { arity: 3 }
             - (1, 1, "r")
     cte l4 =
-      Project (#0, #1)
-        Get l0
+      Project (#0, #1) // { arity: 2 }
+        Get l0 // { arity: 3 }
     cte l5 =
-      Reduce aggregates=[count(*)]
-        Project ()
-          Join on=(#0 = #2 AND #1 = #3) type=differential
-            ArrangeBy keys=[[#0, #1]]
-              Distinct project=[#0, #1]
-                Project (#0, #1)
-                  Get l3
-            ArrangeBy keys=[[#0, #1]]
-              Distinct project=[#0, #1]
-                Get l4
+      Reduce aggregates=[count(*)] // { arity: 1 }
+        Project () // { arity: 0 }
+          Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+            implementation
+              %0[#0, #1]UKKA » %1[#0, #1]UKKA
+            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+              Distinct project=[#0, #1] // { arity: 2 }
+                Project (#0, #1) // { arity: 2 }
+                  Get l3 // { arity: 3 }
+            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+              Distinct project=[#0, #1] // { arity: 2 }
+                Get l4 // { arity: 2 }
     cte l6 =
-      Project (#1)
-        Get l0
+      Project (#1) // { arity: 1 }
+        Get l0 // { arity: 3 }
     cte l7 =
-      Reduce aggregates=[min(#0)]
-        Get l6
+      Reduce aggregates=[min(#0)] // { arity: 1 }
+        Get l6 // { arity: 1 }
     cte l8 =
-      Union
-        Get l7
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l7
-            Constant
+      Union // { arity: 1 }
+        Get l7 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l7 // { arity: 1 }
+            Constant // { arity: 0 }
               - ()
     cte l9 =
-      Reduce aggregates=[max(#0)]
-        Get l6
+      Reduce aggregates=[max(#0)] // { arity: 1 }
+        Get l6 // { arity: 1 }
     cte l10 =
-      Union
-        Get l9
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l9
-            Constant
+      Union // { arity: 1 }
+        Get l9 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l9 // { arity: 1 }
+            Constant // { arity: 0 }
               - ()
     cte l11 =
-      Project (#0)
-        Get l0
+      Project (#0) // { arity: 1 }
+        Get l0 // { arity: 3 }
     cte l12 =
-      Reduce aggregates=[min(#0)]
-        Get l11
+      Reduce aggregates=[min(#0)] // { arity: 1 }
+        Get l11 // { arity: 1 }
     cte l13 =
-      Union
-        Get l12
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l12
-            Constant
+      Union // { arity: 1 }
+        Get l12 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l12 // { arity: 1 }
+            Constant // { arity: 0 }
               - ()
     cte l14 =
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Get l4
-        ArrangeBy keys=[[]]
-          Union
-            Get l10
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l10
-                Constant
+      CrossJoin type=differential // { arity: 3 }
+        implementation
+          %1[×]U » %0:l4[×]
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Get l4 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l10 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l10 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
     cte l15 =
-      Distinct project=[#0..=#3]
-        Union
-          Project (#0, #1, #3, #2)
-            Map (("r" || integer_to_text(#0)), "r")
-              CrossJoin type=differential
-                ArrangeBy keys=[[]]
-                  Get l11
-                ArrangeBy keys=[[]]
-                  Union
-                    Get l8
-                    Map (null)
-                      Union
-                        Negate
-                          Project ()
-                            Get l8
-                        Constant
+      Distinct project=[#0{min}..=#3] // { arity: 4 }
+        Union // { arity: 4 }
+          Project (#0, #1{min}, #3, #2) // { arity: 4 }
+            Map (("r" || integer_to_text(#0)), "r") // { arity: 4 }
+              CrossJoin type=differential // { arity: 2 }
+                implementation
+                  %1[×]U » %0:l11[×]
+                ArrangeBy keys=[[]] // { arity: 1 }
+                  Get l11 // { arity: 1 }
+                ArrangeBy keys=[[]] // { arity: 1 }
+                  Union // { arity: 1 }
+                    Get l8 // { arity: 1 }
+                    Map (null) // { arity: 1 }
+                      Union // { arity: 0 }
+                        Negate // { arity: 0 }
+                          Project () // { arity: 0 }
+                            Get l8 // { arity: 1 }
+                        Constant // { arity: 0 }
                           - ()
-          Project (#0, #2, #4, #3)
-            Map (("l" || integer_to_text(#0)), "l")
-              Get l14
-          Project (#1, #0, #3, #2)
-            Map (("d" || integer_to_text(#0)), "d")
-              CrossJoin type=differential
-                ArrangeBy keys=[[]]
-                  Get l6
-                ArrangeBy keys=[[]]
-                  Union
-                    Get l13
-                    Map (null)
-                      Union
-                        Negate
-                          Project ()
-                            Get l13
-                        Constant
+          Project (#0, #2{max}, #4, #3) // { arity: 4 }
+            Map (("l" || integer_to_text(#0)), "l") // { arity: 5 }
+              Get l14 // { arity: 3 }
+          Project (#1{min}, #0, #3, #2) // { arity: 4 }
+            Map (("d" || integer_to_text(#0)), "d") // { arity: 4 }
+              CrossJoin type=differential // { arity: 2 }
+                implementation
+                  %1[×]U » %0:l6[×]
+                ArrangeBy keys=[[]] // { arity: 1 }
+                  Get l6 // { arity: 1 }
+                ArrangeBy keys=[[]] // { arity: 1 }
+                  Union // { arity: 1 }
+                    Get l13 // { arity: 1 }
+                    Map (null) // { arity: 1 }
+                      Union // { arity: 0 }
+                        Negate // { arity: 0 }
+                          Project () // { arity: 0 }
+                            Get l13 // { arity: 1 }
+                        Constant // { arity: 0 }
                           - ()
-          Project (#2, #1, #4, #3)
-            Map (("u" || integer_to_text(#1)), "u")
-              Get l14
-          Project (#12, #13, #11, #3)
-            Map ((#0 + #9), (#1 + #10))
-              Join on=(#0 = #4 AND #1 = #5 AND #2 = #7 AND #6 = #8) type=differential
-                ArrangeBy keys=[[#0, #1]]
-                  Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-                    Get l15
-                Get l1
-                Get l2
-  Return
+          Project (#2{max}, #1, #4, #3) // { arity: 4 }
+            Map (("u" || integer_to_text(#1)), "u") // { arity: 5 }
+              Get l14 // { arity: 3 }
+          Project (#12, #13, #11, #3) // { arity: 4 }
+            Map ((#0 + #9), (#1 + #10)) // { arity: 14 }
+              Join on=(#0 = #4 AND #1 = #5 AND #2 = #7 AND #6 = #8) type=differential // { arity: 12 }
+                implementation
+                  %0:l15[#0, #1]KK » %1:l1[#0, #1]KK » %2:l2[#0, #1]KK
+                ArrangeBy keys=[[#0{min}, #1{min}]] // { arity: 4 }
+                  Filter (#0{min}) IS NOT NULL AND (#1{min}) IS NOT NULL // { arity: 4 }
+                    Get l15 // { arity: 4 }
+                Get l1 // { arity: 3 }
+                Get l2 // { arity: 5 }
+  Return // { arity: 2 }
     With
       cte l16 =
-        Reduce aggregates=[max(#0)]
-          Project (#1)
-            Reduce group_by=[#0] aggregates=[count(*)]
-              Project (#2)
-                Join on=(#0 = #3 AND #1 = #4) type=differential
-                  ArrangeBy keys=[[#0, #1]]
-                    Distinct project=[#0..=#2]
-                      Project (#0, #1, #3)
-                        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-                          Get l15
-                  ArrangeBy keys=[[#0, #1]]
-                    Distinct project=[#0, #1]
-                      Project (#0, #1)
-                        Get l0
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Union
-            Get l5
-            Map (0)
-              Union
-                Negate
-                  Project ()
-                    Get l5
-                Constant
+        Reduce aggregates=[max(#0{count})] // { arity: 1 }
+          Project (#1{count}) // { arity: 1 }
+            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+              Project (#2) // { arity: 1 }
+                Join on=(#0{min} = #3 AND #1{min} = #4) type=differential // { arity: 5 }
+                  implementation
+                    %1[#0, #1]UKKA » %0[#0, #1]KK
+                  ArrangeBy keys=[[#0{min}, #1{min}]] // { arity: 3 }
+                    Distinct project=[#0{min}..=#2] // { arity: 3 }
+                      Project (#0{min}, #1{min}, #3) // { arity: 3 }
+                        Filter (#0{min}) IS NOT NULL AND (#1{min}) IS NOT NULL // { arity: 4 }
+                          Get l15 // { arity: 4 }
+                  ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                    Distinct project=[#0, #1] // { arity: 2 }
+                      Project (#0, #1) // { arity: 2 }
+                        Get l0 // { arity: 3 }
+    Return // { arity: 2 }
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0[×]U » %1[×]U
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l5 // { arity: 1 }
+            Map (0) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l5 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
-        ArrangeBy keys=[[]]
-          Union
-            Get l16
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l16
-                Constant
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l16 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l16 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1217.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1217.slt
@@ -127,7 +127,8 @@ SELECT * FROM part1, part2;
 156  190
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
 
     lines(r INT, line TEXT) AS (
         SELECT r, regexp_split_to_array(input, '\n')[r] as block
@@ -225,127 +226,145 @@ SELECT * FROM part1, part2;
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#0, #2, #3)
-        Map (text_to_integer(substr(#1, #2, 1)))
-          FlatMap generate_series(1, char_length(#1), 1)
-            Project (#1, #2)
-              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-                  ReadStorage materialize.public.input
+      Project (#0, #2, #3) // { arity: 3 }
+        Map (text_to_integer(substr(#1, #2, 1))) // { arity: 4 }
+          FlatMap generate_series(1, char_length(#1), 1) // { arity: 3 }
+            Project (#1, #2) // { arity: 2 }
+              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
+                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
+                  ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      ArrangeBy keys=[[#0, #1]]
-        Get l0
+      ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+        Get l0 // { arity: 3 }
     cte l2 =
-      Project (#0..=#3, #5)
-        Get l3
+      Project (#0..=#3, #5{min}) // { arity: 5 }
+        Get l3 // { arity: 6 }
     cte l3 =
-      Reduce group_by=[#0..=#4] aggregates=[min(#5)]
-        Union
-          Project (#6, #7, #2, #3, #9, #10)
-            Map ((#4 + 1), (#5 + #8))
-              Join on=(#6 = (#0 + #2) AND #7 = (#1 + #3)) type=differential
-                ArrangeBy keys=[[(#0 + #2), (#1 + #3)]]
-                  Filter (#4 < 3)
-                    Get l3
-                Get l1
-          Project (#5, #6, #3, #2, #9, #8)
-            Map ((#4 + #7), 1)
-              Join on=(#5 = (#0 + #3) AND #6 = (#1 + #2)) type=differential
-                ArrangeBy keys=[[(#0 + #3), (#1 + #2)]]
-                  Get l2
-                Get l1
-          Project (#5, #6, #8, #9, #11, #10)
-            Map (-(#3), -(#2), (#4 + #7), 1)
-              Join on=(#5 = (#0 - #3) AND #6 = (#1 - #2)) type=differential
-                ArrangeBy keys=[[(#0 - #3), (#1 - #2)]]
-                  Get l2
-                Get l1
-          Constant
+      Reduce group_by=[#0..=#4] aggregates=[min(#5)] // { arity: 6 }
+        Union // { arity: 6 }
+          Project (#6, #7, #2, #3, #9, #10) // { arity: 6 }
+            Map ((#4 + 1), (#5 + #8)) // { arity: 11 }
+              Join on=(#6 = (#0 + #2) AND #7 = (#1 + #3)) type=differential // { arity: 9 }
+                implementation
+                  %0:l3[(#0 + #2), (#1 + #3)]KKif » %1:l1[#0, #1]KKif
+                ArrangeBy keys=[[(#0 + #2), (#1 + #3)]] // { arity: 6 }
+                  Filter (#4 < 3) // { arity: 6 }
+                    Get l3 // { arity: 6 }
+                Get l1 // { arity: 3 }
+          Project (#5, #6, #3, #2, #9, #8) // { arity: 6 }
+            Map ((#4 + #7), 1) // { arity: 10 }
+              Join on=(#5 = (#0 + #3) AND #6 = (#1 + #2)) type=differential // { arity: 8 }
+                implementation
+                  %0:l2[(#0 + #3), (#1 + #2)]KK » %1:l1[#0, #1]KK
+                ArrangeBy keys=[[(#0 + #3), (#1 + #2)]] // { arity: 5 }
+                  Get l2 // { arity: 5 }
+                Get l1 // { arity: 3 }
+          Project (#5, #6, #8, #9, #11, #10) // { arity: 6 }
+            Map (-(#3), -(#2), (#4 + #7), 1) // { arity: 12 }
+              Join on=(#5 = (#0 - #3) AND #6 = (#1 - #2)) type=differential // { arity: 8 }
+                implementation
+                  %0:l2[(#0 - #3), (#1 - #2)]KK » %1:l1[#0, #1]KK
+                ArrangeBy keys=[[(#0 - #3), (#1 - #2)]] // { arity: 5 }
+                  Get l2 // { arity: 5 }
+                Get l1 // { arity: 3 }
+          Constant // { arity: 6 }
             - (1, 1, 0, 1, 0, 0)
             - (1, 1, 1, 0, 0, 0)
     cte l4 =
-      Reduce aggregates=[min(#0)]
-        Project (#2)
-          Join on=(#0 = #3 AND #1 = #4) type=differential
-            ArrangeBy keys=[[#0, #1]]
-              Project (#0, #1, #5)
-                Get l3
-            ArrangeBy keys=[[]]
-              Reduce aggregates=[max(#0)]
-                Project (#0)
-                  Get l0
-            ArrangeBy keys=[[]]
-              Reduce aggregates=[max(#0)]
-                Project (#1)
-                  Get l0
+      Reduce aggregates=[min(#0{min})] // { arity: 1 }
+        Project (#2{min}) // { arity: 1 }
+          Join on=(#0 = #3{max} AND #1 = #4{max}) type=differential // { arity: 5 }
+            implementation
+              %1[×]UA » %2[×]UA » %0:l3[#0, #1]KK
+            ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+              Project (#0, #1, #5{min}) // { arity: 3 }
+                Get l3 // { arity: 6 }
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Reduce aggregates=[max(#0)] // { arity: 1 }
+                Project (#0) // { arity: 1 }
+                  Get l0 // { arity: 3 }
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Reduce aggregates=[max(#0)] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Get l0 // { arity: 3 }
     cte l5 =
-      Project (#0..=#3, #5)
-        Filter (#4 >= 4)
-          Get l6
+      Project (#0..=#3, #5{min}) // { arity: 5 }
+        Filter (#4 >= 4) // { arity: 6 }
+          Get l6 // { arity: 6 }
     cte l6 =
-      Reduce group_by=[#0..=#4] aggregates=[min(#5)]
-        Union
-          Project (#6, #7, #2, #3, #9, #10)
-            Map ((#4 + 1), (#5 + #8))
-              Join on=(#6 = (#0 + #2) AND #7 = (#1 + #3)) type=differential
-                ArrangeBy keys=[[(#0 + #2), (#1 + #3)]]
-                  Filter (#4 < 10)
-                    Get l6
-                Get l1
-          Project (#5, #6, #3, #2, #9, #8)
-            Map ((#4 + #7), 1)
-              Join on=(#5 = (#0 + #3) AND #6 = (#1 + #2)) type=differential
-                ArrangeBy keys=[[(#0 + #3), (#1 + #2)]]
-                  Get l5
-                Get l1
-          Project (#5, #6, #8, #9, #11, #10)
-            Map (-(#3), -(#2), (#4 + #7), 1)
-              Join on=(#5 = (#0 - #3) AND #6 = (#1 - #2)) type=differential
-                ArrangeBy keys=[[(#0 - #3), (#1 - #2)]]
-                  Get l5
-                Get l1
-          Constant
+      Reduce group_by=[#0..=#4] aggregates=[min(#5)] // { arity: 6 }
+        Union // { arity: 6 }
+          Project (#6, #7, #2, #3, #9, #10) // { arity: 6 }
+            Map ((#4 + 1), (#5 + #8)) // { arity: 11 }
+              Join on=(#6 = (#0 + #2) AND #7 = (#1 + #3)) type=differential // { arity: 9 }
+                implementation
+                  %0:l6[(#0 + #2), (#1 + #3)]KKif » %1:l1[#0, #1]KKif
+                ArrangeBy keys=[[(#0 + #2), (#1 + #3)]] // { arity: 6 }
+                  Filter (#4 < 10) // { arity: 6 }
+                    Get l6 // { arity: 6 }
+                Get l1 // { arity: 3 }
+          Project (#5, #6, #3, #2, #9, #8) // { arity: 6 }
+            Map ((#4 + #7), 1) // { arity: 10 }
+              Join on=(#5 = (#0 + #3) AND #6 = (#1 + #2)) type=differential // { arity: 8 }
+                implementation
+                  %0:l5[(#0 + #3), (#1 + #2)]KKif » %1:l1[#0, #1]KKif
+                ArrangeBy keys=[[(#0 + #3), (#1 + #2)]] // { arity: 5 }
+                  Get l5 // { arity: 5 }
+                Get l1 // { arity: 3 }
+          Project (#5, #6, #8, #9, #11, #10) // { arity: 6 }
+            Map (-(#3), -(#2), (#4 + #7), 1) // { arity: 12 }
+              Join on=(#5 = (#0 - #3) AND #6 = (#1 - #2)) type=differential // { arity: 8 }
+                implementation
+                  %0:l5[(#0 - #3), (#1 - #2)]KKif » %1:l1[#0, #1]KKif
+                ArrangeBy keys=[[(#0 - #3), (#1 - #2)]] // { arity: 5 }
+                  Get l5 // { arity: 5 }
+                Get l1 // { arity: 3 }
+          Constant // { arity: 6 }
             - (1, 1, 0, 1, 0, 0)
             - (1, 1, 1, 0, 0, 0)
-  Return
+  Return // { arity: 2 }
     With
       cte l7 =
-        Reduce aggregates=[min(#0)]
-          Project (#2)
-            Join on=(#0 = #3 AND #1 = #4) type=differential
-              ArrangeBy keys=[[#0, #1]]
-                Project (#0, #1, #5)
-                  Filter (#4 >= 4)
-                    Get l6
-              ArrangeBy keys=[[]]
-                Reduce aggregates=[max(#0)]
-                  Project (#0)
-                    Get l0
-              ArrangeBy keys=[[]]
-                Reduce aggregates=[max(#0)]
-                  Project (#1)
-                    Get l0
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Union
-            Get l4
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l4
-                Constant
+        Reduce aggregates=[min(#0{min})] // { arity: 1 }
+          Project (#2{min}) // { arity: 1 }
+            Join on=(#0 = #3{max} AND #1 = #4{max}) type=differential // { arity: 5 }
+              implementation
+                %1[×]UA » %2[×]UA » %0:l6[#0, #1]KKif
+              ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+                Project (#0, #1, #5{min}) // { arity: 3 }
+                  Filter (#4 >= 4) // { arity: 6 }
+                    Get l6 // { arity: 6 }
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Reduce aggregates=[max(#0)] // { arity: 1 }
+                  Project (#0) // { arity: 1 }
+                    Get l0 // { arity: 3 }
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Reduce aggregates=[max(#0)] // { arity: 1 }
+                  Project (#1) // { arity: 1 }
+                    Get l0 // { arity: 3 }
+    Return // { arity: 2 }
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0[×]U » %1[×]U
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l4 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l4 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
-        ArrangeBy keys=[[]]
-          Union
-            Get l7
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l7
-                Constant
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l7 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l7 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1218.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1218.slt
@@ -126,7 +126,8 @@ SELECT * FROM part1, part2;
 73  34133752459
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
 
     lines(r INT, line TEXT) AS (
         SELECT r, regexp_split_to_array(input, '\n')[r] as line
@@ -219,143 +220,152 @@ SELECT * FROM part1, part2;
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#1, #2)
-        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-            ReadStorage materialize.public.input
+      Project (#1, #2) // { arity: 2 }
+        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
+          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
+            ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Distinct project=[#0..=#4]
-        Union
-          Project (#0, #1, #7..=#9)
-            Map ((#0 + (#4 * #6)), (#1 + (#5 * #6)), (#2 + 1))
-              Join on=(#2 = #3) type=differential
-                ArrangeBy keys=[[#2]]
-                  Project (#2..=#4)
-                    Get l1
-                ArrangeBy keys=[[#0]]
-                  Project (#0, #4..=#6)
-                    Map (regexp_split_to_array[" ", case_insensitive=false](#1), array_index(#2, 1), case when (#3 = "U") then -1 else case when ("D" = array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 1)) then 1 else 0 end end, case when (#3 = "L") then -1 else case when ("R" = array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 1)) then 1 else 0 end end, text_to_integer(array_index(#2, 2)))
-                      Get l0
-          Constant
+      Distinct project=[#0..=#4] // { arity: 5 }
+        Union // { arity: 5 }
+          Project (#0, #1, #7..=#9) // { arity: 5 }
+            Map ((#0 + (#4 * #6)), (#1 + (#5 * #6)), (#2 + 1)) // { arity: 10 }
+              Join on=(#2 = #3) type=differential // { arity: 7 }
+                implementation
+                  %0:l1[#2]K » %1:l0[#0]K
+                ArrangeBy keys=[[#2]] // { arity: 3 }
+                  Project (#2..=#4) // { arity: 3 }
+                    Get l1 // { arity: 5 }
+                ArrangeBy keys=[[#0]] // { arity: 4 }
+                  Project (#0, #4..=#6) // { arity: 4 }
+                    Map (regexp_split_to_array[" ", case_insensitive=false](#1), array_index(#2, 1), case when (#3 = "U") then -1 else case when ("D" = array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 1)) then 1 else 0 end end, case when (#3 = "L") then -1 else case when ("R" = array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 1)) then 1 else 0 end end, text_to_integer(array_index(#2, 2))) // { arity: 7 }
+                      Get l0 // { arity: 2 }
+          Constant // { arity: 5 }
             - (0, 0, 0, 0, 1)
     cte l2 =
-      Reduce aggregates=[sum(((#0 + #2) * (#1 - #3)))]
-        Project (#0..=#3)
-          Get l1
+      Reduce aggregates=[sum(((#0 + #2) * (#1 - #3)))] // { arity: 1 }
+        Project (#0..=#3) // { arity: 4 }
+          Get l1 // { arity: 5 }
     cte l3 =
-      Union
-        Get l2
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l2
-            Constant
+      Union // { arity: 1 }
+        Get l2 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l2 // { arity: 1 }
+            Constant // { arity: 0 }
               - ()
     cte l4 =
-      Reduce aggregates=[sum(#0)]
-        Project (#2)
-          Map (text_to_integer(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 2)))
-            Get l0
+      Reduce aggregates=[sum(#0)] // { arity: 1 }
+        Project (#2) // { arity: 1 }
+          Map (text_to_integer(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 2))) // { arity: 3 }
+            Get l0 // { arity: 2 }
     cte l5 =
-      Union
-        Get l4
-        Map (null)
-          Union
-            Negate
-              Project ()
-                Get l4
-            Constant
+      Union // { arity: 1 }
+        Get l4 // { arity: 1 }
+        Map (null) // { arity: 1 }
+          Union // { arity: 0 }
+            Negate // { arity: 0 }
+              Project () // { arity: 0 }
+                Get l4 // { arity: 1 }
+            Constant // { arity: 0 }
               - ()
     cte l6 =
-      Distinct project=[#0..=#4]
-        Union
-          Project (#0, #1, #7..=#9)
-            Map ((#0 + integer_to_bigint((#4 * #6))), (#1 + integer_to_bigint((#5 * #6))), (#2 + 1))
-              Join on=(#2 = #3) type=differential
-                ArrangeBy keys=[[#2]]
-                  Project (#2..=#4)
-                    Get l6
-                ArrangeBy keys=[[#0]]
-                  Project (#0, #4, #5, #7)
-                    Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), substr(#2, 8, 1), case when (#3 = "3") then -1 else case when ("1" = substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 8, 1)) then 1 else 0 end end, case when (#3 = "2") then -1 else case when ("0" = substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 8, 1)) then 1 else 0 end end, decode(("0" || substr(#2, 3, 5)), "hex"), (((65536 * get_byte(#6, 0)) + (256 * get_byte(#6, 1))) + get_byte(#6, 2)))
-                      Get l0
-          Constant
+      Distinct project=[#0..=#4] // { arity: 5 }
+        Union // { arity: 5 }
+          Project (#0, #1, #7..=#9) // { arity: 5 }
+            Map ((#0 + integer_to_bigint((#4 * #6))), (#1 + integer_to_bigint((#5 * #6))), (#2 + 1)) // { arity: 10 }
+              Join on=(#2 = #3) type=differential // { arity: 7 }
+                implementation
+                  %0:l6[#2]K » %1:l0[#0]K
+                ArrangeBy keys=[[#2]] // { arity: 3 }
+                  Project (#2..=#4) // { arity: 3 }
+                    Get l6 // { arity: 5 }
+                ArrangeBy keys=[[#0]] // { arity: 4 }
+                  Project (#0, #4, #5, #7) // { arity: 4 }
+                    Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), substr(#2, 8, 1), case when (#3 = "3") then -1 else case when ("1" = substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 8, 1)) then 1 else 0 end end, case when (#3 = "2") then -1 else case when ("0" = substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 8, 1)) then 1 else 0 end end, decode(("0" || substr(#2, 3, 5)), "hex"), (((65536 * get_byte(#6, 0)) + (256 * get_byte(#6, 1))) + get_byte(#6, 2))) // { arity: 8 }
+                      Get l0 // { arity: 2 }
+          Constant // { arity: 5 }
             - (0, 0, 0, 0, 1)
-  Return
+  Return // { arity: 2 }
     With
       cte l7 =
-        Reduce aggregates=[sum(((#0 + #2) * (#1 - #3)))]
-          Project (#0..=#3)
-            Get l6
+        Reduce aggregates=[sum(((#0 + #2) * (#1 - #3)))] // { arity: 1 }
+          Project (#0..=#3) // { arity: 4 }
+            Get l6 // { arity: 5 }
       cte l8 =
-        Union
-          Get l7
-          Map (null)
-            Union
-              Negate
-                Project ()
-                  Get l7
-              Constant
+        Union // { arity: 1 }
+          Get l7 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l7 // { arity: 1 }
+              Constant // { arity: 0 }
                 - ()
       cte l9 =
-        Reduce aggregates=[sum(#0)]
-          Project (#3)
-            Map (decode(("0" || substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 3, 5)), "hex"), (((65536 * get_byte(#2, 0)) + (256 * get_byte(#2, 1))) + get_byte(#2, 2)))
-              Get l0
+        Reduce aggregates=[sum(#0)] // { arity: 1 }
+          Project (#3) // { arity: 1 }
+            Map (decode(("0" || substr(array_index(regexp_split_to_array[" ", case_insensitive=false](#1), 3), 3, 5)), "hex"), (((65536 * get_byte(#2, 0)) + (256 * get_byte(#2, 1))) + get_byte(#2, 2))) // { arity: 4 }
+              Get l0 // { arity: 2 }
       cte l10 =
-        Union
-          Get l9
-          Map (null)
-            Union
-              Negate
-                Project ()
-                  Get l9
-              Constant
+        Union // { arity: 1 }
+          Get l9 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l9 // { arity: 1 }
+              Constant // { arity: 0 }
                 - ()
-    Return
-      Project (#4, #5)
-        Map ((((abs(#0) / 2) + (#1 / 2)) + 1), numeric_to_bigint((((abs(#2) / 2) + bigint_to_numeric((#3 / 2))) + 1)))
-          CrossJoin type=delta
-            ArrangeBy keys=[[]]
-              Union
-                Get l3
-                Map (null)
-                  Union
-                    Negate
-                      Project ()
-                        Get l3
-                    Constant
+    Return // { arity: 2 }
+      Project (#4, #5) // { arity: 2 }
+        Map ((((abs(#0{sum}) / 2) + (#1{sum} / 2)) + 1), numeric_to_bigint((((abs(#2{sum}) / 2) + bigint_to_numeric((#3{sum} / 2))) + 1))) // { arity: 6 }
+          CrossJoin type=delta // { arity: 4 }
+            implementation
+              %0 » %1[×]U » %2[×]U » %3[×]U
+              %1 » %0[×]U » %2[×]U » %3[×]U
+              %2 » %0[×]U » %1[×]U » %3[×]U
+              %3 » %0[×]U » %1[×]U » %2[×]U
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Union // { arity: 1 }
+                Get l3 // { arity: 1 }
+                Map (null) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l3 // { arity: 1 }
+                    Constant // { arity: 0 }
                       - ()
-            ArrangeBy keys=[[]]
-              Union
-                Get l5
-                Map (null)
-                  Union
-                    Negate
-                      Project ()
-                        Get l5
-                    Constant
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Union // { arity: 1 }
+                Get l5 // { arity: 1 }
+                Map (null) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l5 // { arity: 1 }
+                    Constant // { arity: 0 }
                       - ()
-            ArrangeBy keys=[[]]
-              Union
-                Get l8
-                Map (null)
-                  Union
-                    Negate
-                      Project ()
-                        Get l8
-                    Constant
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Union // { arity: 1 }
+                Get l8 // { arity: 1 }
+                Map (null) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l8 // { arity: 1 }
+                    Constant // { arity: 0 }
                       - ()
-            ArrangeBy keys=[[]]
-              Union
-                Get l10
-                Map (null)
-                  Union
-                    Negate
-                      Project ()
-                        Get l10
-                    Constant
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Union // { arity: 1 }
+                Get l10 // { arity: 1 }
+                Map (null) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l10 // { arity: 1 }
+                    Constant // { arity: 0 }
                       - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1219.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1219.slt
@@ -180,7 +180,8 @@ SELECT * FROM part1, part2;
 42458  -257636238955235
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
 
     blocks(block1 TEXT, block2 TEXT) AS (
         SELECT
@@ -323,85 +324,91 @@ SELECT * FROM part1, part2;
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#0, #2, #6..=#9)
-        Map (array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2)), substr(#3, 2, 1), ((#4 = "<") OR (#4 = ">")), case when #5 then substr(#3, 1, 1) else "x" end, case when #5 then #4 else ">" end, case when #5 then text_to_integer(array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 1)) else 0 end, case when #5 then array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 2) else #3 end)
-          FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#1) array_length 1), 1)
-            Project (#3, #4)
-              Filter (#3) IS NOT NULL
-                Map (regexp_split_to_array["\{", case_insensitive=false](#1), array_index(#2, 1), btrim(array_index(#2, 2), "}"))
-                  FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-                    Project (#1)
-                      Map (array_index(regexp_split_to_array["\n\n", case_insensitive=false](#0), 1))
-                        ReadStorage materialize.public.input
+      Project (#0, #2, #6..=#9) // { arity: 6 }
+        Map (array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2)), substr(#3, 2, 1), ((#4 = "<") OR (#4 = ">")), case when #5 then substr(#3, 1, 1) else "x" end, case when #5 then #4 else ">" end, case when #5 then text_to_integer(array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 1)) else 0 end, case when #5 then array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 2) else #3 end) // { arity: 10 }
+          FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#1) array_length 1), 1) // { arity: 3 }
+            Project (#3, #4) // { arity: 2 }
+              Filter (#3) IS NOT NULL // { arity: 5 }
+                Map (regexp_split_to_array["\{", case_insensitive=false](#1), array_index(#2, 1), btrim(array_index(#2, 2), "}")) // { arity: 5 }
+                  FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0)) // { arity: 2 }
+                    Project (#1) // { arity: 1 }
+                      Map (array_index(regexp_split_to_array["\n\n", case_insensitive=false](#0{input}), 1)) // { arity: 2 }
+                        ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Union
-        Project (#7, #3..=#6)
-          Map (regexp_split_to_array[",", case_insensitive=false](btrim(btrim(#1, "\}"), "\{")), text_to_integer(substr(array_index(#2, 1), 3)), text_to_integer(substr(array_index(#2, 2), 3)), text_to_integer(substr(array_index(#2, 3), 3)), text_to_integer(substr(array_index(#2, 4), 3)), "in")
-            FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-              Project (#1)
-                Map (array_index(regexp_split_to_array["\n\n", case_insensitive=false](#0), 2))
-                  ReadStorage materialize.public.input
-        Project (#6, #1..=#4)
-          TopK group_by=[#0..=#4] order_by=[#5 asc nulls_last] limit=1
-            Project (#0..=#4, #6, #10)
-              Filter case when (#8 = "<") then case when (#7 = "x") then (#1 < #9) else case when (#7 = "m") then (#2 < #9) else case when (#7 = "a") then (#3 < #9) else case when (#7 = "s") then (#4 < #9) else false end end end end else case when (#8 = ">") then case when (#7 = "x") then (#1 > #9) else case when (#7 = "m") then (#2 > #9) else case when (#7 = "a") then (#3 > #9) else case when (#7 = "s") then (#4 > #9) else false end end end end else false end end
-                Join on=(#0 = #5) type=differential
-                  ArrangeBy keys=[[#0]]
-                    Filter (#0) IS NOT NULL
-                      Get l1
-                  ArrangeBy keys=[[#0]]
-                    Get l0
+      Union // { arity: 5 }
+        Project (#7, #3..=#6) // { arity: 5 }
+          Map (regexp_split_to_array[",", case_insensitive=false](btrim(btrim(#1, "\}"), "\{")), text_to_integer(substr(array_index(#2, 1), 3)), text_to_integer(substr(array_index(#2, 2), 3)), text_to_integer(substr(array_index(#2, 3), 3)), text_to_integer(substr(array_index(#2, 4), 3)), "in") // { arity: 8 }
+            FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0)) // { arity: 2 }
+              Project (#1) // { arity: 1 }
+                Map (array_index(regexp_split_to_array["\n\n", case_insensitive=false](#0{input}), 2)) // { arity: 2 }
+                  ReadStorage materialize.public.input // { arity: 1 }
+        Project (#6, #1..=#4) // { arity: 5 }
+          TopK group_by=[#0, #1, #2, #3, #4] order_by=[#5 asc nulls_last] limit=1 // { arity: 7 }
+            Project (#0..=#4, #6, #10) // { arity: 7 }
+              Filter case when (#8 = "<") then case when (#7 = "x") then (#1 < #9) else case when (#7 = "m") then (#2 < #9) else case when (#7 = "a") then (#3 < #9) else case when (#7 = "s") then (#4 < #9) else false end end end end else case when (#8 = ">") then case when (#7 = "x") then (#1 > #9) else case when (#7 = "m") then (#2 > #9) else case when (#7 = "a") then (#3 > #9) else case when (#7 = "s") then (#4 > #9) else false end end end end else false end end // { arity: 11 }
+                Join on=(#0 = #5) type=differential // { arity: 11 }
+                  implementation
+                    %0:l1[#0]K » %1:l0[#0]K
+                  ArrangeBy keys=[[#0]] // { arity: 5 }
+                    Filter (#0) IS NOT NULL // { arity: 5 }
+                      Get l1 // { arity: 5 }
+                  ArrangeBy keys=[[#0]] // { arity: 6 }
+                    Get l0 // { arity: 6 }
     cte l2 =
-      Reduce aggregates=[sum((((#0 + #1) + #2) + #3))]
-        Project (#1..=#4)
-          Filter (#0 = "A")
-            Get l1
+      Reduce aggregates=[sum((((#0 + #1) + #2) + #3))] // { arity: 1 }
+        Project (#1..=#4) // { arity: 4 }
+          Filter (#0 = "A") // { arity: 5 }
+            Get l1 // { arity: 5 }
     cte l3 =
-      Project (#0..=#9, #12..=#15)
-        Join on=(#0 = #10 AND #1 = #11) type=differential
-          ArrangeBy keys=[[#0, #1]]
-            Filter (#0) IS NOT NULL
-              Get l4
-          ArrangeBy keys=[[#0, #1]]
-            Get l0
+      Project (#0..=#9, #12..=#15) // { arity: 14 }
+        Join on=(#0 = #10 AND #1 = #11) type=differential // { arity: 16 }
+          implementation
+            %0:l4[#0, #1]KK » %1:l0[#0, #1]KK
+          ArrangeBy keys=[[#0, #1]] // { arity: 10 }
+            Filter (#0) IS NOT NULL // { arity: 10 }
+              Get l4 // { arity: 10 }
+          ArrangeBy keys=[[#0, #1]] // { arity: 6 }
+            Get l0 // { arity: 6 }
     cte l4 =
-      Union
-        Project (#13, #28, #16, #18, #20, #21, #23, #24, #26, #27)
-          Map ((#10 = "x"), (#11 = ">"), case when (#14 AND #15) then greatest((#12 + 1), #2) else #2 end, (#11 = "<"), case when (#14 AND #17) then least((#12 - 1), #3) else #3 end, (#10 = "m"), case when (#15 AND #19) then greatest((#12 + 1), #4) else #4 end, case when (#17 AND #19) then least((#12 - 1), #5) else #5 end, (#10 = "a"), case when (#15 AND #22) then greatest((#12 + 1), #6) else #6 end, case when (#17 AND #22) then least((#12 - 1), #7) else #7 end, (#10 = "s"), case when (#15 AND #25) then greatest((#12 + 1), #8) else #8 end, case when (#17 AND #25) then least((#12 - 1), #9) else #9 end, 1)
-            Get l3
-        Project (#0, #14, #17, #19, #21, #22, #24, #25, #27, #28)
-          Map ((#1 + 1), (#10 = "x"), (#11 = "<"), case when (#15 AND #16) then greatest(#12, #2) else #2 end, (#11 = ">"), case when (#15 AND #18) then least(#12, #3) else #3 end, (#10 = "m"), case when (#16 AND #20) then greatest(#12, #4) else #4 end, case when (#18 AND #20) then least(#12, #5) else #5 end, (#10 = "a"), case when (#16 AND #23) then greatest(#12, #6) else #6 end, case when (#18 AND #23) then least(#12, #7) else #7 end, (#10 = "s"), case when (#16 AND #26) then greatest(#12, #8) else #8 end, case when (#18 AND #26) then least(#12, #9) else #9 end)
-            Get l3
-        Constant
+      Union // { arity: 10 }
+        Project (#13, #28, #16, #18, #20, #21, #23, #24, #26, #27) // { arity: 10 }
+          Map ((#10 = "x"), (#11 = ">"), case when (#14 AND #15) then greatest((#12 + 1), #2) else #2 end, (#11 = "<"), case when (#14 AND #17) then least((#12 - 1), #3) else #3 end, (#10 = "m"), case when (#15 AND #19) then greatest((#12 + 1), #4) else #4 end, case when (#17 AND #19) then least((#12 - 1), #5) else #5 end, (#10 = "a"), case when (#15 AND #22) then greatest((#12 + 1), #6) else #6 end, case when (#17 AND #22) then least((#12 - 1), #7) else #7 end, (#10 = "s"), case when (#15 AND #25) then greatest((#12 + 1), #8) else #8 end, case when (#17 AND #25) then least((#12 - 1), #9) else #9 end, 1) // { arity: 29 }
+            Get l3 // { arity: 14 }
+        Project (#0, #14, #17, #19, #21, #22, #24, #25, #27, #28) // { arity: 10 }
+          Map ((#1 + 1), (#10 = "x"), (#11 = "<"), case when (#15 AND #16) then greatest(#12, #2) else #2 end, (#11 = ">"), case when (#15 AND #18) then least(#12, #3) else #3 end, (#10 = "m"), case when (#16 AND #20) then greatest(#12, #4) else #4 end, case when (#18 AND #20) then least(#12, #5) else #5 end, (#10 = "a"), case when (#16 AND #23) then greatest(#12, #6) else #6 end, case when (#18 AND #23) then least(#12, #7) else #7 end, (#10 = "s"), case when (#16 AND #26) then greatest(#12, #8) else #8 end, case when (#18 AND #26) then least(#12, #9) else #9 end) // { arity: 29 }
+            Get l3 // { arity: 14 }
+        Constant // { arity: 10 }
           - ("in", 1, 1, 4000, 1, 4000, 1, 4000, 1, 4000)
-  Return
+  Return // { arity: 2 }
     With
       cte l5 =
-        Reduce aggregates=[sum((((integer_to_bigint(((1 + #1) - #0)) * integer_to_bigint(((1 + #3) - #2))) * integer_to_bigint(((1 + #5) - #4))) * integer_to_bigint(((1 + #7) - #6))))]
-          Project (#2..=#9)
-            Filter (#0 = "A")
-              Get l4
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Union
-            Get l2
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l2
-                Constant
+        Reduce aggregates=[sum((((integer_to_bigint(((1 + #1) - #0)) * integer_to_bigint(((1 + #3) - #2))) * integer_to_bigint(((1 + #5) - #4))) * integer_to_bigint(((1 + #7) - #6))))] // { arity: 1 }
+          Project (#2..=#9) // { arity: 8 }
+            Filter (#0 = "A") // { arity: 10 }
+              Get l4 // { arity: 10 }
+    Return // { arity: 2 }
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0[×]U » %1[×]U
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l2 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l2 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
-        ArrangeBy keys=[[]]
-          Union
-            Get l5
-            Map (null)
-              Union
-                Negate
-                  Project ()
-                    Get l5
-                Constant
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l5 // { arity: 1 }
+            Map (null) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l5 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1220.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1220.slt
@@ -17,7 +17,8 @@ CREATE TABLE input (input TEXT);
 # no input data
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
 
     lines(line TEXT) AS ( SELECT regexp_split_to_table(input, '\n') FROM input ),
     links(name TEXT, link TEXT) AS (
@@ -139,254 +140,284 @@ SELECT * FROM signal WHERE target = 'cn' AND pulse = 'hi';
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#1)
-        FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0))
-          ReadStorage materialize.public.input
+      Project (#1) // { arity: 1 }
+        FlatMap unnest_array(regexp_split_to_array["\n", case_insensitive=false](#0{input})) // { arity: 2 }
+          ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Project (#3, #4)
-        Map (regexp_split_to_array[" ", case_insensitive=false](#0), substr(array_index(#2, 1), 2), btrim(array_index(#2, integer_to_bigint(#1)), ","))
-          FlatMap generate_series(3, (regexp_split_to_array[" ", case_insensitive=false](#0) array_length 1), 1)
-            Get l0
+      Project (#3, #4) // { arity: 2 }
+        Map (regexp_split_to_array[" ", case_insensitive=false](#0), substr(array_index(#2, 1), 2), btrim(array_index(#2, integer_to_bigint(#1)), ",")) // { arity: 5 }
+          FlatMap generate_series(3, (regexp_split_to_array[" ", case_insensitive=false](#0) array_length 1), 1) // { arity: 2 }
+            Get l0 // { arity: 1 }
     cte l2 =
-      Distinct project=[#0, #1] monotonic
-        Union
-          Project (#0, #2)
-            Filter (#1 > 0)
-              Map ((#1 - 1))
-                Get l2
-          Project (#2, #3)
-            Filter (#1 = 0) AND (#0 < 4100)
-              Map ((#0 + 1), 20)
-                Get l2
-          Constant
+      Distinct project=[#0, #1] monotonic // { arity: 2 }
+        Union // { arity: 2 }
+          Project (#0, #2) // { arity: 2 }
+            Filter (#1 > 0) // { arity: 3 }
+              Map ((#1 - 1)) // { arity: 3 }
+                Get l2 // { arity: 2 }
+          Project (#2, #3) // { arity: 2 }
+            Filter (#1 = 0) AND (#0 < 4100) // { arity: 4 }
+              Map ((#0 + 1), 20) // { arity: 4 }
+                Get l2 // { arity: 2 }
+          Constant // { arity: 2 }
             - (1, 1)
     cte l3 =
-      Union
-        Project (#2, #0, #3, #4)
-          Filter (#1 = 0)
-            Map ("roadcaster", 1, "lo")
-              Get l2
-        Filter (#2 > 0)
-          Get l12
-        Filter (#2 > 0)
-          Get l26
+      Union // { arity: 4 }
+        Project (#2, #0, #3, #4) // { arity: 4 }
+          Filter (#1 = 0) // { arity: 5 }
+            Map ("roadcaster", 1, "lo") // { arity: 5 }
+              Get l2 // { arity: 2 }
+        Filter (#2 > 0) // { arity: 4 }
+          Get l12 // { arity: 4 }
+        Filter (#2 > 0) // { arity: 4 }
+          Get l26 // { arity: 4 }
     cte l4 =
-      ArrangeBy keys=[[#1]]
-        Project (#0..=#3)
-          Filter (#4 = "lo") AND (#1) IS NOT NULL
-            Get l27
+      ArrangeBy keys=[[#1]] // { arity: 4 }
+        Project (#0..=#3) // { arity: 4 }
+          Filter (#4 = "lo") AND (#1) IS NOT NULL // { arity: 5 }
+            Get l27 // { arity: 5 }
     cte l5 =
-      Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#0), 1), substr(#1, 2))
-        Get l0
+      Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#0), 1), substr(#1, 2)) // { arity: 3 }
+        Get l0 // { arity: 1 }
     cte l6 =
-      Project (#0..=#3, #5)
-        Map ((#3 + 1))
-          Join on=(#1 = #4) type=differential
-            Get l4
-            ArrangeBy keys=[[#0]]
-              Project (#2)
-                Filter ("%" = substr(#1, 1, 1))
-                  Get l5
+      Project (#0..=#3, #5) // { arity: 5 }
+        Map ((#3 + 1)) // { arity: 6 }
+          Join on=(#1 = #4) type=differential // { arity: 5 }
+            implementation
+              %0:l4[#1]Kef » %1:l5[#0]Kef
+            Get l4 // { arity: 4 }
+            ArrangeBy keys=[[#0]] // { arity: 1 }
+              Project (#2) // { arity: 1 }
+                Filter ("%" = substr(#1, 1, 1)) // { arity: 3 }
+                  Get l5 // { arity: 3 }
     cte l7 =
-      Distinct project=[#0, #2, #3, #1]
-        Project (#0..=#3)
-          Get l6
+      Distinct project=[#0, #2, #3, #1] // { arity: 4 }
+        Project (#0..=#3) // { arity: 4 }
+          Get l6 // { arity: 5 }
     cte l8 =
-      Reduce group_by=[#0..=#3] aggregates=[count(*)]
-        Project (#0..=#3)
-          Filter ((#6 < #1) OR ((#1 = #6) AND ((#7 < #2) OR ((#2 = #7) AND (#4 < #0)))))
-            Join on=(#3 = #5) type=differential
-              ArrangeBy keys=[[#3]]
-                Get l7
-              Get l4
+      Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
+        Project (#0..=#3) // { arity: 4 }
+          Filter ((#6 < #1) OR ((#1 = #6) AND ((#7 < #2) OR ((#2 = #7) AND (#4 < #0))))) // { arity: 8 }
+            Join on=(#3 = #5) type=differential // { arity: 8 }
+              implementation
+                %1:l4[#1]Kef » %0:l7[#3]Kef
+              ArrangeBy keys=[[#3]] // { arity: 4 }
+                Get l7 // { arity: 4 }
+              Get l4 // { arity: 4 }
     cte l9 =
-      ArrangeBy keys=[[#0..=#3]]
-        Get l7
+      ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+        Get l7 // { arity: 4 }
     cte l10 =
-      Union
-        Get l8
-        Project (#0..=#3, #8)
-          Map (0)
-            Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential
-              ArrangeBy keys=[[#0..=#3]]
-                Union
-                  Negate
-                    Project (#0..=#3)
-                      Get l8
-                  Get l7
-              Get l9
+      Union // { arity: 5 }
+        Get l8 // { arity: 5 }
+        Project (#0..=#3, #8) // { arity: 5 }
+          Map (0) // { arity: 9 }
+            Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential // { arity: 8 }
+              implementation
+                %1:l9[#0..=#3]UKKKK » %0[#0..=#3]KKKK
+              ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+                Union // { arity: 4 }
+                  Negate // { arity: 4 }
+                    Project (#0..=#3) // { arity: 4 }
+                      Get l8 // { arity: 5 }
+                  Get l7 // { arity: 4 }
+              Get l9 // { arity: 4 }
     cte l11 =
-      Union
-        Get l10
-        Map (error("more than one record produced in subquery"))
-          Project (#0..=#3)
-            Filter (#4 > 1)
-              Reduce group_by=[#0..=#3] aggregates=[count(*)]
-                Project (#0..=#3)
-                  Get l10
+      Union // { arity: 5 }
+        Get l10 // { arity: 5 }
+        Map (error("more than one record produced in subquery")) // { arity: 5 }
+          Project (#0..=#3) // { arity: 4 }
+            Filter (#4{count} > 1) // { arity: 5 }
+              Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
+                Project (#0..=#3) // { arity: 4 }
+                  Get l10 // { arity: 5 }
     cte l12 =
-      Project (#1, #2, #4, #10)
-        Map (case when (0 = (#9 % 2)) then "hi" else "lo" end)
-          Join on=(#0 = #5 AND #1 = #8 AND #2 = #6 AND #3 = #7) type=differential
-            ArrangeBy keys=[[#0, #2, #3, #1]]
-              Get l6
-            ArrangeBy keys=[[#0..=#3]]
-              Union
-                Get l11
-                Project (#0..=#3, #8)
-                  Map (null)
-                    Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential
-                      ArrangeBy keys=[[#0..=#3]]
-                        Union
-                          Negate
-                            Distinct project=[#0..=#3]
-                              Project (#0..=#3)
-                                Get l11
-                          Get l7
-                      Get l9
+      Project (#1, #2, #4, #10) // { arity: 4 }
+        Map (case when (0 = (#9{count} % 2)) then "hi" else "lo" end) // { arity: 11 }
+          Join on=(#0 = #5 AND #1 = #8 AND #2 = #6 AND #3 = #7) type=differential // { arity: 10 }
+            implementation
+              %0:l6[#0, #2, #3, #1]KKKK » %1[#0..=#3]KKKK
+            ArrangeBy keys=[[#0, #2, #3, #1]] // { arity: 5 }
+              Get l6 // { arity: 5 }
+            ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
+              Union // { arity: 5 }
+                Get l11 // { arity: 5 }
+                Project (#0..=#3, #8) // { arity: 5 }
+                  Map (null) // { arity: 9 }
+                    Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential // { arity: 8 }
+                      implementation
+                        %1:l9[#0..=#3]UKKKK » %0[#0..=#3]KKKK
+                      ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+                        Union // { arity: 4 }
+                          Negate // { arity: 4 }
+                            Distinct project=[#0..=#3] // { arity: 4 }
+                              Project (#0..=#3) // { arity: 4 }
+                                Get l11 // { arity: 5 }
+                          Get l7 // { arity: 4 }
+                      Get l9 // { arity: 4 }
     cte l13 =
-      Filter (#1) IS NOT NULL
-        Get l27
+      Filter (#1) IS NOT NULL // { arity: 5 }
+        Get l27 // { arity: 5 }
     cte l14 =
-      Project (#0..=#3, #5)
-        Map ((#3 + 1))
-          Join on=(#1 = #4) type=differential
-            ArrangeBy keys=[[#1]]
-              Project (#0..=#3)
-                Get l13
-            ArrangeBy keys=[[#0]]
-              Project (#2)
-                Filter ("&" = substr(#1, 1, 1))
-                  Get l5
+      Project (#0..=#3, #5) // { arity: 5 }
+        Map ((#3 + 1)) // { arity: 6 }
+          Join on=(#1 = #4) type=differential // { arity: 5 }
+            implementation
+              %1:l5[#0]Kef » %0:l13[#1]Kef
+            ArrangeBy keys=[[#1]] // { arity: 4 }
+              Project (#0..=#3) // { arity: 4 }
+                Get l13 // { arity: 5 }
+            ArrangeBy keys=[[#0]] // { arity: 1 }
+              Project (#2) // { arity: 1 }
+                Filter ("&" = substr(#1, 1, 1)) // { arity: 3 }
+                  Get l5 // { arity: 3 }
     cte l15 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l14
+      Distinct project=[#0] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Get l14 // { arity: 5 }
     cte l16 =
-      ArrangeBy keys=[[#0]]
-        Get l15
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Get l15 // { arity: 1 }
     cte l17 =
-      Reduce group_by=[#0] aggregates=[count(*)]
-        Project (#0)
-          Join on=(#0 = #1) type=differential
-            Get l16
-            ArrangeBy keys=[[#0]]
-              Project (#1)
-                Filter (#1) IS NOT NULL
-                  Get l1
+      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+        Project (#0) // { arity: 1 }
+          Join on=(#0 = #1) type=differential // { arity: 2 }
+            implementation
+              %0:l16[#0]UK » %1:l1[#0]K
+            Get l16 // { arity: 1 }
+            ArrangeBy keys=[[#0]] // { arity: 1 }
+              Project (#1) // { arity: 1 }
+                Filter (#1) IS NOT NULL // { arity: 2 }
+                  Get l1 // { arity: 2 }
     cte l18 =
-      Union
-        Get l17
-        Project (#0, #2)
-          Map (0)
-            Join on=(#0 = #1) type=differential
-              ArrangeBy keys=[[#0]]
-                Union
-                  Negate
-                    Project (#0)
-                      Get l17
-                  Get l15
-              Get l16
+      Union // { arity: 2 }
+        Get l17 // { arity: 2 }
+        Project (#0, #2) // { arity: 2 }
+          Map (0) // { arity: 3 }
+            Join on=(#0 = #1) type=differential // { arity: 2 }
+              implementation
+                %1:l16[#0]UK » %0[#0]K
+              ArrangeBy keys=[[#0]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l17 // { arity: 2 }
+                  Get l15 // { arity: 1 }
+              Get l16 // { arity: 1 }
     cte l19 =
-      Union
-        Get l18
-        Map (error("more than one record produced in subquery"))
-          Project (#0)
-            Filter (#1 > 1)
-              Reduce group_by=[#0] aggregates=[count(*)]
-                Project (#0)
-                  Get l18
+      Union // { arity: 2 }
+        Get l18 // { arity: 2 }
+        Map (error("more than one record produced in subquery")) // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Filter (#1{count} > 1) // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                Project (#0) // { arity: 1 }
+                  Get l18 // { arity: 2 }
     cte l20 =
-      Project (#0..=#4, #6)
-        Join on=(#1 = #5) type=differential
-          ArrangeBy keys=[[#1]]
-            Get l14
-          ArrangeBy keys=[[#0]]
-            Union
-              Get l19
-              Project (#0, #2)
-                Map (null)
-                  Join on=(#0 = #1) type=differential
-                    ArrangeBy keys=[[#0]]
-                      Union
-                        Negate
-                          Distinct project=[#0]
-                            Project (#0)
-                              Get l19
-                        Get l15
-                    Get l16
+      Project (#0..=#4, #6{count}) // { arity: 6 }
+        Join on=(#1 = #5) type=differential // { arity: 7 }
+          implementation
+            %0:l14[#1]K » %1[#0]K
+          ArrangeBy keys=[[#1]] // { arity: 5 }
+            Get l14 // { arity: 5 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Union // { arity: 2 }
+              Get l19 // { arity: 2 }
+              Project (#0, #2) // { arity: 2 }
+                Map (null) // { arity: 3 }
+                  Join on=(#0 = #1) type=differential // { arity: 2 }
+                    implementation
+                      %1:l16[#0]UK » %0[#0]K
+                    ArrangeBy keys=[[#0]] // { arity: 1 }
+                      Union // { arity: 1 }
+                        Negate // { arity: 1 }
+                          Distinct project=[#0] // { arity: 1 }
+                            Project (#0) // { arity: 1 }
+                              Get l19 // { arity: 2 }
+                        Get l15 // { arity: 1 }
+                    Get l16 // { arity: 1 }
     cte l21 =
-      Distinct project=[#0, #2, #3, #1]
-        Project (#0..=#3)
-          Get l20
+      Distinct project=[#0, #2, #3, #1] // { arity: 4 }
+        Project (#0..=#3) // { arity: 4 }
+          Get l20 // { arity: 6 }
     cte l22 =
-      Reduce group_by=[#0..=#3] aggregates=[count(*)]
-        Project (#0..=#3)
-          Filter (#7 = "hi")
-            TopK group_by=[#0..=#4] order_by=[#5 desc nulls_first, #6 desc nulls_first] limit=1 exp_group_size=1000
-              Project (#0..=#4, #6..=#8)
-                Filter ((#6 < #1) OR ((#1 = #6) AND ((#7 < #2) OR ((#2 = #7) AND (#4 <= #0)))))
-                  Join on=(#3 = #5) type=differential
-                    ArrangeBy keys=[[#3]]
-                      Get l21
-                    ArrangeBy keys=[[#1]]
-                      Get l13
+      Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
+        Project (#0..=#3) // { arity: 4 }
+          Filter (#7 = "hi") // { arity: 8 }
+            TopK group_by=[#0, #1, #2, #3, #4] order_by=[#5 desc nulls_first, #6 desc nulls_first] limit=1 exp_group_size=1000 // { arity: 8 }
+              Project (#0..=#4, #6..=#8) // { arity: 8 }
+                Filter ((#6 < #1) OR ((#1 = #6) AND ((#7 < #2) OR ((#2 = #7) AND (#4 <= #0))))) // { arity: 9 }
+                  Join on=(#3 = #5) type=differential // { arity: 9 }
+                    implementation
+                      %0:l21[#3]K » %1:l13[#1]K
+                    ArrangeBy keys=[[#3]] // { arity: 4 }
+                      Get l21 // { arity: 4 }
+                    ArrangeBy keys=[[#1]] // { arity: 5 }
+                      Get l13 // { arity: 5 }
     cte l23 =
-      ArrangeBy keys=[[#0..=#3]]
-        Get l21
+      ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+        Get l21 // { arity: 4 }
     cte l24 =
-      Union
-        Get l22
-        Project (#0..=#3, #8)
-          Map (0)
-            Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential
-              ArrangeBy keys=[[#0..=#3]]
-                Union
-                  Negate
-                    Project (#0..=#3)
-                      Get l22
-                  Get l21
-              Get l23
+      Union // { arity: 5 }
+        Get l22 // { arity: 5 }
+        Project (#0..=#3, #8) // { arity: 5 }
+          Map (0) // { arity: 9 }
+            Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential // { arity: 8 }
+              implementation
+                %1:l23[#0..=#3]UKKKK » %0[#0..=#3]KKKK
+              ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+                Union // { arity: 4 }
+                  Negate // { arity: 4 }
+                    Project (#0..=#3) // { arity: 4 }
+                      Get l22 // { arity: 5 }
+                  Get l21 // { arity: 4 }
+              Get l23 // { arity: 4 }
     cte l25 =
-      Union
-        Get l24
-        Map (error("more than one record produced in subquery"))
-          Project (#0..=#3)
-            Filter (#4 > 1)
-              Reduce group_by=[#0..=#3] aggregates=[count(*)]
-                Project (#0..=#3)
-                  Get l24
+      Union // { arity: 5 }
+        Get l24 // { arity: 5 }
+        Map (error("more than one record produced in subquery")) // { arity: 5 }
+          Project (#0..=#3) // { arity: 4 }
+            Filter (#4{count} > 1) // { arity: 5 }
+              Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
+                Project (#0..=#3) // { arity: 4 }
+                  Get l24 // { arity: 5 }
     cte l26 =
-      Project (#1, #2, #4, #11)
-        Map (case when (#5 = #10) then "lo" else "hi" end)
-          Join on=(#0 = #6 AND #1 = #9 AND #2 = #7 AND #3 = #8) type=differential
-            ArrangeBy keys=[[#0, #2, #3, #1]]
-              Get l20
-            ArrangeBy keys=[[#0..=#3]]
-              Union
-                Get l25
-                Project (#0..=#3, #8)
-                  Map (null)
-                    Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential
-                      ArrangeBy keys=[[#0..=#3]]
-                        Union
-                          Negate
-                            Distinct project=[#0..=#3]
-                              Project (#0..=#3)
-                                Get l25
-                          Get l21
-                      Get l23
+      Project (#1, #2, #4, #11) // { arity: 4 }
+        Map (case when (#5{count} = #10{count}) then "lo" else "hi" end) // { arity: 12 }
+          Join on=(#0 = #6 AND #1 = #9 AND #2 = #7 AND #3 = #8) type=differential // { arity: 11 }
+            implementation
+              %0:l20[#0, #2, #3, #1]KKKK » %1[#0..=#3]KKKK
+            ArrangeBy keys=[[#0, #2, #3, #1]] // { arity: 6 }
+              Get l20 // { arity: 6 }
+            ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
+              Union // { arity: 5 }
+                Get l25 // { arity: 5 }
+                Project (#0..=#3, #8) // { arity: 5 }
+                  Map (null) // { arity: 9 }
+                    Join on=(#0 = #4 AND #1 = #5 AND #2 = #6 AND #3 = #7) type=differential // { arity: 8 }
+                      implementation
+                        %1:l23[#0..=#3]UKKKK » %0[#0..=#3]KKKK
+                      ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+                        Union // { arity: 4 }
+                          Negate // { arity: 4 }
+                            Distinct project=[#0..=#3] // { arity: 4 }
+                              Project (#0..=#3) // { arity: 4 }
+                                Get l25 // { arity: 5 }
+                          Get l21 // { arity: 4 }
+                      Get l23 // { arity: 4 }
     cte l27 =
-      Project (#0, #5, #1..=#3)
-        Join on=(#0 = #4) type=differential
-          ArrangeBy keys=[[#0]]
-            Get l3
-          ArrangeBy keys=[[#0]]
-            Filter (#0) IS NOT NULL
-              Get l1
-  Return
-    Filter (#1 = "cn") AND (#4 = "hi")
-      Get l27
+      Project (#0, #5, #1..=#3) // { arity: 5 }
+        Join on=(#0 = #4) type=differential // { arity: 6 }
+          implementation
+            %0:l3[#0]K » %1:l1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 4 }
+            Get l3 // { arity: 4 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              Get l1 // { arity: 2 }
+  Return // { arity: 5 }
+    Filter (#1 = "cn") AND (#4 = "hi") // { arity: 5 }
+      Get l27 // { arity: 5 }
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1222.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1222.slt
@@ -125,7 +125,8 @@ SELECT * FROM part1, part2;
 23  3
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
 
     lines(r INT, line TEXT) AS (
         SELECT r, regexp_split_to_array(input, '\n')[r] as line
@@ -207,237 +208,273 @@ SELECT * FROM part1, part2;
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#1, #2)
-        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-            ReadStorage materialize.public.input
+      Project (#1, #2) // { arity: 2 }
+        Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
+          FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
+            ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Distinct project=[#0]
-        Project (#0)
-          Get l7
+      Distinct project=[#0] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l7 // { arity: 4 }
     cte l2 =
-      Reduce group_by=[#0] aggregates=[any((#0 = #1))]
-        CrossJoin type=differential
-          ArrangeBy keys=[[]]
-            Get l1
-          ArrangeBy keys=[[]]
-            Get l10
+      Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0:l1[×] » %1:l10[×]
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l1 // { arity: 1 }
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Get l10 // { arity: 1 }
     cte l3 =
-      ArrangeBy keys=[[#0]]
-        Get l1
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Get l1 // { arity: 1 }
     cte l4 =
-      Union
-        Get l2
-        Project (#0, #2)
-          Map (false)
-            Join on=(#0 = #1) type=differential
-              ArrangeBy keys=[[#0]]
-                Union
-                  Negate
-                    Project (#0)
-                      Get l2
-                  Get l1
-              Get l3
+      Union // { arity: 2 }
+        Get l2 // { arity: 2 }
+        Project (#0, #2) // { arity: 2 }
+          Map (false) // { arity: 3 }
+            Join on=(#0 = #1) type=differential // { arity: 2 }
+              implementation
+                %1:l3[#0]UK » %0[#0]K
+              ArrangeBy keys=[[#0]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l2 // { arity: 2 }
+                  Get l1 // { arity: 1 }
+              Get l3 // { arity: 1 }
     cte l5 =
-      Union
-        Get l4
-        Map (error("more than one record produced in subquery"))
-          Project (#0)
-            Filter (#1 > 1)
-              Reduce group_by=[#0] aggregates=[count(*)]
-                Project (#0)
-                  Get l4
+      Union // { arity: 2 }
+        Get l4 // { arity: 2 }
+        Map (error("more than one record produced in subquery")) // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Filter (#1{count} > 1) // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                Project (#0) // { arity: 1 }
+                  Get l4 // { arity: 2 }
     cte l6 =
-      Project (#0, #1, #3, #5)
-        Join on=(#0 = #2 = #4) type=delta
-          ArrangeBy keys=[[#0]]
-            Project (#0, #2)
-              FlatMap generate_series(text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 1)), 1)), text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 2)), 1)), 1)
-                Get l0
-          ArrangeBy keys=[[#0]]
-            Project (#0, #2)
-              FlatMap generate_series(text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 1)), 2)), text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 2)), 2)), 1)
-                Get l0
-          ArrangeBy keys=[[#0]]
-            Project (#0, #2)
-              FlatMap generate_series(text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 1)), 3)), text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 2)), 3)), 1)
-                Get l0
+      Project (#0, #1, #3, #5) // { arity: 4 }
+        Join on=(#0 = #2 = #4) type=delta // { arity: 6 }
+          implementation
+            %0 » %1[#0]K » %2[#0]K
+            %1 » %0[#0]K » %2[#0]K
+            %2 » %0[#0]K » %1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Project (#0, #2) // { arity: 2 }
+              FlatMap generate_series(text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 1)), 1)), text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 2)), 1)), 1) // { arity: 3 }
+                Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Project (#0, #2) // { arity: 2 }
+              FlatMap generate_series(text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 1)), 2)), text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 2)), 2)), 1) // { arity: 3 }
+                Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Project (#0, #2) // { arity: 2 }
+              FlatMap generate_series(text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 1)), 3)), text_to_integer(array_index(regexp_split_to_array[",", case_insensitive=false](array_index(regexp_split_to_array["~", case_insensitive=false](#1), 2)), 3)), 1) // { arity: 3 }
+                Get l0 // { arity: 2 }
     cte l7 =
-      Union
-        Threshold
-          Union
-            Get l6
-            Negate
-              Get l16
-        Project (#0..=#2, #6)
-          Map (case when #5 then #3 else (#3 - 1) end)
-            Join on=(#0 = #4) type=differential
-              ArrangeBy keys=[[#0]]
-                Get l7
-              ArrangeBy keys=[[#0]]
-                Union
-                  Get l5
-                  Project (#0, #2)
-                    Map (null)
-                      Join on=(#0 = #1) type=differential
-                        ArrangeBy keys=[[#0]]
-                          Union
-                            Negate
-                              Distinct project=[#0]
-                                Project (#0)
-                                  Get l5
-                            Get l1
-                        Get l3
+      Union // { arity: 4 }
+        Threshold // { arity: 4 }
+          Union // { arity: 4 }
+            Get l6 // { arity: 4 }
+            Negate // { arity: 4 }
+              Get l16 // { arity: 4 }
+        Project (#0..=#2, #6) // { arity: 4 }
+          Map (case when #5{any} then #3 else (#3 - 1) end) // { arity: 7 }
+            Join on=(#0 = #4) type=differential // { arity: 6 }
+              implementation
+                %0:l7[#0]K » %1[#0]K
+              ArrangeBy keys=[[#0]] // { arity: 4 }
+                Get l7 // { arity: 4 }
+              ArrangeBy keys=[[#0]] // { arity: 2 }
+                Union // { arity: 2 }
+                  Get l5 // { arity: 2 }
+                  Project (#0, #2) // { arity: 2 }
+                    Map (null) // { arity: 3 }
+                      Join on=(#0 = #1) type=differential // { arity: 2 }
+                        implementation
+                          %1:l3[#0]UK » %0[#0]K
+                        ArrangeBy keys=[[#0]] // { arity: 1 }
+                          Union // { arity: 1 }
+                            Negate // { arity: 1 }
+                              Distinct project=[#0] // { arity: 1 }
+                                Project (#0) // { arity: 1 }
+                                  Get l5 // { arity: 2 }
+                            Get l1 // { arity: 1 }
+                        Get l3 // { arity: 1 }
     cte l8 =
-      Distinct project=[#0, #1]
-        Project (#0, #4)
-          Filter (#0 != #4)
-            Join on=(#1 = #5 AND #2 = #6 AND #7 = (#3 + 1)) type=differential
-              ArrangeBy keys=[[#1, #2, (#3 + 1)]]
-                Get l7
-              ArrangeBy keys=[[#1..=#3]]
-                Get l7
+      Distinct project=[#0, #1] // { arity: 2 }
+        Project (#0, #4) // { arity: 2 }
+          Filter (#0 != #4) // { arity: 8 }
+            Join on=(#1 = #5 AND #2 = #6 AND #7 = (#3 + 1)) type=differential // { arity: 8 }
+              implementation
+                %0:l7[#1, #2, (#3 + 1)]KKK » %1:l7[#1..=#3]KKK
+              ArrangeBy keys=[[#1, #2, (#3 + 1)]] // { arity: 4 }
+                Get l7 // { arity: 4 }
+              ArrangeBy keys=[[#1..=#3]] // { arity: 4 }
+                Get l7 // { arity: 4 }
     cte l9 =
-      Project (#1)
-        Get l8
+      Project (#1) // { arity: 1 }
+        Get l8 // { arity: 2 }
     cte l10 =
-      Distinct project=[#0]
-        Union
-          Project (#0)
-            Filter (#3 = 1)
-              Get l7
-          Get l9
+      Distinct project=[#0] // { arity: 1 }
+        Union // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Filter (#3 = 1) // { arity: 4 }
+              Get l7 // { arity: 4 }
+          Get l9 // { arity: 1 }
     cte l11 =
-      Project (#0)
-        Get l0
+      Project (#0) // { arity: 1 }
+        Get l0 // { arity: 2 }
     cte l12 =
-      Distinct project=[#0]
-        Get l11
+      Distinct project=[#0] // { arity: 1 }
+        Get l11 // { arity: 1 }
     cte l13 =
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Get l12
-        ArrangeBy keys=[[]]
-          Get l8
+      CrossJoin type=differential // { arity: 3 }
+        implementation
+          %0:l12[×] » %1:l8[×]
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Get l12 // { arity: 1 }
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Get l8 // { arity: 2 }
     cte l14 =
-      ArrangeBy keys=[[#0]]
-        Get l9
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Get l9 // { arity: 1 }
     cte l15 =
-      Reduce aggregates=[count(distinct #0)]
-        Project (#0)
-          Join on=(#0 = #1 = #2) type=delta
-            ArrangeBy keys=[[#0]]
-              Get l11
-            ArrangeBy keys=[[#0]]
-              Union
-                Negate
-                  Distinct project=[#0]
-                    Project (#0)
-                      Filter (#3 = 1)
-                        Join on=(#1 = #2) type=differential
-                          ArrangeBy keys=[[#1]]
-                            Project (#0, #2)
-                              Filter (#0 = #1)
-                                Get l13
-                          ArrangeBy keys=[[#0]]
-                            Reduce group_by=[#0] aggregates=[count(*)]
-                              Project (#0)
-                                Join on=(#0 = #1) type=differential
-                                  ArrangeBy keys=[[#0]]
-                                    Distinct project=[#0]
-                                      Project (#2)
-                                        Get l13
-                                  Get l14
-                Get l12
-            ArrangeBy keys=[[#0]]
-              Get l12
+      Reduce aggregates=[count(distinct #0)] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Join on=(#0 = #1 = #2) type=delta // { arity: 3 }
+            implementation
+              %0:l11 » %2:l12[#0]UK » %1[#0]K
+              %1 » %2:l12[#0]UK » %0:l11[#0]K
+              %2:l12 » %0:l11[#0]K » %1[#0]K
+            ArrangeBy keys=[[#0]] // { arity: 1 }
+              Get l11 // { arity: 1 }
+            ArrangeBy keys=[[#0]] // { arity: 1 }
+              Union // { arity: 1 }
+                Negate // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Filter (#3{count} = 1) // { arity: 4 }
+                        Join on=(#1 = #2) type=differential // { arity: 4 }
+                          implementation
+                            %1[#0]UKAef » %0:l13[#1]Kef
+                          ArrangeBy keys=[[#1]] // { arity: 2 }
+                            Project (#0, #2) // { arity: 2 }
+                              Filter (#0 = #1) // { arity: 3 }
+                                Get l13 // { arity: 3 }
+                          ArrangeBy keys=[[#0]] // { arity: 2 }
+                            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                              Project (#0) // { arity: 1 }
+                                Join on=(#0 = #1) type=differential // { arity: 2 }
+                                  implementation
+                                    %0[#0]UKA » %1:l14[#0]K
+                                  ArrangeBy keys=[[#0]] // { arity: 1 }
+                                    Distinct project=[#0] // { arity: 1 }
+                                      Project (#2) // { arity: 1 }
+                                        Get l13 // { arity: 3 }
+                                  Get l14 // { arity: 1 }
+                Get l12 // { arity: 1 }
+            ArrangeBy keys=[[#0]] // { arity: 1 }
+              Get l12 // { arity: 1 }
     cte l16 =
-      Get l6
+      Get l6 // { arity: 4 }
     cte l17 =
-      Reduce group_by=[#0, #1] aggregates=[count(*)]
-        Project (#0, #3)
-          Join on=(#1 = #2) type=differential
-            ArrangeBy keys=[[#1]]
-              Get l22
-            ArrangeBy keys=[[#0]]
-              Get l8
+      Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+        Project (#0, #3) // { arity: 2 }
+          Join on=(#1 = #2) type=differential // { arity: 4 }
+            implementation
+              %0:l22[#1]K » %1:l8[#0]K
+            ArrangeBy keys=[[#1]] // { arity: 2 }
+              Get l22 // { arity: 2 }
+            ArrangeBy keys=[[#0]] // { arity: 2 }
+              Get l8 // { arity: 2 }
     cte l18 =
-      Distinct project=[#0]
-        Project (#1)
-          Get l17
+      Distinct project=[#0] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          Get l17 // { arity: 3 }
     cte l19 =
-      ArrangeBy keys=[[#0]]
-        Get l18
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Get l18 // { arity: 1 }
     cte l20 =
-      Reduce group_by=[#0] aggregates=[count(*)]
-        Project (#0)
-          Join on=(#0 = #1) type=differential
-            Get l19
-            Get l14
+      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+        Project (#0) // { arity: 1 }
+          Join on=(#0 = #1) type=differential // { arity: 2 }
+            implementation
+              %0:l19[#0]UK » %1:l14[#0]K
+            Get l19 // { arity: 1 }
+            Get l14 // { arity: 1 }
     cte l21 =
-      Union
-        Get l20
-        Project (#0, #2)
-          Map (0)
-            Join on=(#0 = #1) type=differential
-              ArrangeBy keys=[[#0]]
-                Union
-                  Negate
-                    Project (#0)
-                      Get l20
-                  Get l18
-              Get l19
+      Union // { arity: 2 }
+        Get l20 // { arity: 2 }
+        Project (#0, #2) // { arity: 2 }
+          Map (0) // { arity: 3 }
+            Join on=(#0 = #1) type=differential // { arity: 2 }
+              implementation
+                %1:l19[#0]UK » %0[#0]K
+              ArrangeBy keys=[[#0]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l20 // { arity: 2 }
+                  Get l18 // { arity: 1 }
+              Get l19 // { arity: 1 }
     cte l22 =
-      Distinct project=[#0, #1]
-        Union
-          Project (#0, #1)
-            Filter (#3 = 1)
-              Join on=(#1 = #2) type=differential
-                ArrangeBy keys=[[#1]]
-                  Get l8
-                ArrangeBy keys=[[#0]]
-                  Reduce group_by=[#0] aggregates=[count(*)]
-                    Get l9
-          Project (#0, #1)
-            Join on=(#1 = #3 AND #2 = #4) type=differential
-              ArrangeBy keys=[[#1, #2]]
-                Get l17
-              ArrangeBy keys=[[#0, #1]]
-                Union
-                  Get l21
-                  Map (error("more than one record produced in subquery"))
-                    Project (#0)
-                      Filter (#1 > 1)
-                        Reduce group_by=[#0] aggregates=[count(*)]
-                          Project (#0)
-                            Get l21
-  Return
+      Distinct project=[#0, #1] // { arity: 2 }
+        Union // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            Filter (#3{count} = 1) // { arity: 4 }
+              Join on=(#1 = #2) type=differential // { arity: 4 }
+                implementation
+                  %1[#0]UKAef » %0:l8[#1]Kef
+                ArrangeBy keys=[[#1]] // { arity: 2 }
+                  Get l8 // { arity: 2 }
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                    Get l9 // { arity: 1 }
+          Project (#0, #1) // { arity: 2 }
+            Join on=(#1 = #3 AND #2{count} = #4{count}) type=differential // { arity: 5 }
+              implementation
+                %0:l17[#1, #2]KK » %1[#0, #1]KK
+              ArrangeBy keys=[[#1, #2{count}]] // { arity: 3 }
+                Get l17 // { arity: 3 }
+              ArrangeBy keys=[[#0, #1{count}]] // { arity: 2 }
+                Union // { arity: 2 }
+                  Get l21 // { arity: 2 }
+                  Map (error("more than one record produced in subquery")) // { arity: 2 }
+                    Project (#0) // { arity: 1 }
+                      Filter (#1{count} > 1) // { arity: 2 }
+                        Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                          Project (#0) // { arity: 1 }
+                            Get l21 // { arity: 2 }
+  Return // { arity: 2 }
     With
       cte l23 =
-        Reduce aggregates=[count(*)]
-          Project ()
-            Get l22
-    Return
-      CrossJoin type=differential
-        ArrangeBy keys=[[]]
-          Union
-            Get l15
-            Map (0)
-              Union
-                Negate
-                  Project ()
-                    Get l15
-                Constant
+        Reduce aggregates=[count(*)] // { arity: 1 }
+          Project () // { arity: 0 }
+            Get l22 // { arity: 2 }
+    Return // { arity: 2 }
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0[×]U » %1[×]U
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l15 // { arity: 1 }
+            Map (0) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l15 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
-        ArrangeBy keys=[[]]
-          Union
-            Get l23
-            Map (0)
-              Union
-                Negate
-                  Project ()
-                    Get l23
-                Constant
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Union // { arity: 1 }
+            Get l23 // { arity: 1 }
+            Map (0) // { arity: 1 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l23 // { arity: 1 }
+                Constant // { arity: 0 }
                   - ()
 
 Source materialize.public.input

--- a/test/sqllogictest/advent-of-code/2023/aoc_1223.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1223.slt
@@ -165,7 +165,8 @@ SELECT * FROM longest ORDER BY d DESC;
 12  20  0  0
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
 
     lines(r INT, line TEXT) AS (
         SELECT r, regexp_split_to_array(input, '\n')[r] as line
@@ -290,201 +291,238 @@ EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
 SELECT * FROM longest ORDER BY d DESC;
 ----
 Explained Query:
-  Finish order_by=[#2 desc nulls_first] output=[#0..=#3]
+  Finish order_by=[#2{max} desc nulls_first] output=[#0..=#3]
     With Mutually Recursive
       cte l0 =
-        Project (#0, #2)
-          Filter ("#" != substr(#1, #2, 1))
-            FlatMap generate_series(1, char_length(#1), 1)
-              Project (#1, #2)
-                Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                  FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-                    ReadStorage materialize.public.input
+        Project (#0, #2) // { arity: 2 }
+          Filter ("#" != substr(#1, #2, 1)) // { arity: 3 }
+            FlatMap generate_series(1, char_length(#1), 1) // { arity: 3 }
+              Project (#1, #2) // { arity: 2 }
+                Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
+                  FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
+                    ReadStorage materialize.public.input // { arity: 1 }
       cte l1 =
-        Distinct project=[#0, #1]
-          Get l0
+        Distinct project=[#0, #1] // { arity: 2 }
+          Get l0 // { arity: 2 }
       cte l2 =
-        ArrangeBy keys=[[#0, #1]]
-          Get l0
+        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+          Get l0 // { arity: 2 }
       cte l3 =
-        Distinct project=[#0..=#3]
-          Union
-            Project (#0..=#2, #1)
-              Distinct project=[#0..=#2]
-                Union
-                  Project (#0, #1, #4)
-                    Map ((#0 + 1))
-                      Join on=(#0 = #2 AND #1 = #3) type=differential
-                        Get l2
-                        ArrangeBy keys=[[#0, #1]]
-                          Distinct project=[#0, #1]
-                            Project (#0, #1)
-                              Join on=(#1 = #3 AND #2 = (#0 + 1)) type=differential
-                                ArrangeBy keys=[[(#0 + 1), #1]]
-                                  Get l1
-                                Get l2
-                  Project (#0, #1, #4)
-                    Map ((#0 - 1))
-                      Join on=(#0 = #2 AND #1 = #3) type=differential
-                        Get l2
-                        ArrangeBy keys=[[#0, #1]]
-                          Distinct project=[#0, #1]
-                            Project (#0, #1)
-                              Join on=(#1 = #3 AND #2 = (#0 - 1)) type=differential
-                                ArrangeBy keys=[[(#0 - 1), #1]]
-                                  Get l1
-                                Get l2
-            Project (#0, #1, #0, #4)
-              Map ((#1 + 1))
-                Join on=(#0 = #2 AND #1 = #3) type=differential
-                  Get l2
-                  ArrangeBy keys=[[#0, #1]]
-                    Distinct project=[#0, #1]
-                      Project (#0, #1)
-                        Join on=(#0 = #2 AND #3 = (#1 + 1)) type=differential
-                          ArrangeBy keys=[[#0, (#1 + 1)]]
-                            Get l1
-                          Get l2
-            Project (#0, #1, #0, #4)
-              Map ((#1 - 1))
-                Join on=(#0 = #2 AND #1 = #3) type=differential
-                  Get l2
-                  ArrangeBy keys=[[#0, #1]]
-                    Distinct project=[#0, #1]
-                      Project (#0, #1)
-                        Join on=(#0 = #2 AND #3 = (#1 - 1)) type=differential
-                          ArrangeBy keys=[[#0, (#1 - 1)]]
-                            Get l1
-                          Get l2
+        Distinct project=[#0..=#3] // { arity: 4 }
+          Union // { arity: 4 }
+            Project (#0..=#2, #1) // { arity: 4 }
+              Distinct project=[#0..=#2] // { arity: 3 }
+                Union // { arity: 3 }
+                  Project (#0, #1, #4) // { arity: 3 }
+                    Map ((#0 + 1)) // { arity: 5 }
+                      Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                        implementation
+                          %1[#0, #1]UKKA » %0:l2[#0, #1]KK
+                        Get l2 // { arity: 2 }
+                        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                          Distinct project=[#0, #1] // { arity: 2 }
+                            Project (#0, #1) // { arity: 2 }
+                              Join on=(#1 = #3 AND #2 = (#0 + 1)) type=differential // { arity: 4 }
+                                implementation
+                                  %0:l1[(#0 + 1), #1]KK » %1:l2[#0, #1]KK
+                                ArrangeBy keys=[[(#0 + 1), #1]] // { arity: 2 }
+                                  Get l1 // { arity: 2 }
+                                Get l2 // { arity: 2 }
+                  Project (#0, #1, #4) // { arity: 3 }
+                    Map ((#0 - 1)) // { arity: 5 }
+                      Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                        implementation
+                          %1[#0, #1]UKKA » %0:l2[#0, #1]KK
+                        Get l2 // { arity: 2 }
+                        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                          Distinct project=[#0, #1] // { arity: 2 }
+                            Project (#0, #1) // { arity: 2 }
+                              Join on=(#1 = #3 AND #2 = (#0 - 1)) type=differential // { arity: 4 }
+                                implementation
+                                  %0:l1[(#0 - 1), #1]KK » %1:l2[#0, #1]KK
+                                ArrangeBy keys=[[(#0 - 1), #1]] // { arity: 2 }
+                                  Get l1 // { arity: 2 }
+                                Get l2 // { arity: 2 }
+            Project (#0, #1, #0, #4) // { arity: 4 }
+              Map ((#1 + 1)) // { arity: 5 }
+                Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                  implementation
+                    %1[#0, #1]UKKA » %0:l2[#0, #1]KK
+                  Get l2 // { arity: 2 }
+                  ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                    Distinct project=[#0, #1] // { arity: 2 }
+                      Project (#0, #1) // { arity: 2 }
+                        Join on=(#0 = #2 AND #3 = (#1 + 1)) type=differential // { arity: 4 }
+                          implementation
+                            %0:l1[#0, (#1 + 1)]KK » %1:l2[#0, #1]KK
+                          ArrangeBy keys=[[#0, (#1 + 1)]] // { arity: 2 }
+                            Get l1 // { arity: 2 }
+                          Get l2 // { arity: 2 }
+            Project (#0, #1, #0, #4) // { arity: 4 }
+              Map ((#1 - 1)) // { arity: 5 }
+                Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                  implementation
+                    %1[#0, #1]UKKA » %0:l2[#0, #1]KK
+                  Get l2 // { arity: 2 }
+                  ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                    Distinct project=[#0, #1] // { arity: 2 }
+                      Project (#0, #1) // { arity: 2 }
+                        Join on=(#0 = #2 AND #3 = (#1 - 1)) type=differential // { arity: 4 }
+                          implementation
+                            %0:l1[#0, (#1 - 1)]KK » %1:l2[#0, #1]KK
+                          ArrangeBy keys=[[#0, (#1 - 1)]] // { arity: 2 }
+                            Get l1 // { arity: 2 }
+                          Get l2 // { arity: 2 }
       cte l4 =
-        Project (#0, #1)
-          Filter (#2 != 2)
-            Reduce group_by=[#0, #1] aggregates=[count(*)]
-              Project (#0, #1)
-                Get l3
+        Project (#0, #1) // { arity: 2 }
+          Filter (#2{count} != 2) // { arity: 3 }
+            Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+              Project (#0, #1) // { arity: 2 }
+                Get l3 // { arity: 4 }
       cte l5 =
-        ArrangeBy keys=[[#0, #1]]
-          Get l3
+        ArrangeBy keys=[[#0, #1]] // { arity: 4 }
+          Get l3 // { arity: 4 }
       cte l6 =
-        Project (#0..=#4, #7, #8)
-          Filter ((#0 != #7) OR (#1 != #8))
-            Join on=(#3 = #5 AND #4 = #6) type=differential
-              ArrangeBy keys=[[#3, #4]]
-                Get l9
-              Get l5
+        Project (#0..=#4, #7, #8) // { arity: 7 }
+          Filter ((#0 != #7) OR (#1 != #8)) // { arity: 9 }
+            Join on=(#3 = #5 AND #4 = #6) type=differential // { arity: 9 }
+              implementation
+                %0:l9[#3, #4]KK » %1:l5[#0, #1]KK
+              ArrangeBy keys=[[#3, #4]] // { arity: 5 }
+                Get l9 // { arity: 5 }
+              Get l5 // { arity: 4 }
       cte l7 =
-        Distinct project=[#0, #1]
-          Project (#3, #4)
-            Get l6
+        Distinct project=[#0, #1] // { arity: 2 }
+          Project (#3, #4) // { arity: 2 }
+            Get l6 // { arity: 7 }
       cte l8 =
-        ArrangeBy keys=[[#0, #1]]
-          Get l4
+        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+          Get l4 // { arity: 2 }
       cte l9 =
-        Project (#0, #1, #4, #2, #3)
-          Reduce group_by=[#0, #1, #3, #4] aggregates=[min(#2)]
-            Union
-              Project (#0, #1, #6, #2, #3)
-                Map (1)
-                  Join on=(#0 = #4 AND #1 = #5) type=differential
-                    Get l5
-                    Get l8
-              Project (#0, #1, #9, #5, #6)
-                Map ((#2 + 1))
-                  Join on=(#3 = #7 AND #4 = #8) type=differential
-                    ArrangeBy keys=[[#3, #4]]
-                      Get l6
-                    ArrangeBy keys=[[#0, #1]]
-                      Union
-                        Negate
-                          Project (#0, #1)
-                            Join on=(#0 = #2 AND #1 = #3) type=differential
-                              ArrangeBy keys=[[#0, #1]]
-                                Get l7
-                              Get l8
-                        Get l7
+        Project (#0, #1, #4{min}, #2, #3) // { arity: 5 }
+          Reduce group_by=[#0, #1, #3, #4] aggregates=[min(#2)] // { arity: 5 }
+            Union // { arity: 5 }
+              Project (#0, #1, #6, #2, #3) // { arity: 5 }
+                Map (1) // { arity: 7 }
+                  Join on=(#0 = #4 AND #1 = #5) type=differential // { arity: 6 }
+                    implementation
+                      %1:l8[#0, #1]UKK » %0:l5[#0, #1]KK
+                    Get l5 // { arity: 4 }
+                    Get l8 // { arity: 2 }
+              Project (#0, #1, #9, #5, #6) // { arity: 5 }
+                Map ((#2 + 1)) // { arity: 10 }
+                  Join on=(#3 = #7 AND #4 = #8) type=differential // { arity: 9 }
+                    implementation
+                      %0:l6[#3, #4]KK » %1[#0, #1]KK
+                    ArrangeBy keys=[[#3, #4]] // { arity: 7 }
+                      Get l6 // { arity: 7 }
+                    ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                      Union // { arity: 2 }
+                        Negate // { arity: 2 }
+                          Project (#0, #1) // { arity: 2 }
+                            Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                              implementation
+                                %0:l7[#0, #1]UKK » %1:l8[#0, #1]UKK
+                              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                                Get l7 // { arity: 2 }
+                              Get l8 // { arity: 2 }
+                        Get l7 // { arity: 2 }
       cte l10 =
-        Union
-          Negate
-            Distinct project=[#0, #1]
-              Project (#0, #1)
-                Filter (#0 = #2) AND (#1 = #3)
-                  FlatMap wrap2(1, 2, 12, 20, 130, 126, 141, 140)
-                    Get l4
-          Get l4
+        Union // { arity: 2 }
+          Negate // { arity: 2 }
+            Distinct project=[#0, #1] // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Filter (#0 = #2) AND (#1 = #3) // { arity: 4 }
+                  FlatMap wrap2(1, 2, 12, 20, 130, 126, 141, 140) // { arity: 4 }
+                    Get l4 // { arity: 2 }
+          Get l4 // { arity: 2 }
       cte l11 =
-        Distinct project=[#0, #1]
-          Get l10
+        Distinct project=[#0, #1] // { arity: 2 }
+          Get l10 // { arity: 2 }
       cte l12 =
-        Filter ((#2 < #0) OR ((#0 = #2) AND (#3 < #1)))
-          CrossJoin type=differential
-            ArrangeBy keys=[[]]
-              Get l11
-            ArrangeBy keys=[[]]
-              Get l4
+        Filter ((#2 < #0) OR ((#0 = #2) AND (#3 < #1))) // { arity: 4 }
+          CrossJoin type=differential // { arity: 4 }
+            implementation
+              %0:l11[×] » %1:l4[×]
+            ArrangeBy keys=[[]] // { arity: 2 }
+              Get l11 // { arity: 2 }
+            ArrangeBy keys=[[]] // { arity: 2 }
+              Get l4 // { arity: 2 }
       cte l13 =
-        Distinct project=[#0, #1]
-          Project (#2, #3)
-            Get l12
+        Distinct project=[#0, #1] // { arity: 2 }
+          Project (#2, #3) // { arity: 2 }
+            Get l12 // { arity: 4 }
       cte l14 =
-        Reduce group_by=[#0, #1] aggregates=[count(*)]
-          Project (#0, #1)
-            Join on=(#2 = #4 AND #3 = #5) type=differential
-              ArrangeBy keys=[[#2, #3]]
-                Get l12
-              ArrangeBy keys=[[#0, #1]]
-                Union
-                  Negate
-                    Distinct project=[#0, #1]
-                      Project (#0, #1)
-                        Filter (#0 = #2) AND (#1 = #3)
-                          FlatMap wrap2(1, 2, 12, 20, 130, 126, 141, 140)
-                            Get l13
-                  Get l13
+        Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+          Project (#0, #1) // { arity: 2 }
+            Join on=(#2 = #4 AND #3 = #5) type=differential // { arity: 6 }
+              implementation
+                %0:l12[#2, #3]KK » %1[#0, #1]KK
+              ArrangeBy keys=[[#2, #3]] // { arity: 4 }
+                Get l12 // { arity: 4 }
+              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                Union // { arity: 2 }
+                  Negate // { arity: 2 }
+                    Distinct project=[#0, #1] // { arity: 2 }
+                      Project (#0, #1) // { arity: 2 }
+                        Filter (#0 = #2) AND (#1 = #3) // { arity: 4 }
+                          FlatMap wrap2(1, 2, 12, 20, 130, 126, 141, 140) // { arity: 4 }
+                            Get l13 // { arity: 2 }
+                  Get l13 // { arity: 2 }
       cte l15 =
-        ArrangeBy keys=[[#0, #1]]
-          Get l11
+        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+          Get l11 // { arity: 2 }
       cte l16 =
-        Union
-          Get l14
-          Project (#0, #1, #4)
-            Map (0)
-              Join on=(#0 = #2 AND #1 = #3) type=differential
-                ArrangeBy keys=[[#0, #1]]
-                  Union
-                    Negate
-                      Project (#0, #1)
-                        Get l14
-                    Get l11
-                Get l15
+        Union // { arity: 3 }
+          Get l14 // { arity: 3 }
+          Project (#0, #1, #4) // { arity: 3 }
+            Map (0) // { arity: 5 }
+              Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                implementation
+                  %1:l15[#0, #1]UKK » %0[#0, #1]KK
+                ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                  Union // { arity: 2 }
+                    Negate // { arity: 2 }
+                      Project (#0, #1) // { arity: 2 }
+                        Get l14 // { arity: 3 }
+                    Get l11 // { arity: 2 }
+                Get l15 // { arity: 2 }
       cte l17 =
-        Project (#0, #1, #3, #2)
-          Reduce group_by=[#0, #1, #3] aggregates=[max(#2)]
-            Union
-              Project (#7, #8, #19, #20)
-                Filter (1 != ((#3 >> #18) % 2))
-                  Map (bigint_to_integer(#17), (#2 + #6), (#3 + (1 << #18)))
-                    Join on=(#0 = #4 AND #1 = #5 AND #7 = #9 = #11 = #13 = #15 AND #8 = #10 = #12 = #14 = #16) type=delta
-                      ArrangeBy keys=[[#0, #1]]
-                        Get l17
-                      ArrangeBy keys=[[#0, #1], [#3, #4]]
-                        Get l9
-                      Get l8
-                      ArrangeBy keys=[[#0, #1]]
-                        Get l10
-                      Get l15
-                      ArrangeBy keys=[[#0, #1]]
-                        Union
-                          Get l16
-                          Map (error("more than one record produced in subquery"))
-                            Project (#0, #1)
-                              Filter (#2 > 1)
-                                Reduce group_by=[#0, #1] aggregates=[count(*)]
-                                  Project (#0, #1)
-                                    Get l16
-              Constant
+        Project (#0, #1, #3{max}, #2) // { arity: 4 }
+          Reduce group_by=[#0, #1, #3] aggregates=[max(#2)] // { arity: 4 }
+            Union // { arity: 4 }
+              Project (#7, #8, #19, #20) // { arity: 4 }
+                Filter (1 != ((#3 >> #18) % 2)) // { arity: 21 }
+                  Map (bigint_to_integer(#17{count}), (#2 + #6{min}), (#3 + (1 << #18))) // { arity: 21 }
+                    Join on=(#0 = #4 AND #1 = #5 AND #7 = #9 = #11 = #13 = #15 AND #8 = #10 = #12 = #14 = #16) type=delta // { arity: 18 }
+                      implementation
+                        %0:l17 » %1:l9[#0, #1]KK » %2:l8[#0, #1]UKK » %4:l15[#0, #1]UKK » %3:l10[#0, #1]KK » %5[#0, #1]KK
+                        %1:l9 » %2:l8[#0, #1]UKK » %4:l15[#0, #1]UKK » %0:l17[#0, #1]KK » %3:l10[#0, #1]KK » %5[#0, #1]KK
+                        %2:l8 » %4:l15[#0, #1]UKK » %1:l9[#3, #4]KK » %0:l17[#0, #1]KK » %3:l10[#0, #1]KK » %5[#0, #1]KK
+                        %3:l10 » %2:l8[#0, #1]UKK » %4:l15[#0, #1]UKK » %1:l9[#3, #4]KK » %0:l17[#0, #1]KK » %5[#0, #1]KK
+                        %4:l15 » %2:l8[#0, #1]UKK » %1:l9[#3, #4]KK » %0:l17[#0, #1]KK » %3:l10[#0, #1]KK » %5[#0, #1]KK
+                        %5 » %2:l8[#0, #1]UKK » %4:l15[#0, #1]UKK » %1:l9[#3, #4]KK » %0:l17[#0, #1]KK » %3:l10[#0, #1]KK
+                      ArrangeBy keys=[[#0, #1]] // { arity: 4 }
+                        Get l17 // { arity: 4 }
+                      ArrangeBy keys=[[#0, #1], [#3, #4]] // { arity: 5 }
+                        Get l9 // { arity: 5 }
+                      Get l8 // { arity: 2 }
+                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                        Get l10 // { arity: 2 }
+                      Get l15 // { arity: 2 }
+                      ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+                        Union // { arity: 3 }
+                          Get l16 // { arity: 3 }
+                          Map (error("more than one record produced in subquery")) // { arity: 3 }
+                            Project (#0, #1) // { arity: 2 }
+                              Filter (#2{count} > 1) // { arity: 3 }
+                                Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+                                  Project (#0, #1) // { arity: 2 }
+                                    Get l16 // { arity: 3 }
+              Constant // { arity: 4 }
                 - (12, 20, 0, 0)
-    Return
-      Get l17
+    Return // { arity: 4 }
+      Get l17 // { arity: 4 }
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1224.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1224.slt
@@ -17,7 +17,8 @@ CREATE TABLE input (input TEXT);
 # no input data
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE
 
     lines(r INT, line TEXT) AS (
         SELECT r, regexp_split_to_array(input, '\n')[r] as line
@@ -119,18 +120,20 @@ SELECT x, y, ox, oy, COUNT(*) FROM coincidence_xz GROUP BY x, y, ox, oy HAVING C
 Explained Query:
   With
     cte l0 =
-      ArrangeBy keys=[[#5]]
-        Project (#0..=#2, #6, #8, #7)
-          Map ((#3 - -117), integer_to_numeric(#5), (#4 - #7))
-            CrossJoin type=differential
-              ArrangeBy keys=[[]]
-                Project (#1, #3..=#6)
-                  Filter (#1 < 10)
-                    Map (regexp_split_to_array[" ", case_insensitive=false](array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1))), text_to_numeric(btrim(array_index(#2, 1), ",")), text_to_numeric(btrim(array_index(#2, 3), ",")), text_to_numeric(btrim(array_index(#2, 5), ",")), text_to_numeric(btrim(array_index(#2, 7), ",")))
-                      FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-                        ReadStorage materialize.public.input
-              ArrangeBy keys=[[]]
-                Constant
+      ArrangeBy keys=[[#5]] // { arity: 6 }
+        Project (#0..=#2, #6, #8, #7) // { arity: 6 }
+          Map ((#3 - -117), integer_to_numeric(#5), (#4 - #7)) // { arity: 9 }
+            CrossJoin type=differential // { arity: 6 }
+              implementation
+                %0[×]if » %1[×]if
+              ArrangeBy keys=[[]] // { arity: 5 }
+                Project (#1, #3..=#6) // { arity: 5 }
+                  Filter (#1 < 10) // { arity: 7 }
+                    Map (regexp_split_to_array[" ", case_insensitive=false](array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))), text_to_numeric(btrim(array_index(#2, 1), ",")), text_to_numeric(btrim(array_index(#2, 3), ",")), text_to_numeric(btrim(array_index(#2, 5), ",")), text_to_numeric(btrim(array_index(#2, 7), ","))) // { arity: 7 }
+                      FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
+                        ReadStorage materialize.public.input // { arity: 1 }
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Constant // { arity: 1 }
                   total_rows (diffs absed): 1001
                   first_rows:
                     - (0)
@@ -153,16 +156,18 @@ Explained Query:
                     - (16)
                     - (17)
                     - (18)
-  Return
-    Project (#0, #1, #4, #2, #3)
-      Filter (#3 > 1)
-        Map (-117)
-          Reduce group_by=[(#0 + ((#2 * (((#5 - #0) * #8) - ((#6 - #1) * #7))) / ((#2 * #8) - (#3 * #7)))), (#1 + ((#3 * (((#5 - #0) * #8) - ((#6 - #1) * #7))) / ((#2 * #8) - (#3 * #7)))), #4] aggregates=[count(*)]
-            Project (#1..=#5, #7..=#10)
-              Filter (#0 < #6) AND ((#3 * #10) != (#4 * #9))
-                Join on=(#5 = #11) type=differential
-                  Get l0
-                  Get l0
+  Return // { arity: 5 }
+    Project (#0, #1, #4, #2, #3{count}) // { arity: 5 }
+      Filter (#3{count} > 1) // { arity: 5 }
+        Map (-117) // { arity: 5 }
+          Reduce group_by=[(#0 + ((#2 * (((#5 - #0) * #8) - ((#6 - #1) * #7))) / ((#2 * #8) - (#3 * #7)))), (#1 + ((#3 * (((#5 - #0) * #8) - ((#6 - #1) * #7))) / ((#2 * #8) - (#3 * #7)))), #4] aggregates=[count(*)] // { arity: 4 }
+            Project (#1..=#5, #7..=#10) // { arity: 9 }
+              Filter (#0 < #6) AND ((#3 * #10) != (#4 * #9)) // { arity: 12 }
+                Join on=(#5 = #11) type=differential // { arity: 12 }
+                  implementation
+                    %0:l0[#5]K » %1:l0[#5]K
+                  Get l0 // { arity: 6 }
+                  Get l0 // { arity: 6 }
 
 Source materialize.public.input
 

--- a/test/sqllogictest/advent-of-code/2023/aoc_1225.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1225.slt
@@ -78,7 +78,8 @@ SELECT * FROM part1;
 54
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN FOR WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 50)
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) FOR
+WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 50)
 
     lines(r INT, line TEXT) AS (
         SELECT r, regexp_split_to_array(input, '\n')[r] as line
@@ -130,150 +131,157 @@ SELECT * FROM part1;
 Explained Query:
   With Mutually Recursive
     cte l0 =
-      Project (#3, #4)
-        Map (regexp_split_to_array[" ", case_insensitive=false](#0), btrim(array_index(#2, 1), ":"), btrim(array_index(#2, integer_to_bigint(#1)), ","))
-          FlatMap generate_series(2, (regexp_split_to_array[" ", case_insensitive=false](#0) array_length 1), 1)
-            Project (#2)
-              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0), integer_to_bigint(#1)))
-                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0) array_length 1), 1)
-                  ReadStorage materialize.public.input
+      Project (#3, #4) // { arity: 2 }
+        Map (regexp_split_to_array[" ", case_insensitive=false](#0), btrim(array_index(#2, 1), ":"), btrim(array_index(#2, integer_to_bigint(#1)), ",")) // { arity: 5 }
+          FlatMap generate_series(2, (regexp_split_to_array[" ", case_insensitive=false](#0) array_length 1), 1) // { arity: 2 }
+            Project (#2) // { arity: 1 }
+              Map (array_index(regexp_split_to_array["\n", case_insensitive=false](#0{input}), integer_to_bigint(#1))) // { arity: 3 }
+                FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
+                  ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Map (case when (#0 < "n") then 1 else -1 end)
-        Union
-          Project (#0)
-            Get l0
-          Project (#1)
-            Get l0
+      Map (case when (#0 < "n") then 1 else -1 end) // { arity: 2 }
+        Union // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Get l0 // { arity: 2 }
+          Project (#1) // { arity: 1 }
+            Get l0 // { arity: 2 }
     cte l2 =
-      Project (#1)
-        Get l7
+      Project (#1{sum}) // { arity: 1 }
+        Get l7 // { arity: 2 }
     cte l3 =
-      Reduce aggregates=[sum(#0), count(#0)]
-        Get l2
+      Reduce aggregates=[sum(#0), count(#0)] // { arity: 2 }
+        Get l2 // { arity: 1 }
     cte l4 =
-      Project (#2)
-        Map ((#0 / bigint_to_numeric(case when (#1 = 0) then null else #1 end)))
-          Union
-            Get l3
-            Map (null, 0)
-              Union
-                Negate
-                  Project ()
-                    Get l3
-                Constant
+      Project (#2) // { arity: 1 }
+        Map ((#0{sum} / bigint_to_numeric(case when (#1{count} = 0) then null else #1{count} end))) // { arity: 3 }
+          Union // { arity: 2 }
+            Get l3 // { arity: 2 }
+            Map (null, 0) // { arity: 2 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l3 // { arity: 2 }
+                Constant // { arity: 0 }
                   - ()
     cte l5 =
-      Reduce aggregates=[sum((#0 * #0)), sum(#0), count(#0)]
-        Get l2
+      Reduce aggregates=[sum((#0 * #0)), sum(#0), count(#0)] // { arity: 3 }
+        Get l2 // { arity: 1 }
     cte l6 =
-      Project (#3)
-        Map (sqrtnumeric(case when ((#0) IS NULL OR (#1) IS NULL OR (case when (#2 = 0) then null else #2 end) IS NULL OR (case when (0 = (#2 - 1)) then null else (#2 - 1) end) IS NULL) then null else greatest(((#0 - ((#1 * #1) / bigint_to_numeric(case when (#2 = 0) then null else #2 end))) / bigint_to_numeric(case when (0 = (#2 - 1)) then null else (#2 - 1) end)), 0) end))
-          Union
-            Get l5
-            Map (null, null, 0)
-              Union
-                Negate
-                  Project ()
-                    Get l5
-                Constant
+      Project (#3) // { arity: 1 }
+        Map (sqrtnumeric(case when ((#0{sum}) IS NULL OR (#1{sum}) IS NULL OR (case when (#2{count} = 0) then null else #2{count} end) IS NULL OR (case when (0 = (#2{count} - 1)) then null else (#2{count} - 1) end) IS NULL) then null else greatest(((#0{sum} - ((#1{sum} * #1{sum}) / bigint_to_numeric(case when (#2{count} = 0) then null else #2{count} end))) / bigint_to_numeric(case when (0 = (#2{count} - 1)) then null else (#2{count} - 1) end)), 0) end)) // { arity: 4 }
+          Union // { arity: 3 }
+            Get l5 // { arity: 3 }
+            Map (null, null, 0) // { arity: 3 }
+              Union // { arity: 0 }
+                Negate // { arity: 0 }
+                  Project () // { arity: 0 }
+                    Get l5 // { arity: 3 }
+                Constant // { arity: 0 }
                   - ()
     cte [recursion_limit=50, return_at_limit] l7 =
-      Union
-        Threshold
-          Union
-            Get l1
-            Negate
-              Get l8
-        Reduce group_by=[#0] aggregates=[sum(((#1 - #2) / #3))]
-          Project (#0, #3..=#5)
-            Join on=(#1 = #2) type=delta
-              ArrangeBy keys=[[], [#1]]
-                Union
-                  Filter (#1) IS NOT NULL
-                    Get l0
-                  Project (#1, #0)
-                    Filter (#0) IS NOT NULL
-                      Get l0
-              ArrangeBy keys=[[#0]]
-                Filter (#0) IS NOT NULL
-                  Get l7
-              ArrangeBy keys=[[]]
-                Union
-                  Get l4
-                  Map (null)
-                    Union
-                      Negate
-                        Project ()
-                          Get l4
-                      Constant
+      Union // { arity: 2 }
+        Threshold // { arity: 2 }
+          Union // { arity: 2 }
+            Get l1 // { arity: 2 }
+            Negate // { arity: 2 }
+              Get l8 // { arity: 2 }
+        Reduce group_by=[#0] aggregates=[sum(((#1 - #2) / #3))] // { arity: 2 }
+          Project (#0, #3..=#5) // { arity: 4 }
+            Join on=(#1 = #2) type=delta // { arity: 6 }
+              implementation
+                %0 » %2[×]U » %3[×]U » %1:l7[#0]K
+                %1:l7 » %2[×]U » %3[×]U » %0[#1]K
+                %2 » %3[×]U » %0[×] » %1:l7[#0]K
+                %3 » %2[×]U » %0[×] » %1:l7[#0]K
+              ArrangeBy keys=[[], [#1]] // { arity: 2 }
+                Union // { arity: 2 }
+                  Filter (#1) IS NOT NULL // { arity: 2 }
+                    Get l0 // { arity: 2 }
+                  Project (#1, #0) // { arity: 2 }
+                    Filter (#0) IS NOT NULL // { arity: 2 }
+                      Get l0 // { arity: 2 }
+              ArrangeBy keys=[[#0]] // { arity: 2 }
+                Filter (#0) IS NOT NULL // { arity: 2 }
+                  Get l7 // { arity: 2 }
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Get l4 // { arity: 1 }
+                  Map (null) // { arity: 1 }
+                    Union // { arity: 0 }
+                      Negate // { arity: 0 }
+                        Project () // { arity: 0 }
+                          Get l4 // { arity: 1 }
+                      Constant // { arity: 0 }
                         - ()
-              ArrangeBy keys=[[]]
-                Union
-                  Get l6
-                  Map (null)
-                    Union
-                      Negate
-                        Project ()
-                          Get l6
-                      Constant
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Get l6 // { arity: 1 }
+                  Map (null) // { arity: 1 }
+                    Union // { arity: 0 }
+                      Negate // { arity: 0 }
+                        Project () // { arity: 0 }
+                          Get l6 // { arity: 1 }
+                      Constant // { arity: 0 }
                         - ()
     cte [recursion_limit=50, return_at_limit] l8 =
-      Get l1
-  Return
+      Get l1 // { arity: 2 }
+  Return // { arity: 1 }
     With
       cte l9 =
-        Reduce aggregates=[count(*)]
-          Project ()
-            Filter (#1 < 0)
-              Get l7
+        Reduce aggregates=[count(*)] // { arity: 1 }
+          Project () // { arity: 0 }
+            Filter (#1{sum} < 0) // { arity: 2 }
+              Get l7 // { arity: 2 }
       cte l10 =
-        Union
-          Get l9
-          Map (0)
-            Union
-              Negate
-                Project ()
-                  Get l9
-              Constant
+        Union // { arity: 1 }
+          Get l9 // { arity: 1 }
+          Map (0) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l9 // { arity: 1 }
+              Constant // { arity: 0 }
                 - ()
       cte l11 =
-        Reduce aggregates=[count(*)]
-          Project ()
-            Filter (#1 > 0)
-              Get l7
+        Reduce aggregates=[count(*)] // { arity: 1 }
+          Project () // { arity: 0 }
+            Filter (#1{sum} > 0) // { arity: 2 }
+              Get l7 // { arity: 2 }
       cte l12 =
-        Union
-          Get l11
-          Map (0)
-            Union
-              Negate
-                Project ()
-                  Get l11
-              Constant
+        Union // { arity: 1 }
+          Get l11 // { arity: 1 }
+          Map (0) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l11 // { arity: 1 }
+              Constant // { arity: 0 }
                 - ()
-    Return
-      Project (#2)
-        Map ((#0 * #1))
-          CrossJoin type=differential
-            ArrangeBy keys=[[]]
-              Union
-                Get l10
-                Map (null)
-                  Union
-                    Negate
-                      Project ()
-                        Get l10
-                    Constant
+    Return // { arity: 1 }
+      Project (#2) // { arity: 1 }
+        Map ((#0{count} * #1{count})) // { arity: 3 }
+          CrossJoin type=differential // { arity: 2 }
+            implementation
+              %0[×]U » %1[×]U
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Union // { arity: 1 }
+                Get l10 // { arity: 1 }
+                Map (null) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l10 // { arity: 1 }
+                    Constant // { arity: 0 }
                       - ()
-            ArrangeBy keys=[[]]
-              Union
-                Get l12
-                Map (null)
-                  Union
-                    Negate
-                      Project ()
-                        Get l12
-                    Constant
+            ArrangeBy keys=[[]] // { arity: 1 }
+              Union // { arity: 1 }
+                Get l12 // { arity: 1 }
+                Map (null) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l12 // { arity: 1 }
+                    Constant // { arity: 0 }
                       - ()
 
 Source materialize.public.input


### PR DESCRIPTION
Adds more options to the EXPLAINs in the Advent of Code slts.

### Motivation

My main motivation for this is that I'd like to see the details of join plan changes in https://github.com/MaterializeInc/materialize/pull/31281

Also, it's better to be uniform across our slts, and tpch as well as ldbc slts already use these options that I'm adding in this PR for aoc.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
