### PR TITLE
limits test: Bump some statement timeouts and increase agent size

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -367,7 +367,7 @@ steps:
         label: "Product limits"
         depends_on: build-x86_64
         agents:
-          queue: hetzner-x86-64-dedi-8cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: limits

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1281,6 +1281,7 @@ class ArrayAgg(Generator):
 
     @classmethod
     def body(cls) -> None:
+        print("> SET statement_timeout='300s'")
         print(
             f"""> CREATE TABLE t ({
             ", ".join(
@@ -1498,6 +1499,7 @@ class PostgresSources(Generator):
 
     @classmethod
     def body(cls) -> None:
+        print("> SET statement_timeout='300s'")
         print("$ postgres-execute connection=mz_system")
         print(f"ALTER SYSTEM SET max_sources = {cls.COUNT * 10};")
         print("$ postgres-execute connection=mz_system")


### PR DESCRIPTION
Somehow creating objects has gotten much slower, I'm still investigating: https://github.com/MaterializeInc/database-issues/issues/8970

Fixes: https://github.com/MaterializeInc/database-issues/issues/8970

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
