### PR TITLE
compute/correction_v2: fix stage size tracking

### DIFF
--- a/src/compute/src/sink/correction_v2.rs
+++ b/src/compute/src/sink/correction_v2.rs
@@ -271,12 +271,17 @@ impl<D: Data> CorrectionV2<D> {
     /// Once this method returns, all remaining updates before `upper` are contained in a single
     /// chain. Note that this chain might also contain updates beyond `upper` though!
     fn consolidate_before(&mut self, upper: &Antichain<Timestamp>) {
-        let mut chains = std::mem::take(&mut self.chains);
-        if let Some(chain) = self.stage.flush() {
-            chains.push(chain);
+        if self.chains.is_empty() && self.stage.is_empty() {
+            return;
         }
 
+        let mut chains = std::mem::take(&mut self.chains);
+        chains.extend(self.stage.flush());
+
         if chains.is_empty() {
+            // We can only get here if the stage contained updates but they all got consolidated
+            // away by `flush`, so we need to update the metrics before we return.
+            self.update_metrics();
             return;
         }
 
@@ -922,6 +927,10 @@ impl<D: Data> Default for Stage<D> {
 }
 
 impl<D: Data> Stage<D> {
+    fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
     /// Insert a batch of updates, possibly producing a ready [`Chain`].
     fn insert(&mut self, updates: &mut Vec<(D, Timestamp, Diff)>) -> Option<Chain<D>> {
         if updates.is_empty() {


### PR DESCRIPTION
This commit fixes a bug in size metrics tracking for the `CorrectionV2` stage. In `consolidate_before`, we would call `stage.flush()` and if this returned no updates we would assume that the stage had been empty and immediately return without updating the metrics. However, `stage.flush()` performs a `consolidate`, which can cancel out updates, and we would miss recording these deletions in the metrics.

This fix chosen here is to perform the emptiness checking and early return before calling `stage.flush()`. I find this more obvious than to keeping the current flow and adding a second `update_metrics` to `consolidate_before`, but both would work.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8971

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
