### PR TITLE
feature-benchmark: Ignore new regressions

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -49,6 +49,9 @@ ADDITIONAL_BENCHMARKING_SYSTEM_PARAMETERS = {
     # performance in benchmarks, see for example FastPathLimit scenario: 55%
     # more memory, 5% faster
     "persist_blob_cache_mem_limit_bytes": "1048576",
+    # This would increase the memory usage of many tests, making it harder to
+    # tell small memory increase regressions
+    "persist_blob_cache_scale_with_threads": "false",
 }
 
 

--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -28,6 +28,12 @@ def get_ancestor_overrides_for_performance_regressions(
 
     min_ancestor_mz_version_per_commit = dict()
 
+    if scenario_class_name == "ManySmallInserts":
+        # PR#31309 ([adapter] don't block on builtin table write in Session creation) increases latency for inserts
+        min_ancestor_mz_version_per_commit[
+            "e8c42c65afb7acd55eb7e530a92c89a9165f2e33"
+        ] = MzVersion.parse_mz("v0.133.0")
+
     if scenario_class_name == "SwapSchema":
         # PR#30883 (Columnar in logging dataflows) increases Mz memory usage
         min_ancestor_mz_version_per_commit[
@@ -188,6 +194,8 @@ _MIN_ANCESTOR_MZ_VERSION_PER_COMMIT_TO_ACCOUNT_FOR_SCALABILITY_REGRESSIONS: dict
     str, MzVersion
 ] = {
     # insert newer commits at the top
+    # PR#31309 ([adapter] don't block on builtin table write in Session creation) increases latency for inserts
+    "e8c42c65afb7acd55eb7e530a92c89a9165f2e33": MzVersion.parse_mz("v0.133.0"),
     # PR#30238 (adapter: Remove the global write lock) introduces regressions against v0.123.0
     "98678454a334a470ceea46b126586c7e60a0d8a5": MzVersion.parse_mz("v0.124.0"),
     # PR#28307 (Render regions for object build and let bindings) introduces regressions against v0.112.0


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/11127

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
