### PR TITLE
cloudtest: Fix expected error message

### DIFF
--- a/test/cloudtest/test_managed_cluster.py
+++ b/test/cloudtest/test_managed_cluster.py
@@ -386,7 +386,7 @@ def test_graceful_reconfiguration(mz: MaterializeApplication) -> None:
         input=dedent(
             """
             ! ALTER CLUSTER cluster_with_source set (size='2') WITH (WAIT UNTIL READY (TIMEOUT='10s', ON TIMEOUT ROLLBACK))
-            contains: cannot create more than one replica of clusters containing sources or sinks
+            contains: cannot create more than one replica of a cluster containing sources or sinks
             """
         ),
         no_reset=True,


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/11143#019501e1-d6ce-478c-af92-a951f1d1da0e

Follow-up to https://github.com/MaterializeInc/materialize/pull/31399

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
