### PR TITLE
cluster tests: Bump timeouts for flaky test-github-8734

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -87,12 +87,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     def process(name: str) -> None:
         # incident-70 requires more memory, runs in separate CI step
         # concurrent-connections is too flaky
-        # TODO: Reenable test-github-8734 when database-issues#8963 is fixed
         if name in (
             "default",
             "test-incident-70",
             "test-concurrent-connections",
-            "test-github-8734",
         ):
             return
         with c.test_case(name):
@@ -3700,11 +3698,11 @@ def check_read_frontier_not_stuck(c: Composition, object_name: str):
     # we need to wait a bit for the object's frontier to show up.
     result = c.sql_query(query)
     if not result:
-        time.sleep(2)
+        time.sleep(5)
         result = c.sql_query(query)
 
     before = int(result[0][0])
-    time.sleep(2)
+    time.sleep(5)
     after = int(c.sql_query(query)[0][0])
     assert before < after, f"read frontier of {object_name} is stuck"
 


### PR DESCRIPTION
Fixes: https://github.com/MaterializeInc/database-issues/issues/8963

@teskje Does this make sense or should 2 seconds be a fixed limit?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
