### PR TITLE
Force tokio thread names to fit Linux limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,12 +3288,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -5159,6 +5156,7 @@ dependencies = [
  "mz-storage-types",
  "mz-timely-util",
  "mz-txn-wal",
+ "num_cpus",
  "tokio",
  "tower",
  "tracing",
@@ -7701,11 +7699,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -48,7 +48,7 @@ skip = [
     { name = "windows-sys", version = "0.52.0" },
     # Newer versions of crates like `tempfile` are held back by crates like `atty`.
     # This is very Unfortunate as we don't actually use these platforms.
-    { name = "hermit-abi", version = "0.2.6" },
+    { name = "hermit-abi", version = "0.3.9" },
     { name = "redox_syscall", version = "0.2.10" },
 
     # Will require updating many crates

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -37,7 +37,7 @@ mz-ore = { path = "../ore", default-features = false }
 mz-server-core = { path = "../server-core" }
 mz-tracing = { path = "../tracing" }
 mz-pgwire-common = { path = "../pgwire-common" }
-num_cpus = "1.14.0"
+num_cpus = "1.16.0"
 openssl = { version = "0.10.48", features = ["vendored"] }
 prometheus = { version = "0.13.3", default-features = false }
 proxy-header = "0.1.2"

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -37,6 +37,7 @@ mz-storage-client = { path = "../storage-client" }
 mz-storage-types = { path = "../storage-types" }
 mz-timely-util = { path = "../timely-util" }
 mz-txn-wal = { path = "../txn-wal" }
+num_cpus = "1.16.0"
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util"] }
 tower = "0.4.13"
 tracing = "0.1.37"

--- a/src/clusterd/src/lib.rs
+++ b/src/clusterd/src/lib.rs
@@ -141,15 +141,29 @@ struct Args {
     worker_core_affinity: bool,
 }
 
-#[tokio::main]
-pub async fn main() {
+pub fn main() {
     mz_ore::panic::install_enhanced_handler();
 
     let args = cli::parse_args(CliConfig {
         env_prefix: Some("CLUSTERD_"),
         enable_version_flag: true,
     });
-    if let Err(err) = run(args).await {
+
+    let ncpus_useful = usize::max(1, std::cmp::min(num_cpus::get(), num_cpus::get_physical()));
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(ncpus_useful)
+        // The default thread name exceeds the Linux limit on thread name
+        // length, so pick something shorter.
+        .thread_name_fn(|| {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
+            let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
+            format!("tokio:work-{}", id)
+        })
+        .enable_all()
+        .build()
+        .unwrap();
+    if let Err(err) = runtime.block_on(run(args)) {
         panic!("clusterd: fatal: {}", err.display_with_causes());
     }
 }

--- a/src/clusterd/src/lib.rs
+++ b/src/clusterd/src/lib.rs
@@ -153,11 +153,13 @@ pub fn main() {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(ncpus_useful)
         // The default thread name exceeds the Linux limit on thread name
-        // length, so pick something shorter.
+        // length, so pick something shorter. The maximum length is 16 including
+        // a \0 terminator. This gives us four decimals, which should be enough
+        // for most existing computers.
         .thread_name_fn(|| {
             use std::sync::atomic::{AtomicUsize, Ordering};
             static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-            let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
+            let id = ATOMIC_ID.fetch_add(1, Ordering::Relaxed);
             format!("tokio:work-{}", id)
         })
         .enable_all()

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -73,7 +73,7 @@ mz-sql = { path = "../sql" }
 mz-storage-types = { path = "../storage-types" }
 mz-tracing = { path = "../tracing", optional = true }
 nix = "0.26.1"
-num_cpus = "1.14.0"
+num_cpus = "1.16.0"
 openssl = { version = "0.10.48", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
 opentelemetry = { version = "0.24.0", features = ["trace"] }

--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -700,7 +700,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
             // length, so pick something shorter.
             .thread_name_fn(|| {
                 static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-                let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
+                let id = ATOMIC_ID.fetch_add(1, Ordering::Relaxed);
                 format!("tokio:work-{}", id)
             })
             .enable_all()

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -25,7 +25,7 @@ mz-avro = { path = "../avro" }
 mz-ccsr = { path = "../ccsr" }
 mz-ore = { path = "../ore", features = ["cli", "network", "async"] }
 mz-ssh-util = { path = "../ssh-util" }
-num_cpus = "1.14.0"
+num_cpus = "1.16.0"
 prost = { version = "0.13.4", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }

--- a/src/orchestrator-process/Cargo.toml
+++ b/src/orchestrator-process/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0.125"
 scopeguard = "1.1.0"
 sha1 = "0.10.5"
 sysinfo = "0.29.11"
-tokio = { version = "1.38.0", features = [ "fs", "process", "time" ] }
+tokio = { version = "1.38.0", features = ["fs", "process", "time"] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -35,7 +35,7 @@ mz-persist-types = { path = "../persist-types" }
 mz-repr = { path = "../repr" }
 mz-timestamp-oracle = { path = "../timestamp-oracle" }
 mz-txn-wal = { path = "../txn-wal" }
-num_cpus = "1.14.0"
+num_cpus = "1.16.0"
 num_enum = "0.7.3"
 prometheus = { version = "0.13.3", default-features = false }
 serde = { version = "1.0.152", features = ["derive", "rc"] }

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -50,7 +50,7 @@ mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }
 mz-timely-util = { path = "../timely-util" }
 mz-postgres-client = { path = "../postgres-client" }
-num_cpus = "1.14.0"
+num_cpus = "1.16.0"
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.5.1", features = ["boxed_union"] }
@@ -73,7 +73,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = tru
 criterion = { version = "0.5.1", features = ["html_reports"] }
 datadriven = { version = "0.8.0", features = ["async"] }
 futures-task = "0.3.21"
-num_cpus = "1.14.0"
+num_cpus = "1.16.0"
 tempfile = "3.14.0"
 
 [build-dependencies]

--- a/src/rocksdb/Cargo.toml
+++ b/src/rocksdb/Cargo.toml
@@ -16,7 +16,7 @@ derivative = "2.2.0"
 itertools = { version = "0.12.1" }
 mz-ore = { path = "../ore", features = ["async", "metrics", "test"] }
 mz-rocksdb-types = { path = "../rocksdb-types" }
-num_cpus = "1.14.0"
+num_cpus = "1.16.0"
 prometheus = { version = "0.13.3", default-features = false }
 tokio = { version = "1.38.0", features = ["macros", "sync", "rt"] }
 serde = { version = "1.0.152", features = ["derive"] }


### PR DESCRIPTION
At the moment, we cannot distinguish tokio thread names in Linux because they're longer than the limit, cutting off their end. With this change, we do the same we do in environmentd, which is to supply a custom thread name function and construct the builder manually.

Updates `num_cpus` to the latest version.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
