### PR TITLE
explain: Switch default to global plan instead of physical plan

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3837,7 +3837,7 @@ pub struct ExplainPlanStatement<T: AstInfo> {
 
 impl<T: AstInfo> ExplainPlanStatement<T> {
     pub fn stage(&self) -> ExplainStage {
-        self.stage.unwrap_or(ExplainStage::PhysicalPlan)
+        self.stage.unwrap_or(ExplainStage::GlobalPlan)
     }
 
     pub fn format(&self) -> ExplainFormat {


### PR DESCRIPTION
Was forgotten in https://github.com/MaterializeInc/materialize/pull/31185

> 3c1c409 changes the default for a bare EXPLAIN to use EXPLAIN PHYSICAL PLAN. But I only changed the default in order to catch every bare EXPLAIN, and I change the default back in c97eb41.

@mgree This is a good argument for at least having one test remaining that has a bare `EXPLAIN` I guess ;)

Noticed by @ggevay in https://materializeinc.slack.com/archives/C08ACQNGSQK/p1739461427061339

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
