### PR TITLE
[persist] Preserve causal chain for azure errors

### DIFF
--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -286,6 +286,14 @@ impl From<deadpool_postgres::tokio_postgres::Error> for ExternalError {
     }
 }
 
+impl From<azure_core::Error> for ExternalError {
+    fn from(value: azure_core::Error) -> Self {
+        ExternalError::Indeterminate(Indeterminate {
+            inner: anyhow!(value),
+        })
+    }
+}
+
 impl From<deadpool_postgres::PoolError> for ExternalError {
     fn from(x: deadpool_postgres::PoolError) -> Self {
         match x {


### PR DESCRIPTION
### Motivation

Observed these were missing while debugging.

### Tips for reviewer

The core issue is that the `anyhow!("context: {}", e)` formatting approach does not preserve error causes. ~`e.context("context")` just converts an error type to anyhow's error and tacks on some context, so it will preserve the chain of sources.~ Turns out azure has its own context-preserving mechanism, so I'm just using that and then converting to anyhow directly.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
