### PR TITLE
test: bump delay for observing `mz_frontiers` from 2 to 3

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -3704,9 +3704,9 @@ def check_read_frontier_not_stuck(c: Composition, object_name: str):
         result = c.sql_query(query)
 
     before = int(result[0][0])
-    time.sleep(2)
+    time.sleep(3)
     after = int(c.sql_query(query)[0][0])
-    assert before < after, f"read frontier of {object_name} is stuck"
+    assert before < after, f"read frontier of {object_name} is stuck, {before} >= {after}"
 
 
 def workflow_test_refresh_mv_restart(

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -3704,7 +3704,9 @@ def check_read_frontier_not_stuck(c: Composition, object_name: str):
     before = int(result[0][0])
     time.sleep(3)
     after = int(c.sql_query(query)[0][0])
-    assert before < after, f"read frontier of {object_name} is stuck, {before} >= {after}"
+    assert (
+        before < after
+    ), f"read frontier of {object_name} is stuck, {before} >= {after}"
 
 
 def workflow_test_refresh_mv_restart(

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -87,12 +87,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     def process(name: str) -> None:
         # incident-70 requires more memory, runs in separate CI step
         # concurrent-connections is too flaky
-        # TODO: Reenable test-github-8734 when database-issues#8963 is fixed
         if name in (
             "default",
             "test-incident-70",
             "test-concurrent-connections",
-            "test-github-8734",
         ):
             return
         with c.test_case(name):


### PR DESCRIPTION
From: https://github.com/MaterializeInc/database-issues/issues/8963

> I'm pretty sure I know what's happening, and don't think this is a release blocker.
>
> When connecting to Materialize/starting a new session we update the `mz_sessions` table. Previously we would block the connection startup on this write finishing, but https://github.com/MaterializeInc/materialize/pull/31309 changed this behavior where we return the connection immediately, queuing a background append, and only blocking if that session tries to query the `mz_sessions` table before the said background write has completed.
>
> Also for context, all tables has a single logical frontier, appending to one table will bump the write frontier (and thus read frontier) for all tables.
>
> I believe that the now failing assertion, `check_read_frontier_not_stuck(...)`, previously would succeed all the time because [querying for the read frontier](https://github.com/MaterializeInc/materialize/blob/main/test/cluster/mzcompose.py#L3701) would establish a new connection, thus kicking off a write to `mz_sessions`, and bumping the frontier of the table 't' we are asserting on.
>
> After https://github.com/MaterializeInc/materialize/pull/31309 we're no longer blocking the connection, and thus query, on the write to `mz_sessions` so we're most likely relying on the [1 second "advance timelines" tick](https://github.com/MaterializeInc/materialize/blob/main/src/adapter/src/coord.rs#L3385-L3396) to advance the frontier of 't'. I'm guessing our 2 second sleep is occasionally not long enough to have the timeline advance _and_ observe the update in `mz_frontiers`.

### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/8963

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
