### PR TITLE
self-managed: Add tags

### DIFF
--- a/misc/python/materialize/release/cut_self_managed_release.py
+++ b/misc/python/materialize/release/cut_self_managed_release.py
@@ -76,6 +76,11 @@ def main():
         )
         print(f"Pushing to {remote_lts_branch}")
         spawn.runv(["git", "push", args.remote, f"HEAD:{lts_branch}"])
+
+        tag = f"self-managed-{helm_chart_version}"
+        print(f"Pushing tag {tag} to remote")
+        spawn.runv(["git", "tag", tag])
+        spawn.runv(["git", "push", args.remote, tag])
     finally:
         # The caller may have started in a detached HEAD state.
         if current_branch:


### PR DESCRIPTION
Edit: Now only sets the tag:
Tag for self-managed code: `self-managed-v25.1.0` (before: none)
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
