### PR TITLE
Revert "ci: Move cargo test to Hetzner (and disable real-S3 tests)"

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -287,10 +287,12 @@ steps:
       # some tests run into stack overflows
       RUST_MIN_STACK: "4194304"
     plugins:
+      - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: cargo-test
     agents:
-      queue: hetzner-x86-64-dedi-32cpu-128gb
+      # Because of scratch-aws-access
+      queue: builder-linux-aarch64-mem
 
   - id: testdrive
     label: "Testdrive"

--- a/src/aws-util/src/s3_uploader.rs
+++ b/src/aws-util/src/s3_uploader.rs
@@ -379,7 +379,6 @@ mod tests {
     #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(coverage, ignore)] // https://github.com/MaterializeInc/database-issues/issues/5586
     #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `TLS_method` on OS `linux`
-    #[ignore] // TODO: Reenable against minio so it can run locally
     async fn multi_part_upload_success() -> Result<(), S3MultiPartUploadError> {
         let sdk_config = defaults().load().await;
         let (bucket, key) = match s3_bucket_key_for_test() {
@@ -431,7 +430,6 @@ mod tests {
     #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(coverage, ignore)] // https://github.com/MaterializeInc/database-issues/issues/5586
     #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `TLS_method` on OS `linux`
-    #[ignore] // TODO: Reenable against minio so it can run locally
     async fn multi_part_upload_buffer() -> Result<(), S3MultiPartUploadError> {
         let sdk_config = defaults().load().await;
         let (bucket, key) = match s3_bucket_key_for_test() {
@@ -490,7 +488,6 @@ mod tests {
     #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(coverage, ignore)] // https://github.com/MaterializeInc/database-issues/issues/5586
     #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `TLS_method` on OS `linux`
-    #[ignore] // TODO: Reenable against minio so it can run locally
     async fn multi_part_upload_no_data() -> Result<(), S3MultiPartUploadError> {
         let sdk_config = defaults().load().await;
         let (bucket, key) = match s3_bucket_key_for_test() {

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -1094,7 +1094,6 @@ mod tests {
     #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(coverage, ignore)] // https://github.com/MaterializeInc/database-issues/issues/5586
     #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `TLS_method` on OS `linux`
-    #[ignore] // TODO: Reenable against minio so it can run locally
     async fn s3_blob() -> Result<(), ExternalError> {
         let config = match S3BlobConfig::new_for_test().await? {
             Some(client) => client,

--- a/src/storage-operators/src/s3_oneshot_sink/pgcopy.rs
+++ b/src/storage-operators/src/s3_oneshot_sink/pgcopy.rs
@@ -214,7 +214,6 @@ mod tests {
     #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(coverage, ignore)] // https://github.com/MaterializeInc/database-issues/issues/5586
     #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `TLS_method` on OS `linux`
-    #[ignore] // TODO: Reenable against minio so it can run locally
     async fn test_multiple_files() -> Result<(), anyhow::Error> {
         let sdk_config = mz_aws_util::defaults().load().await;
         let (bucket, path) = match s3_bucket_path_for_test() {


### PR DESCRIPTION
This reverts commit b0fe52487f9f34d8ff332096a986709a393548a5.

In case https://github.com/MaterializeInc/materialize/pull/31485 isn't green either

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
