### PR TITLE
compute: persistent worker command channel

### DIFF
--- a/src/compute/src/command_channel.rs
+++ b/src/compute/src/command_channel.rs
@@ -1,0 +1,196 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A channel for broadcasting compute commands from worker 0 to other workers.
+//!
+//! Compute uses a dataflow to distribute commands between workers. This is to ensure workers
+//! retain a consistent dataflow state across reconnects. If each worker would receive its commands
+//! directly from the controller, there wouldn't be any guarantee that after a reconnect all
+//! workers have seen the same sequence of commands. This is particularly problematic for
+//! `CreateDataflow` commands, since Timely requires that all workers render the same dataflows in
+//! the same order. So the controller instead sends commands only to worker 0, which then
+//! broadcasts them to other workers through the Timely fabric, taking care of the correct
+//! sequencing.
+
+use std::sync::{Arc, Mutex};
+
+use crossbeam_channel::TryRecvError;
+use mz_compute_client::protocol::command::ComputeCommand;
+use mz_compute_types::dataflows::{BuildDesc, DataflowDescription};
+use mz_ore::cast::CastFrom;
+use timely::communication::Allocate;
+use timely::dataflow::channels::pact::Exchange;
+use timely::dataflow::operators::generic::source;
+use timely::dataflow::operators::Operator;
+use timely::scheduling::{Scheduler, SyncActivator};
+use timely::worker::Worker as TimelyWorker;
+
+/// A sender pushing commands onto the command channel.
+pub struct Sender {
+    tx: crossbeam_channel::Sender<ComputeCommand>,
+    activator: Arc<Mutex<Option<SyncActivator>>>,
+}
+
+impl Sender {
+    /// Broadcasts the given command to all workers.
+    pub fn send(&self, command: ComputeCommand) {
+        if self.tx.send(command).is_err() {
+            unreachable!("command channel never shuts down");
+        }
+
+        self.activator
+            .lock()
+            .expect("poisoned")
+            .as_ref()
+            .map(|a| a.activate());
+    }
+}
+
+/// A receiver reading commands from the command channel.
+pub struct Receiver {
+    rx: crossbeam_channel::Receiver<ComputeCommand>,
+}
+
+impl Receiver {
+    /// Returns the next available command, if any.
+    ///
+    /// This returns `None` when there are currently no commands but there might be commands again
+    /// in the future.
+    pub fn try_recv(&self) -> Option<ComputeCommand> {
+        match self.rx.try_recv() {
+            Ok(cmd) => Some(cmd),
+            Err(TryRecvError::Empty) => None,
+            Err(TryRecvError::Disconnected) => {
+                unreachable!("command channel never shuts down");
+            }
+        }
+    }
+}
+
+/// Render the command channel dataflow.
+pub fn render<A: Allocate>(
+    timely_worker: &mut TimelyWorker<A>,
+) -> (Sender, Receiver) {
+    let (input_tx, input_rx) = crossbeam_channel::unbounded();
+    let (output_tx, output_rx) = crossbeam_channel::unbounded();
+    let activator = Arc::new(Mutex::new(None));
+
+    // TODO(teskje): This implementation relies on Timely channels preserving the order of their
+    // inputs, which is not something they guarantee. We can avoid that by using explicit indexing,
+    // like storage's command sequencer does.
+    timely_worker.dataflow_named::<u64, _, _>("command_channel", {
+        let activator = Arc::clone(&activator);
+        move |scope| {
+            source(scope, "command_channel::source", |cap, info| {
+                let sync_activator = scope.sync_activator_for(info.address.to_vec());
+                *activator.lock().expect("poisoned") = Some(sync_activator);
+
+                let worker_id = scope.index();
+                let peers = scope.peers();
+
+                // Only worker 0 broadcasts commands, other workers must drop their capability to
+                // avoid holding up dataflow progress.
+                let mut capability = (worker_id == 0).then_some(cap);
+
+                move |output| {
+                    let Some(cap) = &mut capability else {
+                        // Non-leader workers will still receive `UpdateConfiguration` commands
+                        // and we must drain those to not leak memory.
+                        while let Ok(cmd) = input_rx.try_recv() {
+                            assert_ne!(worker_id, 0);
+                            assert!(matches!(cmd, ComputeCommand::UpdateConfiguration(_)));
+                        }
+                        return;
+                    };
+
+                    assert_eq!(worker_id, 0);
+
+                    let input: Vec<_> = input_rx.try_iter().collect();
+                    for cmd in input {
+                        let worker_cmds = split_command(cmd, peers);
+                        output.session(&cap).give_iterator(worker_cmds);
+                        cap.downgrade(&(cap.time() + 1));
+                    }
+                }
+            })
+            .sink(
+                Exchange::new(|(idx, _)| u64::cast_from(*idx)),
+                "command_channel::sink",
+                move |input| {
+                    while let Some((_cap, data)) = input.next() {
+                        for (_idx, cmd) in data.drain(..) {
+                            let _ = output_tx.send(cmd);
+                        }
+                    }
+                },
+            );
+        }
+    });
+
+    let tx = Sender {
+        tx: input_tx,
+        activator,
+    };
+    let rx = Receiver { rx: output_rx };
+
+    (tx, rx)
+}
+
+/// Split the given command into the given number of parts.
+///
+/// Returns an iterator that produces each command part, along with its part index.
+fn split_command(
+    command: ComputeCommand,
+    parts: usize,
+) -> impl Iterator<Item = (usize, ComputeCommand)> {
+    use itertools::Either;
+
+    let commands = match command {
+        ComputeCommand::CreateDataflow(dataflow) => {
+            // A list of descriptions of objects for each part to build.
+            let mut builds_parts = vec![Vec::new(); parts];
+            // Partition each build description among `parts`.
+            for build_desc in dataflow.objects_to_build {
+                let build_part = build_desc.plan.partition_among(parts);
+                for (plan, objects_to_build) in build_part.into_iter().zip(builds_parts.iter_mut())
+                {
+                    objects_to_build.push(BuildDesc {
+                        id: build_desc.id,
+                        plan,
+                    });
+                }
+            }
+
+            // Each list of build descriptions results in a dataflow description.
+            let commands = builds_parts
+                .into_iter()
+                .map(move |objects_to_build| DataflowDescription {
+                    source_imports: dataflow.source_imports.clone(),
+                    index_imports: dataflow.index_imports.clone(),
+                    objects_to_build,
+                    index_exports: dataflow.index_exports.clone(),
+                    sink_exports: dataflow.sink_exports.clone(),
+                    as_of: dataflow.as_of.clone(),
+                    until: dataflow.until.clone(),
+                    debug_name: dataflow.debug_name.clone(),
+                    initial_storage_as_of: dataflow.initial_storage_as_of.clone(),
+                    refresh_schedule: dataflow.refresh_schedule.clone(),
+                    time_dependence: dataflow.time_dependence.clone(),
+                })
+                .map(ComputeCommand::CreateDataflow);
+            Either::Left(commands)
+        }
+        command => {
+            let commands = std::iter::repeat_n(command, parts);
+            Either::Right(commands)
+        }
+    };
+
+    commands.into_iter().enumerate()
+}

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -223,18 +223,6 @@ impl ComputeState {
         }
     }
 
