### PR TITLE
bin/scratch: Fix mypy type

### DIFF
--- a/misc/python/materialize/scratch.py
+++ b/misc/python/materialize/scratch.py
@@ -27,7 +27,7 @@ from mypy_boto3_ec2.type_defs import (
     FilterTypeDef,
     InstanceNetworkInterfaceSpecificationTypeDef,
     InstanceTypeDef,
-    RunInstancesRequestRequestTypeDef,
+    RunInstancesRequestServiceResourceCreateInstancesTypeDef,
 )
 from prettytable import PrettyTable
 from pydantic import BaseModel
@@ -179,7 +179,7 @@ def launch(
     say(f"launching instance {display_name or '(unnamed)'}")
     with open(MZ_ROOT / "misc" / "scratch" / "provision.bash") as f:
         provisioning_script = f.read()
-    kwargs: RunInstancesRequestRequestTypeDef = {
+    kwargs: RunInstancesRequestServiceResourceCreateInstancesTypeDef = {
         "MinCount": 1,
         "MaxCount": 1,
         "ImageId": ami,


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/31410

Noticed by Jan in https://materializeinc.slack.com/archives/CM7ATT65S/p1739439309198359

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
