### PR TITLE
storage: when dropping objects, eagerly clean up state and update builtins

### DIFF
--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -395,7 +395,7 @@ where
                 // `tokio::sync::mpsc::UnboundedReceiver::recv` is documented as cancel safe.
                 command = self.command_rx.recv() => {
                     let Some(mut command) = command else {
-                        // Controller is no longer interested in this replica. Shut down.
+                        tracing::debug!(%self.replica_id, "controller is no longer interested in this replica, shutting down message loop");
                         break;
                     };
 
@@ -410,7 +410,7 @@ where
                     };
 
                     if self.response_tx.send((Some(self.replica_id), response)).is_err() {
-                        // Controller is no longer interested in this replica. Shut down.
+                        tracing::debug!(%self.replica_id, "controller (receiver) is no longer interested in this replica, shutting down message loop");
                         break;
                     }
                 }

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -110,11 +110,6 @@ where
         instance
     }
 
-    /// Returns the number of replicas of this storage instance.
-    pub fn replica_count(&self) -> usize {
-        self.replicas.len()
-    }
-
     /// Returns the IDs of all replicas connected to this storage instance.
     pub fn replica_ids(&self) -> impl Iterator<Item = ReplicaId> + '_ {
         self.replicas.keys().copied()

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1793,7 +1793,10 @@ where
                         ingestions_to_drop.insert(*id);
                         source_statistics_to_drop.push(*id);
                     }
-                    DataSource::Other | DataSource::Introspection(_) | DataSource::Progress => (),
+                    DataSource::Progress => {
+                        collections_to_drop.push(*id);
+                    }
+                    DataSource::Other | DataSource::Introspection(_) => (),
                     DataSource::Sink { .. } => {}
                 }
             }


### PR DESCRIPTION
NOTE: This is now a whole bunch of other cleanups that were enabled/or made feasible by this initial change to eagerly clean out state and update builtin collections 

Before this change, we had a more sequentialized/blocking protocol for
dropping sources (and other collections):

1. envd receives DDL that drops source
2. envd releases read holds and sends AllowCompaction to clusterd
3. clusterd drops source and sends back a DroppedId message
4. envd cleans up it's collection state and updates builtin collections:
 - updating mz_storage_shards (the global id -> shard id mapping)
 - updating source/sink status to "dropped"
 - removing statistics tracking

Especially the transition between 3. and 4. can block a while if a
cluster is unresponsive.

Plus, in some situations we don't get DroppedId messages, so we would
not do these updates/cleanups. The common of these situations are:
- dropping a replica right after dropping sources/sinks
- dropping a whole cluster

Now, we eagerly apply updates to our builtin collections and also
eagerly clean up state. The protocol becomes:

1. envd receives DDL that drops source
2. in parallel:
 2.a: envd releases read holds and sends AllowCompaction to clusterd
 2.b. envd cleans up it's collection state and updates builtin collections:
  - updating mz_storage_shards (the global id -> shard id mapping)
  - updating source/sink status to "dropped"
  - removing statistics tracking
3. clusterd drops source and sends back a DroppedId message

The benefits of this change:
- less code
- control flow of dropping things is more localized and easier to
  understand
- we fix problems where we inadvertently didn't drop state and update
  builtin collections (this could be done independently of this change, but with the changed code structure it's more obvious what happens, and should happen, when dropping an object)

And, for the more-protocol-asserts aficionado: this fixes bugs in "active copies" tracking and re-enables stricter assertions about what types of messages we expect when.

Here's Lamport Diagrams that show the change in the distributed protocol:
![dropping-sink-non-blocking](https://github.com/user-attachments/assets/34fd9c72-c60c-4b3c-a52b-8e0f87af222b)