-    /// Return whether a collection with the given ID exists.
-    pub fn collection_exists(&self, id: GlobalId) -> bool {
-        self.collections.contains_key(&id)
-    }
-
-    /// Return a reference to the identified collection.
-    ///
-    /// Panics if the collection doesn't exist.
-    pub fn expect_collection(&self, id: GlobalId) -> &CollectionState {
-        self.collections.get(&id).expect("collection must exist")
-    }
-
     /// Return a mutable reference to the identified collection.
     ///
     /// Panics if the collection doesn't exist.

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod server;
 
 mod arrangement;
+mod command_channel;
 mod compute_state;
 mod extensions;
 mod logging;

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -11,13 +11,14 @@
 
 //! Materialize's compute layer.
 
-pub(crate) mod arrangement;
-pub mod compute_state;
-pub(crate) mod extensions;
-pub(crate) mod logging;
-pub(crate) mod metrics;
-pub(crate) mod render;
-pub(crate) mod row_spine;
 pub mod server;
-pub(crate) mod sink;
+
+mod arrangement;
+mod compute_state;
+mod extensions;
+mod logging;
+mod metrics;
+mod render;
+mod row_spine;
+mod sink;
 mod typedefs;

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -10,22 +10,21 @@
 //! An interactive dataflow server.
 
 use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use std::{iter, thread};
 
 use anyhow::Error;
