### PR TITLE
adapter: Partial revert of `e8c42c65afb7acd55eb7e530a92c89a9165f2e33` remove GROUP_COMMIT_BATCH_DURATION

### DIFF
--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -117,13 +117,6 @@ pub const ENABLE_EXPRESSION_CACHE: Config<bool> = Config::new(
     "Use a cache to store optimized expressions to help speed up start times.",
 );
 
-/// Amount of time we'll wait between explict group commit triggers before running another.
-pub const GROUP_COMMIT_BATCH_DURATION: Config<Duration> = Config::new(
-    "group_commit_batch_duration",
-    Duration::from_millis(25),
-    "Amount of time we'll wait between group commit triggers to let writes batch.",
-);
-
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -142,5 +135,4 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&DEFAULT_SINK_PARTITION_STRATEGY)
         .add(&ENABLE_CONTINUAL_TASK_BUILTINS)
         .add(&ENABLE_EXPRESSION_CACHE)
-        .add(&GROUP_COMMIT_BATCH_DURATION)
 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -4172,9 +4172,7 @@ pub fn serve(
             connection_limit_callback,
         );
 
-        let dyncfgs = catalog.system_config().dyncfgs();
-        let group_commit_metrics = metrics.group_commit_metrics();
-        let (group_commit_tx, group_commit_rx) = appends::notifier(dyncfgs, group_commit_metrics);
+        let (group_commit_tx, group_commit_rx) = appends::notifier();
 
         let parent_span = tracing::Span::current();
         let thread = thread::Builder::new()

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -43,8 +43,6 @@ pub struct Metrics {
     pub handle_scheduling_decisions_seconds: HistogramVec,
     pub row_set_finishing_seconds: HistogramVec,
     pub session_startup_table_writes_seconds: HistogramVec,
-    pub group_commit_trigger_count: IntCounter,
-    pub group_commit_batch_defer_seconds: HistogramVec,
 }
 
 impl Metrics {
@@ -182,15 +180,6 @@ impl Metrics {
                 help: "If we had to wait for builtin table writes before processing a query, how long did we wait for.",
                 buckets: histogram_seconds_buckets(0.000_008, 4.0),
             )),
-            group_commit_trigger_count: registry.register(metric!(
-                name: "mz_group_commit_trigger_count",
-                help: "How many group commits where explicitly triggered and run.",
-            )),
-            group_commit_batch_defer_seconds: registry.register(metric!(
-                name: "mz_group_commit_batch_defer_seconds",
-                help: "If we defered dropping a group commit permit, how long did we defer for.",
-                buckets: histogram_seconds_buckets(0.000_008, 1.0),
-            )),
         }
     }
 
@@ -203,15 +192,6 @@ impl Metrics {
             row_set_finishing_seconds: self.row_set_finishing_seconds(),
             session_startup_table_writes_seconds: self
                 .session_startup_table_writes_seconds
-                .with_label_values(&[]),
-        }
-    }
-
-    pub(crate) fn group_commit_metrics(&self) -> GroupCommitMetrics {
-        GroupCommitMetrics {
-            group_commit_trigger_count: self.group_commit_trigger_count.clone(),
-            group_commit_batch_defer_seconds: self
-                .group_commit_batch_defer_seconds
                 .with_label_values(&[]),
         }
     }
@@ -232,13 +212,6 @@ impl SessionMetrics {
     pub(crate) fn session_startup_table_writes_seconds(&self) -> &Histogram {
         &self.session_startup_table_writes_seconds
     }
-}
-
-/// Metrics associated with explicitly triggering a group commit.
-#[derive(Debug, Clone)]
-pub struct GroupCommitMetrics {
-    pub(crate) group_commit_trigger_count: IntCounter,
-    pub(crate) group_commit_batch_defer_seconds: Histogram,
 }
 
 pub(crate) fn session_type_label_value(user: &User) -> &'static str {


### PR DESCRIPTION
Partial revert of https://github.com/MaterializeInc/materialize/commit/e8c42c65afb7acd55eb7e530a92c89a9165f2e33

### Motivation

https://github.com/MaterializeInc/database-issues/issues/8963

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
