### PR TITLE
cargo test: Disable two very flaky tests

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -672,6 +672,7 @@ ORDER BY mseh.began_at ASC;",
 }
 
 #[mz_ore::test]
+#[ignore] // TODO: Reenable when database-issues#8967 is fixed
 fn test_statement_logging_sampling() {
     let (server, client) = setup_statement_logging(1.0, 0.5);
     test_statement_logging_sampling_inner(server, client);
@@ -680,6 +681,7 @@ fn test_statement_logging_sampling() {
 /// Test that we are not allowed to set `statement_logging_sample_rate`
 /// arbitrarily high, but that it is constrained by `statement_logging_max_sample_rate`.
 #[mz_ore::test]
+#[ignore] // TODO: Reenable when database-issues#8967 is fixed
 fn test_statement_logging_sampling_constrained() {
     let (server, client) = setup_statement_logging(0.5, 1.0);
     test_statement_logging_sampling_inner(server, client);


### PR DESCRIPTION
Two occurrences yesterday, seems quite likely to keep flaking
See https://github.com/MaterializeInc/database-issues/issues/8967
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