-use crossbeam_channel::{RecvError, TryRecvError};
+use crossbeam_channel::{RecvError, SendError};
 use mz_cluster::client::{ClusterClient, ClusterSpec};
 use mz_compute_client::protocol::command::ComputeCommand;
 use mz_compute_client::protocol::history::ComputeCommandHistory;
 use mz_compute_client::protocol::response::ComputeResponse;
 use mz_compute_client::service::ComputeClient;
-use mz_compute_types::dataflows::{BuildDesc, DataflowDescription};
-use mz_ore::cast::CastFrom;
 use mz_ore::halt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::tracing::TracingHandle;
@@ -34,16 +33,12 @@ use mz_service::local::LocalActivator;
 use mz_storage_types::connections::ConnectionContext;
 use mz_txn_wal::operator::TxnsContext;
 use timely::communication::Allocate;
-use timely::dataflow::channels::pact::Exchange;
-use timely::dataflow::operators::generic::source;
-use timely::dataflow::operators::Operator;
-use timely::progress::{Antichain, Timestamp};
-use timely::scheduling::Scheduler;
+use timely::progress::Antichain;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
-use tokio::sync::mpsc::error::SendError;
 use tracing::{info, trace, warn};
 
+use crate::command_channel;
 use crate::compute_state::{ActiveComputeState, ComputeState, ReportedFrontier};
 use crate::metrics::{ComputeMetrics, WorkerMetrics};
 
