### PR TITLE
Disable statistics in parquet writer

### DIFF
--- a/src/storage-operators/src/s3_oneshot_sink/parquet.rs
+++ b/src/storage-operators/src/s3_oneshot_sink/parquet.rs
@@ -19,6 +19,7 @@ use mz_ore::future::OreFutureExt;
 use mz_repr::{GlobalId, RelationDesc, Row};
 use mz_storage_types::sinks::s3_oneshot_sink::S3KeyManager;
 use mz_storage_types::sinks::{S3SinkFormat, S3UploadInfo};
+use parquet::file::properties::EnabledStatistics;
 use parquet::{
     arrow::arrow_writer::ArrowWriter,
     basic::Compression,
@@ -290,6 +291,7 @@ impl ParquetFile {
             // Max compatibility
             .set_writer_version(WriterVersion::PARQUET_1_0)
             .set_compression(Compression::SNAPPY)
+            .set_statistics_enabled(EnabledStatistics::None)
             .build();
 
         // TODO: Consider using an lgalloc buffer here instead of a vec


### PR DESCRIPTION
COPY TO S3 parquet writer [enables page statistics by default](https://docs.rs/parquet/53.0.0/parquet/file/properties/struct.WriterPropertiesBuilder.html#method.set_statistics_enabled).  This can cause incompatibility with some parquet implementations.

### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/8956

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
