### PR TITLE
Fix EXPLAIN around Char and Varchar

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1633,11 +1633,11 @@ impl ExprHumanizer for ConnCatalog<'_> {
         Some(self.resolve_full_name(entry.name()).into_parts())
     }
 
-    fn humanize_scalar_type(&self, typ: &ScalarType) -> String {
+    fn humanize_scalar_type(&self, typ: &ScalarType, postgres_compat: bool) -> String {
         use ScalarType::*;
 
         match typ {
-            Array(t) => format!("{}[]", self.humanize_scalar_type(t)),
+            Array(t) => format!("{}[]", self.humanize_scalar_type(t, postgres_compat)),
             List {
                 custom_id: Some(item_id),
                 ..
@@ -1650,12 +1650,15 @@ impl ExprHumanizer for ConnCatalog<'_> {
                 self.minimal_qualification(item.name()).to_string()
             }
             List { element_type, .. } => {
-                format!("{} list", self.humanize_scalar_type(element_type))
+                format!(
+                    "{} list",
+                    self.humanize_scalar_type(element_type, postgres_compat)
+                )
             }
             Map { value_type, .. } => format!(
                 "map[{}=>{}]",
-                self.humanize_scalar_type(&ScalarType::String),
-                self.humanize_scalar_type(value_type)
+                self.humanize_scalar_type(&ScalarType::String, postgres_compat),
+                self.humanize_scalar_type(value_type, postgres_compat)
             ),
             Record {
                 custom_id: Some(item_id),
@@ -1668,15 +1671,19 @@ impl ExprHumanizer for ConnCatalog<'_> {
                 "record({})",
                 fields
                     .iter()
-                    .map(|f| format!("{}: {}", f.0, self.humanize_column_type(&f.1)))
+                    .map(|f| format!(
+                        "{}: {}",
+                        f.0,
+                        self.humanize_column_type(&f.1, postgres_compat)
+                    ))
                     .join(",")
             ),
             PgLegacyChar => "\"char\"".into(),
-            Char { length } => match length {
+            Char { length } if !postgres_compat => match length {
                 None => "char".into(),
                 Some(length) => format!("char({})", length.into_u32()),
             },
-            VarChar { max_length } => match max_length {
+            VarChar { max_length } if !postgres_compat => match max_length {
                 None => "varchar".into(),
                 Some(length) => format!("varchar({})", length.into_u32()),
             },

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1672,6 +1672,14 @@ impl ExprHumanizer for ConnCatalog<'_> {
                     .join(",")
             ),
             PgLegacyChar => "\"char\"".into(),
+            Char { length } => match length {
+                None => "char".into(),
+                Some(length) => format!("char({})", length.into_u32()),
+            },
+            VarChar { max_length } => match max_length {
+                None => "varchar".into(),
+                Some(length) => format!("varchar({})", length.into_u32()),
+            },
             UInt16 => "uint2".into(),
             UInt32 => "uint4".into(),
             UInt64 => "uint8".into(),

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -647,7 +647,9 @@ impl Coordinator {
                 .try_into()?,
             _ => coord_bail!(
                 "can't use {} as a mz_timestamp for AS OF or UP TO",
-                catalog.for_session(session).humanize_column_type(&ty)
+                catalog
+                    .for_session(session)
+                    .humanize_column_type(&ty, false)
             ),
         })
     }

--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -458,7 +458,9 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for AvailableCollections {
                     "{}",
                     separated(
                         ", ",
-                        types.iter().map(|c| ctx.humanizer.humanize_column_type(c))
+                        types
+                            .iter()
+                            .map(|c| ctx.humanizer.humanize_column_type(c, false))
                     )
                 )?;
                 writeln!(f, "]")?;

--- a/src/expr-parser/src/catalog.rs
+++ b/src/expr-parser/src/catalog.rs
@@ -83,8 +83,8 @@ impl ExprHumanizer for TestCatalog {
         self.humanize_id_unqualified(id).map(|name| vec![name])
     }
 
-    fn humanize_scalar_type(&self, ty: &ScalarType) -> String {
-        DummyHumanizer.humanize_scalar_type(ty)
+    fn humanize_scalar_type(&self, ty: &ScalarType, postgres_compat: bool) -> String {
+        DummyHumanizer.humanize_scalar_type(ty, postgres_compat)
     }
 
     fn column_names_for_id(&self, id: GlobalId) -> Option<Vec<String>> {

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -182,8 +182,8 @@ impl ExprHumanizer for TestCatalog {
         self.humanize_id_unqualified(id).map(|name| vec![name])
     }
 
-    fn humanize_scalar_type(&self, ty: &ScalarType) -> String {
-        DummyHumanizer.humanize_scalar_type(ty)
+    fn humanize_scalar_type(&self, ty: &ScalarType, postgres_compat: bool) -> String {
+        DummyHumanizer.humanize_scalar_type(ty, postgres_compat)
     }
 
     fn column_names_for_id(&self, _id: GlobalId) -> Option<Vec<String>> {

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -579,7 +579,17 @@ impl<'a> EagerUnaryFunc<'a> for CastStringToChar {
 
 impl fmt::Display for CastStringToChar {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("text_to_char")
+        match self.length {
+            Some(length) => {
+                write!(
+                    f,
+                    "text_to_char[len={}, fail_on_len={}]",
+                    length.into_u32(),
+                    self.fail_on_len
+                )
+            }
+            None => f.write_str("text_to_char[len=None]"),
+        }
     }
 }
 
@@ -707,7 +717,17 @@ impl<'a> EagerUnaryFunc<'a> for CastStringToVarChar {
 
 impl fmt::Display for CastStringToVarChar {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("text_to_varchar")
+        match self.length {
+            Some(length) => {
+                write!(
+                    f,
+                    "text_to_varchar[len={}, fail_on_len={}]",
+                    length.into_u32(),
+                    self.fail_on_len
+                )
+            }
+            None => f.write_str("text_to_varchar[len=None]"),
+        }
     }
 }
 

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -588,7 +588,7 @@ impl fmt::Display for CastStringToChar {
                     self.fail_on_len
                 )
             }
-            None => f.write_str("text_to_char[len=None]"),
+            None => f.write_str("text_to_char[len=unbounded]"),
         }
     }
 }
@@ -726,7 +726,7 @@ impl fmt::Display for CastStringToVarChar {
                     self.fail_on_len
                 )
             }
-            None => f.write_str("text_to_varchar[len=None]"),
+            None => f.write_str("text_to_varchar[len=unbounded]"),
         }
     }
 }

