### PR TITLE
adapter: remove problematic function from `mz_cluster_replica_history`

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -7819,10 +7819,7 @@ pub static MZ_CLUSTER_REPLICA_HISTORY: LazyLock<BuiltinView> = LazyLock::new(|| 
             creates.replica_name,
             creates.occurred_at AS created_at,
             drops.occurred_at AS dropped_at,
-            mz_unsafe.mz_error_if_null(
-                    mz_cluster_replica_sizes.credits_per_hour, 'Replica of unknown size'
-                )
-                AS credits_per_hour
+            mz_cluster_replica_sizes.credits_per_hour as credits_per_hour
         FROM
             creates
                 LEFT JOIN drops ON creates.replica_id = drops.replica_id


### PR DESCRIPTION
Chatted with @frankmcsherry @bosconi and @SangJunBak about this, we think it should be fairly safe. If not I will cut a patch release!

### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/8965

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
