### PR TITLE
Always enable lgalloc, unless disabled

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -289,8 +289,10 @@ def cluster_replica_size_map() -> dict[str, dict[str, Any]]:
         bootstrap_cluster_replica_size(): replica_size(1, 1),
         "2-4": replica_size(4, 2),
         "free": replica_size(0, 0, disabled=True),
-        "1cc": replica_size(1, 1, is_cc=True),
-        "1C": replica_size(1, 1, is_cc=True),
+        "1cc": replica_size(1, 1),
+        "1C": replica_size(1, 1),
+        "1-no-disk": replica_size(1, 1, is_cc=False),
+        "2-no-disk": replica_size(2, 1, is_cc=False),
     }
 
     for i in range(0, 6):

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -269,7 +269,7 @@ def cluster_replica_size_map() -> dict[str, dict[str, Any]]:
         workers: int,
         scale: int,
         disabled: bool = False,
-        is_cc: bool = False,
+        is_cc: bool = True,
         memory_limit: str | None = None,
     ) -> dict[str, Any]:
         return {

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -47,7 +47,7 @@ pub const LINEAR_JOIN_YIELDING: Config<&str> = Config::new(
      work, respectively, rather than falling back to some default.",
 );
 
-/// Enable lgalloc for columnation.
+/// Enable lgalloc.
 pub const ENABLE_LGALLOC: Config<bool> = Config::new("enable_lgalloc", true, "Enable lgalloc.");
 
 /// Enable lgalloc for columnation.

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -48,9 +48,12 @@ pub const LINEAR_JOIN_YIELDING: Config<&str> = Config::new(
 );
 
 /// Enable lgalloc for columnation.
+pub const ENABLE_LGALLOC: Config<bool> = Config::new("enable_lgalloc", true, "Enable lgalloc.");
+
+/// Enable lgalloc for columnation.
 pub const ENABLE_COLUMNATION_LGALLOC: Config<bool> = Config::new(
     "enable_columnation_lgalloc",
-    false,
+    true,
     "Enable allocating regions from lgalloc.",
 );
 
@@ -182,6 +185,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_MATERIALIZED_VIEW_SINK_V2)
         .add(&ENABLE_CORRECTION_V2)
         .add(&LINEAR_JOIN_YIELDING)