--- a/src/repr/src/explain.rs
+++ b/src/repr/src/explain.rs
@@ -438,9 +438,11 @@ pub trait ExprHumanizer: fmt::Debug {
     fn humanize_id_parts(&self, id: GlobalId) -> Option<Vec<String>>;
 
     /// Returns a human-readable name for the specified scalar type.
+    /// Used in, e.g., EXPLAIN and error msgs.
     fn humanize_scalar_type(&self, ty: &ScalarType) -> String;
 
     /// Returns a human-readable name for the specified column type.
+    /// Used in, e.g., EXPLAIN and error msgs.
     fn humanize_column_type(&self, typ: &ColumnType) -> String {
         format!(
             "{}{}",

--- a/src/repr/src/explain.rs
+++ b/src/repr/src/explain.rs
@@ -438,15 +438,19 @@ pub trait ExprHumanizer: fmt::Debug {
     fn humanize_id_parts(&self, id: GlobalId) -> Option<Vec<String>>;
 
     /// Returns a human-readable name for the specified scalar type.
-    /// Used in, e.g., EXPLAIN and error msgs.
-    fn humanize_scalar_type(&self, ty: &ScalarType) -> String;
+    /// Used in, e.g., EXPLAIN and error msgs, in which case exact Postgres compatibility is less
+    /// important than showing as much detail as possible. Also used in `pg_typeof`, where Postgres
+    /// compatibility is more important.
+    fn humanize_scalar_type(&self, ty: &ScalarType, postgres_compat: bool) -> String;
 
     /// Returns a human-readable name for the specified column type.
-    /// Used in, e.g., EXPLAIN and error msgs.
-    fn humanize_column_type(&self, typ: &ColumnType) -> String {
+    /// Used in, e.g., EXPLAIN and error msgs, in which case exact Postgres compatibility is less
+    /// important than showing as much detail as possible. Also used in `pg_typeof`, where Postgres
+    /// compatibility is more important.
+    fn humanize_column_type(&self, typ: &ColumnType, postgres_compat: bool) -> String {
         format!(
             "{}{}",
-            self.humanize_scalar_type(&typ.scalar_type),
+            self.humanize_scalar_type(&typ.scalar_type, postgres_compat),
             if typ.nullable { "?" } else { "" }
         )
     }
@@ -507,8 +511,8 @@ impl<'a> ExprHumanizer for ExprHumanizerExt<'a> {
         }
     }
 
-    fn humanize_scalar_type(&self, ty: &ScalarType) -> String {
-        self.inner.humanize_scalar_type(ty)
+    fn humanize_scalar_type(&self, ty: &ScalarType, postgres_compat: bool) -> String {
+        self.inner.humanize_scalar_type(ty, postgres_compat)
     }
 
     fn column_names_for_id(&self, id: GlobalId) -> Option<Vec<String>> {
@@ -574,7 +578,7 @@ impl ExprHumanizer for DummyHumanizer {
         None
     }
 
-    fn humanize_scalar_type(&self, ty: &ScalarType) -> String {
+    fn humanize_scalar_type(&self, ty: &ScalarType, _postgres_compat: bool) -> String {
         // The debug implementation is better than nothing.
         format!("{:?}", ty)
     }
@@ -685,7 +689,7 @@ impl<'a> Display for HumanizedAnalyses<'a> {
                 Some(types) => {
                     let types = types
                         .into_iter()
-                        .map(|c| self.humanizer.humanize_column_type(c))
+                        .map(|c| self.humanizer.humanize_column_type(c, false))
                         .collect::<Vec<_>>();
 
                     bracketed("(", ")", separated(", ", types)).to_string()

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1009,7 +1009,8 @@ where
         let arg_types: Vec<_> = types
             .into_iter()
             .map(|ty| match ty {
-                CoercibleScalarType::Coerced(ty) => ecx.humanize_scalar_type(&ty),
+                // This will be used in error msgs, therefore we call with `postgres_compat` false.
+                CoercibleScalarType::Coerced(ty) => ecx.humanize_scalar_type(&ty, false),
                 CoercibleScalarType::Record(_) => "record".to_string(),
                 CoercibleScalarType::Uncoerced => "unknown".to_string(),
             })
@@ -1809,7 +1810,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                 let elem_type = match elem_type.array_of_self_elem_type() {
                     Ok(elem_type) => elem_type,
                     Err(elem_type) => bail_unsupported!(
-                        format!("array_fill on {}", ecx.humanize_scalar_type(&elem_type))
+                        format!("array_fill on {}", ecx.humanize_scalar_type(&elem_type, false))
                     ),
                 };
 
@@ -1825,7 +1826,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                 let elem_type = match elem_type.array_of_self_elem_type() {
                     Ok(elem_type) => elem_type,
                     Err(elem_type) => bail_unsupported!(
-                        format!("array_fill on {}", ecx.humanize_scalar_type(&elem_type))
+                        format!("array_fill on {}", ecx.humanize_scalar_type(&elem_type, false))
                     ),
                 };
 
@@ -2520,7 +2521,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                 let name = match ecx.scalar_type(&exprs[0]) {
                     CoercibleScalarType::Uncoerced => "unknown".to_string(),
                     CoercibleScalarType::Record(_) => "record".to_string(),
-                    CoercibleScalarType::Coerced(ty) => ecx.humanize_scalar_type(&ty),
+                    CoercibleScalarType::Coerced(ty) => ecx.humanize_scalar_type(&ty, true),
                 };
 
                 // For consistency with other functions, verify that
@@ -3023,7 +3024,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                 let elem_type = match elem_type.array_of_self_elem_type() {
                     Ok(elem_type) => elem_type,
                     Err(elem_type) => bail_unsupported!(
-                        format!("array_agg on {}", ecx.humanize_scalar_type(&elem_type))
+                        format!("array_agg on {}", ecx.humanize_scalar_type(&elem_type, false))
                     ),
                 };
 
@@ -3759,7 +3760,7 @@ pub static MZ_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                 let err = || {
                     Err(sql_err!(
                         "function map_build({}) does not exist",
-                        ecx.humanize_scalar_type(&ty.clone())
+                        ecx.humanize_scalar_type(&ty.clone(), false)
                     ))
                 };
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1810,6 +1810,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                 let elem_type = match elem_type.array_of_self_elem_type() {
                     Ok(elem_type) => elem_type,
                     Err(elem_type) => bail_unsupported!(
+                        // This will be used in error msgs, therefore we call with `postgres_compat` false.
                         format!("array_fill on {}", ecx.humanize_scalar_type(&elem_type, false))
                     ),
                 };

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -834,8 +834,8 @@ impl CoercibleScalarExpr {
             sql_bail!(
                 "{} must have type {}, not type {}",
                 ecx.name,
-                ecx.humanize_scalar_type(ty),
-                ecx.humanize_scalar_type(&expr_ty),
+                ecx.humanize_scalar_type(ty, false),
+                ecx.humanize_scalar_type(&expr_ty, false),
             );
         }
         Ok(expr)

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -844,12 +844,16 @@ impl<'a> StatementContext<'a> {
         Ok(out)
     }
 
-    pub fn humanize_scalar_type(&self, typ: &ScalarType) -> String {
-        self.catalog.humanize_scalar_type(typ)
+    /// The returned String is more detailed when the `postgres_compat` flag is not set. However,
+    /// the flag should be set in, e.g., the implementation of the `pg_typeof` function.
+    pub fn humanize_scalar_type(&self, typ: &ScalarType, postgres_compat: bool) -> String {
+        self.catalog.humanize_scalar_type(typ, postgres_compat)
     }
 
-    pub fn humanize_column_type(&self, typ: &ColumnType) -> String {
-        self.catalog.humanize_column_type(typ)
+    /// The returned String is more detailed when the `postgres_compat` flag is not set. However,
+    /// the flag should be set in, e.g., the implementation of the `pg_typeof` function.
+    pub fn humanize_column_type(&self, typ: &ColumnType, postgres_compat: bool) -> String {
+        self.catalog.humanize_column_type(typ, postgres_compat)
     }
 
     pub(crate) fn build_tunnel_definition(

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3033,8 +3033,8 @@ pub fn plan_create_continual_task(
                         "statement {}: column {} is of type {} but expression is of type {}",
                         idx,
                         desc.get_name(e.column).as_str().quoted(),
-                        qcx.humanize_scalar_type(&e.target_type),
-                        qcx.humanize_scalar_type(&e.source_type),
+                        qcx.humanize_scalar_type(&e.target_type, false),
+                        qcx.humanize_scalar_type(&e.source_type, false),
                     )
                 })?;
 

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -1070,8 +1070,8 @@ pub fn guess_best_common_type(
             sql_bail!(
                 "{} types {} and {} cannot be matched",
                 ecx.name,
-                ecx.humanize_scalar_type(candidate),
-                ecx.humanize_scalar_type(typ),
+                ecx.humanize_scalar_type(candidate, false),
+                ecx.humanize_scalar_type(typ, false),
             );
         };
 
@@ -1217,8 +1217,8 @@ pub fn plan_cast(
         None => Err(PlanError::InvalidCast {
             name: ecx.name.into(),
             ccx,
-            from: ecx.humanize_scalar_type(from),
-            to: ecx.humanize_scalar_type(to),
+            from: ecx.humanize_scalar_type(from, false),
+            to: ecx.humanize_scalar_type(to, false),
         }),
     };
 

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -586,7 +586,7 @@ pub(crate) fn generate_column_casts(
 
             PlanError::TableContainsUningestableTypes {
                 name: table.name.to_string(),
-                type_: scx.humanize_scalar_type(&scalar_type),
+                type_: scx.humanize_scalar_type(&scalar_type, false),
                 column: column.name.to_string(),
             }
         })?;

--- a/src/transform/src/typecheck.rs
+++ b/src/transform/src/typecheck.rs
@@ -1305,7 +1305,7 @@ where
 
     let mut it = cols.iter().peekable();
     while let Some(col) = it.next() {
-        s.push_str(&humanizer.humanize_column_type(col));
+        s.push_str(&humanizer.humanize_column_type(col, false));
 
         if it.peek().is_some() {
             s.push_str(", ");
@@ -1359,14 +1359,14 @@ impl ColumnTypeDifference {
 
         match self {
             NotSubtype { sub, sup } => {
-                let sub = h.humanize_scalar_type(sub);
-                let sup = h.humanize_scalar_type(sup);
+                let sub = h.humanize_scalar_type(sub, false);
+                let sup = h.humanize_scalar_type(sup, false);
 
                 writeln!(f, "{sub} is a not a subtype of {sup}")
             }
             Nullability { sub, sup } => {
-                let sub = h.humanize_column_type(sub);
-                let sup = h.humanize_column_type(sup);
+                let sub = h.humanize_column_type(sub, false);
+                let sup = h.humanize_column_type(sup, false);
 
                 writeln!(f, "{sub} is nullable but {sup} is not")
             }
@@ -1481,8 +1481,8 @@ impl<'a> TypeError<'a> {
                 diffs,
                 message,
             } => {
-                let got = humanizer.humanize_column_type(got);
-                let expected = humanizer.humanize_column_type(expected);
+                let got = humanizer.humanize_column_type(got, false);
+                let expected = humanizer.humanize_column_type(expected, false);
                 writeln!(
                     f,
                     "mismatched column types: {message}\n      got {got}\nexpected {expected}"

--- a/test/sqllogictest/array_fill.slt
+++ b/test/sqllogictest/array_fill.slt
@@ -195,10 +195,10 @@ SELECT array_fill(LIST[1], array[3, 2])
 query error array_fill on integer list not yet supported
 SELECT array_fill(LIST[1], array[3, 2], array[2, 3])
 
-query error array_fill on character not yet supported
+query error db error: ERROR: array_fill on char\(1\) not yet supported
 SELECT array_fill('c'::char, array[3, 2])
 
-query error array_fill on character not yet supported
+query error db error: ERROR: array_fill on char\(1\) not yet supported
 SELECT array_fill('c'::char, array[3, 2], array[2, 3])
 
 query error array_fill on map\[text=>integer\] not yet supported

--- a/test/sqllogictest/char.slt
+++ b/test/sqllogictest/char.slt
@@ -23,7 +23,7 @@ SELECT 'a'::character = 'a'::"char";
 ----
 true
 
-query error coalesce could not convert type character to "char"
+query error db error: ERROR: coalesce could not convert type char\(1\) to "char"
 SELECT pg_typeof(coalesce('1'::"char", '1'::char));
 
 # Fixes database-issues#5191
@@ -90,14 +90,14 @@ SELECT pg_typeof('abc'::text::"char");
 
 # Fixes database-issues#5222
 
-query error db error: ERROR: coalesce could not convert type "char" to character
+query error db error: ERROR: coalesce could not convert type "char" to char
 SELECT COALESCE('a'::char, 'a'::"char");
 
-query error coalesce could not convert type "char" to character varying
+query error db error: ERROR: coalesce could not convert type "char" to varchar
 SELECT COALESCE('a'::varchar, 'a'::"char");
 
-query error coalesce could not convert type character to "char"
+query error db error: ERROR: coalesce could not convert type char\(1\) to "char"
 SELECT COALESCE('a'::"char", 'a'::char);
 
-query error db error: ERROR: coalesce could not convert type character varying to "char"
+query error db error: ERROR: coalesce could not convert type varchar to "char"
 SELECT COALESCE('a'::"char", 'a'::varchar);

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -698,22 +698,22 @@ SELECT avg(b), sum(b) FROM abc
 # ----
 # 3 years 5 mons 7 days 00:00:19
 
-query error db error: ERROR: function sum\(character varying\) does not exist
+query error db error: ERROR: function sum\(varchar\) does not exist
 SELECT avg(a) FROM abc
 
 query error db error: ERROR: function sum\(boolean\) does not exist
 SELECT avg(c) FROM abc
 
-query error db error: ERROR: function sum\(record\(f1: character varying,f2: boolean\?\)\) does not exist
+query error db error: ERROR: function sum\(record\(f1: varchar,f2: boolean\?\)\) does not exist
 SELECT avg((a,c)) FROM abc
 
-query error db error: ERROR: function sum\(character varying\) does not exist
+query error db error: ERROR: function sum\(varchar\) does not exist
 SELECT sum(a) FROM abc
 
 query error db error: ERROR: function sum\(boolean\) does not exist
 SELECT sum(c) FROM abc
 
-query error db error: ERROR: function sum\(record\(f1: character varying,f2: boolean\?\)\) does not exist
+query error db error: ERROR: function sum\(record\(f1: varchar,f2: boolean\?\)\) does not exist
 SELECT sum((a,c)) FROM abc
 
 statement ok

--- a/test/sqllogictest/github-5536.slt
+++ b/test/sqllogictest/github-5536.slt
@@ -44,14 +44,14 @@ Explained Query:
               Filter (#0 <= #0) AND (#0 >= #0)
                 ReadStorage materialize.public.t5
           ArrangeBy keys=[[]]
-            Filter (#1 = text_to_char(text_to_varchar(boolean_to_text(like["0.31161855206970124"](padchar(#1))))))
+            Filter (#1 = text_to_char[len=None](text_to_varchar[len=None](boolean_to_text(like["0.31161855206970124"](padchar(#1))))))
               ReadStorage materialize.public.t3
           ArrangeBy keys=[[]]
             ReadStorage materialize.public.t5
 
 Source materialize.public.t0
 Source materialize.public.t3
-  filter=((#1 = text_to_char(text_to_varchar(boolean_to_text(like["0.31161855206970124"](padchar(#1)))))))
+  filter=((#1 = text_to_char[len=None](text_to_varchar[len=None](boolean_to_text(like["0.31161855206970124"](padchar(#1)))))))
 Source materialize.public.t5
 
 Target cluster: quickstart

--- a/test/sqllogictest/github-5536.slt
+++ b/test/sqllogictest/github-5536.slt
@@ -44,14 +44,14 @@ Explained Query:
               Filter (#0 <= #0) AND (#0 >= #0)
                 ReadStorage materialize.public.t5
           ArrangeBy keys=[[]]
-            Filter (#1 = text_to_char[len=None](text_to_varchar[len=None](boolean_to_text(like["0.31161855206970124"](padchar(#1))))))
+            Filter (#1 = text_to_char[len=unbounded](text_to_varchar[len=unbounded](boolean_to_text(like["0.31161855206970124"](padchar(#1))))))
               ReadStorage materialize.public.t3
           ArrangeBy keys=[[]]
             ReadStorage materialize.public.t5
 
 Source materialize.public.t0
 Source materialize.public.t3
-  filter=((#1 = text_to_char[len=None](text_to_varchar[len=None](boolean_to_text(like["0.31161855206970124"](padchar(#1)))))))
+  filter=((#1 = text_to_char[len=unbounded](text_to_varchar[len=unbounded](boolean_to_text(like["0.31161855206970124"](padchar(#1)))))))
 Source materialize.public.t5
 
 Target cluster: quickstart

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -524,7 +524,7 @@ SELECT '{a=>1, b=>2}'::map[text=>int] <@ '{a=>1, b=>2, c=>3}'::map[text=>int]
 ----
 true
 
-query error CAST does not support casting from map\[text=>map\[text=>character\]\] to map\[text=>map\[text=>character\]\]
+query error db error: ERROR: CAST does not support casting from map\[text=>map\[text=>char\]\] to map\[text=>map\[text=>char\(1\)\]\]
 SELECT '{hello=>{world=>a}}'::map[text=>map[text=>char]] <@ '{hello=>c}'::map[text=>char]
 ----
 false

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -1929,7 +1929,7 @@ TopK order_by=[#0 asc nulls_last]
               Filter (select(Get l1) AND (integer_to_numeric(#2) > select(Get l2)))
                 Get materialize.public.partsupp
     Return
-      Filter ((select(Get l3) AND (#3 = #7)) AND (#8 = text_to_char("CANADA")))
+      Filter ((select(Get l3) AND (#3 = #7)) AND (#8 = text_to_char[len=None]("CANADA")))
         CrossJoin
           Get materialize.public.supplier
           Get materialize.public.nation

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -1929,7 +1929,7 @@ TopK order_by=[#0 asc nulls_last]
               Filter (select(Get l1) AND (integer_to_numeric(#2) > select(Get l2)))
                 Get materialize.public.partsupp
     Return
-      Filter ((select(Get l3) AND (#3 = #7)) AND (#8 = text_to_char[len=None]("CANADA")))
+      Filter ((select(Get l3) AND (#3 = #7)) AND (#8 = text_to_char[len=unbounded]("CANADA")))
         CrossJoin
           Get materialize.public.supplier
           Get materialize.public.nation

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -1922,7 +1922,7 @@ Finish order_by=[#0 asc nulls_last] output=[#0, #1]
               Filter (select(Get l1) AND (integer_to_numeric(#2) > select(Get l2)))
                 Get materialize.public.partsupp
     Return
-      Filter ((select(Get l3) AND (#3 = #7)) AND (#8 = text_to_char[len=None]("CANADA")))
+      Filter ((select(Get l3) AND (#3 = #7)) AND (#8 = text_to_char[len=unbounded]("CANADA")))
         CrossJoin
           Get materialize.public.supplier
           Get materialize.public.nation

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -1922,7 +1922,7 @@ Finish order_by=[#0 asc nulls_last] output=[#0, #1]
               Filter (select(Get l1) AND (integer_to_numeric(#2) > select(Get l2)))
                 Get materialize.public.partsupp
     Return
-      Filter ((select(Get l3) AND (#3 = #7)) AND (#8 = text_to_char("CANADA")))
+      Filter ((select(Get l3) AND (#3 = #7)) AND (#8 = text_to_char[len=None]("CANADA")))
         CrossJoin
           Get materialize.public.supplier
           Get materialize.public.nation

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -304,7 +304,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT lower('a'::char);
 ----
-Map (lower(char_to_text(text_to_char[len=1, fail_on_len=false](text_to_char[len=None]("a")))))
+Map (lower(char_to_text(text_to_char[len=1, fail_on_len=false](text_to_char[len=unbounded]("a")))))
   Constant
     - ()
 
@@ -317,7 +317,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 'a'::"char" < 'a'::varchar;
 ----
-Map (("char"_to_text(text_to_"char"("a")) < varchar_to_text(text_to_varchar[len=None]("a"))))
+Map (("char"_to_text(text_to_"char"("a")) < varchar_to_text(text_to_varchar[len=unbounded]("a"))))
   Constant
     - ()
 
@@ -330,7 +330,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 'a'::"char" < 'a'::char;
 ----
-Map (("char"_to_text(text_to_"char"("a")) < char_to_text(text_to_char[len=1, fail_on_len=false](text_to_char[len=None]("a")))))
+Map (("char"_to_text(text_to_"char"("a")) < char_to_text(text_to_char[len=1, fail_on_len=false](text_to_char[len=unbounded]("a")))))
   Constant
     - ()
 
@@ -343,7 +343,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 'a'::char < 'a'::varchar;
 ----
-Map ((text_to_char[len=1, fail_on_len=false](text_to_char[len=None]("a")) < text_to_char[len=None](text_to_varchar[len=None]("a"))))
+Map ((text_to_char[len=1, fail_on_len=false](text_to_char[len=unbounded]("a")) < text_to_char[len=unbounded](text_to_varchar[len=unbounded]("a"))))
   Constant
     - ()
 
@@ -357,7 +357,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 'a'::char < 'a'::text;
 ----
-Map ((char_to_text(text_to_char[len=1, fail_on_len=false](text_to_char[len=None]("a"))) < "a"))
+Map ((char_to_text(text_to_char[len=1, fail_on_len=false](text_to_char[len=unbounded]("a"))) < "a"))
   Constant
     - ()
 
@@ -369,7 +369,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 'a'::varchar < 'a'::text;
 ----
-Map ((varchar_to_text(text_to_varchar[len=None]("a")) < "a"))
+Map ((varchar_to_text(text_to_varchar[len=unbounded]("a")) < "a"))
   Constant
     - ()
 
@@ -382,7 +382,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT coalesce('a'::char, 'a'::varchar, 'a'::text);
 ----
-Map (coalesce(text_to_char[len=1, fail_on_len=false](text_to_char[len=None]("a")), text_to_char[len=None](text_to_varchar[len=None]("a")), text_to_char[len=None]("a")))
+Map (coalesce(text_to_char[len=1, fail_on_len=false](text_to_char[len=unbounded]("a")), text_to_char[len=unbounded](text_to_varchar[len=unbounded]("a")), text_to_char[len=unbounded]("a")))
   Constant
     - ()
 
@@ -394,7 +394,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT coalesce('a'::char, 'a'::text, 'a'::varchar);
 ----
-Map (coalesce(text_to_char[len=1, fail_on_len=false](text_to_char[len=None]("a")), text_to_char[len=None]("a"), text_to_char[len=None](text_to_varchar[len=None]("a"))))
+Map (coalesce(text_to_char[len=1, fail_on_len=false](text_to_char[len=unbounded]("a")), text_to_char[len=unbounded]("a"), text_to_char[len=unbounded](text_to_varchar[len=unbounded]("a"))))
   Constant
     - ()
 
@@ -1729,7 +1729,7 @@ Explained Query:
   Union // { types: "(varchar?)" }
     ReadStorage materialize.public.t1 // { types: "(varchar(3)?)" }
     Project (#1) // { types: "(varchar?)" }
-      Map (text_to_varchar[len=None](#0)) // { types: "(char(2)?, varchar?)" }
+      Map (text_to_varchar[len=unbounded](#0)) // { types: "(char(2)?, varchar?)" }
         ReadStorage materialize.public.t3 // { types: "(char(2)?)" }
 
 Source materialize.public.t1

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -1662,3 +1662,117 @@ values ('2023-01-01T00:00:00.666'::timestamp(6)) union all values ('2023-01-01T0
 
 query error numeric field overflow
 SELECT '1e-307'::float8::numeric
+
+statement ok
+CREATE TABLE t1(a varchar(3));
+
+statement ok
+CREATE TABLE t2(b varchar(4));
+
+statement error db error: ERROR: value too long for type character varying\(3\)
+INSERT INTO t1 VALUES ('123456');
+
+# From the Postgres docs: https://www.postgresql.org/docs/current/datatype-character.html
+# "An attempt to store a longer string into a column of these types will result in an error, unless the excess
+# characters are all spaces, in which case the string will be truncated to the maximum length. (This somewhat bizarre
+# exception is required by the SQL standard.)"
+statement ok
+INSERT INTO t1 VALUES ('111   ');
+
+statement ok
+INSERT INTO t1 VALUES ('123');
+
+statement ok
+INSERT INTO t2 VALUES ('1234');
+
+query T multiline
+EXPLAIN WITH (TYPES)
+(SELECT * FROM t1) UNION ALL (SELECT * FROM t2);
+----
+Explained Query:
+  Union // { types: "(varchar?)" }
+    ReadStorage materialize.public.t1 // { types: "(varchar(3)?)" }
+    ReadStorage materialize.public.t2 // { types: "(varchar(4)?)" }
+
+Source materialize.public.t1
+Source materialize.public.t2
+
+Target cluster: quickstart
+
+EOF
+
+query T
+(SELECT * FROM t1) UNION ALL (SELECT * FROM t2);
+----
+111
+123
+1234
+
+query T
+(SELECT * FROM t2) UNION ALL (SELECT * FROM t1);
+----
+111
+123
+1234
+
+statement ok
+CREATE TABLE t3(b char(2));
+
+statement ok
+INSERT INTO t3 VALUES ('ab');
+
+query T multiline
+EXPLAIN WITH (TYPES)
+(SELECT * FROM t1) UNION ALL (SELECT * FROM t3);
+----
+Explained Query:
+  Union // { types: "(varchar?)" }
+    ReadStorage materialize.public.t1 // { types: "(varchar(3)?)" }
+    Project (#1) // { types: "(varchar?)" }
+      Map (text_to_varchar[len=None](#0)) // { types: "(char(2)?, varchar?)" }
+        ReadStorage materialize.public.t3 // { types: "(char(2)?)" }
+
+Source materialize.public.t1
+Source materialize.public.t3
+
+Target cluster: quickstart
+
+EOF
+
+query T
+(SELECT * FROM t1) UNION ALL (SELECT * FROM t3);
+----
+ab
+111
+123
+
+statement ok
+CREATE TABLE t4(b char(3));
+
+statement ok
+INSERT INTO t4 VALUES ('ab ');
+
+query T multiline
+EXPLAIN WITH (TYPES)
+(SELECT * FROM t3) UNION (SELECT * FROM t4);
+----
+Explained Query:
+  Distinct project=[#0] // { types: "(char?)" }
+    Union // { types: "(char?)" }
+      ReadStorage materialize.public.t3 // { types: "(char(2)?)" }
+      ReadStorage materialize.public.t4 // { types: "(char(3)?)" }
+
+Source materialize.public.t3
+Source materialize.public.t4
+
+Target cluster: quickstart
+
+EOF
+
+# Trailing spaces are treated as semantically insignificant in both Postgres and Materialize, so the above
+# 'ab' and 'ab ' end up deduplicated.
+# See also in char-varchar-distinct.td
+query T
+(SELECT * FROM t3) UNION (SELECT * FROM t4);
+----
+ab

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -304,7 +304,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT lower('a'::char);
 ----
-Map (lower(char_to_text(text_to_char(text_to_char("a")))))
+Map (lower(char_to_text(text_to_char[len=1, fail_on_len=false](text_to_char[len=None]("a")))))
   Constant
     - ()
 
@@ -317,7 +317,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 'a'::"char" < 'a'::varchar;
 ----
-Map (("char"_to_text(text_to_"char"("a")) < varchar_to_text(text_to_varchar("a"))))
+Map (("char"_to_text(text_to_"char"("a")) < varchar_to_text(text_to_varchar[len=None]("a"))))
   Constant
     - ()
 
@@ -330,7 +330,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 'a'::"char" < 'a'::char;
 ----
-Map (("char"_to_text(text_to_"char"("a")) < char_to_text(text_to_char(text_to_char("a")))))
+Map (("char"_to_text(text_to_"char"("a")) < char_to_text(text_to_char[len=1, fail_on_len=false](text_to_char[len=None]("a")))))
   Constant
     - ()
 
@@ -343,7 +343,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 'a'::char < 'a'::varchar;
 ----
-Map ((text_to_char(text_to_char("a")) < text_to_char(text_to_varchar("a"))))
+Map ((text_to_char[len=1, fail_on_len=false](text_to_char[len=None]("a")) < text_to_char[len=None](text_to_varchar[len=None]("a"))))
   Constant
     - ()
 
@@ -357,7 +357,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 'a'::char < 'a'::text;
 ----
-Map ((char_to_text(text_to_char(text_to_char("a"))) < "a"))
+Map ((char_to_text(text_to_char[len=1, fail_on_len=false](text_to_char[len=None]("a"))) < "a"))
   Constant
     - ()
 
@@ -369,7 +369,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 'a'::varchar < 'a'::text;
 ----
-Map ((varchar_to_text(text_to_varchar("a")) < "a"))
+Map ((varchar_to_text(text_to_varchar[len=None]("a")) < "a"))
   Constant
     - ()
 
@@ -382,7 +382,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT coalesce('a'::char, 'a'::varchar, 'a'::text);
 ----
-Map (coalesce(text_to_char(text_to_char("a")), text_to_char(text_to_varchar("a")), text_to_char("a")))
+Map (coalesce(text_to_char[len=1, fail_on_len=false](text_to_char[len=None]("a")), text_to_char[len=None](text_to_varchar[len=None]("a")), text_to_char[len=None]("a")))
   Constant
     - ()
 
@@ -394,7 +394,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT coalesce('a'::char, 'a'::text, 'a'::varchar);
 ----
-Map (coalesce(text_to_char(text_to_char("a")), text_to_char("a"), text_to_char(text_to_varchar("a"))))
+Map (coalesce(text_to_char[len=1, fail_on_len=false](text_to_char[len=None]("a")), text_to_char[len=None]("a"), text_to_char[len=None](text_to_varchar[len=None]("a"))))
   Constant
     - ()
 

--- a/test/testdrive/char-varchar-distinct.td
+++ b/test/testdrive/char-varchar-distinct.td
@@ -8,10 +8,11 @@
 # by the Apache License, Version 2.0.
 
 #
-# Make sure the distinct operator inside a detaflow operates correctly
+# Make sure the distinct operator inside a dataflow operates correctly
 # with respect to CHAR/VARCHAR, especially in the presence of trailing
 # spaces.
 #
+# The reason for this being a td and not slt is that td has "" wrapping on the output, which is convenient here.
 
 > SELECT 'a '::char(5) UNION DISTINCT SELECT 'a  '::char(5);
 "a    "


### PR DESCRIPTION
Char and Varchar can involve a length. Additionally, the cast functions `text_to_char` and `text_to_varchar` involve a `fail_on_len` option. We were not printing these extra fields in EXPLAIN and in error msgs, causing confusion in various situations, e.g.,
https://github.com/MaterializeInc/database-issues/issues/8807#issuecomment-2518662460
https://github.com/MaterializeInc/database-issues/issues/1291
https://github.com/MaterializeInc/materialize/pull/27029

The first commit attends to `text_to_varchar` and `text_to_char`.

The second commit attends to the type names, changing them in EXPLAIN, error msgs, and `pg_typeof`.

The third commit reverts the change for `pg_typeof`, to keep Postgres compatibility.

Nightly: https://buildkite.com/materialize/nightly/builds/11207

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/8975

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
