### PR TITLE
0dt test: Reduce threads/runtime of upsert-sources workflow

### DIFF
--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -1401,7 +1401,7 @@ def workflow_upsert_sources(c: Composition) -> None:
     c.down(destroy_volumes=True)
     c.up("zookeeper", "kafka", "schema-registry", "postgres", "mysql", "mz_old")
     c.up("testdrive", persistent=True)
-    num_threads = 100
+    num_threads = 50
 
     c.sql(
         f"""
@@ -1428,7 +1428,7 @@ def workflow_upsert_sources(c: Composition) -> None:
         )
     )
 
-    end_time = datetime.now() + timedelta(seconds=300)
+    end_time = datetime.now() + timedelta(seconds=200)
     mz1 = "mz_old"
     mz2 = "mz_new"
 


### PR DESCRIPTION
Started OoMing now in this range probably: https://github.com/MaterializeInc/materialize/compare/b0a509fabf...49066b21e9

But I'm not sure which PR is responsible. Running faster could make this test ingest data faster and thus cause OoMs, so it's not necessarily a regression.

Example OoM: [Zero downtime](https://buildkite.com/materialize/nightly/builds/11147#01950378-876b-4dc3-826b-fd0af5024423)

This is kind of a weird stress test anyway, that is just trying to find race conditions.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
