### PR TITLE
Remove the serde for StackWrapper

### DIFF
--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -559,11 +559,12 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
     let mut final_row = Row::default();
     let mut datum_vec = DatumVec::new();
     let snapshot_updates = raw_data
+        .map::<Vec<_>, _, _>(Clone::clone)
         .distribute()
         .map(move |((oid, output_index, event), time, diff)| {
             let output = &table_info
-                .get(oid)
-                .and_then(|outputs| outputs.get(output_index))
+                .get(&oid)
+                .and_then(|outputs| outputs.get(&output_index))
                 .expect("table_info contains all outputs");
 
             let event = event
@@ -580,7 +581,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                     })
                 });
 
-            ((*output_index, event), *time, *diff)
+            ((output_index, event), time, diff)
         })
         .as_collection();
 


### PR DESCRIPTION
Removes the serde implementation for StackWrapper and ChunkedStack. It does
not seem to be correct, and given that we don't want to support it going
forward, I'm inclined to remove it rather than fix it.

Fixes https://github.com/MaterializeInc/database-issues/issues/8968

Signed-off-by: Moritz Hoffmann <mh@materialize.com>

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