@@ -107,16 +102,18 @@ pub fn serve(
 
 /// Endpoint used by workers to receive compute commands.
 struct CommandReceiver {
-    inner: crossbeam_channel::Receiver<ComputeCommand>,
+    /// The channel supplying commands.
+    inner: command_channel::Receiver,
+    /// The ID of the Timely worker.
     worker_id: usize,
 }
 
 impl CommandReceiver {
-    fn new(inner: crossbeam_channel::Receiver<ComputeCommand>, worker_id: usize) -> Self {
+    fn new(inner: command_channel::Receiver, worker_id: usize) -> Self {
         Self { inner, worker_id }
     }
 
-    fn try_recv(&self) -> Result<ComputeCommand, TryRecvError> {
+    fn try_recv(&self) -> Option<ComputeCommand> {
         self.inner.try_recv().map(|cmd| {
             trace!(worker = ?self.worker_id, command = ?cmd, "received command");
             cmd
@@ -126,55 +123,20 @@ impl CommandReceiver {
 
 /// Endpoint used by workers to send sending compute responses.
 pub(crate) struct ResponseSender {
-    inner: mpsc::UnboundedSender<ComputeResponse>,
+    /// The channel consuming responses.
+    inner: crossbeam_channel::Sender<ComputeResponse>,
+    /// The ID of the Timely worker.
     worker_id: usize,
 }
 
 impl ResponseSender {
-    fn new(inner: mpsc::UnboundedSender<ComputeResponse>, worker_id: usize) -> Self {
+    fn new(inner: crossbeam_channel::Sender<ComputeResponse>, worker_id: usize) -> Self {
         Self { inner, worker_id }
     }
 
     pub fn send(&self, response: ComputeResponse) -> Result<(), SendError<ComputeResponse>> {
         trace!(worker = ?self.worker_id, response = ?response, "sending response");
         self.inner.send(response)
-    }
-}
-
-struct CommandReceiverQueue {
-    queue: Rc<RefCell<VecDeque<Result<ComputeCommand, TryRecvError>>>>,
-}
-
-impl CommandReceiverQueue {
-    fn try_recv(&self) -> Result<ComputeCommand, TryRecvError> {
-        match self.queue.borrow_mut().pop_front() {
-            Some(Ok(cmd)) => Ok(cmd),
-            Some(Err(e)) => Err(e),
-            None => Err(TryRecvError::Empty),
-        }
-    }
-
-    /// Block until a command is available.
-    /// This method takes the worker as an argument such that it can step timely while no result
-    /// is available.
-    fn recv<A: Allocate>(&self, worker: &mut Worker<A>) -> Result<ComputeCommand, RecvError> {
-        while self.is_empty() {
-            let start = Instant::now();
-            worker.timely_worker.step_or_park(None);
-            worker
-                .metrics
-                .timely_step_duration_seconds
-                .observe(start.elapsed().as_secs_f64());
-        }
-        match self.try_recv() {
-            Ok(cmd) => Ok(cmd),
-            Err(TryRecvError::Disconnected) => Err(RecvError),
-            Err(TryRecvError::Empty) => unreachable!("checked above"),
-        }
-    }
-
-    fn is_empty(&self) -> bool {
-        self.queue.borrow().is_empty()
     }
 }
 
@@ -185,13 +147,10 @@ impl CommandReceiverQueue {
 struct Worker<'w, A: Allocate> {
     /// The underlying Timely worker.
     timely_worker: &'w mut TimelyWorker<A>,
-    /// The channel over which communication handles for newly connected clients
-    /// are delivered.
-    client_rx: crossbeam_channel::Receiver<(
-        crossbeam_channel::Receiver<ComputeCommand>,
-        mpsc::UnboundedSender<ComputeResponse>,
-        mpsc::UnboundedSender<LocalActivator>,
-    )>,
+    /// The channel over which commands are received.
+    command_rx: CommandReceiver,
+    /// The channel over which responses are sent.
+    response_tx: ResponseSender,
     compute_state: Option<ComputeState>,
     /// Compute metrics.
     metrics: WorkerMetrics,
@@ -225,9 +184,19 @@ impl ClusterSpec for Config {
         let worker_id = timely_worker.index();
         let metrics = self.metrics.for_worker(worker_id);
 
+        // Create the command channel that broadcasts commands from worker 0 to other workers. We
+        // reuse this channel between client connections, to avoid bugs where different workers end
+        // up creating incompatible sides of the channel dataflow after reconnects.
+        // See database-issues#8964.
+        let (cmd_tx, cmd_rx) = command_channel::render(timely_worker);
+        let (resp_tx, resp_rx) = crossbeam_channel::unbounded();
+
+        spawn_channel_adapter(client_rx, cmd_tx, resp_rx, worker_id);
+
         Worker {
             timely_worker,
-            client_rx,
+            command_rx: CommandReceiver::new(cmd_rx, worker_id),
+            response_tx: ResponseSender::new(resp_tx, worker_id),
             metrics,
             context: self.context.clone(),
             persist_clients: Arc::clone(&self.persist_clients),
@@ -284,168 +253,16 @@ fn set_core_affinity(_worker_id: usize) {
 }
 
 impl<'w, A: Allocate + 'static> Worker<'w, A> {
-    /// Waits for client connections and runs them to completion.
+    /// Runs a compute worker.
     pub fn run(&mut self) {
-        let mut shutdown = false;
-        while !shutdown {
-            match self.client_rx.recv() {
-                Ok((rx, tx, activator_tx)) => {
-                    self.setup_channel_and_run_client(rx, tx, activator_tx)
-                }
-                Err(_) => shutdown = true,
-            }
+        loop {
+            self.run_client();
         }
     }
 
-    fn split_command<T: Timestamp>(
-        command: ComputeCommand<T>,
-        parts: usize,
-    ) -> Vec<ComputeCommand<T>> {
-        match command {
-            ComputeCommand::CreateDataflow(dataflow) => {
-                // A list of descriptions of objects for each part to build.
-                let mut builds_parts = vec![Vec::new(); parts];
-                // Partition each build description among `parts`.
-                for build_desc in dataflow.objects_to_build {
-                    let build_part = build_desc.plan.partition_among(parts);
-                    for (plan, objects_to_build) in
-                        build_part.into_iter().zip(builds_parts.iter_mut())
-                    {
-                        objects_to_build.push(BuildDesc {
-                            id: build_desc.id,
-                            plan,
-                        });
-                    }
-                }
-
-                // Each list of build descriptions results in a dataflow description.
-                builds_parts
-                    .into_iter()
-                    .map(|objects_to_build| DataflowDescription {
-                        source_imports: dataflow.source_imports.clone(),
-                        index_imports: dataflow.index_imports.clone(),
-                        objects_to_build,
-                        index_exports: dataflow.index_exports.clone(),
-                        sink_exports: dataflow.sink_exports.clone(),
-                        as_of: dataflow.as_of.clone(),
-                        until: dataflow.until.clone(),
-                        debug_name: dataflow.debug_name.clone(),
-                        initial_storage_as_of: dataflow.initial_storage_as_of.clone(),
-                        refresh_schedule: dataflow.refresh_schedule.clone(),
-                        time_dependence: dataflow.time_dependence.clone(),
-                    })
-                    .map(ComputeCommand::CreateDataflow)
-                    .collect()
-            }
-            command => vec![command; parts],
-        }
-    }
-
-    fn setup_channel_and_run_client(
-        &mut self,
-        command_rx: crossbeam_channel::Receiver<ComputeCommand>,
-        response_tx: mpsc::UnboundedSender<ComputeResponse>,
-        activator_tx: mpsc::UnboundedSender<LocalActivator>,
-    ) {
-        let cmd_queue = Rc::new(RefCell::new(
-            VecDeque::<Result<ComputeCommand, TryRecvError>>::new(),
-        ));
-        let peers = self.timely_worker.peers();
-        let worker_id = self.timely_worker.index();
-
-        let command_rx = CommandReceiver::new(command_rx, worker_id);
-        let response_tx = ResponseSender::new(response_tx, worker_id);
-
-        self.timely_worker.dataflow::<u64, _, _>({
-            let cmd_queue = Rc::clone(&cmd_queue);
-
-            move |scope| {
-                source(scope, "CmdSource", |capability, info| {
-                    // Send activator for this operator back.
-                    let activator = scope.sync_activator_for(info.address.to_vec());
-                    let activator = LocalActivator::new(activator);
-                    // This might fail if the client has already shut down, which is fine. The rest
-                    // of the operator implementation knows how to handle a disconnected client.
-                    let _ = activator_tx.send(activator);
-
-                    //Hold onto capbility until we receive a disconnected error
-                    let mut cap_opt = Some(capability);
-                    // Drop capability if we are not the leader, as our queue will
-                    // be empty and we will never use nor importantly downgrade it.
-                    if worker_id != 0 {
-                        cap_opt = None;
-                    }
-
-                    move |output| {
-                        let mut disconnected = false;
-                        if let Some(cap) = cap_opt.as_mut() {
-                            let time = cap.time().clone();
-                            let mut session = output.session(&cap);
-
-                            loop {
-                                match command_rx.try_recv() {
-                                    Ok(cmd) => {
-                                        // Commands must never be accepted from another worker. This
-                                        // implementation does not guarantee an ordering of events
-                                        // sent to different workers.
-                                        assert_eq!(worker_id, 0);
-                                        session.give_iterator(
-                                            Self::split_command(cmd, peers).into_iter().enumerate(),
-                                        );
-                                    }
-                                    Err(TryRecvError::Disconnected) => {
-                                        disconnected = true;
-                                        break;
-                                    }
-                                    Err(TryRecvError::Empty) => {
-                                        break;
-                                    }
-                                };
-                            }
-                            cap.downgrade(&(time + 1));
-                        } else {
-                            // Non-leader workers will still receive `UpdateConfiguration` commands
-                            // and we must drain those to not leak memory.
-                            if let Ok(cmd) = command_rx.try_recv() {
-                                assert_ne!(worker_id, 0);
-                                assert!(matches!(cmd, ComputeCommand::UpdateConfiguration(_)));
-                            }
-                        }
-
-                        if disconnected {
-                            cap_opt = None;
-                        }
-                    }
-                })
-                .sink(
-                    Exchange::new(|(idx, _)| u64::cast_from(*idx)),
-                    "CmdReceiver",
-                    move |input| {
-                        let mut queue = cmd_queue.borrow_mut();
-                        if input.frontier().is_empty() {
-                            queue.push_back(Err(TryRecvError::Disconnected))
-                        }
-                        while let Some((_, data)) = input.next() {
-                            for (_, cmd) in data.drain(..) {
-                                queue.push_back(Ok(cmd));
-                            }
-                        }
-                    },
-                );
-            }
-        });
-
-        self.run_client(
-            CommandReceiverQueue {
-                queue: Rc::clone(&cmd_queue),
-            },
-            response_tx,
-        )
-    }
-
-    /// Draws commands from a single client until disconnected.
-    fn run_client(&mut self, command_rx: CommandReceiverQueue, mut response_tx: ResponseSender) {
-        if let Err(_) = self.reconcile(&command_rx, &mut response_tx) {
+    /// Handles commands for a client connection, returns when the epoch changes.
+    fn run_client(&mut self) {
+        if let Err(_) = self.reconcile() {
             return;
         }
 
@@ -453,8 +270,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
         let mut last_maintenance = Instant::now();
 
         // Commence normal operation.
-        let mut shutdown = false;
-        while !shutdown {
+        loop {
             // Get the maintenance interval, default to zero if we don't have a compute state.
             let maintenance_interval = self
                 .compute_state
@@ -470,7 +286,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                 sleep_duration = None;
 
                 // Report frontier information back the coordinator.
-                if let Some(mut compute_state) = self.activate_compute(&mut response_tx) {
+                if let Some(mut compute_state) = self.activate_compute() {
                     compute_state.compute_state.traces.maintenance();
                     // Report operator hydration before frontiers, as reporting frontiers may
                     // affect hydration reporting.
@@ -494,23 +310,12 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
             timer.observe_duration();
 
             // Handle any received commands.
-            let mut cmds = vec![];
-            let mut empty = false;
-            while !empty {
-                match command_rx.try_recv() {
-                    Ok(cmd) => cmds.push(cmd),
-                    Err(TryRecvError::Empty) => empty = true,
-                    Err(TryRecvError::Disconnected) => {
-                        empty = true;
-                        shutdown = true;
-                    }
-                }
-            }
+            let cmds: Vec<_> = iter::from_fn(|| self.command_rx.try_recv()).collect();
             for cmd in cmds {
-                self.handle_command(&mut response_tx, cmd);
+                self.handle_command(cmd);
             }
 
-            if let Some(mut compute_state) = self.activate_compute(&mut response_tx) {
+            if let Some(mut compute_state) = self.activate_compute() {
                 compute_state.process_peeks();
                 compute_state.process_subscribes();
                 compute_state.process_copy_tos();
@@ -518,7 +323,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
         }
     }
 
-    fn handle_command(&mut self, response_tx: &mut ResponseSender, cmd: ComputeCommand) {
+    fn handle_command(&mut self, cmd: ComputeCommand) {
         match &cmd {
             ComputeCommand::CreateInstance(_) => {
                 self.compute_state = Some(ComputeState::new(
@@ -531,23 +336,36 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
             }
             _ => (),
         }
-        self.activate_compute(response_tx)
-            .unwrap()
-            .handle_compute_command(cmd);
+        self.activate_compute().unwrap().handle_compute_command(cmd);
     }
 
-    fn activate_compute<'a>(
-        &'a mut self,
-        response_tx: &'a mut ResponseSender,
-    ) -> Option<ActiveComputeState<'a, A>> {
+    fn activate_compute(&mut self) -> Option<ActiveComputeState<'_, A>> {
         if let Some(compute_state) = &mut self.compute_state {
             Some(ActiveComputeState {
                 timely_worker: &mut *self.timely_worker,
                 compute_state,
-                response_tx,
+                response_tx: &mut self.response_tx,
             })
         } else {
             None
+        }
+    }
+
+    /// Receive the next compute command.
+    ///
+    /// This method blocks if no command is currently available, but takes care to step the Timely
+    /// worker while doing so.
+    fn recv_command(&mut self) -> ComputeCommand {
+        loop {
+            if let Some(cmd) = self.command_rx.try_recv() {
+                return cmd;
+            }
+
+            let start = Instant::now();
+            self.timely_worker.step_or_park(None);
+            self.metrics
+                .timely_step_duration_seconds
+                .observe(start.elapsed().as_secs_f64());
         }
     }
 
@@ -569,16 +387,12 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
     /// Some additional tidying happens, cleaning up pending peeks, reported frontiers, and creating a new
     /// subscribe response buffer. We will need to be vigilant with future modifications to `ComputeState` to
     /// line up changes there with clean resets here.
-    fn reconcile(
-        &mut self,
-        command_rx: &CommandReceiverQueue,
-        response_tx: &mut ResponseSender,
-    ) -> Result<(), RecvError> {
+    fn reconcile(&mut self) -> Result<(), RecvError> {
         // To initialize the connection, we want to drain all commands until we receive a
         // `ComputeCommand::InitializationComplete` command to form a target command state.
         let mut new_commands = Vec::new();
         loop {
-            match command_rx.recv(self)? {
+            match self.recv_command() {
                 ComputeCommand::InitializationComplete => break,
                 command => new_commands.push(command),
             }
@@ -823,7 +637,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
 
         // Execute the commands to bring us to `new_commands`.
         for command in todo_commands.into_iter() {
-            self.handle_command(response_tx, command);
+            self.handle_command(command);
         }
 
         // Overwrite `self.command_history` to reflect `new_commands`.
@@ -837,4 +651,50 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
         }
         Ok(())
     }
+}
+
+/// Spawn a thread to bridge between [`ClusterClient`] and [`Worker`] channels.
+///
+/// The [`Worker`] expects a pair of persistent channels, with punctuation marking reconnects,
+/// while the [`ClusterClient`] provides a new pair of channels on each reconnect.
+fn spawn_channel_adapter(
+    client_rx: crossbeam_channel::Receiver<(
+        crossbeam_channel::Receiver<ComputeCommand>,
+        mpsc::UnboundedSender<ComputeResponse>,
+        mpsc::UnboundedSender<LocalActivator>,
+    )>,
+    command_tx: command_channel::Sender,
+    response_rx: crossbeam_channel::Receiver<ComputeResponse>,
+    worker_id: usize,
+) {
+    thread::Builder::new()
+        // "cca" stands for "compute channel adapter". We need to shorten that because Linux has a
+        // 15-character limit for thread names.
+        .name(format!("cca-{worker_id}"))
+        .spawn(move || {
+            while let Ok((command_rx, response_tx, activator_tx)) = client_rx.recv() {
+                // Serve this connection until we see any of the channels disconnect.
+
+                let activator = LocalActivator::new(thread::current());
+                if activator_tx.send(activator).is_err() {
+                    continue;
+                }
+
+                loop {
+                    crossbeam_channel::select! {
+                        recv(command_rx) -> msg => match msg {
+                            Ok(cmd) => command_tx.send(cmd),
+                            Err(_) => break,
+                        },
+                        recv(response_rx) -> msg => {
+                            let resp = msg.expect("worker connected");
+                            if response_tx.send(resp).is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        })
+        .unwrap();
 }


### PR DESCRIPTION
This PR makes the compute workers reuse their broadcast command channels across client reconnects, rather than creating a new ones for each connection. Doing so avoids bugs caused by workers rendering the channel dataflow with different operator IDs upon reconnecting multiple times.

The change only applies to the compute cluster, so the `ClusterClient`, which is shared between both compute and storage, still retains its previous behavior of using a new set of channels for each client connection. To interface between the `ClusterClient` and the compute workers, a "channel adapter" is introduced to bridge between the two.

Now that compute's internal command channel isn't recreated for each client connection anymore, we need something else to distinguish client connections and know when a reconciliation must be performed. To this end, the channel adapter keeps an epoch that it increases on each client reconnect and uses it to tag commands sent through the command channel. The compute worker learns to monitor for epoch changes and initiate a reconciliation when it observes one. Additionally, the compute worker is modified to tag responses with the current epoch and the channel adapter learns to filter out responses with outdated epochs, which were intended for previous client connections.

This change will also allow us to remove the activator back channel from workers to the `ClusterClient`, which is nice because blocking on that channel has been a reason for stalls in the past. [Draft implementation.](https://github.com/MaterializeInc/materialize/pull/31529)

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/8964

Also connected to https://github.com/MaterializeInc/incidents-and-escalations/issues/174

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
