### PR TITLE
terraform tests: Set default replication factors

### DIFF
--- a/test/terraform/aws-persistent/main.tf
+++ b/test/terraform/aws-persistent/main.tf
@@ -24,6 +24,15 @@ module "materialize_infrastructure" {
   environment  = "dev"
   install_materialize_operator = true
 
+  helm_values = {
+      defaultReplicationFactor = {
+          system = 1
+          probe = 1
+          support = 1
+          analytics = 1
+      }
+  }
+
   # VPC Configuration
   vpc_cidr             = "10.0.0.0/16"
   availability_zones   = ["us-east-1a", "us-east-1b"]

--- a/test/terraform/aws-temporary/main.tf
+++ b/test/terraform/aws-temporary/main.tf
@@ -26,6 +26,15 @@ module "materialize_infrastructure" {
   environment  = "dev"
   install_materialize_operator = true
 
+  helm_values = {
+      defaultReplicationFactor = {
+          system = 1
+          probe = 1
+          support = 1
+          analytics = 1
+      }
+  }
+
   # VPC Configuration
   vpc_cidr             = "10.0.0.0/16"
   availability_zones   = ["us-east-1a", "us-east-1b"]

--- a/test/terraform/gcp-temporary/main.tf
+++ b/test/terraform/gcp-temporary/main.tf
@@ -42,6 +42,15 @@ module "materialize" {
   }
 
   install_materialize_operator = true
+
+  helm_values = {
+      defaultReplicationFactor = {
+          system = 1
+          probe = 1
+          support = 1
+          analytics = 1
+      }
+  }
 }
 
 variable "project_id" {


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/31452. Some testdrive tests require these clusters to be usable.

Seen failing in https://buildkite.com/materialize/nightly/builds/11143#019501e1-d68b-407e-8801-4a60b5a18f5d

Green test run: https://buildkite.com/materialize/nightly/builds/11151

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