+        .add(&ENABLE_LGALLOC)
         .add(&ENABLE_COLUMNATION_LGALLOC)
         .add(&ENABLE_LGALLOC_EAGER_RECLAMATION)
         .add(&COMPUTE_SERVER_MAINTENANCE_INTERVAL)

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -270,7 +270,7 @@ impl ComputeState {
 
         self.linear_join_spec = LinearJoinSpec::from_config(config);
 
-        if ENABLE_COLUMNATION_LGALLOC.get(config) {
+        if ENABLE_LGALLOC.get(config) {
             if let Some(path) = &self.context.scratch_directory {
                 let eager_return = ENABLE_LGALLOC_EAGER_RECLAMATION.get(config);
                 let interval = LGALLOC_BACKGROUND_INTERVAL.get(config);
@@ -297,6 +297,11 @@ impl ComputeState {
             info!("disabling lgalloc");
             lgalloc::lgalloc_set_config(lgalloc::LgAlloc::new().disable());
         }
+
+        mz_ore::region::ENABLE_LGALLOC_REGION.store(
+            ENABLE_COLUMNATION_LGALLOC.get(config),
+            std::sync::atomic::Ordering::Relaxed,
+        );
 
         // Remember the maintenance interval locally to avoid reading it from the config set on
         // every server iteration.

--- a/test/testdrive/cc_cluster_sizes.td
+++ b/test/testdrive/cc_cluster_sizes.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET allowed_cluster_replica_sizes = "1";
+ALTER SYSTEM SET allowed_cluster_replica_sizes = '1-no-disk';
 ALTER SYSTEM SET disk_cluster_replicas_default = false;
 
 # Cannot create clusters with cc cluster size naming schemes
@@ -92,7 +92,7 @@ contains: DISK option not supported for modern cluster sizes because disk is alw
 contains: DISK option not supported for modern cluster sizes because disk is always enabled
 
 # But it's okay if you're going back to a legacy size.
-> ALTER CLUSTER c SET (DISK = true, SIZE = '1')
+> ALTER CLUSTER c SET (DISK = true, SIZE = '1-no-disk')
 > SELECT disk FROM mz_clusters WHERE name = 'c'
 true
 > DROP CLUSTER c

--- a/test/testdrive/cc_cluster_sizes.td
+++ b/test/testdrive/cc_cluster_sizes.td
@@ -26,7 +26,7 @@ ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true
 contains:unknown cluster replica size 1cc
 
 # The existing cluster names are fine
-> CREATE CLUSTER c SIZE '1';
+> CREATE CLUSTER c SIZE '1-no-disk';
 
 # But ensure we cannot ALTER our way to a cc name either
 ! ALTER CLUSTER c SET (SIZE '1cc');
@@ -50,7 +50,7 @@ true
 > DROP CLUSTER c
 
 # Create a cluster with a legacy size with disk enabled.
-> CREATE CLUSTER c SIZE '1', DISK = true
+> CREATE CLUSTER c SIZE '1-no-disk', DISK = true
 > SELECT disk FROM mz_clusters WHERE name = 'c'
 true
 
@@ -70,7 +70,7 @@ true
 
 # Same test as before, except the legacy size cluster has disk explicitly
 # disabled.
-> CREATE CLUSTER c SIZE '1', DISK = false
+> CREATE CLUSTER c SIZE '1-no-disk', DISK = false
 > ALTER CLUSTER c SET (SIZE = '1cc')
 > SELECT disk FROM mz_clusters WHERE name = 'c'
 true
@@ -78,7 +78,7 @@ true
 
 # Same test as before, except the legacy size cluster has no disk explicitly
 # configured.
-> CREATE CLUSTER c SIZE = '1'
+> CREATE CLUSTER c SIZE = '1-no-disk'
 > SELECT disk FROM mz_clusters WHERE name = 'c'
 false
 > ALTER CLUSTER c SET (SIZE = '1cc')
@@ -98,10 +98,10 @@ true
 > DROP CLUSTER c
 
 # Ensure that altering from a legacy size to a legacy size does not enable disk.
-> CREATE CLUSTER c SIZE = '1'
+> CREATE CLUSTER c SIZE = '1-no-disk'
 > SELECT disk FROM mz_clusters WHERE name = 'c'
 false
-> ALTER CLUSTER c SET (SIZE = '2')
+> ALTER CLUSTER c SET (SIZE = '2-no-disk')
 > SELECT disk FROM mz_clusters WHERE name = 'c'
 false
 > DROP CLUSTER c

--- a/test/testdrive/disk-feature-flag.td
+++ b/test/testdrive/disk-feature-flag.td
@@ -11,10 +11,10 @@ $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.mater
 ALTER SYSTEM SET enable_disk_cluster_replicas = false
 ALTER SYSTEM SET disk_cluster_replicas_default = false
 
-! CREATE CLUSTER no SIZE = '1', REPLICATION FACTOR 0, DISK;
+! CREATE CLUSTER no SIZE = '1-no-disk', REPLICATION FACTOR 0, DISK;
 exact:`WITH (DISK)` for cluster replicas is not available
 
-> CREATE CLUSTER no SIZE = '1', REPLICATION FACTOR 0;
+> CREATE CLUSTER no SIZE = '1-no-disk', REPLICATION FACTOR 0;
 
 ! ALTER CLUSTER no SET (REPLICATION FACTOR 1, DISK);
 exact:`WITH (DISK)` for cluster replicas is not available
@@ -28,7 +28,7 @@ ALTER SYSTEM SET enable_disk_cluster_replicas = true
 > DROP CLUSTER IF EXISTS c;
 
 # Can set unmanaged cluster replica options directly, mixing and matching disk
-> CREATE CLUSTER c REPLICAS (r1 (SIZE '1', DISK), r2 (SIZE '1'))
+> CREATE CLUSTER c REPLICAS (r1 (SIZE '1-no-disk', DISK), r2 (SIZE '1-no-disk'))
 
 > SELECT r.name, r.size, r.disk FROM mz_catalog.mz_clusters c, mz_catalog.mz_cluster_replicas r WHERE c.name = 'c' AND c.id = r.cluster_id;
 r1 1 true
@@ -37,7 +37,7 @@ r2 1 false
 > DROP CLUSTER c;
 
 # Can set on managed clusters
-> CREATE CLUSTER c SIZE '1', REPLICATION FACTOR = 2, DISK;
+> CREATE CLUSTER c SIZE '1-no-disk', REPLICATION FACTOR = 2, DISK;
 
 > SELECT r.name, r.size, r.disk FROM mz_catalog.mz_clusters c, mz_catalog.mz_cluster_replicas r WHERE c.name = 'c' AND c.id = r.cluster_id;
 r1 1 true
@@ -49,7 +49,7 @@ r2 1 true
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET disk_cluster_replicas_default = true
 
-> CREATE CLUSTER c REPLICAS (r1 (SIZE '1', DISK), r2 (SIZE '1'))
+> CREATE CLUSTER c REPLICAS (r1 (SIZE '1-no-disk', DISK), r2 (SIZE '1-no-disk'))
 
 > SELECT r.name, r.size, r.disk FROM mz_catalog.mz_clusters c, mz_catalog.mz_cluster_replicas r WHERE c.name = 'c' AND c.id = r.cluster_id;
 r1 1 true
@@ -64,11 +64,11 @@ ALTER SYSTEM RESET disk_cluster_replicas_default
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_disk_cluster_replicas = false
 
-! CREATE CLUSTER c REPLICAS (dff_3 (size '1', disk))
+! CREATE CLUSTER c REPLICAS (dff_3 (size '1-no-disk', disk))
 contains:`WITH (DISK)` for cluster replicas is not available
 
 # Cannot set DISK on unmanaged clusters (the option is per replica)
-! CREATE CLUSTER c REPLICAS (dff_3 (size '1')), DISK;
+! CREATE CLUSTER c REPLICAS (dff_3 (size '1-no-disk')), DISK;
 contains:DISK not supported for unmanaged clusters
 
 # The following test that we don't crash envd with bad parameters, and instead just fallback

--- a/test/testdrive/disk-feature-flag.td
+++ b/test/testdrive/disk-feature-flag.td
@@ -31,8 +31,8 @@ ALTER SYSTEM SET enable_disk_cluster_replicas = true
 > CREATE CLUSTER c REPLICAS (r1 (SIZE '1-no-disk', DISK), r2 (SIZE '1-no-disk'))
 
 > SELECT r.name, r.size, r.disk FROM mz_catalog.mz_clusters c, mz_catalog.mz_cluster_replicas r WHERE c.name = 'c' AND c.id = r.cluster_id;
-r1 1 true
-r2 1 false
+r1 1-no-disk true
+r2 1-no-disk false
 
 > DROP CLUSTER c;
 
@@ -40,8 +40,8 @@ r2 1 false
 > CREATE CLUSTER c SIZE '1-no-disk', REPLICATION FACTOR = 2, DISK;
 
 > SELECT r.name, r.size, r.disk FROM mz_catalog.mz_clusters c, mz_catalog.mz_cluster_replicas r WHERE c.name = 'c' AND c.id = r.cluster_id;
-r1 1 true
-r2 1 true
+r1 1-no-disk true
+r2 1-no-disk true
 
 > DROP CLUSTER c;
 
@@ -52,8 +52,8 @@ ALTER SYSTEM SET disk_cluster_replicas_default = true
 > CREATE CLUSTER c REPLICAS (r1 (SIZE '1-no-disk', DISK), r2 (SIZE '1-no-disk'))
 
 > SELECT r.name, r.size, r.disk FROM mz_catalog.mz_clusters c, mz_catalog.mz_cluster_replicas r WHERE c.name = 'c' AND c.id = r.cluster_id;
-r1 1 true
-r2 1 true
+r1 1-no-disk true
+r2 1-no-disk true
 
 > DROP CLUSTER c;
 


### PR DESCRIPTION
Modernize the infrastructure around lgalloc. In the past, it needed to be explicitly enabled, but now it needs to be disabled and is on by default. This reflects our current setup better where we expect to have access to lgalloc if we have disk. The setting still serves as a switch to disable it in case it is needed.

Introduces a new setting `enable_lgalloc` that gates access to lgalloc as a whole. The old `enable_columnation_lgalloc` controls the behavior of `Region::new_auto` instead, which is closer to the name.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
